### PR TITLE
Remove semicolon after function declaration

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/promises/index.html
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.html
@@ -18,9 +18,9 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Timeouts_and_intervals", "Learn/JavaScript/Asynchronous/Async_await", "Learn/JavaScript/Asynchronous")}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>Promises</strong> are a comparatively new feature of the JavaScript language that allow you to defer further actions until after a previous action has completed, or respond to its failure.</span> This is useful for setting up a sequence of async operations to work correctly. This article shows you how promises work, how you'll see them in use with web APIs, and how to write your own.</p>
+<p class="summary"><strong>Promises</strong> are a comparatively new feature of the JavaScript language that allow you to defer further actions until after a previous action has completed, or respond to its failure. This is useful for setting up a sequence of async operations to work correctly. This article shows you how promises work, how you'll see them in use with web APIs, and how to write your own.</p>
 
-<table class="learn-box standard-table">
+<table class="learn-box">
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>
@@ -213,7 +213,7 @@ tags:
 
   <pre class="brush: js">let promise3 = promise2.then(myBlob =&gt; {
 
-})</pre>
+});</pre>
  </li>
  <li>
    <p>Now let's fill in the body of the <code>.then()</code> callback. Add the following lines inside the curly braces:</p>
@@ -534,7 +534,7 @@ document.body.appendChild(para);</pre>
       }, interval);
     }
   });
-};</pre>
+}</pre>
 
 <p>Here we are passing two arguments into a custom function — a message to do something with, and the time interval to pass before doing the thing. Inside the function we then return a new <code>Promise</code> object — invoking the function will return the promise we want to use.</p>
 

--- a/files/en-us/learn/javascript/asynchronous/promises/index.html
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.html
@@ -279,7 +279,7 @@ document.body.appendChild(image);</pre>
 
 <h2 id="Promise_terminology_recap">Promise terminology recap</h2>
 
-<p>There was a lot to cover in the above section, so let's go back over it quickly to give you a <a href="/en-US/docs/Learn/JavaScript/Asynchronous/Promises#promise_terminology_recap">short guide that you can bookmark</a> and use to refresh your memory in the future. You should also go over the above section again a few more times to make sure these concepts stick.</p>
+<p>There was a lot to cover in the above section, so let's go back over it quickly to give you a short guide that you can bookmark and use to refresh your memory in the future. You should also go over the above section again a few more times to make sure these concepts stick.</p>
 
 <ol>
  <li>When a promise is created, it is neither in a success or failure state. It is said to be <strong>pending</strong>.</li>
@@ -594,7 +594,6 @@ document.body.appendChild(para);</pre>
  <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous/Concepts">General asynchronous programming concepts</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous/Introducing">Introducing asynchronous JavaScript</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous/Timeouts_and_intervals">Cooperative asynchronous JavaScript: Timeouts and intervals</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous/Promises">Graceful asynchronous programming with Promises</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous/Async_await">Making asynchronous programming easier with async and await</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous/Choosing_the_right_approach">Choosing the right approach</a></li>
 </ul>


### PR DESCRIPTION
- remove `seosummary` and `standard-table` class
- add semicolon after function expression
- fixes #8417
