### PR TITLE
[Markdown] (Web/API] Remove unsupported elements from Web/API

### DIFF
--- a/files/en-us/web/api/document/xmlencoding/index.html
+++ b/files/en-us/web/api/document/xmlencoding/index.html
@@ -23,7 +23,7 @@ browser-compat: api.Document.xmlEncoding
 
 <p>...the result should be "UTF-16".</p>
 
-<p>However, Firefox 3.0 includes information on endianness (e.g., UTF-16BE for big endian encoding), and while this extra information is removed as of Firefox 3.1b3, Firefox 3.1b3 is still consulting the file's encoding, rather than the XML Declaration as the spec defines it ("An attribute specifying, <u><em>as part of the XML declaration</em></u>, the encoding of this document.").</p>
+<p>However, Firefox 3.0 includes information on endianness (e.g., UTF-16BE for big endian encoding), and while this extra information is removed as of Firefox 3.1b3, Firefox 3.1b3 is still consulting the file's encoding, rather than the XML Declaration as the spec defines it ("An attribute specifying, <em>as part of the XML declaration</em>, the encoding of this document.").</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/element/getelementsbyclassname/index.html
+++ b/files/en-us/web/api/element/getelementsbyclassname/index.html
@@ -83,8 +83,8 @@ browser-compat: api.Element.getElementsByClassName
 
 <p>You can use either the {{domxref("HTMLCollection.item", "item()")}} method on the
   returned <code>HTMLCollection</code> or standard array syntax to examine individual
-  elements in the collection. However <u><strong>the following code will not
-      work</strong></u> as one might expect because <code>"matches"</code> will change as
+  elements in the collection. However, the following code will not
+      work as one might expect because <code>"matches"</code> will change as
   soon as any <code>"colorbox"</code> class is removed.</p>
 
 <pre class="brush: js">var matches = element.getElementsByClassName('colorbox');

--- a/files/en-us/web/api/globaleventhandlers/onpointerdown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerdown/index.html
@@ -48,14 +48,35 @@ var <var>downHandler</var> = <var>target</var>.onpointerdown;
 
 <h2 id="Example">Example</h2>
 
+<h3>Responding to pointer down events</h3>
+
 <p>This example demonstrates how to watch for and act upon <code>pointerdown</code> events
   using <code>onpointerdown</code>. You could also use <code>addEventListener()</code>, of
   course.</p>
 
-<h4 id="JavaScript">JavaScript</h4>
+<h4 id="HTML">HTML</h4>
 
-<p>First, let's look at the JavaScript code that handles the <code>pointerdown</code>
-  event.</p>
+<pre class="brush: html">&lt;div id="target"&gt;
+    Tap me, click me, or touch me!
+&lt;/div&gt;</pre>
+
+<h4 id="CSS">CSS</h4>
+
+<p>The CSS sets up the appearance of the target, and doesn't affect its functionality at  all.</p>
+
+<pre class="brush: css">#target {
+  width: 400px;
+  height: 30px;
+  text-align: center;
+  font: 16px "Open Sans", "Helvetica", sans-serif;
+  color: white;
+  background-color: blue;
+  border: 2px solid darkblue;
+  cursor: pointer;
+  user-select: none;
+}</pre>
+
+<h4 id="JavaScript">JavaScript</h4>
 
 <pre class="brush: js">var targetBox = document.getElementById("target");
 
@@ -105,7 +126,7 @@ function handleUp(evt) {
   evt.preventDefault();
 }</pre>
 
-<p>This code's job is to just restore the original text into the target box after the
+<p>This code restores the original text into the target box after the
   user's interaction with the element ends (for example, when they release the mouse
   button, or when they lift the stylus or finger from the screen).</p>
 
