### PR TITLE
Removing css tool link

### DIFF
--- a/files/en-us/web/css/index.md
+++ b/files/en-us/web/css/index.md
@@ -87,7 +87,6 @@ The [CSS layout cookbook](/en-US/docs/Web/CSS/Layout_cookbook) aims to bring tog
 - You can use the [W3C CSS Validation Service](https://jigsaw.w3.org/css-validator/) to check if your CSS is valid. This is an invaluable debugging tool.
 - [Firefox Developer Tools](/en-US/docs/Tools) lets you view and edit a page's live CSS via the [Inspector](/en-US/docs/Tools/Page_Inspector) and [Style Editor](/en-US/docs/Tools/Style_Editor) tools.
 - The [Web Developer extension](https://addons.mozilla.org/en-US/firefox/addon/web-developer/) for Firefox lets you track and edit live CSS on watched sites.
-- The Web community has created various other [miscellaneous CSS tools](/en-US/docs/Web/CSS/Tools) for you to use.
 
 ## Meta bugs
 


### PR DESCRIPTION
As @rachelandrew removed the CSS tool's page #8522 , there is no need to link to that page anymore.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
