### PR TITLE
[Markdown] [Web/API] Fix unconvertible strong/code markup

### DIFF
--- a/files/en-us/web/api/animation/currenttime/index.html
+++ b/files/en-us/web/api/animation/currenttime/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Animation.currentTime
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
-<p>The <code><strong>Animation</strong></code><strong><code>.currentTime</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns and sets the current time value of the animation in milliseconds, whether running or paused.</p>
+<p>The <strong><code>Animation.currentTime</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns and sets the current time value of the animation in milliseconds, whether running or paused.</p>
 
 <p>If the animation lacks a {{domxref("AnimationTimeline", "timeline")}}, is inactive, or hasn't been played yet, <code>currentTime</code>'s return value is <code>null</code>.</p>
 

--- a/files/en-us/web/api/animation/effect/index.html
+++ b/files/en-us/web/api/animation/effect/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Animation.effect
 ---
 <div>{{ SeeCompatTable() }} {{ APIRef("Web Animations") }}</div>
 
-<p>The <code><strong>Animation</strong></code><strong><code>.effect</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> gets and sets the target effect of an animation. The target effect may be either an effect object of a type based on {{domxref("AnimationEffect")}}, such as {{domxref("KeyframeEffect")}}, or <code>null</code>.</p>
+<p>The <strong><code>Animation.effect</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> gets and sets the target effect of an animation. The target effect may be either an effect object of a type based on {{domxref("AnimationEffect")}}, such as {{domxref("KeyframeEffect")}}, or <code>null</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/animation/finished/index.html
+++ b/files/en-us/web/api/animation/finished/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Animation.finished
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
-<p>The <code><strong>Animation</strong></code><strong><code>.finished</code></strong> read-only property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns a {{jsxref("Promise")}} which resolves once the animation has finished playing.</p>
+<p>The <strong><code>Animation.finished</code></strong> read-only property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns a {{jsxref("Promise")}} which resolves once the animation has finished playing.</p>
 
 <div class="note">
 <p><strong>Note:</strong> Every time the animation leaves the <code>finished</code> play state (that is, when it starts playing again), a new <code>Promise</code> is created for this property. The new <code>Promise</code> will resolve once the new animation sequence has completed.</p>

--- a/files/en-us/web/api/animation/id/index.html
+++ b/files/en-us/web/api/animation/id/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Animation.id
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
-<p>The <code><strong>Animation</strong></code><strong><code>.id</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns or sets a string used to identify the animation.</p>
+<p>The <strong><code>Animation.id</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns or sets a string used to identify the animation.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/animation/pending/index.html
+++ b/files/en-us/web/api/animation/pending/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Animation.pending
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
-<p>The read-only <code><strong>Animation</strong></code><strong><code>.pending</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> indicates whether the animation is currently waiting for an asynchronous operation such as initiating playback or pausing a running animation.</p>
+<p>The read-only <strong><code>Animation.pending</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> indicates whether the animation is currently waiting for an asynchronous operation such as initiating playback or pausing a running animation.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/animation/playbackrate/index.html
+++ b/files/en-us/web/api/animation/playbackrate/index.html
@@ -14,7 +14,7 @@ browser-compat: api.Animation.playbackRate
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
-<p>The <code><strong>Animation</strong></code><strong><code>.playbackRate</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns or sets the playback rate of the animation.</p>
+<p>The <strong><code>Animation.playbackRate</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns or sets the playback rate of the animation.</p>
 
 <p>Animations have a <strong>playback rate</strong> that provides a scaling factor from the rate of change of the animation's {{domxref("DocumentTimeline", "timeline")}} time values to the animation’s current time. The playback rate is initially <code>1</code>.</p>
 

--- a/files/en-us/web/api/animation/playstate/index.html
+++ b/files/en-us/web/api/animation/playstate/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Animation.playState
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
-<p>The <code><strong>Animation</strong></code><strong><code>.playState</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns and sets an enumerated value describing the playback state of an animation.</p>
+<p>The <strong><code>Animation.playState</code></strong> property of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> returns and sets an enumerated value describing the playback state of an animation.</p>
 
 <div class="note">
 <p><strong>Note:</strong> This property is read-only for CSS Animations and Transitions.</p>

--- a/files/en-us/web/api/cachestorage/delete/index.html
+++ b/files/en-us/web/api/cachestorage/delete/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CacheStorage.delete
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
-<p>The <code><strong>delete</strong></code><strong><code>()</code></strong> method of the
+<p>The <strong><code>delete()</code></strong> method of the
   {{domxref("CacheStorage")}} interface finds the {{domxref("Cache")}} object matching the
   <code>cacheName</code>, and if found, deletes the {{domxref("Cache")}} object and
   returns a {{jsxref("Promise")}} that resolves to <code>true</code>. If no

--- a/files/en-us/web/api/cachestorage/keys/index.html
+++ b/files/en-us/web/api/cachestorage/keys/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CacheStorage.keys
 <p>{{APIRef("Service Workers API")}}</p>
 
 <p>The
-    <code><strong>keys</strong></code><strong><code>()</code></strong> method of the
+    <strong><code>keys()</code></strong> method of the
     {{domxref("CacheStorage")}} interface returns a {{jsxref("Promise")}} that will
     resolve with an array containing strings corresponding to all of the named
     {{domxref("Cache")}} objects tracked by the {{domxref("CacheStorage")}} object in the

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.html
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasGradient.addColorStop
 <div>{{APIRef("Canvas API")}}</div>
 
 <p>The
-  <code><strong>CanvasGradient</strong></code><strong><code>.addColorStop()</code></strong>
+  <strong><code>CanvasGradient.addColorStop()</code></strong>
   method adds a new color stop, defined by an <code>offset</code> and a
   <code>color</code>, to a given canvas gradient.</p>
 

--- a/files/en-us/web/api/canvaspattern/settransform/index.html
+++ b/files/en-us/web/api/canvaspattern/settransform/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasPattern.setTransform
 <div>{{APIRef("Canvas API")}}</div>
 
 <p>The
