### PR TITLE
Fix various dl api

### DIFF
--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -28,15 +28,16 @@ browser-compat: api.AnalyserNode.AnalyserNode
  <dd>A reference to an {{domxref("AudioContext")}} or {{domxref("OfflineAudioContext")}}.</dd>
  <dt><em>options</em> {{optional_inline}}</dt>
  <dd>
- <ul>
-  <li><strong><code>fftSize</code></strong>: The desired initial size of the <a href="https://en.wikipedia.org/wiki/Fast_Fourier_transform">FFT</a> for <a href="https://en.wikipedia.org/wiki/Frequency_domain">frequency-domain</a> analysis. <br>
-   The default is <code>2048</code>.</li>
-  <li><strong><code>maxDecibels</code></strong>: The desired initial maximum power in <a href="https://en.wikipedia.org/wiki/Decibel">dB</a> for FFT analysis.<br>
-   The default is <code>-30</code>.</li>
-  <li><strong><code>minDecibels</code></strong>: The desired initial minimum power in dB for FFT analysis.<br>
-   The default is <code>-100</code>.</li>
-  <li><strong><code>smoothingTimeConstant</code></strong>: The desired initial smoothing constant for the FFT analysis. The default is <code>0.8</code>.</li>
- </ul>
+   <p>An object with the following properties, all optional:</p>
+   <ul>
+    <li><strong><code>fftSize</code></strong>: The desired initial size of the <a href="https://en.wikipedia.org/wiki/Fast_Fourier_transform">FFT</a> for <a href="https://en.wikipedia.org/wiki/Frequency_domain">frequency-domain</a> analysis. <br>
+     The default is <code>2048</code>.</li>
+    <li><strong><code>maxDecibels</code></strong>: The desired initial maximum power in <a href="https://en.wikipedia.org/wiki/Decibel">dB</a> for FFT analysis.<br>
+     The default is <code>-30</code>.</li>
+    <li><strong><code>minDecibels</code></strong>: The desired initial minimum power in dB for FFT analysis.<br>
+     The default is <code>-100</code>.</li>
+    <li><strong><code>smoothingTimeConstant</code></strong>: The desired initial smoothing constant for the FFT analysis. The default is <code>0.8</code>.</li>
+   </ul>
  </dd>
 </dl>
 

--- a/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.html
+++ b/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.html
@@ -48,17 +48,19 @@ browser-compat: api.AudioWorkletGlobalScope.registerProcessor
 <dl>
   <dt><code>NotSupportedError</code></dt>
   <dd>
+    <p>Thrown under the following conditions:</p>
     <ul>
-      <li>The <em>name</em> is an empty string, or</li>
-      <li>a constructor under the given <em>name</em> is already registered. Registering
+      <li>The <em>name</em> is an empty string.</li>
+      <li>A constructor under the given <em>name</em> is already registered. Registering
         the same name twice is not allowed.</li>
     </ul>
   </dd>
   <dt><code>TypeError</code></dt>
   <dd>
+    <p>Thrown under the following conditions:</p>
     <ul>
