### PR TITLE
WebDriver conformance changes for Firefox 92

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -74,6 +74,9 @@ tags:
 <h4 id="removals_wasm">Removals</h4>
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
+<ul>
+  <li>Improved support for the <code>webSocketUrl</code> capability, which now returns the WebDriver BiDi websocket URL if <code>true</code> was passed and if BiDi is supported. ({{bug(1692984)}}).</li>
+</ul>
 
 <h4 id="removals_webdriver">Removals</h4>
 


### PR DESCRIPTION
The following PR contains all the user facing changes to Marionette for the Firefox 92 release. Here a [list of all the changes](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&f1=cf_status_firefox92&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&f2=cf_status_firefox92&v1=fixed&component=Marionette&v2=verified&product=Testing&)

Only included [Bug 1692984 - Add support for "webSocketUrl” capability to Marionette](https://bugzilla.mozilla.org/show_bug.cgi?id=1692984) in the release notes. 

Quick review of the other bugs:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1721012: beta merge perma failure fix
- https://bugzilla.mozilla.org/show_bug.cgi?id=1719692: internal change: we use the Shared log helper to get the log level instead of marionettePrefs in the MarionetteEventsChild js window actor. This fixes an inconsistency, but shouldn't have any end user impact.
- https://bugzilla.mozilla.org/show_bug.cgi?id=1723145: stop supporting OS.File: internal cleanup
- https://bugzilla.mozilla.org/show_bug.cgi?id=1721982: already mentioned for 91 
- https://bugzilla.mozilla.org/show_bug.cgi?id=1682936: re-enables an existing test

@jgraham can you please cross-check? Thanks.