### PR TITLE
Remove dead links and anchors in headings for Plugins/Guide

### DIFF
--- a/files/en-us/plugins/guide/index.html
+++ b/files/en-us/plugins/guide/index.html
@@ -235,7 +235,7 @@ tags:
  <li><a href="/en-US/docs/Plugins/Guide/Constants#version_feature_constants">Version Feature Constants</a></li>
 </ul>
 
-<h3 id="Original_document_information">Original document information</h3>
+<h2 id="Original_document_information">Original document information</h2>
 
 <ul>
  <li>Copyright Information: Netscape Communication</li>

--- a/files/en-us/plugins/guide/index.html
+++ b/files/en-us/plugins/guide/index.html
@@ -7,346 +7,236 @@ tags:
   - NeedsContent
   - Plugins
 ---
-<h2 id="Npapi-pagePlug-in_Basics"><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics">Plug-in Basics</a></h2>
+<h2 id="Npapi-pagePlug-in_Basics">Plug-in Basics</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Plug-in_Basics">Plug-in Basics</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Plug-ins_Are_Used">How Plug-ins Are Used</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#how_plug-ins_are_used">How Plug-ins Are Used</a>
 
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Plug-ins_and_Helper_Applications">Plug-ins and Helper Applications</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#plug-ins_and_helper_applications">Plug-ins and Helper Applications</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Plug-ins_Work">How Plug-ins Work</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Understanding_the_Runtime_Model">Understanding the Runtime Model</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Plug-in_Detection">Plug-in Detection</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#how_plug-ins_work">How Plug-ins Work</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#understanding_the_runtime_model">Understanding the Runtime Model</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#plug-in_detection">Plug-in Detection</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Gecko_Finds_Plug-ins">How Gecko Finds Plug-ins</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Checking_Plug-ins_by_MIME_Type">Checking Plug-ins by MIME Type</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#how_gecko_finds_plug-ins">How Gecko Finds Plug-ins</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#checking_plug-ins_by_mime_type">Checking Plug-ins by MIME Type</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Overview_of_Plug-in_Structure">Overview of Plug-in Structure</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#overview_of_plug-in_structure">Overview of Plug-in Structure</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Understanding_the_Plug-in_API">Understanding the Plug-in API</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Plug-ins_and_Platform_Independence">Plug-ins and Platform Independence</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#understanding_the_plug-in_api">Understanding the Plug-in API</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#plug-ins_and_platform_independence">Plug-ins and Platform Independence</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Windowed_and_Windowless_Plug-ins">Windowed and Windowless Plug-ins</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#The_Default_Plug-in">The Default Plug-in</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Using_HTML_to_Display_Plug-ins">Using HTML to Display Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#windowed_and_windowless_plug-ins">Windowed and Windowless Plug-ins</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#the_default_plug-in">The Default Plug-in</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#using_html_to_display_plug-ins">Using HTML to Display Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Plug-in_Display_Modes">Plug-in Display Modes</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Using_the_object_Element_for_Plug-in_Display">Using the object Element for Plug-in Display</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Nesting_Rules_for_HTML_Elements">Nesting Rules for HTML Elements</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Using_the_Appropriate_Attributes">Using the Appropriate Attributes</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Using_the_embed_Element_for_Plug-in_Display">Using the embed Element for Plug-in Display</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Using_Custom_embed_Attributes">Using Custom embed Attributes</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#plug-in_display_modes">Plug-in Display Modes</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#using_the_object_element_for_plug-in_display">Using the object Element for Plug-in Display</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#nesting_rules_for_html_elements">Nesting Rules for HTML Elements</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#using_the_appropriate_attributes">Using the Appropriate Attributes</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#using_the_embed_element_for_plug-in_display">Using the embed Element for Plug-in Display</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#using_custom_embed_attributes">Using Custom embed Attributes</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Plug-in_References">Plug-in References</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#plug-in_references">Plug-in References</a></li>
 </ul>
 
