### PR TITLE
Add Web Share API to GroupData.json [ADVICE FIRST BEFORE MERGE!]

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1975,6 +1975,17 @@
         "RTCSessionDescriptionCallback"
       ]
     },
+    "Web Share API": {
+      "overview": ["Web Share API"],
+      "guides": [],
+      "interfaces": [],
+      "methods": [
+        "Navigator.canShare()",
+        "Navigator.share()"
+      ],
+      "properties": [],
+      "events": []
+    },
     "Websockets API": {
       "overview": ["Websockets API"],
       "guides": [


### PR DESCRIPTION
For #8381 I created a "Web Share API" doc. This API includes `navigator.canShare()` and `navigator.share()` methods.

This PR updates the groupdata to add a new sidebar menu for "Web Share API" with those two methods. I had expected to add this new API to both the methods.

Before I do ... (or merge this) ...  the two methods currently link to "{{APIRef("HTML DOM")}}". Is it the "right thing" to do to create this sidebar and apply it to those methods, or can I somehow have both sidebars?