### PR TITLE
Fixes 8143 shortens path to Demos

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -2744,7 +2744,7 @@
 /en-US/docs/DOM_improvements_in_Firefox_3	/en-US/docs/Mozilla/Firefox/Releases/3/DOM_improvements
 /en-US/docs/DataTypeSet	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet
 /en-US/docs/Deer_Park	/en-US/docs/Mozilla/Firefox/Releases/1.5
-/en-US/docs/Demos_of_open_web_technologies	/en-US/docs/Web/Demos_of_open_web_technologies
+/en-US/docs/Demos_of_open_web_technologies	/en-US/docs/Web/Demos
 /en-US/docs/Detecting_device_orientation	/en-US/docs/Web/Events/Detecting_device_orientation
 /en-US/docs/Determining_the_dimensions_of_elements	/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
 /en-US/docs/DeviceAcceleration	/en-US/docs/Web/API/DeviceMotionEventAcceleration
@@ -5897,7 +5897,7 @@
 /en-US/docs/Online_Offline_Events	/en-US/docs/Web/API/Navigator/Online_and_offline_events
 /en-US/docs/Online_and_offline_events	/en-US/docs/Web/API/Navigator/Online_and_offline_events
 /en-US/docs/OpenWebApps	/en-US/docs/Web/Progressive_web_apps
-/en-US/docs/OpenWebDemos	/en-US/docs/Web/Demos_of_open_web_technologies
+/en-US/docs/OpenWebDemos	/en-US/docs/Web/Demos
 /en-US/docs/Optimizing_Your_Pages_for_Speculative_Parsing	/en-US/docs/Glossary/speculative_parsing
 /en-US/docs/Other_JavaScript_tools	/en-US/docs/Tools
 /en-US/docs/PHP	/en-US/docs/Glossary/PHP
@@ -10185,6 +10185,7 @@
 /en-US/docs/Web/CSS_Typed_OM	/en-US/docs/Web/API/CSS_Typed_OM_API
 /en-US/docs/Web/CSS_Typed_OM_API	/en-US/docs/Web/API/CSS_Typed_OM_API
 /en-US/docs/Web/CSS_Typed_Object_Model_API	/en-US/docs/Web/API/CSS_Typed_OM_API
+/en-US/docs/Web/Demos_of_open_web_technologies	/en-US/docs/Web/Demos
 /en-US/docs/Web/Events/Activate	/en-US/docs/Web/API/Element/DOMActivate_event
 /en-US/docs/Web/Events/DOMContentLoaded	/en-US/docs/Web/API/Window/DOMContentLoaded_event
 /en-US/docs/Web/Events/DOMMouseScroll	/en-US/docs/Web/API/Element/DOMMouseScroll_event

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -116516,7 +116516,7 @@
       "jackarmley"
     ]
   },
-  "Web/Demos_of_open_web_technologies": {
+  "Web/Demos": {
     "modified": "2020-06-23T09:20:53.721Z",
     "contributors": [
       "mrmowji",

--- a/files/en-us/web/css/index.md
+++ b/files/en-us/web/css/index.md
@@ -95,6 +95,6 @@ The [CSS layout cookbook](/en-US/docs/Web/CSS/Layout_cookbook) aims to bring tog
 
 ## See also
 
-- [CSS demos](/en-US/docs/Web/Demos_of_open_web_technologies#css): Get a creative boost by exploring examples of the latest CSS technologies in action.
+- [CSS demos](/en-US/docs/Web/Demos#css): Get a creative boost by exploring examples of the latest CSS technologies in action.
 - Web languages to which CSS is often applied: [HTML](/en-US/docs/Web/HTML), [SVG](/en-US/docs/Web/SVG), [MathML](/en-US/docs/Web/MathML), {{Glossary("XHTML")}}, and [XML](/en-US/docs/Web/XML/XML_introduction).
 - [Stack Overflow questions about CSS](https://stackoverflow.com/questions/tagged/css)

--- a/files/en-us/web/demos/index.html
+++ b/files/en-us/web/demos/index.html
@@ -1,6 +1,6 @@
 ---
 title: Demos of open web technologies
-slug: Web/Demos_of_open_web_technologies
+slug: Web/Demos
 tags:
   - 2D
   - 3D

--- a/files/en-us/web/html/element/canvas/index.html
+++ b/files/en-us/web/html/element/canvas/index.html
@@ -174,6 +174,6 @@ ctx.fillRect(10, 10, 100, 100);</pre>
  <li><a href="/en-US/docs/Web/API/Canvas_API">MDN canvas portal</a></li>
  <li><a href="/en-US/docs/Web/API/Canvas_API/Tutorial">Canvas tutorial</a></li>
  <li><a href="https://simon.html5.org/dump/html5-canvas-cheat-sheet.html">Canvas cheat sheet</a></li>
- <li><a href="/en-US/docs/Web/Demos_of_open_web_technologies">Canvas-related demos</a></li>
+ <li><a href="/en-US/docs/Web/Demos#canvas">Canvas-related demos</a></li>
  <li><a href="https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HTML-canvas-guide/Introduction/Introduction.html">Canvas introduction by Apple</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #8143


> What was wrong/why is this fix needed? (quick summary only)

Previous name was too long

> Anything else that could help us review it

In one of the source links, I have added an anchor for #canvas . It wasn't there earlier.
```bash
~/content$ yarn content move Web/Demos_of_open_web_technologies Web/Demos
yarn run v1.22.11
$ env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/tool/cli.js move Web/Demos_of_open_web_technologies Web/Demos
Will move 1 documents from Web/Demos_of_open_web_technologies to Web/Demos for en-US
Web/Demos_of_open_web_technologies → Web/Demos
? Proceed? Yes
Moved 1 documents.
Done in 15.03s.
```