### PR TITLE
[Markdown] [Web/API] Fix some unconvertible tables

### DIFF
--- a/files/en-us/web/api/audioprocessingevent/index.html
+++ b/files/en-us/web/api/audioprocessingevent/index.html
@@ -64,8 +64,7 @@ browser-compat: api.AudioProcessingEvent
   <tr>
    <td><code>outputBuffer</code> {{ReadOnlyInline}}</td>
    <td>{{domxref("AudioBuffer")}}</td>
-   <td>
-    <p>The buffer where the output audio data should be written. The number of channels is defined as a parameter, <code>numberOfOutputChannels</code>, of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}. Note the returned <code>AudioBuffer</code> is only valid in the scope of the <code>onaudioprocess</code> function.</p>
+   <td>The buffer where the output audio data should be written. The number of channels is defined as a parameter, <code>numberOfOutputChannels</code>, of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}. Note the returned <code>AudioBuffer</code> is only valid in the scope of the <code>onaudioprocess</code> function.
    </td>
   </tr>
  </tbody>

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
@@ -53,15 +53,11 @@ browser-compat: api.BackgroundFetchManager.fetch
    <tbody>
     <tr>
      <td><code>AbortError</code></td>
-     <td>
-      <p>Indicates the fetch was aborted.</p>
-     </td>
+     <td>Indicates the fetch was aborted.</td>
     </tr>
     <tr>
      <td><code>NotAllowedError</code></td>
-     <td>
-      <p>Indicates that user permission has not been granted to make background fetches.</p>
-     </td>
+     <td>Indicates that user permission has not been granted to make background fetches.</td>
     </tr>
    </tbody>
   </table>

--- a/files/en-us/web/api/cache/add/index.html
+++ b/files/en-us/web/api/cache/add/index.html
@@ -51,24 +51,13 @@ browser-compat: api.Cache.add
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col"><strong>Exception</strong></th>
-   <th scope="col"><strong>Happens when</strong></th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>TypeError</code></td>
-   <td>
+<dl>
+  <dt><code>TypeError</code></dt>
+  <dd>
     <p>The URL scheme is not <code>http</code> or <code>https</code>.</p>
-
     <p>The Response status is not in the 200 range (i.e., not a successful response.) This occurs if the request does not return successfully, but also if the request is a <em>cross-origin no-cors</em> request (in which case the reported status is always 0.)</p>
-   </td>
-  </tr>
- </tbody>
-</table>
+  </dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/cache/addall/index.html
+++ b/files/en-us/web/api/cache/addall/index.html
@@ -49,27 +49,13 @@ browser-compat: api.Cache.addAll
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col"><strong>Exception</strong></th>
-      <th scope="col"><strong>Happens when</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>TypeError</code></td>
-      <td>
-        <p>The URL scheme is not <code>http</code> or <code>https</code>.</p>
-
-        <p>The Response status is not in the 200 range (i.e., not a successful response.)
-          This occurs if the request does not return successfully, but also if the request
-          is a <em>cross-origin no-cors</em> request (in which case the reported status is
-          always 0.)</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<dl>
+  <dt><code>TypeError</code></dt>
+  <dd>
+    <p>The URL scheme is not <code>http</code> or <code>https</code>.</p>
+    <p>The Response status is not in the 200 range (i.e., not a successful response.) This occurs if the request does not return successfully, but also if the request is a <em>cross-origin no-cors</em> request (in which case the reported status is always 0.)</p>
+  </dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
@@ -21,10 +21,10 @@ browser-compat: api.CanvasRenderingContext2D.drawWindow
 
 <p>This API cannot be used by Web content. It is synchronous, and as such can't capture
   cross-origin (out of process) iframes with Fission.  If you're using it from an
-  extension, you should switch to {{WebExtAPIRef('tabs.captureTab')}} to capture the 
-  tab's image as a <a class="external" href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs" 
-  rel="external">data: url</a> and then render the captured image onto canvas using 
-  {{domxref("CanvasRenderingContext2D.drawImage")}}. If you're writing chrome code, 
+  extension, you should switch to {{WebExtAPIRef('tabs.captureTab')}} to capture the
+  tab's image as a <a class="external" href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"
+  rel="external">data: url</a> and then render the captured image onto canvas using
+  {{domxref("CanvasRenderingContext2D.drawImage")}}. If you're writing chrome code,
   you probably want <a
     href="https://searchfox.org/mozilla-central/rev/9b282b34b5/dom/chrome-webidl/WindowGlobalActors.webidl#81-98">WindowGlobalParent.drawSnapshot</a>
   from the parent process.</p>
@@ -64,13 +64,16 @@ browser-compat: api.CanvasRenderingContext2D.drawWindow
   </dd>
   <dt><code>flags</code> {{optional_inline}}</dt>
   <dd>Used to better control the <code>drawWindow</code> call. Flags can be ORed together.
+
     <table class="standard-table">
-      <tbody>
+      <thead>
         <tr>
-          <td class="header">Constant</td>
-          <td class="header">Value</td>
-          <td class="header">Description</td>
+          <th>Constant</th>
+          <th>Value</th>
+          <th>Description</th>
         </tr>
+      </thead>
+      <tbody>
         <tr>
           <td><code>DRAWWINDOW_DRAW_CARET</code></td>
           <td><code>0x01</code></td>
@@ -79,8 +82,10 @@ browser-compat: api.CanvasRenderingContext2D.drawWindow
         <tr>
           <td><code>DRAWWINDOW_DO_NOT_FLUSH</code></td>
           <td><code>0x02</code></td>
