### PR TITLE
WebXR docs: Rm syntax from properties; normalize Value section

### DIFF
--- a/files/en-us/web/api/navigator/xr/index.html
+++ b/files/en-us/web/api/navigator/xr/index.html
@@ -22,18 +22,14 @@ browser-compat: api.Navigator.xr
 provided by the {{domxref("Navigator")}}  interface returns an {{domxref("XRSystem")}} object
 which can be used to access the <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a>.</p>
 
-<h2 id="Syntax">Syntax</h2>
-
-<pre class="brush: js">const <var>xr</var> = navigator.xr</pre>
-
-<h3 id="Value">Value</h3>
+<h2 id="Value">Value</h2>
 
 <p>The {{domxref("XRSystem")}} object used to interface with the <a
     href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a> in the current
   context. This can be used to present augmented and/or virtual reality imagery to the
   user.</p>
 
-<h2 id="Usage_notes">Usage notes</h2>
+<h2 id="Example">Example</h2>
 
 <p>Each {{domxref("Window")}} has its own instance of {{domxref("Navigator")}}, which can
   be accessed as {{domxref("Window.navigator","window.navigator")}} or as
@@ -65,5 +61,5 @@ which can be used to access the <a href="/en-US/docs/Web/API/WebXR_Device_API">W
 <ul>
   <li><a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a>: 2D and 3D accelerated
     graphics for the web</li>
-  <li><a href="/en-US/docs/Web/API/Canvas_API">Canvas API</a>: Easy 2D graphics API</li>
+  <li><a href="/en-US/docs/Web/API/Canvas_API">Canvas API</a>: 2D graphics API</li>
 </ul>

--- a/files/en-us/web/api/xranchor/anchorspace/index.md
+++ b/files/en-us/web/api/xranchor/anchorspace/index.md
@@ -15,7 +15,7 @@ browser-compat: api.XRAnchor.anchorSpace
 
 The read-only **`anchorSpace`** property of the {{domxref("XRAnchor")}} interface returns an {{domxref("XRSpace")}} object to locate the anchor relative to other `XRSpace` objects. It can be passed to {{domxref("XRFrame.getPose()")}} subsequently.
 
-### Value
+## Value
 
 An {{domxref("XRSpace")}} object.
 

