### PR TITLE
Adds Glossary page for Clickjacking

### DIFF
--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -21,5 +21,5 @@ tags:
  <li><a href="https://en.wikipedia.org/wiki/Clickjacking">Clickjacking</a>on Wikipedia</li>
  <li><a href="https://owasp.org/www-community/attacks/Clickjacking">Clickjacking</a> on OWASP</li>
  <li><a href="https://www.getastra.com/blog/knowledge-base/clickjacking-all-you-need-to-know/#Example_of_Clickjacking_in_Action">Example of Clickjacking in action</a></li>
- <li><a href="https://portswigger.net/web-security/clickjacking">Another article about Clickjacking</a></li>
+ <li><a href="https://portswigger.net/web-security/clickjacking">Clickjacking (UI redressing)</a> on PortSwigger Web Security Academy</li>
 </ul>

--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -11,13 +11,13 @@ tags:
 ---
 <p>Clickjacking is an interface-based attack that tricks website users into unwarily clicking on malicious links. In clickjacking, the attackers embed their malicious links into buttons or legitimate pages in a website. In an infected {{glossary("Site")}}, whenever a user clicks on a legitimate link, the attacker gets the confidential information of that user, which ultimately compromises the user's privacy on the Internet.</p> 
 
-<p>Clickjacking can be prevented by implementing a Content Security Policy (CSP) and <a href="https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html">other defense methods</a>.</p>
+<p>Clickjacking can be prevented by implementing a <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors">Content Security Policy (frame-ancestors)</a> and implementing <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes">Set-Cookie attributes</a>.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 
 
 <ul>
- <li><a href="/en-US/docs/Web/Security/Types_of_attacks#clickjacking">Clickjacking</a></li>
+ <li><a href="/en-US/docs/Web/Security#clickjacking_protection">Clickjacking</a></li>
  <li><a href="https://en.wikipedia.org/wiki/Clickjacking">Clickjacking</a>on Wikipedia</li>
  <li><a href="https://owasp.org/www-community/attacks/Clickjacking">Clickjacking</a> on OWASP</li>
  <li><a href="https://www.getastra.com/blog/knowledge-base/clickjacking-all-you-need-to-know/#Example_of_Clickjacking_in_Action">Example of Clickjacking in action</a></li>

--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -19,7 +19,7 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/Security/Types_of_attacks#clickjacking">Clickjacking</a></li>
  <li><a href="https://en.wikipedia.org/wiki/Clickjacking">Clickjacking</a>on Wikipedia</li>
- <li><a href="https://owasp.org/www-community/attacks/Clickjacking">Clickjacking on OWASP</a></li>
+ <li><a href="https://owasp.org/www-community/attacks/Clickjacking">Clickjacking</a> on OWASP</li>
  <li><a href="https://www.getastra.com/blog/knowledge-base/clickjacking-all-you-need-to-know/">Example of Clickjacking in action</a></li>
  <li><a href="https://portswigger.net/web-security/clickjacking">Another article about Clickjacking</a></li>
 </ul>

--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -9,7 +9,7 @@ tags:
   - vulnerability
   - exploit
 ---
-<p>Clickjacking is an interface-based attack that tricks website users into unwarily clicking on malicious links. In clickjacking, the attackers embed their malicious links into buttons or legitimate pages in a website. In an infected {{glossary("Site")}}, whenever a user clicks on a legitimate link, the attacker gets the confidential information of that user - which ultimately compromises the user's privacy on the Internet. Clickjacking falls under the <a href="https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration">A6 – Security Misconfiguration</a> item in OWASP’s 2017 Top 10 list.</p> 
+<p>Clickjacking is an interface-based attack that tricks website users into unwarily clicking on malicious links. In clickjacking, the attackers embed their malicious links into buttons or legitimate pages in a website. In an infected {{glossary("Site")}}, whenever a user clicks on a legitimate link, the attacker gets the confidential information of that user, which ultimately compromises the user's privacy on the Internet.</p> 
 
 <p>Clickjacking can be prevented by implementing a Content Security Policy (CSP) and <a href="https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html">other defense methods</a>.</p>
 

--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -15,7 +15,6 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li><a href="/en-US/docs/Web/Security/Types_of_attacks#clickjacking">Clickjacking</a></li>

--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -1,0 +1,26 @@
+---
+title: Clickjacking
+slug: Glossary/Clickjacking
+tags:
+  - Clickjacking
+  - Interface-based attack
+  - Glossary
+  - Security
+  - vulnerability
+  - exploit
+---
+<p>Clickjacking is an interface-based attack that tricks website users into unwarily clicking on malicious links. In clickjacking, the attackers embed their malicious links into buttons or legitimate pages in a website. In an infected {{glossary("Site")}}, whenever a user clicks on a legitimate link, the attacker gets the confidential information of that user - which ultimately compromises the user's privacy on the Internet. Clickjacking falls under the <a href="https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration">A6 – Security Misconfiguration</a> item in OWASP’s 2017 Top 10 list.</p> 
+
+<p>Clickjacking can be prevented by implementing a Content Security Policy (CSP) and <a href="https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html">other defense methods</a>.</p>
+
+<h2 id="Learn_more">Learn more</h2>
+
+<h3 id="General_knowledge">General knowledge</h3>
+
+<ul>
+ <li><a href="/en-US/docs/Web/Security/Types_of_attacks#clickjacking">Clickjacking</a></li>
+ <li><a href="https://en.wikipedia.org/wiki/Clickjacking">Clickjacking</a>on Wikipedia</li>
+ <li><a href="https://owasp.org/www-community/attacks/Clickjacking">Clickjacking on OWASP</a></li>
+ <li><a href="https://www.getastra.com/blog/knowledge-base/clickjacking-all-you-need-to-know/">Example of Clickjacking in action</a></li>
+ <li><a href="https://portswigger.net/web-security/clickjacking">Another article about Clickjacking</a></li>
+</ul>

--- a/files/en-us/glossary/clickjacking/index.html
+++ b/files/en-us/glossary/clickjacking/index.html
@@ -20,6 +20,6 @@ tags:
  <li><a href="/en-US/docs/Web/Security/Types_of_attacks#clickjacking">Clickjacking</a></li>
  <li><a href="https://en.wikipedia.org/wiki/Clickjacking">Clickjacking</a>on Wikipedia</li>
  <li><a href="https://owasp.org/www-community/attacks/Clickjacking">Clickjacking</a> on OWASP</li>
- <li><a href="https://www.getastra.com/blog/knowledge-base/clickjacking-all-you-need-to-know/">Example of Clickjacking in action</a></li>
+ <li><a href="https://www.getastra.com/blog/knowledge-base/clickjacking-all-you-need-to-know/#Example_of_Clickjacking_in_Action">Example of Clickjacking in action</a></li>
  <li><a href="https://portswigger.net/web-security/clickjacking">Another article about Clickjacking</a></li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
This PR adds a page for the Clickjacking entry in Glossary from https://datatracker.ietf.org/doc/html/rfc7034.

This is my first time contributing to MDN, so apologies if I have missed out anything. 