### PR TITLE
Fix MediaCapabilities.decodingInfo() example

### DIFF
--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.html
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.html
@@ -48,7 +48,7 @@ browser-compat: api.MediaCapabilities.decodingInfo
 const mediaConfig = {
     type : 'file', // or 'media-source'
     audio : {
-        contentType : &quot;audio/ogg&quot;, // valid content type
+        contentType : &quot;audio/ogg; codecs=vorbis&quot;, // valid content type
         channels : 2,     // audio channels used by the track
         bitrate : 132700, // number of bits used to encode 1s of audio
         samplerate : 5200 // number of audio samples making up that 1s.


### PR DESCRIPTION
The example given doesn't work as intended because a codec must be specified for the `audio/ogg` mime type for the browser to report the info without ambiguity.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

No issue exists to my knowledge

> What was wrong/why is this fix needed? (quick summary only)

The code doesn't work as expected. This can be checked by running the two statements in the browser console.

> Anything else that could help us review it

Nothing specific, feel free to reach out if you have queries.