### PR TITLE
Fixes #3222

### DIFF
--- a/files/en-us/tools/debugger/how_to/pretty-print_a_minified_file/index.html
+++ b/files/en-us/tools/debugger/how_to/pretty-print_a_minified_file/index.html
@@ -17,5 +17,5 @@ tags:
 <p>The <strong>Pretty print source</strong> icon is available only if the source file is minified (i.e., not an original file), and is not already "prettified".</p>
 
 <div class="note">
-<p><strong>Note</strong>: Currently Firefox does not support pretty printing inline Javascript.</p>
+<p><strong>Note</strong>: Currently Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1010150">does not support</a> pretty printing inline Javascript.</p>
 </div>

--- a/files/en-us/tools/debugger/how_to/pretty-print_a_minified_file/index.html
+++ b/files/en-us/tools/debugger/how_to/pretty-print_a_minified_file/index.html
@@ -17,5 +17,5 @@ tags:
 <p>The <strong>Pretty print source</strong> icon is available only if the source file is minified (i.e., not an original file), and is not already "prettified".</p>
 
 <div class="note">
-<p><strong>Note</strong>: if you want to prettify some inline JavaScript code, just double click the code in the inspector pane.</p>
+<p><strong>Note</strong>: Currently Firefox does not support pretty printing inline Javascript.</p>
 </div>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #3222

> What was wrong/why is this fix needed? (quick summary only)
Can't pprint inline JS on FF 91 on Win 10 either.  Possibly due to [https://bugzilla.mozilla.org/show_bug.cgi?id=1010150](Can't pretty-print / deobfuscate / beautify inline scripts)

> Anything else that could help us review it
This bug needs-triage. Feel free to put on hold until then.