-  <code><strong>CanvasPattern</strong></code><strong><code>.setTransform()</code></strong>
+  <strong><code>CanvasPattern.setTransform()</code></strong>
   method uses an {{domxref("SVGMatrix")}} or {{domxref("DOMMatrix")}} object as the
   pattern's transformation matrix and invokes it on the pattern.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/arc/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arc/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.arc
 <div>{{APIRef}}</div>
 
 <p>The
-    <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.arc()</code></strong>
+    <strong><code>CanvasRenderingContext2D.arc()</code></strong>
     method of the <a href="/en-US/docs/Web/API/CanvasRenderingContext2D">Canvas 2D API
     </a>adds a circular arc to the current sub-path.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.arcTo
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.arcTo()</code></strong>
+  <strong><code>CanvasRenderingContext2D.arcTo()</code></strong>
   method of the Canvas 2D API adds a circular arc to the current sub-path, using the given
   control points and radius. The arc is automatically connected to the path's latest point
   with a straight line, if necessary for the specified parameters.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.beginPath
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.beginPath()</code></strong>
+  <strong><code>CanvasRenderingContext2D.beginPath()</code></strong>
   method of the Canvas 2D API starts a new path by emptying the list of sub-paths. Call
   this method when you want to create a new path.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.bezierCurveTo
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.bezierCurveTo()</code></strong>
+  <strong><code>CanvasRenderingContext2D.bezierCurveTo()</code></strong>
   method of the Canvas 2D API adds a cubic <a
     href="https://en.wikipedia.org/wiki/B%C3%A9zier_curve">Bézier curve</a> to the current
   sub-path. It requires three points: the first two are control points and the third one

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.clearRect
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.clearRect()</code></strong>
+  <strong><code>CanvasRenderingContext2D.clearRect()</code></strong>
   method of the Canvas 2D API erases the pixels in a rectangular area by setting them to
   transparent black.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.clip
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.clip()</code></strong>
+  <strong><code>CanvasRenderingContext2D.clip()</code></strong>
   method of the Canvas 2D API turns the current or given path into the current clipping
   region. The previous clipping region, if any, is intersected with the current or given
   path to create the new clipping region.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.closePath
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.closePath()</code></strong>
+  <strong><code>CanvasRenderingContext2D.closePath()</code></strong>
   method of the Canvas 2D API attempts to add a straight line from the current point to
   the start of the current sub-path. If the shape has already been closed or has only one
   point, this function does nothing.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.createLinearGradient
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.createLinearGradient()</code></strong>
+  <strong><code>CanvasRenderingContext2D.createLinearGradient()</code></strong>
   method of the Canvas 2D API creates a gradient along the line connecting two given
   coordinates.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.createPattern
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.createPattern()</code></strong>
+  <strong><code>CanvasRenderingContext2D.createPattern()</code></strong>
   method of the Canvas 2D API creates a pattern using the specified image and repetition.
   This method returns a {{domxref("CanvasPattern")}}.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.createRadialGradient
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.createRadialGradient()</code></strong>
+  <strong><code>CanvasRenderingContext2D.createRadialGradient()</code></strong>
   method of the Canvas 2D API creates a radial gradient using the size and coordinates of
   two circles.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CanvasRenderingContext2D.currentTransform
 <div>{{deprecated_header}}{{non-standard_header}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.currentTransform</code></strong>
+  <strong><code>CanvasRenderingContext2D.currentTransform</code></strong>
   property of the Canvas 2D API returns or sets a {{domxref("DOMMatrix")}} (current
   specification) or {{domxref("SVGMatrix")}} {{deprecated_inline}} (old specification)
   object for the current transformation matrix.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/direction/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/direction/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.direction
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.direction</code></strong>
+  <strong><code>CanvasRenderingContext2D.direction</code></strong>
   property of the Canvas 2D API specifies the current text direction used to draw text.
 </p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.drawFocusIfNeeded
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.drawFocusIfNeeded()</code></strong>
+  <strong><code>CanvasRenderingContext2D.drawFocusIfNeeded()</code></strong>
   method of the Canvas 2D API draws a focus ring around the current or given path, if the
   specified element is focused.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CanvasRenderingContext2D.drawWindow
 <div>{{APIRef}} {{deprecated_header}}</div>
 
 <p>The deprecated, non-standard and internal only
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.drawWindow()</code></strong>
+  <strong><code>CanvasRenderingContext2D.drawWindow()</code></strong>
   method of the Canvas 2D API renders a region of a window into the <code>canvas</code>.
   The contents of the window's viewport are rendered, ignoring viewport clipping and
   scrolling.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.ellipse
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.ellipse()</code></strong>
+  <strong><code>CanvasRenderingContext2D.ellipse()</code></strong>
   method of the Canvas 2D API adds an elliptical arc to the current sub-path.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/canvasrenderingcontext2d/fill/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fill/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.fill
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.fill()</code></strong>
+  <strong><code>CanvasRenderingContext2D.fill()</code></strong>
   method of the Canvas 2D API fills the current or given path with the current
   {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}}.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.fillRect
 <div>{{APIRef}}</div>
 
 <p>The
-    <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.fillRect()</code></strong>
+    <strong><code>CanvasRenderingContext2D.fillRect()</code></strong>
     method of the Canvas 2D API draws a rectangle that is filled according to the current
     {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}}.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.fillStyle
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.fillStyle</code></strong>
+  <strong><code>CanvasRenderingContext2D.fillStyle</code></strong>
   property of the <a href="/en-US/docs/Web/API/Canvas_API">Canvas 2D API</a> specifies the
   color, gradient, or pattern to use inside shapes. The default style is <code>#000</code>
   (black).</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.filter
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.filter</code></strong>
+  <strong><code>CanvasRenderingContext2D.filter</code></strong>
   property of the Canvas 2D API provides filter effects such as blurring and grayscaling.
   It is similar to the CSS {{cssxref("filter")}} property and accepts the same values.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/font/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/font/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.font
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.font</code></strong>
+  <strong><code>CanvasRenderingContext2D.font</code></strong>
   property of the Canvas 2D API specifies the current text style to use when drawing text.
   This string uses the same syntax as the <a href="/en-US/docs/Web/CSS/font">CSS font</a>
   specifier.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.getTransform
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.getTransform()</code></strong>
+  <strong><code>CanvasRenderingContext2D.getTransform()</code></strong>
   method of the Canvas 2D API retrieves the current transformation matrix being applied to
   the context.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.globalAlpha
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.globalAlpha</code></strong>
+  <strong><code>CanvasRenderingContext2D.globalAlpha</code></strong>
   property of the Canvas 2D API specifies the alpha (transparency) value that is applied
   to shapes and images before they are drawn onto the canvas.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.html