-<h3 id="Npapi-pagePlug-in_Development_Overview"><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview">Plug-in Development Overview</a></h3>
+<h3 id="Npapi-pagePlug-in_Development_Overview">Plug-in Development Overview</h3>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview">Plug-in Development Overview</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Writing_Plug-ins">Writing Plug-ins</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Registering_Plug-ins">Registering Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#writing_plug-ins">Writing Plug-ins</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#registering_plug-ins">Registering Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#MS_Windows">MS Windows</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Unix">Unix</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Mac_OS_X">Mac OS X</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#ms_windows">MS Windows</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#unix">Unix</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#mac_os_x">Mac OS X</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Drawing_a_Plug-in_Instance">Drawing a Plug-in Instance</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Handling_Memory">Handling Memory</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Sending_and_Receiving_Streams">Sending and Receiving Streams</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Working_with_URLs">Working with URLs</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Getting_Version_and_UI_Information">Getting Version and UI Information</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Displaying_Messages_on_the_Status_Line">Displaying Messages on the Status Line</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Making_Plug-ins_Scriptable">Making Plug-ins Scriptable</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Building_Plug-ins">Building Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#drawing_a_plug-in_instance">Drawing a Plug-in Instance</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#handling_memory">Handling Memory</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#sending_and_receiving_streams">Sending and Receiving Streams</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#working_with_urls">Working with URLs</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#getting_version_and_ui_information">Getting Version and UI Information</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#displaying_messages_on_the_status_line">Displaying Messages on the Status Line</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#making_plug-ins_scriptable">Making Plug-ins Scriptable</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#building_plug-ins">Building Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Building,_Platforms,_and_Compilers">Building, Platforms, and Compilers</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Building_Carbonized_Plug-ins_for_Mac_OS_X">Building Carbonized Plug-ins for Mac OS X</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Type_Libraries">Type Libraries</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#building,_platforms,_and_compilers">Building, Platforms, and Compilers</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#building_carbonized_plug-ins_for_mac_os_x">Building Carbonized Plug-ins for Mac OS X</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#type_libraries">Type Libraries</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Installing_Plug-ins">Installing Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#installing_plug-ins">Installing Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Native_Installers">Native Installers</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#XPI_Plug-ins_Installations">XPI Plug-ins Installations</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#native_installers">Native Installers</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#xpi_plug-ins_installations">XPI Plug-ins Installations</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Development_Overview#Plug-in_Installation_and_the_Windows_Registry">Plug-in Installation and the Windows Registry</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Plug-in_Development_Overview#plug-in_installation_and_the_windows_registry">Plug-in Installation and the Windows Registry</a></li>
 </ul>
 
-<h2 id="Npapi-pageInitialization_and_Destruction"><a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction">Initialization and Destruction</a></h2>
+<h2 id="Npapi-pageInitialization_and_Destruction">Initialization and Destruction</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction">Initialization and Destruction</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction#Initialization">Initialization</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction#Instance_Creation">Instance Creation</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction#Instance_Destruction">Instance Destruction</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction#Shutdown">Shutdown</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction#Initialize_and_Shutdown_Example">Initialize and Shutdown Example</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction#initialization">Initialization</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction#instance_creation">Instance Creation</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction#instance_destruction">Instance Destruction</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction#shutdown">Shutdown</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Initialization_and_Destruction#initialize_and_shutdown_example">Initialize and Shutdown Example</a></li>
 </ul>
 
