### PR TITLE
Updated URL to Helmet Referrer Policy repo

### DIFF
--- a/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.html
+++ b/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.html
@@ -41,7 +41,7 @@ tags:
 
 <ul>
  <li><a href="https://docs.djangoproject.com/en/stable/topics/security/">Security in Django</a> (especially see <a href="https://docs.djangoproject.com/en/stable/topics/security/#cross-site-request-forgery-csrf-protection">Cross site request forgery (CSRF) protection</a>).</li>
- <li><a href="https://github.com/helmetjs/referrer-policy">helmetjs referrer-policy</a> — middleware for setting Referrer-Policy in Node.js/Express apps (see also <a href="https://github.com/helmetjs">helmetjs</a> for more security provisions).</li>
+ <li><a href="https://github.com/helmetjs/helmet/tree/main/middlewares/referrer-policy">helmetjs referrer-policy</a> — middleware for setting Referrer-Policy in Node.js/Express apps (see also <a href="https://github.com/helmetjs">helmetjs</a> for more security provisions).</li>
 </ul>
 
 <h2 id="Policy_and_requirements">Policy and requirements</h2>


### PR DESCRIPTION
The previous URL for Helmet Referrer Policy went to an archive that didn't have any information.

I located the most current, up-to-date version of the documentation on the Helmet repo and updated the URL accordingly.
