### PR TITLE
Glossary - bunch of prep for markdown conversion

### DIFF
--- a/files/en-us/glossary/accessibility_tree/index.html
+++ b/files/en-us/glossary/accessibility_tree/index.html
@@ -8,7 +8,7 @@ tags:
   - Glossary
   - Reference
 ---
-<p><span class="seoSummary">The <strong>accessibility tree</strong> contains {{Glossary("accessibility")}}-related information for most HTML elements.</span></p>
+<p>The <strong>accessibility tree</strong> contains {{Glossary("accessibility")}}-related information for most HTML elements.</p>
 
 <p>Browsers convert markup into an internal representation called the <em><a href="/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree">DOM tree</a></em>. The DOM tree contains objects representing all the markup’s elements, attributes, and text nodes. Browsers then create an accessibility tree based on the DOM tree, which is used by platform-specific Accessibility APIs to provide a representation that can be understood by assistive technologies, such as screen readers.</p>
 

--- a/files/en-us/glossary/ajax/index.html
+++ b/files/en-us/glossary/ajax/index.html
@@ -8,7 +8,7 @@ tags:
   - Infrastructure
   - 'l10n:priority'
 ---
-<p><span class="seoSummary"><strong>Ajax</strong>, which initially stood for Asynchronous {{Glossary("JavaScript")}} And {{Glossary("XML")}}, is a programming practice of building complex, dynamic webpages using a technology known as {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}.</span></p>
+<p><strong>Ajax</strong>, which initially stood for Asynchronous {{Glossary("JavaScript")}} And {{Glossary("XML")}}, is a programming practice of building complex, dynamic webpages using a technology known as {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}.</p>
 
 <p>Ajax allows you to update parts of the {{Glossary("DOM")}} of an {{Glossary("HTML")}} page instead without the need for a full page refresh. Ajax also lets you work asynchronously, meaning your code continues to run while the targeted part of your web page is trying to reload (compared to synchronously, which blocks your code from running until that part of your page is done reloading).</p>
 

--- a/files/en-us/glossary/alpha/index.html
+++ b/files/en-us/glossary/alpha/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>For example, the color <code>#8921F2</code> (also described as <code>rgb(137, 33, 242)</code> or <code>hsl(270, 89%, 54)</code>) is a nice shade of purple. Below you see a small box of that color in the top-left corner and a box of the <em>same</em> color but with an alpha channel set at 0.5 (50% opacity). The two boxes are drawn on top of a paragraph of text.</p>
 
-<p style="text-align: center;"><img alt="Image showing the effect of an alpha channel on a color." src="alpha-channel-example.png"></p>
+<p><img alt="Image showing the effect of an alpha channel on a color." src="alpha-channel-example.png"></p>
 
 <p>As you can see, the color without an alpha channel completely blocks the background text, while the box with the alpha channel leaves it visible through the purple background color.</p>
 

--- a/files/en-us/glossary/aria/index.html
+++ b/files/en-us/glossary/aria/index.html
@@ -5,7 +5,7 @@ tags:
   - Accessibility
   - Glossary
 ---
-<p><span class="seoSummary"><strong>ARIA</strong> (<em>Accessible Rich {{glossary("Internet")}} Applications</em>) is a {{Glossary("W3C")}} specification for adding semantics and other metadata to {{Glossary("HTML")}} to cater to users of assistive technology.</span></p>
+<p><strong>ARIA</strong> (<em>Accessible Rich {{glossary("Internet")}} Applications</em>) is a {{Glossary("W3C")}} specification for adding semantics and other metadata to {{Glossary("HTML")}} to cater to users of assistive technology.</p>
 
 <p>For example, you could add the attribute <code>role="alert"</code> to a {{HTMLElement("p")}} {{glossary("tag")}} to notify a sight-challenged user that the information is important and time-sensitive (which you might otherwise convey through text color).</p>
 

--- a/files/en-us/glossary/asynchronous/index.html
+++ b/files/en-us/glossary/asynchronous/index.html
@@ -7,7 +7,7 @@ tags:
   - WebMechanics
   - asynchronous
 ---
-<p><span class="seoSummary">The term <strong>asynchronous</strong> refers to </span>two or more objects or events <strong>not</strong> existing or happening at the same time (<span class="seoSummary">or multiple related things happening without waiting for the previous one to complete).</span> In computing, the word "asynchronous" is used in two major contexts.</p>
+<p>The term <strong>asynchronous</strong> refers to two or more objects or events <strong>not</strong> existing or happening at the same time (or multiple related things happening without waiting for the previous one to complete). In computing, the word "asynchronous" is used in two major contexts.</p>
 
 <dl>
  <dt>Networking and communications</dt>

--- a/files/en-us/glossary/bandwidth/index.html
+++ b/files/en-us/glossary/bandwidth/index.html
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - Infrastructure
 ---
-<p><span style="color: rgb(37, 37, 37); font-family: sans-serif; line-height: 22.3999996185303px;">Bandwidth is the measure of how much information can pass through a data connection in a given amount of time. It is usually measured in multiples of bits-per-second (bps), for example megabits-per-second (Mbps) or gigabits-p</span>er-second (Gbps).</p>
+<p>Bandwidth is the measure of how much information can pass through a data connection in a given amount of time. It is usually measured in multiples of bits-per-second (bps), for example megabits-per-second (Mbps) or gigabits-per-second (Gbps).</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/boolean/index.html
+++ b/files/en-us/glossary/boolean/index.html
@@ -9,7 +9,9 @@ tags:
   - Programming Languages
   - data types
 ---
