### PR TITLE
Fix misspelling word -> "scr" to "src"

### DIFF
--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -379,7 +379,7 @@ browser-compat: html.elements.input
    <td>Size of the control</td>
   </tr>
   <tr>
-   <td>{{htmlattrxref("scr", "input", "", 1)}}</td>
+   <td>{{htmlattrxref("src", "input", "", 1)}}</td>
    <td>image</td>
    <td>Same as <code>src</code> attribute for {{htmlelement('img')}}; address of image resource</td>
   </tr>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Fix misspelling word on attributes table of <input> tag
The correct attribute is "src"