### PR TITLE
Fix an error in CSS_Box_Alignment (gap vs grid-gap property)

### DIFF
--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -164,7 +164,7 @@ In the below example, a grid layout uses the `gap` shorthand to set a `10px` gap
 
 {{EmbedGHLiveSample("css-examples/box-alignment/overview/grid-gap.html", '100%', 500)}}
 
-In this example I am using the {{cssxref("gap")}} property in addition to {{cssxref("gap")}}. The gap properties were originally prefixed with `grid-` in the Grid Layout specification and some browsers only support these prefixed versions.
+In this example I am using the `grid-gap` property instead of {{cssxref("gap")}}. The gap properties were originally prefixed with `grid-` in the Grid Layout specification and some browsers only support these prefixed versions.
 
 - {{cssxref("row-gap")}}
 - {{cssxref("column-gap")}}


### PR DESCRIPTION
The example uses grid-gap only.

CSS/grid-gap redirects to CSS/gap, so using cssxref("grid-gap")
triggers a "flaw" alert. Just use ``grid-gap``.