-<h2 id="Npapi-pageDrawing_and_Event_Handling"><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling">Drawing and Event Handling</a></h2>
+<h2 id="Npapi-pageDrawing_and_Event_Handling">Drawing and Event Handling</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling">Drawing and Event Handling</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#The_NPWindow_Structure">The NPWindow Structure</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Drawing_Plug-ins">Drawing Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#the_npwindow_structure">The NPWindow Structure</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#drawing_plug-ins">Drawing Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Printing_the_Plug-in">Printing the Plug-in</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Setting_the_Window">Setting the Window</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Getting_Information">Getting Information</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#printing_the_plug-in">Printing the Plug-in</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#setting_the_window">Setting the Window</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#getting_information">Getting Information</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Windowed_Plug-ins">Windowed Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#windowed_plug-ins">Windowed Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Mac_OS">Mac OS</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Windows">Windows</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Unix">Unix</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Event_Handling_for_Windowed_Plug-ins">Event Handling for Windowed Plug-ins</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#mac_os">Mac OS</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#windows">Windows</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#unix">Unix</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#event_handling_for_windowed_plug-ins">Event Handling for Windowed Plug-ins</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Windowless_Plug-ins">Windowless Plug-ins</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#windowless_plug-ins">Windowless Plug-ins</a>
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Specifying_That_a_Plug-in_Is_Windowless">Specifying That a Plug-in Is Windowless</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Invalidating_the_Drawing_Area">Invalidating the Drawing Area</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Forcing_a_Paint_Message">Forcing a Paint Message</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Making_a_Plug-in_Opaque">Making a Plug-in Opaque</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Making_a_Plug-in_Transparent">Making a Plug-in Transparent</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Creating_Pop-up_Menus_and_Dialog_Boxes">Creating Pop-up Menus and Dialog Boxes</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Drawing_and_Event_Handling#Event_Handling_for_Windowless_Plug-ins">Event Handling for Windowless Plug-ins</a></li>
-  </ul>
- </li>
-</ul>
-
-<h2 id="Npapi-pageStreams"><a href="/en-US/docs/Plugins/Guide/Streams">Streams</a></h2>
-
-<ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Receiving_a_Stream">Receiving a Stream</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Telling_the_Plug-in_When_a_Stream_Is_Created">Telling the Plug-in When a Stream Is Created</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Telling_the_Plug-in_When_a_Stream_Is_Deleted">Telling the Plug-in When a Stream Is Deleted</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Finding_Out_How_Much_Data_the_Plug-in_Can_Accept">Finding Out How Much Data the Plug-in Can Accept</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Writing_the_Stream_to_the_Plug-in">Writing the Stream to the Plug-in</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Sending_the_Stream_in_Random-Access_Mode">Sending the Stream in Random-Access Mode</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Sending_the_Stream_in_File_Mode">Sending the Stream in File Mode</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Sending_a_Stream">Sending a Stream</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Creating_a_Stream">Creating a Stream</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Pushing_Data_into_the_Stream">Pushing Data into the Stream</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Deleting_the_Stream">Deleting the Stream</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Streams#Example_of_Sending_a_Stream">Example of Sending a Stream</a></li>
-</ul>
-
-<h2 id="Npapi-pageURLs"><a href="/en-US/docs/Plugins/Guide/URLs">URLs</a></h2>
-
-<ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/URLs#Getting_URLs">Getting URLs</a>
-
-  <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/URLs#Getting_the_URL_and_Displaying_the_Page">Getting the URL and Displaying the Page</a></li>
-  </ul>
- </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/URLs#Posting_URLs">Posting URLs</a>
-  <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/URLs#Posting_Data_to_an_HTTP_Server">Posting Data to an HTTP Server</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/URLs#Uploading_Files_to_an_FTP_Server">Uploading Files to an FTP Server</a></li>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/URLs#Sending_Mail">Sending Mail</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#specifying_that_a_plug-in_is_windowless">Specifying That a Plug-in Is Windowless</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#invalidating_the_drawing_area">Invalidating the Drawing Area</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#forcing_a_paint_message">Forcing a Paint Message</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#making_a_plug-in_opaque">Making a Plug-in Opaque</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#making_a_plug-in_transparent">Making a Plug-in Transparent</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#creating_pop-up_menus_and_dialog_boxes">Creating Pop-up Menus and Dialog Boxes</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/Drawing_and_Event_Handling#event_handling_for_windowless_plug-ins">Event Handling for Windowless Plug-ins</a></li>
   </ul>
  </li>
 </ul>
 
