### PR TITLE
fixing comment and notation example in :nth-child() CSS Ref

### DIFF
--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -20,8 +20,7 @@ li:nth-child(2) {
   color: lime;
 }
 
-/* Selects every fourth element
-   among any group of siblings */
+/* Select each element from any group of siblings whichever is a multiple of four. */
 :nth-child(4n) {
   color: lime;
 }
@@ -71,7 +70,7 @@ li:nth-child(2) {
 - `:nth-child(3n+4)`
   - : Represents elements **4** \[=(3×0)+4], **7** \[=(3×1)+4], **10** \[=(3×2)+4], **13** \[=(3×3)+4], **etc.**
 - `:nth-child(-n+3)`
-  - : Represents the first three elements. \[=-0+3, -1+3, -2+3]
+  - : Represents the first three elements. **3** \[=-0+3], **2** \[=-1+3], **1** [=-2+3]
 - `p:nth-child(n)`
   - : Represents every `<p>` element in a group of siblings. This selects the same elements as a simple `p` selector (although with a higher specificity).
 - `p:nth-child(1)` or `p:nth-child(0n+1)`


### PR DESCRIPTION
:nth-child(4n) will "select every element from any group of siblings, whichever is a multiple of four", but "selects every fourth element among any group of siblings" may seem confusing.
Adding the calculation result to the :nth-child(-n+3) example same as in the above examples.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
