### PR TITLE
Drop “Use relative links” section from “Creating hyperlinks” doc

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.html
+++ b/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.html
@@ -203,15 +203,6 @@ to download Firefox&lt;/p&gt;
  <li>Minimize instances where multiple copies of the same text are linked to different places. This can cause problems for screen reader users, if there's a list of links out of context that are labeled "click here", "click here", "click here".</li>
 </ul>
 
-<h3 id="Use_relative_links_wherever_possible">Use relative links wherever possible</h3>
-
-<p>From the description above, you might think that it's a good idea to just use absolute links all the time because they don't break when a page is moved like relative links. However, you should use relative links wherever possible when linking to other locations within the <em>same website</em>. When you link to another website, you'll need to use an absolute link.</p>
-
-<ul>
- <li>For a start, it's easier to scan your code — relative URLs are generally shorter than absolute URLs, which makes reading code much easier.</li>
- <li>Second, it's more efficient to use relative URLs wherever possible. When you use an absolute URL, the browser starts by looking up the real location of the server on the Domain Name System ({{glossary("DNS")}}) — see <a href="/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works">How the web works</a> for more information. Then it goes to that server and finds the file that's being requested. With a relative URL, the browser just looks up the file that's being requested on the same server. If you use absolute URLs where relative URLs would do, you're constantly making your browser do extra work, meaning that it will perform less efficiently.</li>
-</ul>
-
 <h3 id="Linking_to_non-HTML_resources_—_leave_clear_signposts">Linking to non-HTML resources — leave clear signposts</h3>
 
 <p>When linking to a resource that will be downloaded (like a PDF or Word document), streamed (like video or audio), or has another potentially unexpected effect (opens a popup window, or loads a Flash movie), you should add clear wording to reduce any confusion.</p>


### PR DESCRIPTION
The information in this section about browsers making repeat DNS lookups for absolute URLs is plain wrong, and the other reason — “makes reading code much easier” — doesn’t seem like a super-compelling reason.

The choice between using relative URLs and absolute URLs is something depends on what kind of content it is and what the anticipation is for reusing/moving the content elsewhere. So a blanket “Use relative links wherever possible” recommendation doesn’t really make sense anyway. Fixes https://github.com/mdn/content/issues/8517.