-          <td>Do not flush pending layout notifications that could otherwise be batched
-            up.</td>
+          <td>
+            Do not flush pending layout notifications that could otherwise be
+            batched up.
+          </td>
         </tr>
         <tr>
           <td><code>DRAWWINDOW_DRAW_VIEW</code></td>
@@ -90,9 +95,12 @@ browser-compat: api.CanvasRenderingContext2D.drawWindow
         <tr>
           <td><code>DRAWWINDOW_USE_WIDGET_LAYERS</code></td>
           <td><code>0x08</code></td>
-          <td>Use the widget layer manager if available. This means hardware acceleration
-            may be used, but it might actually be slower or lower quality than normal. It
-            will, however, more accurately reflect the pixels rendered to the screen.</td>
+          <td>
+            Use the widget layer manager if available. This means hardware
+            acceleration may be used, but it might actually be slower or lower
+            quality than normal. It will, however, more accurately reflect the
+            pixels rendered to the screen.
+          </td>
         </tr>
         <tr>
           <td><code>DRAWWINDOW_ASYNC_DECODE_IMAGES</code></td>

--- a/files/en-us/web/api/closeevent/code/index.html
+++ b/files/en-us/web/api/closeevent/code/index.html
@@ -16,12 +16,14 @@ browser-compat: api.CloseEvent.code
 <p>A status code. As detailed in the following table, sourced from <a href="https://www.iana.org/assignments/websocket/websocket.xml#close-code-number">the IANA website</a>:</p>
 
 <table class="standard-table">
+  <thead>
+    <tr>
+     <th>Status code</th>
+     <th>Name</th>
+     <th>Description</th>
+    </tr>
+  </thead>
   <tbody>
-   <tr>
-    <td class="header">Status code</td>
-    <td class="header">Name</td>
-    <td class="header">Description</td>
-   </tr>
    <tr>
     <td><code>0</code>–<code>999</code></td>
     <td></td>
@@ -149,5 +151,3 @@ browser-compat: api.CloseEvent.code
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
-
-

--- a/files/en-us/web/api/cssomstring/index.html
+++ b/files/en-us/web/api/cssomstring/index.html
@@ -13,11 +13,12 @@ tags:
 <h4 id="Implementation_differences">Implementation differences</h4>
 
 <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Browser</th>
+      <th>DOMString or USVString for CSSOMString</th>
+    </tr>
  <tbody>
-  <tr>
-   <td class="header">Browser</td>
-   <td class="header">DOMString or USVString for CSSOMString</td>
-  </tr>
   <tr>
    <td>Firefox (Gecko)</td>
    <td>USVString</td>

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -38,11 +38,13 @@ browser-compat: api.CSSPrimitiveValue.getFloatValue
   <dd>An <code>unsigned short</code> representing the code for the unit type, in which the
     value should be returned. Valid values are:
     <table class="standard-table">
-      <tbody>
+      <thead>
         <tr>
-          <td class="header">Constant</td>
-          <td class="header">Description</td>
+          <th>Constant</th>
+          <th>Description</th>
         </tr>
+      </thead>
+      <tbody>
         <tr>
           <td><code>CSS_CM</code></td>
           <td>The value is a {{cssxref("&lt;length&gt;")}} in centimeters.</td>

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -38,11 +38,13 @@ browser-compat: api.CSSPrimitiveValue
  <dt>{{DOMxRef("CSSPrimitiveValue.primitiveType")}} {{readonlyInline}}</dt>
  <dd>An <code>unsigned short</code> representing the type of the value. Possible values are:
  <table class="standard-table">
+  <thead>
+    <tr>
+     <th>Constant</th>
+     <th>Description</th>
+    </tr>
+  </thead>
   <tbody>
-   <tr>
-    <td class="header">Constant</td>
-    <td class="header">Description</td>
-   </tr>
    <tr>
     <td><code>CSS_ATTR</code></td>
     <td>The value is an {{CSSxRef("attr()")}} function. The value can be obtained by using the <code>getStringValue()</code> method.</td>

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
@@ -36,11 +36,13 @@ browser-compat: api.CSSPrimitiveValue.primitiveType
 </p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Constant</td>
-      <td class="header">Description</td>
+      <th>Constant</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>CSS_ATTR</code></td>
       <td>The value is an {{cssxref("attr()")}} function. The value can be obtained by

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -39,11 +39,13 @@ browser-compat: api.CSSPrimitiveValue.setFloatValue
   <dd>An <code>unsigned short</code> representing the code for the unit type, in which the
     value should be returned. Valid values are:
     <table class="standard-table">
-      <tbody>
+      <thead>
         <tr>
-          <td class="header">Constant</td>
-          <td class="header">Description</td>
+          <th>Constant</th>
+          <th>Description</th>
         </tr>
+      </thead>
+      <tbody>
         <tr>
           <td><code>CSS_CM</code></td>
           <td>The value is a {{cssxref("&lt;length&gt;")}} in centimeters.</td>

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -39,11 +39,13 @@ browser-compat: api.CSSPrimitiveValue.setStringValue
   <dd>An <code>unsigned short</code> representing the type of the value. Possible values
     are:
     <table class="standard-table">
-      <tbody>
+      <thead>
         <tr>
-          <td class="header">Constant</td>
-          <td class="header">Description</td>
+          <th>Constant</th>
+          <th>Description</th>
         </tr>
