### PR TITLE
Add spec and browser compat tables to XMLHttpRequest()

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.html
@@ -2,21 +2,19 @@
 title: XMLHttpRequest()
 slug: Web/API/XMLHttpRequest/XMLHttpRequest
 tags:
-- API
-- Constructor
-- Creating an XMLHttpRequest
-- Fetching Data
-- Loading Data
-- NeedsBrowserCompatibility
-- NeedsExample
-- NeedsSpecTable
-- Reading Data
-- Reference
-- Server Access
-- XHR
-- XMLHttpRequest
+ - API
+ - Constructor
+ - Creating an XMLHttpRequest
+ - Fetching Data
+ - Loading Data
+ - Reading Data
+ - Reference
+ - Server Access
+ - XHR
+ - XMLHttpRequest
+browser-compat: api.XMLHttpRequest.XMLHttpRequest
 ---
-<div>{{draft}}{{APIRef('XMLHttpRequest')}}</div>
+<div>{{APIRef('XMLHttpRequest')}}</div>
 
 <p>The <code><strong>XMLHttpRequest()</strong></code> constructor
     creates a new {{domxref("XMLHttpRequest")}}.</p>
@@ -55,7 +53,7 @@ tags:
 <h3 id="Parameters_(non-standard)">Parameters (non-standard)</h3>
 
 <dl>
-  <dt><code>objParameters</code> {{gecko_minversion_inline("16.0")}}</dt>
+  <dt><code>objParameters</code></dt>
   <dd>There are two flags you can set:
     <dl>
       <dt><code>mozAnon</code></dt>
@@ -76,6 +74,14 @@ tags:
     </dl>
   </dd>
 </dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specification}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.html
@@ -77,7 +77,7 @@ browser-compat: api.XMLHttpRequest.XMLHttpRequest
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specification}}
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
The browser and compat tables where missing; also remove `{{draft}}`, fixed the tags, and a deprecated macro that was useless