-<h2 id="Npapi-pageMemory"><a href="/en-US/docs/Plugins/Guide/Memory">Memory</a></h2>
+<h2 id="Npapi-pageStreams">Streams</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Streams">Streams</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Memory#Allocating_and_freeing_memory">Allocating and freeing memory</a>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#receiving_a_stream">Receiving a Stream</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#telling_the_plug-in_when_a_stream_is_created">Telling the Plug-in When a Stream Is Created</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#telling_the_plug-in_when_a_stream_is_deleted">Telling the Plug-in When a Stream Is Deleted</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#finding_out_how_much_data_the_plug-in_can_accept">Finding Out How Much Data the Plug-in Can Accept</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#writing_the_stream_to_the_plug-in">Writing the Stream to the Plug-in</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#sending_the_stream_in_random-access_mode">Sending the Stream in Random-Access Mode</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#sending_the_stream_in_file_mode">Sending the Stream in File Mode</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#sending_a_stream">Sending a Stream</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#creating_a_stream">Creating a Stream</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#pushing_data_into_the_stream">Pushing Data into the Stream</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#deleting_the_stream">Deleting the Stream</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Streams#example_of_sending_a_stream">Example of Sending a Stream</a></li>
+</ul>
+
+<h2 id="Npapi-pageURLs">URLs</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/URLs">URLs</a></p>
+
+<ul>
+ <li><a href="/en-US/docs/Plugins/Guide/URLs#getting_urls">Getting URLs</a>
 
   <ul>
