### PR TITLE
Remove duplicated hardcoded id in Pointer Events

### DIFF
--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -360,7 +360,7 @@ tags:
 <p><strong>Note:</strong> The <code>button</code> property indicates a change in the state of the button. However, as in the case of touch, when multiple events occur with one event, all of them have the same value.</p>
 </div>
 
-<h2>Pointer capture</h2>
+<h2>Capturing the pointer</h2>
 
 <p>Pointer capture allows events for a particular {{domxref("PointerEvent","pointer event")}} to be re-targeted to a particular element instead of the normal <a href="#hit_test">hit test</a> at a pointer's location. This can be used to ensure that an element continues to receive pointer events even if the pointer device's contact moves off the element (for example by scrolling).</p>
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -360,7 +360,7 @@ tags:
 <p><strong>Note:</strong> The <code>button</code> property indicates a change in the state of the button. However, as in the case of touch, when multiple events occur with one event, all of them have the same value.</p>
 </div>
 
-<h2 id="Pointer_capture">Pointer capture</h2>
+<h2>Pointer capture</h2>
 
 <p>Pointer capture allows events for a particular {{domxref("PointerEvent","pointer event")}} to be re-targeted to a particular element instead of the normal <a href="#hit_test">hit test</a> at a pointer's location. This can be used to ensure that an element continues to receive pointer events even if the pointer device's contact moves off the element (for example by scrolling).</p>
 


### PR DESCRIPTION
There were two headings with the same creating a sectioning flaw. This fixes it.