+      </thead>
+      <tbody>
         <tr>
           <td><code>CSS_ATTR</code></td>
           <td>The value is an {{cssxref("attr()")}} function.</td>

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -38,11 +38,13 @@ browser-compat: api.CSSValue.cssValueType
   Possible values are:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Constant</td>
-      <td class="header">Description</td>
+      <th>Constant</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>CSS_CUSTOM</code></td>
       <td>The value is a custom value.</td>

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -33,11 +33,13 @@ browser-compat: api.CSSValue
  <dt>{{DOMxRef("CSSValue.cssValueType")}}{{ReadOnlyInline}}</dt>
  <dd>An <code>unsigned short</code> representing a code defining the type of the value. Possible values are:
  <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Constant</th>
+      <th>Description</th>
+    </tr>
+  </thead>
   <tbody>
-   <tr>
-    <td class="header">Constant</td>
-    <td class="header">Description</td>
-   </tr>
    <tr>
     <td><code>CSS_CUSTOM</code></td>
     <td>The value is a custom value.</td>

--- a/files/en-us/web/api/document/createnodeiterator/index.html
+++ b/files/en-us/web/api/document/createnodeiterator/index.html
@@ -33,9 +33,9 @@ browser-compat: api.Document.createNodeIterator
     <table class="standard-table">
       <thead>
         <tr>
-          <th class="header" scope="col">Constant</th>
-          <th class="header" scope="col">Numerical value</th>
-          <th class="header" scope="col">Description</th>
+          <th>Constant</th>
+          <th>Numerical value</th>
+          <th>Description</th>
         </tr>
       </thead>
       <tbody>
@@ -47,14 +47,11 @@ browser-compat: api.Document.createNodeIterator
         <tr>
           <td><code>NodeFilter.SHOW_ATTRIBUTE</code> {{deprecated_inline}}</td>
           <td><code>2</code></td>
-          <td>
-            <p>Shows attribute {{ domxref("Attr") }} nodes.</p>
-
-            <p>This is meaningful only when creating a {{ domxref("TreeWalker") }} with an
+          <td>Shows attribute {{ domxref("Attr") }} nodes. This is meaningful only when creating a {{ domxref("TreeWalker") }} with an
               {{ domxref("Attr") }} node as its root. In this case, it means that the
               attribute node will appear in the first position of the iteration or
               traversal. Since attributes are never children of other nodes, they do not
-              appear when traversing over the document tree.</p>
+              appear when traversing over the document tree.
           </td>
         </tr>
         <tr>

--- a/files/en-us/web/api/document/createtreewalker/index.html
+++ b/files/en-us/web/api/document/createtreewalker/index.html
@@ -32,12 +32,14 @@ browser-compat: api.Document.createTreeWalker
     It is a convenient way of filtering for certain types of node. It defaults to
     <code>0xFFFFFFFF</code> representing the <code>SHOW_ALL</code> constant.
     <table class="standard-table">
-      <tbody>
+      <thead>
         <tr>
-          <td class="header">Constant</td>
-          <td class="header">Numerical value</td>
-          <td class="header">Description</td>
+          <th>Constant</th>
+          <th>Numerical value</th>
+          <th>Description</th>
         </tr>
+      </thead>
+      <tbody>
         <tr>
           <td><code>NodeFilter.SHOW_ALL</code></td>
           <td><code>-1</code> (that is the max value of <code>unsigned long</code>)</td>
@@ -127,8 +129,8 @@ browser-compat: api.Document.createTreeWalker
 
 <h2 id="Example">Example</h2>
 
-<p>The following example goes through all nodes in the body, 
-  filters out any non nodes that aren't elements (with the `NodeFilter.SHOW_ELEMENT` value), 
+<p>The following example goes through all nodes in the body,
+  filters out any non nodes that aren't elements (with the `NodeFilter.SHOW_ELEMENT` value),
   marks each remaining node as acceptable (The <code>acceptNode()</code> method could make
   a different decision.), and then makes use of tree walker iterator
   that is created to advance through the nodes (now all elements) and push them into an

--- a/files/en-us/web/api/document/evaluate/index.html
+++ b/files/en-us/web/api/document/evaluate/index.html
@@ -99,12 +99,14 @@ alert(alertText); // Alerts the text of all h2 elements
 	<code>evaluate</code> method:</p>
 
 <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Result Type</th>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
 	<tbody>
-		<tr>
-			<td class="header">Result Type</td>
-			<td class="header">Value</td>
-			<td class="header">Description</td>
-		</tr>
 		<tr>
 			<td><code>ANY_TYPE</code></td>
 			<td>0</td>

--- a/files/en-us/web/api/element/setpointercapture/index.html
+++ b/files/en-us/web/api/element/setpointercapture/index.html
@@ -64,10 +64,7 @@ browser-compat: api.Element.setPointerCapture
   <tbody>
     <tr>
       <td><code>NotFoundError</code></td>
-      <td><code><var>pointerId</var></code> does not match any of the active pointers.
-        <div class="note"><p><strong>Note:</strong> Firefox versions <em>before</em> Firefox
-          82 incorrectly throw <code>InvalidPointerId</code>.</p></div>
-      </td>
+      <td><code><var>pointerId</var></code> does not match any of the active pointers.</td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/api/encoding_api/encodings/index.html
+++ b/files/en-us/web/api/encoding_api/encodings/index.html
@@ -246,14 +246,7 @@ tags:
       </tr>
       <tr>
         <td>
