### PR TITLE
Replace broken html entity with actual ellipsis

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.html
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.html
@@ -34,7 +34,7 @@ tags:
   &lt;legend&gt;Planet information&lt;/legend&gt;
   &lt;label for="planetsSelect"&gt;Planet:&lt;/label&gt;
   &lt;select id="planetsSelect" aria-controls="planetInfo"&gt;
-    &lt;option value=""&gt;Select a planet...&lt;/option&gt;
+    &lt;option value=""&gt;Select a planet…&lt;/option&gt;
     &lt;option value="mercury"&gt;Mercury&lt;/option&gt;
     &lt;option value="venus"&gt;Venus&lt;/option&gt;
     &lt;option value="earth"&gt;Earth&lt;/option&gt;

--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.html
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.html
@@ -34,7 +34,7 @@ tags:
   &lt;legend&gt;Planet information&lt;/legend&gt;
   &lt;label for="planetsSelect"&gt;Planet:&lt;/label&gt;
   &lt;select id="planetsSelect" aria-controls="planetInfo"&gt;
-    &lt;option value=""&gt;Select a planet&amp;hellip;&lt;/option&gt;
+    &lt;option value=""&gt;Select a planet...&lt;/option&gt;
     &lt;option value="mercury"&gt;Mercury&lt;/option&gt;
     &lt;option value="venus"&gt;Venus&lt;/option&gt;
     &lt;option value="earth"&gt;Earth&lt;/option&gt;


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None.

> What was wrong/why is this fix needed? (quick summary only)

The HTML entity for ellipsis in the following code block is not encoded correctly. This PR addresses the issue by replacing it with a simple ellipsis.

<img width="589" alt="Screen Shot 2021-09-01 at 21 15 30" src="https://user-images.githubusercontent.com/25715018/131688172-50c6d63e-18cb-4157-a05f-c5f325c0e89c.png">

> Anything else that could help us review it

Screenshot of the result:

<img width="586" alt="Screen Shot 2021-09-01 at 21 16 06" src="https://user-images.githubusercontent.com/25715018/131688524-c3fc3106-7384-4cac-a251-1ca9964016ae.png">
