### PR TITLE
Remove deprecated baseProfile svg attribute

### DIFF
--- a/files/en-us/web/svg/tutorial/getting_started/index.html
+++ b/files/en-us/web/svg/tutorial/getting_started/index.html
@@ -14,7 +14,6 @@ tags:
 <p>Let us dive straight in with a simple example. Take a look at the following code.</p>
 
 <pre class="brush: xml">&lt;svg version="1.1"
-     baseProfile="full"
      width="300" height="200"
      xmlns="http://www.w3.org/2000/svg"&gt;
 


### PR DESCRIPTION
From getting started guide.

It has nothing to do here in a getting started guide.

Arguably removing `version="1.1"` should be done too, as it is also deprecated in svg v2.