### PR TITLE
Fix link for "image" element

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
@@ -34,7 +34,7 @@ browser-compat: api.CanvasRenderingContext2D.createPattern
     of the following:
     <ul>
       <li>{{domxref("HTMLImageElement")}} ({{HTMLElement("img")}})</li>
-      <li>{{domxref("SVGImageElement")}} ({{HTMLElement("image")}})</li>
+      <li>{{domxref("SVGImageElement")}} ({{SVGElement("image")}})</li>
       <li>{{domxref("HTMLVideoElement")}} ({{HTMLElement("video")}}, by using the capture
         of the video)</li>
       <li>{{domxref("HTMLCanvasElement")}} ({{HTMLElement("canvas")}})</li>


### PR DESCRIPTION
Fixes #8465

CanvasRenderingContext2D.createParameter's image parameter that refers to the SVGImageElement links to the HTML image element rather than the expected SVG image element documentation.
