### PR TITLE
Fixes #8540 - Adds Exceptions from RegExp()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -74,6 +74,12 @@ RegExp(pattern[, flags])
       - : Matches only from the index indicated by the `lastIndex` property of
         this regular expression in the target string. Does not attempt to match from any
         later indexes.
+        
+### Exceptions
+
+- If `pattern` cannot be parsed as a valid regular expression, a {{jsxref("SyntaxError")}} is thrown.
+- If `flags` contains repeated characters or any character outside of those allowed, a 
+  {{jsxref("SyntaxError")}} is thrown.
 
 ## Examples
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #8540

> What was wrong/why is this fix needed? (quick summary only)

The exceptions thrown are not documented.

> Anything else that could help us review it

The regexp `|` reported in the bug is not exactly invalid and could be treated as equivalent to matching against` '' `. Both, `|` and `''` return an array containing a single empty string. There are many others that consist of regexp special chars and appear invalid but are actually quite valid eg. `]`, `}`. These either return a match or an explainable `null`:-
1. `'{}'.match('}') // returns ["}"]`
2. `'[]['.match(']') // returns ["]"]`
3. `']'.match('][]') // returns null`

But there are others that cause Syntax Error such as these:-
1. `'hello, world'.match('*') // SyntaxError: nothing to repeat`
2. `'hello, world'.match('[') // SyntaxError: unterminated character class`
3. `'hello, world'.match('a{3,2}') // SyntaxError: numbers out of order in {} quantifier`

The PR addresses the second category.