### PR TITLE
Fix consecutive <dd> elements in Web/API

### DIFF
--- a/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.html
+++ b/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.html
@@ -37,17 +37,17 @@ browser-compat: api.AuthenticatorAttestationResponse.attestationObject
 
 <dl>
   <dt><code>authData</code></dt>
-  <dd>The same as {{domxref("AuthenticatorAssertionResponse.authenticatorData")}}. Note
+  <dd><p>The same as {{domxref("AuthenticatorAssertionResponse.authenticatorData")}}. Note
     that in {{domxref("AuthenticatorAssertionResponse")}}, the
     <code>authenticatorData</code> is exposed as a property in a JavaScript object while
     in {{domxref("AuthenticatorAttestationResponse")}}, the <code>authenticatorData</code>
-    is a property in a <a href="https://datatracker.ietf.org/doc/html/rfc7049">CBOR</a> map.</dd>
-  <dd>The same {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} field is
+    is a property in a <a href="https://datatracker.ietf.org/doc/html/rfc7049">CBOR</a> map.</p>
+  <p>The same {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} field is
     used by both <code>AuthenticatorAttestationResponse</code> and by
     <code>AuthenticatorAssertionResponse</code>. When used in attestation, it contains an
     optional field, <code>attestedCredentialData</code>. This field is not included when
     used in the <code>AuthenticatorAssertionResponse</code>. The attestedCredentialData
-    field contains the <code>credentialId</code> and <code>credentialPublicKey</code>.
+    field contains the <code>credentialId</code> and <code>credentialPublicKey</code>.</p>
   </dd>
   <dt><code>fmt</code></dt>
   <dd>A text string that indicates the format of the attStmt. The <a

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
@@ -29,17 +29,17 @@ browser-compat: api.BaseAudioContext.createScriptProcessor
 
 <dl>
   <dt><code>bufferSize</code></dt>
-  <dd>The buffer size in units of sample-frames. If specified, the bufferSize must be one
+  <dd><p>The buffer size in units of sample-frames. If specified, the bufferSize must be one
     of the following values: 256, 512, 1024, 2048, 4096, 8192, 16384. If it's not passed
     in, or if the value is 0, then the implementation will choose the best buffer size for
     the given environment, which will be a constant power of 2 throughout the lifetime of
-    the node.</dd>
-  <dd>This value controls how frequently the <code>audioprocess</code> event is dispatched
+    the node.</p>
+  <p>This value controls how frequently the <code>audioprocess</code> event is dispatched
     and how many sample-frames need to be processed each call. Lower values for
     <code>bufferSize</code> will result in a lower (better) latency. Higher values will be
     necessary to avoid audio breakup and glitches. It is recommended for authors to not
     specify this buffer size and allow the implementation to pick a good buffer size to
-    balance between latency and audio quality.</dd>
+    balance between latency and audio quality.</p></dd>
   <dt><code>numberOfInputChannels</code></dt>
   <dd>Integer specifying the number of channels for this node's input, defaults to 2.
     Values of up to 32 are supported.</dd>

--- a/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
@@ -31,126 +31,104 @@ browser-compat: api.BiquadFilterNode.BiquadFilterNode
   <dt><em>context</em></dt>
   <dd>A reference to an {{domxref("AudioContext")}}.</dd>
   <dt><em>options</em> {{optional_inline}}</dt>
-  <dd>Options are as follows:
-    <ul>
-      <li><code>type</code>: One of "<code>lowpass</code>", "<code>highpass</code>",
-        "<code>bandpass</code>", "<code>lowshelf</code>", "<code>highshelf</code>",
-        "<code>peaking</code>", "<code>notch</code>", "<code>allpass</code>". The meaning
-        of the other options depends on the value of this one. The defaults for all are as
-        follows:
-        <ul>
-          <li><code>Q</code>: <code>1</code></li>
-          <li><code>detune</code>: <code>0</code></li>
-          <li><code>frequency</code>: <code>350</code></li>
-          <li><code>gain</code>: <code>0</code></li>
-        </ul>
-      </li>
-    </ul>
-
-    <p><code>lowpass</code>: (Default) Allows frequencies below a cutoff frequency to pass
-      through, and attenuates frequencies above the cutoff. This is a standard
-      second-order resonant lowpass filter with 12dB/octave rolloff.</p>
-
-    <ul>
-      <li><code>Q</code>: Controls how peaked the response will be at the cutoff
-        frequency. A large value makes the response more peaked. Please note that for this
-        filter type, this value is not a traditional Q, but is a resonance value in
-        decibels.</li>
-      <li><code>frequency</code>: The cutoff frequency.</li>
-      <li><code>gain</code>: Not used.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>highpass</code>: A highpass filter is the opposite of a lowpass filter.
-      Frequencies above the cutoff frequency are passed through, but frequencies below the
-      cutoff are attenuated. It implements a standard second-order resonant highpass
-      filter with 12dB/octave rolloff.</p>
-
-    <ul>
-      <li><code>Q</code>: Controls how peaked the response will be at the cutoff
-        frequency. A large value makes the response more peaked. Please note that for this
-        filter type, this value is not a traditional Q, but is a resonance value in
-        decibels.</li>
-      <li><code>frequency</code>: The cutoff frequency.</li>
-      <li><code>gain</code>: Not used.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>bandpass</code>: A bandpass filter allows a range of frequencies to pass
-      through and attenuates the frequencies below and above this frequency range. It
-      implements a second-order bandpass filter.</p>
-
-    <ul>
-      <li><code>Q</code>: Controls the width of the band. The width becomes narrower as
-        the Q value increases.</li>
-      <li><code>frequency</code>: The center of the frequency band.</li>
-      <li><code>gain</code>: Not used.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>lowshelf</code>: The lowshelf filter allows all frequencies through, but adds
-      a boost (or attenuation) to the lower frequencies. It implements a second-order
-      lowshelf filter.</p>
-
-    <ul>
-      <li><code>Q</code>: Not used.</li>
-      <li><code>frequency</code>: The upper limit of the frequencies where the boost, or
-        attenuation, is applied.</li>
-      <li><code>gain</code>: The boost, in dB, to be applied. If the value is negative,
-        the frequencies are attenuated.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>highshelf</code>: The highshelf filter is the opposite of the lowshelf filter
-      and allows all frequencies through, but adds a boost to the higher frequencies. It
-      implements a second-order highshelf filter.</p>
-
-    <ul>
-      <li><code>Q</code>: Not used.</li>
-      <li><code>frequency</code>: The lower limit of the frequencies where the boost, or
-        attenuation, is applied.</li>
-      <li><code>gain</code>: The boost, in dB, to be applied. If the value is negative,
-        the frequencies are attenuated.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>peaking</code>: The peaking filter allows all frequencies through, adding a
-      boost, or attenuation, to a range of frequencies.</p>
-
-    <ul>
-      <li><code>Q</code>: The width of the band of frequencies that are boosted. A large
-        value implies a narrow width.</li>
-      <li><code>frequency</code>: The center frequency of the boost range.</li>
-      <li><code>gain</code>: The boost, in dB, to be applied. If the value is negative,
-        the frequencies are attenuated.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>notch</code>: The notch filter (also known as a band-stop, or band-rejection
-      filter) is the opposite of a bandpass filter. It allows all frequencies through,
-      except for a set of frequencies.</p>
-
-    <ul>
-      <li><code>Q</code>: The width of the band of frequencies that are attenuated. A
-        large value implies a narrow width.</li>
-      <li><code>frequency</code>: The center frequency of the attenuation range.</li>
-      <li><code>gain</code>: Not used.</li>
-    </ul>
-  </dd>
-  <dd>
-    <p><code>allpass</code>: An allpass filter allows all frequencies through, but changes
-      the phase relationship between the various frequencies. It implements a second-order
-      allpass filter.</p>
-
-    <ul>
-      <li><code>Q</code>: The sharpness of the phase transition at the center frequency. A
-        larger value implies a sharper transition and a larger group delay.</li>
-      <li><code>frequency</code>: The frequency where the center of the phase transition
-        occurs. Viewed another way, this is the frequency with maximal group delay.</li>
-      <li><code>gain</code>: Not used.</li>
-    </ul>
+  <dd><p>An object with the following properties:</p>
+    <dl>
+      <dt><code>type</code></dt>
+      <dd><p>One of the following strings. The meaning
+        of the other options depends on the value of <code>type</code>.</p>
+        <dl>
+          <dt><code>lowpass</code></dt>
+          <dd>
+            <p>The default. Allows frequencies below a cutoff frequency to pass through, and attenuates frequencies above the cutoff. This is a standard second-order resonant lowpass filter with 12dB/octave rolloff. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: controls how peaked the response will be at the cutoff frequency. A large value makes the response more peaked. Please note that for this filter type, this value is not a traditional Q, but is a resonance value in decibels.</li>
+              <li><code>frequency</code>: the cutoff frequency.</li>
+              <li><code>gain</code>: not used.</li>
+            </ul>
+          </dd>
+          <dt><code>highpass</code></dt>
+          <dd>
+            <p>A highpass filter is the opposite of a lowpass filter.
+            Frequencies above the cutoff frequency are passed through, but frequencies below the cutoff are attenuated. It implements a standard second-order resonant highpass filter with 12dB/octave rolloff. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: controls how peaked the response will be at the cutoff frequency. A large value makes the response more peaked. Please note that for this filter type, this value is not a traditional Q, but is a resonance value in decibels.</li>
+              <li><code>frequency</code>: the cutoff frequency.</li>
+              <li><code>gain</code>: not used.</li>
+            </ul>
+          </dd>
+          <dt><code>bandpass</code></dt>
+          <dd>
+            <p>A bandpass filter allows a range of frequencies to pass
+            through and attenuates the frequencies below and above this frequency range. It implements a second-order bandpass filter. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: controls the width of the band. The width becomes narrower as the Q value increases.</li>
+              <li><code>frequency</code>: the center of the frequency band.</li>
+              <li><code>gain</code>: not used.</li>
+            </ul>
+          </dd>
+          <dt><code>lowshelf</code></dt>
+          <dd>
+            <p>The lowshelf filter allows all frequencies through, but adds
+            a boost (or attenuation) to the lower frequencies. It implements a second-order lowshelf filter. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: not used.</li>
+              <li><code>frequency</code>: the upper limit of the frequencies where the boost, or attenuation, is applied.</li>
+              <li><code>gain</code>: the boost, in dB, to be applied. If the value is negative, the frequencies are attenuated.</li>
+            </ul>
+          </dd>
+          <dt><code>highshelf</code></dt>
+          <dd>
+            <p>The highshelf filter is the opposite of the lowshelf filter
+            and allows all frequencies through, but adds a boost to the higher frequencies. It implements a second-order highshelf filter. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: not used.</li>
+              <li><code>frequency</code>: the lower limit of the frequencies where the boost, or attenuation, is applied.</li>
+              <li><code>gain</code>: the boost, in dB, to be applied. If the value is negative, the frequencies are attenuated.</li>
+            </ul>
+          </dd>
+          <dt><code>peaking</code></dt>
+          <dd>
+            <p>The peaking filter allows all frequencies through, adding a
+            boost, or attenuation, to a range of frequencies. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: the width of the band of frequencies that are boosted. A large value implies a narrow width.</li>
+              <li><code>frequency</code>: the center frequency of the boost range.</li>
+              <li><code>gain</code>: the boost, in dB, to be applied. If the value is negative, the frequencies are attenuated.</li>
+            </ul>
+          </dd>
+          <dt><code>notch</code></dt>
+          <dd>
+            <p>The notch filter (also known as a band-stop, or band-rejection filter) is the opposite of a bandpass filter. It allows all frequencies through, except for a set of frequencies. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: the width of the band of frequencies that are attenuated. A large value implies a narrow width.</li>
+              <li><code>frequency</code>: the center frequency of the attenuation range.</li>
+              <li><code>gain</code>: not used.</li>
+            </ul>
+          </dd>
+          <dt><code>allpass</code></dt>
+          <dd>
+            <p>An allpass filter allows all frequencies through, but changes
+          the phase relationship between the various frequencies. It implements a second-order allpass filter. With this type of filter, the meaning of the other options are as follows:</p>
+            <ul>
+              <li><code>Q</code>: the sharpness of the phase transition at the center frequency. A larger value implies a sharper transition and a larger group delay.</li>
+              <li><code>frequency</code>: the frequency where the center of the phase transition occurs. Viewed another way, this is the frequency with maximal group delay.</li>
+              <li><code>gain</code>: not used.</li>
+            </ul>
+          </dd>
+        </dl>
+      </dd>
+      <dt><code>Q</code></dt>
+      <dd>Defaults to 1. The meaning of this option depends on the value of <code>type</code>.</dd>
+      <dt><code>detune</code></dt>
+      <dd>Defaults to 0.</dd>
+      <dt><code>frequency</code></dt>
+      <dd>Defaults to 350.</dd>
+      <dt><code>gain</code></dt>
+      <dd>Defaults to 0. The meaning of this option depends on the value of <code>type</code>.</dd>
+    </dl>
   </dd>
 </dl>
