### PR TITLE
Closing div tag of hidden div block relocated.

### DIFF
--- a/files/en-us/learn/css/css_layout/multiple-column_layout/index.html
+++ b/files/en-us/learn/css/css_layout/multiple-column_layout/index.html
@@ -116,12 +116,13 @@ tags:
   cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis
   dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
 &lt;/div&gt;</pre>
-</div>
+
 
 <pre class="brush: css">.container {
   column-width: 200px;
 }
 </pre>
+</div>
 </div>
 
 <p>{{ EmbedLiveSample('Multicol_2', '100%', 400) }}</p>


### PR DESCRIPTION
The` </div> ` of hidden block was inserted before the following code snippet

```
<pre class="brush: css">.container {
  column-width: 200px;
}
```

So currently this css code snippet is repeatedly appearing.

I have moved the ` </div> ` below this code snippet to hide the repetition.