### PR TITLE
"Array Iterator" never appear in codes

### DIFF
--- a/files/en-us/web/api/css_typed_om_api/index.html
+++ b/files/en-us/web/api/css_typed_om_api/index.html
@@ -55,7 +55,7 @@ tags:
 	<dt>{{domxref('CSSUnparsedValue.forEach()')}}</dt>
 	<dd>Method executing a provided function once for each element of the CSSUnparsedValue.</dd>
 	<dt>{{domxref('CSSUnparsedValue.keys()')}}</dt>
-	<dd>Method returning a new Array Iterator object that contains the keys for each index in the array.</dd>
+	<dd>Method returning a new _array iterator_ object that contains the keys for each index in the array.</dd>
 </dl>
 
 <h3 id="domxrefCSSKeywordValue_Serialization"><code>CSSKeywordValue</code> Serialization</h3>

--- a/files/en-us/web/api/css_typed_om_api/index.html
+++ b/files/en-us/web/api/css_typed_om_api/index.html
@@ -55,7 +55,7 @@ tags:
 	<dt>{{domxref('CSSUnparsedValue.forEach()')}}</dt>
 	<dd>Method executing a provided function once for each element of the CSSUnparsedValue.</dd>
 	<dt>{{domxref('CSSUnparsedValue.keys()')}}</dt>
-	<dd>Method returning a new _array iterator_ object that contains the keys for each index in the array.</dd>
+	<dd>Method returning a new <em>array iterator</em> object that contains the keys for each index in the array.</dd>
 </dl>
 
 <h3 id="domxrefCSSKeywordValue_Serialization"><code>CSSKeywordValue</code> Serialization</h3>

--- a/files/en-us/web/api/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/index.html
@@ -59,9 +59,9 @@ browser-compat: api.CSSTransformValue
 	<dt>{{domxref('CSSUnparsedValue.forEach()')}}</dt>
 	<dd>Executes a provided function once for each element of the <code>CSSTransformValue</code> object.</dd>
 	<dt>{{domxref('CSSUnparsedValue.keys()')}}</dt>
-	<dd>Returns a new <strong><code>Array Iterator</code></strong> object that contains the keys for each index in the <code>CSSTransformValue</code> object.</dd>
+	<dd>Returns a new <em>array iterator</em> object that contains the keys for each index in the <code>CSSTransformValue</code> object.</dd>
 	<dt>{{domxref('CSSUnparsedValue.values()')}}</dt>
-	<dd>Returns a new <strong><code>Array Iterator</code></strong> object that contains the values for each index in the <code>CSSTransformValue</code> object.</dd>
+	<dd>Returns a new <em>array iterator</em> object that contains the values for each index in the <code>CSSTransformValue</code> object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/csstransformvalue/keys/index.html
+++ b/files/en-us/web/api/csstransformvalue/keys/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CSSTransformValue.keys
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
 <p>The <strong><code>CSSTransformValue.keys()</code></strong> method
-  returns a new <code><strong>Array Iterator</strong></code> object that contains the keys
+  returns a new <em>array iterator</em> object that contains the keys
   for each index in the array.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/csstransformvalue/values/index.html
+++ b/files/en-us/web/api/csstransformvalue/values/index.html
@@ -16,7 +16,7 @@ browser-compat: api.CSSTransformValue.values
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
 <p>The <strong><code>CSSTransformValue.values()</code></strong>  returns a
-  new <strong><code>Array Iterator</code></strong> object that contains the values for
+  new <em>array iterator</em> object that contains the values for
   each index in the CSSTransformValue object.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/index.html
@@ -40,9 +40,9 @@ browser-compat: api.CSSUnparsedValue
  <dt>{{domxref('CSSUnparsedValue.forEach()')}}</dt>
  <dd>Executes a provided function once for each element of the <code>CSSUnparsedValue</code> object.</dd>
  <dt>{{domxref('CSSUnparsedValue.keys()')}}</dt>
- <dd>Returns a new <strong><code>Array Iterator</code></strong> object that contains the keys for each index in the <code>CSSUnparsedValue</code> object.</dd>
+ <dd>Returns a new <em>array iterator</em> object that contains the keys for each index in the <code>CSSUnparsedValue</code> object.</dd>
  <dt>{{domxref('CSSUnparsedValue.values()')}}</dt>
