### PR TITLE
Removed broken transcluded examples in WebGLRenderingContext

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/index.html
@@ -330,20 +330,6 @@ var gl = canvas.getContext('webgl');
  <dd>Returns an extension object.</dd>
 </dl>
 
-<h2 id="Examples">Examples</h2>
-
-<h3 id="WebGL_context_feature_detection">WebGL context feature detection</h3>
-
-<p>{{page("/en-US/docs/Web/API/WebGL_API/By_example/Detect_WebGL", "detect-webgl-intro")}}</p>
-
-<h3 id="Effect_of_canvas_size_on_rendering_with_WebGL">Effect of canvas size on rendering with WebGL</h3>
-
-<p>{{page("/en-US/docs/Web/API/WebGL_API/By_example/Canvas_size_and_WebGL", "canvas-size-and-webgl-intro")}}</p>
-
-<p>{{page("/en-US/docs/Web/API/WebGL_API/By_example/Canvas_size_and_WebGL", "canvas-size-and-webgl-source")}}</p>
-
-<p>{{EmbedLiveSample("canvas-size-and-webgl-source", 660,180 ,"" , "/Web/API/WebGL_API/By_example/Canvas_size_and_WebGL")}}</p>
-
 <h2 id="Specifications">Specifications</h2>
 
 {{Specifications}}


### PR DESCRIPTION
These examples are broken and don't exist on the other pages.

More, they don't bring much (if anything) buried on this page.

So I just removed them.