+
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/api/contentindex/add/index.html
+++ b/files/en-us/web/api/contentindex/add/index.html
@@ -71,12 +71,15 @@ browser-compat: api.ContentIndex.add
 
 <dl>
   <dt><code>TypeError</code></dt>
-  <dd>If the service worker's registration is not present or the service worker does not
-    contain a {{domxref('FetchEvent')}}.</dd>
-  <dd>If the <code>id</code>, <code>title</code>, <code>description</code> or
-    <code>url</code> are missing, not of type {{jsxref('String')}}, or an empty
-    {{jsxref('String')}}.</dd>
-  <dd>If <code>icons</code> images are not of image type.</dd>
+  <dd><p>This exception is thrown in the following conditions:</p>
+    <ul>
+      <li>The service worker's registration is not present or the service worker does not
+      contain a {{domxref('FetchEvent')}}.</li>
+      <li>The <code>id</code>, <code>title</code>, <code>description</code> or
+      <code>url</code> are missing, not of type {{jsxref('String')}}, or an empty {{jsxref('String')}}.</li>
+      <li>The items referenced by <code>icons</code> are not of image type.</li>
+    </ul>
+  </dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/css/index.html
+++ b/files/en-us/web/api/css/index.html
@@ -40,8 +40,7 @@ browser-compat: api.CSS
  <dt>{{DOMxRef("CSS.escape()")}}</dt>
  <dd>Can be used to escape a string mostly for use as part of a CSS selector.</dd>
  <dt>{{DOMxRef("CSS.factory_functions", 'CSS factory functions')}}</dt>
- <dd>Can be used to return a new <code><a href="/en-US/docs/Web/API/CSSUnitValue">CSSUnitValue</a></code> with a value of the parameter number of the units of the name of the factory function method used.</dd>
- <dd>
+ <dd><p>Can be used to return a new <code><a href="/en-US/docs/Web/API/CSSUnitValue">CSSUnitValue</a></code> with a value of the parameter number of the units of the name of the factory function method used.</p>
  <pre class="brush: js">CSS.em(3) // CSSUnitValue {value: 3, unit: "em"}</pre>
  </dd>
 </dl>

--- a/files/en-us/web/api/cssstyledeclaration/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/index.html
@@ -50,7 +50,6 @@ browser-compat: api.CSSStyleDeclaration
  <dd>Returns the property value given a property name.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.item()")}}</dt>
  <dd>Returns a CSS property name by its index, or the empty string if the index is out-of-bounds.</dd>
- <dd>An alternative to accessing <code>nodeList[<var>i</var>]</code> (which instead returns <code>undefined</code> when <code><var>i</var></code> is out-of-bounds). This is mostly useful for non-JavaScript DOM implementations.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.removeProperty()")}}</dt>
  <dd>Removes a property from the CSS declaration block.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.setProperty()")}}</dt>

--- a/files/en-us/web/api/datatransfer/setdragimage/index.html
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.html
@@ -36,11 +36,11 @@ browser-compat: api.DataTransfer.setDragImage
 
 <dl>
   <dt><em>img |</em> element</dt>
-  <dd>An image {{domxref("Element")}} element to use for the drag feedback image.</dd>
-  <dd>If {{domxref("Element")}} is an img element, then set the drag data store bitmap to
+  <dd><p>An image {{domxref("Element")}} element to use for the drag feedback image.</p>
+  <p>If {{domxref("Element")}} is an img element, then set the drag data store bitmap to
     the element's image (at its intrinsic size); otherwise, set the drag data store bitmap
     to an image generated from the given element (the exact mechanism for doing so is not
-    currently specified).</dd>
+    currently specified).</p></dd>
   <dt><em>xOffset</em></dt>
   <dd>A <code>long</code> indicating the horizontal offset within the image.</dd>
   <dt><em>yOffset</em></dt>

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
@@ -26,8 +26,8 @@ browser-compat: api.DedicatedWorkerGlobalScope.postMessage
  <dt><em>aMessage</em></dt>
  <dd>The object to deliver to the main thread; this will be in the data field in the event delivered to the {{domxref("Worker.onmessage")}} handler. This may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</dd>
  <dt><em>transferList</em> {{optional_inline}}</dt>
- <dd>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.</dd>
- <dd>Only {{domxref("MessagePort")}} and {{jsxref("ArrayBuffer")}} objects can be transferred.</dd>
+ <dd><p>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.</p>
+ <p>Only {{domxref("MessagePort")}} and {{jsxref("ArrayBuffer")}} objects can be transferred.</p></dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>

--- a/files/en-us/web/api/document/createelementns/index.html
+++ b/files/en-us/web/api/document/createelementns/index.html
@@ -35,7 +35,7 @@ browser-compat: api.Document.createElementNS
     {{DOMxRef("element.nodeName", "nodeName")}} property of the created element is
     initialized with the value of <var>qualifiedName</var>.</dd>
   <dt><var>options</var>{{Optional_Inline}}</dt>
-  <dd>An optional <code>ElementCreationOptions</code> object containing a single property
+  <dd><p>An optional <code>ElementCreationOptions</code> object containing a single property
     named <code>is</code>, whose value is the tag name for a custom element previously
     defined using <code>customElements.define()</code>. For backwards compatibility with
     previous versions of the <a class="external external-icon"
@@ -43,10 +43,10 @@ browser-compat: api.Document.createElementNS
     some browsers will allow you to pass a string here instead of an object, where the
     string's value is the custom element's tag name. See <a class="external external-icon"
       href="https://developers.google.com/web/fundamentals/primers/customelements/#extendhtml">Extending