- <dd>Returns a new <strong><code>Array Iterator</code></strong> object that contains the values for each index in the <code>CSSUnparsedValue</code> object.</dd>
+ <dd>Returns a new <em>array iterator</em> object that contains the values for each index in the <code>CSSUnparsedValue</code> object.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.html
@@ -17,7 +17,7 @@ browser-compat: api.CSSUnparsedValue.keys
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
 <p>The <strong><code>CSSUnparsedValue.keys()</code></strong> method
-  returns a new <code><strong>Array Iterator</strong></code> object that contains the keys
+  returns a new <em>array iterator</em> object that contains the keys
   for each index in the array.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/cssunparsedvalue/values/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.html
@@ -17,7 +17,7 @@ browser-compat: api.CSSUnparsedValue.values
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
 <p>The <strong><code>CSSUnparsedValue.values()</code></strong> method
-  returns a new <strong><code>Array Iterator</code></strong> object that contains the
+  returns a new <em>array iterator</em> object that contains the
   values for each index in the CSSUnparsedValue object.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.html
@@ -31,13 +31,13 @@ browser-compat: api.FileSystemDirectoryHandle
  <dt>{{domxref('FileSystemDirectoryHandle.getDirectoryHandle()')}}</dt>
  <dd>Returns a {{domxref('FileSystemDirectoryHandle')}} for a subdirectory with the specified name within the directory handle on which the method is called.</dd>
  <dt>{{domxref('FileSystemDirectoryHandle.keys()')}}</dt>
- <dd>Returns a new Array Iterator containing the keys for each item in <code>FileSystemDirectoryHandle</code>.</dd>
+ <dd>Returns a new <em>array iterator</em> containing the keys for each item in <code>FileSystemDirectoryHandle</code>.</dd>
  <dt>{{domxref('FileSystemDirectoryHandle.removeEntry()')}}</dt>
  <dd>Attempts to remove an entry if the directory handle contains a file or directory called the name specified.</dd>
  <dt>{{domxref('FileSystemDirectoryHandle.resolve()')}}</dt>
  <dd>Returns an {{jsxref('Array')}} of directory names from the parent handle to the specified child entry, with the name of the child entry as the last array item.</dd>
  <dt>{{domxref('FileSystemDirectoryHandle.values()')}}</dt>
- <dd>Returns a new Array Iterator containing the values for each index in the <code>FileSystemDirectoryHandle</code> object.</dd>
+ <dd>Returns a new <em>array iterator</em> containing the values for each index in the <code>FileSystemDirectoryHandle</code> object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemDirectoryHandle.keys
 </div>
 
 <p>The <strong><code>keys()</code></strong> method of the
-  {{domxref("FileSystemDirectoryHandle")}} interface returns a new Array Iterator
+  {{domxref("FileSystemDirectoryHandle")}} interface returns a new <em>array iterator</em>
   containing the keys for each item in <code>FileSystemDirectoryHandle</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemDirectoryHandle.values
 </div>
 
 <p>The <strong><code>values()</code></strong> method of the
-  {{domxref("FileSystemDirectoryHandle")}} interface returns a new Array Iterator
+  {{domxref("FileSystemDirectoryHandle")}} interface returns a new <em>array iterator</em>
   containing the values for each index in the <code>FileSystemDirectoryHandle</code>
   object.</p>
 

--- a/files/en-us/web/api/keyboardlayoutmap/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/index.html
@@ -24,11 +24,11 @@ browser-compat: api.KeyboardLayoutMap
 	<dt>{{domxref('KeyboardLayoutMap.entries')}} {{readonlyinline}} {{experimental_inline}}</dt>
 	<dd>Returns an array of a given object's own enumerable property <code>[key, value]</code> pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a <code>for-in</code> loop enumerates properties in the prototype chain as well). </dd>
 	<dt>{{domxref('KeyboardLayoutMap.keys')}} {{readonlyinline}} {{experimental_inline}}</dt>
-	<dd>Returns a new Array Iterator object that contains the keys for each index in the array.</dd>
+	<dd>Returns a new _array iterator_ object that contains the keys for each index in the array.</dd>
 	<dt>{{domxref('KeyboardLayoutMap.size')}} {{readonlyinline}} {{experimental_inline}}</dt>
 	<dd>Returns the number of elements in the <code>KeyboardLayoutMap</code> object.</dd>
 	<dt>{{domxref('KeyboardLayoutMap.values')}} {{readonlyinline}} {{experimental_inline}}</dt>
