### PR TITLE
There is no identity operator in ECMAScript

### DIFF
--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -141,9 +141,9 @@ The result of evaluating an equality operator is always of type `Boolean` based 
 - {{JSxRef("Operators/Inequality", "!=")}}
   - : Inequality operator.
 - {{JSxRef("Operators/Strict_equality", "===")}}
-  - : Identity operator.
+  - : Strict equality operator.
 - {{JSxRef("Operators/Strict_inequality", "!==")}}
-  - : Nonidentity operator.
+  - : Strict inequality operator.
 
 ### Bitwise shift operators
 


### PR DESCRIPTION
https://262.ecma-international.org/11.0/#sec-equality-operators
https://262.ecma-international.org/11.0/#sec-strict-equality-comparison

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

Since there is no identity operator, rename to Strict equality and Strict inequality operator to avoid confusion for developers coming from other languages where there might be an identity operator.

> Anything else that could help us review it