-          <p>"<code>csiso2022jp</code>", "<code>iso-2022-jp</code>"</p>
-
-          <div class="note">
-            <p><strong>Note:</strong> Firefox used to accept <code>iso-2022-jp-2</code>
-              sequences silently when an <code>iso-2022-jp</code> decoder was
-              instantiated; however this was removed in version 56 to simplify the API,
-              as no other browsers support it and no pages seem to use it.</p>
-          </div>
+          "<code>csiso2022jp</code>", "<code>iso-2022-jp</code>"
         </td>
         <td>
           <code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-JP', "'iso-2022-jp'")}}</code>

--- a/files/en-us/web/api/filereader/index.html
+++ b/files/en-us/web/api/filereader/index.html
@@ -36,6 +36,13 @@ browser-compat: api.FileReader
  <dt>{{domxref("FileReader.readyState")}} {{readonlyinline}}</dt>
  <dd>A number indicating the state of the <code>FileReader</code>. This is one of the following:
  <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
   <tbody>
    <tr>
     <td><code>EMPTY</code></td>

--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.html
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.html
@@ -109,35 +109,23 @@ element.getData();
 console.log("Data fetched");
 </pre>
 
-<p>Executing this code twice in a row gives the results shown in the table below:</p>
+<p>Executing this code twice in a row gives the following results.</p>
 
-<table class="standard-table">
-	<caption>Results when data isn't cached (left) vs. when it is found in the cache</caption>
-	<thead>
-		<tr>
-			<th scope="col">Data isn't cached</th>
-			<th scope="col">Data is cached</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>
-			<pre>
+<p>When the data is not cached:</p>
+
+<pre>
 Fetching data
 Data fetched
 Loaded data
 </pre>
-			</td>
-			<td>
-			<pre>
+
+<p>When the data is cached:</p>
+
+<pre>
 Fetching data
 Loaded data
 Data fetched
 </pre>
-			</td>
-		</tr>
-	</tbody>
-</table>
 
 <p>Even worse, sometimes the element's <code>data</code> property will be set and other times it won't be by the time this code finishes running.</p>
 

--- a/files/en-us/web/api/htmloptionscollection/index.html
+++ b/files/en-us/web/api/htmloptionscollection/index.html
@@ -21,22 +21,10 @@ browser-compat: api.HTMLOptionsCollection
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <td class="header">Name</td>
-   <td class="header">Type</td>
-   <td class="header">Description</td>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>length</code></td>
-   <td><a href="/en-US/docs/unsigned_long" title="unsigned long"><code>unsigned long</code></a></td>
-   <td>As optionally allowed by the spec, this property isn't read-only. You can either remove options from the end by lowering the value, or add blank options at the end by raising the value. Mozilla allows this, while other implementations could potentially throw a <a href="/en-US/docs/Web/API/DOMException">DOMException</a>.</td>
-  </tr>
- </tbody>
-</table>
+<dl>
+  <dt><code>length</code></dt>
+  <dd><code>unsigned long</code>. As optionally allowed by the spec, this property isn't read-only. You can either remove options from the end by lowering the value, or add blank options at the end by raising the value. Mozilla allows this, while other implementations could potentially throw a <a href="/en-US/docs/Web/API/DOMException">DOMException</a>.</dd>
+</dl>
 
 <h2 id="Methods">Methods</h2>
 

--- a/files/en-us/web/api/htmltrackelement/index.html
+++ b/files/en-us/web/api/htmltrackelement/index.html
@@ -34,12 +34,14 @@ browser-compat: api.HTMLTrackElement
  <dt>{{domxref("HTMLTrackElement.readyState")}} {{ReadOnlyInline}}</dt>
  <dd>Returns  an <code>unsigned short</code> that show the readiness state of the track:
  <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Constant</th>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
   <tbody>
-   <tr>
-    <td class="header">Constant</td>
-    <td class="header">Value</td>
-    <td class="header">Description</td>
-   </tr>
    <tr>
     <td><code>NONE</code></td>
     <td>0</td>

--- a/files/en-us/web/api/keyboardevent/location/index.html
+++ b/files/en-us/web/api/keyboardevent/location/index.html
@@ -19,12 +19,14 @@ browser-compat: api.KeyboardEvent.location
 <p>Possible values are:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Constant</td>
-      <td class="header">Value</td>
-      <td class="header">Description</td>
+      <th>Constant</th>
+      <th>Value</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>DOM_KEY_LOCATION_STANDARD</code></td>
       <td>0</td>

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.html
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.html
@@ -17,12 +17,14 @@ browser-compat: api.MouseEvent.relatedTarget
   secondary target for the mouse event, if there is one. That is:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Event name</td>
-      <td class="header"><code>target</code></td>
-      <td class="header"><code>relatedTarget</code></td>
+      <th>Event name</th>
+      <th><code>target</code></th>
+      <th><code>relatedTarget</code></th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{Event("mouseenter")}}</td>
       <td>The {{domxref("EventTarget")}} the pointing device entered to</td>

