### PR TITLE
Markdown Learn/Server-Side: Table - strip class (standard-table and learn-table)

### DIFF
--- a/files/en-us/learn/server-side/django/admin_site/index.html
+++ b/files/en-us/learn/server-side/django/admin_site/index.html
@@ -18,7 +18,8 @@ tags:
 
 <p>Now that we've created models for the <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website, we'll use the Django Admin site to add some "real" book data. First we'll show you how to register the models with the admin site, then we'll show you how to login and create some data. At the end of the article we will show some of the ways you can further improve the presentation of the Admin site.</p>
 
-<table class="learn-box standard-table">
+<p>original</p>
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>
@@ -30,6 +31,63 @@ tags:
   </tr>
  </tbody>
 </table>
+
+<p>remove classes - standard-table and learn-box</p>
+<table>
+    <tbody>
+     <tr>
+      <th scope="row">Prerequisites:</th>
+      <td>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</td>
+     </tr>
+     <tr>
+      <th scope="row">Objective:</th>
+      <td>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</td>
+     </tr>
+    </tbody>
+   </table>
+
+   <p>using class = properties</p>
+   <table class="properties">
+       <tbody>
+        <tr>
+         <th scope="row">Prerequisites:</th>
+         <td>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</td>
+        </tr>
+        <tr>
+         <th scope="row">Objective:</th>
+         <td>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</td>
+        </tr>
+       </tbody>
+      </table>
+   
+
+      <p>Githubable</p>
+      <table>
+        <thead>
+            <tr>
+              <th scope="col">Prerequisites</th>
+              <th scope="col">Objective:</th>
+            </tr>
+          </thead>
+          <tbody>
+           <tr>
+            <td>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</td>
+            <td>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</td>
+           </tr>
+          </tbody>
+         </table>   
+   
+   <ul>
+       <li><strong>Prerequisites:</strong> First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</li>
+       <li><strong>Objective:</strong> To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</li>
+   </ul>
+   
+   <dl>
+       <dt>Prerequisites:</dt>
+       <dd>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</dd>
+       <dt>Objective:</dt>
+       <dd>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</dd>
+   </dl>
 
 <h2 id="Overview">Overview</h2>
 

--- a/files/en-us/learn/server-side/django/admin_site/index.html
+++ b/files/en-us/learn/server-side/django/admin_site/index.html
@@ -18,7 +18,6 @@ tags:
 
 <p>Now that we've created models for the <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website, we'll use the Django Admin site to add some "real" book data. First we'll show you how to register the models with the admin site, then we'll show you how to login and create some data. At the end of the article we will show some of the ways you can further improve the presentation of the Admin site.</p>
 
-<p>original</p>
 <table>
  <tbody>
   <tr>
@@ -32,62 +31,6 @@ tags:
  </tbody>
 </table>
 
-<p>remove classes - standard-table and learn-box</p>
-<table>
-    <tbody>
-     <tr>
-      <th scope="row">Prerequisites:</th>
-      <td>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</td>
-     </tr>
-     <tr>
-      <th scope="row">Objective:</th>
-      <td>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</td>
-     </tr>
-    </tbody>
-   </table>
-
-   <p>using class = properties</p>
-   <table class="properties">
-       <tbody>
-        <tr>
-         <th scope="row">Prerequisites:</th>
-         <td>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</td>
-        </tr>
-        <tr>
-         <th scope="row">Objective:</th>
-         <td>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</td>
-        </tr>
-       </tbody>
-      </table>
-   
-
-      <p>Githubable</p>
-      <table>
-        <thead>
-            <tr>
-              <th scope="col">Prerequisites</th>
-              <th scope="col">Objective:</th>
-            </tr>
-          </thead>
-          <tbody>
-           <tr>
-            <td>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</td>
-            <td>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</td>
-           </tr>
-          </tbody>
-         </table>   
-   
-   <ul>
-       <li><strong>Prerequisites:</strong> First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</li>
-       <li><strong>Objective:</strong> To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</li>
-   </ul>
-   
-   <dl>
-       <dt>Prerequisites:</dt>
-       <dd>First complete: <a href="/en-US/docs/Learn/Server-side/Django/Models">Django Tutorial Part 3: Using models</a>.</dd>
-       <dt>Objective:</dt>
-       <dd>To understand the benefits and limitations of the Django admin site, and use it to create some records for our models.</dd>
-   </dl>
 
 <h2 id="Overview">Overview</h2>
 