--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.md
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.md
@@ -38,13 +38,7 @@ or by drawing the shape of their room using their XR input device. Theoretically
 advanced system might use sensors or other detection methods to determine the bounds of
 a dedicated XR room (notice how we carefully don't call it a holodeck?).
 
-## Syntax
-
-```js
-bounds = xrReferenceSpace.boundsGeometry;
-```
-
-### Value
+## Value
 
 The `boundsGeometry` property is an array of {{domxref("DOMPointReadOnly")}}
 objects, each of which defines one vertex in a polygon inside which the viewer is

--- a/files/en-us/web/api/xrcpudepthinformation/data/index.md
+++ b/files/en-us/web/api/xrcpudepthinformation/data/index.md
@@ -19,7 +19,7 @@ The *read-only* **`data`** property of the {{DOMxRef("XRCPUDepthInformation")}
 
 The data is stored in row-major format, without padding, with each entry corresponding to distance from the view's near plane to the users' environment, in unspecified units. The size of each data entry and the type is determined by {{domxref("XRSession.depthDataFormat", "depthDataFormat")}}. The values can be converted from unspecified units to meters by multiplying them by {{domxref("XRDepthInformation.rawValueToMeters", "rawValueToMeters")}}. The {{domxref("XRDepthInformation.normDepthBufferFromNormView", "normDepthBufferFromNormView")}} property can be used to transform from normalized view coordinates (an origin in the top left corner of the view, with X axis growing to the right, and Y axis growing downward) into the depth buffer’s coordinate system.
 
-### Value
+## Value
 
 An {{jsxref("ArrayBuffer")}}.
 

--- a/files/en-us/web/api/xrdepthinformation/height/index.md
+++ b/files/en-us/web/api/xrdepthinformation/height/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRDepthInformation.height
 
 The *read-only* **`height`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the height of the depth buffer (number of rows).
 
-### Value
+## Value
 
 An unsigned long integer.
 

--- a/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.md
+++ b/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRDepthInformation.normDepthBufferFromNormView
 
 The *read-only* **`normDepthBufferFromNormView`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the 3D geometric transform that needs to be applied when indexing into the depth buffer.
 
-### Value
+## Value
 
 An {{domxref("XRRigidTransform")}} that needs to be applied when indexing into the depth buffer. The transformation that the matrix represents changes the coordinate system from normalized view coordinates to normalized depth-buffer coordinates that can then be scaled by depth buffer’s `width` and `height` to obtain the absolute depth buffer coordinates.
 

--- a/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.md
+++ b/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.md
@@ -19,7 +19,7 @@ The *read-only* **`rawValueToMeters`** property of the {{DOMxRef("XRDepthInfor
 
 For CPU depth information, see also the {{domxref("XRCPUDepthInformation.getDepthInMeters()")}} method.
 
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/xrdepthinformation/width/index.md
+++ b/files/en-us/web/api/xrdepthinformation/width/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRDepthInformation.width
 
 The *read-only* **`width`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the width of the depth buffer (number of columns).
 
-### Value
+## Value
 
 An unsigned long integer.
 

--- a/files/en-us/web/api/xrframe/session/index.md
+++ b/files/en-us/web/api/xrframe/session/index.md
@@ -20,13 +20,7 @@ browser-compat: api.XRFrame.session
 
 An `XRFrame` object's *read-only* **`session`** property returns the {{domxref("XRSession")}} object that generated the frame.
 
-## Syntax
-
-```js
-var xrSession = xrFrame.session;
-```
-
-### Value
+## Value
 
 A {{domxref("XRSession")}} object representing the WebXR session for which
 this `XRFrame` describes the object positions and orientations.

--- a/files/en-us/web/api/xrframe/trackedanchors/index.md
+++ b/files/en-us/web/api/xrframe/trackedanchors/index.md
@@ -15,7 +15,7 @@ browser-compat: api.XRFrame.trackedAnchors
 
 The read-only **`trackedAnchor`** property of the {{domxref("XRFrame")}} interface returns an {{domxref("XRAnchorSet")}} object containing all anchors still tracked in the frame.
 
-### Value
+## Value
 
 An {{domxref("XRAnchorSet")}} object.
 

--- a/files/en-us/web/api/xrinputsource/gripspace/index.md
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.md
@@ -20,13 +20,7 @@ browser-compat: api.XRInputSource.gripSpace
 
 The read-only {{domxref("XRInputSource")}} property **`gripSpace`** returns an {{domxref("XRSpace")}} whose native origin tracks the pose used to render virtual objects so they appear to be held in (or part of) the user's hand. For example, if a user were holding a virtual straight rod, the native origin of this `XRSpace` would be located at the approximate center of mass of the user's fist.
 
-## Syntax
-
-```js
-var xrSpace = xrInputSource.gripSpace;
-```
-
-### Value
+## Value
 
 An {{domxref("XRSpace")}} object representing the position and orientation of the input
 device in virtual space, suitable for rendering an image of the device into the scene.

--- a/files/en-us/web/api/xrinputsource/handedness/index.md
+++ b/files/en-us/web/api/xrinputsource/handedness/index.md
@@ -27,13 +27,7 @@ The read-only {{domxref("XRInputSource")}} property
 **`handedness`** indicates which of the user's hands the WebXR
 input source is associated with, or if it's not associated with a hand at all.
 
-## Syntax
-
-```js
-xrInputSource.handedness;
-```
-
-### Value
+## Value
 
 A string indicating whether the input controller is held in one of
 the user's hands, and if it is, which hand. The value is one of the following:

--- a/files/en-us/web/api/xrinputsource/profiles/index.md
+++ b/files/en-us/web/api/xrinputsource/profiles/index.md
@@ -27,13 +27,7 @@ The read-only {{domxref("XRInputSource")}} property **`profiles`** returns an ar
 > **Note:** The `profiles` list is always empty when the WebXR
 > session is in inline mode.
 
-## Syntax
-
-```js
-let profileList = xrInputSource.profiles;
-```
-
-### Value
+## Value
 
 An array of {{domxref("DOMString")}} objects, each describing one configuration profile
 for the input device represented by the `XRInputSource` object. Each input

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.md
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.md
@@ -36,13 +36,7 @@ A target ray emitted by a hand controller:
 
 The target ray can be anything from a simple line (ideally fading over distance) to an animated effect, such as the science-fiction "phaser" style shown in the screenshot above.
 
-## Syntax
-
-```js
-let rayMode = xrInputSource.targetRayMode;
-```
-
-### Value
+## Value
 
 A string indicating which method to use when generating and presenting the target ray to
 the user. The possible values are:

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.md
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.md
@@ -38,20 +38,11 @@ orientation of the controller device itself. These values, interpreted in the co
 the input source's {{domxref("XRInputSource.targetRayMode", "targetRayMode")}}, can be
 used both to fully interpret the device as an input source.
 
-**<<<--- needs diagram showing targetRaySpace relative to gripSpace and
-world space --->>>**
-
 To obtain an `XRSpace` representing the input controller's position and
 orientation in virtual space, use the {{domxref("XRInputSource.gripSpace",
   "gripSpace")}} property.
 
-## Syntax
-
-```js
-let targetRaySpace = xrInputSource.targetRaySpace;
-```
-
-### Value
+## Value
 
 An {{domxref("XRSpace")}} object—typically an {{domxref("XRReferenceSpace")}} or
 {{domxref("XRBoundedReferenceSpace")}}—which represents the position and orientation of

--- a/files/en-us/web/api/xrinputsourcearray/length/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/length/index.md
@@ -28,13 +28,7 @@ The read-only **`length`** property returns an integer value
 indicating the number of items in the input source list represented by
 the {{domxref("XRInputSourceArray")}} object.
 
-## Syntax
-
-```js
-let inputSourceCount = xrInputSourceArray.length;
-```
-
-### Value
+## Value
 
 An integer value indicating the number of {{domxref("XRInputSource")}} objects
 representing WebXR input sources are includled in the array.

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.md
@@ -30,13 +30,7 @@ representing the event frame during which a [WebXR](/en-US/docs/Web/API/WebXR_De
 This may thus be an event which occurred in the past rather than a current or impending
 event.
 
-## Syntax
-
-```js
-let inputFrame = xrInputSourceEvent.frame;
-```
-
-### Value
+## Value
 
 An {{domxref("XRFrame")}} indicating the event frame at which the user input event
 described by the object took place.

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
@@ -31,13 +31,7 @@ The {{domxref("XRInputSourceEvent")}} interface's read-only
 lets you handle the event appropriately given the particulars of the user input device
 being manipulated.
 
-## Syntax
-
-```js
-let inputSource = xrInputSourceEvent.inputSource;
-```
-
-### Value
+## Value
 
 An {{domxref("XRInputSource")}} object identifying the source of the user input event.
 This event indicates an action the user has taken using a WebXR input controller, such

--- a/files/en-us/web/api/xrinputsourceschangeevent/added/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/added/index.md
@@ -26,13 +26,7 @@ property {{domxref("XRInputSourcesChangeEvent.added", "added")}} is a list of ze
 more input sources, each identified using an {{domxref("XRInputSource")}} object,
 which have been newly made available for use.
 
-## Syntax
-
-```js
-let addedInputs = xrInputSourcesChangeEvent.added;
-```
-
-### Value
+## Value
 
 An {{jsxref("Array")}} of zero or more {{domxref("XRInputSource")}} objects, each
 representing one input device added to the XR system.

--- a/files/en-us/web/api/xrinputsourceschangeevent/removed/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/removed/index.md
@@ -28,13 +28,7 @@ browser-compat: api.XRInputSourcesChangeEvent.removed
 The read-only {{domxref("XRInputSourcesChangeEvent")}} property {{domxref("XRInputSourcesChangeEvent.removed", "removed")}} is an array of
 zero or more {{domxref("XRInputSource")}} objects representing the input sources that have been removed from the {{domxref("XRSession")}}.
 
-## Syntax
-
-```js
-removedInputs = xrInputSourcesChangeEvent.removed;
-```
-
-### Value
+## Value
 
 An {{jsxref("Array")}} of zero or more {{domxref("XRInputSource")}} objects, each representing one input device removed from the XR system.
 

--- a/files/en-us/web/api/xrinputsourceschangeevent/session/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/session/index.md
@@ -28,13 +28,7 @@ The {{domxref("XRInputSourcesChangeEvent")}} property
 {{domxref("XRInputSourcesChangeEvent.session", "session")}} specifies the
 {{domxref("XRSession")}} to which the input source list change event applies.
 
-## Syntax
-
-```js
-let inputsSession = xrInputSourcesChangeEvent.session;
-```
-
-### Value
+## Value
 
 An {{domxref("XRSession")}} indicating the WebXR session to which the input source list
 change applies.

--- a/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRLightEstimate.primaryLightDirection
 
 The _read-only_ **`primaryLightDirection`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{domxref("DOMPointReadOnly")}} representing the direction to the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
 
-### Value
+## Value
 
 A {{domxref("DOMPointReadOnly")}} object. If no estimated values from the user's environment are available, the point will be `{ x: 0.0, y: 1.0, z: 0.0, w: 0.0 }`, representing a light shining straight down from above.
 

--- a/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRLightEstimate.primaryLightIntensity
 
 The _read-only_ **`primaryLightIntensity`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{domxref("DOMPointReadOnly")}} representing the intensity of the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
 
-### Value
+## Value
 
 A {{domxref("DOMPointReadOnly")}} object where an RGB value is mapped to the `x`, `y`, and `z` values. The `w` value is always `1.0`. If no estimated values from the user's environment are available, the point will be `{x: 0.0, y: 0.0, z: 0.0, w: 1.0}`, representing no illumination.
 

--- a/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
+++ b/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
@@ -19,7 +19,7 @@ The _read-only_ **`sphericalHarmonicsCoefficients`** property of the {{DOMxRef("
 
 Spheral harmonic lighting is a technique that uses spherical functions instead of standard lighting equations. See [Wikipedia](https://en.wikipedia.org/wiki/Spherical_harmonic_lighting) for more information.
 
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} containing 9 spherical harmonics coefficients. The array contains 27 elements in total, with every 3 elements defining red, green, and blue components for each coefficient.
 

--- a/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
+++ b/files/en-us/web/api/xrlightprobe/onreflectionchange/index.md
@@ -18,7 +18,7 @@ browser-compat: api.XRLightProbe.onreflectionchange
 
 The **`onreflectionchange`** property of the {{DOMxRef("XRLightProbe")}} interface is and event handler for the {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
 
-### Value
+## Value
 
 A function to be invoked whenever the {{domxref("XRLightProbe")}} receives a {{domxref("XRLightProbe.reflectionchange_event", "reflectionchange")}} event.
 

--- a/files/en-us/web/api/xrlightprobe/probespace/index.md
+++ b/files/en-us/web/api/xrlightprobe/probespace/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRLightProbe.probeSpace
 
 The _read-only_ **`probeSpace`** property of the {{DOMxRef("XRLightProbe")}} interface returns an {{domxref("XRSpace")}} tracking the position and orientation that the lighting estimations are relative to.
 
-### Value
+## Value
 
 An {{domxref("XRSpace")}} object.
 

--- a/files/en-us/web/api/xrpermissionstatus/granted/index.md
+++ b/files/en-us/web/api/xrpermissionstatus/granted/index.md
@@ -28,13 +28,7 @@ identifying one of the WebXR features for which permission has been granted as o
 time at which the Permission API's {{domxref("Permissions.query",
   "navigator.permissions.query()")}} method was called.
 
-## Syntax
-
-```js
-grantedFeatures = xrPermissionStatus.granted;
-```
-
-### Value
+## Value
 
 An array of strings, each identifying a single WebXR feature
 which the app or site has been granted permission to use. Currently, all of these

--- a/files/en-us/web/api/xrpose/angularvelocity/index.md
+++ b/files/en-us/web/api/xrpose/angularvelocity/index.md
@@ -17,13 +17,7 @@ The `angularVelocity` read-only property of the
 the angular velocity in radians per second relative to the base
 {{DOMxRef("XRSpace")}}.
 
-## Syntax
-
-```js
-let radiansPerSecond = xrPose.angularVelocity;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("DOMPointReadOnly")}} describing the angular velocity in radians
 per second relative to the base {{DOMxRef("XRSpace")}}. Returns {{jsxref("null")}}

--- a/files/en-us/web/api/xrpose/emulatedposition/index.md
+++ b/files/en-us/web/api/xrpose/emulatedposition/index.md
@@ -33,13 +33,7 @@ The `emulatedPosition` read-only attribute of the
 {{domxref("XRPose.transform", "transform")}} is directly taken from the XR device, or
 it's simulated or computed based on other sources.
 
-## Syntax
-
-```js
-let emulated = xrPose.emulatedPosition;
-```
-
-### Value
+## Value
 
 A Boolean which is `true` if the pose's position is computed based on
 estimates or is derived from sources other than direct sensor data. If the position is

--- a/files/en-us/web/api/xrpose/linearvelocity/index.md
+++ b/files/en-us/web/api/xrpose/linearvelocity/index.md
@@ -17,13 +17,7 @@ The `linearVelocity` read-only property of the
 the linear velocity in meters per second relative to the base
 {{DOMxRef("XRSpace")}}.
 
-## Syntax
-
-```js
-let metersPerSecond = xrPose.linearVelocity;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("DOMPointReadOnly")}} describing the linear velocity in meters
 per second relative to the base {{DOMxRef("XRSpace")}}. Returns {{jsxref("null")}}

--- a/files/en-us/web/api/xrpose/transform/index.md
+++ b/files/en-us/web/api/xrpose/transform/index.md
@@ -26,13 +26,7 @@ the position and orientation of the pose relative to the base {{DOMxRef("XRSpace
 as specified when the pose was obtained by calling
 {{domxref("XRFrame.getPose()")}}.
 
-## Syntax
-
-```js
-let poseTransform = xrPose.transform;
-```
-
-### Value
+## Value
 
 An {{domxref("XRRigidTransform")}} which provides the position and orientation of the
 {{domxref("XRPose")}} relative to the {{domxref("XRFrame")}} to which this

--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.md
@@ -28,13 +28,7 @@ The read-only {{domxref("XRReferenceSpaceEvent")}} property
 **`referenceSpace`** specifies the reference space which is the
 originator of the event.
 
-## Syntax
-
-```js
-let refSpace = xrReferenceSpaceEvent.referenceSpace;
-```
-
-### Value
+## Value
 
 An {{domxref("XRReferenceSpace")}} indicating the source of the event.
 

--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.md
@@ -36,13 +36,7 @@ native origin after the changes the event represents are applied. The
 used to convert coordinates from the pre-event coordinate system to the post-event
 coordiante system.
 
-## Syntax
-
-```js
-let refSpace = xrReferenceSpaceEvent.transform;
-```
-
-### Value
+## Value
 
 An {{domxref("XRRigidTransform")}} object providing a transform that can be used to
 convert coordinates from the pre-event coordinate system to the post-event coordinate

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.md
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.md
@@ -26,13 +26,7 @@ in the device.
 This property is read-only; however, you can indirectly change its
 value using  {{domxref("XRSession.updateRenderState")}}.
 
-## Syntax
-
-```js
-var xrWebGLLayer = xrRenderState.baseLayer;
-```
-
-### Value
+## Value
 
 A {{domxref("XRWebGLLayer")}} object which is used as the source of the world's
 contents when rendering each frame of the scene.

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.md
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.md
@@ -22,13 +22,7 @@ The **`depthFar`** read-only property of the
 {{domxref("XRRenderState")}} interface returns the distance in meters of the far clip
 plane from the viewer.
 
-## Syntax
-
-```js
-var aDouble = XRRenderState.depthFar;
-```
-
-### Value
+## Value
 
 A {{jsxref("Number")}}.
 

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.md
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.md
@@ -22,13 +22,7 @@ The **`depthNear`** read-only property of the
 {{domxref("XRRenderState")}} interface returns the distance in meters of the near clip
 plane from the viewer.
 
-## Syntax
-
-```js
-var aDouble = XRRenderState.depthNear;
-```
-
-### Value
+## Value
 
 A {{jsxref("Number")}}.
 

--- a/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.md
+++ b/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.md
@@ -18,13 +18,7 @@ property of the {{DOMxRef("XRRenderState")}} interface returns the default verti
 field of view for `"inline"` sessions and `null` for all immersive
 sessions.
 
-## Syntax
-
-```js
-var inlineVerticalFieldOfView = xrRenderState.inlineVerticalFieldOfView;
-```
-
-### Value
+## Value
 
 A {{JSxRef("Number")}} for `"inline"` sessions, which represents the default
 field of view, and `null` for immersive sessions.

--- a/files/en-us/web/api/xrrigidtransform/inverse/index.md
+++ b/files/en-us/web/api/xrrigidtransform/inverse/index.md
@@ -29,13 +29,7 @@ transform. That is, you can always get the inverse of any
 `XRRigidTransform` using its `inverse` property, instead of having
 to explicitly generate it.
 
-## Syntax
-
-```js
-let transformInverse = xrRigidTransform.inverse;
-```
-
-### Value
+## Value
 
 An {{domxref("XRRigidTransform")}} which contains the inverse of the
 `XRRigidTransform` on which it's accessed.

--- a/files/en-us/web/api/xrrigidtransform/matrix/index.md
+++ b/files/en-us/web/api/xrrigidtransform/matrix/index.md
@@ -30,13 +30,7 @@ vector by the 3D rotation specified by the {{domxref("XRRigidTransform.orientati
   "orientation")}}, then translate
 it by the {{domxref("XRRigidTransform.position", "position")}}.
 
-## Syntax
-
-```js
-let matrix = xrRigidTransform.matrix;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} containing 16 entries which represents the 4x4 transform
 matrix which is described by

--- a/files/en-us/web/api/xrrigidtransform/orientation/index.md
+++ b/files/en-us/web/api/xrrigidtransform/orientation/index.md
@@ -30,13 +30,7 @@ specifying the rotational component of the transform represented by the object.
 If you specify a quaternion whose length is not exactly 1.0 meters, it will be
 normalized for you.
 
-## Syntax
-
-```js
-let orientation = xrRigidTransform.orientation;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMPointReadOnly")}} object which contains a unit quaternion providing the
 orientation component of the transform. As a unit quaternion, the length of the returned

--- a/files/en-us/web/api/xrrigidtransform/position/index.md
+++ b/files/en-us/web/api/xrrigidtransform/position/index.md
@@ -26,13 +26,7 @@ The read-only {{domxref("XRRigidTransform")}} property
 provides the 3D point, specified in meters, describing the translation component of the
 transform.
 
-## Syntax
-
-```js
-let pos = xrRigidTransform.position;
-```
-
-### Value
+## Value
 
 A read-only {{domxref("DOMPointReadOnly")}} indicating the 3D position component of the
 transform matrix. The units are meters.

--- a/files/en-us/web/api/xrsession/depthdataformat/index.md
+++ b/files/en-us/web/api/xrsession/depthdataformat/index.md
@@ -19,7 +19,7 @@ browser-compat: api.XRSession.depthDataFormat
 The *read-only* **`depthDataFormat`** property of an `immersive-ar`
 {{DOMxRef("XRSession")}} describes which depth sensing data format is used.
 
-### Value
+## Value
 
 This property can return the following values:
 

--- a/files/en-us/web/api/xrsession/depthusage/index.md
+++ b/files/en-us/web/api/xrsession/depthusage/index.md
@@ -19,7 +19,7 @@ browser-compat: api.XRSession.depthUsage
 The *read-only* **`depthUsage`** property of an `immersive-ar`
 {{DOMxRef("XRSession")}} describes which depth-sensing usage is used.
 
-### Value
+## Value
 
 This property can return the following values:
 

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -19,13 +19,7 @@ browser-compat: api.XRSession.domOverlayState
 The *read-only* **`domOverlayState`** property of an `immersive-ar`
 {{DOMxRef("XRSession")}} provides information about the DOM overlay, if the feature is enabled.
 
-## Syntax
-
-```js
-session.domOverlayState;
-```
-
-### Value
+## Value
 
 Returns {{jsxref("null")}} if the DOM overlay feature is not supported or not enabled or an object containing information about the dom overlay state with the following properties:
 

--- a/files/en-us/web/api/xrsession/environmentblendmode/index.md
+++ b/files/en-us/web/api/xrsession/environmentblendmode/index.md
@@ -25,13 +25,7 @@ property identifies if, and to what degree, the computer-generated imagery is ov
 This is used to differentiate between fully-immersive VR sessions and AR sessions which render
 over a pass-through image of the real world, possibly partially transparently.
 
-## Syntax
-
-```js
-xrSession.environmentBlendMode;
-```
-
-### Value
+## Value
 
 A string defining if and how virtual, rendered content is overlaid atop the image of the real world.
 

--- a/files/en-us/web/api/xrsession/inputsources/index.md
+++ b/files/en-us/web/api/xrsession/inputsources/index.md
@@ -27,13 +27,7 @@ Keyboards, gamepads, and mice are _not_ considered WebXR input sources.
 
 > **Note:** Traditional gamepad controllers are supported using the [Gamepad API](/en-US/docs/Web/API/Gamepad_API).
 
-## Syntax
-
-```js
-inputSources = xrSession.inputSources;
-```
-
-### Value
+## Value
 
 An {{domxref("XRInputSourceArray")}} object listing all of the currently-connected
 input controllers which are linked specifically to the XR device currently in use. The

--- a/files/en-us/web/api/xrsession/interactionmode/index.md
+++ b/files/en-us/web/api/xrsession/interactionmode/index.md
@@ -22,13 +22,7 @@ browser-compat: api.XRSession.interactionMode
 The {{domxref("XRSession")}} interface's *read-only* **`interactionMode`** property
 describes the best space (according to the user agent) for the application to draw an interactive UI for the current session.
 
-## Syntax
-
-```js
-xrSession.interactionMode;
-```
-
-### Value
+## Value
 
 A string describing the best space (according to the user agent) for the application to draw an interactive UI
 for the current session.

--- a/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
+++ b/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRSession.preferredReflectionFormat
 
 The _read-only_ **`preferredReflectionFormat`** property of the {{DOMxRef("XRSession")}} interface returns this session's preferred reflection format used for lighting estimation texture data.
 
-### Value
+## Value
 
 A string representing the reflection format. Possible values:
 

--- a/files/en-us/web/api/xrsession/renderstate/index.md
+++ b/files/en-us/web/api/xrsession/renderstate/index.md
@@ -29,13 +29,7 @@ mode, and the {{domxref("XRWebGLLayer")}} to render into for inline composition.
 While this property is read only, you can call the {{domxref("XRSession")}} method
 {{domxref("XRSession.updateRenderState", "updateRenderState()")}} to make changes.
 
-## Syntax
-
-```js
-var xrRenderState = XRSession.renderState;
-```
-
-### Value
+## Value
 
 An {{DOMxRef("XRRenderState")}} object describing how to render the scene.
 

--- a/files/en-us/web/api/xrsession/visibilitystate/index.md
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.md
@@ -26,13 +26,7 @@ Every time the visibility state changes, a
 {{DOMxRef("XRSession.visibilitychange_event","visibilitychange")}} event is fired on the
 {{DOMxRef("XRSession")}} object.
 
-## Syntax
-
-```js
-visibilityState = xrSession.visibilityState;
-```
-
-### Value
+## Value
 
 A string indicating whether or not the XR content is
 visible to the user and if it is, whether or not it's currently the primary focus.

--- a/files/en-us/web/api/xrsessionevent/session/index.md
+++ b/files/en-us/web/api/xrsessionevent/session/index.md
@@ -28,13 +28,7 @@ The read-only {{domxref("XRSessionEvent")}} interface's
 **`session`** property indicates which
 {{domxref("XRSession")}} the event is about.
 
-## Syntax
-
-```js
-xrSession = xrSessionEvent.session;
-```
-
-### Value
+## Value
 
 An {{domxref("XRSession")}} object indicating which WebXR session the event refers to.
 

--- a/files/en-us/web/api/xrview/eye/index.md
+++ b/files/en-us/web/api/xrview/eye/index.md
@@ -26,13 +26,7 @@ property is a string indicating which eye's viewpoint the `XRView` represents: `
 `right`. For views which represent neither eye, such as monoscopic views,
 this property's value is `none`.
 
-## Syntax
-
-```js
-view.eye;
-```
-
-### Value
+## Value
 
 A string that can be one of the following values:
 

--- a/files/en-us/web/api/xrview/projectionmatrix/index.md
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.md
@@ -31,13 +31,7 @@ expects to see.
 > **Note:** Failure to apply proper perspective, or inconsistencies
 > in perspective, may result in possibly serious user discomfort or distress.
 
-## Syntax
-
-```js
-let projectionMatrix = xrView.projectionMatrix;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} object representing the projection matrix for the view.
 The projection matrix for each eye's view is used to ensure that the correct area of the

--- a/files/en-us/web/api/xrview/transform/index.md
+++ b/files/en-us/web/api/xrview/transform/index.md
@@ -38,13 +38,7 @@ With the `transform`, you can then position the view as a camera within the
 {{domxref("XRRigidTransform.matrix", "matrix")}} of the transform's
 {{domxref("XRRigidTransform.inverse", "inverse")}}.
 
-## Syntax
-
-```js
-let viewTransform = xrView.transform;
-```
-
-### Value
+## Value
 
 A {{domxref("XRRigidTransform")}} object specifying the position and orientation of the
 viewpoint represented by the `XRView`.

--- a/files/en-us/web/api/xrviewerpose/views/index.md
+++ b/files/en-us/web/api/xrviewerpose/views/index.md
@@ -34,13 +34,7 @@ Stereo views require two views to render properly, with the left eye's view havi
 {{domxref("XRView.eye", "eye")}} set to the string `left` and the right eye's
 view a value of `right`.
 
-## Syntax
-
-```js
-let viewList = xrViewerPose.views;
-```
-
-### Value
+## Value
 
 An array of {{domxref("XRView")}} objects, one for each view available as part of the
 scene for the current viewer pose. This array's length may potentially vary over the

--- a/files/en-us/web/api/xrviewport/height/index.md
+++ b/files/en-us/web/api/xrviewport/height/index.md
@@ -30,13 +30,7 @@ with {{domxref("XRViewport.width", "width")}} and the origin point given by
 {{domxref("XRViewport.x", "x")}} and {{domxref("XRViewport.y", "y")}}, this defines the
 area within which rendered content will be drawn.
 
-## Syntax
-
-```js
-height = xrViewport.height;
-```
-
-### Value
+## Value
 
 The viewport's height in pixels.
 

--- a/files/en-us/web/api/xrviewport/width/index.md
+++ b/files/en-us/web/api/xrviewport/width/index.md
@@ -30,13 +30,7 @@ using this property along with the viewport's {{domxref("XRViewport.height", "he
 and its origin given by its properties {{domxref("XRViewport.x", "x")}} and
 {{domxref("XRViewport.y", "y")}}.
 
-## Syntax
-
-```js
-width = xrViewport.width;
-```
-
-### Value
+## Value
 
 The viewport's width in pixels.
 

--- a/files/en-us/web/api/xrviewport/x/index.md
+++ b/files/en-us/web/api/xrviewport/x/index.md
@@ -34,13 +34,7 @@ viewport's {{domxref("XRViewport.y", "y")}} property identifies the `y`
 component of the origin, and its is given by the {{domxref("XRViewPort.width",
   "width")}} and {{domxref("XRViewport.height", "height")}} properties.
 
-## Syntax
-
-```js
-x = xrViewport.x;
-```
-
-### Value
+## Value
 
 The offset from the left edge of the rendering surface to the left edge of the
 viewport, in pixels.

--- a/files/en-us/web/api/xrviewport/y/index.md
+++ b/files/en-us/web/api/xrviewport/y/index.md
@@ -33,13 +33,7 @@ viewport's {{domxref("XRViewport.x", "x")}} property identifies the `x`
 component of the origin, and its is given by the {{domxref("XRViewPort.width",
   "width")}} and {{domxref("XRViewport.height", "height")}} properties.
 
-## Syntax
-
-```js
-y = xrViewport.y;
-```
-
-### Value
+## Value
 
 The offset from the bottom edge of the rendering surface to the bottom edge of the
 viewport, in pixels.

--- a/files/en-us/web/api/xrwebgldepthinformation/texture/index.md
+++ b/files/en-us/web/api/xrwebgldepthinformation/texture/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRWebGLDepthInformation.texture
 
 The _read-only_ **`texture`** property of the {{DOMxRef("XRWebGLDepthInformation")}} interface is a {{domxref("WebGLTexture")}} containing depth buffer information as an opaque texture.
 
-### Value
+## Value
 
 A {{domxref("WebGLTexture")}}.
 

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -30,13 +30,7 @@ compositor](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals#The_WebXR_composit
 standard WebGL framebuffer, except for the differences covered in the section
 {{anch("How opaque framebuffers are special")}} below.
 
-## Syntax
-
-```js
-let framebuffer = xrWebGLLayer.framebuffer;
-```
-
-### Value
+## Value
 
 A {{domxref("WebGLFramebuffer")}} object representing the framebuffer into which the 3D
 scene is being rendered, or `null` if the [XR

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
@@ -32,13 +32,7 @@ framebuffer, in pixels.
 You can get the width of the framebuffer using the
 {{domxref("XRWebGLLayer.framebufferWidth", "framebufferWidth")}} property.
 
-## Syntax
-
-```js
-let bufferHeight = xrWebGLLayer.framebufferHeight;
-```
-
-### Value
+## Value
 
 The height in pixels of the XR device's framebuffer. Each of the framebuffer's
 attachments (pixel, depth, color, and/or stencil buffers, for example) are all this many

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
@@ -31,13 +31,7 @@ in pixels.
 You can get the height of the framebuffer using the
 {{domxref("XRWebGLLayer.framebufferHeight", "framebufferHeight")}} property.
 
-## Syntax
-
-```js
-let bufferWidth = xrWebGLLayer.framebufferWidth;
-```
-
-### Value
+## Value
 
 The width in pixels of the XR device's framebuffer. Each of the framebuffer's
 attachments (pixel, depth, color, and/or stencil buffers, for example) are all this many

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
@@ -32,13 +32,7 @@ position of vertices, this property is `false`.
 The value of `ignoreDepthValues` can only be set when the
 {{domxref("XRWebGLLayer")}} is instantiated, by setting the corresponding value in the [constructor's](/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer) `layerInit` parameter.
 
-## Syntax
-
-```js
-let ignoringDepthBuffer = xrWebGLLayer.ignoreDepthValues;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the WebGL context's depth buffer is being
 used while computing the locations of points in the 3D world. Otherwise, if this is


### PR DESCRIPTION
This is me trying to make the WebXR doc set to be a role-model per our latest API docs guidelines.

- Remove syntax sections from property pages
- Normalize Value section to be an h2