--- a/files/en-us/web/api/mousescrollevent/index.html
+++ b/files/en-us/web/api/mousescrollevent/index.html
@@ -23,23 +23,36 @@ browser-compat: api.MouseScrollEvent
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td><code>void <a href="/en-US/docs/XPCOM_Interface_Reference/nsIDOMMouseScrollEvent#initMouseScrollEvent%28%29">initMouseScrollEvent</a>(in DOMString typeArg, in boolean canBubbleArg, in boolean cancelableArg, in nsIDOMAbstractView viewArg, in long detailArg, in long screenXArg, in long screenYArg, in long clientXArg, in long clientYArg, in boolean ctrlKeyArg, in boolean altKeyArg, in boolean shiftKeyArg, in boolean metaKeyArg, in unsigned short buttonArg, in nsIDOMEventTarget relatedTargetArg, in long axis);</code></td>
-  </tr>
- </tbody>
-</table>
+<pre>void initMouseScrollEvent(
+  in DOMString typeArg,
+  in boolean canBubbleArg,
+  in boolean cancelableArg,
+  in nsIDOMAbstractView viewArg,
+  in long detailArg,
+  in long screenXArg,
+  in long screenYArg,
+  in long clientXArg,
+  in long clientYArg,
+  in boolean ctrlKeyArg,
+  in boolean altKeyArg,
+  in boolean shiftKeyArg,
+  in boolean metaKeyArg,
+  in unsigned short buttonArg,
+  in nsIDOMEventTarget relatedTargetArg,
+  in long axis);
+</pre>
 
 <h2 id="Attributes">Attributes</h2>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Attribute</th>
+     <th>Type</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Attribute</td>
-   <td class="header">Type</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>axis</code> {{ReadOnlyInline}}</td>
    <td><code>long</code></td>
@@ -53,12 +66,14 @@ browser-compat: api.MouseScrollEvent
 <h3 id="Delta_modes">Delta modes</h3>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Constant</th>
+     <th>Value</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Constant</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>HORIZONTAL_AXIS</code></td>
    <td><code>0x01</code></td>

--- a/files/en-us/web/api/mousewheelevent/index.html
+++ b/files/en-us/web/api/mousewheelevent/index.html
@@ -22,12 +22,14 @@ browser-compat: api.MouseWheelEvent
 <h2 id="Properties">Properties</h2>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Attribute</th>
+     <th>Type</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Attribute</td>
-   <td class="header">Type</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>wheelDelta</code> {{ReadOnlyInline}}</td>
    <td><code>long</code></td>

--- a/files/en-us/web/api/mscandidatewindowhide/index.html
+++ b/files/en-us/web/api/mscandidatewindowhide/index.html
@@ -27,20 +27,7 @@ slug: Web/API/MSCandidateWindowHide
 
 <h2 id="Syntax">Syntax</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="row">Event Property</th>
-   <td>object.oncandidatewindowhide = handler;</td>
-  </tr>
-  <tr>
-   <th scope="row">addEventListener Method</th>
-   <td>object.addEventListener("MSCandidateWindowHide", handler, useCapture)</td>
-  </tr>
- </tbody>
-</table>
-
-<p>nbsp;</p>
+<pre class="brush: js">object.addEventListener("MSCandidateWindowHide", handler, useCapture)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/mscandidatewindowshow/index.html
+++ b/files/en-us/web/api/mscandidatewindowshow/index.html
@@ -29,19 +29,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="row">Event Property</th>
-   <td>object.oncandidatewindowshow = handler;</td>
-  </tr>
-  <tr>
-   <th scope="row">addEventListener Method</th>
-   <td>object.addEventListener("MSCandidateWindowShow", handler, useCapture)</td>
-  </tr>
- </tbody>
-</table>
-
+<pre class="brush: js">object.addEventListener("MSCandidateWindowShow", handler, useCapture)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/mscandidatewindowupdate/index.html
+++ b/files/en-us/web/api/mscandidatewindowupdate/index.html
@@ -29,19 +29,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="row">Event Property</th>
-   <td>object.oncandidatewindowupdate = handler;</td>
-  </tr>
-  <tr>
-   <th scope="row">addEventListener Method</th>
-   <td>object.addEventListener("MSCandidateWindowUpdate", handler, useCapture)</td>
-  </tr>
- </tbody>
-</table>
-
+<pre class="brush: js">object.addEventListener("MSCandidateWindowUpdate", handler, useCapture)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/mssitemodejumplistitemremoved/index.html
+++ b/files/en-us/web/api/mssitemodejumplistitemremoved/index.html
@@ -12,20 +12,7 @@ slug: Web/API/mssitemodejumplistitemremoved
 
 <h2 id="Syntax">Syntax</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="row">Event Property</th>
-   <td>object.oncandidatewindowhide = handler;</td>
-  </tr>
-  <tr>
-   <th scope="row">addEventListener Method</th>
-   <td>object.addEventListener("mssitemodejumplistitemremoved", handler, useCapture)</td>
-  </tr>
- </tbody>
-</table>
-
-
+<pre class="brush: js">object.addEventListener("mssitemodejumplistitemremoved", handler, useCapture)</pre>
 
 <h2 id="General_info">General info</h2>
 

--- a/files/en-us/web/api/msthumbnailclick/index.html
+++ b/files/en-us/web/api/msthumbnailclick/index.html
@@ -14,19 +14,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="row">Event Property</th>
-   <td>object.onmsthumbnailclick = handler;</td>
-  </tr>
-  <tr>
-   <th scope="row">addEventListener Method</th>
-   <td>object.addEventListener("msthumbnailclick", handler, useCapture)</td>
-  </tr>
- </tbody>
-</table>
-
+<pre class="brush: js">object.addEventListener("msthumbnailclick", handler, useCapture)</pre>
 
 <h2 id="General_info">General info</h2>
 