-      native HTML elements</a> for more information on how to use this parameter.</dd>
-  <dd>The new element will be given an <code>is</code> attribute whose value is the custom
+      native HTML elements</a> for more information on how to use this parameter.</p>
+  <p>The new element will be given an <code>is</code> attribute whose value is the custom
     element's tag name. Custom elements are an experimental feature only available in some
-    browsers.</dd>
+    browsers.</p></dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -214,11 +214,11 @@ browser-compat: api.Document.execCommand
   <dd>Removes the <a href="/en-US/docs/Web/HTML/Element/a">anchor element</a> from a
     selected hyperlink.</dd>
   <dt><code>useCSS</code> {{Deprecated_inline}}</dt>
-  <dd>Toggles the use of HTML tags or CSS for the generated markup. Requires a boolean
-    true/false as a value argument.</dd>
-  <dd>NOTE: This argument is logically backwards (i.e. use <code>false</code> to use CSS,
+  <dd><p>Toggles the use of HTML tags or CSS for the generated markup. Requires a boolean
+    true/false as a value argument.</p>
+  <div class="notecard note"><p><strong>Note:</strong> This argument is logically backwards (i.e. use <code>false</code> to use CSS,
     <code>true</code> to use HTML) and unsupported by Internet Explorer. This has been
-    deprecated in favor of <code>styleWithCSS</code>.</dd>
+    deprecated in favor of <code>styleWithCSS</code>.</p></div></dd>
   <dt><code>styleWithCSS</code></dt>
   <dd>Replaces the <code>useCSS</code> command. <code>true</code> modifies/generates
     <code>style</code> attributes in markup, false generates presentational elements.<br></dd>

--- a/files/en-us/web/api/element/animate/index.html
+++ b/files/en-us/web/api/element/animate/index.html
@@ -39,10 +39,9 @@ browser-compat: api.Element.animate
         Formats </a>for more details.</p>
   </dd>
   <dt><code>options</code></dt>
-  <dd>Either an <strong>integer representing the animation's duration</strong> (in
+  <dd><p>Either an <strong>integer representing the animation's duration</strong> (in
     milliseconds), <strong>or</strong> an Object containing one or more timing
-    properties: </dd>
-  <dd>
+    properties:</p>
     <dl>
       <dt><code>id {{optional_inline}}</code></dt>
       <dd>A property unique to <code>animate()</code>: a <a

--- a/files/en-us/web/api/element/getanimations/index.html
+++ b/files/en-us/web/api/element/getanimations/index.html
@@ -42,8 +42,8 @@ browser-compat: api.Element.getAnimations
 
 <dl>
   <dt><code>options {{optional_inline}}</code></dt>
-  <dd>An options object containing the following property:</dd>
   <dd>
+    <p>An options object containing the following property:</p>
     <dl>
       <dt><code>subtree</code></dt>
       <dd>A boolean value which, if <code>true</code>, causes animations that target

--- a/files/en-us/web/api/element/scrollintoview/index.html
+++ b/files/en-us/web/api/element/scrollintoview/index.html
@@ -44,8 +44,8 @@ browser-compat: api.Element.scrollIntoView
   </dd>
   <dt><code><var>scrollIntoViewOptions</var></code> {{optional_inline}}
     {{experimental_inline}}</dt>
-  <dd>Is an Object with the following properties:</dd>
   <dd>
+    <p>Is an Object with the following properties:</p>
     <dl>
       <dt><code>behavior</code> {{optional_inline}}</dt>
       <dd>Defines the transition animation.<br>

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -83,7 +83,7 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
     </dl>
   </dd>
   <dt><code><var>useCapture</var></code> {{optional_inline}}</dt>
-  <dd>A boolean value indicating whether events of this type will be dispatched to
+  <dd><p>A boolean value indicating whether events of this type will be dispatched to
     the registered <code><var>listener</var></code> <em>before</em> being dispatched to
     any <code>EventTarget</code> beneath it in the DOM tree. Events that are bubbling
     upward through the tree will not trigger a listener designated to use capture. Event
@@ -94,8 +94,7 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
       Level 3 Events</a> and <a
       href="https://www.quirksmode.org/js/events_order.html#link4">JavaScript Event
       order</a> for a detailed explanation. If not specified,
-    <code><var>useCapture</var></code> defaults to <code>false</code>.</dd>
-  <dd>
+    <code><var>useCapture</var></code> defaults to <code>false</code>.</p>
     <div class="notecard note">
       <p><strong>Note:</strong> For event listeners attached to the event target, the event is in the target phase,
         rather than the capturing and bubbling phases.

--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.html
@@ -57,12 +57,12 @@ browser-compat: api.EventTarget.removeEventListener
     </ul>
   </dd>
   <dt><code>useCapture</code> {{optional_inline}}</dt>
-  <dd>Specifies whether the {{domxref("EventListener")}} to be removed is registered as a
+  <dd><p>Specifies whether the {{domxref("EventListener")}} to be removed is registered as a
     capturing listener or not. If this parameter is absent, a default value of
-    <code>false</code> is assumed.</dd>
-  <dd>If a listener is registered twice, one with capture and one without, you must remove
+    <code>false</code> is assumed.</p>
+  <p>If a listener is registered twice, one with capture and one without, you must remove
     each one separately. Removal of a capturing listener does not affect a non-capturing
-    version of the same listener, and vice versa.</dd>
+    version of the same listener, and vice versa.</p></dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/history/pushstate/index.html
+++ b/files/en-us/web/api/history/pushstate/index.html
@@ -30,19 +30,21 @@ browser-compat: api.History.pushState
 
 <dl>
   <dt><code>state</code></dt>
-  <dd>The <code>state</code> object is a JavaScript object which is associated with the
+  <dd>
+    <p>The <code>state</code> object is a JavaScript object which is associated with the
     new history entry created by <code>pushState()</code>. Whenever the user navigates to
     the new <code>state</code>, a {{event("popstate")}} event is fired, and
     the <code>state</code> property of the event contains a copy of the history entry's
-    <code>state</code> object.</dd>
-  <dd>The <code>state</code> object can be anything that can be serialized. Because
+    <code>state</code> object.</p>
+    <p>The <code>state</code> object can be anything that can be serialized. Because
     Firefox saves <code>state</code> objects to the user's disk so they can be restored
     after the user restarts the browser, we impose a size limit of 2 MiB on the
     serialized representation of a <code>state</code> object. If you pass a
     <code>state</code> object whose serialized representation is larger than this
     to <code>pushState()</code>, the method will throw an exception. If you need more
     space than this, you're encouraged to use {{domxref("Window.sessionStorage",
-    "sessionStorage")}} and/or {{domxref("Window.localStorage", "localStorage")}}.</dd>
+    "sessionStorage")}} and/or {{domxref("Window.localStorage", "localStorage")}}.</p>
+  </dd>
   <dt><code>title</code></dt>
   <dd><a href="https://github.com/whatwg/html/issues/2174">Most browsers currently ignore
       this parameter</a>, although they may use it in the future. Passing the empty string

--- a/files/en-us/web/api/htmlcollection/index.html
+++ b/files/en-us/web/api/htmlcollection/index.html
@@ -29,11 +29,15 @@ browser-compat: api.HTMLCollection
 
 <dl>
  <dt>{{domxref("HTMLCollection.item()")}}</dt>
- <dd>Returns the specific node at the given zero-based <code>index</code> into the list. Returns <code>null</code> if the <code>index</code> is out of range.</dd>
- <dd>An alternative to accessing <code>collection[<var>i</var>]</code> (which instead returns  <code>undefined</code> when <code><var>i</var></code> is out-of-bounds). This is mostly useful for non-JavaScript DOM implementations.</dd>
+ <dd>
+   <p>Returns the specific node at the given zero-based <code>index</code> into the list. Returns <code>null</code> if the <code>index</code> is out of range.</p>
+   <p>An alternative to accessing <code>collection[<var>i</var>]</code> (which instead returns  <code>undefined</code> when <code><var>i</var></code> is out-of-bounds). This is mostly useful for non-JavaScript DOM implementations.</p>
+ </dd>
  <dt>{{domxref("HTMLCollection.namedItem()")}}</dt>
- <dd>Returns the specific node whose ID or, as a fallback, name matches the string specified by <code>name</code>. Matching by name is only done as a last resort, only in HTML, and only if the referenced element supports the <code>name</code> attribute. Returns <code>null</code> if no node exists by the given name.</dd>
- <dd>An alternative to accessing <code>collection[<var>name</var>]</code> (which instead returns <code>undefined</code> when <code><var>name</var></code> does not exist). This is mostly useful for non-JavaScript DOM implementations.</dd>
+ <dd>
+   <p>Returns the specific node whose ID or, as a fallback, name matches the string specified by <code>name</code>. Matching by name is only done as a last resort, only in HTML, and only if the referenced element supports the <code>name</code> attribute. Returns <code>null</code> if no node exists by the given name.</p>
+   <p>An alternative to accessing <code>collection[<var>name</var>]</code> (which instead returns <code>undefined</code> when <code><var>name</var></code> does not exist). This is mostly useful for non-JavaScript DOM implementations.</p>
+ </dd>
 </dl>
 
 <h2 id="Usage_in_JavaScript">Usage in JavaScript</h2>

--- a/files/en-us/web/api/htmlelement/focus/index.html
+++ b/files/en-us/web/api/htmlelement/focus/index.html
@@ -27,9 +27,9 @@ browser-compat: api.HTMLElement.focus
 
 <dl>
 	<dt><code>options</code> {{optional_inline}}</dt>
