### PR TITLE
Fix typo in macro name + redirected link

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
@@ -102,7 +102,7 @@ browser-compat: api.RTCPeerConnection.signalingState
   </dd>
   <dt><code>closed</code></dt>
   <dd>
-    The {{domref("RTCPeerConnection")}} has been closed.
+    The {{domxref("RTCPeerConnection")}} has been closed.
   </dd>
 </dl>
 
@@ -126,5 +126,5 @@ var state = pc.signalingState;</pre>
       session</a></li>
   <li>{{domxref("RTCPeerConnection")}}</li>
   <li>{{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}}</li>
-  <li><a href="/en-US/docs/Web/Guide/API/WebRTC">WebRTC</a></li>
+  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
 </ul>


### PR DESCRIPTION
`domref` instead of `domxref`