--- a/files/en-us/web/api/mutationrecord/index.html
+++ b/files/en-us/web/api/mutationrecord/index.html
@@ -17,12 +17,14 @@ browser-compat: api.MutationRecord
 <h2 id="Properties">Properties</h2>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Property</th>
+     <th>Type</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Property</td>
-   <td class="header">Type</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td>{{domxref("MutationRecord.type")}}</td>
    <td><code>String</code></td>

--- a/files/en-us/web/api/nodefilter/acceptnode/index.html
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.html
@@ -18,11 +18,13 @@ browser-compat: api.NodeFilter.acceptNode
   <code>NodeFilter</code>. Possible return values are:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Constant</td>
-      <td class="header">Description</td>
+      <th scope="col">Constant</th>
+      <th scope="col">Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>NodeFilter.FILTER_ACCEPT</code></td>
       <td>Value returned by the {{ domxref("NodeFilter.acceptNode()") }} method when a

--- a/files/en-us/web/api/nodefilter/acceptnode/index.html
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.html
@@ -20,8 +20,8 @@ browser-compat: api.NodeFilter.acceptNode
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Constant</th>
-      <th scope="col">Description</th>
+      <th>Constant</th>
+      <th>Description</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/api/nodefilter/index.html
+++ b/files/en-us/web/api/nodefilter/index.html
@@ -33,8 +33,8 @@ browser-compat: api.NodeFilter
 	<table class="standard-table">
 		<thead>
 			<tr>
-				<th scope="col">Constant</th>
-				<th scope="col">Description</th>
+				<th>Constant</th>
+				<th>Description</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/files/en-us/web/api/nodefilter/index.html
+++ b/files/en-us/web/api/nodefilter/index.html
@@ -33,8 +33,8 @@ browser-compat: api.NodeFilter
 	<table class="standard-table">
 		<thead>
 			<tr>
-				<th class="header" scope="col">Constant</th>
-				<th class="header" scope="col">Description</th>
+				<th scope="col">Constant</th>
+				<th scope="col">Description</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.html
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.html
@@ -25,7 +25,7 @@ browser-compat: api.NodeIterator.whatToShow
 	<thead>
     <tr>
       <th>Constant</th>
-			<th>Numerical value</th>
+      <th>Numerical value</th>
       <th>Description</th>
     </tr>
   </thead>

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.html
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.html
@@ -22,12 +22,14 @@ browser-compat: api.NodeIterator.whatToShow
 <p>The values that can be combined to form the bitmask are:</p>
 
 <table class="standard-table">
+	<thead>
+    <tr>
+      <th>Constant</th>
+			<th>Numerical value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
 	<tbody>
-		<tr>
-			<td class="header">Constant</td>
-			<td class="header">Numerical value</td>
-			<td class="header">Description</td>
-		</tr>
 		<tr>
 			<td><code>NodeFilter.SHOW_ALL</code></td>
 			<td><code>-1</code> (that is the max value of <code>unsigned long</code>)</td>

--- a/files/en-us/web/api/performanceentry/entrytype/index.html
+++ b/files/en-us/web/api/performanceentry/entrytype/index.html
@@ -79,9 +79,7 @@ browser-compat: api.PerformanceEntry.entryType
       <td><code>paint</code></td>
       <td>{{domxref('PerformancePaintTiming')}}</td>
       <td>{{domxref("DOMString")}}</td>
-      <td>
-        <p>Either <code>'first-paint'</code> or <code>'first-contentful-paint'</code>.</p>
-      </td>
+      <td>Either <code>'first-paint'</code> or <code>'first-contentful-paint'</code>.</td>
     </tr>
     <tr>
       <td><code>longtask</code></td>

--- a/files/en-us/web/api/svgrect/the__x__property/index.html
+++ b/files/en-us/web/api/svgrect/the__x__property/index.html
@@ -7,11 +7,13 @@ slug: Web/API/SVGRect/The__X__property
 <h2 id="Usage_context">Usage context</h2>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Name</th>
+     <th>x</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td>Name</td>
-   <td>x</td>
-  </tr>
   <tr>
    <td>Value</td>
    <td><a href="https://www.w3.org/TR/css3-values/#lengths">&lt;length&gt;</a> | <a href="https://www.w3.org/TR/css3-values/#percentages">&lt;percentage&gt;</a></td>

--- a/files/en-us/web/api/treewalker/whattoshow/index.html
+++ b/files/en-us/web/api/treewalker/whattoshow/index.html
@@ -19,7 +19,7 @@ browser-compat: api.TreeWalker.whatToShow
   <thead>
     <tr>
       <th>Constant</th>
-			<th>Numerical value</th>
+      <th>Numerical value</th>
       <th>Description</th>
     </tr>
   </thead>

--- a/files/en-us/web/api/treewalker/whattoshow/index.html
+++ b/files/en-us/web/api/treewalker/whattoshow/index.html
@@ -16,12 +16,14 @@ browser-compat: api.TreeWalker.whatToShow
   children may be included, if relevant. The possible values are:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Constant</td>
-      <td class="header">Numerical value</td>
-      <td class="header">Description</td>
+      <th>Constant</th>
+			<th>Numerical value</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>NodeFilter.SHOW_ALL</code></td>
       <td><code>-1</code> (that is the max value of <code>unsigned long</code>)</td>

