### PR TITLE
htmlmediaelement : default playback rate - exception if value unsupported

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
@@ -23,6 +23,9 @@ browser-compat: api.HTMLMediaElement.defaultPlaybackRate
 
 <p>A double. 1.0 is "normal speed," values lower than 1.0 make the media play slower than normal, higher values make it play faster. The value 0.0 is invalid and throws a <code>NOT_SUPPORTED_ERR</code> exception.</p>
 
+<p>The user agent will throw a <code>NotSupportedError</code> exception if the specified value is not supported.</p>
+
+
 <h2 id="Example">Example</h2>
 
 <pre class="brush: js">var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
@@ -21,7 +21,7 @@ browser-compat: api.HTMLMediaElement.defaultPlaybackRate
 
 <h3 id="Value">Value</h3>
 
-<p>A double. 1.0 is "normal speed," values lower than 1.0 make the media play slower than normal, higher values make it play faster. The value 0.0 is invalid and throws a <code>NOT_SUPPORTED_ERR</code> exception.</p>
+<p>A double. 1.0 is "normal speed," values lower than 1.0 make the media play slower than normal, higher values make it play faster.</p>
 
 <p>The user agent will throw a <code>NotSupportedError</code> exception if the specified value is not supported.</p>
 


### PR DESCRIPTION
Fixes #8578 

MDN said values 0.0 was unsupported. The spec says nothing about supported values - just that the user agent should throw an error if the value isn't supported. 

Note there was some discussion of what values might be supported in https://github.com/whatwg/html/issues/2754 . But the "0.0" value is not disallowed anywhere.