-   <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Memory#Mac_OS">Mac OS</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/URLs#getting_the_url_and_displaying_the_page">Getting the URL and Displaying the Page</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Memory#Flushing_memory_(Mac_OS_only)">Flushing memory (Mac OS only)</a></li>
-</ul>
-
-<h2 id="Npapi-pageVersion.2C_UI.2C_and_Status_Information"><a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information">Version, UI, and Status Information</a></h2>
-
-<ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Version_UI_and_Status_Information#Displaying_a_Status_Line_Message">Displaying a Status Line Message</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Version_UI_and_Status_Information#Getting_Agent_Information">Getting Agent Information</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Version_UI_and_Status_Information#Getting_the_Current_Version">Getting the Current Version</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Version_UI_and_Status_Information#Finding_Out_if_a_Feature_Exists">Finding Out if a Feature Exists</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Version_UI_and_Status_Information#Reloading_a_Plug-in">Reloading a Plug-in</a></li>
-</ul>
-
-<h2 id="Npapi-pagePlug-in_Side_Plug-in_API"><a href="/en-US/docs/Plugins/Guide/Plug-in_Side_Plug-in_API">Plug-in Side Plug-in API</a></h2>
-
-<p>This chapter describes methods in the plug-in API that are available from the plug-in object. The names of all of these methods begin with <code>NPP_</code> to indicate that they are implemented by the plug-in and called by the browser. For an overview of how these two sides of the plug-in API interact, see the <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Plug-ins_Work">How Plug-ins Work</a> and <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Overview_of_Plug-in_Structure">Overview of Plug-in Structure</a> sections in the introduction.</p>
-
-<ul>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_Destroy">NPP_Destroy</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_DestroyStream">NPP_DestroyStream</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_GetValue">NPP_GetValue</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_GetValue">NP_GetValue</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_HandleEvent">NPP_HandleEvent</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_Initialize">NP_Initialize</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_New">NPP_New</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_NewStream">NPP_NewStream</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_Print">NPP_Print</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_SetValue">NPP_SetValue</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_SetWindow">NPP_SetWindow</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_Shutdown">NP_Shutdown</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_StreamAsFile">NPP_StreamAsFile</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_URLNotify">NPP_URLNotify</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_Write">NPP_Write</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_WriteReady">NPP_WriteReady</a></code></li>
-</ul>
-
-<h2 id="Npapi-pageBrowser_Side_Plug-in_API"><a href="/en-US/docs/Plugins/Guide/Browser_Side_Plug-in_API">Browser Side Plug-in API</a></h2>
-
-
-<p>This chapter describes methods in the plug-in API that are available from the browser. The names of all of these methods begin with <code>NPN_</code> to indicate that they are implemented by the browser and called by the plug-in. For an overview of how these two sides of the plug-in API interact, see the <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Plug-ins_Work">How Plug-ins Work</a> and <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Overview_of_Plug-in_Structure">Overview of Plug-in Structure</a> sections in the introduction.</p>
-
-<div class="warning"><strong>Warning:</strong> You must only call these from the main thread; calling them from other threads is not supported and may have unpredictable results.</div>
-
-<dl>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_DestroyStream">NPN_DestroyStream</a></code></dt>
- <dd>Closes and deletes a stream.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_ForceRedraw">NPN_ForceRedraw</a></code></dt>
- <dd>Forces a paint message for a windowless plug-in.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetAuthenticationInfo">NPN_GetAuthenticationInfo</a></code></dt>
- <dd>This function is called by plug-ins to get HTTP authentication information from the browser.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetURL">NPN_GetURL</a></code></dt>
- <dd>Asks the browser to create a stream for the specified URL.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetURLNotify">NPN_GetURLNotify</a></code></dt>
- <dd>Requests creation of a new stream with the contents of the specified URL; gets notification of the result.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetValue">NPN_GetValue</a></code></dt>
- <dd>Allows the plug-in to query the browser for information.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetValueForURL">NPN_GetValueForURL</a></code></dt>
- <dd>Provides information to a plug-in which is associated with a given URL, for example the cookies or preferred proxy.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_InvalidateRect">NPN_InvalidateRect</a></code></dt>
- <dd>Invalidates specified drawing area prior to repainting or refreshing a windowless plug-in.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_InvalidateRegion">NPN_InvalidateRegion</a></code></dt>
- <dd>Invalidates specified drawing region prior to repainting or refreshing a windowless plug-in.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_MemAlloc">NPN_MemAlloc</a></code></dt>
- <dd>Allocates memory from the browser's memory space.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_MemFlush">NPN_MemFlush</a></code></dt>
- <dd>Requests that the browser free a specified amount of memory.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_MemFree">NPN_MemFree</a></code></dt>
- <dd>Deallocates a block of allocated memory.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_NewStream">NPN_NewStream</a></code></dt>
- <dd>Requests the creation of a new data stream produced by the plug-in and consumed by the browser.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_PluginThreadAsyncCall">NPN_PluginThreadAsyncCall</a></code></dt>
- <dd>Thread-safe way to request that the browser calls a plug-in function on the browser or plug-in thread (the thread on which the plug-in was initiated).</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_PopPopupsEnabledState">NPN_PopPopupsEnabledState</a></code></dt>
- <dd>Pops the popups-enabled state.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_PostURL">NPN_PostURL</a></code></dt>
- <dd>Posts data to a URL.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_PostURLNotify">NPN_PostURLNotify</a></code></dt>
- <dd>Posts data to a URL, and receives notification of the result.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_PushPopupsEnabledState">NPN_PushPopupsEnabledState</a></code></dt>
- <dd>Pushes the popups-enabled state.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_ReloadPlugins">NPN_ReloadPlugins</a></code></dt>
- <dd>Reloads all plug-ins in the Plugins directory.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_RequestRead">NPN_RequestRead</a></code></dt>
- <dd>Requests a range of bytes for a seekable stream.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_SetValue">NPN_SetValue</a></code></dt>
- <dd>Sets windowless plug-in as transparent or opaque.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_SetValueForURL">NPN_SetValueForURL</a></code></dt>
- <dd>Allows a plug-in to change the stored information associated with a URL, in particular its cookies.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_Status">NPN_Status</a></code></dt>
- <dd>Displays a message on the status line of the browser window.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_UserAgent">NPN_UserAgent</a></code></dt>
- <dd>Returns the browser's user agent field.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_Version">NPN_Version</a></code></dt>
- <dd>Returns version information for the Plug-in API.</dd>
- <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_Write">NPN_Write</a></code></dt>
- <dd>Pushes data into a stream produced by the plug-in and consumed by the browser.</dd>
-</dl>
-
-
-<h2 id="Npapi-pageScripting_plugins"><a href="/en-US/docs/Plugins/Guide/Scripting_plugins">Scripting plugins</a></h2>
-
-<ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#How_the_DOM_handles_scripting">How the DOM handles scripting</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#Threading_model">Threading model</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#Security_model">Security model</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#What's_in_the_plugin_code?">What's in the plugin code?</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#Accessing_browser_objects_from_a_plugin">Accessing browser objects from a plugin</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#How_to_call_plugin_native_methods">How to call plugin native methods</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins#The_API_extensions">The API extensions</a>
+ <li><a href="/en-US/docs/Plugins/Guide/URLs#posting_urls">Posting URLs</a>
   <ul>