-	<dd>Returns a new Array Iterator object that contains the values for each index in the <code>KeyboardLayoutMap</code> object.</dd>
+	<dd>Returns a new _array iterator_ object that contains the values for each index in the <code>KeyboardLayoutMap</code> object.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/keyboardlayoutmap/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/index.html
@@ -24,11 +24,11 @@ browser-compat: api.KeyboardLayoutMap
 	<dt>{{domxref('KeyboardLayoutMap.entries')}} {{readonlyinline}} {{experimental_inline}}</dt>
 	<dd>Returns an array of a given object's own enumerable property <code>[key, value]</code> pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a <code>for-in</code> loop enumerates properties in the prototype chain as well). </dd>
 	<dt>{{domxref('KeyboardLayoutMap.keys')}} {{readonlyinline}} {{experimental_inline}}</dt>
-	<dd>Returns a new _array iterator_ object that contains the keys for each index in the array.</dd>
+	<dd>Returns a new <em>array iterator</em> object that contains the keys for each index in the array.</dd>
 	<dt>{{domxref('KeyboardLayoutMap.size')}} {{readonlyinline}} {{experimental_inline}}</dt>
 	<dd>Returns the number of elements in the <code>KeyboardLayoutMap</code> object.</dd>
 	<dt>{{domxref('KeyboardLayoutMap.values')}} {{readonlyinline}} {{experimental_inline}}</dt>
-	<dd>Returns a new _array iterator_ object that contains the values for each index in the <code>KeyboardLayoutMap</code> object.</dd>
+	<dd>Returns a new <em>array iterator</em> object that contains the values for each index in the <code>KeyboardLayoutMap</code> object.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/stylepropertymapreadonly/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.html
@@ -36,9 +36,9 @@ browser-compat: api.StylePropertyMapReadOnly
  <dt>{{domxref('StylePropertyMapReadOnly.has()')}}</dt>
  <dd>Indicates whether the specified property is in the <code>StylePropertyMapReadOnly</code> object.</dd>
  <dt>{{domxref('StylePropertyMapReadOnly.keys()')}}</dt>
- <dd>Returns a new Array Iterator containing the keys for each item in <code>StylePropertyMapReadOnly</code>.</dd>
+ <dd>Returns a new <em>array iterator</em> containing the keys for each item in <code>StylePropertyMapReadOnly</code>.</dd>
  <dt>{{domxref('StylePropertyMapReadOnly.values()')}}</dt>