@@ -113,48 +134,12 @@ function handleUp(evt) {
   is called to ensure that the <code>mouseup</code> event isn't triggered unnecessarily.
 </p>
 
-<details>
-  <summary>
-    <h4 id="HTML">HTML</h4>
-  </summary>
-
-  <p>The HTML is extremely simple:</p>
-
-  <pre class="brush: html">&lt;div id="target"&gt;
-  Tap me, click me, or touch me!
-&lt;/div&gt;</pre>
-</details>
-
-<details>
-  <summary>
-    <h4 id="CSS">CSS</h4>
-  </summary>
-
-  <p>The CSS sets up the appearance of the target, and doesn't affect its functionality at
-    all.</p>
-
-  <pre class="brush: css">#target {
-  width: 400px;
-  height: 30px;
-  text-align: center;
-  font: 16px "Open Sans", "Helvetica", sans-serif;
-  color: white;
-  background-color: blue;
-  border: 2px solid darkblue;
-  cursor: pointer;
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-}</pre>
-</details>
-
 <h4 id="Result">Result</h4>
 
 <p>The resulting output is shown below. Try tapping, clicking, or touching the box and see
   what happens. For full effect, try it with a variety of pointer types.</p>
 
-<p>{{EmbedLiveSample("Example", 450, 50)}}</p>
+<p>{{EmbedLiveSample("Responding_to_pointer_down_events", 450, 50)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -176,7 +176,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>maxLength</code></td>
-   <td><em><code>long</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("maxlength", "input") }} attribute, containing the <u><strong>maximum number of characters</strong></u> (in Unicode code points) that the value can have. (If you set this to a negative number, an exception will be thrown.)</td>
+   <td><em><code>long</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("maxlength", "input") }} attribute, containing the maximum number of characters (in Unicode code points) that the value can have. (If you set this to a negative number, an exception will be thrown.)</td>
   </tr>
   <tr>
    <td><code>min</code></td>
@@ -184,11 +184,11 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>minLength</code></td>
-   <td><em><code>long</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("minlength", "input") }} attribute, containing the <u><strong>minimum number of characters</strong></u> (in Unicode code points) that the value can have. (If you set this to a negative number, an exception will be thrown.)</td>
+   <td><em><code>long</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("minlength", "input") }} attribute, containing the minimum number of characters (in Unicode code points) that the value can have. (If you set this to a negative number, an exception will be thrown.)</td>
   </tr>
   <tr>
    <td><code>pattern</code></td>
-   <td><em><code>string</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("pattern", "input") }} attribute, containing a <u><strong>regular expression</strong></u> that the control's value is checked against. Use the {{htmlattrxref("title","input")}} attribute to describe the pattern to help the user. This attribute applies when the value of the {{htmlattrxref("type","input")}} attribute is <code>text</code>, <code>search</code>, <code>tel</code>, <code>url</code> or <code>email</code>; otherwise it is ignored.</td>
+   <td><em><code>string</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("pattern", "input") }} attribute, containing a regular expression that the control's value is checked against. Use the {{htmlattrxref("title","input")}} attribute to describe the pattern to help the user. This attribute applies when the value of the {{htmlattrxref("type","input")}} attribute is <code>text</code>, <code>search</code>, <code>tel</code>, <code>url</code> or <code>email</code>; otherwise it is ignored.</td>
   </tr>
   <tr>
    <td><code>placeholder</code></td>
@@ -216,7 +216,7 @@ browser-compat: api.HTMLInputElement
   </tr>
   <tr>
    <td><code>size</code></td>