-	<dd>An optional object providing options to control aspects of the focusing process.
-		This object may contain the following property:</dd>
 	<dd>
+    <p>An optional object providing options to control aspects of the focusing process.
+		This object may contain the following property:</p>
 		<dl>
 			<dt><code>preventScroll</code> {{optional_inline}}</dt>
 			<dd>A Boolean value indicating whether or not the browser should scroll the

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.html
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.html
@@ -91,12 +91,13 @@ browser-compat: api.HTMLInputElement.stepDown
 
 <dl>
   <dt><em><code>stepDecrement</code></em></dt>
-  <dd>The optional  <code><em>stepDecrement</em></code> parameter is a numeric value.  If
-    no parameter is passed, <em>stepDecrement</em> defaults to 1.</dd>
-  <dd>If the value is a float, the value will increment as if
+  <dd>
+    <p>The optional  <code><em>stepDecrement</em></code> parameter is a numeric value.  If no parameter is passed, <em>stepDecrement</em> defaults to 1.</p>
+    <p>If the value is a float, the value will increment as if
     <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor">Math.floor(stepDecrement)</a></code>
     was passed. If the value is negative, the value will be incremented instead of
-    decremented.</dd>
+    decremented.</p>
+  </dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/htmloutputelement/index.html
+++ b/files/en-us/web/api/htmloutputelement/index.html
@@ -49,8 +49,10 @@ browser-compat: api.HTMLOutputElement
  <dt>{{domxref("HTMLOutputElement.checkValidity()")}}</dt>
  <dd>Checks the validity of the element and returns a boolean value holding the check result.</dd>
  <dt>{{domxref("HTMLOutputElement.reportValidity()")}}</dt>
- <dd>This method reports the problems with the constraints on the element, if any, to the user. If there are problems, fires an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event at the element, and returns <code>false</code>; if there are no problems, it returns <code>true</code>.</dd>
- <dd>When the problem is reported, the user agent may focus the element and change the scrolling position of the document or perform some other action that brings the element to the user's attention. User agents may report more than one constraint violation if this element suffers from multiple problems at once. If the element is not rendered, then the user agent may report the error for the running script instead of notifying the user.</dd>
+ <dd>
+   <p>This method reports the problems with the constraints on the element, if any, to the user. If there are problems, fires an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event at the element, and returns <code>false</code>; if there are no problems, it returns <code>true</code>.</p>
+   <p>When the problem is reported, the user agent may focus the element and change the scrolling position of the document or perform some other action that brings the element to the user's attention. User agents may report more than one constraint violation if this element suffers from multiple problems at once. If the element is not rendered, then the user agent may report the error for the running script instead of notifying the user.</p>
+ </dd>
  <dt>{{domxref("HTMLOutputElement.setCustomValidity()")}}</dt>
  <dd>Sets a custom validity message for the element. If this message is not the empty string, then the element is suffering from a custom validity error, and does not validate.</dd>
 </dl>

--- a/files/en-us/web/api/idbdatabase/transaction/index.html
+++ b/files/en-us/web/api/idbdatabase/transaction/index.html
@@ -34,30 +34,30 @@ browser-compat: api.IDBDatabase.transaction
 
 <dl>
   <dt><code>storeNames</code></dt>
-  <dd>The names of object stores that are in the scope of the new transaction, declared as
+  <dd>
+    <p>The names of object stores that are in the scope of the new transaction, declared as
     an array of strings. Specify only the object stores that you need to access.<br>
     If you need to access only one object store, you can specify its name as a string.
-    Therefore the following lines are equivalent:</dd>
-  <dd>
+    Therefore the following lines are equivalent:</p>
     <pre class="brush: js">var transaction = db.transaction(['my-store-name']);
 var transaction = db.transaction('my-store-name');</pre>
-  </dd>
-  <dd>If you need to access all object stores in the database, you can use the property
-    {{domxref("IDBDatabase.objectStoreNames")}}:
+    <p>If you need to access all object stores in the database, you can use the property
+    {{domxref("IDBDatabase.objectStoreNames")}}:</p>
     <pre
       class="brush: js">var transaction = db.transaction(db.objectStoreNames);</pre>
+    <p>Passing an empty array will throw an exception.</p>
   </dd>
-  <dd>Passing an empty array will throw an exception.</dd>
   <dt><code>mode</code> {{optional_inline}}</dt>
-  <dd>The types of access that can be performed in the transaction. Transactions are
+  <dd>
+    <p>The types of access that can be performed in the transaction. Transactions are
     opened in one of three modes: <code>readonly</code>, <code>readwrite</code> and
     <code>readwriteflush</code> (non-standard, Firefox-only.) <code>versionchange</code>
     mode can't be specified here. If you don't provide the parameter, the default access
     mode is <code>readonly</code>. To avoid slowing things down, don't open a
     <code>readwrite</code> transaction unless you actually need to write into the
-    database.</dd>
-  <dd>If you need to open the object store in <code>readwrite</code> mode to change data,
-    you would use the following:
+    database.</p>
+    <p>If you need to open the object store in <code>readwrite</code> mode to change data,
+    you would use the following:</p>
     <pre
       class="brush:js;">var transaction = db.transaction('my-store-name', "readwrite");</pre>
 

--- a/files/en-us/web/api/keyframeeffectoptions/index.html
+++ b/files/en-us/web/api/keyframeeffectoptions/index.html
@@ -35,7 +35,22 @@ browser-compat: api.KeyframeEffectOptions
  <dd>Determines how values build from iteration to iteration in this animation. Can be set to <code>accumulate</code> or <code>replace</code> (see above). Defaults to <code>replace</code>.</dd>
  <dt><code>pseudoElement</code> {{Experimental_Inline}} {{Optional_Inline}}</dt>
  <dd>The selector of the pseudo-element to be targeted, if any. Defaults to <code>null</code>.</dd>
- <dd>{{Page("/en-US/docs/Web/API/Web_Animations_API/Animation_timing_properties", "Properties")}}</dd>
+ <dt>{{domxref("EffectTiming.delay", "delay")}} {{optional_inline}}</dt>
+ <dd>The number of milliseconds to delay the start of the animation. Defaults to 0.</dd>
+ <dt>{{domxref("EffectTiming.direction", "direction")}} {{optional_inline}}</dt>
+ <dd>Whether the animation runs forwards (<code>normal</code>), backwards (<code>reverse</code>), switches direction after each iteration (<code>alternate</code>), or runs backwards and switches direction after each iteration (<code>alternate-reverse</code>). Defaults to <code>"normal"</code>.</dd>
+ <dt>{{domxref("EffectTiming.duration", "duration")}} {{optional_inline}}</dt>
+ <dd>The number of milliseconds each iteration of the animation takes to complete. Defaults to 0. Although this is technically optional, keep in mind that your animation will not run if this value is 0.</dd>
+ <dt>{{domxref("EffectTiming.easing", "easing")}} {{optional_inline}}</dt>
+ <dd>The rate of the animation's change over time. Accepts the pre-defined values <code>"linear"</code>, <code>"ease"</code>, <code>"ease-in"</code>, <code>"ease-out"</code>, and <code>"ease-in-out"</code>, or a custom <code>"cubic-bezier"</code> value like <code>"cubic-bezier(0.42, 0, 0.58, 1)"</code>. Defaults to <code>"linear"</code>.</dd>
+ <dt>{{domxref("EffectTiming.endDelay", "endDelay")}} {{optional_inline}}</dt>
+ <dd>The number of milliseconds to delay after the end of an animation. This is primarily of use when sequencing animations based on the end time of another animation. Defaults to 0. </dd>
+ <dt>{{domxref("EffectTiming.fill", "fill")}} {{optional_inline}}</dt>
+ <dd>Dictates whether the animation's effects should be reflected by the element(s) prior to playing (<code>"backwards"</code>), retained after the animation has completed playing (<code>"forwards"</code>), or <code>both</code>. Defaults to <code>"none"</code>.</dd>
+ <dt>{{domxref("EffectTiming.iterationStart", "iterationStart")}} {{optional_inline}}</dt>
+ <dd>Describes at what point in the iteration the animation should start. 0.5 would indicate starting halfway through the first iteration for example, and with this value set, an animation with 2 iterations would end halfway through a third iteration. Defaults to 0.0.</dd>
+ <dt>{{domxref("EffectTiming.iterations", "iterations")}} {{optional_inline}}</dt>
+ <dd>The number of times the animation should repeat. Defaults to <code>1</code>, and can also take a value of {{jsxref("Infinity")}} to make it repeat for as long as the element exists.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/mutationobserver/observe/index.html
+++ b/files/en-us/web/api/mutationobserver/observe/index.html
@@ -44,14 +44,15 @@ browser-compat: api.MutationObserver.observe
   <dd>A DOM {{domxref("Node")}} (which may be an {{domxref("Element")}}) within the DOM
     tree to watch for changes, or to be the root of a subtree of nodes to be watched.</dd>
   <dt><code><var>options</var></code></dt>
-  <dd>A {{domxref("MutationObserverInit")}} object providing options that describe which
+  <dd>
+    <p>A {{domxref("MutationObserverInit")}} object providing options that describe which
     DOM mutations should be reported to
     <code><var>mutationObserver</var></code>’s <code><var>callback</var></code>. At a
     minimum, one of <code>childList</code>, <code>attributes</code>, and/or
     <code>characterData</code> must be <code>true</code> when you call
     {{domxref("MutationObserver.observe", "observe()")}}. Otherwise, a