@@ -14,7 +14,7 @@ browser-compat: api.CanvasRenderingContext2D.globalCompositeOperation
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.globalCompositeOperation</code></strong>
+  <strong><code>CanvasRenderingContext2D.globalCompositeOperation</code></strong>
   property of the Canvas 2D API sets the type of compositing operation to apply when
   drawing new shapes.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.isPointInPath
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.isPointInPath()</code></strong>
+  <strong><code>CanvasRenderingContext2D.isPointInPath()</code></strong>
   method of the Canvas 2D API reports whether or not the specified point is contained in
   the current path.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.isPointInStroke
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.isPointInStroke()</code></strong>
+  <strong><code>CanvasRenderingContext2D.isPointInStroke()</code></strong>
   method of the Canvas 2D API reports whether or not the specified point is inside the
   area contained by the stroking of a path.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.lineCap
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.lineCap</code></strong>
+  <strong><code>CanvasRenderingContext2D.lineCap</code></strong>
   property of the Canvas 2D API determines the shape used to draw the end points of lines.
 </p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.lineDashOffset
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.lineDashOffset</code></strong>
+  <strong><code>CanvasRenderingContext2D.lineDashOffset</code></strong>
   property of the Canvas 2D API sets the line dash offset, or "phase."</p>
 
 <div class="notecard note">

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.lineJoin
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.lineJoin</code></strong>
+  <strong><code>CanvasRenderingContext2D.lineJoin</code></strong>
   property of the Canvas 2D API determines the shape used to join two line segments where
   they meet.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.lineWidth
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.lineWidth</code></strong>
+  <strong><code>CanvasRenderingContext2D.lineWidth</code></strong>
   property of the Canvas 2D API sets the thickness of lines.</p>
 
 <div class="notecard note">

--- a/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.moveTo
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.moveTo()</code></strong>
+  <strong><code>CanvasRenderingContext2D.moveTo()</code></strong>
   method of the Canvas 2D API begins a new sub-path at the point specified by the given
   <code>(x, y)</code> coordinates.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.putImageData
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.putImageData()</code></strong>
+  <strong><code>CanvasRenderingContext2D.putImageData()</code></strong>
   method of the Canvas 2D API paints data from the given {{domxref("ImageData")}} object
   onto the canvas. If a dirty rectangle is provided, only the pixels from that rectangle
   are painted. This method is not affected by the canvas transformation matrix.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.quadraticCurveTo
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.quadraticCurveTo()</code></strong>
+  <strong><code>CanvasRenderingContext2D.quadraticCurveTo()</code></strong>
   method of the Canvas 2D API adds a quadratic <a
     href="https://en.wikipedia.org/wiki/B%C3%A9zier_curve">Bézier curve</a> to the current
   sub-path. It requires two points: the first one is a control point and the second one is

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.rect
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.rect()</code></strong>
+  <strong><code>CanvasRenderingContext2D.rect()</code></strong>
   method of the Canvas 2D API adds a rectangle to the current path.</p>
 
 <p>Like other methods that modify the current path, this method does not directly render

--- a/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.resetTransform
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.resetTransform()</code></strong>
+  <strong><code>CanvasRenderingContext2D.resetTransform()</code></strong>
   method of the Canvas 2D API resets the current transform to the identity matrix.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.restore
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.restore()</code></strong>
+  <strong><code>CanvasRenderingContext2D.restore()</code></strong>
   method of the Canvas 2D API restores the most recently saved canvas state by popping the
   top entry in the drawing state stack. If there is no saved state, this method does
   nothing.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.rotate
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.rotate()</code></strong>
+  <strong><code>CanvasRenderingContext2D.rotate()</code></strong>
   method of the Canvas 2D API adds a rotation to the transformation matrix.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.save
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.save()</code></strong>
+  <strong><code>CanvasRenderingContext2D.save()</code></strong>
   method of the Canvas 2D API saves the entire state of the canvas by pushing the current
   state onto a stack.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.scale
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.scale()</code></strong>
+  <strong><code>CanvasRenderingContext2D.scale()</code></strong>
   method of the Canvas 2D API adds a scaling transformation to the canvas units
   horizontally and/or vertically.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.scrollPathIntoView
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.scrollPathIntoView()</code></strong>
+  <strong><code>CanvasRenderingContext2D.scrollPathIntoView()</code></strong>
   method of the Canvas 2D API scrolls the current or given path into view. It is similar
   to {{domxref("Element.scrollIntoView()")}}.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.setTransform
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.setTransform()</code></strong>
+  <strong><code>CanvasRenderingContext2D.setTransform()</code></strong>
   method of the Canvas 2D API resets (overrides) the current transformation to the
   identity matrix, and then invokes a transformation described by the arguments of this
   method. This lets you scale, rotate, translate (move), and skew the context.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowBlur
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.shadowBlur</code></strong>
+  <strong><code>CanvasRenderingContext2D.shadowBlur</code></strong>
   property of the Canvas 2D API specifies the amount of blur applied to shadows. The
   default is <code>0</code> (no blur).</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowColor
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.shadowColor</code></strong>
+  <strong><code>CanvasRenderingContext2D.shadowColor</code></strong>
   property of the Canvas 2D API specifies the color of shadows.</p>
 
 <p>Be aware that the shadow's rendered opacity will be affected by the opacity of the

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowOffsetX
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.shadowOffsetX</code></strong>
+  <strong><code>CanvasRenderingContext2D.shadowOffsetX</code></strong>
   property of the Canvas 2D API specifies the distance that shadows will be offset
   horizontally.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.shadowOffsetY
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.shadowOffsetY</code></strong>
+  <strong><code>CanvasRenderingContext2D.shadowOffsetY</code></strong>
   property of the Canvas 2D API specifies the distance that shadows will be offset
   vertically.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.stroke
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.stroke()</code></strong>
+  <strong><code>CanvasRenderingContext2D.stroke()</code></strong>
   method of the Canvas 2D API strokes (outlines) the current or given path with the
   current stroke style.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.strokeRect
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.strokeRect()</code></strong>
+  <strong><code>CanvasRenderingContext2D.strokeRect()</code></strong>
   method of the Canvas 2D API draws a rectangle that is stroked (outlined) according to
   the current {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}} and other
   context settings.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.textAlign
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.textAlign</code></strong>
+  <strong><code>CanvasRenderingContext2D.textAlign</code></strong>
   property of the Canvas 2D API specifies the current text alignment used when drawing
   text.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.textBaseline
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.textBaseline</code></strong>
+  <strong><code>CanvasRenderingContext2D.textBaseline</code></strong>
   property of the Canvas 2D API specifies the current text baseline used when drawing
   text.</p>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.transform
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.transform()</code></strong>
+  <strong><code>CanvasRenderingContext2D.transform()</code></strong>
   method of the Canvas 2D API multiplies the current transformation with the matrix
   described by the arguments of this method. This lets you scale, rotate, translate
   (move), and skew the context.</p>

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CanvasRenderingContext2D.translate
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>CanvasRenderingContext2D</strong></code><strong><code>.translate()</code></strong>
+  <strong><code>CanvasRenderingContext2D.translate()</code></strong>
   method of the Canvas 2D API adds a translation transformation to the current matrix.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/clients/get/index.html
