### PR TITLE
Deprecate BasicCardRequest/BasicCardResponse

### DIFF
--- a/files/en-us/web/api/basiccardrequest/index.html
+++ b/files/en-us/web/api/basiccardrequest/index.html
@@ -15,9 +15,11 @@ tags:
   - Reference
   - card
   - payment
+  - Deprecated
+  - Non-standard
 browser-compat: api.BasicCardRequest
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>BasicCardRequest</code></strong> dictionary is a JavaScript object-structure that can be used in the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a>. The properties of <code>BasicCardRequest</code> are defined in the {{anch("Specifications", "Basic Card Payment spec")}}).</p>
 
@@ -119,7 +121,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
+++ b/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
@@ -11,9 +11,11 @@ tags:
 - Property
 - Reference
 - supportedNetworks
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardRequest.supportedNetworks
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>supportedNetworks</code></strong> property of the
   {{domxref("BasicCardRequest")}} dictionary contains an array of
@@ -69,7 +71,7 @@ var request = new PaymentRequest(supportedInstruments, details, options);
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardrequest/supportedtypes/index.html
+++ b/files/en-us/web/api/basiccardrequest/supportedtypes/index.html
@@ -15,9 +15,11 @@ tags:
 - Reference
 - payment
 - supportedTypes
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardRequest.supportedTypes
 ---
-<p>{{securecontext_header}}{{deprecated_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The obsolete <strong><code>supportedTypes</code></strong>
     property of the {{domxref("BasicCardRequest")}} dictionary can optionally be provided

--- a/files/en-us/web/api/basiccardresponse/billingaddress/index.html
+++ b/files/en-us/web/api/basiccardresponse/billingaddress/index.html
@@ -11,9 +11,11 @@ tags:
 - Property
 - Reference
 - billingAddress
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardResponse.billingAddress
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>billingAddress</code></strong> property of the
   {{domxref("BasicCardResponse")}} dictionary contains the billing address of the card
@@ -65,7 +67,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/cardholdername/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardholdername/index.html
@@ -10,9 +10,11 @@ tags:
 - Property
 - Reference
 - cardholderName
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardResponse.cardholderName
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>cardNumber</code></strong> property of the
   {{domxref("BasicCardResponse")}} dictionary contains the cardholder name of the card
@@ -63,7 +65,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/cardnumber/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardnumber/index.html
@@ -11,9 +11,11 @@ tags:
 - Property
 - Reference
 - cardNumber
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardResponse.cardNumber
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>cardNumber</code></strong> property of the
   {{domxref("BasicCardResponse")}} dictionary contains the number of the card used to make
@@ -63,7 +65,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
@@ -11,9 +11,11 @@ tags:
 - Property
 - Reference
 - cardSecurityCode
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardResponse.cardSecurityCode
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>cardSecurityCode</code></strong> property of the
   {{domxref("BasicCardResponse")}} dictionary contains the security code of the card used
@@ -63,7 +65,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/expirymonth/index.html
+++ b/files/en-us/web/api/basiccardresponse/expirymonth/index.html
@@ -11,9 +11,11 @@ tags:
 - Property
 - Reference
 - expiryMonth
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardResponse.expiryMonth
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>expiryMonth</code></strong> property of the
   {{domxref("BasicCardResponse")}} dictionary contains the expiry month of the card used
@@ -64,7 +66,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/expiryyear/index.html
+++ b/files/en-us/web/api/basiccardresponse/expiryyear/index.html
@@ -11,9 +11,11 @@ tags:
 - Property
 - Reference
 - expiryYear
+- Deprecated
+- Non-standard
 browser-compat: api.BasicCardResponse.expiryYear
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>expiryYear</code></strong> property of the
   {{domxref("BasicCardResponse")}} dictionary contains the expiry year of the card used to
@@ -64,7 +66,7 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/basiccardresponse/index.html
+++ b/files/en-us/web/api/basiccardresponse/index.html
@@ -10,9 +10,11 @@ tags:
   - Payment Request
   - Payment Request API
   - Reference
+  - Deprecated
+  - Non-standard
 browser-compat: api.BasicCardResponse
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>BasicCardResponse</code></strong> dictionary (related to the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a>, although defined in the {{anch("Specifications", "Basic Card Payment spec")}}) defines an object structure for payment response details such as the number/expiry date of the card used to make the payment, and the billing address.</p>
 
@@ -98,7 +100,7 @@ try {
 
 <h2 id="Specifications">Specifications</h2>
 
-{{Specifications}}
+<p>This feature is no longer part of any specification.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
See https://w3c.github.io/payment-method-basic-card/#sotd:

> The Web Payments Working Group has discontinued work on this document.

...and see https://github.com/w3c/payment-method-basic-card#deprecated---basic-card

> ⚠️ The W3C Web Payments Working Group has discontinued work on the Basic Card Payment Method.⚠️

So this change drops all the spec URLs for the BasicCardRequest and BasicCardResponse articles and all their child articles, while also marking them all as deprecated and non-standard.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/12231