### PR TITLE
Swap two paragraphs in Parameters in Detail section

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -107,11 +107,11 @@ value will be the value at the time `callbackFn` visits them.
 Elements that are deleted after the call to `map` begins and before being
 visited are not visited.
 
+**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+
 Due to the algorithm defined in the specification, if the array which `map`
 was called upon is sparse, resulting array will also be sparse keeping same indices
 blank.
-
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 ## Polyfill
 


### PR DESCRIPTION
`Warning` message says "...in the previous paragraph", but previous paragraph tells that the `map()`method keeps sparsity of the original array. Guess it meant the one before instead

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
No issue as far as I'm aware of

> What was wrong/why is this fix needed? (quick summary only)

Warning message feels completely out of context
![image](https://user-images.githubusercontent.com/11510394/131322548-d4615370-0e6f-4068-bc79-e39289957208.png)

> Anything else that could help us review it
link to the article where this issues was found https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