-    <code>TypeError</code> exception will be thrown.</dd>
-  <dd>Options are as follows:
+    <code>TypeError</code> exception will be thrown.</p>
+    <p>Options are as follows:</p>
     <dl>
       <dt>{{domxref("MutationObserverInit.subtree", "subtree")}} {{optional_inline}}</dt>
       <dd>Set to <code>true</code> to extend monitoring to the entire subtree of nodes

--- a/files/en-us/web/api/nodelist/index.html
+++ b/files/en-us/web/api/nodelist/index.html
@@ -52,8 +52,10 @@ console.log(child_nodes.length); // outputs "3"
 
 <dl>
  <dt>{{domxref("NodeList.item()")}}</dt>
- <dd>Returns an item in the list by its index, or <code>null</code> if the index is out-of-bounds.</dd>
- <dd>An alternative to accessing <code>nodeList[<var>i</var>]</code> (which instead returns  <code>undefined</code> when <code><var>i</var></code> is out-of-bounds). This is mostly useful for non-JavaScript DOM implementations.</dd>
+ <dd>
+   <p>Returns an item in the list by its index, or <code>null</code> if the index is out-of-bounds.</p>
+   <p>An alternative to accessing <code>nodeList[<var>i</var>]</code> (which instead returns  <code>undefined</code> when <code><var>i</var></code> is out-of-bounds). This is mostly useful for non-JavaScript DOM implementations.</p>
+ </dd>
  <dt>{{domxref("NodeList.entries()")}}</dt>
  <dd>Returns an {{jsxref("Iteration_protocols","iterator")}}, allowing code to go through all key/value pairs contained in the collection. (In this case, the keys are numbers starting from <code>0</code> and the values are nodes.)</dd>
  <dt>{{domxref("NodeList.forEach()")}}</dt>

--- a/files/en-us/web/api/paymentrequest/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentrequest/index.html
@@ -86,9 +86,9 @@ browser-compat: api.PaymentRequest.PaymentRequest
     </dl>
   </dd>
   <dt><code>options</code> {{optional_inline}}</dt>
-  <dd>Lets you set options that control the behavior of the user agent. This parameter
-    contains the following fields:</dd>
   <dd>
+    <p>Lets you set options that control the behavior of the user agent. This parameter
+    contains the following fields:</p>
     <dl>
       <dt><code>requestPayerName</code></dt>
       <dd>A Boolean indicating whether the user agent should collect the payer's name and

--- a/files/en-us/web/api/performancenavigationtiming/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/index.html
@@ -54,8 +54,10 @@ browser-compat: api.PerformanceNavigationTiming
  <dt>{{domxref('PerformanceNavigationTiming.loadEventStart')}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMHighResTimeStamp")}} representing the time value equal to the time immediately before the load event of the current document is fired.</dd>
  <dt>{{domxref('PerformanceNavigationTiming.redirectCount')}} {{readonlyInline}}</dt>
- <dd>A number representing the number of redirects since the last non-redirect navigation under the current browsing context.</dd>
- <dd>If there was no redirect, or if the redirect was from another origin, and that origin does not permit it's timing information to be exposed to the current origin then the value will be 0.</dd>
+ <dd>
+   <p>A number representing the number of redirects since the last non-redirect navigation under the current browsing context.</p>
+   <p>If there was no redirect, or if the redirect was from another origin, and that origin does not permit it's timing information to be exposed to the current origin then the value will be 0.</p>
+ </dd>
  <dt>{{domxref('PerformanceNavigationTiming.requestStart')}} {{readonlyInline}}</dt>
  <dd>A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the user agent starts requesting the resource from the server, or from relevant application caches or from local resources.</dd>
  <dt>{{domxref('PerformanceNavigationTiming.responseStart')}} {{readonlyInline}}</dt>

--- a/files/en-us/web/api/presentationrequest/reconnect/index.html
+++ b/files/en-us/web/api/presentationrequest/reconnect/index.html
@@ -9,13 +9,17 @@ browser-compat: api.PresentationRequest.reconnect
 ---
 <p>When the <code><dfn>reconnect</dfn>(presentationId)</code> method is called on a <code>PresentationRequest</code> <var>presentationRequest</var>, the <a href="https://www.w3.org/TR/presentation-api/#dfn-user-agents">user agent</a> <em>MUST</em> run the following steps to <dfn>reconnect to a presentation</dfn>:</p>
 
-<dl>
- <dt>Input</dt>
- <dd><var>presentationRequest</var>, the <a href="https://www.w3.org/TR/presentation-api/#idl-def-presentationrequest"><code>PresentationRequest</code></a> object that <code><a href="https://www.w3.org/TR/presentation-api/#dom-presentationrequest-reconnect">reconnect()</a></code> was called on.</dd>
- <dd><var>presentationId</var>, a valid <a href="https://www.w3.org/TR/presentation-api/#dfn-presentation-identifier">presentation identifier</a></dd>
- <dt>Output</dt>
- <dd><var>P</var>, a <a href="https://www.w3.org/TR/presentation-api/#dfn-promise">Promise</a></dd>
-</dl>
+<h2>Input</h2>
+
+<ul>
+ <li><var>presentationRequest</var>, the <a href="https://www.w3.org/TR/presentation-api/#idl-def-presentationrequest"><code>PresentationRequest</code></a> object that <code><a href="https://www.w3.org/TR/presentation-api/#dom-presentationrequest-reconnect">reconnect()</a></code> was called on.</li>
+ <li><var>presentationId</var>, a valid <a href="https://www.w3.org/TR/presentation-api/#dfn-presentation-identifier">presentation identifier</a></li>
+</ul>
+
+<h2>Output</h2>
+ <p><var>P</var>, a <a href="https://www.w3.org/TR/presentation-api/#dfn-promise">Promise</a>.</p>
+
+<h2>Algorithm</h2>
 
 <ol>
  <li>Using the document's <a href="https://www.w3.org/TR/presentation-api/#dfn-settings-object">settings object</a> run the <a href="https://www.w3.org/TR/presentation-api/#dfn-prohibits-mixed-security-contexts-algorithm">prohibits mixed security contexts algorithm</a>.</li>

--- a/files/en-us/web/api/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/index.html
@@ -75,7 +75,6 @@ browser-compat: api.RTCIceCandidate
 	<dt>{{domxref("RTCIceCandidate.toJSON", "toJSON()")}}</dt>
 	<dd>Returns a {{Glossary("JSON")}} representation of the <code>RTCIceCandidate</code>'s current configuration.
 		The format of the representation is the same as the <code>candidateInfo</code> object that can optionally be passed to the {{domxref("RTCIceCandidate.RTCIceCandidate()","RTCIceCandidate() constructor")}} to configure a candidate.</dd>
-	<dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
@@ -60,41 +60,40 @@ browser-compat: api.RTCPeerConnection.createOffer
     keep the same credentials and therefore not restart ICE. <strong>The default is
       <code>false</code></strong>.</dd>
   <dt><code>offerToReceiveAudio</code> {{optional_inline}} (Legacy)</dt>
-  <dd>A legacy Boolean option which used to control whether or not to offer to the remote
+  <dd>
+    <p>A legacy Boolean option which used to control whether or not to offer to the remote
     peer the opportunity to try to send audio. If this value is <code>false</code>, the
     remote peer will not be offered to send audio data, even if the local side will be
     sending audio data. If this value is <code>true</code>, the remote peer will be
     offered to send audio data, even if the local side will <em>not</em> be sending audio
     data. The default behavior is to offer to receive audio only if the local side is
-    sending audio, not otherwise.</dd>
-  <dd>To emulate this behavior in modern implementations, the presence of this member with
+    sending audio, not otherwise.</p>
+    <p>To emulate this behavior in modern implementations, the presence of this member with
     a value <code>false</code>, will set the direction of all existing audio transceivers
     to exclude reception (i.e. set to either <code>"sendonly"</code> or
-    <code>"inactive"</code>).</dd>
-  <dd>In modern implementations, the presence of this member with a value
+    <code>"inactive"</code>).</p>
+    <p>In modern implementations, the presence of this member with a value
     <code>true</code>, will ensure there is at least one transceiver set to receive audio
-    that has not been stopped, and if there isn't one, one will be created.</dd>
-  <dd>
+    that has not been stopped, and if there isn't one, one will be created.</p>
     <div class="note"><p><strong>Note:</strong> You shouldn't use this legacy property.
       Instead, use {{domxref("RTCRtpTransceiver")}} to control whether or not to accept
       incoming audio.</p></div>
   </dd>
   <dt><code>offerToReceiveVideo</code> {{optional_inline}} (Legacy)</dt>
-  <dd>A legacy Boolean option which used to control whether or not to offer to the remote
+  <dd><p>A legacy Boolean option which used to control whether or not to offer to the remote
     peer the opportunity to try to send video. If this value is <code>false</code>, the
     remote peer will not be offered to send video data, even if the local side will be
     sending video data. If this value is <code>true</code>, the remote peer will be
     offered to send video data, even if the local side will <em>not</em> be sending video
     data. The default behavior is to offer to receive video only if the local side is
