### PR TITLE
Fix typo of properties in DeviceOrientationEvent

### DIFF
--- a/files/en-us/web/api/deviceorientationevent/index.html
+++ b/files/en-us/web/api/deviceorientationevent/index.html
@@ -31,9 +31,9 @@ browser-compat: api.DeviceOrientationEvent
  <dd>A number representing the motion of the device around the x axis, express in degrees with values ranging from -180 (inclusive) to 180 (exclusive). This represents a front to back motion of the device.</dd>
  <dt>{{domxref("DeviceOrientationEvent.gamma")}} {{readonlyinline}}</dt>
  <dd>A number representing the motion of the device around the y axis, express in degrees with values ranging from -90 (inclusive) to 90 (exclusive). This represents a left to right motion of the device.</dd>
- <dt>DeviceOrientationEvent.webkitCompassHeading {{readonlyinline}}</dt>
+ <dt><code>DeviceOrientationEvent.webkitCompassHeading</code> {{Non-Standard_Inline}} {{readonlyinline}}</dt>
  <dd>A number represents the difference between the motion of the device around the z axis of the world system and the direction of the north, express in degrees with values ranging from 0 to 360.</dd>
- <dt>DeviceOrientationEvent.webkitCompassAccuracy {{readonlyinline}}</dt>
+ <dt><code>DeviceOrientationEvent.webkitCompassAccuracy</code> {{Non-Standard_Inline}} {{readonlyinline}}</dt>
  <dd>The accuracy of the compass means that the deviation is positive or negative. It's usually 10.</dd>
 </dl>
 


### PR DESCRIPTION
Two non-standard properties were missing the `<code>` tags.