### PR TITLE
[Markdown] [Web/API] Remove name attribute api

### DIFF
--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
@@ -186,13 +186,13 @@ browser-compat: api.FileSystem
 <p>This section defines and explains terms used in the File and Directory Entries API.</p>
 
 <dl>
- <dt><a name="gloss_blob">blob</a></dt>
+ <dt>blob</dt>
  <dd>Stands for binary large object. A blob is a set of binary data that is stored as a single object. It is a general-purpose way to reference binary data in web applications. A blob can be an image or an audio file.</dd>
- <dt><a name="gloss_Blob">Blob</a></dt>
+ <dt>Blob</dt>
  <dd>Blob—with a capital B—is a data structure that is immutable, which means that binary data referenced by a Blob cannot be modified directly. This makes Blobs act predictably when they are passed to asynchronous APIs.</dd>
- <dt><a name="gloss_persistent_storage">persistent storage</a></dt>
+ <dt>persistent storage</dt>
  <dd>Persistent storage is storage that stays in the browser unless the user expunges it or the app deletes it. </dd>
- <dt><a name="gloss_temporary_storage">temporary storage</a></dt>
+ <dt>temporary storage</dt>
  <dd>Transient storage is available to any web app. It is automatic and does not need to be requested, but the browser can delete the storage without warning.</dd>
 </dl>
 

