### PR TITLE
SVG: x and y attributes can be set for <cursor> and <symbol>

### DIFF
--- a/files/en-us/web/svg/attribute/x/index.html
+++ b/files/en-us/web/svg/attribute/x/index.html
@@ -46,6 +46,7 @@ tags:
   <li>{{SVGElement("pattern")}}</li>
   <li>{{SVGElement("rect")}}</li>
   <li>{{SVGElement("svg")}}</li>
+  <li>{{SVGElement("symbol")}}</li>
   <li>{{SVGElement("text")}}</li>
   <li>{{SVGElement("tref")}}</li>
   <li>{{SVGElement("tspan")}}</li>

--- a/files/en-us/web/svg/attribute/x/index.html
+++ b/files/en-us/web/svg/attribute/x/index.html
@@ -13,6 +13,7 @@ tags:
 
 <ul>
   <li>{{SVGElement("altGlyph")}}</li>
+  <li>{{SVGElement("cursor")}}</li>
   <li>{{SVGElement("feBlend")}}</li>
   <li>{{SVGElement("feColorMatrix")}}</li>
   <li>{{SVGElement("feComponentTransfer")}}</li>

--- a/files/en-us/web/svg/attribute/y/index.html
+++ b/files/en-us/web/svg/attribute/y/index.html
@@ -46,6 +46,7 @@ tags:
   <li>{{SVGElement("pattern")}}</li>
   <li>{{SVGElement("rect")}}</li>
   <li>{{SVGElement("svg")}}</li>
+  <li>{{SVGElement("symbol")}}</li>
   <li>{{SVGElement("text")}}</li>
   <li>{{SVGElement("tref")}}</li>
   <li>{{SVGElement("tspan")}}</li>

--- a/files/en-us/web/svg/attribute/y/index.html
+++ b/files/en-us/web/svg/attribute/y/index.html
@@ -13,6 +13,7 @@ tags:
 
 <ul>
   <li>{{SVGElement("altGlyph")}}</li>
+  <li>{{SVGElement("cursor")}}</li>
   <li>{{SVGElement("feBlend")}}</li>
   <li>{{SVGElement("feColorMatrix")}}</li>
   <li>{{SVGElement("feComponentTransfer")}}</li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None

> What was wrong/why is this fix needed? (quick summary only)

The documentation for [symbol](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol) and [cursor](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/cursor) SVG elements correctly says that these elements allow `x` and `y` attributes. However, the section "You can use this attribute with the following SVG elements" for these attributes misses these elements.

The PR adds `cursor` and `symbol` elements into the list of supported elements in the documentation for `x` and `y` attributes.

> Anything else that could help us review it