+++ b/files/en-us/web/api/clients/get/index.html
@@ -13,7 +13,7 @@ browser-compat: api.Clients.get
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
-<p>The <code><strong>get</strong></code><strong><code>()</code></strong> method of the
+<p>The <strong><code>get()</code></strong> method of the
   {{domxref("Clients")}} interface gets a service worker client matching a given
   <code>id</code> and returns it in a {{jsxref("Promise")}}.</p>
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -12,7 +12,7 @@ browser-compat: api.CompositionEvent.initCompositionEvent
 ---
 <p>{{deprecated_header}}{{APIRef("DOM Events")}}</p>
 
-<p>The <code><strong>initCompositionEvent</strong></code><strong><code>()</code></strong>
+<p>The <strong><code>initCompositionEvent()</code></strong>
   method of the {{domxref("CompositionEvent")}} interface initializes the attributes of a
   <code>CompositionEvent</code> object instance.</p>
 

--- a/files/en-us/web/api/eventsource/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/eventsource/index.html
@@ -11,7 +11,7 @@ browser-compat: api.EventSource.EventSource
 ---
 <div>{{APIRef('WebSockets API')}}</div>
 
-<p>The <code><strong>EventSource</strong></code><strong><code>()</code></strong>
+<p>The <strong><code>EventSource()</code></strong>
   constructor returns a newly-created {{domxref("EventSource")}}, which represents a
   remote resource.</p>
 

--- a/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.html
+++ b/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.html
@@ -13,7 +13,7 @@ browser-compat: api.ExtendableMessageEvent.ExtendableMessageEvent
 <p>{{APIRef("Service Workers API")}}</p>
 
 <p>The
-  <code><strong>Extendable</strong></code><strong><code>MessageEvent()</code></strong>
+  <strong><code>ExtendableMessageEvent()</code></strong>
   constructor creates a new {{domxref("ExtendableMessageEvent")}} object instance.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/filesystemdirectoryentry/createreader/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/createreader/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemDirectoryEntry.createReader
 <p>{{APIRef("File and Directory Entries API")}}</p>
 
 <p>The {{domxref("FileSystemDirectoryEntry")}} interface's method
-  <code><strong>createReader</strong></code><strong><code>()</code></strong> returns a
+  <strong><code>createReader()</code></strong> returns a
   {{domxref("FileSystemDirectoryReader")}} object which can be used to read the entries in
   the directory.</p>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemDirectoryEntry.getDirectory
 <p>{{APIRef("File and Directory Entries API")}}</p>
 
 <p>The {{domxref("FileSystemDirectoryEntry")}} interface's method
-  <code><strong>getDirectory</strong></code><strong><code>()</code></strong> returns a
+  <strong><code>getDirectory()</code></strong> returns a
   {{domxref("FileSystemDirectoryEntry")}} object corresponding to a directory contained
   somewhere within the directory subtree rooted at the directory on which it's called.</p>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemDirectoryEntry.getFile
 <p>{{APIRef("File and Directory Entries API")}}</p>
 
 <p>The {{domxref("FileSystemDirectoryEntry")}} interface's method
-  <code><strong>getFile</strong></code><strong><code>()</code></strong> returns a
+  <strong><code>getFile()</code></strong> returns a
   {{domxref("FileSystemFileEntry")}} object corresponding to a file contained somewhere
   within the directory subtree rooted at the directory on which it's called.</p>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.html
@@ -17,7 +17,7 @@ browser-compat: api.FileSystemDirectoryEntry.removeRecursively
 <p>{{APIRef("File System API")}}{{deprecated_header}}{{SeeCompatTable}}</p>
 
 <p>The {{domxref("FileSystemDirectoryEntry")}} interface's method
-  <code><strong>removeRecursively</strong></code><strong><code>()</code></strong> removes
+  <strong><code>removeRecursively()</code></strong> removes
   the directory as well as all of its content, hierarchically iterating over its entire
   subtree of descendant files and directories.</p>
 

--- a/files/en-us/web/api/filesystementry/copyto/index.html
+++ b/files/en-us/web/api/filesystementry/copyto/index.html
@@ -17,7 +17,7 @@ browser-compat: api.FileSystemEntry.copyTo
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
 <p>The {{domxref("FileSystemEntry")}} interface's method
-    <code><strong>copyTo</strong></code><strong><code>()</code></strong> copies the file
+    <strong><code>copyTo()</code></strong> copies the file
     specified by the entry to a new location on the file system.</p>
 
 <p>There are some

--- a/files/en-us/web/api/filesystementry/getmetadata/index.html
+++ b/files/en-us/web/api/filesystementry/getmetadata/index.html
@@ -17,7 +17,7 @@ browser-compat: api.FileSystemEntry.getMetadata
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
 <p>The {{domxref("FileSystemEntry")}} interface's method