-   <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPString">NPString</a></code></li>
-   <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPVariant">NPVariant</a></code>
-    <ul>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_ReleaseVariantValue">NPN_ReleaseVariantValue</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetStringIdentifier">NPN_GetStringIdentifier</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetStringIdentifiers">NPN_GetStringIdentifiers</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetIntIdentifier">NPN_GetIntIdentifier</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_IdentifierIsString">NPN_IdentifierIsString</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_UTF8FromIdentifier">NPN_UTF8FromIdentifier</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_IntFromIdentifier">NPN_IntFromIdentifier</a></code></li>
-    </ul>
-   </li>
-   <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPObject">NPObject</a></code>
-    <ul>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_CreateObject">NPN_CreateObject</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_RetainObject">NPN_RetainObject</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_ReleaseObject">NPN_ReleaseObject</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_Invoke">NPN_Invoke</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_InvokeDefault">NPN_InvokeDefault</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_Evaluate">NPN_Evaluate</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetProperty">NPN_GetProperty</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_SetProperty">NPN_SetProperty</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_RemoveProperty">NPN_RemoveProperty</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_HasProperty">NPN_HasProperty</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_HasMethod">NPN_HasMethod</a></code></li>
-     <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_SetException">NPN_SetException</a></code></li>
-    </ul>
-   </li>
-   <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPClass">NPClass</a></code></li>
+   <li><a href="/en-US/docs/Plugins/Guide/URLs#posting_data_to_an_http_server">Posting Data to an HTTP Server</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/URLs#uploading_files_to_an_ftp_server">Uploading Files to an FTP Server</a></li>
+   <li><a href="/en-US/docs/Plugins/Guide/URLs#sending_mail">Sending Mail</a></li>
   </ul>
  </li>
 </ul>
 
-<h2 id="Npapi-pageStructures"><a href="/en-US/docs/Plugins/Guide/Structures">Structures</a></h2>
+<h2 id="Npapi-pageMemory">Memory</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Memory">Memory</a></p>
 
 <ul>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPAnyCallbackStruct">NPAnyCallbackStruct</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPByteRange">NPByteRange</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPEmbedPrint">NPEmbedPrint</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPEvent">NPEvent</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPFullPrint">NPFullPrint</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP">NPP</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_Port">NP_Port</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPPrint">NPPrint</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPPrintCallbackStruct">NPPrintCallbackStruct</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPRect">NPRect</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPRegion">NPRegion</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPSavedData">NPSavedData</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPSetWindowCallbackStruct">NPSetWindowCallbackStruct</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPStream">NPStream</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPWindow">NPWindow</a></code></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Memory#allocating_and_freeing_memory">Allocating and freeing memory</a>
+
+  <ul>
+   <li><a href="/en-US/docs/Plugins/Guide/Memory#mac_os">Mac OS</a></li>
+  </ul>
+ </li>
+ <li><a href="/en-US/docs/Plugins/Guide/Memory#flushing_memory_(mac_os_only)">Flushing memory (Mac OS only)</a></li>
 </ul>
 