--- a/files/en-us/learn/server-side/django/authentication/index.html
+++ b/files/en-us/learn/server-side/django/authentication/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>In this tutorial, we'll show you how to allow users to log in to your site with their own accounts, and how to control what they can do and see based on whether or not they are logged in and their <em>permissions</em>. As part of this demonstration, we'll extend the <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website, adding login and logout pages, and user- and staff-specific pages for viewing books that have been borrowed.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>Now you've created (and tested) an awesome <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website, you're going to want to install it on a public web server so that it can be accessed by library staff and members over the Internet. This article provides an overview of how you might go about finding a host to deploy your website, and what you need to do in order to get your site ready for production.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/development_environment/index.html
+++ b/files/en-us/learn/server-side/django/development_environment/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>Now that you know what Django is for, we'll show you how to set up and test a Django development environment on Windows, Linux (Ubuntu), and macOS — whatever common operating system you are using, this article should give you what you need to be able to start developing Django apps.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/django_assessment_blog/index.html
+++ b/files/en-us/learn/server-side/django/django_assessment_blog/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>In this assessment you'll use the Django knowledge you've picked up in the <a href="/en-US/docs/Learn/Server-side/Django">Django Web Framework (Python)</a> module to create a very basic blog.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/forms/index.html
+++ b/files/en-us/learn/server-side/django/forms/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>In this tutorial, we'll show you how to work with HTML Forms in Django, and, in particular, the easiest way to write forms to create, update, and delete model instances. As part of this demonstration, we'll extend the <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website so that librarians can renew books, and create, update, and delete authors using our own forms (rather than using the admin application).</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/generic_views/index.html
+++ b/files/en-us/learn/server-side/django/generic_views/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>This tutorial extends our <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website, adding list and detail pages for books and authors. Here we'll learn about generic class-based views, and show how they can reduce the amount of code you have to write for common use cases. We'll also go into URL handling in greater detail, showing how to perform basic pattern matching.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/home_page/index.html
+++ b/files/en-us/learn/server-side/django/home_page/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>We're now ready to add the code that displays our first complete page — a home page for the <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website. The home page will show the number of records we have for each model type and provide sidebar navigation links to our other pages. Along the way we'll gain practical experience in writing basic URL maps and views, getting records from the database, and using templates.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/introduction/index.html
+++ b/files/en-us/learn/server-side/django/introduction/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>We'll outline the main features, including some of the advanced functionality that we won't have time to cover in detail in this module. We'll also show you some of the main building blocks of a Django application (although at this point you won't yet have a development environment in which to test it).</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/models/index.html
+++ b/files/en-us/learn/server-side/django/models/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>This article shows how to define models for the LocalLibrary website. It explains what a model is, how it is declared, and some of the main field types. It also briefly shows a few of the main ways you can access model data.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/sessions/index.html
+++ b/files/en-us/learn/server-side/django/sessions/index.html
@@ -20,7 +20,7 @@ tags:
 
 <p>This tutorial extends our <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">LocalLibrary</a> website, adding a session-based visit-counter to the home page. This is a relatively simple example, but it does show how you can use the session framework to provide persistent behavior for anonymous users in your own sites.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/skeleton_website/index.html
