### PR TITLE
SVG <by>: add missed </li>

### DIFF
--- a/files/en-us/web/svg/attribute/by/index.html
+++ b/files/en-us/web/svg/attribute/by/index.html
@@ -15,7 +15,7 @@ browser-compat: svg.elements.animate.by
 <p>You can use this attribute with the following SVG elements:</p>
 
 <ul>
-  <li>{{SVGElement("animate")}}
+  <li>{{SVGElement("animate")}}</li>
   <li>{{SVGElement("animateColor")}}</li>
   <li>{{SVGElement("animateMotion")}}</li>
   <li>{{SVGElement("animateTransform")}}</li>

--- a/files/en-us/web/svg/attribute/preserveaspectratio/index.html
+++ b/files/en-us/web/svg/attribute/preserveaspectratio/index.html
@@ -252,7 +252,7 @@ rect:hover, rect:active {
   <li>{{SVGElement("feImage")}}</li>
   <li>{{SVGElement("marker")}}</li>
   <li>{{SVGElement("pattern")}}</li>
-  <li>{{SVGElement("view")}}.</li>
+  <li>{{SVGElement("view")}}</li>
 </ul>
 
 <h3 id="feImage">feImage</h3>

--- a/files/en-us/web/svg/attribute/viewbox/index.html
+++ b/files/en-us/web/svg/attribute/viewbox/index.html
@@ -16,9 +16,9 @@ tags:
 <ul>
   <li>{{SVGElement("marker")}}</li>
   <li>{{SVGElement("pattern")}}</li>
-  <li>{{ SVGElement("svg") }}</li>
-  <li>{{ SVGElement("symbol") }}</li>
-  <li>{{ SVGElement("view") }}.</li>
+  <li>{{SVGElement("svg")}}</li>
+  <li>{{SVGElement("symbol")}}</li>
+  <li>{{SVGElement("view")}}</li>
 </ul>
 
 <div id="topExample">


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None

> What was wrong/why is this fix needed? (quick summary only)

There is `</li>` missed in the docs for `<by>`. Also, I've dropped `.` from 2 lists for consistency with other SVG attributes docs.

> Anything else that could help us review it