-<h2 id="Npapi-pageConstants"><a href="/en-US/docs/Plugins/Guide/Constants">Constants</a></h2>
+<h2 id="Npapi-pageVersion.2C_UI.2C_and_Status_Information">Version, UI, and Status Information</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information">Version, UI, and Status Information</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Constants#Error_Codes">Error Codes</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Constants#Result_Codes">Result Codes</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Constants#Plug-in_Version_Constants">Plug-in Version Constants</a></li>
- <li><a href="/en-US/docs/Gecko_Plugin_API_Reference/Constants#Version_Feature_Constants">Version Feature Constants</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information#displaying_a_status_line_message">Displaying a Status Line Message</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information#getting_agent_information">Getting Agent Information</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information#getting_the_current_version">Getting the Current Version</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information#finding_out_if_a_feature_exists">Finding Out if a Feature Exists</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Version_UI_and_Status_Information#reloading_a_plug-in">Reloading a Plug-in</a></li>
 </ul>
 
-<h2 id="External_resources">External resources</h2>
+<h2 id="Npapi-pagePlug-in_Side_Plug-in_API">Plug-in Side Plug-in API</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Plug-in_Side_Plug-in_API">Plug-in Side Plug-in API</a></p>
+
+<p>This chapter describes methods in the plug-in API that are available from the plug-in object. The names of all of these methods begin with <code>NPP_</code> to indicate that they are implemented by the plug-in and called by the browser. For an overview of how these two sides of the plug-in API interact, see the <a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#how_plug-ins_work">How Plug-ins Work</a> and <a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#overview_of_plug-in_structure">Overview of Plug-in Structure</a> sections in the introduction.</p>
+
+<h2 id="Npapi-pageBrowser_Side_Plug-in_API">Browser Side Plug-in API</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Browser_Side_Plug-in_API">Browser Side Plug-in API</a></p>
+
+<p>This chapter describes methods in the plug-in API that are available from the browser. The names of all of these methods begin with <code>NPN_</code> to indicate that they are implemented by the browser and called by the plug-in. For an overview of how these two sides of the plug-in API interact, see the <a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#how_plug-ins_work">How Plug-ins Work</a> and <a href="/en-US/docs/Plugins/Guide/Plug-in_Basics#overview_of_plug-in_structure">Overview of Plug-in Structure</a> sections in the introduction.</p>
+
+<h2 id="Npapi-pageScripting_plugins">Scripting plugins</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Scripting_plugins">Scripting plugins</a></p>
 
 <ul>
- <li><a href="/en-US/docs/Plugins/External_resources_for_plugin_creation">External projects and articles for plugin creation</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#how_the_dom_handles_scripting">How the DOM handles scripting</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#threading_model">Threading model</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#security_model">Security model</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#what's_in_the_plugin_code?">What's in the plugin code?</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#accessing_browser_objects_from_a_plugin">Accessing browser objects from a plugin</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#how_to_call_plugin_native_methods">How to call plugin native methods</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Scripting_plugins#the_api_extensions">The API extensions</a></li>
 </ul>
 
-<div class="originaldocinfo">
+<h2 id="Npapi-pageStructures">Structures</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Structures">Structures</a></p>
+
+<h2 id="Npapi-pageConstants">Constants</h2>
+
+<p>Main page: <a href="/en-US/docs/Plugins/Guide/Constants">Constants</a></p>
+
+<ul>
+ <li><a href="/en-US/docs/Plugins/Guide/Constants#error_codes">Error Codes</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Constants#result_codes">Result Codes</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Constants#plug-in_version_constants">Plug-in Version Constants</a></li>
+ <li><a href="/en-US/docs/Plugins/Guide/Constants#version_feature_constants">Version Feature Constants</a></li>
+</ul>
+
 <h3 id="Original_document_information">Original document information</h3>
 
 <ul>
  <li>Copyright Information: Netscape Communication</li>
 </ul>
-</div>


### PR DESCRIPTION
There were dozens of dead links on this page (linking to the deleted Plugins reference).

I also fixed all fragments, and moved links out of headings.

Overall this fixes 198 flaws; that is almost 2% of all flaws on MDN.

One day, we will be able to just delete the whole plugin guide!