### PR TITLE
Remove link to mozSetFileNameArray, deleted

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -354,8 +354,6 @@ browser-compat: api.HTMLInputElement
  <dd>Sets the files selected on the input to the given array of {{domxref("File")}} objects. This is an alternative to <code>mozSetFileNameArray()</code> which can be used in frame scripts: a chrome script can <a href="/en-US/docs/Extensions/Using_the_DOM_File_API_in_chrome_code">open files as File objects</a> and send them via <a href="/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox/The_message_manager">message manager</a>.</dd>
  <dt>{{domxref("HTMLInputElement.mozGetFileNameArray()")}} {{non-standard_inline}}</dt>
  <dd>Returns an array of all the file names from the input.</dd>
- <dt>{{domxref("HTMLInputElement.mozSetFileNameArray()")}} {{non-standard_inline}}</dt>
- <dd>Sets the filenames for the files selected on the input. Not for use in <a href="/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox/Limitations_of_frame_scripts">frame scripts</a>, because it accesses the file system.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>


### PR DESCRIPTION
This entry has been deleted. As it was non-standard, and was removed, I removed the link.