### PR TITLE
Array some: Inconsistent Parameter Name

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -40,7 +40,7 @@ some(function callbackFn(element, index, array) { ... }, thisArg)
 
 ### Parameters
 
-- `callback`
+- `callbackFn`
 
   - : A function to test for each element, taking three arguments:
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

In the syntax it says `callbackFn`, but in the parameter description it says `callback`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some