-    <code><strong>getMetadata</strong></code><strong><code>()</code></strong> obtains a
+    <strong><code>getMetadata()</code></strong> obtains a
     {{domxref("Metadata")}} object with information about the file system entry, such as
     its modification date and time and its size.</p>
 

--- a/files/en-us/web/api/filesystementry/getparent/index.html
+++ b/files/en-us/web/api/filesystementry/getparent/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemEntry.getParent
 <p>{{APIRef("File and Directory Entries API")}}</p>
 
 <p>The {{domxref("FileSystemEntry")}} interface's method
-    <code><strong>getParent</strong></code><strong><code>()</code></strong> obtains a
+    <strong><code>getParent()</code></strong> obtains a
     {{domxref("FileSystemDirectoryEntry")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/filesystementry/moveto/index.html
+++ b/files/en-us/web/api/filesystementry/moveto/index.html
@@ -17,7 +17,7 @@ browser-compat: api.FileSystemEntry.moveTo
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}{{deprecated_header}}</p>
 
 <p>The {{domxref("FileSystemEntry")}} interface's method
-    <code><strong>moveTo</strong></code><strong><code>()</code></strong> moves the file
+    <strong><code>moveTo()</code></strong> moves the file
     specified by the entry to a new location on the file system, or renames the file if
     the destination directory is the same as the source.</p>
 

--- a/files/en-us/web/api/filesystementry/remove/index.html
+++ b/files/en-us/web/api/filesystementry/remove/index.html
@@ -18,7 +18,7 @@ browser-compat: api.FileSystemEntry.remove
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
 <p>The {{domxref("FileSystemEntry")}} interface's method
-    <code><strong>remove</strong></code><strong><code>()</code></strong> deletes the file
+    <strong><code>remove()</code></strong> deletes the file
     or directory from the file system. Directories must be empty before they can be
     removed.</p>
 

--- a/files/en-us/web/api/filesystementry/tourl/index.html
+++ b/files/en-us/web/api/filesystementry/tourl/index.html
@@ -17,7 +17,7 @@ browser-compat: api.FileSystemEntry.toURL
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
 <p>The {{domxref("FileSystemEntry")}} interface's method
-    <code><strong>toURL</strong></code><strong><code>()</code></strong> creates and
+    <strong><code>toURL()</code></strong> creates and
     returns a string containing a URL which can be used to identify the file system entry.
     This is done by exposing a new URL scheme—<code>filesystem:</code>—that can be used as
     the value of <code>src</code> and <code>href</code> attributes.</p>

--- a/files/en-us/web/api/filesystemfileentry/file/index.html
+++ b/files/en-us/web/api/filesystemfileentry/file/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemFileEntry.file
 <p>{{APIRef("File and Directory Entries API")}}</p>
 
 <p>The {{domxref("FileSystemFileEntry")}} interface's method
-  <code><strong>file</strong></code><strong><code>()</code></strong> returns a
+  <strong><code>file()</code></strong> returns a
   {{domxref("File")}} object which can be used to read data from the file represented by
   the directory entry.</p>
 

--- a/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLAnchorElement.referrerPolicy
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>HTMLAnchorElement</strong></code><strong><code>.referrerPolicy</code></strong>
+  <strong><code>HTMLAnchorElement.referrerPolicy</code></strong>
   property reflect the HTML {{htmlattrxref("referrerpolicy","a")}} attribute of the
   {{HTMLElement("a")}} element defining which referrer is sent when fetching the resource.
 </p>

--- a/files/en-us/web/api/htmlareaelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlareaelement/referrerpolicy/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLAreaElement.referrerPolicy
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>HTMLAreaElement</strong></code><strong><code>.referrerPolicy</code></strong>
+  <strong><code>HTMLAreaElement.referrerPolicy</code></strong>
   property reflect the HTML {{htmlattrxref("referrerpolicy","area")}} attribute of the
   {{HTMLElement("area")}} element defining which referrer is sent when fetching the
   resource.</p>

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLCanvasElement.transferControlToOffscreen
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>HTMLCanvasElement</strong></code><strong><code>.transferControlToOffscreen()</code></strong>
+  <strong><code>HTMLCanvasElement.transferControlToOffscreen()</code></strong>
   method transfers control to an {{domxref("OffscreenCanvas")}} object, either on the main
   thread or on a worker.</p>
 

--- a/files/en-us/web/api/htmlfontelement/color/index.html
+++ b/files/en-us/web/api/htmlfontelement/color/index.html
@@ -13,7 +13,7 @@ browser-compat: api.HTMLFontElement.color
 <div>{{deprecated_header}}{{APIRef("HTML DOM")}}</div>
 
 <p>The obsolete
-    <code><strong>HTMLFontElement</strong></code><strong><code>.color</code></strong>
+    <strong><code>HTMLFontElement.color</code></strong>
     property is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("color",
     "font")}} HTML attribute, containing either a named color or a color specified in the
     hexadecimal #RRGGBB format.</p>

--- a/files/en-us/web/api/htmlfontelement/face/index.html
+++ b/files/en-us/web/api/htmlfontelement/face/index.html
@@ -16,7 +16,7 @@ browser-compat: api.HTMLFontElement.face
 <div>{{ APIRef("HTML DOM") }}</div>
 
 <p>The obsolete
-    <code><strong>HTMLFontElement</strong></code><strong><code>.face</code></strong>
+    <strong><code>HTMLFontElement.face</code></strong>
     property is a {{domxref("DOMString")}} that reflects the {{ htmlattrxref("face",
     "font") }} HTML attribute, containing a comma-separated list of one or more font
     names.</p>

--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLIFrameElement.referrerPolicy
 <div>{{APIRef}}</div>
 
 <p>The
-  <code><strong>HTMLIFrameElement</strong></code><strong><code>.referrerPolicy</code></strong>
+  <strong><code>HTMLIFrameElement.referrerPolicy</code></strong>
   property reflects the HTML {{htmlattrxref("referrerpolicy","iframe")}} attribute of the
   {{HTMLElement("iframe")}} element defining which referrer is sent when fetching the
   resource.</p>

--- a/files/en-us/web/api/htmliframeelement/src/index.html
+++ b/files/en-us/web/api/htmliframeelement/src/index.html
@@ -5,7 +5,7 @@ browser-compat: api.HTMLIFrameElement.src
 ---
 <div>{{APIRef}}</div>
 
