### PR TITLE
Add missing "closed" state to interface overview

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -162,7 +162,7 @@ browser-compat: api.RTCPeerConnection
     while connecting or reconnecting to another peer.
     It is one of the following values:
     <code>stable</code>, <code>have-local-offer</code>, <code>have-remote-offer</code>,
-    <code>have-local-pranswer</code>, or <code>have-remote-pranswer</code>.
+    <code>have-local-pranswer</code>, <code>have-remote-pranswer</code>, or <code>closed</code>.
   </dd>
 </dl>
 


### PR DESCRIPTION
In #8554 we add a missing enum state `closed` to the property page.

We also need to add it to the list of possible states on the interface page. This fixes it.