### PR TITLE
Enable years after 9999 in input type="date" pattern example

### DIFF
--- a/files/en-us/web/html/element/input/date/index.html
+++ b/files/en-us/web/html/element/input/date/index.html
@@ -254,7 +254,7 @@ input:valid+span::after {
 
 <pre class="brush: html">&lt;form&gt;
   &lt;label&gt;Enter your birthday:
-    &lt;input type="date" name="bday" required pattern="\d{4}-\d{2}-\d{2}"&gt;
+    &lt;input type="date" name="bday" required pattern="\d{4,}-\d{2}-\d{2}"&gt;
     &lt;span class="validity"&gt;&lt;/span&gt;
   &lt;/label&gt;
   &lt;p&gt;


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The example given in the `input type="date"` article for patterns will stop working after the year 9999. From now on, any valid year can be used.
By changing this value, this pattern can simply be copy pasted in many use cases. 
