### PR TITLE
Drop Syntax section from WebSocket»readyState property doc

### DIFF
--- a/files/en-us/web/api/websocket/readystate/index.html
+++ b/files/en-us/web/api/websocket/readystate/index.html
@@ -14,11 +14,6 @@ browser-compat: api.WebSocket.readyState
 <p>The <strong><code>WebSocket.readyState</code></strong> read-only property returns the
   current state of the {{domxref("WebSocket")}} connection.</p>
 
-<h2 id="Syntax">Syntax</h2>
-
-<pre
-  class="brush: js">var readyState = <em>WebSocket</em>.readyState;</pre>
-
 <h2 id="Value">Value</h2>
 
 <p>One of the following <code>unsigned short</code> values:</p>

--- a/files/en-us/web/api/websocket/readystate/index.html
+++ b/files/en-us/web/api/websocket/readystate/index.html
@@ -17,7 +17,7 @@ browser-compat: api.WebSocket.readyState
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">var readyState = <em>aWebSocket</em>.readyState;</pre>
+  class="brush: js">var readyState = <em>WebSocket</em>.readyState;</pre>
 
 <h2 id="Value">Value</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
There is a typo in the Syntax section. It should be `WebSocket.readyState` and not `aWebSocket.readyState`.


> Anything else that could help us review it