-<p>The <code><strong>HTMLIFrameElement</strong></code><strong><code>.src</code></strong>
+<p>The <strong><code>HTMLIFrameElement.src</code></strong>
     property reflects the HTML {{htmlattrxref("referrerpolicy","src")}} attribute of the
     {{HTMLElement("iframe")}} element defining which referrer is sent when fetching the
     resource.</p>

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLImageElement.referrerPolicy
 <div>{{APIRef("HTML DOM")}}</div>
 
 <p>The
-  <code><strong>HTMLImageElement</strong></code><strong><code>.referrerPolicy</code></strong>
+  <strong><code>HTMLImageElement.referrerPolicy</code></strong>
   property reflects the HTML {{htmlattrxref("referrerpolicy","img")}} attribute of the
   {{HTMLElement("img")}} element defining which referrer is sent when fetching the
   resource.</p>

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLLinkElement.referrerPolicy
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
 <p>The
-  <code><strong>HTMLLinkElement</strong></code><strong><code>.referrerPolicy</code></strong>
+  <strong><code>HTMLLinkElement.referrerPolicy</code></strong>
   property reflect the HTML {{htmlattrxref("referrerpolicy","link")}} attribute of the
   {{HTMLElement("link")}} element defining which referrer is sent when fetching the
   resource.</p>

--- a/files/en-us/web/api/htmltimeelement/datetime/index.html
+++ b/files/en-us/web/api/htmltimeelement/datetime/index.html
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTimeElement.dateTime
 <div>{{ APIRef("HTML DOM") }}</div>
 
 <p>The
-  <code><strong>HTMLTimeElement</strong></code><strong><code>.dateTime</code></strong>
+  <strong><code>HTMLTimeElement.dateTime</code></strong>
   property is a {{domxref("DOMString")}} that reflects the {{ htmlattrxref("datetime",
   "time") }} HTML attribute, containing a machine-readable form of the element's date and
   time value.</p>

--- a/files/en-us/web/api/idledeadline/timeremaining/index.html
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.html
@@ -12,7 +12,7 @@ browser-compat: api.IdleDeadline.timeRemaining
 ---
 <p>{{APIRef("Background Tasks")}}{{SeeCompatTable}}</p>
 
-<p>The <code><strong>timeRemaining</strong></code><strong><code>()</code></strong> method
+<p>The <strong><code>timeRemaining()</code></strong> method
   on the {{domxref("IdleDeadline")}} interface returns the estimated number of
   milliseconds remaining in the current idle period. The callback can call this method at
   any time to determine how much time it can continue to work before it must return. For

--- a/files/en-us/web/api/imagebitmap/close/index.html
+++ b/files/en-us/web/api/imagebitmap/close/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ImageBitmap.close
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
-<p>The <code><strong>ImageBitmap</strong></code><strong><code>.close()</code></strong>
+<p>The <strong><code>ImageBitmap.close()</code></strong>
   method disposes of all graphical resources associated with an <code>ImageBitmap</code>.
 </p>
 

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.html
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.html
@@ -16,7 +16,7 @@ browser-compat: api.MediaDevices.getSupportedConstraints
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
 <p>The
-  <code><strong>getSupportedConstraints</strong></code><strong><code>()</code></strong>
+  <strong><code>getSupportedConstraints()</code></strong>
   method of the {{domxref("MediaDevices")}} interface returns an object based on the
   {{domxref("MediaTrackSupportedConstraints")}} dictionary, whose member fields each
   specify one of the constrainable properties the {{Glossary("user agent")}} understands.

--- a/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
@@ -18,7 +18,7 @@ browser-compat: api.MediaRecorderErrorEvent.MediaRecorderErrorEvent
 <p>{{APIRef("MediaStream Recording")}}</p>
 
 <p>The
-    <code><strong>MediaRecorderErrorEvent</strong></code><strong><code>()</code></strong>
+    <strong><code>MediaRecorderErrorEvent()</code></strong>
     constructor creates a new {{domxref("MediaRecorderErrorEvent")}} object that
     represents an error that occurred during the recording of media by the <a
       href="/en-US/docs/Web/API/MediaStream_Recording_API">MediaStream Recording

--- a/files/en-us/web/api/mediastreamtrack/applyconstraints/index.html
+++ b/files/en-us/web/api/mediastreamtrack/applyconstraints/index.html
@@ -14,7 +14,7 @@ browser-compat: api.MediaStreamTrack.applyConstraints
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
 <p>The
-    <code><strong>applyConstraints</strong></code><strong><code>()</code></strong> method
+    <strong><code>applyConstraints()</code></strong> method
     of the {{domxref("MediaStreamTrack")}} interface applies a set of constraints to the
     track; these constraints let the Web site or app establish ideal values and acceptable
     ranges of values for the constrainable properties of the track, such as frame rate,

--- a/files/en-us/web/api/path2d/addpath/index.html
+++ b/files/en-us/web/api/path2d/addpath/index.html
@@ -12,7 +12,7 @@ browser-compat: api.Path2D.addPath
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
-<p>The <code><strong>Path2D</strong></code><strong><code>.addPath()</code></strong> method
+<p>The <strong><code>Path2D.addPath()</code></strong> method
   of the Canvas 2D API adds one {{domxref("Path2D")}} object to another
   <code>Path2D</code> object.</p>
 

--- a/files/en-us/web/api/performance/navigation/index.html
+++ b/files/en-us/web/api/performance/navigation/index.html
@@ -16,7 +16,7 @@ browser-compat: api.Performance.navigation
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
 <p>The legacy
-  <code><strong>Performance</strong></code><strong><code>.navigation</code></strong>
+  <strong><code>Performance.navigation</code></strong>
   read-only property returns a {{domxref("PerformanceNavigation")}} object representing
   the type of navigation that occurs in the given browsing context, such as the number of
   redirections needed to fetch the resource.</p>

--- a/files/en-us/web/api/performance/timing/index.html
+++ b/files/en-us/web/api/performance/timing/index.html
@@ -15,7 +15,7 @@ browser-compat: api.Performance.timing
 <p>{{APIRef("Navigation Timing")}}{{deprecated_header}}</p>
 
 <p>The legacy
