### PR TITLE
Fix broken link in navigator.mediaDevices

### DIFF
--- a/files/en-us/web/api/navigator/mediadevices/index.html
+++ b/files/en-us/web/api/navigator/mediadevices/index.html
@@ -28,7 +28,7 @@ browser-compat: api.Navigator.mediaDevices
 
 <p>The {{domxref("MediaDevices")}} singleton object. Usually, you just use this object's
   members directly, such as by calling
-  {{domxref("navigator.mediaDevices.getUserMedia()")}}.</p>
+  {{domxref("MediaDevices.getUserMedia", "navigator.mediaDevices.getUserMedia()")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
The link was an example of use, so I kept the text but linked it to the right document.