-      <li>The <em>processorCtor</em> is not a callable constructor, or</li>
-      <li>the {{domxref("AudioWorkletProcessor.parameterDescriptors",
+      <li>The <em>processorCtor</em> is not a callable constructor.</li>
+      <li>The {{domxref("AudioWorkletProcessor.parameterDescriptors",
         "parameterDescriptors")}} property of the constructor exists and doesn't return an
         array of {{domxref("AudioParamDescriptor")}}-based objects.</li>
     </ul>

--- a/files/en-us/web/api/caretposition/index.html
+++ b/files/en-us/web/api/caretposition/index.html
@@ -28,7 +28,7 @@ browser-compat: api.CaretPosition
 
 <dl>
  <dt>{{domxref("CaretPosition.getClientRect")}}</dt>
- <dd></dd>
+ <dd>Returns the client rectangle for the caret range.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/cssgroupingrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/index.html
@@ -17,7 +17,7 @@ browser-compat: api.CSSGroupingRule
 <p><em>This interface also inherits properties from {{domxref("CSSRule")}}.</em></p>
 
 <dl>
- <dt">{{domxref("CSSGroupingRule.cssRules")}}{{readonlyinline}}</dt>
+ <dt>{{domxref("CSSGroupingRule.cssRules")}}{{readonlyinline}}</dt>
  <dd>Returns a {{domxref("CSSRuleList")}} of the CSS rules in the media rule.</dd>
 </dl>
 

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.html
@@ -45,10 +45,7 @@ browser-compat: api.DataTransfer.mozClearDataAt
 
 <h3 id="Return_Value">Return value</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd></dd>
-</dl>
+<p>None.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.html
@@ -55,10 +55,7 @@ browser-compat: api.DataTransfer.mozSetDataAt
 
 <h3 id="Return_Value">Return value</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd></dd>
-</dl>
+<p>None.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/datatransfer/setdata/index.html
+++ b/files/en-us/web/api/datatransfer/setdata/index.html
@@ -40,10 +40,7 @@ browser-compat: api.DataTransfer.setData
 
 <h3 id="Return_value">Return value</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd></dd>
-</dl>
+<p>None.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/datatransfer/setdragimage/index.html
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.html
@@ -49,10 +49,7 @@ browser-compat: api.DataTransfer.setDragImage
 
 <h3 id="Return_Value">Return value</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd></dd>
-</dl>
+<p>None.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/elementinternals/setvalidity/index.html
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.html
@@ -24,7 +24,7 @@ ElementInternals.setValidity(flags, message, anchor);</pre>
 <dl>
   <dt><code>flags</code>{{Optional_Inline}}</dt>
   <dd>A dictionary object containing one or more flags indicating the validity state of the element:
-    <ul>
+    <dl>
       <dt><code>valueMissing</code></dt>
       <dd>A boolean value that is <code>true</code> if the element has a {{htmlattrxref("required", "input")}} attribute, but no value, or <code>false</code> otherwise. If <code>true</code>, the element matches the {{cssxref(":invalid")}} CSS pseudo-class.</dd>
       <dt><code>typeMismatch</code></dt>
@@ -45,7 +45,7 @@ ElementInternals.setValidity(flags, message, anchor);</pre>
       <dd>A boolean value that is <code>true</code> if the user has provided input that the browser is unable to convert.</dd>
       <dt><code>customError</code></dt>
       <dd>A boolean value indicating whether the element's custom validity message has been set to a non-empty string by calling the element's {{domxref('HTMLObjectElement.setCustomValidity', 'setCustomValidity()')}} method.</dd>
-    </ul>
+    </dl>
 
     <div class="notecard note">
       <p><strong>Note:</strong> To set all flags to <code>false</code>, indicating that this element passes all constraints validation, pass in an empty object <code>{}</code>. In this case, you do not need to also pass a <code>message</code>.</p>
@@ -89,5 +89,3 @@ ElementInternals.setValidity(flags, message, anchor);</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/fileentrysync/index.html
+++ b/files/en-us/web/api/fileentrysync/index.html
@@ -92,10 +92,7 @@ browser-compat: api.FileEntrySync
 
 <h5 id="Returns_2">Returns</h5>
 
-<dl>
- <dt><code>File</code></dt>
- <dd></dd>
-</dl>
+<p>A <code>File</code> object.</p>
 
 <h5 id="Exceptions_2">Exceptions</h5>
 

--- a/files/en-us/web/api/fileentrysync/index.html
+++ b/files/en-us/web/api/fileentrysync/index.html
@@ -48,18 +48,15 @@ browser-compat: api.FileEntrySync
 <pre>void createWriter (
 ) raises (<a href="/en-US/docs/Web/API/FileException">FileException</a>);</pre>
 
-<h5 id="Parameter">Parameter</h5>
+<h4 id="Parameter">Parameter</h4>
 
 <p>None.</p>
 
-<h5 id="Returns">Returns</h5>
+<h4 id="Returns">Returns</h4>
 
-<dl>
- <dt><code>FileWriterSync</code></dt>
- <dd></dd>
-</dl>
+<p>A <code>FileWriterSync</code> object.</p>
 
-<h5 id="Exceptions">Exceptions</h5>
+<h4 id="Exceptions">Exceptions</h4>
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
@@ -30,6 +30,7 @@ browser-compat: api.FileSystemDirectoryHandle.getFileHandle
     the file you wish to retrieve.</dd>
   <dt><em>options</em> {{optional_inline}}</dt>
   <dd>
+    <p>An object with the following properties:</p>
     <ul>
       <li><code>create</code>: A {{jsxref('Boolean')}}. Default <code>false</code>. When
         set to <code>true</code> if the file is not found, one with the specified name

--- a/files/en-us/web/api/filesystementrysync/index.html
+++ b/files/en-us/web/api/filesystementrysync/index.html
@@ -108,18 +108,15 @@ browser-compat: api.FileSystemEntrySync
 <pre>Metadata getMetada ()
   raises <code>(<a href="/en-US/docs/Web/API/FileException">FileException</a>)</code>;</pre>
 
-<h5 id="Parameter">Parameter</h5>
+<h4 id="Parameter">Parameter</h4>
 
 <p>None</p>
 
-<h5 id="Returns">Returns</h5>
+<h4 id="Returns">Returns</h4>
 
-<dl>
- <dt><code>Metadata</code></dt>
- <dd></dd>
-</dl>
+<p>A <code>Metadata</code> object.</p>
 
-<h5 id="Exceptions">Exceptions</h5>
+<h4 id="Exceptions">Exceptions</h4>
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
@@ -161,7 +158,7 @@ browser-compat: api.FileSystemEntrySync
   in DirectoryEntrySync <em>parent</em>, optional DOMString <em>newName</em>
 ) raises (<a href="/en-US/docs/Web/API/FileException">FileException</a>);</pre>
 
-<h5 id="Parameters">Parameters</h5>
+<h4 id="Parameters">Parameters</h4>
 
 <dl>
  <dt>parent</dt>
@@ -170,14 +167,11 @@ browser-compat: api.FileSystemEntrySync
  <dd>The new name of the entry. If you do not specify a name, the browser preserves the entry's current name.</dd>
 </dl>
 
-<h5 id="Returns_2">Returns</h5>
+<h4 id="Returns_2">Returns</h4>
 
-<dl>
- <dt><code>FileSystemEntrySync</code></dt>
- <dd>An object that represents an entry in the file system.</dd>
-</dl>
+<p>A <code>FileSystemEntrySync</code> object.</p>
 
-<h5 id="Exceptions_2">Exceptions</h5>
+<h4 id="Exceptions_2">Exceptions</h4>
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
@@ -223,7 +217,7 @@ browser-compat: api.FileSystemEntrySync
   in DirectoryEntrySync <em>parent</em>, optional DOMString <em>newName</em>
 ) raises (<a href="/en-US/docs/Web/API/FileException">FileException</a>);</pre>
 
-<h5 id="Parameters_2">Parameters</h5>
+<h4 id="Parameters_2">Parameters</h4>
 
 <dl>
  <dt>parent</dt>
@@ -232,14 +226,11 @@ browser-compat: api.FileSystemEntrySync
  <dd>The new name of the entry. If you do not specify a name, the browser preserves the FileSystemEntrySync's current name.</dd>
 </dl>
 
-<h5 id="Returns_3">Returns</h5>
+<h4 id="Returns_3">Returns</h4>
 
-<dl>
- <dt><code>FileSystemEntrySync</code></dt>
- <dd>An object that represents an entry in the file system.</dd>
-</dl>
+<p>A <code>FileSystemEntrySync</code> object.</p>
 
-<h5 id="Exceptions_3">Exceptions</h5>
+<h4 id="Exceptions_3">Exceptions</h4>
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
@@ -291,18 +282,15 @@ browser-compat: api.FileSystemEntrySync
 
 <pre>DOMString toURL ();</pre>
 
-<h5 id="Parameter_2">Parameter</h5>
+<h4 id="Parameter_2">Parameter</h4>
 
 <p>None.</p>
 
-<h5 id="Returns_4">Returns</h5>
+<h4 id="Returns_4">Returns</h4>
 
-<dl>
- <dt><code>DOMString</code></dt>
- <dd></dd>
-</dl>
+<p>A <code>DOMString</code> object.</p>
 
-<h5 id="Exceptions_4">Exceptions</h5>
+<h4 id="Exceptions_4">Exceptions</h4>
 
 <p>None</p>
 
@@ -313,18 +301,15 @@ browser-compat: api.FileSystemEntrySync
 <pre>void remove (
 ) raises (<a href="/en-US/docs/Web/API/FileException">FileException</a>);</pre>
 
-<h5 id="Parameter_3">Parameter</h5>
+<h4 id="Parameter_3">Parameter</h4>
 
 <p>None</p>
 
-<h5 id="Returns_5">Returns</h5>
+<h4 id="Returns_5">Returns</h4>
 
-<dl>
- <dt><code>void</code></dt>
- <dd></dd>
-</dl>
+<p>None.</p>
 
-<h5 id="Exceptions_5">Exceptions</h5>
+<h4 id="Exceptions_5">Exceptions</h4>
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
@@ -359,18 +344,18 @@ browser-compat: api.FileSystemEntrySync
 
 <pre>void getParent ();</pre>
 
-<h5 id="Parameter_4">Parameter</h5>
+<h4 id="Parameter_4">Parameter</h4>
 
 <p>None</p>
 
-<h5 id="Returns_6">Returns</h5>
+<h4 id="Returns_6">Returns</h4>
 
 <dl>
  <dt><code><a href="/en-US/docs/Web/API/DirectoryEntrySync">DirectoryEntrySync</a></code></dt>
  <dd>An object that represents a directory in the file system.</dd>
 </dl>
 
-<h5 id="Exceptions_6">Exceptions</h5>
+<h4 id="Exceptions_6">Exceptions</h4>
 
 <p>None.</p>
 

--- a/files/en-us/web/api/html_dom_api/index.html
+++ b/files/en-us/web/api/html_dom_api/index.html
@@ -439,21 +439,18 @@ nameField.addEventListener("input", event =&gt; {
 
 <h2 id="See_also">See also</h2>
 
-<dl>
- <dt>References</dt>
- <dd>
- <ul>
+<h3>References</h3>
+
+<ul>
   <li><a href="/en-US/docs/Web/HTML/Element">HTML elements reference</a></li>
   <li><a href="/en-US/docs/Web/HTML/Attributes">HTML attribute reference</a></li>
   <li>{{DOMxRef("Document_Object_Model", "Document Object Model (DOM)", "", "1")}} reference</li>
- </ul>
- </dd>
- <dt>Guides</dt>
- <dd>
- <ul>
+</ul>
+
+<h3>Guides</h3>
+
+<ul>
   <li>
    <p><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Manipulating_documents">Manipulating documents</a>: A beginner's guide to manipulating the DOM.</p>
   </li>
- </ul>
- </dd>
-</dl>
+</ul>

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -116,7 +116,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
   in ErrorCallback errorCallback
 );</pre>
 
-<h5 id="Parameters">Parameters</h5>
+<h4 id="Parameters">Parameters</h4>
 
 <dl>
  <dt>type</dt>
@@ -134,14 +134,11 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
  <dd>The error callback that is called when errors happen or when the request to obtain the file system is denied. Its argument is the <code>FileError</code> object.</dd>
 </dl>
 
-<h5 id="Returns">Returns</h5>
+<h4 id="Returns">Returns</h4>
 
-<dl>
- <dt><code>void</code></dt>
- <dd></dd>
-</dl>
+<p>None.</p>
 
-<h5 id="Exceptions">Exceptions</h5>
+<h4 id="Exceptions">Exceptions</h4>
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileError">FileError</a> with the following code:</p>
 
@@ -169,7 +166,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 );
 </pre>
 
-<h5 id="Parameters_2">Parameters</h5>
+<h4 id="Parameters_2">Parameters</h4>
 
 <dl>
  <dt>url</dt>
@@ -180,14 +177,11 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
  <dd>The error callback that is called when errors happen or when the request to obtain the entry object is denied.</dd>
 </dl>
 
-<h5 id="Returns_2">Returns</h5>
+<h4 id="Returns_2">Returns</h4>
 
-<dl>
- <dt><code>void</code></dt>
- <dd></dd>
-</dl>
+<p>None.</p>
 
-<h5 id="Exceptions_2">Exceptions</h5>
+<h4 id="Exceptions_2">Exceptions</h4>
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileError">FileError</a> with the following code:</p>
 

--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
@@ -17,15 +17,12 @@ browser-compat: api.MediaQueryListEvent.MediaQueryListEvent
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>myMqlEvent</em> = <em>new MediaQueryListEvent(init);</em></pre>
+<pre class="brush: js">var <em>myMqlEvent</em> = <em>new MediaQueryListEvent(init);</em></pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt>
-    <p>init</p>
-  </dt>
+  <dt><code>init</code></dt>
   <dd>
     <p>An init object that defines features of the new object instance. The available
       properties are:</p>

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.html
@@ -38,9 +38,7 @@ browser-compat: api.MediaRecorder.MediaRecorder
     from a stream created using {{domxref("MediaDevices.getUserMedia",
     "navigator.mediaDevices.getUserMedia()")}} or from an {{HTMLElement("audio")}},
     {{HTMLElement("video")}} or {{HTMLElement("canvas")}} element.</dd>
-  <dt>
-    <p><strong><code>options</code> </strong>{{optional_inline}}</p>
-  </dt>
+  <dt><strong><code>options</code> </strong>{{optional_inline}}</dt>
   <dd>
     <p>A dictionary object that can contain the following properties:</p>
 

--- a/files/en-us/web/api/messageevent/messageevent/index.html
+++ b/files/en-us/web/api/messageevent/messageevent/index.html
@@ -26,9 +26,7 @@ browser-compat: api.MessageEvent.MessageEvent
   <dt><code><strong>type</strong></code></dt>
   <dd>The type of <code>MessageEvent</code> that will be created. This can be one of XXX
   </dd>
-  <dt>
-    <p><strong><code>init</code> </strong>{{optional_inline}}</p>
-  </dt>
+  <dt><strong><code>init</code> </strong>{{optional_inline}}</dt>
   <dd>
     <p>A dictionary object that can contain the following properties:</p>
 

--- a/files/en-us/web/api/microdata_dom_api/index.html
+++ b/files/en-us/web/api/microdata_dom_api/index.html
@@ -136,7 +136,7 @@ interface <dfn>PropertyNodeList</dfn> : NodeList {
  <dt><code>collection . length</code></dt>
  <dd>Returns the number of elements in the collection.</dd>
  <dt><code>element = collection . item(index)</code></dt>
- <dd></dd>
+ <dd>Returns the element with index from the collection. The items are sorted in tree order.</dd>
  <dt><code>collection[index]</code></dt>
  <dd>Returns the element with index from the collection. The items are sorted in tree order.</dd>
  <dt><code>propertyNodeList = collection . namedItem(name)</code></dt>

--- a/files/en-us/web/api/ndefreader/scan/index.html
+++ b/files/en-us/web/api/ndefreader/scan/index.html
@@ -22,6 +22,7 @@ browser-compat: api.NDEFReader.scan
 <dl>
   <dt><code>options</code> {{optional_inline}}</dt>
   <dd>
+    <p>An object with the following properties:</p>
     <ul>
       <li><code>signal</code> -- An {{DOMxRef("AbortSignal")}} that allows cancelling
         this <code>scan()</code> operation.</li>

--- a/files/en-us/web/api/ndefreader/write/index.html
+++ b/files/en-us/web/api/ndefreader/write/index.html
@@ -61,6 +61,7 @@ browser-compat: api.NDEFReader.write
   </dd>
   <dt><code>options</code> {{optional_inline}}</dt>
   <dd>
+    <p>An object with the following properties:</p>
     <ul>
       <li><code>overwrite</code> -- A {{JSxRef("Boolean")}} specifying whether or not
         existing records should be overwritten, if such exists.</li>

--- a/files/en-us/web/api/ndefreader/write/index.html
+++ b/files/en-us/web/api/ndefreader/write/index.html
@@ -39,7 +39,7 @@ browser-compat: api.NDEFReader.write
       <dd>A string indicating the type of data stored in <code>data</code>. It must be one of the following values:
         <dl>
           <dt><code>"absolute-url"</code></dt>
-          <dt>An absolute URL to the data.</dt>
+          <dd>An absolute URL to the data.</dd>
           <dt><code>"empty"</code></dt>
           <dd>An empty {{domxref("NDEFRecord")}}.</dd>
           <dt><code>"mime"</code></dt>

--- a/files/en-us/web/api/notification/index.html
+++ b/files/en-us/web/api/notification/index.html
@@ -38,7 +38,7 @@ browser-compat: api.Notification
  </ul>
  </dd>
  <dt>{{domxref("Notification.maxActions")}} {{readonlyinline}}</dt>
- <dd></dd>
+ <dd>The maximum number of actions supported by the device and the User Agent.</dd>
 </dl>
 
 <h3 id="Instance_properties">Instance properties</h3>

--- a/files/en-us/web/api/request/mode/index.html
+++ b/files/en-us/web/api/request/mode/index.html
@@ -26,9 +26,7 @@ browser-compat: api.Request.mode
 <h3 id="Value">Value</h3>
 
 <dl>
-  <dt>
-    <p>A <code>RequestMode</code> value.</p>
-  </dt>
+  <dt>A <code>RequestMode</code> value.</dt>
   <dd>
     <p>The associated <dfn>mode</dfn>, available values of which are:</p>
 

--- a/files/en-us/web/api/rtcconfiguration/index.html
+++ b/files/en-us/web/api/rtcconfiguration/index.html
@@ -113,23 +113,17 @@ browser-compat: api.RTCConfiguration
 
   <dt>{{domxref("RTCConfiguration.iceTransportPolicy", "iceTransportPolicy")}} {{optional_inline}}</dt>
   <dd>
-    The current ICE transport policy;
+    <p>The current ICE transport policy;
     if the policy isn't specified, <code>all</code> is assumed by default,
     allowing all candidates to be considered.
-    Possible values are:
+    Possible values are:</p>
     <dl>
-      <tr>
-        <td><code>"all"</code></td>
-        <td>All ICE candidates will be considered.</td>
-       </tr>
-       <tr>
-        <td><code>"public" </code>{{deprecated_inline}}</td>
-        <td>Only ICE candidates with public IP addresses will be considered. <em>Removed from the specification's May 13, 2016 working draft.</em></td>
-       </tr>
-       <tr>
-        <td><code>"relay"</code></td>
-        <td>Only ICE candidates whose IP addresses are being relayed, such as those being passed through a STUN or TURN server, will be considered.</td>
-       </tr>
+      <dt><code>"all"</code></dt>
+      <dd>All ICE candidates will be considered.</dd>
+      <dt><code>"public" </code>{{deprecated_inline}}</dt>
+      <dd>Only ICE candidates with public IP addresses will be considered. <em>Removed from the specification's May 13, 2016 working draft.</em></dd>
+      <dt><code>"relay"</code></dt>
+      <dd>Only ICE candidates whose IP addresses are being relayed, such as those being passed through a STUN or TURN server, will be considered.</dd>
     </dl>
   </dd>
 

--- a/files/en-us/web/api/serial/requestport/index.html
+++ b/files/en-us/web/api/serial/requestport/index.html
@@ -22,6 +22,7 @@ browser-compat: api.Serial.requestPort
 <dl>
   <dt>options</dt>
   <dd>
+    <p>An object with the following properties:</p>
     <dl>
       <dt><code>filters</code></dt>
       <dd>A list of objects containing vendor and product IDs used to search for attached devices. The <a href="https://www.usb.org/">USB Implementors Forum</a> assigns IDs to specific companies. Each company assigns IDS to it's products. Filters contain the following values:

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -49,14 +49,16 @@ browser-compat: api.SVGMarkerElement.preserveAspectRatio
       </dl>
     </dd>
   <dt><code>meetOrSlice</code></dt>
-  <dl>
-    <dt><code>0</code></dt>
-    <dd><code>SVG_MEETORSLICE_UNKNOWN</code></dd>
-    <dt><code>1</code></dt>
-    <dd><code>SVG_MEETORSLICE_MEET</code></dd>
-    <dt><code>2</code></dt>
-    <dd><code>SVG_MEETORSLICE_SLICE</code></dd>
-   </dl>
+  <dd>One of the following numeric constants:
+    <dl>
+      <dt><code>0</code></dt>
+      <dd><code>SVG_MEETORSLICE_UNKNOWN</code></dd>
+      <dt><code>1</code></dt>
+      <dd><code>SVG_MEETORSLICE_MEET</code></dd>
+      <dt><code>2</code></dt>
+      <dd><code>SVG_MEETORSLICE_SLICE</code></dd>
+     </dl>
+  </dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
This is part of https://github.com/mdn/content/issues/8474.

This PR fixes a few assorted `<dl>` conversion problems. Usually this is when a list immediately starts a `<dd>` without any introductory text, which is technically allowed in our `<dl>`, but is not supported by the converter, and is almost always improved by some introductory text.