--- a/files/en-us/web/api/fileexception/index.html
+++ b/files/en-us/web/api/fileexception/index.html
@@ -45,7 +45,7 @@ var fileEntry = fs.root.getFile('log.txt', {create: true, exclusive:true}0;
  </thead>
  <tbody>
   <tr>
-   <td><a name="attr_code"><code>code</code></a></td>
+   <td><code>code</code></td>
    <td><code>unsigned short</code></td>
    <td>The most appropriate error code for the condition.</td>
   </tr>
@@ -66,53 +66,53 @@ var fileEntry = fs.root.getFile('log.txt', {create: true, exclusive:true}0;
    <th scope="col">Description</th>
   </tr>
   <tr>
-   <td><code><a name="NON_TRANSIENT_ERR">ENCODING_ERR</a></code></td>
+   <td><code>ENCODING_ERR</code></td>
    <td>5</td>
    <td>The URL is malformed. Make sure that the URL is complete and valid.</td>
   </tr>
   <tr>
-   <td><code><a name="NON_TRANSIENT_ERR">INVALID_MODIFICATION_ERR</a></code></td>
+   <td><code>INVALID_MODIFICATION_ERR</code></td>
    <td>9</td>
    <td>The modification requested is not allowed. Examples of invalid modifications include moving a directory into its own child or moving a file into its parent directory without changing its name.</td>
   </tr>
   <tr>
-   <td><code><a name="CONSTRAINT_ERR">INVALID_STATE_ERR</a></code></td>
+   <td><code>INVALID_STATE_ERR</code></td>
    <td>7</td>
    <td>The operation cannot be performed on the current state of the interface object. For example, the state that was cached in an interface object has changed since it was last read from disk.</td>
   </tr>
   <tr>
-   <td><code><a name="VER_ERR">NO_MODIFICATION_ALLOWED_ERR</a></code></td>
+   <td><code>NO_MODIFICATION_ALLOWED_ERR</code></td>
    <td>6</td>
    <td>The state of the underlying file system prevents any writing to a file or a directory.</td>
   </tr>
   <tr>
-   <td><code><a name="NOT_FOUND_ERR">NOT_FOUND_ERR</a></code></td>
+   <td><code>NOT_FOUND_ERR</code></td>
    <td>1</td>
    <td>A required file or directory could not be found at the time an operation was processed. For example, a file did not exist but was being opened.</td>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="NON_TRANSIENT_ERR">NOT_READABLE_ERR</a></code></td>
+   <td><code>NOT_READABLE_ERR</code></td>
    <td>4</td>
    <td>
     <p>The file or directory cannot be read, typically due to permission problems that occur after a reference to a file has been acquired (for example, the file or directory is concurrently locked by another application).</p>
    </td>
   </tr>
   <tr>
-   <td><code><a name="TIMEOUT_ERR">PATH_EXISTS_ERR</a></code></td>
+   <td><code>PATH_EXISTS_ERR</code></td>
    <td>12</td>
    <td>The file or directory with the same path already exists.</td>
   </tr>
   <tr>
-   <td><code><a name="QUOTA_ERR">QUOTA_EXCEEDED_ERR</a></code></td>
+   <td><code>QUOTA_EXCEEDED_ERR</code></td>
    <td>10</td>
    <td>
     <p>Either there's not enough remaining storage space or the storage quota was reached and the user declined to give more space to the database.</p>
    </td>
   </tr>
   <tr>
-   <td><code><a name="SECURITY_ERR">SECURITY_ERR</a></code></td>
+   <td><code>SECURITY_ERR</code></td>
    <td>2</td>
    <td>
     <p>Access to the files were denied for one of the following reasons:</p>
@@ -125,7 +125,7 @@ var fileEntry = fs.root.getFile('log.txt', {create: true, exclusive:true}0;
    </td>
   </tr>
   <tr>
-   <td><code><a name="READ_ONLY_ERR">TYPE_MISMATCH_ERR</a></code></td>
+   <td><code>TYPE_MISMATCH_ERR</code></td>
    <td>11</td>
    <td>The user has attempted to look up a file or directory, but the Entry found is of the wrong type. For example, the app is accessing a DirectoryEntry when the user is requesting a FileEntry.</td>
   </tr>

--- a/files/en-us/web/api/filesystemsync/index.html
+++ b/files/en-us/web/api/filesystemsync/index.html
@@ -38,12 +38,12 @@ browser-compat: api.FileSystemSync
  </thead>
  <tbody>
   <tr>
-   <td><a name="attr_name"><code>name</code></a></td>
+   <td><code>name</code></td>
    <td><code>readonly DOMString</code></td>
    <td>Name of the file system. The name must be unique across the list of exposed file systems.</td>
   </tr>
   <tr>
-   <td><a name="attr_root"><code>root</code></a></td>
+   <td><code>root</code></td>
    <td><code>readonly DirectoryEntry</code></td>
    <td>The root directory of the file system.</td>
   </tr>

--- a/files/en-us/web/api/idbcursorsync/index.html
+++ b/files/en-us/web/api/idbcursorsync/index.html
@@ -43,22 +43,22 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><a name="attr_count"><code>count</code></a></td>
+   <td><code>count</code></td>
    <td><code>readonly unsigned long long</code></td>
    <td>The total number of objects that share the current key.</td>
   </tr>
   <tr>
-   <td><a name="attr_direction"><code>direction</code></a></td>
+   <td><code>direction</code></td>
    <td><code>readonly unsigned short</code></td>
    <td>The direction of traversal of the cursor. See Constants for possible values.</td>
   </tr>
   <tr>
-   <td><a name="attr_key"><code>key</code></a></td>
+   <td><code>key</code></td>
    <td><code>readonly any</code></td>
    <td>The key for the record at the cursor's position.</td>
   </tr>
   <tr>
-   <td><a name="attr_value"><code>value</code></a></td>
+   <td><code>value</code></td>
    <td><code>any</code></td>
    <td>
     <p>The value for the record at the cursor's position. Setting this attribute can raise an IDBDatabaseException with the following codes:</p>
@@ -88,22 +88,22 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><a name="const_next"><code>NEXT</code></a></td>
+   <td><code>NEXT</code></td>
    <td>0</td>
    <td>This cursor includes duplicates, and its direction is monotonically increasing in the order of keys.</td>
   </tr>
   <tr>
-   <td><a name="const_next_no_duplicate"><code>NEXT_NO_DUPLICATE</code></a></td>
+   <td><code>NEXT_NO_DUPLICATE</code></td>
    <td>1</td>
    <td>This cursor does not include duplicates, and its direction is monotonically increasing in the order of keys.</td>
   </tr>
   <tr>
-   <td><a name="const_prev"><code>PREV</code></a></td>
+   <td><code>PREV</code></td>
    <td>2</td>
    <td>This cursor includes duplicates, and its direction is monotonically decreasing in the order of keys.</td>
   </tr>
   <tr>
-   <td><a name="const_prev_no_duplicate"><code>PREV_NO_DUPLICATE</code></a></td>
+   <td><code>PREV_NO_DUPLICATE</code></td>
    <td>3</td>
    <td>This cursor does not include duplicates, and its direction is monotonically decreasing in the order of keys.</td>
   </tr>

--- a/files/en-us/web/api/idbdatabaseexception/index.html
+++ b/files/en-us/web/api/idbdatabaseexception/index.html
@@ -28,12 +28,12 @@ browser-compat: api.IDBDatabaseException
  </thead>
  <tbody>
   <tr>
-   <td><a name="attr_code"><code>code</code></a></td>
+   <td><code>code</code></td>
    <td><code>unsigned short</code></td>
    <td>The most appropriate error code for the condition.</td>
   </tr>
   <tr>
-   <td><a name="attr_message"><code>message</code></a></td>
+   <td><code>message</code></td>
    <td><code>DOMString</code></td>
    <td>Error message describing the exception raised.</td>
   </tr>
@@ -56,27 +56,27 @@ browser-compat: api.IDBDatabaseException
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="ABORT_ERR">ABORT_ERR</a></code></td>
+   <td><code>ABORT_ERR</code></td>
    <td><code>8</code></td>
    <td>A request was aborted, for example, through a call to<a href="/en-US/docs/Web/API/IDBTransaction#abort"> <code>IDBTransaction.abort</code></a>.</td>
   </tr>
   <tr>
-   <td><code><a name="CONSTRAINT_ERR">CONSTRAINT_ERR</a></code></td>
+   <td><code>CONSTRAINT_ERR</code></td>
    <td><code>4</code></td>
    <td>A mutation operation in the transaction failed because a constraint was not satisfied. For example, an object, such as an object store or index, already exists and a request attempted to create a new one.</td>
   </tr>
   <tr>
-   <td><code><a name="DATA_ERR">DATA_ERR</a></code></td>
+   <td><code>DATA_ERR</code></td>
    <td><code>5</code></td>
    <td>Data provided to an operation does not meet requirements.</td>
   </tr>
   <tr>
-   <td><code><a name="NON_TRANSIENT_ERR">NON_TRANSIENT_ERR</a></code></td>
+   <td><code>NON_TRANSIENT_ERR</code></td>
    <td><code>2</code></td>
    <td>An operation was not allowed on an object. Unless the cause of the error is corrected, retrying the same operation would result in failure.</td>
   </tr>
   <tr>
-   <td><code><a name="NOT_ALLOWED_ERR">NOT_ALLOWED_ERR</a></code></td>
+   <td><code>NOT_ALLOWED_ERR</code></td>
    <td><code>6</code></td>
    <td>
     <p>An operation was called on an object where it is not allowed or at a time when it is not allowed. It also occurs if a request is made on a source object that has been deleted or removed.</p>
@@ -85,37 +85,37 @@ browser-compat: api.IDBDatabaseException
    </td>
   </tr>
   <tr>
-   <td><code><a name="NOT_FOUND_ERR">NOT_FOUND_ERR</a></code></td>
+   <td><code>NOT_FOUND_ERR</code></td>
    <td><code>3</code></td>
    <td>The operation failed because the requested database object could not be found; for example, an object store did not exist but was being opened.</td>
   </tr>
   <tr>
-   <td><code><a name="QUOTA_ERR">QUOTA_ERR</a></code></td>
+   <td><code>QUOTA_ERR</code></td>
    <td><code>11</code></td>
    <td>Either there's not enough remaining storage space or the storage quota was reached and the user declined to give more space to the database.</td>
   </tr>
   <tr>
-   <td><code><a name="READ_ONLY_ERR">READ_ONLY_ERR</a></code></td>
+   <td><code>READ_ONLY_ERR</code></td>
    <td><code>9</code></td>
    <td>A mutation operation was attempted in a <code>READ_ONLY</code> transaction.</td>
   </tr>
   <tr>
-   <td><code><a name="TIMEOUT_ERR">TIMEOUT_ERR</a></code></td>
+   <td><code>TIMEOUT_ERR</code></td>
    <td><code>10</code></td>
    <td>A lock for the transaction could not be obtained in a reasonable time.</td>
   </tr>
   <tr>
-   <td><a name="TRANSACTION_INACTIVE_ERR"><code>TRANSACTION_INACTIVE_ERR</code></a></td>
+   <td><code>TRANSACTION_INACTIVE_ERR</code></td>
    <td><code>7</code></td>
    <td>A request was made against a transaction that is either not currently active or is already finished.</td>
   </tr>
   <tr>
-   <td><code><a name="UNKNOWN_ERR">UNKNOWN_ERR</a></code></td>
+   <td><code>UNKNOWN_ERR</code></td>
    <td><code>1</code></td>
    <td>The operation failed for reasons unrelated to the database itself, and it is not covered by any other error code--for example, a failure due to disk IO errors.</td>
   </tr>
   <tr>
-   <td><code><a name="VER_ERR">VER_ERR</a></code></td>
+   <td><code>VER_ERR</code></td>
    <td><code>12</code></td>
    <td>A request to open a database with a version lower than the one it already has. This can only happen with <a href="/en-US/docs/Web/API/IDBOpenDBRequest"><code>IDBOpenDBRequest</code></a>.</td>
   </tr>

--- a/files/en-us/web/api/idbdatabasesync/index.html
+++ b/files/en-us/web/api/idbdatabasesync/index.html
@@ -51,22 +51,22 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="attr_description">description</a></code></td>
+   <td><code>description</code></td>
    <td><code>readonly DOMString </code></td>
    <td>The human-readable description of the connected database.</td>
   </tr>
   <tr>
-   <td><a name="attr_name"></a><code><a>name</a> </code></td>
+   <td><code>name </code></td>
    <td><code>readonly DOMString </code></td>
    <td>The name of the connected database.</td>
   </tr>
   <tr>
-   <td><a name="attr_objectStores"></a><code><a>objectStores</a> </code></td>
+   <td><code>objectStores </code></td>
    <td><code>readonly DOMStringList </code></td>
    <td>The names of the object stores that exist in the connected database.</td>
   </tr>
   <tr>
-   <td><a name="attr_version"></a><code><a>version</a> </code></td>
+   <td><code>version </code></td>
    <td><code>readonly DOMString</code></td>
    <td>The version of the connected database. Has the null value when the database is first created.</td>
   </tr>

--- a/files/en-us/web/api/idbenvironmentsync/index.html
+++ b/files/en-us/web/api/idbenvironmentsync/index.html
@@ -29,7 +29,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="indexedDBSync">indexedDBSync</a></code></td>
+   <td><code>indexedDBSync</code></td>
    <td><code>readonly <a href="/en-US/docs/Web/API/IDBFactorySync">IDBFactorySync</a></code></td>
    <td>Provides a synchronous means of accessing the capabilities of indexed databases.
      <div class="notecard note">

--- a/files/en-us/web/api/idbindexsync/index.html
+++ b/files/en-us/web/api/idbindexsync/index.html
@@ -57,22 +57,22 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="attr_keyPath">keyPath</a></code></td>
+   <td><code>keyPath</code></td>
    <td><code>readonly DOMString</code></td>
    <td>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> of this index. If this attribute is null, this index is not auto-populated.</td>
   </tr>
   <tr>
-   <td><code><a name="attr_name">name</a></code></td>
+   <td><code>name</code></td>
    <td><code>readonly DOMString</code></td>
    <td>The name of this index.</td>
   </tr>
   <tr>
-   <td><code><a name="attr_storeName">storeName</a></code></td>
+   <td><code>storeName</code></td>
    <td><code>readonly DOMString</code></td>
    <td>This index's referenced <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store">object store</a>.</td>
   </tr>
   <tr>
-   <td><code><a name="attr_unique">unique</a></code></td>
+   <td><code>unique</code></td>
    <td><code>readonly boolean</code></td>
    <td>If true, a key can have only one value within the index; if false, a key can have duplicate values.</td>
   </tr>

--- a/files/en-us/web/api/idbobjectstoresync/index.html
+++ b/files/en-us/web/api/idbobjectstoresync/index.html
@@ -61,7 +61,7 @@ tags:
   <tr>
    <td><code>indexNames</code></td>
    <td><code>readonly DOMStringList</code></td>
-   <td>A list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes on this object store.</td>
+   <td>A list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes</a> on this object store.</td>
   </tr>
   <tr>
    <td><code>keyPath</code></td>

--- a/files/en-us/web/api/idbobjectstoresync/index.html
+++ b/files/en-us/web/api/idbobjectstoresync/index.html
@@ -59,22 +59,22 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="attr_indexNames">indexNames</a></code></td>
+   <td><code>indexNames</code></td>
    <td><code>readonly DOMStringList</code></td>
-   <td>A list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes</a> on this object store.</td>
+   <td>A list of the names of the <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index">indexes on this object store.</td>
   </tr>
   <tr>
-   <td><code><a name="attr_keyPath">keyPath</a></code></td>
+   <td><code>keyPath</code></td>
    <td><code>readonly DOMString</code></td>
    <td>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path">key path</a> of this object store. If this attribute is set to null, then the application must provide a key for each modification operation.</td>
   </tr>
   <tr>
-   <td><code><a name="attr_mode">mode</a></code></td>
+   <td><code>mode</code></td>
    <td><code>readonly unsigned short</code></td>
    <td>The mode for isolating access to the data in this object store. For possible values, see <a href="/en-US/docs/Web/API/IDBObjectStoreSync#constants">Constants</a>.</td>
   </tr>
   <tr>
-   <td><code><a name="attr_name">name</a></code></td>
+   <td><code>name</code></td>
    <td><code>readonly DOMString</code></td>
    <td>The name of this object store.</td>
   </tr>
@@ -95,17 +95,17 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="const_read_only">READ_ONLY</a></code></td>
+   <td><code>READ_ONLY</code></td>
    <td>1</td>
    <td>Modification operations are not allowed on this object store.</td>
   </tr>
   <tr>
-   <td><code><a name="const_read_write">READ_WRITE</a></code></td>
+   <td><code>READ_WRITE</code></td>
    <td>0</td>
    <td>Modification operations are allowed on this object store.</td>
   </tr>
   <tr>
-   <td><code><a name="const_snapshot_read">SNAPSHOT_READ</a></code></td>
+   <td><code>SNAPSHOT_READ</code></td>
    <td>2</td>
    <td>Any read operations must access a snapshot view of the data, which cannot change once it is created.</td>
   </tr>

--- a/files/en-us/web/api/idbtransactionsync/index.html
+++ b/files/en-us/web/api/idbtransactionsync/index.html
@@ -45,12 +45,12 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><a name="attr_db"><code>db</code></a></td>
+   <td><code>db</code></td>
    <td><code><a href="/en-US/docs/Web/API/IDBDatabaseSync">IDBDatabaseSync</a></code></td>
    <td>The <a href="/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection">database connection</a> that this transaction is associated with.</td>
   </tr>
   <tr>
-   <td><a name="attr_static"><code>static</code></a></td>
+   <td><code>static</code></td>
    <td><code>boolean</code></td>
    <td>If true, this transaction is static; if false, this transaction is dynamic.</td>
   </tr>

--- a/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
+++ b/files/en-us/web/api/indexeddb_api/basic_terminology/index.html
@@ -53,7 +53,7 @@ tags:
   <p><strong>IndexedDB does not use Structured Query Language (<abbr>SQL</abbr>).</strong> It uses queries on an index that produces a cursor, which you use to iterate across the result set. If you are not familiar with NoSQL systems, read the <a href="https://en.wikipedia.org/wiki/NoSQL">Wikipedia article on NoSQL</a>.</p>
  </li>
  <li>
-  <p><a name="origin"><strong>IndexedDB adheres to a same-origin policy</strong></a>. An origin is the domain, application layer protocol, and port of a URL of the document where the script is being executed. Each origin has its own associated set of databases. Every database has a name that identifies it within an origin.</p>
+  <p><strong>IndexedDB adheres to a same-origin policy</strong>. An origin is the domain, application layer protocol, and port of a URL of the document where the script is being executed. Each origin has its own associated set of databases. Every database has a name that identifies it within an origin.</p>
 
   <p>The security boundary imposed on IndexedDB prevents applications from accessing data with a different origin. For example, while an app or a page in <a href="https://www.example.com/app/">http://www.example.com/app/</a> can retrieve data from <a href="https://www.example.com/dir/">http://www.example.com/dir/</a>, because they have the same origin, it cannot retrieve data from <a href="https://www.example.com:8080/dir/">http://www.example.com:8080/dir/</a> (different port) or <a class="link-https" href="https://www.example.com/dir/">https://www.example.com/dir/</a> (different protocol), because they have different origins.</p>
 

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -123,7 +123,7 @@ request.onsuccess = function(event) {
 
 <h3 id="Creating_or_updating_the_version_of_the_database">Creating or updating the version of the database</h3>
 
-<p><a name="Updating_the_version_of_the_database"></a>When you create a new database or increase the version number of an existing database (by specifying a higher version number than you did previously, when {{ anch("Opening a database") }}), the <code>onupgradeneeded</code> event will be triggered and an <a href="/en-US/docs/Web/API/IDBVersionChangeEvent">IDBVersionChangeEvent</a> object will be passed to any <code>onversionchange</code> event handler set up on <code>request.result</code> (i.e., <code>db</code> in the example). In the handler for the <code>upgradeneeded</code> event, you should create the object stores needed for this version of the database:</p>
+<p>When you create a new database or increase the version number of an existing database (by specifying a higher version number than you did previously, when {{ anch("Opening a database") }}), the <code>onupgradeneeded</code> event will be triggered and an <a href="/en-US/docs/Web/API/IDBVersionChangeEvent">IDBVersionChangeEvent</a> object will be passed to any <code>onversionchange</code> event handler set up on <code>request.result</code> (i.e., <code>db</code> in the example). In the handler for the <code>upgradeneeded</code> event, you should create the object stores needed for this version of the database:</p>
 
 <pre class="brush:js;">// This event is only implemented in recent browsers
 request.onupgradeneeded = function(event) {

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -89,14 +89,14 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
  </thead>
  <tbody>
   <tr>
-   <td><a name="const_temporary"><code>TEMPORARY</code></a></td>
+   <td><code>TEMPORARY</code></td>
    <td><code>0</code></td>
    <td>
     <p>Transient storage that can be removed by the browser at its discretion.</p>
    </td>
   </tr>
   <tr>
-   <td><a name="const_persistent"><code>PERSISTENT</code></a></td>
+   <td><code>PERSISTENT</code></td>
    <td><code>1</code></td>
    <td>Storage that stays in the browser unless the user or the app expunges it. The user must grant permission before the app can use this type of storage.</td>
   </tr>

--- a/files/en-us/web/api/localfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/index.html
@@ -66,14 +66,14 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
  </thead>
  <tbody>
   <tr>
-   <td><a name="const_temporary"><code>TEMPORARY</code></a></td>
+   <td><code>TEMPORARY</code></td>
    <td><code>0</code></td>
    <td>
     <p>Transient storage that can be removed by the browser at its discretion.</p>
    </td>
   </tr>
   <tr>
-   <td><a name="const_persistent"><code>PERSISTENT</code></a></td>
+   <td><code>PERSISTENT</code></td>
    <td><code>1</code></td>
    <td>Storage that stays in the browser unless the user or the app expunges it.</td>
   </tr>
@@ -95,7 +95,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <dl>
  <dt>type</dt>
- <dd>The storage type of the file system. The values can be either <code><a href="#const_temporary">TEMPORARY</a></code> or <code><a href="#const_persistent">PERSISTENT</a></code>.</dd>
+ <dd>The storage type of the file system. The values can be either <a href="#Constants"><code>TEMPORARY</code> or <code>PERSISTENT</code></a>.</dd>
  <dt>size</dt>
  <dd>The storage space—in bytes—that you need for your app.</dd>
 </dl>

--- a/files/en-us/web/api/xpathexception/index.html
+++ b/files/en-us/web/api/xpathexception/index.html
@@ -33,12 +33,12 @@ browser-compat: api.XPathException
  </thead>
  <tbody>
   <tr>
-   <td><code><a name="INVALID_EXPRESSION_ERR">INVALID_EXPRESSION_ERR</a></code></td>
+   <td><code>INVALID_EXPRESSION_ERR</code></td>
    <td><code>51</code></td>
    <td>If the expression has a syntax error or otherwise is not a legal expression according to the rules of the specific {{domxref("XPathEvaluator")}} or contains specialized extension functions or variables not supported by this implementation.</td>
   </tr>
   <tr>
-   <td><code><a name="TYPE_ERR">TYPE_ERR</a></code></td>
+   <td><code>TYPE_ERR</code></td>
    <td><code>52</code></td>
    <td>If the expression cannot be converted to return the specified type.</td>
   </tr>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7898.

Removes `<a name=...` from the Web/API docs. 

The only place I could find where these are being used for links is https://github.com/mdn/content/compare/main...wbamberg:remove-name-attribute-api?expand=1#diff-fccd055084e20ada96622f32dbb76aa4f9a528b3bb9205163285be0d83f0536d , which I fixed.