### PR TITLE
Remove hidden classes

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.html
@@ -86,15 +86,7 @@ baselines, due to glyphs extending far outside the em square." src="baselines.pn
 
 <p>Edit the code below and see your changes update live in the canvas:</p>
 
-<pre class="brush: js;">ctx.font = '48px serif';
-ctx.textBaseline = 'hanging';
-ctx.strokeText('Hello world', 0, 100);
-</pre>
-
-<div class="hidden">
-<h6 id="Playable_code">Playable code</h6>
-
-<pre class="brush: html">&lt;canvas id="canvas" width="400" height="200" class="playable-canvas"&gt;&lt;/canvas&gt;
+<pre class="brush: html hidden">&lt;canvas id="canvas" width="400" height="200" class="playable-canvas"&gt;&lt;/canvas&gt;
 &lt;div class="playable-buttons"&gt;
   &lt;input id="edit" type="button" value="Edit" /&gt;
   &lt;input id="reset" type="button" value="Reset" /&gt;
@@ -105,7 +97,7 @@ ctx.textBaseline = "hanging";
 ctx.strokeText("Hello world", 0, 100);&lt;/textarea&gt;
 </pre>
 
-<pre class="brush: js">var canvas = document.getElementById('canvas');
+<pre class="brush: js hidden">var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 var textarea = document.getElementById('code');
 var reset = document.getElementById('reset');
@@ -129,9 +121,8 @@ edit.addEventListener('click', function() {
 textarea.addEventListener('input', drawCanvas);
 window.addEventListener('load', drawCanvas);
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Playable_code', 700, 360) }}</p>
+<p>{{ EmbedLiveSample('A_textBaseline_example', 700, 400) }}</p>
 
 <h2 id="Advanced_text_measurements">Advanced text measurements</h2>
 

--- a/files/en-us/web/api/elementinternals/labels/index.html
+++ b/files/en-us/web/api/elementinternals/labels/index.html
@@ -36,7 +36,6 @@ console.log(element.internals_.label);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/elementinternals/reportvalidity/index.html
+++ b/files/en-us/web/api/elementinternals/reportvalidity/index.html
@@ -55,7 +55,6 @@ console.log(element.internals_.reportValidity()); // true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/elementinternals/role/index.html
+++ b/files/en-us/web/api/elementinternals/role/index.html
@@ -30,7 +30,6 @@ browser-compat: api.ElementInternals.role
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/elementinternals/shadowroot/index.html
+++ b/files/en-us/web/api/elementinternals/shadowroot/index.html
@@ -42,7 +42,6 @@ browser-compat: api.ElementInternals.shadowRoot
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/elementinternals/states/index.html
+++ b/files/en-us/web/api/elementinternals/states/index.html
@@ -46,7 +46,6 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.html
+++ b/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.html
@@ -46,7 +46,6 @@ browser-compat: api.HIDConnectionEvent.HIDConnectionEvent
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hiddevice/close/index.html
+++ b/files/en-us/web/api/hiddevice/close/index.html
@@ -37,7 +37,6 @@ browser-compat: api.HIDDevice.close
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hiddevice/productid/index.html
+++ b/files/en-us/web/api/hiddevice/productid/index.html
@@ -37,7 +37,6 @@ browser-compat: api.HIDDevice.productId
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hiddevice/productname/index.html
+++ b/files/en-us/web/api/hiddevice/productname/index.html
@@ -37,7 +37,6 @@ browser-compat: api.HIDDevice.productName
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.html
@@ -49,7 +49,6 @@ browser-compat: api.HIDDevice.receiveFeatureReport
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.html
@@ -59,7 +59,6 @@ for (let i = 0; i < 10; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/hiddevice/vendorid/index.html
+++ b/files/en-us/web/api/hiddevice/vendorid/index.html
@@ -37,7 +37,6 @@ browser-compat: api.HIDDevice.vendorId
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.html
@@ -37,10 +37,8 @@ browser-compat: api.HTMLMediaElement.textTracks
   the list, you can monitor it for changes to detect when new text tracks are added or
   existing ones removed.</p>
 
-<div class="hidden">
-  <p>See {{SectionOnPage("/en-US/docs/Web/API/TextTrackList", "Event handlers")}} to learn
+<p>See {{SectionOnPage("/en-US/docs/Web/API/TextTrackList", "Event handlers")}} to learn
     more about watching for changes to a media element's track list.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/midioutput/clear/index.html
+++ b/files/en-us/web/api/midioutput/clear/index.html
@@ -27,6 +27,5 @@ browser-compat: api.MIDIOutput.clear
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutput/index.html
+++ b/files/en-us/web/api/midioutput/index.html
@@ -43,6 +43,5 @@ browser-compat: api.MIDIOutput
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -54,6 +54,5 @@ browser-compat: api.MIDIOutput.send
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/midiport/close/index.html
+++ b/files/en-us/web/api/midiport/close/index.html
@@ -40,6 +40,5 @@ output.close(); // closes the port</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.html
@@ -51,9 +51,4 @@ browser-compat: api.RTCIceCandidatePairStats.firstRequestTimeStamp
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>Note: change to <code>firstRequestTime<strong>s</strong>tamp</code>, once BCD is
-    updated.</p>
-</div>
-
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -54,6 +54,5 @@ console.log(example.points.appendItem(svgpoint));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/clear/index.html
+++ b/files/en-us/web/api/svgpointlist/clear/index.html
@@ -46,6 +46,5 @@ example.points.clear();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/getitem/index.html
+++ b/files/en-us/web/api/svgpointlist/getitem/index.html
@@ -53,6 +53,5 @@ console.log(example.points.getItem(0));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/index.html
+++ b/files/en-us/web/api/svgpointlist/index.html
@@ -60,6 +60,5 @@ console.log(example.points); //an SVGPointList</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/initialize/index.html
+++ b/files/en-us/web/api/svgpointlist/initialize/index.html
@@ -56,6 +56,5 @@ console.log(example.points.length); //1</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -56,6 +56,5 @@ console.log(example.points.insertItemBefore(svgpoint,2));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/length/index.html
+++ b/files/en-us/web/api/svgpointlist/length/index.html
@@ -36,6 +36,5 @@ console.log(example.points.length); // 5</pre>
 
 <p>{{Specifications}}</p>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/numberofitems/index.html
+++ b/files/en-us/web/api/svgpointlist/numberofitems/index.html
@@ -38,6 +38,5 @@ console.log(example.points.numberOfItems); // 5</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/removeitem/index.html
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.html
@@ -53,6 +53,5 @@ console.log(example.points.removeItem(2));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.html
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.html
@@ -58,6 +58,5 @@ console.log(example.points.replaceItem(svgpoint,1));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequest/abort_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/abort_event/index.html
@@ -49,10 +49,7 @@ browser-compat: api.XMLHttpRequest.abort_event
 
 &lt;textarea readonly class="event-log"&gt;&lt;/textarea&gt;</pre>
 
-<div class="hidden">
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css">.event-log {
+<pre class="brush: css hidden">.event-log {
     width: 25rem;
     height: 4rem;
     border: 1px solid black;
@@ -65,7 +62,6 @@ input {
     margin: .5rem;
 }
 </pre>
-</div>
 
 <h4 id="JS">JS</h4>
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/7902.

This PR removes all remaining uses of the `hidden` class in the Web/API docs (excluding its use on `<pre>` which is still supported in Markdown).

Most of these are the familiar comments about BCD. A couple were live-sample related ones that I'd missed, and a couple more were different - in one of these I kept the text because I couldn't see any reason it was hidden.