--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
@@ -123,6 +123,12 @@ var buffer = context.createBuffer(1, 22050, 22050);</pre>
 <p>Different audio buffers contain different numbers of channels: from the more basic mono (only one channel) and stereo (left and right channels), to more complex sets like quad and 5.1, which have different sound samples contained in each channel, leading to a richer sound experience. The channels are usually represented by standard abbreviations detailed in the table below:</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Name</th>
+     <th>Channels</th>
+   </tr>
+ </thead>
  <tbody>
   <tr>
    <td><em>Mono</em></td>

--- a/files/en-us/web/api/webgl_api/types/index.html
+++ b/files/en-us/web/api/webgl_api/types/index.html
@@ -15,12 +15,14 @@ tags:
 <p>These types are used within a {{domxref("WebGLRenderingContext")}}.</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Type</th>
+     <th>Web IDL type</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Type</td>
-   <td class="header">Web IDL type</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>GLenum</code></td>
    <td><code>unsigned long</code></td>

--- a/files/en-us/web/api/webgl_api/types/index.html
+++ b/files/en-us/web/api/webgl_api/types/index.html
@@ -101,12 +101,14 @@ tags:
 <p>These types are used within a {{domxref("WebGL2RenderingContext")}}. All WebGL 1 types are used as well.</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Type</th>
+     <th>Web IDL type</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Type</td>
-   <td class="header">Web IDL type</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>GLint64</code></td>
    <td><code>long long</code></td>
@@ -120,12 +122,14 @@ tags:
 <p>These types are used within <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">WebGL extensions</a>.</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Type</th>
+     <th>Web IDL type</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Type</td>
-   <td class="header">Web IDL type</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>GLuint64EXT</code></td>
    <td><code>long long</code></td>

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.html
@@ -39,14 +39,16 @@ browser-compat: api.WEBGL_compressed_texture_astc
 <p>The compressed texture formats are exposed by 28 constants and can be used in two functions: {{domxref("WebGLRenderingContext.compressedTexImage2D", "compressedTexImage2D()")}} and {{domxref("WebGLRenderingContext.compressedTexSubImage2D", "compressedTexSubImage2D()")}}.</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+    <th>Constants</th>
+    <th>Blocks</th>
+    <th>Bits per pixel</th>
+    <th>{{jsxref("ArrayBuffer")}} <code>byteLength</code></th>
+    <th>bytes if height and width are 512</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td>Constants</td>
-   <td>Blocks</td>
-   <td>Bits per pixel</td>
-   <td>{{jsxref("ArrayBuffer")}} <code>byteLength</code></td>
-   <td>bytes if height and width are 512</td>
-  </tr>
   <tr>
    <td><code>ext.COMPRESSED_RGBA_ASTC_4x4_KHR<br>
     ext.COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR</code></td>

--- a/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
@@ -140,9 +140,8 @@ browser-compat: api.WebGLRenderingContext.blendFunc
     </tr>
     <tr>
       <td><code>gl.SRC_ALPHA_SATURATE</code></td>
-      <td>
-        <p>min(A<sub>S</sub>, 1 - A<sub>D</sub>), min(A<sub>S</sub>, 1 - A<sub>D</sub>),
-          min(A<sub>S</sub>, 1 - A<sub>D</sub>), 1</p>
+      <td>min(A<sub>S</sub>, 1 - A<sub>D</sub>), min(A<sub>S</sub>, 1 - A<sub>D</sub>),
+          min(A<sub>S</sub>, 1 - A<sub>D</sub>), 1
       </td>
       <td>Multiplies the RGB colors by the smaller of either the source alpha value or the
         value of 1 minus the destination alpha value. The alpha value is multiplied by 1.

--- a/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
@@ -174,9 +174,8 @@ They are all values between 0 and 1, included.</p>
     </tr>
     <tr>
       <td><code>gl.SRC_ALPHA_SATURATE</code></td>
-      <td>
-        <p>min(A<sub>S</sub>, 1 - A<sub>D</sub>), min(A<sub>S</sub>, 1 - A<sub>D</sub>),
-          min(A<sub>S</sub>, 1 - A<sub>D</sub>)</p>
+      <td>min(A<sub>S</sub>, 1 - A<sub>D</sub>), min(A<sub>S</sub>, 1 - A<sub>D</sub>),
+          min(A<sub>S</sub>, 1 - A<sub>D</sub>)
       </td>
       <td>1</td>
       <td>Multiplies the RGB colors by the smaller of either the source alpha color or the

--- a/files/en-us/web/api/websocket/index.html
+++ b/files/en-us/web/api/websocket/index.html
@@ -27,11 +27,13 @@ browser-compat: api.WebSocket
 <h2 id="Constants">Constants</h2>
 
 <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Constant</th>
+      <th>Value</th>
+    </tr>
+  </thead>
  <tbody>
-  <tr>
-   <td class="header">Constant</td>
-   <td class="header">Value</td>
-  </tr>
   <tr>
    <td><code>WebSocket.CONNECTING</code></td>
    <td><code>0</code></td>

--- a/files/en-us/web/api/websocket/readystate/index.html
+++ b/files/en-us/web/api/websocket/readystate/index.html
@@ -19,12 +19,14 @@ browser-compat: api.WebSocket.readyState
 <p>One of the following <code>unsigned short</code> values:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Value</td>
-      <td class="header">State</td>
-      <td class="header">Description</td>
+      <th>Value</th>
+      <th>State</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>0</code></td>
       <td><code>CONNECTING</code></td>