-    sending video, not otherwise.</dd>
-  <dd>To emulate this behavior in modern implementations, the presence of this member with
+    sending video, not otherwise.</p>
+    <p>To emulate this behavior in modern implementations, the presence of this member with
     a value <code>false</code>, will set the direction of all existing video transceivers
     to exclude reception (i.e. set to either <code>"sendonly"</code> or
-    <code>"inactive"</code>).</dd>
-  <dd>In modern implementations, the presence of this member with a value
+    <code>"inactive"</code>).</p>
+    <p>In modern implementations, the presence of this member with a value
     <code>true</code>, will ensure there is at least one transceiver set to receive video
-    that has not been stopped, and if there isn't one, one will be created.</dd>
-  <dd>
+    that has not been stopped, and if there isn't one, one will be created.</p>
     <div class="note"><p><strong>Note:</strong> You shouldn't use this legacy property.
       Instead, use {{domxref("RTCRtpTransceiver")}} to control whether or not to accept
       incoming video.</p></div>

--- a/files/en-us/web/api/svgangle/index.html
+++ b/files/en-us/web/api/svgangle/index.html
@@ -72,11 +72,14 @@ browser-compat: api.SVGAngle
 <dl>
  <dt><code>newValueSpecifiedUnits</code></dt>
  <dd>
- <p>Reset the value as a number with an associated unitType, thereby replacing the values for all of the attributes on the object.</p>
+   <p>Reset the value as a number with an associated unitType, thereby replacing the values for all of the attributes on the object.</p>
 
- <p><strong>Exceptions:</strong></p>
- A {{domxref("DOMException")}} with code <code>NOT_SUPPORTED_ERR</code> is raised if <code>unitType</code> is <code>SVG_ANGLETYPE_UNKNOWN</code> or not a valid unit type constant (one of the other <code>SVG_ANGLETYPE_*</code> constants defined on this interface).</dd>
- <dd>A {{domxref("DOMException")}} with code <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the length corresponds to a read only attribute or when the object itself is read only.</dd>
+   <p><strong>Exceptions:</strong></p>
+   <ul>
+     <li>A {{domxref("DOMException")}} with code <code>NOT_SUPPORTED_ERR</code> is raised if <code>unitType</code> is <code>SVG_ANGLETYPE_UNKNOWN</code> or not a valid unit type constant (one of the other <code>SVG_ANGLETYPE_*</code> constants defined on this interface).</li>
+     <li>A {{domxref("DOMException")}} with code <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the length corresponds to a read only attribute or when the object itself is read only.</li>
+   </ul>
+ </dd>
  <dt><code>convertToSpecifiedUnits</code></dt>
  <dd>Preserve the same underlying stored value, but reset the stored unit identifier to the given <code><em>unitType</em></code>. Object attributes <code>unitType</code>, <code>valueInSpecifiedUnits</code>, and <code>valueAsString</code> might be modified as a result of this method.</dd>
 </dl>

--- a/files/en-us/web/api/touch/touch/index.html
+++ b/files/en-us/web/api/touch/touch/index.html
@@ -21,22 +21,22 @@ browser-compat: api.Touch.Touch
 
 <dl>
  <dt><em>touchInit</em></dt>
- <dd>Is a <code>TouchInit</code> dictionary, having the following fields:</dd>
  <dd>
- <ul>
-  <li><code>"identifier"</code>, required, of type <code>long</code>, that is the identification number for the touch point.</li>
-  <li><code>"target"</code>, required, of type {{domxref("EventTarget")}}, the item at which the touch point started when it was first placed on the surface.</li>
-  <li><code>"clientX"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the horizontal position of the touch on the client window of user's screen, excluding any scroll offset.</li>
-  <li><code>"clientY"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the vertical position of the touch on the client window of the user's screen, excluding any scroll offset.</li>
-  <li><code>"screenX"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the horizontal position of the touch on the user's screen.</li>
-  <li><code>"screenY"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the vertical position of the touch on the user's screen.</li>
-  <li><code>"pageX"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the horizontal position of the touch on the client window of user's screen, including any scroll offset.</li>
-  <li><code>"pageY"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the vertical position of the touch on the client window of the user's screen, including any scroll offset.</li>
-  <li><code>"radiusX"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the radius of the ellipse which most closely circumscribes the touching area (e.g. finger, stylus) along the axis indicated by rotationAngle, in CSS pixels of the same scale as screenX; <code>0</code> if no value is known. The value must not be negative.</li>
-  <li><code>"radiusY"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the radius of the ellipse which most closely circumscribes the touching area (e.g. finger, stylus) along the axis perpendicular to that indicated by rotationAngle, in CSS pixels  of the same scale as screenY; <code>0</code> if no value is known. The value must not be negative.</li>
-  <li><code>"rotationAngle"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the angle (in degrees) that the ellipse described by radiusX and radiusY is rotated clockwise about its center; <code>0</code> if no value is known. The value must be greater than or equal to <code>0</code> and less than <code>90</code>. If the ellipse described by radiusX and radiusY is circular, then rotationAngle has no effect. The user agent may use <code>0</code> as the value in this case, or it may use any other value in the allowed range. (For example, the user agent may use the rotationAngle value from the previous touch event, to avoid sudden changes.).</li>
-  <li><code>"force"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the relative value of pressure applied, in the range <code>0</code> to <code>1</code>, where <code>0</code> is no pressure, and <code>1</code> is the highest level of pressure the touch device is capable of sensing; <code>0</code> if no value is known. In environments where force is known, the absolute pressure represented by the force attribute, and the sensitivity in levels of pressure, may vary.</li>
- </ul>
+   <p>A <code>TouchInit</code> dictionary, having the following fields:</p>
+   <ul>
+     <li><code>"identifier"</code>, required, of type <code>long</code>, that is the identification number for the touch point.</li>
+     <li><code>"target"</code>, required, of type {{domxref("EventTarget")}}, the item at which the touch point started when it was first placed on the surface.</li>
+     <li><code>"clientX"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the horizontal position of the touch on the client window of user's screen, excluding any scroll offset.</li>
+     <li><code>"clientY"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the vertical position of the touch on the client window of the user's screen, excluding any scroll offset.</li>
+     <li><code>"screenX"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the horizontal position of the touch on the user's screen.</li>
+     <li><code>"screenY"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the vertical position of the touch on the user's screen.</li>
+     <li><code>"pageX"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the horizontal position of the touch on the client window of user's screen, including any scroll offset.</li>
+     <li><code>"pageY"</code>, optional and defaulting to <code>0</code>, of type <code>double</code>, that is the vertical position of the touch on the client window of the user's screen, including any scroll offset.</li>
+     <li><code>"radiusX"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the radius of the ellipse which most closely circumscribes the touching area (e.g. finger, stylus) along the axis indicated by rotationAngle, in CSS pixels of the same scale as screenX; <code>0</code> if no value is known. The value must not be negative.</li>
+     <li><code>"radiusY"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the radius of the ellipse which most closely circumscribes the touching area (e.g. finger, stylus) along the axis perpendicular to that indicated by rotationAngle, in CSS pixels  of the same scale as screenY; <code>0</code> if no value is known. The value must not be negative.</li>
+     <li><code>"rotationAngle"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the angle (in degrees) that the ellipse described by radiusX and radiusY is rotated clockwise about its center; <code>0</code> if no value is known. The value must be greater than or equal to <code>0</code> and less than <code>90</code>. If the ellipse described by radiusX and radiusY is circular, then rotationAngle has no effect. The user agent may use <code>0</code> as the value in this case, or it may use any other value in the allowed range. (For example, the user agent may use the rotationAngle value from the previous touch event, to avoid sudden changes.).</li>
+     <li><code>"force"</code>, optional and defaulting to <code>0</code>, of type <code>float</code>, that is the relative value of pressure applied, in the range <code>0</code> to <code>1</code>, where <code>0</code> is no pressure, and <code>1</code> is the highest level of pressure the touch device is capable of sensing; <code>0</code> if no value is known. In environments where force is known, the absolute pressure represented by the force attribute, and the sensitivity in levels of pressure, may vary.</li>
+   </ul>
  </dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/disable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disable/index.html
@@ -24,9 +24,9 @@ browser-compat: api.WebGLRenderingContext.disable
 
 <dl>
   <dt><code>cap</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which WebGL capability to disable. Possible
-    values:</dd>
   <dd>
+    <p>A {{domxref("GLenum")}} specifying which WebGL capability to disable. Possible
+    values:</p>
     <table class="standard-table">
       <thead>
         <tr>
@@ -82,8 +82,8 @@ browser-compat: api.WebGLRenderingContext.disable
         </tr>
       </tbody>
     </table>
-    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
-    following values are available additionally:
+    <p>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
+    following values are available additionally:</p>
 
     <table class="standard-table">
       <thead>

--- a/files/en-us/web/api/webglrenderingcontext/enable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enable/index.html
@@ -24,9 +24,9 @@ browser-compat: api.WebGLRenderingContext.enable
 
 <dl>
   <dt><code>cap</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which WebGL capability to enable. Possible
-    values:</dd>
   <dd>
+    <p>A {{domxref("GLenum")}} specifying which WebGL capability to enable. Possible
+    values:</p>
     <table class="standard-table">
       <thead>
         <tr>
@@ -82,8 +82,8 @@ browser-compat: api.WebGLRenderingContext.enable
         </tr>
       </tbody>
     </table>
-    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
-    following values are available additionally:
+    <p>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
+    following values are available additionally:</p>
 
     <table class="standard-table">
       <thead>