+++ b/files/en-us/learn/server-side/django/skeleton_website/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>This second article in our <a href="/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website">Django Tutorial</a> shows how you can create a "skeleton" website project as a basis, which you can then populate with site-specific settings, paths, models, views, and templates.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/testing/index.html
+++ b/files/en-us/learn/server-side/django/testing/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>As websites grow they become harder to test manually. Not only is there more to test, but, as interactions between components become more complex, a small change in one area can impact other areas, so more changes will be required to ensure everything keeps working and errors are not introduced as more changes are made. One way to mitigate these problems is to write automated tests, which can easily and reliably be run every time you make a change. This tutorial shows how to automate <em>unit testing</em> of your website using Django's test framework.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/tutorial_local_library_website/index.html
+++ b/files/en-us/learn/server-side/django/tutorial_local_library_website/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>The first article in our practical tutorial series explains what you'll learn, and provides an overview of the "local library" example website we'll be working through and evolving in subsequent articles.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/django/web_application_security/index.html
+++ b/files/en-us/learn/server-side/django/web_application_security/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>Protecting user data is an essential part of any website design. We previously explained some of the more common security threats in the article <a href="/en-US/docs/Web/Security">Web security</a> — this article provides a practical demonstration of how Django's in-built protections handle such threats.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>Now you've created (and tested) an awesome <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website">LocalLibrary</a> website, you're going to want to install it on a public web server so that it can be accessed by library staff and members over the Internet. This article provides an overview of how you might go about finding a host to deploy your website, and what you need to do in order to get your site ready for production.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>Now that you know what <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction#introducing_express">Express</a> is for, we'll show you how to set up and test a Node/Express development environment on Windows, or Linux (Ubuntu), or macOS. For any of those operating systems, this article provides what you need to start developing Express apps.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>We're now ready to add the pages that display the <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website">LocalLibrary</a> website books and other data. The pages will include a home page that shows how many records we have of each model type and list and detail pages for all of our models. Along the way, we'll gain practical experience in getting records from the database, and using templates.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/forms/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>In this tutorial we'll show you how to work with HTML Forms in Express using Pug. In particular, we'll discuss how to write forms to create, update, and delete documents from the site's database.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>In this first Express article we answer the questions "What is Node?" and "What is Express?", and give you an overview of what makes the Express web framework special. We'll outline the main features, and show you some of the main building blocks of an Express application (although at this point you won't yet have a development environment in which to test it).</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
@@ -20,7 +20,7 @@ tags:
 
 <p>This article briefly introduces databases, and how to use them with Node/Express apps. It then goes on to show how we can use <a href="https://mongoosejs.com/">Mongoose</a> to provide database access for the <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website">LocalLibrary</a> website. It explains how object schema and models are declared, the main field types, and basic validation. It also briefly shows a few of the main ways in which you can access model data.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/routes/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/routes/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>In this tutorial we'll set up routes (URL handling code) with "dummy" handler functions for all the resource endpoints that we'll eventually need in the <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website">LocalLibrary</a> website. On completion we'll have a modular structure for our route handling code, which we can extend with real handler functions in the following articles. We'll also have a really good understanding of how to create modular routes using Express!</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>This second article in our <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website">Express Tutorial</a> shows how you can create a "skeleton" website project which you can then go on to populate with site-specific routes, templates/views, and database calls.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/express_nodejs/tutorial_local_library_website/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/tutorial_local_library_website/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>The first article in our practical tutorial series explains what you'll learn, and provides an overview of the "local library" example website we'll be working through and evolving in subsequent articles.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p class="summary"></p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/first_steps/introduction/index.html
+++ b/files/en-us/learn/server-side/first_steps/introduction/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p class="summary"><span class="seoSummary">Welcome to the MDN beginner's server-side programming course! In this first article, we look at server-side programming from a high level, answering questions such as "what is it?", "how does it differ from client-side programming?", and "why it is so useful?". After reading this article you'll understand the additional power available to websites through server-side coding.</span></p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/first_steps/web_frameworks/index.html
+++ b/files/en-us/learn/server-side/first_steps/web_frameworks/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p class="summary">The previous article showed you what the communication between web clients and servers looks like, the nature of HTTP requests and responses, and what a server-side web application needs to do in order to respond to requests from a web browser. With this knowledge under our belt, it's time to explore how web frameworks can simplify these tasks, and give you an idea of how you'd choose a framework for your first server-side web application.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>

--- a/files/en-us/learn/server-side/first_steps/website_security/index.html
+++ b/files/en-us/learn/server-side/first_steps/website_security/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p class="summary">Website security requires vigilance in all aspects of website design and usage. This introductory article won't make you a website security guru, but it will help you understand where threats come from, and what you can do to harden your web application against the most common attacks.</p>
 
-<table class="learn-box standard-table">
+<table>
  <tbody>
   <tr>
    <th scope="row">Prerequisites:</th>


### PR DESCRIPTION
This removes the table classes from learn boxes, at the top of learn pages: `learn-box standard-table`. The rendering remains unchanged, as shown below.

![image](https://user-images.githubusercontent.com/5368500/131939325-579fc557-3c96-403b-8140-3ea674c0aaa6.png)

@wbamberg @teoli2003 This is just a general tidy, prior to doing proper markdown conversion. 

Do you have an opinion for the "right way" to have these in markdown? My leaning is towards either leaving "as is" or a definition list like this:

![image](https://user-images.githubusercontent.com/5368500/131939641-206f6483-cf88-4e21-9d90-b138b61e16dd.png)

Do you have an opinion? Who else do we need "buy in" from?