### PR TITLE
Javascript uses interpreter for hoisting

### DIFF
--- a/files/en-us/glossary/hoisting/index.html
+++ b/files/en-us/glossary/hoisting/index.html
@@ -6,9 +6,9 @@ tags:
   - Glossary
   - JavaScript
 ---
-<p>JavaScript <strong>Hoisting</strong> refers to the process whereby the compiler allocates memory for variable and function declarations prior to execution of the code. Declarations that are made using <code>var</code> are initialized with a default value of <code>undefined</code>. Declarations made using <code>let</code> and <code>const</code> are not initialized as part of hoisting.</p>
+<p>JavaScript <strong>Hoisting</strong> refers to the process whereby the interpreter allocates memory for variable and function declarations prior to execution of the code. Declarations that are made using <code>var</code> are initialized with a default value of <code>undefined</code>. Declarations made using <code>let</code> and <code>const</code> are not initialized as part of hoisting.</p>
 
-<p>Conceptually hoisting is often presented as the compiler "splitting variable declaration and initialization, and moving (just) the declarations to the top of the code".
+<p>Conceptually hoisting is often presented as the interpreter "splitting variable declaration and initialization, and moving (just) the declarations to the top of the code".
   This allows variables to appear in code before they are defined.
   Note however, that any variable initialization in the original code will not happen until the line of code is executed.</p>
 


### PR DESCRIPTION
Fixes #8472

Although modern browsers use a JIT compilation, which compiles JavaScript to executable bytecode just as it is about to run, I believe the hoisting stuff is done via interpreter first pass. It certainly predates more modern Javascript.