### PR TITLE
Remove deprecated macro in HTMLTextAreaElement

### DIFF
--- a/files/en-us/web/api/htmltextareaelement/index.html
+++ b/files/en-us/web/api/htmltextareaelement/index.html
@@ -126,7 +126,7 @@ browser-compat: api.HTMLTextAreaElement
    </td>
   </tr>
   <tr>
-   <td><code>wrap</code> {{gecko_minversion_inline("2.0")}}</td>
+   <td><code>wrap</code></td>
    <td><code><em>string</em>:</code> Returns / Sets the {{htmlattrxref("wrap", "textarea")}} HTML attribute, indicating how the control wraps text.</td>
   </tr>
   <tr>


### PR DESCRIPTION
This macro, deprecated, was displaying… nothing.

The info it is conveying is correctly described in the bcd table.

So time to remove it.