### PR TITLE
WebXR: Update syntax blocks for methods/ctors

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.html
@@ -39,8 +39,7 @@ browser-compat: api.WebGLRenderingContext.makeXRCompatible
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">let <em>makeCompatPromise</em> = <em>webGLRenderingContext</em>.makeXRCompatible();</pre>
+<pre class="brush: js">makeXRCompatible()</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/xrframe/getpose/index.md
+++ b/files/en-us/web/api/xrframe/getpose/index.md
@@ -26,7 +26,7 @@ For example, to get the position of a controller relative to the viewer's head, 
 ## Syntax
 
 ```js
-var xrPose = xrFrame.getPose(space, baseSpace);
+getPose(space, baseSpace)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrframe/getviewerpose/index.md
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.md
@@ -26,7 +26,7 @@ See the {{domxref("XRFrame.getPose", "getPose()")}} method for a way to calcula
 ## Syntax
 
 ```js
-var xrViewerPose = xrFrame.getViewerPose(referenceSpace);
+getViewerPose(referenceSpace)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.md
@@ -32,7 +32,7 @@ represented by an {{domxref("XRInputSource")}}.
 ## Syntax
 
 ```js
-newInputSourceEvent = new XRInputSourceEvent(type, eventInitDict);
+new XRInputSourceEvent(type, eventInitDict)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
@@ -32,7 +32,7 @@ you by the WebXR system.
 ## Syntax
 
 ```js
-newInputSourcesChangeEvent = new XRInputSourcesChangeEvent(type, eventInitDict);
+new XRInputSourcesChangeEvent(type, eventInitDict)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
@@ -49,7 +49,7 @@ use this method to let the user use their mouse to pitch and yaw their viewing a
 ## Syntax
 
 ```js
-offsetReferenceSpace = xrReferenceSpace.getOffsetReferenceSpace(originOffset);
+getOffsetReferenceSpace(originOffset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.md
@@ -34,7 +34,7 @@ defined using this type.
 ## Syntax
 
 ```js
-let refSpaceEvent = new XRReferenceSpaceEvent(type, eventInitDict);
+new XRReferenceSpaceEvent(type, eventInitDict)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -31,7 +31,9 @@ coordinate systems across spaces.
 ## Syntax
 
 ```js
-let xrRigidTransform = new XRRigidTransform(position, orientation);
+new XRRigidTransform()
+new XRRigidTransform(position)
+new XRRigidTransform(position, orientation)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.md
@@ -26,7 +26,7 @@ requested by calling {{DOMxRef("XRSession.requestAnimationFrame",
 ## Syntax
 
 ```js
-xrSession.cancelAnimationFrame(handle);
+cancelAnimationFrame(handle)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/end/index.md
+++ b/files/en-us/web/api/xrsession/end/index.md
@@ -25,7 +25,7 @@ the session has fully shut down.
 ## Syntax
 
 ```js
-xrSession.end();
+end()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.md
@@ -43,7 +43,7 @@ You can cancel a previously scheduled animation by calling
 ## Syntax
 
 ```js
-requestID = xrSession.requestAnimationFrame(animationFrameCallback);
+requestAnimationFrame(animationFrameCallback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/requesthittestsource/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsource/index.md
@@ -24,7 +24,7 @@ The **`requestHitTestSource()`** method of the
 ## Syntax
 
 ```js
-requestHitTestSource(options);
+requestHitTestSource(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
@@ -24,7 +24,7 @@ The **`requestHitTestSourceForTransientInput()`** method of the
 ## Syntax
 
 ```js
-requestHitTestSourceForTransientInput(options);
+requestHitTestSourceForTransientInput(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -24,7 +24,8 @@ The **`requestLightProbe()`** method of the
 ## Syntax
 
 ```js
-requestLightProbe(options);
+requestLightProbe()
+requestLightProbe(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.md
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.md
@@ -30,7 +30,7 @@ space requested.
 ## Syntax
 
 ```js
-refSpacePromise = xrSession.requestReferenceSpace(referenceSpaceType);
+requestReferenceSpace(referenceSpaceType)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -30,7 +30,11 @@ rendering of the next frame.
 ## Syntax
 
 ```js
-xrSession.updateRenderState(newState)
+updateRenderState(newState)
+updateRenderState(newState, baseLayer)
+updateRenderState(newState, baseLayer, depthFar)
+updateRenderState(newState, baseLayer, depthFar, depthNear)
+updateRenderState(newState, baseLayer, depthFar, depthNear, inlineVerticalFieldOfView)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsessionevent/xrsessionevent/index.md
+++ b/files/en-us/web/api/xrsessionevent/xrsessionevent/index.md
@@ -29,7 +29,7 @@ reality session.
 ## Syntax
 
 ```js
-newXRSessionEvent = new XRSessionEvent(type, eventInitDict);
+new XRSessionEvent(type, eventInitDict)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.md
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.md
@@ -30,7 +30,7 @@ to use the XR device, the promise is rejected with an appropriate
 ## Syntax
 
 ```js
-xr.isSessionSupported(mode)
+isSessionSupported(mode)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -30,7 +30,8 @@ inline sessions can be in progress at once.
 ## Syntax
 
 ```js
-navigator.xr.requestSession(mode, options)
+requestSession(mode)
+requestSession(mode, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.md
@@ -34,7 +34,7 @@ represented by the view.
 ## Syntax
 
 ```js
-let viewport = xrWebGLLayer.getViewport(view);
+getViewport(view);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
@@ -32,7 +32,8 @@ WebXR device and the WebGL graphics layer used to render the 3D scene.
 ## Syntax
 
 ```js
-let glLayer = new XRWebGLLayer(session, context, layerInit);
+new XRWebGLLayer(session, context)
+new XRWebGLLayer(session, context, layerInit)
 ```
 
 ### Parameters


### PR DESCRIPTION
This is me trying to make the WebXR doc set to be a role-model per our latest API docs guidelines :)

In this PR the syntaxes boxes of methods and constructors are updated to follow the latest guidelines.