### PR TITLE
Fix bugzilla reference for Error cause in 91 relnotes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -42,7 +42,7 @@ tags:
   <li>{{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}} and {{jsxref("Intl/DateTimeFormat/formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}} are now supported in release builds. The <code>formatRange()</code> method returns a localized and formatted string for the range between two {{jsxref("Date")}} objects (e.g. "1/05/21 – 1/10/21"). The <code>formatRangeToParts()</code> method returns an array containing the locale-specific <em>parts</em> of a formatted date range ({{bug(1653024)}}).</li>
   <li>The {{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat() constructor")}} allows four new <code>timeZoneName</code> options for formatting how the timezone is displayed. These include the localized GMT formats <code>shortOffset</code> and <code>longOffset</code>, and the generic non-location formats <code>shortGeneric</code> and <code>longGeneric</code> ({{bug(1653024)}}).</li>
   <li>The {{jsxref("Global_Objects/Error/Error", "Error() constructor")}} can now take the error <code>cause</code> as value in the <code>option</code> parameter.
-    This allows code to catch errors and throw new/modifed versions that retain the original error and stack trace ({{bug(1653024)}}).</li>
+    This allows code to catch errors and throw new/modifed versions that retain the original error and stack trace ({{bug(1679653)}}).</li>
  </ul>
 
 


### PR DESCRIPTION
Bugzilla link should have been https://bugzilla.mozilla.org/show_bug.cgi?id=1679653

Fixes a small copy-paste mistake from #7505 that describes the feature from #6714.