### PR TITLE
Svg Optimization in Mask-type CSS ref

### DIFF
--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -71,8 +71,8 @@ The `mask-type` property is specified as one of the keyword values listed below.
     height: 100px;
     width: 100px;
     background-color: gray;
-    border: solid 1px #000;
-    mask: url(#m);
+    border: solid 1px black;
+    mask: url("#m");
 }
 ```
 
@@ -102,8 +102,8 @@ The `mask-type` property is specified as one of the keyword values listed below.
     height: 100px;
     width: 100px;
     background-color: gray;
-    border: solid 1px #000;
-    mask: url(#m)
+    border: solid 1px black;
+    mask: url("#m");
 }
 ```
 

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -54,17 +54,14 @@ The `mask-type` property is specified as one of the keyword values listed below.
 #### HTML
 
 ```html
-<div class="redsquare"></div>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0">
-  <defs>
-    <mask id="m" maskContentUnits="objectBoundingBox"
-      style="mask-type:alpha">
-      <rect x=".1" y=".1" width=".8" height=".8"
-          fill="red" fill-opacity="0.7"/>
-    </mask>
-  </defs>
-</svg>
+<div class="redsquare">
+   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
+   <defs>
+      <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:alpha">
+         <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7"/>
+      </mask>
+   </defs>
+</div>
 ```
 
 #### CSS
@@ -88,17 +85,15 @@ The `mask-type` property is specified as one of the keyword values listed below.
 #### HTML
 
 ```html
-<div class="redsquare"></div>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0">
-  <defs>
-    <mask id="m" maskContentUnits="objectBoundingBox"
-      style="mask-type:luminance">
-      <rect x=".1" y=".1" width=".8" height=".8"
-          fill="red" fill-opacity="0.7"/>
-    </mask>
-  </defs>
-</svg>
+<div class="redsquare">
+   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
+      <defs>
+         <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:luminance">
+            <rect x=".1" y=".1" width=".8" height=".8"fill="red" fill-opacity=".7"/>
+         </mask>
+      </defs>
+   </svg>
+</div>
 ```
 
 #### CSS

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -54,26 +54,25 @@ The `mask-type` property is specified as one of the keyword values listed below.
 #### HTML
 
 ```html
-<div class="redsquare">
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
-    <defs>
-      <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:alpha">
-        <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7" />
-      </mask>
-    </defs>
-  </svg>
-</div>
+<div class="graysquare"></div>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
+  <defs>
+    <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:alpha">
+      <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7"/>
+    </mask>
+  </defs>
+</svg>
 ```
 
 #### CSS
 
 ```css
-.redsquare {
-  height: 100px;
-  width: 100px;
-  background-color: rgb(128, 128, 128);
-  border: solid 1px black;
-  mask: url("#m");
+.graysquare {
+    height: 100px;
+    width: 100px;
+    background-color: gray;
+    border: solid 1px #000;
+    mask: url(#m);
 }
 ```
 
@@ -86,26 +85,25 @@ The `mask-type` property is specified as one of the keyword values listed below.
 #### HTML
 
 ```html
-<div class="redsquare">
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
-    <defs>
-      <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:luminance">
-        <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7" />
-      </mask>
-    </defs>
-  </svg>
-</div>
+<div class="graysquare"></div>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
+  <defs>
+    <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:luminance">
+      <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7"/>
+    </mask>
+  </defs>
+</svg>
 ```
 
 #### CSS
 
 ```css
-.redsquare {
-  height: 100px;
-  width: 100px;
-  background-color: rgb(128, 128, 128);
-  border: solid 1px black;
-  mask: url("#m");
+.graysquare {
+    height: 100px;
+    width: 100px;
+    background-color: gray;
+    border: solid 1px #000;
+    mask: url(#m)
 }
 ```
 

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -55,12 +55,13 @@ The `mask-type` property is specified as one of the keyword values listed below.
 
 ```html
 <div class="redsquare">
-   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
-   <defs>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
+    <defs>
       <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:alpha">
-         <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7"/>
+        <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7" />
       </mask>
-   </defs>
+    </defs>
+  </svg>
 </div>
 ```
 
@@ -86,13 +87,13 @@ The `mask-type` property is specified as one of the keyword values listed below.
 
 ```html
 <div class="redsquare">
-   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
-      <defs>
-         <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:luminance">
-            <rect x=".1" y=".1" width=".8" height=".8"fill="red" fill-opacity=".7"/>
-         </mask>
-      </defs>
-   </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
+    <defs>
+      <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:luminance">
+        <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7" />
+      </mask>
+    </defs>
+  </svg>
 </div>
 ```
 

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -55,12 +55,10 @@ The `mask-type` property is specified as one of the keyword values listed below.
 
 ```html
 <div class="graysquare"></div>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
-  <defs>
-    <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:alpha">
-      <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7"/>
-    </mask>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 512 512">
+  <mask id="m">
+    <path d="M501 96H11c-6 0-11 5-11 11v298c0 6 5 11 11 11h490c6 0 11-5 11-11V107c0-6-5-11-11-11zm-10 299H21V117h470v278z"/>
+  </mask>
 </svg>
 ```
 
@@ -68,17 +66,22 @@ The `mask-type` property is specified as one of the keyword values listed below.
 
 ```css
 .graysquare {
-    height: 100px;
-    width: 100px;
+    height: 515px;
+    width: 515px;
     background-color: gray;
     border: solid 1px black;
-    mask: url("#m");
+    -webkit-mask: url(#m);
+            mask: url(#m);
+}
+
+mask{
+  mask-type: alpha;
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample('Setting_an_alpha_mask', '100%', '102')}}
+{{EmbedLiveSample('Setting_an_alpha_mask', '100%', '530')}}
 
 ### Setting a luminance mask
 
@@ -86,12 +89,10 @@ The `mask-type` property is specified as one of the keyword values listed below.
 
 ```html
 <div class="graysquare"></div>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0">
-  <defs>
-    <mask id="m" maskContentUnits="objectBoundingBox" style="mask-type:luminance">
-      <rect x=".1" y=".1" width=".8" height=".8" fill="red" fill-opacity=".7"/>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 512 512">
+    <mask id="m">
+  <path d="M501 96H11c-6 0-11 5-11 11v298c0 6 5 11 11 11h490c6 0 11-5 11-11V107c0-6-5-11-11-11zm-10 299H21V117h470v278z"/>
     </mask>
-  </defs>
 </svg>
 ```
 
@@ -99,11 +100,16 @@ The `mask-type` property is specified as one of the keyword values listed below.
 
 ```css
 .graysquare {
-    height: 100px;
-    width: 100px;
+    height: 515px;
+    width: 515px;
     background-color: gray;
     border: solid 1px black;
-    mask: url("#m");
+    -webkit-mask: url(#m);
+            mask: url(#m);
+}
+
+mask{
+  mask-type: luminance;
 }
 ```
 


### PR DESCRIPTION
Making SVG more efficient with less code.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
Some SVG properties are useless in today's world.

> Anything else that could help us review it