-  <code><strong>Performance</strong></code><strong><code>.timing</code></strong> read-only
+  <strong><code>Performance.timing</code></strong> read-only
   property returns a {{domxref("PerformanceTiming")}} object containing latency-related
   performance information.</p>
 

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.html
@@ -16,7 +16,7 @@ browser-compat: api.PerformanceNavigation.redirectCount
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
 <p>The legacy
-  <code><strong>PerformanceNavigation</strong></code><strong><code>.redirectCount</code></strong>
+  <strong><code>PerformanceNavigation.redirectCount</code></strong>
   read-only property returns an <code>unsigned short</code> representing the number of
   REDIRECTs done before reaching the page.</p>
 

--- a/files/en-us/web/api/performancetiming/connectend/index.html
+++ b/files/en-us/web/api/performancetiming/connectend/index.html
@@ -20,7 +20,7 @@ browser-compat: api.PerformanceTiming.connectEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.connectEnd</code></strong>
+  <strong><code>PerformanceTiming.connectEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, where the connection is opened network. If the
   transport layer reports an error and the connection establishment is started again, the

--- a/files/en-us/web/api/performancetiming/connectstart/index.html
+++ b/files/en-us/web/api/performancetiming/connectstart/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.connectStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.connectStart</code></strong>
+  <strong><code>PerformanceTiming.connectStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, where the request to open a connection is sent to
   the network. If the transport layer reports an error and the connection establishment is

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domainLookupEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domainLookupEnd</code></strong>
+  <strong><code>PerformanceTiming.domainLookupEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, where the domain lookup is finished. If a
   persistent connection is used, or the information is stored in a cache or a local

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domainLookupStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domainLookupStart</code></strong>
+  <strong><code>PerformanceTiming.domainLookupStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, where the domain lookup starts. If a persistent
   connection is used, or the information is stored in a cache or a local resource, the

--- a/files/en-us/web/api/performancetiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domComplete
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domComplete</code></strong>
+  <strong><code>PerformanceTiming.domComplete</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the parser finished its work on the main
   document, that is when its {{domxref("Document.readyState")}} changes to

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domContentLoadedEventEnd</code></strong>
+  <strong><code>PerformanceTiming.domContentLoadedEventEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, right after all the scripts that need to be
   executed as soon as possible, in order or not, has been executed.</p>

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domContentLoadedEventStart</code></strong>
+  <strong><code>PerformanceTiming.domContentLoadedEventStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, right before the parser sent the
   {{event("DOMContentLoaded")}} event, that is right after all the scripts that need to be

--- a/files/en-us/web/api/performancetiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domInteractive
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domInteractive</code></strong>
+  <strong><code>PerformanceTiming.domInteractive</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the parser finished its work on the main
   document, that is when its {{domxref("Document.readyState")}} changes to

--- a/files/en-us/web/api/performancetiming/domloading/index.html
+++ b/files/en-us/web/api/performancetiming/domloading/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.domLoading
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.domLoading</code></strong>
+  <strong><code>PerformanceTiming.domLoading</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the parser started its work, that is when its
   {{domxref("Document.readyState")}} changes to <code>'loading'</code> and the

--- a/files/en-us/web/api/performancetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.html
@@ -22,7 +22,7 @@ browser-compat: api.PerformanceTiming.fetchStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.fetchStart</code></strong>
+  <strong><code>PerformanceTiming.fetchStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, the browser is ready to fetch the document using
   an HTTP request. This moment is <em>before</em> the check to any application cache.</p>
@@ -45,6 +45,6 @@ browser-compat: api.PerformanceTiming.fetchStart
 
 <ul>
   <li>The {{domxref("PerformanceTiming")}} interface it belongs
-    to.<code><strong>PerformanceTiming</strong></code><strong><code>.fetchStart</code></strong>
+    to.<strong><code>PerformanceTiming.fetchStart</code></strong>
   </li>
 </ul>

--- a/files/en-us/web/api/performancetiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.html
@@ -22,7 +22,7 @@ browser-compat: api.PerformanceTiming.loadEventEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.loadEventEnd</code></strong>
+  <strong><code>PerformanceTiming.loadEventEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the {{event("load")}} event handler
   terminated, that is when the load event is completed. If this event has not yet been

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.loadEventStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.loadEventStart</code></strong>
+  <strong><code>PerformanceTiming.loadEventStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the {{event("load")}} event was sent for the
   current document. If this event has not yet been sent, it returns <code>0.</code></p>

--- a/files/en-us/web/api/performancetiming/navigationstart/index.html
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.html
@@ -22,7 +22,7 @@ browser-compat: api.PerformanceTiming.navigationStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.navigationStart</code></strong>
+  <strong><code>PerformanceTiming.navigationStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, right after the prompt for unload terminates on
   the previous document in the same browsing context. If there is no previous document,

--- a/files/en-us/web/api/performancetiming/redirectend/index.html
+++ b/files/en-us/web/api/performancetiming/redirectend/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.redirectEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.redirectEnd</code></strong>
+  <strong><code>PerformanceTiming.redirectEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, the last HTTP redirect is completed, that is when
   the last byte of the HTTP response has been received. If there is no redirect, or if one

--- a/files/en-us/web/api/performancetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.redirectStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.redirectStart</code></strong>
+  <strong><code>PerformanceTiming.redirectStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, the first HTTP redirect starts. If there is no
   redirect, or if one of the redirect is not of the same origin, the value returned is

--- a/files/en-us/web/api/performancetiming/requeststart/index.html
+++ b/files/en-us/web/api/performancetiming/requeststart/index.html
@@ -20,7 +20,7 @@ browser-compat: api.PerformanceTiming.requestStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.requestStart</code></strong>
+  <strong><code>PerformanceTiming.requestStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the browser sent the request to obtain the
   actual document, from the server or from a cache. If the transport layer fails after the

--- a/files/en-us/web/api/performancetiming/responseend/index.html
+++ b/files/en-us/web/api/performancetiming/responseend/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.responseEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.responseEnd</code></strong>
+  <strong><code>PerformanceTiming.responseEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, when the browser received the last byte of the
   response, or when the connection is closed if this happened first, from the server from