--- a/files/en-us/web/api/webglrenderingcontext/isenabled/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isenabled/index.html
@@ -27,9 +27,7 @@ browser-compat: api.WebGLRenderingContext.isEnabled
 
 <dl>
   <dt><code>cap</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which WebGL capability to test. Possible values:
-  </dd>
-  <dd>
+  <dd><p>A {{domxref("GLenum")}} specifying which WebGL capability to test. Possible values:</p>
     <table class="standard-table">
       <thead>
         <tr>
@@ -85,8 +83,8 @@ browser-compat: api.WebGLRenderingContext.isEnabled
         </tr>
       </tbody>
     </table>
-    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
-    following values are available additionally:
+    <p>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
+    following values are available additionally:</p>
 
     <table class="standard-table">
       <thead>

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
@@ -62,9 +62,8 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
   <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the color components in the texture.</dd>
-  <dd>Possible values in both WebGL1 and WebGL2</dd>
-  <dt>
+  <dd><p>A {{domxref("GLenum")}} specifying the color components in the texture.</p>
+  <p>Possible values in both WebGL1 and WebGL2</p>
     <table>
       <thead>
         <tr>
@@ -125,10 +124,8 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
         </tr>
       </tbody>
     </table>
-  </dt>
-  <dd>Other possible values in WebGL2 for the versions of <code>texImage2D</code> that
-    take an <code>ArrayBufferView</code> or a <code>GLintptr offset</code></dd>
-</dl>
+  <p>Other possible values in WebGL2 for the versions of <code>texImage2D</code> that
+    take an <code>ArrayBufferView</code> or a <code>GLintptr offset</code></p>
 
 <table>
   <thead>
@@ -754,8 +751,7 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
     </ul>
   </li>
 </ul>
-
-<dl>
+</dd>
   <dt><code>width</code></dt>
   <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>

--- a/files/en-us/web/api/websocket/websocket/index.html
+++ b/files/en-us/web/api/websocket/websocket/index.html
@@ -26,12 +26,14 @@ browser-compat: api.WebSocket.WebSocket
   <dd>The URL to which to connect; this should be the URL to which the WebSocket server
     will respond.</dd>
   <dt><code>protocols</code> {{optional_inline}}</dt>
-  <dd>Either a single protocol string or an array of protocol strings. These strings are
+  <dd>
+    <p>Either a single protocol string or an array of protocol strings. These strings are
     used to indicate sub-protocols, so that a single server can implement multiple
     WebSocket sub-protocols (for example, you might want one server to be able to handle
-    different types of interactions depending on the specified <code>protocol</code>).
+    different types of interactions depending on the specified <code>protocol</code>).</p>
+    <p>If it is omitted, an empty array is used by default, i.e. <code>[]</code>.
+    </p>
   </dd>
-  <dd>If it is omitted, an empty array is used by default, i.e. <code>[]</code>.</dd>
 </dl>
 
 <h3 id="Exceptions_thrown">Exceptions thrown</h3>

--- a/files/en-us/web/api/window/getcomputedstyle/index.html
+++ b/files/en-us/web/api/window/getcomputedstyle/index.html
@@ -41,10 +41,10 @@ window.getComputedStyle(element, pseudoElt);
 
 <dl>
   <dt>{{JSxRef("TypeError")}}</dt>
-  <dd>If the passed object is not an {{DOMxRef("Element")}} or the
-    <code><var>pseudoElt</var></code> is not a valid pseudo-element selector or is
-    {{CSSxRef("::part", "::part()")}} or {{CSSxRef("::slotted", "::slotted()")}}.</dd>
   <dd>
