### PR TITLE
fix: replace broken packaging_and_installation link

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
@@ -83,7 +83,7 @@ Assign `notify()` as a listener to messages from the content script.
 chrome.runtime.onMessage.addListener(notify);
 </pre>
 
-<p>If you want to follow along, clone the <a href="https://github.com/mdn/webextensions-examples">webextensions-examples</a> repository, then <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Packaging_and_installation">package and install</a> "notify-link-clicks-i18n".</p>
+<p>If you want to follow along, clone the <a href="https://github.com/mdn/webextensions-examples">webextensions-examples</a> repository, then <a href="https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox">package and install</a> "notify-link-clicks-i18n".</p>
 
 <h2 id="The_Browser_Toolbox">The Browser Toolbox</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/internationalization/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/internationalization/index.html
@@ -381,7 +381,7 @@ padding-left: 1.5em;</pre>
 
 <h2 id="Testing_out_your_extension">Testing out your extension</h2>
 
-<p>Starting in Firefox 45, you can install extensions temporarily from disk — see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Packaging_and_installation#loading_from_disk">Loading from disk</a>. Do this, and then try testing out our <a href="https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n">notify-link-clicks-i18n</a> extension. Go to one of your favorite websites and click a link to see if a notification appears reporting the URL of the clicked link.</p>
+<p>Starting in Firefox 45, you can <a href="https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox">install extensions temporarily from disk</a>. Do this, and then try testing out our <a href="https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n">notify-link-clicks-i18n</a> extension. Go to one of your favorite websites and click a link to see if a notification appears reporting the URL of the clicked link.</p>
 
 <p>Next, change Firefox's locale to one supported in the extension that you want to test.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes:
Fixes #8162

> What was wrong/why is this fix needed? (quick summary only)
The packaging_and_installation link is broken on the following pages:
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/debugging_(before_firefox_50)