--- a/files/en-us/web/api/performancetiming/responsestart/index.html
+++ b/files/en-us/web/api/performancetiming/responsestart/index.html
@@ -21,7 +21,7 @@ browser-compat: api.PerformanceTiming.responseStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.responseStart</code></strong>
+  <strong><code>PerformanceTiming.responseStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment in
   time (in milliseconds since the UNIX epoch) when the browser received the first byte of
   the response from the server, cache, or local resource.</p>

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
@@ -20,7 +20,7 @@ browser-compat: api.PerformanceTiming.secureConnectionStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.secureConnectionStart</code></strong>
+  <strong><code>PerformanceTiming.secureConnectionStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, where the secure connection handshake starts. If
   no such connection is requested, it returns <code>0</code>.</p>

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.html
@@ -20,7 +20,7 @@ browser-compat: api.PerformanceTiming.unloadEventEnd
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.unloadEventEnd</code></strong>
+  <strong><code>PerformanceTiming.unloadEventEnd</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, the {{event("unload")}} event handler finishes. If
   there is no previous document, or if the previous document, or one of the needed

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.html
@@ -20,7 +20,7 @@ browser-compat: api.PerformanceTiming.unloadEventStart
 </div>
 
 <p>The legacy
-  <code><strong>PerformanceTiming</strong></code><strong><code>.unloadEventStart</code></strong>
+  <strong><code>PerformanceTiming.unloadEventStart</code></strong>
   read-only property returns an <code>unsigned long long</code> representing the moment,
   in milliseconds since the UNIX epoch, the {{event("unload")}} event has been thrown. If
   there is no previous document, or if the previous document, or one of the needed

--- a/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
@@ -18,7 +18,7 @@ browser-compat: api.RTCDTMFSender.insertDTMF
 <p>{{APIRef("WebRTC")}}</p>
 
 <p>The
-    <code><strong>insertDTMF</strong></code><strong><code>()</code></strong> method on the
+    <strong><code>insertDTMF()</code></strong> method on the
     {{domxref("RTCDTMFSender")}} interface starts sending {{Glossary("DTMF")}} tones to the remote peer over the
     {{domxref("RTCPeerConnection")}}.</p>
 

--- a/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
@@ -18,7 +18,7 @@ browser-compat: api.RTCIceCandidate.RTCIceCandidate
 <div>{{APIRef("WebRTC")}}</div>
 
 <p>The
-    <code><strong>RTCIceCandidate</strong></code><strong><code>()</code></strong>
+    <strong><code>RTCIceCandidate()</code></strong>
     constructor creates and returns a new {{domxref("RTCIceCandidate")}} object, which can
     be configured to represent a single {{Glossary("ICE")}} candidate.</p>
 

--- a/files/en-us/web/api/web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/index.html
@@ -112,7 +112,7 @@ tags:
 	<dt>{{domxref("BiquadFilterNode")}}</dt>
 	<dd>The <strong><code>BiquadFilterNode</code></strong> interface represents a simple low-order filter. It is an {{domxref("AudioNode")}} that can represent different kinds of filters, tone control devices, or graphic equalizers. A <code>BiquadFilterNode</code> always has exactly one input and one output.</dd>
 	<dt>{{domxref("ConvolverNode")}}</dt>
-	<dd>The <code><strong>Convolver</strong></code><strong><code>Node</code></strong> interface is an {{domxref("AudioNode")}} that performs a Linear Convolution on a given {{domxref("AudioBuffer")}}, and is often used to achieve a reverb effect.</dd>
+	<dd>The <strong><code>ConvolverNode</code></strong> interface is an {{domxref("AudioNode")}} that performs a Linear Convolution on a given {{domxref("AudioBuffer")}}, and is often used to achieve a reverb effect.</dd>
 	<dt>{{domxref("DelayNode")}}</dt>
 	<dd>The <strong><code>DelayNode</code></strong> interface represents a <a href="https://en.wikipedia.org/wiki/Digital_delay_line">delay-line</a>; an {{domxref("AudioNode")}} audio-processing module that causes a delay between the arrival of an input data and its propagation to the output.</dd>
 	<dt>{{domxref("DynamicsCompressorNode")}}</dt>
@@ -135,7 +135,7 @@ tags:
 	<dt>{{domxref("AudioDestinationNode")}}</dt>
 	<dd>The <strong><code>AudioDestinationNode</code></strong> interface represents the end destination of an audio source in a given context — usually the speakers of your device.</dd>
 	<dt>{{domxref("MediaStreamAudioDestinationNode")}}</dt>
-	<dd>The <code><strong>MediaStreamAudio</strong></code><strong><code>DestinationNode</code></strong> interface represents an audio destination consisting of a <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> {{domxref("MediaStream")}} with a single <code>AudioMediaStreamTrack</code>, which can be used in a similar way to a {{domxref("MediaStream")}} obtained from {{ domxref("MediaDevices.getUserMedia", "getUserMedia()") }}. It is an {{domxref("AudioNode")}} that acts as an audio destination.</dd>
+	<dd>The <strong><code>MediaStreamAudioDestinationNode</code></strong> interface represents an audio destination consisting of a <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> {{domxref("MediaStream")}} with a single <code>AudioMediaStreamTrack</code>, which can be used in a similar way to a {{domxref("MediaStream")}} obtained from {{ domxref("MediaDevices.getUserMedia", "getUserMedia()") }}. It is an {{domxref("AudioNode")}} that acts as an audio destination.</dd>
 </dl>
 
 <h3 id="Data_analysis_and_visualization">Data analysis and visualization</h3>

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WebGLRenderingContext.commit
 <div>{{APIRef("WebGL")}}</div>
 
 <p>The
-  <code><strong>WebGLRenderingContext</strong></code><strong><code>.commit()</code></strong>
+  <strong><code>WebGLRenderingContext.commit()</code></strong>
   method pushes frames back to the original {{domxref("HTMLCanvasElement")}}, if the
   context is not directly fixed to a specific canvas.</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7898.

As discussed in https://github.com/mdn/yari/issues/4550, this transforms markup like:

`<code><strong>font</strong></code><strong><code>-src</code></strong>`

into

`<strong><code>font-src</code></strong>`
