### PR TITLE
Fix punctuation markdown

### DIFF
--- a/files/en-us/web/api/xrpose/index.md
+++ b/files/en-us/web/api/xrpose/index.md
@@ -40,7 +40,7 @@ The pose for a viewer (or camera) is represented by the {{domxref("XRViewerPose"
 viewerPose = xrFrame.getViewerPose(adjReferenceSpace);
 ```
 
-Here, `adjReferenceSpace` is a reference space which has been updated using the base frame of reference for the frame and any adjustments needed to position the viewer based on movement or rotation which is being supplied from a source other than the XR device, such as keyboard or mouse inputs**.**
+Here, `adjReferenceSpace` is a reference space which has been updated using the base frame of reference for the frame and any adjustments needed to position the viewer based on movement or rotation which is being supplied from a source other than the XR device, such as keyboard or mouse inputs.
 
 See the article [Movement, orientation, and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion) for further details and an example with thorough explanations of what's going on.
 

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -64,7 +64,7 @@ data transfer, but also marking all [cookies with
 the `secure` attribute](/en-US/docs/Web/HTTP/Cookies) and providing automatic redirects from HTTP
 pages to their HTTPS counterparts. Sites may also use the
 {{HTTPHeader("Strict-Transport-Security")}} HTTP header to ensure that browsers connect
-to them only over an encrypted channel**.**
+to them only over an encrypted channel.
 
 ## Using CSP
 

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -55,7 +55,7 @@ Comments are used to add hints, notes, suggestions, or warnings to JavaScript co
 
 JavaScript has two long-standing ways to add comments to code.
 
-The first way is the `//` comment**;** this makes all text following it on the same line into a comment. For example:
+The first way is the `//` comment; this makes all text following it on the same line into a comment. For example:
 
 ```js
 function comment() {

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -145,7 +145,7 @@ In strict mode, this would have raised an exception.
 
 When in strict mode, if `delete` is used on a direct reference to a
 variable, a function argument or a function name, it will throw a
-{{jsxref("SyntaxError")}}**.** Therefore, to avoid syntax errors in
+{{jsxref("SyntaxError")}}. Therefore, to avoid syntax errors in
 strict mode, you must use the `delete` operator in the form of
 `delete object.property` or `delete object['property']`.
 


### PR DESCRIPTION
Minor fix: removes broken and unnecessary bold on single punctuation marks.

Example: `**.**` (formerly `<strong>.</strong>`) shows as \*\*.\*\*, not as **.**