-   <td><em><code>unsigned long</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("size", "input") }} attribute, containing <u><strong>visual size of the control</strong></u>. This value is in pixels unless the value of {{htmlattrxref("type","input")}} is <code>text</code> or <code>password</code>, in which case, it is an integer number of characters. Applies only when {{htmlattrxref("type","input")}} is set to <code>text</code>, <code>search</code>, <code>tel</code>, <code>url</code>, <code>email</code>, or <code>password</code>; otherwise it is ignored.</td>
+   <td><em><code>unsigned long</code>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("size", "input") }} attribute, containing visual size of the control. This value is in pixels unless the value of {{htmlattrxref("type","input")}} is <code>text</code> or <code>password</code>, in which case, it is an integer number of characters. Applies only when {{htmlattrxref("type","input")}} is set to <code>text</code>, <code>search</code>, <code>tel</code>, <code>url</code>, <code>email</code>, or <code>password</code>; otherwise it is ignored.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/paymentresponse/retry/index.html
+++ b/files/en-us/web/api/paymentresponse/retry/index.html
@@ -100,9 +100,6 @@ browser-compat: api.PaymentResponse.retry
 
 <h2 id="Examples">Examples</h2>
 
-<p><u><strong>try { await paymentRequest.retry(errorFields); } catch (DOMException err) {
-      ... }</strong></u></p>
-
 <pre class="brush: js">async function doPaymentRequest() {
   const request = new PaymentRequest(methodData, details, options);
   const response = await request.show();

--- a/files/en-us/web/api/speechrecognitionevent/emma/index.html
+++ b/files/en-us/web/api/speechrecognitionevent/emma/index.html
@@ -16,9 +16,9 @@ browser-compat: api.SpeechRecognitionEvent.emma
 <div>{{APIRef("Web Speech API")}}{{deprecated_header}}</div>
 
 <p>The <strong><code>emma</code></strong> read-only property of the
-  {{domxref("SpeechRecognitionEvent")}} interface returns an <cite>E</cite><cite>xtensible
+  {{domxref("SpeechRecognitionEvent")}} interface returns an Extensible
     MultiModal Annotation markup language (EMMA) — XML — representation of the
-    result.</cite></p>
+    result.</p>
 
 <div class="note">
   <p><strong>Note:</strong> EMMA is defined in the specification <a

--- a/files/en-us/web/api/speechrecognitionevent/index.html
+++ b/files/en-us/web/api/speechrecognitionevent/index.html
@@ -22,7 +22,7 @@ browser-compat: api.SpeechRecognitionEvent
 
 <dl>
  <dt>{{domxref("SpeechRecognitionEvent.emma")}} {{readonlyinline}}</dt>
- <dd>Returns an <cite>E</cite><cite>xtensible MultiModal Annotation markup language (EMMA) — XML — representation of the result.</cite></dd>
+ <dd>Returns an Extensible MultiModal Annotation markup language (EMMA) — XML — representation of the result.</dd>
  <dt>{{domxref("SpeechRecognitionEvent.interpretation")}} {{readonlyinline}}</dt>
  <dd>Returns the semantic meaning of what the user said.</dd>
  <dt>{{domxref("SpeechRecognitionEvent.resultIndex")}} {{readonlyinline}}</dt>

--- a/files/en-us/web/api/speechrecognitionresult/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/index.html
@@ -22,7 +22,7 @@ browser-compat: api.SpeechRecognitionResult
 	<dt>{{domxref("SpeechRecognitionResult.isFinal")}} {{readonlyinline}}</dt>
 	<dd>A boolean value that states whether this result is final (true) or not (false) — if so, then this is the final time this result will be returned; if not, then this result is an interim result, and may be updated later on.</dd>
 	<dt>{{domxref("SpeechRecognitionResult.length")}} {{readonlyinline}}</dt>
-	<dd>Returns <cite>the length of the "array" — the </cite>number of {{domxref("SpeechRecognitionAlternative")}} objects contained in the result (also referred to as "n-best alternatives".)</dd>
+	<dd>Returns the length of the "array" — the number of {{domxref("SpeechRecognitionAlternative")}} objects contained in the result (also referred to as "n-best alternatives".)</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/speechrecognitionresult/length/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/length/index.html
@@ -16,8 +16,8 @@ browser-compat: api.SpeechRecognitionResult.length
 <p>{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}</p>
 
 <p>The <code><strong>length</strong></code> read-only property of the
-  {{domxref("SpeechRecognitionResult")}} interface returns <cite>the length of the "array"
-    — the </cite>number of {{domxref("SpeechRecognitionAlternative")}} objects contained
+  {{domxref("SpeechRecognitionResult")}} interface returns the length of the "array"
+    — the number of {{domxref("SpeechRecognitionAlternative")}} objects contained
   in the result (also referred to as "n-best alternatives".)</p>
 
 <p>The number of alternatives contained in the result depends on what the

--- a/files/en-us/web/api/speechrecognitionresultlist/index.html
+++ b/files/en-us/web/api/speechrecognitionresultlist/index.html
@@ -20,7 +20,7 @@ browser-compat: api.SpeechRecognitionResultList
 
 <dl>
 	<dt>{{domxref("SpeechRecognitionResultList.length")}} {{readonlyinline}}</dt>
-	<dd>Returns <cite>the length of the "array" — the </cite>number of {{domxref("SpeechRecognitionResult")}} objects in the list.</dd>
+	<dd>Returns the length of the "array" — the number of {{domxref("SpeechRecognitionResult")}} objects in the list.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/speechrecognitionresultlist/length/index.html
+++ b/files/en-us/web/api/speechrecognitionresultlist/length/index.html
@@ -16,8 +16,8 @@ browser-compat: api.SpeechRecognitionResultList.length
 <p>{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}</p>
 
 <p>The <code><strong>length</strong></code> read-only property of the
-  {{domxref("SpeechRecognitionResultList")}} interface returns <cite>the length of the
-    "array" — the </cite>number of {{domxref("SpeechRecognitionResult")}} objects in the
+  {{domxref("SpeechRecognitionResultList")}} interface returns the length of the
+    "array" — the number of {{domxref("SpeechRecognitionResult")}} objects in the
   list.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/webrtc_api/index.html
+++ b/files/en-us/web/api/webrtc_api/index.html
@@ -231,27 +231,27 @@ tags:
  </tbody>
 </table>
 
-<h3 id="WebRTC-proper_protocols">WebRTC-proper protocols</h4>
+<h3 id="WebRTC-proper_protocols">WebRTC-proper protocols</h3>
 
 <ul>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-alpn/"><cite>Application Layer Protocol Negotiation for Web Real-Time Communications</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-audio/"><cite>WebRTC Audio Codec and Processing Requirements</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-channel/"><cite>RTCWeb Data Channels</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-protocol/"><cite>RTCWeb Data Channel Protocol</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-rtp-usage/"><cite>Web Real-Time Communication (WebRTC): Media Transport and Use of RTP</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-security-arch/"><cite>WebRTC Security Architecture</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-transports/"><cite>Transports for RTCWEB</cite></a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-alpn/">Application Layer Protocol Negotiation for Web Real-Time Communications</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-audio/">WebRTC Audio Codec and Processing Requirements</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-channel/">RTCWeb Data Channels</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-protocol/">RTCWeb Data Channel Protocol</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-rtp-usage/">Web Real-Time Communication (WebRTC): Media Transport and Use of RTP</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-security-arch/">WebRTC Security Architecture</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-rtcweb-transports/">Transports for RTCWEB</a></li>
 </ul>
 
 <h3 id="Related_supporting_protocols">Related supporting protocols</h3>
 
 <ul>
  <li><a href="https://datatracker.ietf.org/doc/html/rfc5245">Interactive Connectivity Establishment (ICE): A Protocol for Network Address Translator (NAT) Traversal for Offer/Answer Protocol</a></li>
- <li><a href="https://datatracker.ietf.org/doc/html/rfc5389"><cite>Session Traversal Utilities for NAT (STUN)</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/html/rfc7064"><cite>URI Scheme for the Session Traversal Utilities for NAT (STUN) Protocol</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/html/rfc7065"><cite>Traversal Using Relays around NAT (TURN) Uniform Resource Identifiers</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/html/rfc3264"><cite>An Offer/Answer Model with Session Description Protocol (SDP)</cite></a></li>
- <li><a href="https://datatracker.ietf.org/doc/draft-ietf-tram-turn-third-party-authz/"><cite>Session Traversal Utilities for NAT (STUN) Extension for Third Party Authorization</cite></a></li>
+ <li><a href="https://datatracker.ietf.org/doc/html/rfc5389">Session Traversal Utilities for NAT (STUN)</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/html/rfc7064">URI Scheme for the Session Traversal Utilities for NAT (STUN) Protocol</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/html/rfc7065">Traversal Using Relays around NAT (TURN) Uniform Resource Identifiers</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/html/rfc3264">An Offer/Answer Model with Session Description Protocol (SDP)</a></li>
+ <li><a href="https://datatracker.ietf.org/doc/draft-ietf-tram-turn-third-party-authz/">Session Traversal Utilities for NAT (STUN) Extension for Third Party Authorization</a></li>
 </ul>
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webrtc_api/protocols/index.html
+++ b/files/en-us/web/api/webrtc_api/protocols/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h2 id="STUN">STUN</h2>
 
-<p><a href="https://en.wikipedia.org/wiki/STUN">Session Traversal Utilities for <u>NAT</u> (STU<u>N</u>)</a> (acronym within an acronym) is a protocol to discover your public address and determine any restrictions in your router that would prevent a direct connection with a peer.</p>
+<p><a href="https://en.wikipedia.org/wiki/STUN">Session Traversal Utilities for NAT (STUN)</a> is a protocol to discover your public address and determine any restrictions in your router that would prevent a direct connection with a peer.</p>
 
 <p>The client will send a request to a STUN server on the Internet who will reply with the client’s public address and whether or not the client is accessible behind the router’s NAT.</p>
 

--- a/files/en-us/web/api/window/ondragdrop/index.html
+++ b/files/en-us/web/api/window/ondragdrop/index.html
@@ -21,9 +21,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><s>window.ondragdrop = funcRef;</s>
-window.addEventListener("dragdrop", funcRef, useCapturing);
-</pre>
+<pre class="brush: js">window.ondragdrop = funcRef;</pre>
 
 <dl>
  <dt>funcRef </dt>

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -111,22 +111,6 @@ function openRequestedPopup() {
 <p>To open a <em>new</em> window on every call of <code>window.open()</code>, use the
   special value <code>_blank</code> for <code><var>windowName</var></code>.</p>
 
-<div class="notecard note">
-  <p><strong>Note:</strong> The use of <code>window.open()</code> to
-    reopen an existing window with name <code><var>windowName</var></code> is not valid for all browsers and more with variable conditions.
-    <s>Firefox (50.0.1) functions as described: from the same domain+port reopen with same
-      name will access the previously created window</s>. Google Chrome (55.0.2883.87 m )
-    on the other hand will do it only from the same parent (as if the window was created
-    dependent, which is the "opener"). This is a wide limitation and generates
-    unbelievable complexity of development. Firefox (51.) gets the handle but cannot run
-    any <code>Element.focus()</code> while Chrome can run <code>focus()</code> from opener
-    to child but not between siblings nor, reverse, from child to opener. This function is
-    the lonely key to get back the handle on a window if the developer has access only to
-    its name (the name can be saved with cookies or local storage but not the window
-    object handle). For now 10/01/2017 the differencies of behavior found recently have
-    not still been tested for others Browsers.</p>
-</div>
-
 <h2 id="Window_features">Window features</h2>
 
 <p><code><var>windowFeatures</var></code> is an optional string containing a


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7898 .

This PR removes some HTML elements that are not supported in our Markdown at all:

* `<cite>` (featuring some impressively random markup)
* `<u>`
* `<s>`
* `<details>`