-<p><span class="seoSummary">In computer science, a <strong>Boolean</strong> is a logical data type that can have only the values <code>true</code> or <code>false</code>.</span> For example, in JavaScript, Boolean conditionals are often used to decide which sections of code to execute (such as in <a href="/en-US/docs/Web/JavaScript/Reference/Statements/if...else">if statements</a>) or repeat (such as in <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for">for loops</a>).</p>
+<p>In computer science, a <strong>Boolean</strong> is a logical data type that can have only the values <code>true</code> or <code>false</code>.</p> 
+
+<p>For example, in JavaScript, Boolean conditionals are often used to decide which sections of code to execute (such as in <a href="/en-US/docs/Web/JavaScript/Reference/Statements/if...else">if statements</a>) or repeat (such as in <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for">for loops</a>).</p>
 
 <p>Below is some JavaScript pseudocode (it's not truly executable code) demonstrating this concept.</p>
 

--- a/files/en-us/glossary/breadcrumb/index.html
+++ b/files/en-us/glossary/breadcrumb/index.html
@@ -9,7 +9,7 @@ tags:
   - Site map
   - breadcrumb
 ---
-<p><span class="seoSummary">A <strong>breadcrumb</strong>, or breadcrumb trail, is a navigational aid that is typically placed between a site's header and the main content, displaying either a hierarchy of the current page in relation to the site's structure, from top level to current page, or a list of the links the user followed to get to the current page, in the order visited. </span></p>
+<p>A <strong>breadcrumb</strong>, or breadcrumb trail, is a navigational aid that is typically placed between a site's header and the main content, displaying either a hierarchy of the current page in relation to the site's structure, from top level to current page, or a list of the links the user followed to get to the current page, in the order visited. </p>
 
 <p>A location breadcrumb for this document might look something like this:</p>
 

--- a/files/en-us/glossary/brotli_compression/index.html
+++ b/files/en-us/glossary/brotli_compression/index.html
@@ -8,7 +8,9 @@ tags:
   - Web Performance
   - compression
 ---
-<p><span class="seoSummary"><strong>Brotli</strong> is a general-purpose lossless compression algorithm.</span> It compresses data using a combination of a modern variant of the LZ77 algorithm, Huffman coding, and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods. Brotli provides better compression ratios than <a href="/en-US/docs/Glossary/GZip_compression">gzip</a> and deflate speeds are comparable, but brotli compressing is a slower process than Gzip compression, so gzip may be a better option for the compression of non-<a href="/en-US/docs/Glossary/Cache">cacheable</a> content.</p>
+<p><strong>Brotli</strong> is a general-purpose lossless compression algorithm.</p> 
+
+<p>It compresses data using a combination of a modern variant of the LZ77 algorithm, Huffman coding, and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods. Brotli provides better compression ratios than <a href="/en-US/docs/Glossary/GZip_compression">gzip</a> and deflate speeds are comparable, but brotli compressing is a slower process than Gzip compression, so gzip may be a better option for the compression of non-<a href="/en-US/docs/Glossary/Cache">cacheable</a> content.</p>
 
 <p>Brotli is compatible with most modern browsers, but you may want to consider a fallback.</p>
 

--- a/files/en-us/glossary/call_stack/index.html
+++ b/files/en-us/glossary/call_stack/index.html
@@ -38,16 +38,16 @@ greeting();
 <ol>
  <li>Ignore all functions, until it reaches the <code>greeting()</code> function invocation.</li>
  <li>Add the <code>greeting()</code> function to the call stack list.
-  <div class="note">
-  <p>Call stack list:<br>
+  <div class="notecard note">
+  <p><strong>Note:</strong> Call stack list:<br>
    - greeting</p>
   </div>
  </li>
  <li>Execute all lines of code inside the <code>greeting()</code> function.</li>
  <li>Get to the <code>sayHi()</code> function invocation.</li>
  <li>Add the <code>sayHi()</code> function to the call stack list.
-  <div class="note">
-  <p>Call stack list:<br>
+  <div class="notecard note">
+  <p><strong>Note:</strong> Call stack list:<br>
    - sayHi<br>
    - greeting</p>
   </div>
@@ -55,15 +55,15 @@ greeting();
  <li>Execute all lines of code inside the <code>sayHi()</code> function, until reaches its end.</li>
  <li>Return execution to the line that invoked <code>sayHi()</code> and continue executing the rest of the <code>greeting()</code> function.</li>
  <li>Delete the <code>sayHi()</code> function from our call stack list.
-  <div class="note">
-  <p>Call stack list:<br>
+  <div class="notecard note">
+  <p><strong>Note:</strong> Call stack list:<br>
    - greeting</p>
   </div>
  </li>
  <li>When everything inside the <code>greeting()</code> function has been executed, return to its invoking line to continue executing the rest of the JS code.</li>
  <li>Delete the <code>greeting()</code> function from the call stack list.
-  <div class="note">
-  <p>Call stack list:<br>
+  <div class="notecard note">
+  <p><strong>Note:</strong> Call stack list:<br>
    EMPTY</p>
   </div>
  </li>

--- a/files/en-us/glossary/canvas/index.html
+++ b/files/en-us/glossary/canvas/index.html
@@ -8,7 +8,9 @@ tags:
   - HTML
   - JavaScript
 ---
-<p><span class="seoSummary">The <strong>canvas element</strong> is part of <a href="https://en.wikipedia.org/wiki/HTML5">HTML5</a> and allows for dynamic, <a href="https://en.wikipedia.org/wiki/Scripting_language" title="Scripting language">scriptable</a> <a href="https://en.wikipedia.org/wiki/Rendering_(computer_graphics)" title="Rendering (computer graphics)">rendering</a> of 2D and 3D shapes and <a href="https://en.wikipedia.org/wiki/Bitmap">bitmap</a> images.</span> It is a low level, procedural model that updates a <a href="https://en.wikipedia.org/wiki/Bitmap">bitmap</a> and does not have a built-in <a href="https://en.wikipedia.org/wiki/Scene_graph" title="Scene graph">scene graph</a>. It provides an empty graphic zone on which specific {{Glossary("JavaScript")}} {{Glossary("API","APIs")}} can draw (such as Canvas 2D or {{Glossary("WebGL")}}).</p>
+<p>The <strong>canvas element</strong> is part of <a href="https://en.wikipedia.org/wiki/HTML5">HTML5</a> and allows for dynamic, <a href="https://en.wikipedia.org/wiki/Scripting_language" title="Scripting language">scriptable</a> <a href="https://en.wikipedia.org/wiki/Rendering_(computer_graphics)" title="Rendering (computer graphics)">rendering</a> of 2D and 3D shapes and <a href="https://en.wikipedia.org/wiki/Bitmap">bitmap</a> images.</p> 
+
+<p>It is a low level, procedural model that updates a <a href="https://en.wikipedia.org/wiki/Bitmap">bitmap</a> and does not have a built-in <a href="https://en.wikipedia.org/wiki/Scene_graph" title="Scene graph">scene graph</a>. It provides an empty graphic zone on which specific {{Glossary("JavaScript")}} {{Glossary("API","APIs")}} can draw (such as Canvas 2D or {{Glossary("WebGL")}}).</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/caret/index.html
+++ b/files/en-us/glossary/caret/index.html
@@ -12,7 +12,9 @@ tags:
   - text input
   - text insertion point
 ---
-<p><span class="seoSummary">A <strong>caret</strong> (sometimes called a "text cursor") is an indicator displayed on the screen to indicate where text input will be inserted.</span> Most user interfaces represent the caret using a thin vertical line or a character-sized box that flashes, but this can vary. This point in the text is called the <strong>insertion point</strong>. The word "caret" differentiates the text insertion point from the mouse cursor.</p>
+<p>A <strong>caret</strong> (sometimes called a "text cursor") is an indicator displayed on the screen to indicate where text input will be inserted.</p>
+
+<p>Most user interfaces represent the caret using a thin vertical line or a character-sized box that flashes, but this can vary. This point in the text is called the <strong>insertion point</strong>. The word "caret" differentiates the text insertion point from the mouse cursor.</p>
 
 <p>On the web, a caret is used to represent the insertion point in {{HTMLElement("input")}} and {{HTMLElement("textarea")}} elements, as well as any elements whose {{htmlattrxref("contenteditable")}} attribute is set, thereby allowing the contents of the element to be edited by the user.</p>
 

--- a/files/en-us/glossary/certificate_authority/index.html
+++ b/files/en-us/glossary/certificate_authority/index.html
@@ -6,13 +6,15 @@ tags:
   - Glossary
   - Security
 ---
-<p><span class="seoSummary">A certificate authority (CA) is an organization that {{Glossary("Signature/Security", "signs")}} {{Glossary("Digital certificate", "digital certificates")}} and their associated {{Glossary("Key", "public keys")}}, thereby asserting that the contained information and keys are correct.</span> </p>
+<p>A certificate authority (CA) is an organization that {{Glossary("Signature/Security", "signs")}} {{Glossary("Digital certificate", "digital certificates")}} and their associated {{Glossary("Key", "public keys")}}, thereby asserting that the contained information and keys are correct.</p>
 
 <p>For a website digital certificate, this information minimally includes the name of the organization that requested the digital certificate (e.g., Mozilla Corporation), the site that it is for (e.g., mozilla.org), and the certificate authority.</p>
 
 <p>Certificate authorities are the part of the Internet <a href="https://en.wikipedia.org/wiki/Public_key_infrastructure">public key infrastructure</a> that allows browsers to verify website identity and securely connect over SSL (and HTTPS).</p>
 
-<div class="note"><strong>Note:</strong> Web browsers come preloaded with a list of "root certificates". The browser can use these to reliably check that the website certificate was signed by a certificate authority  that "chains back" to the root certificate (i.e. was trusted by the owner of the root certificate or an intermediate CA). Ultimately this process relies on every CA performing adequate identity checks before signing a certificate!</div>
+<div class="notecard note">
+<p><strong>Note:</strong> Web browsers come preloaded with a list of "root certificates". The browser can use these to reliably check that the website certificate was signed by a certificate authority  that "chains back" to the root certificate (i.e. was trusted by the owner of the root certificate or an intermediate CA). Ultimately this process relies on every CA performing adequate identity checks before signing a certificate!</p>
+</div>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/character_set/index.html
+++ b/files/en-us/glossary/character_set/index.html
@@ -6,7 +6,7 @@ tags:
   - character encoding
   - character set
 ---
-<p><span class="seoSummary">A <strong>character set</strong> is an encoding system to let computers know how to recognize {{Glossary("Character")}}, including letters, numbers, punctuation marks, and whitespace.</span></p>
+<p>A <strong>character set</strong> is an encoding system to let computers know how to recognize {{Glossary("Character")}}, including letters, numbers, punctuation marks, and whitespace.</p>
 
 <p>In earlier times, countries developed their own character sets due to their different languages used, such as Kanji JIS codes (e.g. Shift-JIS, EUC-JP, etc.) for Japanese, Big5 for traditional Chinese, and KOI8-R for Russian. However, {{Glossary("Unicode")}} gradually became most acceptable character set for its universal language support.</p>
 

--- a/files/en-us/glossary/cipher_suite/index.html
+++ b/files/en-us/glossary/cipher_suite/index.html
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - Security
 ---
-<p><span class="seoSummary">A cipher suite is a combination of a key exchange algorithm, authentication method, bulk encryption {{Glossary("cipher")}}, and message authentication code.</span></p>
+<p>A cipher suite is a combination of a key exchange algorithm, authentication method, bulk encryption {{Glossary("cipher")}}, and message authentication code.</p>
 
 <p>In a {{Glossary("cryptosystem")}} like {{Glossary("TLS")}}, the client and server must agree on a cipher suite before they can begin communicating securely.  A typical cipher suite looks like ECDHE_RSA_WITH_AES_128_GCM_SHA256 or ECDHE-RSA-AES128-GCM-SHA256, indicating:</p>
 

--- a/files/en-us/glossary/client_hints/index.html
+++ b/files/en-us/glossary/client_hints/index.html
@@ -22,8 +22,7 @@ tags:
 <pre class="brush: http">Accept-CH: Width, Downlink</pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the <code><a href="/en-US/docs/Web/HTML/Element/meta#attr-http-equiv">http-equiv</a></code> attribute.</p>
+  <p><strong>Note:</strong> Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the <code><a href="/en-US/docs/Web/HTML/Element/meta#attr-http-equiv">http-equiv</a></code> attribute.</p>
   <pre>&lt;meta http-equiv="Accept-CH" content="Width, Viewport-Width, Downlink"&gt;</pre>
 </div>
 

--- a/files/en-us/glossary/code_splitting/index.html
+++ b/files/en-us/glossary/code_splitting/index.html
@@ -8,7 +8,7 @@ tags:
   - code splitting
   - latency
 ---
-<p><span class="seoSummary"><strong>Code splitting</strong> is the splitting of code into various bundles or components which can then be loaded on demand or in parallel.</span></p>
+<p><strong>Code splitting</strong> is the splitting of code into various bundles or components which can then be loaded on demand or in parallel.</p>
 
 <p>As an application grows in complexity or is maintained, CSS and JavaScripts files or  bundles grow in byte size, especially as the number and size of included third-party libraries increases. To prevent the requirement of downloading ginormous files, scripts can be split into multiple smaller files. Then features required at page load can be downloaded immediately with additional scripts being <a href="/en-US/docs/Glossary/Lazy_load">lazy loaded</a> after the page or application is interactive, thus improving performance. While the total amount of code is the same (and perhaps even a few bytes larger), the amount of code needed during initial load can be reduced.</p>
 

--- a/files/en-us/glossary/conditional/index.html
+++ b/files/en-us/glossary/conditional/index.html
@@ -6,7 +6,7 @@ tags:
   - CodingScripting
   - Glossary
 ---
-<p><span class="seoSummary">A <strong>condition</strong> is a set of rules that can interrupt normal code execution or change it, depending on whether the condition is completed or not.</span></p>
+<p>A <strong>condition</strong> is a set of rules that can interrupt normal code execution or change it, depending on whether the condition is completed or not.</p>
 
 <p>An instruction or a set of instructions is executed if a specific condition is fulfilled. Otherwise, another instruction is executed. It is also possible to repeat the execution of an instruction, or set of instructions, while a condition is not yet fulfilled.</p>
 

--- a/files/en-us/glossary/continuous_media/index.html
+++ b/files/en-us/glossary/continuous_media/index.html
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - Media
 ---
-<p><span class="seoSummary">Continuous media is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.</span></p>
+<p>Continuous media is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.</p>
 
 <p>CSS can be used in a variety of contexts, including print media. And some CSS, particularly those that are used for layout, behave differently depending on the context they are in.</p>
 

--- a/files/en-us/glossary/cors-safelisted_response_header/index.html
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.html
@@ -7,7 +7,7 @@ tags:
   - Glossary
   - HTTP
 ---
-<p><span class="seoSummary">A <em>CORS-safelisted response header</em> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> in a <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> response that it is considered <em>safe</em> to expose to client scripts. Only safelisted response headers are made available to web pages.</span></p>
+<p>A <em>CORS-safelisted response header</em> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> in a <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> response that it is considered <em>safe</em> to expose to client scripts. Only safelisted response headers are made available to web pages.</p>
 
 <p>By default, the safelist includes the following response headers:</p>
 <ul>

--- a/files/en-us/glossary/cross_axis/index.html
+++ b/files/en-us/glossary/cross_axis/index.html
@@ -9,11 +9,11 @@ tags:
 ---
 <p>The cross axis in {{glossary("flexbox")}} runs perpendicular to the {{glossary("main axis")}}, therefore if your {{cssxref("flex-direction")}} is either <code>row</code> or <code>row-reverse</code> then the cross axis runs down the columns.</p>
 
-<p><img alt="The cross axis runs down the column" src="basics3.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="The cross axis runs down the column" src="basics3.png"></p>
 
 <p>If your main axis is <code>column</code> or <code>column-reverse</code> then the cross axis runs along the rows.</p>
 
-<p><img alt="The cross axis runs along the row." src="basics4.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="The cross axis runs along the row." src="basics4.png"></p>
 
 <p>Alignment of items on the cross axis is achieved with the <code>align-items</code> property on the flex container or <code>align-self</code> property on individual items. In the case of a multi-line flex container, with additional space on the cross axis, you can use <code>align-content</code> to control the spacing of the rows.</p>
 

--- a/files/en-us/glossary/cryptography/index.html
+++ b/files/en-us/glossary/cryptography/index.html
@@ -7,7 +7,9 @@ tags:
   - Privacy
   - Security
 ---
-<p><span class="seoSummary"><strong>Cryptography</strong>, or cryptology, is the science that studies how to encode and transmit messages securely. Cryptography designs and studies algorithms used to encode and decode messages in an insecure environment, and their applications.</span> More than just <strong>data confidentiality</strong>, cryptography also tackles <strong>identification</strong>, <strong>authentication</strong>, <strong>non-repudiation</strong>, and <strong>data integrity</strong>. Therefore it also studies usage of cryptographic methods in context, <strong>cryptosystems</strong>.</p>
+<p><strong>Cryptography</strong>, or cryptology, is the science that studies how to encode and transmit messages securely. Cryptography designs and studies algorithms used to encode and decode messages in an insecure environment, and their applications.</p>
+
+<p>More than just <strong>data confidentiality</strong>, cryptography also tackles <strong>identification</strong>, <strong>authentication</strong>, <strong>non-repudiation</strong>, and <strong>data integrity</strong>. Therefore it also studies usage of cryptographic methods in context, <strong>cryptosystems</strong>.</p>
 
 <section id="Quick_links">
 <ol>

--- a/files/en-us/glossary/csrf/index.html
+++ b/files/en-us/glossary/csrf/index.html
@@ -5,7 +5,9 @@ tags:
   - Glossary
   - Security
 ---
-<p><span class="seoSummary"><strong>CSRF</strong> (Cross-Site Request Forgery) is an attack that impersonates a trusted user and sends a website unwanted commands.</span> This can be done, for example, by including malicious parameters in a {{glossary("URL")}} behind a link that purports to go somewhere else:</p>
+<p><strong>CSRF</strong> (Cross-Site Request Forgery) is an attack that impersonates a trusted user and sends a website unwanted commands.</p>
+
+<p>This can be done, for example, by including malicious parameters in a {{glossary("URL")}} behind a link that purports to go somewhere else:</p>
 
 <pre class="brush: html">&lt;img src="https://www.example.com/index.php?action=delete&amp;id=123"&gt;
 </pre>

--- a/files/en-us/glossary/css/index.html
+++ b/files/en-us/glossary/css/index.html
@@ -8,7 +8,9 @@ tags:
   - Web
   - l10n:priority
 ---
-<p><span class="seoSummary"><strong>CSS</strong> (Cascading Style Sheets) is a declarative language that controls how webpages look in the {{glossary("browser")}}.</span> The browser applies CSS style declarations to selected elements to display them properly. A style declaration contains the properties and their values, which determine how a webpage looks.</p>
+<p><strong>CSS</strong> (Cascading Style Sheets) is a declarative language that controls how webpages look in the {{glossary("browser")}}.</p>
+
+<p>The browser applies CSS style declarations to selected elements to display them properly. A style declaration contains the properties and their values, which determine how a webpage looks.</p>
 
 <p>CSS is one of the three core Web technologies, along with {{Glossary("HTML")}} and {{Glossary("JavaScript")}}. CSS usually styles {{Glossary("Element","HTML elements")}}, but can be also used with other markup languages like {{Glossary("SVG")}} or {{Glossary("XML")}}.</p>
 

--- a/files/en-us/glossary/css_preprocessor/index.html
+++ b/files/en-us/glossary/css_preprocessor/index.html
@@ -5,7 +5,9 @@ tags:
   - CSS
   - Glossary
 ---
-<p><span class="seoSummary">A <strong>CSS preprocessor</strong> is a program that lets you generate {{Glossary("CSS")}} from the preprocessor's own unique {{Glossary("syntax")}}.</span> There are many CSS preprocessors to choose from, however most CSS preprocessors will add some features that don't exist in pure CSS, such as mixin, nesting selector, inheritance selector, and so on. These features make the CSS structure more readable and easier to maintain.</p>
+<p>A <strong>CSS preprocessor</strong> is a program that lets you generate {{Glossary("CSS")}} from the preprocessor's own unique {{Glossary("syntax")}}.</p>
+
+<p>There are many CSS preprocessors to choose from, however most CSS preprocessors will add some features that don't exist in pure CSS, such as mixin, nesting selector, inheritance selector, and so on. These features make the CSS structure more readable and easier to maintain.</p>
 
 <p>To use a CSS preprocessor, you must install a CSS compiler on your web {{Glossary("server")}}; Or use the CSS preprocessor to compile on the development environment, and then upload compiled CSS file to the web server.</p>
 

--- a/files/en-us/glossary/database/index.html
+++ b/files/en-us/glossary/database/index.html
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - Sql
 ---
-<p><span class="seoSummary">A <strong>database</strong> is a storing system that collects organized data, to make some works easier like searching, structure, and extend.</span></p>
+<p>A <strong>database</strong> is a storing system that collects organized data, to make some works easier like searching, structure, and extend.</p>
 
 <p>In web development, most databases use the relational database management system (RDBMS) to organize data and programming in {{glossary("SQL")}}. Some databases, however, don't follow the former mechanism to organized data, which called NoSQL.</p>
 

--- a/files/en-us/glossary/delta/index.html
+++ b/files/en-us/glossary/delta/index.html
@@ -7,7 +7,9 @@ tags:
   - difference
   - value
 ---
-<p><span class="seoSummary">The term <strong>delta</strong> refers to the difference between two values or states.</span> The name originates from the Greek letter Δ (delta), which is equivalent to the letter <em>D</em> in the Roman alphabet. <em>Delta</em> refers to the use of the letter Δ as a shorthand for <em>difference</em>.</p>
+<p>The term <strong>delta</strong> refers to the difference between two values or states.</p>
+
+<p>The name originates from the Greek letter Δ (delta), which is equivalent to the letter <em>D</em> in the Roman alphabet. <em>Delta</em> refers to the use of the letter Δ as a shorthand for <em>difference</em>.</p>
 
 <p>The term <em>delta</em> is commonly used when communicating changes in speed, position, or acceleration of a physical or virtual object. It's also used when describing changes in the volume or frequency of sound waves.</p>
 

--- a/files/en-us/glossary/digital_certificate/index.html
+++ b/files/en-us/glossary/digital_certificate/index.html
@@ -6,7 +6,9 @@ tags:
   - Glossary
   - Security
 ---
-<p><span class="seoSummary">A digital certificate is a data file that binds a publicly known {{Glossary("Key", "cryptographic key")}} to an organization.</span> A digital certificate contains information about an organization, such as the common name (e.g., mozilla.org), the organization unit (e.g., Mozilla Corporation), and the location (e.g., Mountain View). Digital certificates are most commonly signed by a {{Glossary("certificate authority")}}, attesting to the certificate's authenticity.</p>
+<p>A digital certificate is a data file that binds a publicly known {{Glossary("Key", "cryptographic key")}} to an organization.</p>
+
+<p>A digital certificate contains information about an organization, such as the common name (e.g., mozilla.org), the organization unit (e.g., Mozilla Corporation), and the location (e.g., Mountain View). Digital certificates are most commonly signed by a {{Glossary("certificate authority")}}, attesting to the certificate's authenticity.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/dmz/index.html
+++ b/files/en-us/glossary/dmz/index.html
@@ -6,7 +6,9 @@ tags:
   - Networking
   - Security
 ---
-<p><span class="seoSummary">A <strong>DMZ</strong> (DeMilitarized Zone) is a way to provide an insulated secure interface between an internal network (corporate or private) and the outside untrusted world — usually the Internet.</span> It exposes only certain defined endpoints, while denying access to the internal network from {{Glossary('node/networking', 'external nodes')}}.</p>
+<p>A <strong>DMZ</strong> (DeMilitarized Zone) is a way to provide an insulated secure interface between an internal network (corporate or private) and the outside untrusted world — usually the Internet.</p>
+
+<p>It exposes only certain defined endpoints, while denying access to the internal network from {{Glossary('node/networking', 'external nodes')}}.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/document_environment/index.html
+++ b/files/en-us/glossary/document_environment/index.html
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - JavaScript
 ---
-<p><span class="seoSummary">When the JavaScript global environment is a window or an iframe, it is called a <em>document environment</em>. A global environment is an environment that doesn't have an outer environment. </span></p>
+<p>When the JavaScript global environment is a window or an iframe, it is called a <em>document environment</em>. A global environment is an environment that doesn't have an outer environment.</p>
 
 <h2 id="Learn_More">Learn More</h2>
 

--- a/files/en-us/glossary/dynamic_programming_language/index.html
+++ b/files/en-us/glossary/dynamic_programming_language/index.html
@@ -9,8 +9,8 @@ tags:
 
 <p>This is opposed to so-called static programming languages, in which such changes are normally not possible.</p>
 
-<div class="note">
-<p>Note that while there is indeed a connection between this dynamic/static property of programming languages and <a href="/en-US/docs/Glossary/Dynamic_typing">dynamic</a>/<a href="/en-US/docs/Glossary/Static_typing">static-typing</a>, the two are far from synonymous.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> Note that while there is indeed a connection between this dynamic/static property of programming languages and <a href="/en-US/docs/Glossary/Dynamic_typing">dynamic</a>/<a href="/en-US/docs/Glossary/Static_typing">static-typing</a>, the two are far from synonymous.</p>
 </div>
 
 <h2 id="Learn_more">Learn more</h2>

--- a/files/en-us/glossary/entity/index.html
+++ b/files/en-us/glossary/entity/index.html
@@ -7,10 +7,10 @@ tags:
   - Glossary
   - HTML
 ---
-<p><span class="seoSummary">An {{glossary("HTML")}} <strong>entity </strong>is a piece of text ("string") that begins with an ampersand (<code>&amp;</code>) and ends with a semicolon (<code>;</code>) . Entities are frequently used to display reserved characters (which would otherwise be interpreted as HTML code), and invisible characters (like non-breaking spaces). You can also use them in place of other characters that are difficult to type with a standard keyboard.  </span></p>
+<p>An {{glossary("HTML")}} <strong>entity </strong>is a piece of text ("string") that begins with an ampersand (<code>&amp;</code>) and ends with a semicolon (<code>;</code>) . Entities are frequently used to display reserved characters (which would otherwise be interpreted as HTML code), and invisible characters (like non-breaking spaces). You can also use them in place of other characters that are difficult to type with a standard keyboard.</p>
 
-<div class="note">
-<p>Many characters have memorable entities. For example, the entity for the copyright symbol (<code>©</code>) is <code>&amp;copy;</code>. For less memorable characters, such as <code>&amp;#8212;</code> or <code>&amp;#x2014;</code>, you can use a <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">reference chart</a> or <a href="https://mothereff.in/html-entities">decoder tool</a>.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> Many characters have memorable entities. For example, the entity for the copyright symbol (<code>©</code>) is <code>&amp;copy;</code>. For less memorable characters, such as <code>&amp;#8212;</code> or <code>&amp;#x2014;</code>, you can use a <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">reference chart</a> or <a href="https://mothereff.in/html-entities">decoder tool</a>.</p>
 </div>
 
 <h2 id="Reserved_characters">Reserved characters</h2>
@@ -19,7 +19,7 @@ tags:
 
 <p>To display these characters as text, replace them with their corresponding character entities, as shown in the following table.</p>
 
-<table class="standard-table">
+<table>
  <thead>
   <tr>
    <th scope="col">Character</th>

--- a/files/en-us/glossary/entity_header/index.html
+++ b/files/en-us/glossary/entity_header/index.html
@@ -6,8 +6,7 @@ tags:
   - WebMechanics
 ---
 <div class="notecard warning">
-  <h4>Warning</h4>
-  <p>The current HTTP/1.1 specification no longer refers to entities, entity headers or entity-body. Some of the fields are now referred to as {{glossary("Representation header")}} fields.</p>
+  <p><strong>Warning:</strong> The current HTTP/1.1 specification no longer refers to entities, entity headers or entity-body. Some of the fields are now referred to as {{glossary("Representation header")}} fields.</p>
 </div>
 
 <p>An entity header is an {{glossary("HTTP_header", "HTTP header")}} that describes the payload of an HTTP message (i.e. metadata about the message body). Entity headers include: {{HTTPHeader("Content-Length")}}, {{HTTPHeader("Content-Language")}}, {{HTTPHeader("Content-Encoding")}}, {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Expires")}}, etc. Entity headers may be present in both HTTP request and response messages.</p>

--- a/files/en-us/glossary/favicon/index.html
+++ b/files/en-us/glossary/favicon/index.html
@@ -7,7 +7,9 @@ tags:
   - favicon
   - user agent
 ---
-<p><span class="seoSummary">A favicon (favorite icon) is a tiny icon included along with a website, which is displayed in places like the browser's address bar, page tabs and bookmarks menu.</span> Note, however, that most modern browsers replaced the favicon from the address bar by an image indicating whether or not the website is using {{Glossary("https","HTTPS")}}.</p>
+<p>A favicon (favorite icon) is a tiny icon included along with a website, which is displayed in places like the browser's address bar, page tabs and bookmarks menu.</p>
+
+<p>Note, however, that most modern browsers replaced the favicon from the address bar by an image indicating whether or not the website is using {{Glossary("https","HTTPS")}}.</p>
 
 <p>Usually, a favicon is 16 x 16 pixels in size and stored in the {{Glossary("GIF")}}, {{Glossary("PNG")}}, or ICO file format.</p>
 

--- a/files/en-us/glossary/first-class_function/index.html
+++ b/files/en-us/glossary/first-class_function/index.html
@@ -21,8 +21,8 @@ foo();
 
 <p>We assigned an <strong>Anonymous Function</strong> in a {{glossary("Variable")}}, then we used that variable to invoke the function by adding parentheses <code>()</code> at the end.</p>
 
-<div class="note">
-<p><strong>Even if your function was named,</strong> you can use the variable name to invoke it. Naming it will be helpful when debugging your code. <em>But it won't affect the way we invoke it.</em></p>
+<div class="notecard note">
+<p><strong>Note:</strong> <strong>Even if your function was named,</strong> you can use the variable name to invoke it. Naming it will be helpful when debugging your code. <em>But it won't affect the way we invoke it.</em></p>
 </div>
 
 <h2 id="Example_Pass_a_function_as_an_Argument">Example | Pass a function as an Argument</h2>
@@ -41,8 +41,8 @@ greeting(sayHello, "JavaScript!");
 
 <p>We are passing our <code>sayHello()</code> function as an argument to the <code>greeting()</code> function, this explains how we are treating the function as a <strong>value</strong>.</p>
 
-<div class="note">
-<p>The function that we pass as an argument to another function, is called a <strong>{{glossary("Callback function")}}</strong>. <em><code>sayHello</code> is a Callback function.</em></p>
+<div class="notecard note">
+<p><strong>Note:</strong> The function that we pass as an argument to another function, is called a <strong>{{glossary("Callback function")}}</strong>. <em><code>sayHello</code> is a Callback function.</em></p>
 </div>
 
 <h2 id="Example_Return_a_function">Example | Return a function</h2>
@@ -58,8 +58,8 @@ greeting(sayHello, "JavaScript!");
 
 <p>In this example; We need to return a function from another function - <em>We can return a function because we treated function in JavaScript as a <strong>value</strong>.</em></p>
 
-<div class="note">
-<p>A function that returns a function is called a <strong>Higher-Order Function</strong>.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> A function that returns a function is called a <strong>Higher-Order Function</strong>.</p>
 </div>
 
 <p>Back to our example; Now, we need to invoke <code>sayHello</code> function and its returned <code>Anonymous Function</code>. To do so, we have two ways:</p>
@@ -77,8 +77,8 @@ myFunc();
 
 <p>This way, it returns the <code>Hello!</code> message.</p>
 
-<div class="note">
-<p>You have to use another variable. If you invoked <code>sayHello</code> directly, it would return the function itself <strong>without invoking its returned function</strong>.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> You have to use another variable. If you invoked <code>sayHello</code> directly, it would return the function itself <strong>without invoking its returned function</strong>.</p>
 </div>
 
 <h3 id="2-_Using_double_parentheses">2- Using double parentheses</h3>

--- a/files/en-us/glossary/first_cpu_idle/index.html
+++ b/files/en-us/glossary/first_cpu_idle/index.html
@@ -7,4 +7,4 @@ tags:
   - Performance
   - Web Performance
 ---
-<p class="seoSummary"><strong>First CPU Idle</strong> measures when a page is minimally interactive, or when the window is quiet enough to handle user input. It is a non-standard Google web performance metric. Generally, it occurs when most, but not necessarily all visible UI elements are interactive, and the user interface responds, on average, to most user input within 50ms. It is also known as <a href="/en-US/docs/Glossary/First_interactive">First interactive</a>.</p>
+<p><strong>First CPU Idle</strong> measures when a page is minimally interactive, or when the window is quiet enough to handle user input. It is a non-standard Google web performance metric. Generally, it occurs when most, but not necessarily all visible UI elements are interactive, and the user interface responds, on average, to most user input within 50ms. It is also known as <a href="/en-US/docs/Glossary/First_interactive">First interactive</a>.</p>

--- a/files/en-us/glossary/first_input_delay/index.html
+++ b/files/en-us/glossary/first_input_delay/index.html
@@ -6,7 +6,9 @@ tags:
   - Reference
   - Web Performance
 ---
-<p><span class="seoSummary"><strong>First input delay</strong> (FID) measures the time from when a user first interacts with your site (i.e. when they click a link, tap on a button, or use a custom, JavaScript-powered control) to the time when the browser is actually able to respond to that interaction.</span> It is the length of time, in milliseconds, between the first user interaction on a web page and the browser’s response to that interaction. Scrolling and zooming are not included in this metric.</p>
+<p><strong>First input delay</strong> (FID) measures the time from when a user first interacts with your site (i.e. when they click a link, tap on a button, or use a custom, JavaScript-powered control) to the time when the browser is actually able to respond to that interaction.</p>
+
+<p>It is the length of time, in milliseconds, between the first user interaction on a web page and the browser’s response to that interaction. Scrolling and zooming are not included in this metric.</p>
 
 <p>The time between when content is painted to the page and when all the functionality becomes responsive to human interaction often varies based on the size and complexity of the JavaScript needing to be downloaded, parsed, and executed on the main thread, and on the device speed or lack thereof (think low end mobile devices). The longer the delay, the worse the user experience. Reducing site initialization time and eliminating<a href="/en-US/docs/Web/API/Long_Tasks_API"> long tasks</a> can help eliminate first input delays.</p>
 

--- a/files/en-us/glossary/first_interactive/index.html
+++ b/files/en-us/glossary/first_interactive/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p>{{draft}}</p>
 
-<p class="seoSummary"><strong>First Interactive,</strong> also known as <a href="/en-US/docs/Glossary/First_CPU_idle">first CPU idle</a>, is a non-standard web performance metric that measures when the user's window is quiet enough to handle user input, or what is termed as minimally interactive.</p>
+<p><strong>First Interactive,</strong> also known as <a href="/en-US/docs/Glossary/First_CPU_idle">first CPU idle</a>, is a non-standard web performance metric that measures when the user's window is quiet enough to handle user input, or what is termed as minimally interactive.</p>
 
 <p>Minimally interactive is defined as when some, but not necessarily all, UI elements on the page have loaded and are interactive, and, on average, respond to user input in a reasonable amount of time.</p>
 

--- a/files/en-us/glossary/first_paint/index.html
+++ b/files/en-us/glossary/first_paint/index.html
@@ -7,7 +7,7 @@ tags:
   - Performance
   - Web Performance
 ---
-<p><span class="seoSummary"><strong>First Paint</strong>, part of the <a href="/en-US/docs/Web/PerformancePaintTiming">Paint Timing API</a>, is the time between navigation and when the browser renders the first pixels to the screen, </span>rendering anything that is visually different from what was on the screen prior to navigation. It answers the question "Is it happening?"</p>
+<p><strong>First Paint</strong>, part of the <a href="/en-US/docs/Web/PerformancePaintTiming">Paint Timing API</a>, is the time between navigation and when the browser renders the first pixels to the screen, rendering anything that is visually different from what was on the screen prior to navigation. It answers the question "Is it happening?"</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/glossary/forbidden_header_name/index.html
+++ b/files/en-us/glossary/forbidden_header_name/index.html
@@ -41,8 +41,7 @@ tags:
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The <code>User-Agent</code> header is no longer forbidden, <a href="https://fetch.spec.whatwg.org/#terminology-headers">as per spec</a> — see forbidden header name list (this was implemented in Firefox 43) — it can now be set in a Fetch <a href="/en-US/docs/Web/API/Headers">Headers</a> object, or via XHR <a href="/en-US/docs/Web/API/XMLHttpRequest#setrequestheader%28%29">setRequestHeader()</a>.  However, Chrome will silently drop the header from Fetch requests (see <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=571722">Chromium bug 571722</a>).</p>
+  <p><strong>Note:</strong> The <code>User-Agent</code> header is no longer forbidden, <a href="https://fetch.spec.whatwg.org/#terminology-headers">as per spec</a> — see forbidden header name list (this was implemented in Firefox 43) — it can now be set in a Fetch <a href="/en-US/docs/Web/API/Headers">Headers</a> object, or via XHR <a href="/en-US/docs/Web/API/XMLHttpRequest#setrequestheader%28%29">setRequestHeader()</a>.  However, Chrome will silently drop the header from Fetch requests (see <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=571722">Chromium bug 571722</a>).</p>
 </div>
 
 <section id="Quick_links">

--- a/files/en-us/glossary/fork/index.html
+++ b/files/en-us/glossary/fork/index.html
@@ -7,7 +7,9 @@ tags:
   - Tools
   - git
 ---
-<p><span class="seoSummary">A fork is a copy of an existing software project at some point to add someone's own modifications to the project. Basically, if the license of the original software allows, you can copy the code to develop your own version of it, with your own additions,</span> which will be a "fork".</p>
+<p>A fork is a copy of an existing software project at some point to add someone's own modifications to the project.</p>
+
+<p>Basically, if the license of the original software allows, you can copy the code to develop your own version of it, with your own additions, which will be a "fork".</p>
 
 <p>Forks are often seen in free and open source software development. This is now a more popular term thanks to contribution model using Git (and/or the GitHub platform).</p>
 

--- a/files/en-us/glossary/fuzzing/index.html
+++ b/files/en-us/glossary/fuzzing/index.html
@@ -9,7 +9,7 @@ tags:
   - Security
   - Testing
 ---
-<p><span class="seoSummary"><strong>Fuzzing</strong> is a technique for testing software using automated tools to provide invalid or unexpected input to a program or function in a program, then checking the results to see if the program crashes or otherwise acts inappropriately. This is an important way to ensure that software is stable, reliable, and secure, and we use fuzzing a lot at Mozilla.</span></p>
+<p><strong>Fuzzing</strong> is a technique for testing software using automated tools to provide invalid or unexpected input to a program or function in a program, then checking the results to see if the program crashes or otherwise acts inappropriately. This is an important way to ensure that software is stable, reliable, and secure, and we use fuzzing a lot at Mozilla.</p>
 
 <ul>
  <li><a class="external" href="https://www.squarefree.com/categories/fuzzing/">Jesse's blog posts about fuzzing</a></li>

--- a/files/en-us/glossary/garbage_collection/index.html
+++ b/files/en-us/glossary/garbage_collection/index.html
@@ -5,7 +5,9 @@ tags:
   - CodingScripting
   - Glossary
 ---
-<p><span class="seoSummary"><strong><a href="/en-US/docs/Web/JavaScript/Memory_Management#garbage_collection">Garbage collection</a></strong> is a term used in {{Glossary("computer programming")}} to describe the process of finding and deleting {{Glossary("object", "objects")}} which are no longer being {{Glossary("object reference", "referenced")}} by other objects.</span> In other words, garbage collection is the process of removing any objects which are not being used by any other objects. Often abbreviated "GC," garbage collection is a fundamental component of the <a href="/en-US/docs/Web/JavaScript/Memory_Management">memory management</a> system used by {{Glossary("JavaScript")}}.</p>
+<p><strong><a href="/en-US/docs/Web/JavaScript/Memory_Management#garbage_collection">Garbage collection</a></strong> is a term used in {{Glossary("computer programming")}} to describe the process of finding and deleting {{Glossary("object", "objects")}} which are no longer being {{Glossary("object reference", "referenced")}} by other objects.</p>
+
+<p>In other words, garbage collection is the process of removing any objects which are not being used by any other objects. Often abbreviated "GC," garbage collection is a fundamental component of the <a href="/en-US/docs/Web/JavaScript/Memory_Management">memory management</a> system used by {{Glossary("JavaScript")}}.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/gecko/index.html
+++ b/files/en-us/glossary/gecko/index.html
@@ -9,7 +9,7 @@ tags:
   - Intro
   - Mozilla
 ---
-<p id="Summary"><span class="seoSummary"><strong>Gecko</strong> is the layout engine developed by the Mozilla Project and used in many apps/devices, including {{glossary("Mozilla Firefox","Firefox")}} and {{glossary("Firefox OS")}}.</span></p>
+<p><strong>Gecko</strong> is the layout engine developed by the Mozilla Project and used in many apps/devices, including {{glossary("Mozilla Firefox","Firefox")}} and {{glossary("Firefox OS")}}.</p>
 
 <p>Web {{glossary("browser","browsers")}} need software called a layout engine to interpret {{glossary("HTML")}}, {{glossary("CSS")}}, {{glossary("JavaScript")}}, and embedded content (like images) and draw everything to your screen. Besides this, Gecko makes sure associated {{glossary("API","APIs")}} work well on every operating system Gecko supports, and that appropriate APIs are exposed only to relevant support targets. This means that Gecko includes, among other things, a networking stack, graphics stack, layout engine, a JavaScript virtual machine, and porting layers.</p>
 

--- a/files/en-us/glossary/general_header/index.html
+++ b/files/en-us/glossary/general_header/index.html
@@ -8,6 +8,5 @@ tags:
 <p><strong>General header</strong> is an outdated term used to refer to an {{glossary('HTTP_header', 'HTTP header')}} that can be used in both request and response messages, but which doesn't apply to the content itself (a header that applied to the content was called an {{glossary("entity header")}}). Depending on the context they are used in, general headers might either be {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} (e.g. {{HTTPheader("Cache-Control")}}).</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Current versions of the HTTP/1.1 specification do not specifically categorize headers as "general headers". These are now simply refered to as {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} depending on context.</p>
+  <p><strong>Note:</strong> Current versions of the HTTP/1.1 specification do not specifically categorize headers as "general headers". These are now simply refered to as {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} depending on context.</p>
 </div>

--- a/files/en-us/glossary/hmac/index.html
+++ b/files/en-us/glossary/hmac/index.html
@@ -7,7 +7,9 @@ tags:
   - Hash
   - Security
 ---
-<p><span class="seoSummary"><abbr title="Hash-based message authentication code">HMAC</abbr> is a protocol used for {{Glossary("cryptography", "cryptographically")}} authenticating messages.</span> It can use any kind of {{Glossary("Cryptographic hash function", "cryptographic functions")}}, and its strength depends on the underlying function (SHA1 or MD5 for instance), and the chosen secret key. With such a combination, the HMAC verification {{Glossary("Algorithm", "algorithm")}} is then known with a compound name such as HMAC-SHA1.</p>
+<p><abbr title="Hash-based message authentication code">HMAC</abbr> is a protocol used for {{Glossary("cryptography", "cryptographically")}} authenticating messages.</p>
+
+<p>It can use any kind of {{Glossary("Cryptographic hash function", "cryptographic functions")}}, and its strength depends on the underlying function (SHA1 or MD5 for instance), and the chosen secret key. With such a combination, the HMAC verification {{Glossary("Algorithm", "algorithm")}} is then known with a compound name such as HMAC-SHA1.</p>
 
 <p>HMAC is used to ensure both integrity and authentication.</p>
 

--- a/files/en-us/glossary/hmac/index.html
+++ b/files/en-us/glossary/hmac/index.html
@@ -7,7 +7,7 @@ tags:
   - Hash
   - Security
 ---
-<p><abbr title="Hash-based message authentication code">HMAC</abbr> is a protocol used for {{Glossary("cryptography", "cryptographically")}} authenticating messages.</p>
+<p><strong>Hash-based message authentication code</strong>(<em>HMAC</em>) is a protocol used for {{Glossary("cryptography", "cryptographically")}} authenticating messages.</p>
 
 <p>It can use any kind of {{Glossary("Cryptographic hash function", "cryptographic functions")}}, and its strength depends on the underlying function (SHA1 or MD5 for instance), and the chosen secret key. With such a combination, the HMAC verification {{Glossary("Algorithm", "algorithm")}} is then known with a compound name such as HMAC-SHA1.</p>
 

--- a/files/en-us/glossary/houdini/index.html
+++ b/files/en-us/glossary/houdini/index.html
@@ -8,7 +8,9 @@ tags:
   - Houdini
   - Reference
 ---
-<p><span class="seoSummary">Houdini is a set of low level APIs that give developers the power to extend CSS, providing the ability to hook into the styling and layout process of a browser’s rendering engine. Houdini gives developers access to the <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a> (<a href="/en-US/docs/Glossary/CSSOM">CSSOM</a>), enabling developers to write code the browser can parse as CSS. </span>The benefit of Houdini is that developers can create CSS features without waiting for web standards specifications to define them and without waiting for every browser to fully implement the features.  </p>
+<p>Houdini is a set of low level APIs that give developers the power to extend CSS, providing the ability to hook into the styling and layout process of a browser’s rendering engine. Houdini gives developers access to the <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a> (<a href="/en-US/docs/Glossary/CSSOM">CSSOM</a>), enabling developers to write code the browser can parse as CSS.</p>
+
+<p>The benefit of Houdini is that developers can create CSS features without waiting for web standards specifications to define them and without waiting for every browser to fully implement the features.  </p>
 
 <p>While many of the features Houdini enables can be created with JavaScript, interacting directly with the CSSOM before JavaScript is enabled provides for faster parse times. Browsers create the CSSOM —  including layout, paint, and composite processes — before applying any style updates found in scripts: layout, paint, and composite processes are repeated for updated JavaScript styles to be implemented. Houdini code doesn't wait for that first rendering cycle to be complete. Rather, it is included in that first cycle, creating renderable, understandable styles.</p>
 

--- a/files/en-us/glossary/html5/index.html
+++ b/files/en-us/glossary/html5/index.html
@@ -15,7 +15,7 @@ tags:
 <p>Any modern site should use the <a href="/en-US/docs/MDN/Guidelines/Code_guidelines/HTML#doctype">HTML doctype</a> — this will ensure that you are using the latest version of HTML.</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> Until 2019, the {{glossary("W3C")}} published a competing HTML5 standard with version numbers. In MDN docs and elsewhere on the web therefore, you may find references to other HTML versions, HTML5.1 for example. Since <a href="https://www.w3.org/blog/news/archives/7753">28 May 2019</a>, the WHATWG Living Standard was announced by the W3C as the sole version of HTML.</p>
+  <p><strong>Note:</strong> Until 2019, the {{glossary("W3C")}} published a competing HTML5 standard with version numbers. Since <a href="https://www.w3.org/blog/news/archives/7753">28 May 2019</a>, the WHATWG Living Standard was announced by the W3C as the sole version of HTML.</p>
 </div>
 
 <h2 id="Learn_more">Learn more</h2>

--- a/files/en-us/glossary/html5/index.html
+++ b/files/en-us/glossary/html5/index.html
@@ -15,8 +15,7 @@ tags:
 <p>Any modern site should use the <a href="/en-US/docs/MDN/Guidelines/Code_guidelines/HTML#doctype">HTML doctype</a> — this will ensure that you are using the latest version of HTML.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Until 2019, the {{glossary("W3C")}} published a competing HTML5 standard with version numbers. In MDN docs and elsewhere on the web therefore, you may find references to other HTML versions, HTML5.1 for example. Since <a href="https://www.w3.org/blog/news/archives/7753">28 May 2019</a>, the WHATWG Living Standard was announced by the W3C as the sole version of HTML.</p>
+  <p><strong>Note:</strong> Until 2019, the {{glossary("W3C")}} published a competing HTML5 standard with version numbers. In MDN docs and elsewhere on the web therefore, you may find references to other HTML versions, HTML5.1 for example. Since <a href="https://www.w3.org/blog/news/archives/7753">28 May 2019</a>, the WHATWG Living Standard was announced by the W3C as the sole version of HTML.</p>
 </div>
 
 <h2 id="Learn_more">Learn more</h2>

--- a/files/en-us/glossary/http_2/index.html
+++ b/files/en-us/glossary/http_2/index.html
@@ -9,7 +9,9 @@ tags:
   - Web Performance
   - 'l10n:priority'
 ---
-<p><span class="seoSummary"><strong>HTTP/2</strong> is a major revision of the <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP">HTTP network protocol</a></span>. The primary goals for HTTP/2 are to reduce {{glossary("latency")}} by enabling full request and response multiplexing, minimize protocol overhead via efficient compression of HTTP header fields, and add support for request prioritization and server push.</p>
+<p><strong>HTTP/2</strong> is a major revision of the <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP">HTTP network protocol</a>.</p>
+
+<p>The primary goals for HTTP/2 are to reduce {{glossary("latency")}} by enabling full request and response multiplexing, minimize protocol overhead via efficient compression of HTTP header fields, and add support for request prioritization and server push.</p>
 
 <p>HTTP/2 does not modify the application semantics of HTTP in any way. All the core concepts found in HTTP 1.1, such as HTTP methods, status codes, URIs, and header fields, remain in place. Instead, HTTP/2 modifies how the data is formatted (framed) and transported between the client and server, both of which manage the entire process, and hides application complexity within the new framing layer. As a result, all existing applications can be delivered without modification.</p>
 

--- a/files/en-us/glossary/http_3/index.html
+++ b/files/en-us/glossary/http_3/index.html
@@ -6,7 +6,9 @@ tags:
   - Intro
   - NeedsContent
 ---
-<p><span class="seoSummary"><strong>HTTP/3</strong> is the upcoming major revision of the <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP">HTTP network protocol</a></span>, succeeding {{glossary("HTTP 2", "HTTP/2")}}. The major point of HTTP/3 is that it uses a new {{glossary("UDP")}} protocol named QUIC, instead of {{glossary("TCP")}}.</p>
+<p><strong>HTTP/3</strong> is the upcoming major revision of the <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP">HTTP network protocol</a>, succeeding {{glossary("HTTP 2", "HTTP/2")}}.</p>
+
+<p>The major point of HTTP/3 is that it uses a new {{glossary("UDP")}} protocol named QUIC, instead of {{glossary("TCP")}}.</p>
 
 <section id="Quick_links">
 <ol>

--- a/files/en-us/glossary/http_header/index.html
+++ b/files/en-us/glossary/http_header/index.html
@@ -47,8 +47,7 @@ X-Cache-Info: cached
 </pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Older versions of the specification referred to:</p>
+  <p><strong>Note:</strong> Older versions of the specification referred to:</p>
   
   <ul>
    <li>{{Glossary("General header")}}: Headers applying to both requests and responses but with no relation to the data eventually transmitted in the body.</li>

--- a/files/en-us/glossary/index.html
+++ b/files/en-us/glossary/index.html
@@ -10,26 +10,26 @@ tags:
   - Landing
   - Terminology
 ---
-<p class="summary" style="padding-top: 0; border-top-width: 0;"><span class="seoSummary">Web technologies contain long lists of jargon and abbreviations that are used in documentation and coding. This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.</span></p>
+<p>Web technologies contain long lists of jargon and abbreviations that are used in documentation and coding. This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.</p>
+
+<p>Glossary terms can be selected from the sidebar.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>If you'd prefer a web development glossary in book form, check out <a href="https://meiert.com/en/blog/the-web-development-glossary/"><em>The Web Development Glossary</em> (EPUB, MOBI, PDF)</a>. It’s a third-party glossary that includes the entries found here, and also adds a wide range of additional entries.</p>
+  <p><strong>Note:</strong> This glossary is a never-ending work in progress. You can help improve it by <a href="/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary">writing new entries</a> or by making the existing ones better.</p>
 </div>
 
-<h2 id="Glossary_of_Terms">Glossary of Terms</h2>
+<div class="notecard note">
+  <p><strong>Note:</strong> If you'd prefer a web development glossary in book form, check out <a href="https://meiert.com/en/blog/the-web-development-glossary/"><em>The Web Development Glossary</em> (EPUB, MOBI, PDF)</a>. It’s a third-party glossary that includes the entries found here, and also adds a wide range of additional entries.</p>
+</div>
 
-<div style="width: 44%; float: right; margin: 4px 0 .5em 1em; line-height: 1.4;">{{LearnBox({"title":"Learn a new term:"})}}</div>
-
-<p>{{GlossaryList({"split": "h3", "css": "multiColumnList"})}}</p>
-
-<h2 id="Contribute_to_the_glossary">Contribute to the glossary</h2>
-
-<p>This glossary is a never-ending work in progress. You can help improve it by <a href="/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary">writing new entries</a> or by making the existing ones better.</p>
+{{LearnBox({"title":"Learn a new word ..."})}}</p>
 
 <section id="Quick_links">
-<!-- section is rendered in sidebar -->
-<ol>
- <li><strong><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a></strong>{{ListSubpagesForSidebar("/en-us/docs/Glossary", 1)}}</li>
-</ol>
-</section>
+  <!-- section is rendered in sidebar -->
+  <ol>
+   <li><strong><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a></strong>{{ListSubpagesForSidebar("/en-us/docs/Glossary", 1)}}</li>
+  </ol>
+  </section>
+
+
+  

--- a/files/en-us/glossary/index.html
+++ b/files/en-us/glossary/index.html
@@ -30,6 +30,3 @@ tags:
    <li><strong><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a></strong>{{ListSubpagesForSidebar("/en-us/docs/Glossary", 1)}}</li>
   </ol>
   </section>
-
-
-  

--- a/files/en-us/glossary/index.html
+++ b/files/en-us/glossary/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>Web technologies contain long lists of jargon and abbreviations that are used in documentation and coding. This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.</p>
 
-<p>Glossary terms can be selected from the sidebar.</p>
+<p>Glossary terms can be selected from the sidebar (or listed below on mobile devices).</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> This glossary is a never-ending work in progress. You can help improve it by <a href="/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary">writing new entries</a> or by making the existing ones better.</p>

--- a/files/en-us/glossary/main_axis/index.html
+++ b/files/en-us/glossary/main_axis/index.html
@@ -18,11 +18,11 @@ tags:
 
 <p>Should you choose <code>row</code> or <code>row-reverse</code> then your main axis will run along the row in the inline direction.</p>
 
-<p><img alt="In this image the flex-direction is row which forms the main axis" src="basics1.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="In this image the flex-direction is row which forms the main axis" src="basics1.png"></p>
 
 <p>Choose <code>column</code> or <code>column-reverse</code> and your main axis will run top to bottom of the page in the block direction.</p>
 
-<p><img alt="" src="basics2.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="" src="basics2.png"></p>
 
 <p>On the main axis you can control the sizing of flex items by adding any available space to the items themselves, by way of <code>flex</code> properties on the items. Or, you can control the space between and around items by using the <code>justify-content</code> property.</p>
 

--- a/files/en-us/glossary/method/index.html
+++ b/files/en-us/glossary/method/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p>A <strong>method</strong> is a {{glossary("function")}} which is a {{glossary("property")}} of an {{glossary("object")}}. There are two kind of methods: <em>Instance Methods</em> which are built-in tasks performed by an object instance, or <em>{{Glossary("static method", "Static Methods")}}</em> which are tasks that are called directly on an object constructor.</p>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note:</strong> In JavaScript functions themselves are objects, so, in that context, a method is actually an {{glossary("object reference")}} to a function.</p>
 </div>
 

--- a/files/en-us/glossary/middleware/index.html
+++ b/files/en-us/glossary/middleware/index.html
@@ -5,7 +5,7 @@ tags:
   - CodingScripting
   - Glossary
 ---
-<p>Middleware is a (loosely defined) term for any software or service that enables the parts of a system to communicate and manage data. It is the software that handles <span style="line-height: 1.5;">communication between components and input/output, so developers can focus on the specific purpose of their application. </span></p>
+<p>Middleware is a (loosely defined) term for any software or service that enables the parts of a system to communicate and manage data. It is the software that handles communication between components and input/output, so developers can focus on the specific purpose of their application.</p>
 
 <p>In server-side web application frameworks, the term is often more specifically used to refer to pre-built software components that can be added to the framework's request/response processing pipeline, to handle tasks such as database access.</p>
 

--- a/files/en-us/glossary/origin/index.html
+++ b/files/en-us/glossary/origin/index.html
@@ -11,50 +11,45 @@ tags:
 
 <p>Some operations are restricted to same-origin content, and this restriction can be lifted using {{Glossary("CORS")}}.</p>
 
-<h2 id="Examples_of_same_origin">Examples of same origin</h2>
+<h2 id="Examples">Examples</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td style="width: 50%;"><code>http://example.com/app1/index.html</code><br>
-    <code>http://example.com/app2/index.html</code></td>
-   <td style="width: 50%;">same origin because same scheme (<code>http</code>) and hostname (<code>example.com</code>)</td>
-  </tr>
-  <tr>
-   <td style="width: 50%;"><code>http://Example.com:80</code><br>
-    <code>http://example.com</code></td>
-   <td style="width: 50%;">same origin because a server delivers HTTP content through port 80 by default</td>
-  </tr>
- </tbody>
-</table>
+<p>These are same origin because they have the same scheme (<code>http</code>) and hostname (<code>example.com</code>), and the different file path does not matter:</p>
+    <ul>
+      <li><code>http://example.com/app1/index.html</code></li>
+      <li><code>http://example.com/app2/index.html</code></li>
+    </ul>
 
-<h2 id="Examples_of_different_origin">Examples of different origin</h2>
+<p>These are same origin because a server delivers HTTP content through port 80 by default:</p>
+    <ul>
+      <li><code>http://Example.com:80</code></li>
+      <li><code>http://example.com</code></li>
+    </ul>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td style="width: 50%;"><code>http://example.com/app1</code><br>
-    <code>https://example.com/app2</code></td>
-   <td>different schemes</td>
-  </tr>
-  <tr>
-   <td style="width: 50%;"><code>http://example.com</code><br>
-    <code>http://www.example.com</code><br>
-    <code>http://myapp.example.com</code></td>
-   <td style="width: 50%;">different hostnames</td>
-  </tr>
-  <tr>
-   <td style="width: 50%;"><code>http://example.com</code><br>
-    <code>http://example.com:8080</code></td>
-   <td style="width: 50%;">different ports</td>
-  </tr>
- </tbody>
-</table>
+<p>These are not same origin because they use different schemes:</p>
+    <ul>
+      <li><code>http://example.com/app1</code></li>
+      <li><code>https://example.com/app2</code></li>
+    </ul>
+
+<p>These are not same origin because they use different hostnames:</p>
+    <ul>
+      <li><code>http://example.com</code></li>
+      <li><code>http://www.example.com</code></li>
+      <li><code>http://myapp.example.com</code></li>
+    </ul>
+
+<p>These are not same origin because they use different ports:</p>
+    <ul>
+      <li><code>http://example.com</code></li>
+      <li><code>http://example.com:8080</code></li>
+    </ul>
+
 
 <h2 id="See_also">See also</h2>
 
 <ul>
   <li><a href="/en-US/docs/Web/Security/Same-origin_policy">Same-origin policy</a></li>
+  <li>{{Glossary("Site")}}</li>
   <li><a href="https://html.spec.whatwg.org/multipage/origin.html#origin">HTML specification: origin</a></li>
 </ul>
 

--- a/files/en-us/glossary/quality_values/index.html
+++ b/files/en-us/glossary/quality_values/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>indicates the order of priority:</p>
 
-<table class="standard-table">
+<table>
 	<thead>
 		<tr>
 			<th scope="col">Value</th>
@@ -40,15 +40,16 @@ tags:
 
 <p>If there is no priority defined for the first two values, the order in the list is irrelevant. Nevertheless, with the same quality, more specific values have priority over less specific ones:</p>
 
-<pre class="brush: plain">text/html;q=0.8,text/*;q=0.8,*/*;q=0.8
-</pre>
+<pre class="brush: plain">text/html;q=0.8,text/*;q=0.8,*/*;q=0.8</pre>
 
-<table class="standard-table">
+<table>
 	<thead>
 		<tr>
 			<th scope="col">Value</th>
 			<th scope="col">Priority</th>
 		</tr>
+	</thead>
+	<tbody>
 		<tr>
 			<td><code>text/html</code></td>
 			<td><code>0.8</code> (but totally specified)</td>
@@ -61,7 +62,7 @@ tags:
 			<td><code>*/*</code></td>
 			<td><code>0.8</code> (not specified)</td>
 		</tr>
-	</thead>
+	</tbody>
 </table>
 
 <p>Some syntax, like the one of {{HTTPHeader("Accept")}}, allow additional specifiers like <code>text/html;level=1</code>. These increase the specificity of the value. Their use is extremely rare.</p>
@@ -78,7 +79,3 @@ tags:
 	<li><a href="/en-US/docs/Web/HTTP/Headers">HTTP headers</a> using q-values in their syntax: {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}}, {{HTTPHeader("TE")}}.</li>
 	<li><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">Header field definitions.</a></li>
 </ul>
-
-<div id="gtx-trans" style="position: absolute; left: 212px; top: 1544.6px;">
-<div class="gtx-trans-icon"></div>
-</div>

--- a/files/en-us/glossary/site/index.html
+++ b/files/en-us/glossary/site/index.html
@@ -10,31 +10,32 @@ tags:
 
 <p>The concept of a <em>site</em> is used in <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#directives">SameSite cookies</a>, as well as a web application's <a href="/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)">Cross-Origin Resource Policy</a>.</p>
 
-<h2 id="Examples_of_the_same_site">Examples of the same site</h2>
+<h2 id="Examples">Examples</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td style="width: 50%;"><code>https://developer.mozilla.org/en-US/docs/</code><br>
-    <code>https://support.mozilla.org/en-US/</code></td>
-   <td style="width: 50%;">same site because the registrable domain of <em>mozilla.org</em> is the same</td>
-  </tr>
-  <tr>
-   <td style="width: 50%;"><code>http://example.com:8080</code><br>
-    <code>https://example.com</code></td>
-   <td style="width: 50%;">same site because scheme and port are not relevant</td>
-  </tr>
- </tbody>
-</table>
+<p>These are the same site because the registrable domain of <em>mozilla.org</em> is the same (different host and files path don't matter):</p>
+  <ul>
+    <li><code>https://developer.mozilla.org/en-US/docs/</code></li>
+    <li><code>https://support.mozilla.org/en-US/</code></li>
+  </ul>
 
-<h2 id="Examples_of_different_site">Examples of different site</h2>
+<p>These are the same site because scheme and port are not relevant:</p>
+    <ul>
+      <li><code>http://example.com:8080</code></li>
+      <li><code>https://example.com</code></li>
+    </ul>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td style="width: 50%;"><code>https://developer.mozilla.org/en-US/docs/</code><br>
-    <code>https://example.com</code></td>
-   <td style="width: 50%;">not same site because the registrable domain of the two URLs differs</td>
-  </tr>
- </tbody>
-</table>
+<p>These are not same site because the registrable domain of the two URLs differs:</p>
+    <ul>
+      <li><code>https://developer.mozilla.org/en-US/docs/</code></li>
+      <li><code>https://example.com</code></li>
+    </ul>
+
+    <h2 id="Learn_more">Learn more</h2>
+
+    <h3 id="General_Knowledge">General knowledge</h3>
+    
+    <ul>
+     <li><a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">What is a URL</a></li>
+     <li>{{Glossary("Origin")}}</li>
+     <li><a href="/en-US/docs/Web/Security/Same-origin_policy">Same-origin policy</a></li>
+    </ul>   

--- a/files/en-us/glossary/site/index.html
+++ b/files/en-us/glossary/site/index.html
@@ -38,4 +38,4 @@ tags:
      <li><a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">What is a URL</a></li>
      <li>{{Glossary("Origin")}}</li>
      <li><a href="/en-US/docs/Web/Security/Same-origin_policy">Same-origin policy</a></li>
-    </ul>   
+    </ul>

--- a/files/en-us/glossary/sql_injection/index.html
+++ b/files/en-us/glossary/sql_injection/index.html
@@ -20,13 +20,11 @@ tags:
 
 <p>After entering username and password, behind the GUI the SQL queries work as follows:</p>
 
-<pre style="margin-left: 0px;"><strong><span style="color: #0000cd;">"SELECT Count(*) FROM Users WHERE Username=' " + txt.User.Text+" ' AND Password=' "+ txt.Password.Text+" ' ";</span></strong></pre>
+<pre class="brush: sql">"SELECT Count(*) FROM Users WHERE Username=' " + txt.User.Text+" ' AND Password=' "+ txt.Password.Text+" ' ";</pre>
 
 <p>Now suppose User enters the Username: admin and Password: passwd123, so after clicking on the Log in button, SQL query will run as follows:</p>
 
-<pre><strong><span style="color: #0000cd;">"SELECT Count(*) FROM Users WHERE Username=' admin ' AND Password=' passwd123 ' ";</span>
-
-</strong></pre>
+<pre class="brush: sql">"SELECT Count(*) FROM Users WHERE Username=' admin ' AND Password=' passwd123 ' ";</pre>
 
 <p>If the credentials are correct, then the user is allowed to log in, so it's a very simple (and therefore insecure) mechanism. Hackers use this insecurity to gain unauthorized access.</p>
 
@@ -38,12 +36,11 @@ tags:
 
 <p>After clicking on the login button, the SQL query will work as follows:</p>
 
-<pre><strong><span style="color: #0000cd;">"SELECT Count(*) FROM Users WHERE Username=' admin ' AND Password=' anything 'or'1'='1 ' ";</span>
-</strong></pre>
+<pre class="brush: sql">"SELECT Count(*) FROM Users WHERE Username=' admin ' AND Password=' anything 'or'1'='1 ' ";</pre>
 
 <p>Just take a closer look at the above query's password section.</p>
 
-<pre><strong>Password=' anything 'or'1'='1 '</strong></pre>
+<pre>Password=' anything 'or'1'='1 '</pre>
 
 
 <p>The password is not 'anything', hence password=anything results in FALSE, but '1'='1' is a TRUE statement and hence returns a TRUE value. Finally, due to the OR operator, the value ( FALSE OR TRUE ) is TRUE, so authentication bypasses successfully. Just due to a simple string (Magical String) the entire database is compromised.</p>
@@ -51,13 +48,13 @@ tags:
 
 <h2 id="How_To_Prevent">How To Prevent</h2>
 
-<p style="margin-left: 40px;">Before executing the queries for the user credentials, make some changes like the following:</p>
+<p>Before executing the queries for the user credentials, make some changes like the following:</p>
 
-<pre><span style="color: #0000ff;">$id = $_GET['id'] </span>
+<pre class="brush: sql">$id = $_GET['id']
 
-<span style="color: #0000ff;">(1) $id = Stripslashes($id)</span>
+(1) $id = Stripslashes($id)
 
-<span style="color: #0000ff;">(2) $id = mysql_real_escape_String($id)</span></pre>
+(2) $id = mysql_real_escape_String($id)</pre>
 
 <p>So due to (1) each single quote (') in the input string is replaced with double quotes ("), and due to (2) before every (') it adds (/). The revised magical string fails to bypass the authentication, and your database stays secure.</p>
 

--- a/files/en-us/glossary/state_machine/index.html
+++ b/files/en-us/glossary/state_machine/index.html
@@ -26,8 +26,6 @@ tags:
  <dd>Given some state, an input can lead to more than one different state.</dd>
 </dl>
 
-<p>.</p>
-
 <p><em>Figure 1: Deterministic Finite State Machine</em></p>
 
 <p><img alt="" src="statemachine1.png"></p>
@@ -47,8 +45,8 @@ tags:
 <h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
- <li style="margin-left: 40px;">{{Interwiki("wikipedia", "Finite-state machine")}} on Wikipedia</li>
- <li style="margin-left: 40px;">{{Interwiki("wikipedia", "UML state machine")}} on Wikipedia</li>
- <li style="margin-left: 40px;">{{Interwiki("wikipedia", "Moore machine")}} on Wikipedia</li>
- <li style="margin-left: 40px;">{{Interwiki("wikipedia", "Mealy machine")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "Finite-state machine")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "UML state machine")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "Moore machine")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "Mealy machine")}} on Wikipedia</li>
 </ul>

--- a/files/en-us/glossary/statement/index.html
+++ b/files/en-us/glossary/statement/index.html
@@ -6,7 +6,7 @@ tags:
   - CodingScripting
   - Glossary
 ---
-<p>In a computer programming language, a <strong>statement</strong> is a line of code commanding a task. <span style="line-height: 1.5;">Every program consists of a sequence of statements.</span></p>
+<p>In a computer programming language, a <strong>statement</strong> is a line of code commanding a task. Every program consists of a sequence of statements.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 

--- a/files/en-us/glossary/tcp_slow_start/index.html
+++ b/files/en-us/glossary/tcp_slow_start/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Congestion_control">Congestion control</h2>
 
-<p>Congestion itself is a state that happens within a network layer when the message traffic is too busy it slows the network response time. T<span style="font-weight: 400;">he server sends data in TCP packets, the user's client then confirms delivery by returning acknowledgements, or ACKs. The connection has a limited capacity depending on hardware and network conditions. If the server sends too many packets too quickly, they will be dropped. Meaning, there will be no acknowledgement. The server registers this as missing ACKs. Congestion control algorithms use this flow of sent packets and ACKs to determine a send rate.</span></p>
+<p>Congestion itself is a state that happens within a network layer when the message traffic is too busy it slows the network response time. The server sends data in TCP packets, the user's client then confirms delivery by returning acknowledgements, or ACKs. The connection has a limited capacity depending on hardware and network conditions. If the server sends too many packets too quickly, they will be dropped. Meaning, there will be no acknowledgement. The server registers this as missing ACKs. Congestion control algorithms use this flow of sent packets and ACKs to determine a send rate.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/glossary/tls/index.html
+++ b/files/en-us/glossary/tls/index.html
@@ -8,12 +8,12 @@ tags:
   - Security
   - Web Performance
 ---
-<p id="Summary"><strong>Transport Layer Security (TLS)</strong>, formerly known as {{Glossary("SSL", "Secure Sockets Layer (SSL)")}}, is a {{Glossary("protocol")}} used by applications to communicate securely across a network, preventing tampering with and eavesdropping on email, web browsing, messaging, and other protocols. Both SSL and TLS are client / server protocols that ensure communication privacy by using cryptographic protocols to provide security over a network. When a server and client communicate using TLS, it ensures that no third party can eavesdrop or tamper with any message.</p>
+<p><strong>Transport Layer Security (TLS)</strong>, formerly known as {{Glossary("SSL", "Secure Sockets Layer (SSL)")}}, is a {{Glossary("protocol")}} used by applications to communicate securely across a network, preventing tampering with and eavesdropping on email, web browsing, messaging, and other protocols. Both SSL and TLS are client / server protocols that ensure communication privacy by using cryptographic protocols to provide security over a network. When a server and client communicate using TLS, it ensures that no third party can eavesdrop or tamper with any message.</p>
 
 <p>All modern browsers support the TLS protocol, requiring the server to provide a valid {{Glossary("Digital certificate", "digital certificate")}} confirming its identity in order to establish a secure connection. It is possible for both the client and server to mutually authenticate each other, if both parties provide their own individual digital certificates.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: TLS 1.0 and 1.1 support will be removed from all major browsers in early 2020; you'll need to make sure your web server supports TLS 1.2 or 1.3 going forward. From version 74 onwards, Firefox will return a <a href="https://support.mozilla.org/en-US/kb/secure-connection-failed-firefox-did-not-connect">Secure Connection Failed</a> error when connecting to servers using the older TLS versions ({{bug(1606734)}}).</p>
+<p><strong>Note:</strong> TLS 1.0 and 1.1 support will be removed from all major browsers in early 2020; you'll need to make sure your web server supports TLS 1.2 or 1.3 going forward. From version 74 onwards, Firefox will return a <a href="https://support.mozilla.org/en-US/kb/secure-connection-failed-firefox-did-not-connect">Secure Connection Failed</a> error when connecting to servers using the older TLS versions ({{bug(1606734)}}).</p>
 </div>
 
 <section id="Quick_links">

--- a/files/en-us/glossary/vendor_prefix/index.html
+++ b/files/en-us/glossary/vendor_prefix/index.html
@@ -7,8 +7,8 @@ tags:
 ---
 <p>Browser vendors sometimes add prefixes to experimental or nonstandard CSS properties and JavaScript APIs, so developers can experiment with new ideas while—in theory—preventing their experiments from being relied upon and then breaking web developers' code during the standardization process. Developers should wait to include the unprefixed property until browser behavior is standardized.</p>
 
-<div class="note">
-<p>Browser vendors are working to stop using vendor prefixes for experimental features. Web developers have been using them on production Web sites, despite their experimental nature. This has made it more difficult for browser vendors to ensure compatibility and to work on new features; it's also been harmful to smaller browsers who wind up forced to add other browsers' prefixes in order to load popular web sites.</p>
+<div class="notecard note">
+<p><strong>Note:</strong> Browser vendors are working to stop using vendor prefixes for experimental features. Web developers have been using them on production Web sites, despite their experimental nature. This has made it more difficult for browser vendors to ensure compatibility and to work on new features; it's also been harmful to smaller browsers who wind up forced to add other browsers' prefixes in order to load popular web sites.</p>
 
 <p>Lately, the trend is to add experimental features behind user-controlled flags or preferences, and to create smaller specifications which can reach a stable state much more quickly.</p>
 </div>

--- a/files/en-us/glossary/xforms/index.html
+++ b/files/en-us/glossary/xforms/index.html
@@ -11,4 +11,6 @@ tags:
 
 <p><strong>XForms</strong> is a convention for building Web forms and processing form data in the {{glossary("XML")}} format. </p>
 
-<p class="notecard note"><strong>Note:</strong> No major browser supports XForms any longer—we suggest using <a href="/en-US/docs/Learn/Forms">HTML5 forms</a> instead.</p>
+<div class="notecard note">
+  <p><strong>Note:</strong> No major browser supports XForms any longer—we suggest using <a href="/en-US/docs/Learn/Forms">HTML5 forms</a> instead.</p>
+</div>


### PR DESCRIPTION
This PR fixes up HTML to ease conversion to markdown. It is not complete:
- Fixes up notes
- Removes about half the instances of seosummary
- Removes style markup in images and text.

@wbamberg et al, there is no consistency in Glossary sidebar. As there is no sidebar macro, my proposal is that we use this macro as a proxy for that - essentially listing all glossary entries: `<div>{{QuickLinksWithSubpages("/en-us/docs/Glossary")}}</div>` - thoughts?