+    <p>If the passed object is not an {{DOMxRef("Element")}} or the
+    <code><var>pseudoElt</var></code> is not a valid pseudo-element selector or is
+    {{CSSxRef("::part", "::part()")}} or {{CSSxRef("::slotted", "::slotted()")}}.</p>
     <div class="notecard note">
       <p><strong>Note:</strong> Valid pseudo-element selector refers to syntactic
         validity, e.g. <code>::unsupported</code> is considered valid, even though the

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -298,21 +298,20 @@ function openRequestedPopup() {
 
 <dl>
   <dt><code>noopener</code></dt>
-  <dd>If this feature is set, the newly-opened window will open as normal, except that it
+  <dd>
+    <p>If this feature is set, the newly-opened window will open as normal, except that it
     will not have access back to the originating window (via {{domxref("Window.opener")}}
     — it returns <code>null</code>). In addition, the <code>window.open()</code> call will
     also return <code>null</code>, so the originating window will not have access to the
     new one either. This is useful for preventing untrusted sites opened via
-    <code>window.open()</code> from tampering with the originating window, and vice versa.
-  </dd>
-  <dd>Note that when <code>noopener</code> is used, nonempty target names other than
+    <code>window.open()</code> from tampering with the originating window, and vice versa.</p>
+    <p>Note that when <code>noopener</code> is used, nonempty target names other than
     <code>_top</code>, <code>_self</code>, and <code>_parent</code> are all treated like
-    <code>_blank</code> in terms of deciding whether to open a new window/tab.<br>
-    <br>
-    This is supported in modern browsers including Chrome, and Firefox 52+. See
+    <code>_blank</code> in terms of deciding whether to open a new window/tab.</p>
+    <p>This is supported in modern browsers including Chrome, and Firefox 52+. See
     <code><a href="/en-US/docs/Web/HTML/Link_types#noopener">rel="noopener"</a></code> for
     more information and for browser compatibility details, including information about
-    ancillary effects.
+    ancillary effects.</p>
   </dd>
   <dt><code>noreferrer</code></dt>
   <dd>If this feature is set, the request to load the content located at the specified URL
@@ -458,12 +457,14 @@ function openRequestedSinglePopup(url) {
 <dl>
   <dt>How can I prevent the confirmation message asking the user whether they want to
     close the window?</dt>
-  <dd>You cannot. <strong>New windows not opened by javascript cannot as a rule be closed
+  <dd>
+    <p>You cannot. <strong>New windows not opened by javascript cannot as a rule be closed
       by JavaScript.</strong> The JavaScript Console in Mozilla-based browsers will report
     the warning message:
     <code>"Scripts may not close windows that were not opened by script."</code> Otherwise
-    the history of URLs visited during the browser session would be lost.</dd>
-  <dd>More on the {{domxref("window.close()")}} method</dd>
+    the history of URLs visited during the browser session would be lost.</p>
+    <p>More on the {{domxref("window.close()")}} method.</p>
+  </dd>
   <dt>How can I bring back the window if it is minimized or behind another window?</dt>
   <dd>First check for the existence of the window object reference of such window and if
     it exists and if it has not been closed, then use the <a
@@ -484,21 +485,23 @@ function openRequestedSinglePopup(url) {
     content and usability of windows. This is in the best interests of both the web author
     and the users.</dd>
   <dt>How do I resize a window to fit its content?</dt>
-  <dd>You cannot reliably because the users can prevent the window from being resized by
+  <dd>
+    <p>You cannot reliably because the users can prevent the window from being resized by
     setting <code>dom.disable_window_move_resize</code> to <code>true</code> in
     <code>about:config</code> or by editing accordingly their <a
-      href="https://www.mozilla.org/support/firefox/edit#user">user.js file</a>.</dd>
-  <dd>In general, users usually disable moving and resizing of existing windows because
+      href="https://www.mozilla.org/support/firefox/edit#user">user.js file</a>.</p>
+    <p>In general, users usually disable moving and resizing of existing windows because
     allowing authors' scripts to do so has been abused overwhelmingly in the past and the
     rare scripts that do not abuse such feature are often wrong, inaccurate when resizing
     the window. 99% of all those scripts disable window resizability and disable
     scrollbars when in fact they should enable both of these features to allow a cautious
-    and sane fallback mechanism if their calculations are wrong.</dd>
-  <dd>The window method <a href="/en-US/docs/Web/API/Window/sizeToContent">sizeToContent()</a>
+    and sane fallback mechanism if their calculations are wrong.</p>
+    <p>The window method <a href="/en-US/docs/Web/API/Window/sizeToContent">sizeToContent()</a>
     can also be disabled. Moving and resizing a window remotely on the user's screen via
     script will very often annoy the users, will disorient the user, and will be wrong at
     best. The web author expects to have full control of (and can decide about) every
-    position and size aspects of the users' browser window ... which is not true.</dd>
+    position and size aspects of the users' browser window ... which is not true.</p>
+  </dd>
   <dt>How do I know whether a window I opened is still open?</dt>
   <dd>You can test for the existence of the window object reference which is the returned
     value in case of success of the window.open() call and then verify that
@@ -516,16 +519,18 @@ function openRequestedSinglePopup(url) {
     the javascript console saying "Error: uncaught
     exception: Permission denied to get property
     &lt;property_name or method_name&gt;. Why is that?</dt>
-  <dd>It is because of the cross-domain script security restriction (also referred as the
+  <dd>
+    <p>It is because of the cross-domain script security restriction (also referred as the
     "Same Origin Policy"). A script loaded in a window (or frame) from a distinct origin
     (domain name) <strong>cannot get nor set</strong> properties of another window (or
     frame) or the properties of any of its HTML objects coming from another distinct
     origin (domain name). Therefore, before executing a script targeting a secondary
     window, the browser in the main window will verify that the secondary window has the
-    same domain name.</dd>
-  <dd>More reading on the cross-domain script security restriction: <a
+    same domain name.</p>
+    <p>More reading on the cross-domain script security restriction: <a
       href="https://www.mozilla.org/projects/security/components/same-origin.html"
-     >http://www.mozilla.org/projects/secu...me-origin.html</a></dd>
+     >http://www.mozilla.org/projects/secu...me-origin.html</a></p>
+   </dd>
 </dl>
 
 <h2 id="Usability_issues">Usability issues</h2>

--- a/files/en-us/web/api/window/open/privileged_features/index.html
+++ b/files/en-us/web/api/window/open/privileged_features/index.html
@@ -15,27 +15,23 @@ slug: Web/API/Window/open/Privileged_features
  <dd>Centers the window in relation to its parent's size and position.</dd>
  <dt><code>minimizable</code></dt>
  <dd>This setting can only apply to dialog windows; <code>minimizable</code> requires <code>dialog=yes</code>. If <code>minimizable</code> is on, the new dialog window will have a minimize system command icon in the titlebar and it will be minimizable. Any non-dialog window is always minimizable and <code>minimizable=no</code> will be ignored.</dd>
- <dt><code>dependent</code></dt>
- <dd>If on, the new window is said to be dependent of its parent window. A dependent window closes when its parent window closes. A dependent window is minimized on the Windows task bar only when its parent window is minimized. On Windows platforms, a dependent window does not show on the task bar. A dependent window also stays in front of the parent window.</dd>
- <dd>Dependent windows are not implemented on MacOS X, this option will be ignored.</dd>
- <dd>The dependent feature is currently under revision to be removed ({{Bug(214867)}})</dd>
- <dd>In MSIE 6, the nearest equivalent to this feature is the <code>showModelessDialog()</code> method.</dd>
  <dt><code>chrome</code></dt>
  <dd>If on, the page is loaded as window's only content, without any of the browser's interface elements. There will be no context menu defined by default and none of the standard keyboard shortcuts will work. The page is supposed to provide a user interface of its own, usually this feature is used to open XUL documents (standard dialogs like the JavaScript Console are opened this way).</dd>
  <dt><code>dialog</code></dt>
  <dd><a href="menusystemcommands.png" title="MenuSystemCommands.png"><img class="internal lwrap" src="menusystemcommands.png"></a> The <code>dialog</code> feature removes all icons (restore, minimize, maximize) from the window's titlebar, leaving only the close button. Mozilla 1.2+ and Netscape 7.1 will render the other menu system commands (in FF 1.0 and in NS 7.0x, the command system menu is not identified with the Firefox/NS 7.0x icon on the left end of the titlebar: that's probably a bug. You can access the command system menu with a right-click on the titlebar). Dialog windows are windows which have no minimize system command icon and no maximize/restore down system command icon on the titlebar nor in correspondent menu item in the command system menu. They are said to be dialog because their normal, usual purpose is to only notify info and to be dismissed, closed. On Mac systems, dialog windows have a different window border and they may get turned into a sheet.</dd>
  <dt><code>modal</code></dt>
- <dd>If on, the new window is said to be modal. The user cannot return to the main window until the modal window is closed. A typical modal window is created by the <a href="/en-US/docs/Web/API/Window/alert">alert() function</a>.</dd>
- <dd>The exact behavior of modal windows depends on the platform and on the Mozilla release version.
+ <dd>
+   <p>If on, the new window is said to be modal. The user cannot return to the main window until the modal window is closed. A typical modal window is created by the <a href="/en-US/docs/Web/API/Window/alert">alert() function</a>.</p>
+   <p>The exact behavior of modal windows depends on the platform and on the Mozilla release version.</p>
  <div class="note">
  <p><strong>Note:</strong> As of {{Gecko("1.9")}}, the Internet Explorer equivalent to this feature is the {{domxref("window.showModalDialog()")}} method. For compatibility reasons, it's now supported in Firefox. Note also that starting in {{Gecko("2.0")}}, you can use {{domxref("window.showModalDialog()")}} without UniversalBrowserWrite privileges.</p>
  </div>
  </dd>
  <dt><code>titlebar</code></dt>
- <dd>By default, all new secondary windows have a titlebar. If set to <var>no or 0</var>, this feature removes the titlebar from the new secondary window.</dd>
- <dd>Mozilla and Firefox users can force new windows to always render the titlebar by setting<br>
- <code>dom.disable_window_open_feature.titlebar</code><br>
- to <var>true</var> in <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config">about:config</a> or in their <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js">user.js file</a>.</dd>
+ <dd>
+   <p>By default, all new secondary windows have a titlebar. If set to <var>no or 0</var>, this feature removes the titlebar from the new secondary window.</p>
+   <p>Mozilla and Firefox users can force new windows to always render the titlebar by setting <code>dom.disable_window_open_feature.titlebar</code> to <var>true</var> in <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config">about:config</a> or in their <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js">user.js file</a>.</p>
+ </dd>
  <dt><code>alwaysRaised</code></dt>
  <dd>If on, the new window will always be displayed on top of other browser windows, regardless of whether it is active or not.</dd>
  <dt><code>alwaysLowered</code></dt>
@@ -45,8 +41,8 @@ slug: Web/API/Window/open/Privileged_features
  <dt><code>z-lock</code></dt>
  <dd>Same as <code>alwaysLowered</code>.</dd>
  <dt><code>close</code></dt>
- <dd>When set to <var>no or 0</var>, this feature removes the system close command icon and system close menu item. It will only work for dialog windows (<code>dialog</code> feature set). <code>close=no</code> will override <code>minimizable=yes</code>.</dd>
- <dd>Mozilla and Firefox users can force new windows to always have a close button by setting<br>
- <code>dom.disable_window_open_feature.close</code><br>
- to <var>true</var> in <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config">about:config</a> or in their <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js">user.js file</a>.</dd>
+ <dd>
+   <p>When set to <var>no or 0</var>, this feature removes the system close command icon and system close menu item. It will only work for dialog windows (<code>dialog</code> feature set). <code>close=no</code> will override <code>minimizable=yes</code>.</p>
+   <p>Mozilla and Firefox users can force new windows to always have a close button by setting <code>dom.disable_window_open_feature.close</code> to <var>true</var> in <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config">about:config</a> or in their <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js">user.js file</a>.</p>
+ </dd>
 </dl>

--- a/files/en-us/web/api/worker/postmessage/index.html
+++ b/files/en-us/web/api/worker/postmessage/index.html
@@ -27,11 +27,15 @@ browser-compat: api.Worker.postMessage
 
 <dl>
  <dt><em>message</em></dt>
- <dd>The object to deliver to the worker; this will be in the <code>data</code> field in the event delivered to the {{domxref("DedicatedWorkerGlobalScope.onmessage")}} handler. This may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</dd>
- <dd>If the <code>message</code> parameter is <em>not</em> provided, a <code>TypeError</code> will be thrown. If the data to be passed to the worker is unimportant, <code>null</code> or <code>undefined</code> can be passed explicitly.</dd>
+ <dd>
+   <p>The object to deliver to the worker; this will be in the <code>data</code> field in the event delivered to the {{domxref("DedicatedWorkerGlobalScope.onmessage")}} handler. This may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</p>
+   <p>If the <code>message</code> parameter is <em>not</em> provided, a <code>TypeError</code> will be thrown. If the data to be passed to the worker is unimportant, <code>null</code> or <code>undefined</code> can be passed explicitly.</p>
+ </dd>
  <dt><em>transfer</em> {{optional_inline}}</dt>
- <dd>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.</dd>
- <dd>Transferable objects are instances of classes like {{jsxref("ArrayBuffer")}}, {{domxref("MessagePort")}} or {{domxref("ImageBitmap")}} objects that can be transferred. <code>null</code> is not an acceptable value for <code>transfer</code>.</dd>
+ <dd>
+   <p>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.</p>
+   <p>Transferable objects are instances of classes like {{jsxref("ArrayBuffer")}}, {{domxref("MessagePort")}} or {{domxref("ImageBitmap")}} objects that can be transferred. <code>null</code> is not an acceptable value for <code>transfer</code>.</p>
+  </dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8474.

This PR fixes `<dl>` elements which don't convert to Markdown because they contain consecutive `<dd>` elements. This is allowed in `<dl>` but not in the version of `<dl>` we support (https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#definition_lists). In practice, when this happens in our source, it is always (?) an error.

Usually this is a matter of converting `<dd>`s to `<p>` elements, but in a couple of places it got a bit more extensive:

* https://github.com/mdn/content/compare/main...wbamberg:fix-consective-dd-api?expand=1#diff-b0eb4660e4265e8b31ac64efb446caf9810e755d3a9954e93312f9142110d87c was a rewrite to be more comprehensible
* https://github.com/mdn/content/compare/main...wbamberg:fix-consective-dd-api?expand=1#diff-039b4c5ecc6a6f87457411ab817d672fb16db813951d6c2b5ed04ad2eb240af3 I deleted the second `<dd>` as it seemed TMI in that context (landing page)
* https://github.com/mdn/content/compare/main...wbamberg:fix-consective-dd-api?expand=1#diff-4898432e26a8d800cf6546e64926102c060e479f2b0293f0a8cc286eaaa90654 I replaced the `{{page}}` macro with copy/paste - there's definitely more work to do in this area but I didn't want to get into it here.
* https://github.com/mdn/content/compare/main...wbamberg:fix-consective-dd-api?expand=1#diff-fb05d1d4239bacbaee2620946c51cf6fecba4577b9a29563c5c92c31b598a315 I deleted some long-removed things.