### PR TITLE
Fix 'Xray vision' URL

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
@@ -94,7 +94,7 @@ tags:
  <li>If a page script redefines a built-in DOM property, the content script sees the original version of the property, not the redefined version.</li>
 </ul>
 
-<p>In Firefox, this behavior is called <a href="/en-US/docs/Mozilla/Tech/Xray_vision">Xray vision</a>.</p>
+<p>In Firefox, this behavior is called <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#xray_vision_in_firefox">Xray vision</a>.</p>
 
 <p>Consider a web page like this:</p>
 


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any).

Didn't find any.

> What was wrong/why is this fix needed?

The current URL gives a "Page not found" error. The new URL points to a header on another page that explains more about 'Xray vision'.

> Anything else that could help us review it

Can provide more if needed.