### PR TITLE
Remove the list of tools from the “JSON” glossary entry

### DIFF
--- a/files/en-us/glossary/json/index.html
+++ b/files/en-us/glossary/json/index.html
@@ -12,13 +12,6 @@ tags:
 
 <p>JSON can represent numbers, booleans, strings, <code>null</code>, arrays (ordered sequences of values), and objects (string-value mappings) made up of these values (or of other arrays and objects).  JSON does not natively represent more complex data types like functions, regular expressions, dates, and so on.  (Date objects by default serialize to a string containing the date in ISO format, so the information isn't completely lost.) If you need JSON to represent additional data types, transform values as they are serialized or before they are deserialized.</p>
 
-<p>Much like XML, JSON has the ability to store hierarchical data unlike the more traditional CSV format. Many tools provide translation between these formats such as the following online converters:</p>
-<ul>
-  <li><a href="https://json-csv.com">JSON to CSV Converter</a> by <a href="https://json-csv.com">json-csv.com</a></li>
-  <li><a href="https://jsontoexcel.com">JSON to CSV Converter</a> by <a href="https://jsontoexcel.com">jsontoexcel.com</a></li>
-  <li><a href="https://conversiontools.io/convert/json-to-csv">JSON to CSV Converter</a> by <a href="https://conversiontools.io">Conversion Tools</a></li>
-</ul>
-
 <h2 id="Learn_more">Learn more</h2>
 
 <h3 id="General_knowledge">General knowledge</h3>

--- a/files/en-us/glossary/json/index.html
+++ b/files/en-us/glossary/json/index.html
@@ -12,7 +12,12 @@ tags:
 
 <p>JSON can represent numbers, booleans, strings, <code>null</code>, arrays (ordered sequences of values), and objects (string-value mappings) made up of these values (or of other arrays and objects).  JSON does not natively represent more complex data types like functions, regular expressions, dates, and so on.  (Date objects by default serialize to a string containing the date in ISO format, so the information isn't completely lost.) If you need JSON to represent additional data types, transform values as they are serialized or before they are deserialized.</p>
 
-<p>Much like XML, JSON has the ability to store hierarchical data unlike the more traditional CSV format. Many tools provide translation between these formats such as this online <a href="https://json-csv.com">JSON to CSV Converter</a> or this alternative <a href="https://jsontoexcel.com">JSON to CSV Converter</a>.</p>
+<p>Much like XML, JSON has the ability to store hierarchical data unlike the more traditional CSV format. Many tools provide translation between these formats such as the following online converters:</p>
+<ul>
+  <li><a href="https://json-csv.com">JSON to CSV Converter</a> by <a href="https://json-csv.com">json-csv.com</a></li>
+  <li><a href="https://jsontoexcel.com">JSON to CSV Converter</a> by <a href="https://jsontoexcel.com">jsontoexcel.com</a></li>
+  <li><a href="https://conversiontools.io/convert/json-to-csv">JSON to CSV Converter</a> by <a href="https://conversiontools.io">Conversion Tools</a></li>
+</ul>
 
 <h2 id="Learn_more">Learn more</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Added link to JSON to CSV converter by Conversion Tools.

> What was wrong/why is this fix needed? (quick summary only)

This is a good alternative that people might use.
There is also JSON to Excel converter (by Conversion Tools), which is ranked at 3-5 position on Google, and it produces a very good result based on the user's feedback, but there was no relevant statement about Excel, so I added only JSON to CSV converter.

> Anything else that could help us review it

I look forward to the feedback or to apply any additional changes.