### PR TITLE
Remove outdated comments in HTMLTableCellElement

### DIFF
--- a/files/en-us/web/api/htmltablecellelement/index.html
+++ b/files/en-us/web/api/htmltablecellelement/index.html
@@ -94,5 +94,5 @@ browser-compat: api.HTMLTableCellElement
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>The HTML elements implementing this interface: {{HTMLElement("th")}} and {{HTMLElement("td")}} by inheritance via {{domxref("HTMLTableHeaderCellElement")}} {{deprecated_inline}} and {{domxref("HTMLTableDataCellElement")}} {{deprecated_inline}}.</li>
+ <li>The HTML elements implementing this interface: {{HTMLElement("th")}} and {{HTMLElement("td")}}.</li>
 </ul>


### PR DESCRIPTION
The comment wasn't true for 10+ years.