### PR TITLE
Added note to rust wasm example about MIME type

### DIFF
--- a/files/en-us/webassembly/rust_to_wasm/index.html
+++ b/files/en-us/webassembly/rust_to_wasm/index.html
@@ -217,7 +217,7 @@ wasm-bindgen = "0.2"</pre>
 <p>Serve the root directory of the project with a local web server, (e.g. <code>python3 -m http.server</code>). If you're not sure how to do that, refer to <a href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server#running_a_simple_local_http_server">Running a simple local HTTP server</a>.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Make sure to use an up to date web server that supports the <code>application/wasm</code> MIME type, older web servers might not support it yet.</p>
+<p><strong>Note:</strong> Make sure to use an up to date web server that supports the <code>application/wasm</code> MIME type. Older web servers might not support it yet.</p>
 </div>
 
 <p>Load <code>index.html</code> from the web server (if you used the python3 example: <a href="http://localhost:8000">http://localhost:8000</a>). An alert box appears on the screen, with <code>Hello, WebAssembly!</code> in it. We've successfully called from JavaScript into Rust, and from Rust into JavaScript.</p>

--- a/files/en-us/webassembly/rust_to_wasm/index.html
+++ b/files/en-us/webassembly/rust_to_wasm/index.html
@@ -216,6 +216,10 @@ wasm-bindgen = "0.2"</pre>
 
 <p>Serve the root directory of the project with a local web server, (e.g. <code>python3 -m http.server</code>). If you're not sure how to do that, refer to <a href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server#running_a_simple_local_http_server">Running a simple local HTTP server</a>.</p>
 
+<div class="notecard note">
+<p><strong>Note</strong>: Make sure to use an up to date web server that supports the <code>application/wasm</code> MIME type, older web servers might not support it yet.</p>
+</div>
+
 <p>Load <code>index.html</code> from the web server (if you used the python3 example: <a href="http://localhost:8000">http://localhost:8000</a>). An alert box appears on the screen, with <code>Hello, WebAssembly!</code> in it. We've successfully called from JavaScript into Rust, and from Rust into JavaScript.</p>
 
 <h2 id="Making_our_package_available_to_npm">Making our package available to npm</h2>


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Fixes #7076


> What was wrong/why is this fix needed? (quick summary only)
As mentioned in issue #7076 older web versions of web servers tend not to support the `application/wasm` MIME type, but the correct MIME types are required for `instantiateStreaming` to work as noted in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming


> Anything else that could help us review it
