### PR TITLE
Fix a link to ArrayBuffer reference

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
@@ -33,8 +33,7 @@ WebAssembly.Module.customSections(module, sectionName)
 
 ### Return value
 
-A (possibly empty) array containing [`ArrayBuffer`](/en-US/docs/Web/API/ArrayBuffer "The documentation about this has not yet been written; please consider contributing!")
-copies of the contents of all custom sections matching `sectionName`.
+A (possibly empty) array containing {{jsxref("ArrayBuffer")}} copies of the contents of all custom sections matching `sectionName`.
 
 ### Exceptions
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There is a link for the ArrayBuffer reference in the Web API Reference, but it is actually in the JavaScript's global objects.
I have fixed it using {{jsxref}} macro.