- <dd>Returns a new Array Iterator containing the values for each index in the <code>StylePropertyMapReadOnly</code> object.</dd>
+ <dd>Returns a new <em>array iterator</em> containing the values for each index in the <code>StylePropertyMapReadOnly</code> object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/stylepropertymapreadonly/keys/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/keys/index.html
@@ -15,7 +15,7 @@ browser-compat: api.StylePropertyMapReadOnly.keys
 <p>{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</p>
 
 <p>The <strong><code>StylePropertyMapReadOnly.keys()</code></strong> method returns a new
-  Array Iterator containing the keys for each item
+  <em>array iterator</em> containing the keys for each item
   in <code>StylePropertyMapReadOnly</code></p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/stylepropertymapreadonly/values/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/values/index.html
@@ -15,7 +15,7 @@ browser-compat: api.StylePropertyMapReadOnly.values
 <p>{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</p>
 
 <p>The <strong><code>StylePropertyMapReadOnly.values()</code></strong> method returns a
-  new Array Iterator containing the values for each index in the
+  new <em>array iterator</em> containing the values for each index in the
   <code>StylePropertyMapReadOnly</code> object.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -327,7 +327,7 @@ The properties and elements returned from this match are as follows:
 - {{jsxref("Array.prototype.join()")}}
   - : Joins all elements of an array into a string.
 - {{jsxref("Array.prototype.keys()")}}
-  - : Returns a new Array Iterator that contains the keys for each index in the array.
+  - : Returns a new _array iterator_ that contains the keys for each index in the array.
 - {{jsxref("Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to an element, or `-1` if none is found.
 - {{jsxref("Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -303,7 +303,7 @@ The properties and elements returned from this match are as follows:
 - {{jsxref("Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array.
 - {{jsxref("Array.prototype.entries()")}}
-  - : Returns a new `Array Iterator` object that contains the key/value pairs for each index in the array.
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array.
 - {{jsxref("Array.prototype.every()")}}
   - : Returns `true` if every element in this array satisfies the testing function.
 - {{jsxref("Array.prototype.fill()")}}
@@ -327,7 +327,7 @@ The properties and elements returned from this match are as follows:
 - {{jsxref("Array.prototype.join()")}}
   - : Joins all elements of an array into a string.
 - {{jsxref("Array.prototype.keys()")}}
-  - : Returns a new `Array Iterator` that contains the keys for each index in the array.
+  - : Returns a new Array Iterator that contains the keys for each index in the array.
 - {{jsxref("Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to an element, or `-1` if none is found.
 - {{jsxref("Array.prototype.map()")}}
@@ -359,9 +359,9 @@ The properties and elements returned from this match are as follows:
 - {{jsxref("Array.prototype.unshift()")}}
   - : Adds one or more elements to the front of an array, and returns the new `length` of the array.
 - {{jsxref("Array.prototype.values()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 - {{jsxref("Array.prototype.@@iterator()", "Array.prototype[@@iterator]()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Array.values
 {{JSRef}}
 
 The **`values()`** method returns a new
-**Array Iterator** object that contains the values for each
+_array iterator_ object that contains the values for each
 index in the array.
 
 {{EmbedInteractiveExample("pages/js/array-values.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Array.values
 {{JSRef}}
 
 The **`values()`** method returns a new
-**`Array Iterator`** object that contains the values for each
+**Array Iterator** object that contains the values for each
 index in the array.
 
 {{EmbedInteractiveExample("pages/js/array-values.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -70,7 +70,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.join", "BigInt64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "BigInt64Array.prototype.keys()")}}
-  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "BigInt64Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "BigInt64Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -50,7 +50,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.copyWithin", "BigInt64Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "BigInt64Array.prototype.entries()")}}
-  - : Returns a new `Array Iterator` object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
 - {{jsxref("TypedArray.every", "BigInt64Array.prototype.every()")}}
   - : Tests whether all elements in the array pass the test provided by a function. See also {{jsxref("Array.prototype.every()")}}.
 - {{jsxref("TypedArray.fill", "BigInt64Array.prototype.fill()")}}
@@ -70,7 +70,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.join", "BigInt64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "BigInt64Array.prototype.keys()")}}
-  - : Returns a new `Array Iterator` that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "BigInt64Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "BigInt64Array.prototype.map()")}}
@@ -92,13 +92,13 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.subarray", "BigInt64Array.prototype.subarray()")}}
   - : Returns a new `BigUint64Array` from the given start and end element index.
 - {{jsxref("TypedArray.values", "BigInt64Array.prototype.values()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
 - {{jsxref("TypedArray.toLocaleString", "BigInt64Array.prototype.toLocaleString()")}}
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigInt64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
 - {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
@@ -50,7 +50,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.copyWithin", "BigUint64Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "BigUint64Array.prototype.entries()")}}
-  - : Returns a new `Array Iterator` object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
 - {{jsxref("TypedArray.every", "BigUint64Array.prototype.every()")}}
   - : Tests whether all elements in the array pass the test provided by a function. See also {{jsxref("Array.prototype.every()")}}.
 - {{jsxref("TypedArray.fill", "BigUint64Array.prototype.fill()")}}
@@ -70,7 +70,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.join", "BigUint64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "BigUint64Array.prototype.keys()")}}
-  - : Returns a new `Array Iterator` that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "BigUint64Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "BigUint64Array.prototype.map()")}}
@@ -92,13 +92,13 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.subarray", "BigUint64Array.prototype.subarray()")}}
   - : Returns a new `BigUint64Array` from the given start and end element index.
 - {{jsxref("TypedArray.values", "BigUint64Array.prototype.values()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
 - {{jsxref("TypedArray.toLocaleString", "BigUint64Array.prototype.toLocaleString()")}}
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigUint64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
 - {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
@@ -70,7 +70,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.join", "BigUint64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "BigUint64Array.prototype.keys()")}}
-  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "BigUint64Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "BigUint64Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -68,7 +68,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.join", "Float32Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "Float32Array.prototype.keys()")}}
-  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "Float32Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float32Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -48,7 +48,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.copyWithin", "Float32Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Float32Array.prototype.entries()")}}
-  - : Returns a new `Array Iterator` object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
 - {{jsxref("TypedArray.every", "Float32Array.prototype.every()")}}
   - : Tests whether all elements in the array pass the test provided by a function. See also {{jsxref("Array.prototype.every()")}}.
 - {{jsxref("TypedArray.fill", "Float32Array.prototype.fill()")}}
@@ -68,7 +68,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.join", "Float32Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "Float32Array.prototype.keys()")}}
-  - : Returns a new `Array Iterator` that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "Float32Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float32Array.prototype.map()")}}
@@ -90,13 +90,13 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.subarray", "Float32Array.prototype.subarray()")}}
   - : Returns a new `Float32Array` from the given start and end element index.
 - {{jsxref("TypedArray.values", "Float32Array.prototype.values()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
 - {{jsxref("TypedArray.toLocaleString", "Float32Array.prototype.toLocaleString()")}}
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
 - {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -68,7 +68,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.join", "Float64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "Float64Array.prototype.keys()")}}
-  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "Float64Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float64Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -48,7 +48,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.copyWithin", "Float64Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Float64Array.prototype.entries()")}}
-  - : Returns a new `Array Iterator` object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
 - {{jsxref("TypedArray.every", "Float64Array.prototype.every()")}}
   - : Tests whether all elements in the array pass the test provided by a function. See also {{jsxref("Array.prototype.every()")}}.
 - {{jsxref("TypedArray.fill", "Float64Array.prototype.fill()")}}
@@ -68,7 +68,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.join", "Float64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "Float64Array.prototype.keys()")}}
-  - : Returns a new `Array Iterator` that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+  - : Returns a new Array Iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "Float64Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float64Array.prototype.map()")}}
@@ -90,13 +90,13 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.subarray", "Float64Array.prototype.subarray()")}}
   - : Returns a new `Float64Array` from the given start and end element index.
 - {{jsxref("TypedArray.values", "Float64Array.prototype.values()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
 - {{jsxref("TypedArray.toLocaleString", "Float64Array.prototype.toLocaleString()")}}
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
 - {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]()")}}
-  - : Returns a new `Array Iterator` object that contains the values for each index in the array.
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -28,7 +28,7 @@ entries()
 
 ### Return value
 
-A new array iterator object.
+A new _array iterator_ object.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -148,7 +148,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
   - : Copies a sequence of array elements within the array. See also
     {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.prototype.entries()")}}
-  - : Returns a new array iterator object that contains the key/value pairs for each index
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index
     in the array. See also {{jsxref("Array.prototype.entries()")}}.
 - {{jsxref("TypedArray.prototype.every()")}}
   - : Tests whether all elements in the array pass the test provided by a function. See
@@ -219,7 +219,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
   - : Returns a new `TypedArray` from the given start and end
     element index.
 - {{jsxref("TypedArray.prototype.values()")}}
-  - : Returns a new array iterator object that contains the values for each index in the
+  - : Returns a new _array iterator_ object that contains the values for each index in the
     array. See also {{jsxref("Array.prototype.values()")}}.
 - {{jsxref("TypedArray.prototype.toLocaleString()")}}
   - : Returns a localized string representing the array and its elements. See also
@@ -229,7 +229,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
     {{jsxref("Array.prototype.toString()")}}.
 - {{jsxref("TypedArray.prototype.@@iterator()",
     "TypedArray.prototype[@@iterator]()")}}
-  - : Returns a new array iterator object that contains the values for each index in the
+  - : Returns a new _array iterator_ object that contains the values for each index in the
     array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.TypedArray.keys
 ---
 {{JSRef}}
 
-The **`keys()`** method returns a new array iterator object
+The **`keys()`** method returns a new _array iterator_ object
 that contains the keys for each index in the array.
 
 {{EmbedInteractiveExample("pages/js/typedarray-keys.html")}}
@@ -28,7 +28,7 @@ keys()
 
 ### Return value
 
-A new array iterator object.
+A new _array iterator_ object.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.TypedArray.values
 ---
 {{JSRef}}
 
-The **`values()`** method returns a new array iterator object
+The **`values()`** method returns a new _array iterator_ object
 that contains the values for each index in the array.
 
 {{EmbedInteractiveExample("pages/js/array-values.html")}}
@@ -27,7 +27,7 @@ values()
 
 ### Return value
 
-A new array iterator object.
+A new _array iterator_ object.
 
 ## Examples
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

"Array Iterator" never appear in codes, so I think it shouldn't be styled as a code like `Array Iterator`.

> Anything else that could help us review it