--- a/files/en-us/web/api/wheelevent/deltamode/index.html
+++ b/files/en-us/web/api/wheelevent/deltamode/index.html
@@ -17,12 +17,14 @@ browser-compat: api.WheelEvent.deltaMode
   Permitted values are:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Constant</td>
-      <td class="header">Value</td>
-      <td class="header">Description</td>
+      <th>Constant</th>
+      <th>Value</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>DOM_DELTA_PIXEL</code></td>
       <td><code>0x00</code></td>

--- a/files/en-us/web/api/wheelevent/index.html
+++ b/files/en-us/web/api/wheelevent/index.html
@@ -45,11 +45,11 @@ browser-compat: api.WheelEvent
  <dd>Returns an <code>unsigned long</code> representing the unit of the <code>delta*</code> values' scroll amount. Permitted values are:
  <table class="standard-table">
   <thead>
-   <tr>
-    <td class="header">Constant</td>
-    <td class="header">Value</td>
-    <td class="header">Description</td>
-   </tr>
+    <tr>
+      <th>Constant</th>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
   </thead>
   <tbody>
    <tr>

--- a/files/en-us/web/api/wheelevent/wheelevent/index.html
+++ b/files/en-us/web/api/wheelevent/wheelevent/index.html
@@ -40,12 +40,14 @@ browser-compat: api.WheelEvent.WheelEvent
         <code>unsigned long</code> representing the unit of the delta values scroll
         amount. Permitted values are:
         <table class="standard-table">
-          <tbody>
+          <thead>
             <tr>
-              <td class="header">Constant</td>
-              <td class="header">Value</td>
-              <td class="header">Description</td>
+              <th>Constant</th>
+              <th>Value</th>
+              <th>Description</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><code>DOM_DELTA_PIXEL</code></td>
               <td><code>0x00</code></td>

--- a/files/en-us/web/api/windoweventhandlers/onhashchange/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onhashchange/index.html
@@ -93,12 +93,14 @@ window.addEventListener('hashchange', hashHandler, false);
 <p>The dispatched <code>hashchange</code> event has the following properties:</p>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <td class="header">Field</td>
-      <td class="header">Type</td>
-      <td class="header">Description</td>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Description</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><code>newURL</code></td>
       <td><code>DOMString</code></td>

--- a/files/en-us/web/api/worklet/index.html
+++ b/files/en-us/web/api/worklet/index.html
@@ -34,8 +34,7 @@ browser-compat: api.Worklet
    <td>
     <p>For programmatically generating an image where a CSS property expects a file. Access this interface through {{DOMxRef("CSS.paintWorklet")}}.</p>
    </td>
-   <td><strong>Chrome:</strong> Main thread<br>
-    <strong>Gecko:</strong> Paint thread</td>
+   <td><strong>Chrome:</strong> Main thread, <strong>Gecko:</strong> Paint thread</td>
    <td><a href="https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet">CSS Painting API</a></td>
   </tr>
   <tr>

--- a/files/en-us/web/api/xmlhttprequest/readystate/index.html
+++ b/files/en-us/web/api/xmlhttprequest/readystate/index.html
@@ -13,12 +13,14 @@ browser-compat: api.XMLHttpRequest.readyState
 <p>The <strong>XMLHttpRequest.readyState</strong> property returns the state an XMLHttpRequest client is in. An <abbr title="XMLHttpRequest">XHR</abbr> client exists in one of the following states:</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Value</th>
+     <th>State</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Value</td>
-   <td class="header">State</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>0</code></td>
    <td><code>UNSENT</code></td>

--- a/files/en-us/web/api/xmlhttprequest/upload/index.html
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.html
@@ -31,12 +31,14 @@ browser-compat: api.XMLHttpRequest.upload
 <p>The following events can be triggered on an upload object and used to monitor the upload:</p>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+     <th>Event</th>
+     <th>Event listener</th>
+     <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Event</td>
-   <td class="header">Event listener</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td>{{event("loadstart")}}</td>
    <td>{{domxref("XMLHttpRequest.onloadstart", "onloadstart")}}</td>

--- a/files/en-us/web/api/xpathresult/index.html
+++ b/files/en-us/web/api/xpathresult/index.html
@@ -48,11 +48,11 @@ browser-compat: api.XPathResult
 
 <table class="standard-table">
  <thead>
-  <tr>
-   <td class="header">Result Type Defined Constant</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
-  </tr>
+   <tr>
+     <th>Result Type Defined Constant</th>
+     <th>Value</th>
+     <th>Description</th>
+   </tr>
  </thead>
  <tbody>
   <tr>

--- a/files/en-us/web/api/xpathresult/resulttype/index.html
+++ b/files/en-us/web/api/xpathresult/resulttype/index.html
@@ -33,9 +33,9 @@ browser-compat: api.XPathResult.resultType
 <table class="standard-table">
   <thead>
     <tr>
-      <td class="header">Result Type Defined Constant</td>
-      <td class="header">Value</td>
-      <td class="header">Description</td>
+      <th>Result Type Defined Constant</th>
+      <th>Value</th>
+      <th>Description</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7898 .

This PR fixes some tables that didn't convert into Markdown. There are a few different strategies here:

* the most common is to give tables a proper heading, which GFM expects
* in some cases a different element, like a `<pre>` or a `<dl>` seemed more appropriate
* in some cases, where it didn't seem to hurt the content, I removed some `<p>` tags inside cells, as GFM doesn't support block elements in cells
* in a few cases I deleted obsolete notes
