### PR TITLE
Fix redirects in macros for WebGL

### DIFF
--- a/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.html
@@ -2,11 +2,11 @@
 title: EXT_disjoint_timer_query.beginQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/beginQueryEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.beginQueryEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -23,10 +23,10 @@ browser-compat: api.EXT_disjoint_timer_query.beginQueryEXT
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the time query. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the time query. Must be
     <code>ext.TIME_ELAPSED_EXT</code>.</dd>
   <dt><code>query</code></dt>
-  <dd>A {{domxref("WebGLTimerQueryEXT")}} object for which to start the time querying.
+  <dd>A {{domxref("WebGLQuery")}} object for which to start the time querying.
   </dd>
 </dl>
 
@@ -55,6 +55,6 @@ ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.html
@@ -2,18 +2,18 @@
 title: EXT_disjoint_timer_query.createQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/createQueryEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.createQueryEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
 
 <p>The <strong><code>EXT_disjoint_timer_query.createQueryEXT()</code></strong> method of
   the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> creates and initializes
-  {{domxref("WebGLTimerQueryEXT")}} objects, which track the time needed to fully complete
+  {{domxref("WebGLQuery")}} objects, which track the time needed to fully complete
   a set of GL commands.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -27,7 +27,7 @@ browser-compat: api.EXT_disjoint_timer_query.createQueryEXT
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("WebGLTimerQueryEXT")}} object.</p>
+<p>A {{domxref("WebGLQuery")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -47,6 +47,6 @@ var query = ext.createQueryExt();
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.html
@@ -2,18 +2,18 @@
 title: EXT_disjoint_timer_query.deleteQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/deleteQueryEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.deleteQueryEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
 
 <p>The <strong><code>EXT_disjoint_timer_query.deleteQueryEXT()</code></strong> method of
   the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> deletes a given
-  {{domxref("WebGLTimerQueryEXT")}} object.</p>
+  {{domxref("WebGLQuery")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,7 +24,7 @@ browser-compat: api.EXT_disjoint_timer_query.deleteQueryEXT
 
 <dl>
   <dt><code>query</code></dt>
-  <dd>A {{domxref("WebGLTimerQueryEXT")}} object to delete.</dd>
+  <dd>A {{domxref("WebGLQuery")}} object to delete.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -53,6 +53,6 @@ ext.deleteQueryEXT(query);
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.html
@@ -2,11 +2,11 @@
 title: EXT_disjoint_timer_query.endQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/endQueryEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.endQueryEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -23,7 +23,7 @@ browser-compat: api.EXT_disjoint_timer_query.endQueryEXT
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the time query. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the time query. Must be
     <code>ext.TIME_ELAPSED_EXT</code>.</dd>
 </dl>
 
@@ -54,6 +54,6 @@ ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.html
@@ -2,11 +2,11 @@
 title: EXT_disjoint_timer_query.getQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/getQueryEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.getQueryEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -24,10 +24,10 @@ browser-compat: api.EXT_disjoint_timer_query.getQueryEXT
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the time query. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the time query. Must be
     <code>ext.TIMESTAMP_EXT</code> or <code>ext.TIME_ELAPSED_EXT</code>.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to return. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to return. Must be
     <code>ext.CURRENT_QUERY_EXT</code> or <code>ext.QUERY_COUNTER_BITS_EXT</code>.</dd>
 </dl>
 
@@ -37,10 +37,10 @@ browser-compat: api.EXT_disjoint_timer_query.getQueryEXT
 
 <ul>
   <li>If <code>pname</code> is <code>ext.CURRENT_QUERY_EXT</code>: A
-    {{domxref("WebGLTimerQueryEXT")}} object, which is the currently active query for the
+    {{domxref("WebGLQuery")}} object, which is the currently active query for the
     given target.</li>
   <li>If <code>pname</code> is <code>ext.QUERY_COUNTER_BITS_EXT</code>: A
-    {{domxref("GLint")}} indicating the number of bits used to hold the query result for
+    {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits used to hold the query result for
     the given target.</li>
 </ul>
 
@@ -66,6 +66,6 @@ var currentQuery = ext.getQueryEXT(ext.TIMESTAMP_EXT,
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.html
@@ -2,11 +2,11 @@
 title: EXT_disjoint_timer_query.getQueryObjectEXT()
 slug: Web/API/EXT_disjoint_timer_query/getQueryObjectEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.getQueryObjectEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -24,9 +24,9 @@ browser-compat: api.EXT_disjoint_timer_query.getQueryObjectEXT
 
 <dl>
   <dt><code>query</code></dt>
-  <dd>A {{domxref("WebGLTimerQueryEXT")}} object from which to return information.</dd>
+  <dd>A {{domxref("WebGLQuery")}} object from which to return information.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to return. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to return. Must be
     <code>ext.QUERY_RESULT_EXT</code> or <code>ext.QUERY_RESULT_AVAILABLE_EXT</code>.</dd>
 </dl>
 
@@ -36,9 +36,9 @@ browser-compat: api.EXT_disjoint_timer_query.getQueryObjectEXT
 
 <ul>
   <li>If <code>pname</code> is <code>ext.QUERY_RESULT_EXT</code>: A
-    {{domxref("GLuint64EXT")}} containing the query result.</li>
+    {{domxref("WebGL_API/Types", "GLuint64EXT")}} containing the query result.</li>
   <li>If <code>pname</code> is <code>ext.QUERY_RESULT_AVAILABLE_EXT</code>: A
-    {{domxref("GLboolean")}} indicating whether or not a query result is available.</li>
+    {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not a query result is available.</li>
 </ul>
 
 <h2 id="Examples">Examples</h2>
@@ -73,6 +73,6 @@ if (available &amp;&amp; !disjoint) {
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.html
@@ -36,19 +36,19 @@ browser-compat: api.EXT_disjoint_timer_query
 
 <dl>
  <dt><code>ext.QUERY_COUNTER_BITS_EXT</code></dt>
- <dd>A {{domxref("GLint")}} indicating the number of bits used to hold the query result for the given target.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits used to hold the query result for the given target.</dd>
  <dt><code>ext.CURRENT_QUERY_EXT</code></dt>
  <dd>A {{domxref("WebGLQuery")}} object, which is the currently active query for the given target.</dd>
  <dt><code>ext.QUERY_RESULT_EXT</code></dt>
- <dd>A {{domxref("GLuint64EXT")}} containing the query result.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLuint64EXT")}} containing the query result.</dd>
  <dt><code>ext.QUERY_RESULT_AVAILABLE_EXT</code></dt>
- <dd>A {{domxref("GLboolean")}} indicating whether or not a query result is available.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not a query result is available.</dd>
  <dt><code>ext.TIME_ELAPSED_EXT</code></dt>
  <dd>Elapsed time (in nanoseconds).</dd>
  <dt><code>ext.TIMESTAMP_EXT</code></dt>
  <dd>The current time.</dd>
  <dt><code>ext.GPU_DISJOINT_EXT</code></dt>
- <dd>A {{domxref("GLboolean")}} indicating whether or not the GPU performed any disjoint operation.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the GPU performed any disjoint operation.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.html
@@ -2,18 +2,18 @@
 title: EXT_disjoint_timer_query.isQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/isQueryEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.isQueryEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
 
 <p>The <strong><code>EXT_disjoint_timer_query.isQueryEXT()</code></strong> method of the
   <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> returns <code>true</code> if the
-  passed object is a {{domxref("WebGLTimerQueryEXT")}} object.</p>
+  passed object is a {{domxref("WebGLQuery")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,13 +24,13 @@ browser-compat: api.EXT_disjoint_timer_query.isQueryEXT
 
 <dl>
   <dt><code>query</code></dt>
-  <dd>A {{domxref("WebGLTimerQueryEXT")}} object to test.</dd>
+  <dd>A {{domxref("WebGLQuery")}} object to test.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether the given object is a
-  {{domxref("WebGLTimerQueryEXT")}} object (<code>true</code>) or not
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given object is a
+  {{domxref("WebGLQuery")}} object (<code>true</code>) or not
   (<code>false</code>).</p>
 
 <h2 id="Examples">Examples</h2>
@@ -55,6 +55,6 @@ ext.isQueryEXT(query);
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.html
@@ -2,11 +2,11 @@
 title: EXT_disjoint_timer_query.queryCounterEXT()
 slug: Web/API/EXT_disjoint_timer_query/queryCounterEXT
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL extension
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
 browser-compat: api.EXT_disjoint_timer_query.queryCounterEXT
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -24,10 +24,10 @@ browser-compat: api.EXT_disjoint_timer_query.queryCounterEXT
 
 <dl>
   <dt><code>query</code></dt>
-  <dd>A {{domxref("WebGLTimerQueryEXT")}} object for which to record the current time.
+  <dd>A {{domxref("WebGLQuery")}} object for which to record the current time.
   </dd>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the time query. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the time query. Must be
     <code>ext.TIMESTAMP_EXT</code>.</dd>
 </dl>
 
@@ -59,6 +59,6 @@ ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLTimerQueryEXT")}}</li>
+  <li>{{domxref("WebGLQuery")}}</li>
   <li>{{domxref("EXT_disjoint_timer_query")}}</li>
 </ul>

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
@@ -26,7 +26,7 @@ browser-compat: api.EXT_texture_filter_anisotropic
  <dt><code>ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT</code></dt>
  <dd>This is the <code>pname</code> argument to the {{domxref("WebGLRenderingContext.getParameter", "gl.getParameter()")}} call, and it returns the maximum available anisotropy.</dd>
  <dt><code>ext.TEXTURE_MAX_ANISOTROPY_EXT</code></dt>
- <dd>This is the <code>pname</code> argument to the {{domxref("WebGLRenderingContext.getTexParameter", "gl.getTexParameter()")}} and {{domxref("WebGLRenderingContext.texParameterf", "gl.texParameterf()")}} / {{domxref("WebGLRenderingContext.texParameteri", "gl.texParameteri()")}} calls and sets the desired maximum anisotropy for a texture.</dd>
+ <dd>This is the <code>pname</code> argument to the {{domxref("WebGLRenderingContext.getTexParameter", "gl.getTexParameter()")}} and {{domxref("WebGLRenderingContext.texParameter", "gl.texParameterf()")}} / {{domxref("WebGLRenderingContext.texParameter", "gl.texParameteri()")}} calls and sets the desired maximum anisotropy for a texture.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.beginQuery
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the query. Possible values:
     <ul>
       <li><code>gl.ANY_SAMPLES_PASSED</code>: Specifies an occlusion query: these queries
         detect whether an object is visible (whether the scoped drawing commands pass the

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.beginTransformFeedback
 
 <dl>
   <dt><code>primitiveMode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the output type of the primitives that will be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the output type of the primitives that will be
     recorded into the buffer objects that are bound for transform feedback. Possible
     values:
     <ul>

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGL2RenderingContext.bindBufferBase
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("Glenum")}} specifying the target for the bind operation. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target for the bind operation. Possible
     values:
     <ul>
       <li><code>gl.TRANSFORM_FEEDBACK_BUFFER</code></li>
@@ -33,7 +33,7 @@ browser-compat: api.WebGL2RenderingContext.bindBufferBase
     </ul>
   </dd>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the <code>target</code>.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the <code>target</code>.</dd>
   <dt><code>buffer</code></dt>
   <dd>A {{domxref("WebGLBuffer")}} which to bind to the binding point
     (<code>target</code>).</dd>

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGL2RenderingContext.bindBufferRange
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("Glenum")}} specifying the target for the bind operation. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target for the bind operation. Possible
     values:
     <ul>
       <li><code>gl.TRANSFORM_FEEDBACK_BUFFER</code></li>
@@ -33,14 +33,14 @@ browser-compat: api.WebGL2RenderingContext.bindBufferRange
     </ul>
   </dd>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the <code>target</code>.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the <code>target</code>.</dd>
   <dt><code>buffer</code></dt>
   <dd>A {{domxref("WebGLBuffer")}} which to bind to the binding point
     (<code>target</code>).</dd>
   <dt>offset</dt>
-  <dd>A {{domxref("GLintptr")}} specifying the starting offset.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying the starting offset.</dd>
   <dt>size</dt>
-  <dd>A {{domxref("GLsizeiptr")}} specifying the amount of data that can be read from the
+  <dd>A {{domxref("WebGL_API/Types", "GLsizeiptr")}} specifying the amount of data that can be read from the
     buffer.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WebGL2RenderingContext.bindSampler
 
 <p>The <strong><code>WebGL2RenderingContext.bindSampler()</code></strong> method of the <a
     href="/en-US/docs/Web/API/WebGL_API">WebGL 2 API</a> binds a
-  passed {{domxref("WebGLSampler")}} object to the texture unit at the passed index.</p>
+  passed {{domxref("WebGLSampler")}} object to the texture unit at the passed index.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.bindSampler
 
 <dl>
   <dt>unit</dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the texture unit to which to bind
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the texture unit to which to bind
     the sampler to.</dd>
   <dt>sampler</dt>
   <dd>A {{domxref("WebGLSampler")}} object to bind.</dd>

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.html
@@ -13,7 +13,7 @@ browser-compat: api.WebGL2RenderingContext.bindTransformFeedback
 
 <p>The <strong><code>WebGL2RenderingContext.bindTransformFeedback()</code></strong> method
   of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL 2 API</a> binds a
-  passed {{domxref("WebGLTransformFeedback")}} object to the current GL state.</p>
+  passed {{domxref("WebGLTransformFeedback")}} object to the current GL state.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.bindTransformFeedback
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the target (binding point). Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target (binding point). Must be
     <code>gl.TRANSFORM_FEEDBACK</code>.</dd>
   <dt><code>transformFeedback</code></dt>
   <dd>A {{domxref("WebGLTransformFeedback")}} object to bind.</dd>

--- a/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.html
@@ -26,11 +26,11 @@ browser-compat: api.WebGL2RenderingContext.blitFramebuffer
 
 <dl>
   <dt><code>srcX0, srcY0, srcX1, srcY1</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the bounds of the source rectangle.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the bounds of the source rectangle.</dd>
   <dt><code>dstX0, dstY0, dstX1, dstY1</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the bounds of the destination rectangle.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the bounds of the destination rectangle.</dd>
   <dt><code>mask</code></dt>
-  <dd>A {{domxref("GLbitfield")}} specifying a bitwise OR mask indicating which buffers
+  <dd>A {{domxref("WebGL_API/Types", "GLbitfield")}} specifying a bitwise OR mask indicating which buffers
     are to be copied. Possible values:
     <ul>
       <li><code>gl.COLOR_BUFFER_BIT</code></li>
@@ -39,7 +39,7 @@ browser-compat: api.WebGL2RenderingContext.blitFramebuffer
     </ul>
   </dd>
   <dt><code>filter</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the interpolation to be applied if the image is
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the interpolation to be applied if the image is
     stretched. Possible values:
     <ul>
       <li><code>gl.NEAREST</code></li>

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
@@ -27,7 +27,7 @@ void gl.clearBufferfi(buffer, drawbuffer, depth, stencil);
 
 <dl>
   <dt><code>buffer</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the buffer to clear. Possible values are:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the buffer to clear. Possible values are:
     <ul>
       <li><code>gl.COLOR</code>: Color buffer.</li>
       <li><code>gl.DEPTH</code>: Depth buffer.</li>
@@ -37,17 +37,17 @@ void gl.clearBufferfi(buffer, drawbuffer, depth, stencil);
     </ul>
   </dd>
   <dt><code>drawBuffer</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the draw buffer to clear.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the draw buffer to clear.</dd>
   <dt><code>values</code></dt>
-  <dd>An {{jsxref("Array")}} of {{domxref("GLint")}}, {{domxref("GLuint")}}
-    or {{domxref("GLfloat")}} values or<br>
+  <dd>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLint")}}, {{domxref("WebGL_API/Types", "GLuint")}}
+    or {{domxref("WebGL_API/Types", "GLfloat")}} values or<br>
     an {{jsxref("Int32Array")}}, {{jsxref("Uint32Array")}} or {{jsxref("Float32Array")}}
     specifying the values to clear to.</dd>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLfloat")}} specifying the value to clear a depth render buffer to.
+  <dd>A {{domxref("WebGL_API/Types", "GLfloat")}} specifying the value to clear a depth render buffer to.
   </dd>
   <dt><code>stencil</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the value to clear the stencil render buffer to.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the value to clear the stencil render buffer to.
   </dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.html
@@ -26,17 +26,17 @@ browser-compat: api.WebGL2RenderingContext.clientWaitSync
   <dt><code>sync</code></dt>
   <dd>A {{domxref("WebGLSync")}} object on which to wait on.</dd>
   <dt>flags</dt>
-  <dd>A {{domxref("GLbitfield")}} specifying a bitwise combination of flags controlling
+  <dd>A {{domxref("WebGL_API/Types", "GLbitfield")}} specifying a bitwise combination of flags controlling
     the flushing behavior. May be <code>gl.SYNC_FLUSH_COMMANDS_BIT</code>.</dd>
   <dt>timeout</dt>
-  <dd>A {{domxref("GLint64")}} specifying a timeout (in nanoseconds) for which to wait for
+  <dd>A {{domxref("WebGL_API/Types", "GLint64")}} specifying a timeout (in nanoseconds) for which to wait for
     the sync object to become signaled. Must not be larger than
     <code>gl.MAX_CLIENT_WAIT_TIMEOUT_WEBGL</code>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLenum")}} indicating the sync object's status.</p>
+<p>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the sync object's status.</p>
 
 <ul>
   <li><code>gl.ALREADY_SIGNALED</code>: Indicates that the sync object was signaled when

--- a/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.html
@@ -27,7 +27,7 @@ void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_3D</code>: A three-dimensional texture.</li>
@@ -35,25 +35,25 @@ void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>xoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the x offset within the compressed texture image.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the x offset within the compressed texture image.
   </dd>
   <dt><code>yoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the y offset within the compressed texture image.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the y offset within the compressed texture image.
   </dd>
   <dt><code>zoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the z offset within the compressed texture image.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the z offset within the compressed texture image.
   </dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the depth of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the depth of the texture.</dd>
   <dt><code>format</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the compressed image format. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the compressed image format. Possible values:
     <ul>
       <li><code>gl.COMPRESSED_R11_EAC</code></li>
       <li><code>gl.COMPRESSED_SIGNED_R11_EAC</code></li>
@@ -68,10 +68,10 @@ void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
     </ul>
   </dd>
   <dt><code>imageSize</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the number of bytes to read from the buffer bound
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the number of bytes to read from the buffer bound
     to <code>gl.PIXEL_UNPACK_BUFFER</code>.</dd>
   <dt><code>offset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the offset in bytes from which to read from the
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the offset in bytes from which to read from the
     buffer bound to <code>gl.PIXEL_UNPACK_BUFFER</code>.</dd>
   <dt><code>srcData</code></dt>
   <dd>An {{domxref("ArrayBufferView")}} that be used as a data store for the compressed
@@ -99,5 +99,5 @@ void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
 
 <ul>
   <li>{{domxref("WebGLRenderingContext.compressedTexSubImage2D()")}}</li>
-  <li>{{domxref("WebGL2RenderingContext.compressedTexImage3D()")}}</li>
+  <li>{{domxref("WebGLRenderingContext.compressedTexImage2D", "WebGL2RenderingContext.compressedTexImage3D()")}}</li>
 </ul>

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGL2RenderingContext.copyBufferSubData
 <dl>
   <dt><code>readTarget<br>
  writeTarget</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) from whose data store
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) from whose data store
     should be read or written. Possible values:
     <ul>
       <li><code>gl.ARRAY_BUFFER</code>: Buffer containing vertex attributes, such as
@@ -46,10 +46,10 @@ browser-compat: api.WebGL2RenderingContext.copyBufferSubData
   </dd>
   <dt><code>readOffset<br>
  writeOffset</code></dt>
-  <dd>A {{domxref("GLintptr")}} specifying the byte offset from which to start reading
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying the byte offset from which to start reading
     from or writing to the buffer.</dd>
   <dt><code>size</code></dt>
-  <dd>A {{domxref("GLsizei")}} in bytes specifying the size of the data to be copied from
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} in bytes specifying the size of the data to be copied from
     <code>readTarget</code> to <code>writeTarget</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.copyTexSubImage3D
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_3D</code>: A three-dimensional texture.</li>
@@ -32,24 +32,24 @@ browser-compat: api.WebGL2RenderingContext.copyTexSubImage3D
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>xoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the x offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the x offset within the texture image.</dd>
   <dt><code>yoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the y offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the y offset within the texture image.</dd>
   <dt><code>zoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the z offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the z offset within the texture image.</dd>
   <dt><code>x</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the x coordinate of the lower left corner where to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the x coordinate of the lower left corner where to
     start copying.</dd>
   <dt><code>y</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the y coordinate of the lower left corner where to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the y coordinate of the lower left corner where to
     start copying.</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
@@ -31,7 +31,7 @@ browser-compat: api.WebGL2RenderingContext.drawArraysInstanced
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the type primitive to render. Possible values
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type primitive to render. Possible values
     are:
     <ul>
       <li><code>gl.POINTS</code>: Draws a single dot.</li>
@@ -49,12 +49,12 @@ browser-compat: api.WebGL2RenderingContext.drawArraysInstanced
     </ul>
   </dd>
   <dt>first</dt>
-  <dd>A {{domxref("GLint")}} specifying the starting index in the array of vector points.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the starting index in the array of vector points.
   </dd>
   <dt>count</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of indices to be rendered.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of indices to be rendered.</dd>
   <dt>instanceCount</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of instances of the range of elements
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of instances of the range of elements
     to execute.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGL2RenderingContext.drawBuffers
 
 <dl>
   <dt><code>buffers</code></dt>
-  <dd>An {{jsxref("Array")}} of {{domxref("GLenum")}} specifying the buffers into which
+  <dd>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLenum")}} specifying the buffers into which
     fragment colors will be written. Possible values are:
     <ul>
       <li><code>gl.NONE</code>: Fragment shader output is not written into any color

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
@@ -32,7 +32,7 @@ browser-compat: api.WebGL2RenderingContext.drawElementsInstanced
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the type primitive to render. Possible values
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type primitive to render. Possible values
     are:
     <ul>
       <li><code>gl.POINTS</code>: Draws a single dot.</li>
@@ -50,9 +50,9 @@ browser-compat: api.WebGL2RenderingContext.drawElementsInstanced
     </ul>
   </dd>
   <dt>count</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of elements to be rendered.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of elements to be rendered.</dd>
   <dt>type</dt>
-  <dd>A {{domxref("GLenum")}} specifying the type of the values in the element array
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type of the values in the element array
     buffer. Possible values are:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code></li>
@@ -65,10 +65,10 @@ browser-compat: api.WebGL2RenderingContext.drawElementsInstanced
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>A {{domxref("GLintptr")}} specifying an offset in the element array buffer. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in the element array buffer. Must be
     a valid multiple of the size of the given <code>type</code>.</dd>
   <dt>instanceCount</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of instances of the set of elements
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of instances of the set of elements
     to execute.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.drawRangeElements
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the type primitive to render. Possible values
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type primitive to render. Possible values
     are:
     <ul>
       <li><code>gl.POINTS</code>: Draws a single dot.</li>
@@ -42,15 +42,15 @@ browser-compat: api.WebGL2RenderingContext.drawRangeElements
     </ul>
   </dd>
   <dt><code>start</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the minimum array index contained in
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the minimum array index contained in
     <code>offset</code>.</dd>
   <dt><code>end</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the maximum array index contained in
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the maximum array index contained in
     <code>offset</code>.</dd>
   <dt>count</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of elements to be rendered.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of elements to be rendered.</dd>
   <dt>type</dt>
-  <dd>A {{domxref("GLenum")}} specifying the type of the values in the element array
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type of the values in the element array
     buffer. Possible values are:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code></li>
@@ -59,7 +59,7 @@ browser-compat: api.WebGL2RenderingContext.drawRangeElements
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>A {{domxref("GLintptr")}} specifying an offset in the element array buffer. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in the element array buffer. Must be
     a valid multiple of the size of the given <code>type</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.endQuery
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the query. Possible values:
     <ul>
       <li><code>gl.ANY_SAMPLES_PASSED</code>: Specifies an occlusion query: these queries
         detect whether an object is visible (whether the scoped drawing commands pass the

--- a/files/en-us/web/api/webgl2renderingcontext/fencesync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/fencesync/index.html
@@ -24,10 +24,10 @@ browser-compat: api.WebGL2RenderingContext.fenceSync
 
 <dl>
   <dt><code>condition</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the condition that must be met to set the sync
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the condition that must be met to set the sync
     object's state to signaled. Must be <code>gl.SYNC_GPU_COMMANDS_COMPLETE</code>.</dd>
   <dt>flags</dt>
-  <dd>A {{domxref("GLbitfield")}} specifying a bitwise combination of flags controlling
+  <dd>A {{domxref("WebGL_API/Types", "GLbitfield")}} specifying a bitwise combination of flags controlling
     the behavior of the sync object. Must be <code>0</code> (exists for extensions only).
   </dd>
 </dl>

--- a/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.html
@@ -28,7 +28,7 @@ browser-compat: api.WebGL2RenderingContext.framebufferTextureLayer
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>
@@ -38,7 +38,7 @@ browser-compat: api.WebGL2RenderingContext.framebufferTextureLayer
     </ul>
   </dd>
   <dt><code>attachment</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the attachment point for the
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the attachment point for the
     <code>texture</code>. Possible values:
     <ul>
       <li><code>gl.COLOR_ATTACHMENT{0-15}</code>: Attaches the texture to one of the
@@ -53,10 +53,10 @@ browser-compat: api.WebGL2RenderingContext.framebufferTextureLayer
   <dt><code>texture</code></dt>
   <dd>A {{domxref("WebGLTexture")}} object whose image to attach.</dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the mipmap level of the texture image to attach.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the mipmap level of the texture image to attach.
   </dd>
   <dt><code>layer</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the layer of the texture image to attach.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the layer of the texture image to attach.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.html
@@ -26,7 +26,7 @@ browser-compat: api.WebGL2RenderingContext.getActiveUniformBlockName
   <dt><code>program</code></dt>
   <dd>A {{domxref("WebGLProgram")}} containing the uniform block.</dd>
   <dt><code>uniformBlockIndex</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the uniform block to whose name to
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the uniform block to whose name to
     retrieve.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.html
@@ -27,25 +27,25 @@ browser-compat: api.WebGL2RenderingContext.getActiveUniformBlockParameter
   <dt><code>program</code></dt>
   <dd>A {{domxref("WebGLProgram")}} containing the active uniform block.</dd>
   <dt><code>uniformBlockIndex</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the active uniform block within the
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the active uniform block within the
     program.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to query. Possible values:
     <ul>
-      <li><code>gl.UNIFORM_BLOCK_BINDING</code>: Returns a {{domxref("GLuint")}}
+      <li><code>gl.UNIFORM_BLOCK_BINDING</code>: Returns a {{domxref("WebGL_API/Types", "GLuint")}}
         indicating the uniform buffer binding point.</li>
-      <li><code>gl.UNIFORM_BLOCK_DATA_SIZE</code>: Returns a {{domxref("GLuint")}}
+      <li><code>gl.UNIFORM_BLOCK_DATA_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLuint")}}
         indicating the minimum total buffer object size.</li>
-      <li><code>gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS</code>: Returns a {{domxref("GLuint")}}
+      <li><code>gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS</code>: Returns a {{domxref("WebGL_API/Types", "GLuint")}}
         indicating the number of active uniforms in the uniform block.</li>
       <li><code>gl.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES</code>: Returns a
         {{jsxref("Uint32Array")}} indicating the list of active uniforms in the uniform
         block.</li>
       <li><code>gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER</code>: Returns a
-        {{domxref("GLboolean")}} indicating whether the uniform block is referenced by the
+        {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the uniform block is referenced by the
         vertex shader.</li>
       <li><code>gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER</code>: Returns a
-        {{domxref("GLboolean")}} indicating whether the uniform block is referenced by the
+        {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the uniform block is referenced by the
         fragment shader.</li>
     </ul>
   </dd>

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.html
@@ -2,11 +2,11 @@
 title: WebGL2RenderingContext.getActiveUniforms()
 slug: Web/API/WebGL2RenderingContext/getActiveUniforms
 tags:
-- API
-- Method
-- Reference
-- WebGL
-- WebGL2
+  - API
+  - Method
+  - Reference
+  - WebGL
+  - WebGL2
 browser-compat: api.WebGL2RenderingContext.getActiveUniforms
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -26,28 +26,28 @@ browser-compat: api.WebGL2RenderingContext.getActiveUniforms
   <dt><code>program</code></dt>
   <dd>A {{domxref("WebGLProgram")}} containing the active uniforms.</dd>
   <dt><code>uniformIndices</code></dt>
-  <dd>An {{jsxref("Array")}} of {{domxref("GLuint")}} specifying the indices of the active
+  <dd>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLuint")}} specifying the indices of the active
     uniforms to query.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to query. Possible values:
     <ul>
       <li><code>gl.UNIFORM_TYPE</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLenum")}} indicating the <a
-          href="/en-US/docs/Web/API/WebGLRenderingContext/getUniform#Return_value">types
+        {{domxref("WebGL_API/Types", "GLenum")}} indicating the <a
+          href="/en-US/docs/Web/API/WebGLRenderingContext/getUniform#return_value">types
           of the uniforms</a>.</li>
       <li><code>gl.UNIFORM_SIZE</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLuint")}} indicating the sizes of the uniforms.</li>
+        {{domxref("WebGL_API/Types", "GLuint")}} indicating the sizes of the uniforms.</li>
       <li><code>gl.UNIFORM_BLOCK_INDEX</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLint")}} indicating the block indices of the uniforms.</li>
+        {{domxref("WebGL_API/Types", "GLint")}} indicating the block indices of the uniforms.</li>
       <li><code>gl.UNIFORM_OFFSET</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLint")}} indicating the uniform buffer offsets.</li>
+        {{domxref("WebGL_API/Types", "GLint")}} indicating the uniform buffer offsets.</li>
       <li><code>gl.UNIFORM_ARRAY_STRIDE</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLint")}} indicating the strides between the elements.</li>
+        {{domxref("WebGL_API/Types", "GLint")}} indicating the strides between the elements.</li>
       <li><code>gl.UNIFORM_MATRIX_STRIDE</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLint")}} indicating the strides between columns of a column-major
+        {{domxref("WebGL_API/Types", "GLint")}} indicating the strides between columns of a column-major
         matrix or a row-major matrix.</li>
       <li><code>gl.UNIFORM_IS_ROW_MAJOR</code>: Returns an {{jsxref("Array")}} of
-        {{domxref("GLboolean")}} indicating whether each of the uniforms is a row-major
+        {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether each of the uniforms is a row-major
         matrix or not.</li>
     </ul>
   </dd>

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGL2RenderingContext.getBufferSubData
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.ARRAY_BUFFER</code>: Buffer containing vertex attributes, such as
         vertex coordinates, texture coordinate data, or vertex color data.</li>
@@ -44,17 +44,17 @@ browser-compat: api.WebGL2RenderingContext.getBufferSubData
     </ul>
   </dd>
   <dt><code>srcByteOffset</code></dt>
-  <dd>A {{domxref("GLintptr")}} specifying the byte offset from which to start reading
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying the byte offset from which to start reading
     from the buffer.</dd>
   <dt><code>dstData</code></dt>
   <dd>An {{domxref("ArrayBufferView")}} to copy the data to. If <code>dstData</code> is a
     {{jsxref("DataView")}} then <code>dstOffset</code> and <code>length</code> are
     interpreted in bytes, otherwise <code>dstData</code>'s element type is used.</dd>
   <dt>dstOffset {{optional_inline}}</dt>
-  <dd>A {{domxref("GLuint")}} specifying the element index offset to start writing in
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset to start writing in
     <code>dstData</code>.</dd>
   <dt><code>length</code> {{optional_inline}}</dt>
-  <dd>A {{domxref("GLuint")}} specifying the number of elements to copy. If this is 0 or
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the number of elements to copy. If this is 0 or
     not specified, <code>getBufferSubData</code> will copy until the end of
     <code>dstData</code>.</dd>
 </dl>

--- a/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.html
@@ -32,7 +32,7 @@ browser-compat: api.WebGL2RenderingContext.getFragDataLocation
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLint")}} indicating the assigned color number binding, or <code>-1</code>
+<p>A {{domxref("WebGL_API/Types", "GLint")}} indicating the assigned color number binding, or <code>-1</code>
   otherwise.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.html
@@ -24,23 +24,23 @@ browser-compat: api.WebGL2RenderingContext.getIndexedParameter
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("Glenum")}} specifying the target for which to return information.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target for which to return information.
     Possible values:
     <ul>
       <li><code>gl.TRANSFORM_FEEDBACK_BUFFER_BINDING</code>: Returns a
         {{domxref("WebGLBuffer")}}.</li>
-      <li><code>gl.TRANSFORM_FEEDBACK_BUFFER_SIZE</code>: Returns a
-        {{domxref("GLsizeiptr")}}.</li>
-      <li><code>gl.TRANSFORM_FEEDBACK_BUFFER_START</code>: Returns a
-        {{domxref("GLintptr")}}.</li>
-      <li><code>gl.UNIFORM_BUFFER_BINDING</code>: Returns a {{domxref("WebGLBuffer")}}.
+      <li><code>gl.TRANSFORM_FEEDBACK_BUFFER_SIZE</code>: Returns a
+        {{domxref("WebGL_API/Types", "GLsizeiptr")}}.</li>
+      <li><code>gl.TRANSFORM_FEEDBACK_BUFFER_START</code>: Returns a
+        {{domxref("WebGL_API/Types", "GLintptr")}}.</li>
+      <li><code>gl.UNIFORM_BUFFER_BINDING</code>: Returns a {{domxref("WebGLBuffer")}}.
       </li>
-      <li><code>gl.UNIFORM_BUFFER_SIZE</code>: Returns a {{domxref("GLsizeiptr")}}.</li>
-      <li><code>gl.UNIFORM_BUFFER_START</code>: Returns a {{domxref("GLintptr")}}.</li>
+      <li><code>gl.UNIFORM_BUFFER_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLsizeiptr")}}.</li>
+      <li><code>gl.UNIFORM_BUFFER_START</code>: Returns a {{domxref("WebGL_API/Types", "GLintptr")}}.</li>
     </ul>
   </dd>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the <code>target</code> that is
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the <code>target</code> that is
     queried.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.html
@@ -24,18 +24,18 @@ browser-compat: api.WebGL2RenderingContext.getInternalformatParameter
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("Glenum")}} specifying the target renderbuffer object. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target renderbuffer object. Possible values:
     <ul>
       <li><code>gl.RENDERBUFFER</code>: Buffer data storage for single images in a
         renderable internal format.</li>
     </ul>
   </dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the internal format about which to retrieve
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the internal format about which to retrieve
     information (must be a color-renderable, depth-renderable or stencil-renderable
     format).</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the type of information to query. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type of information to query. Possible
     values:
     <ul>
       <li><code>gl.SAMPLES</code>: Returns a {{jsxref("Int32Array")}} containing sample

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.getQuery
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target of the query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target of the query. Possible values:
     <ul>
       <li><code>gl.ANY_SAMPLES_PASSED</code>: Specifies an occlusion query: these queries
         detect whether an object is visible (whether the scoped drawing commands pass the
@@ -36,7 +36,7 @@ browser-compat: api.WebGL2RenderingContext.getQuery
     </ul>
   </dd>
   <dt>pname</dt>
-  <dd>A {{domxref("GLenum")}} specifying the query object target. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the query object target. Must be
     <code>gl.CURRENT_QUERY</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.html
@@ -26,11 +26,11 @@ browser-compat: api.WebGL2RenderingContext.getQueryParameter
   <dt>query</dt>
   <dd>A {{domxref("WebGLQuery")}} object.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to return. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to return. Possible values:
     <ul>
-      <li><code>gl.QUERY_RESULT</code>: Returns a {{domxref("GLuint")}} containing the
+      <li><code>gl.QUERY_RESULT</code>: Returns a {{domxref("WebGL_API/Types", "GLuint")}} containing the
         query result.</li>
-      <li><code>gl.QUERY_RESULT_AVAILABLE</code>: Returns a {{domxref("GLboolean")}}
+      <li><code>gl.QUERY_RESULT_AVAILABLE</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}}
         indicating whether or not a query result is available.</li>
     </ul>
   </dd>
@@ -38,8 +38,8 @@ browser-compat: api.WebGL2RenderingContext.getQueryParameter
 
 <h3 id="Return_value">Return value</h3>
 
-<p>Depends on the <code>pname</code> parameter, either a {{domxref("GLuint")}} or a
-  {{domxref("GLboolean")}}.</p>
+<p>Depends on the <code>pname</code> parameter, either a {{domxref("WebGL_API/Types", "GLuint")}} or a
+  {{domxref("WebGL_API/Types", "GLboolean")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.html
@@ -26,25 +26,25 @@ browser-compat: api.WebGL2RenderingContext.getSamplerParameter
   <dt>sampler</dt>
   <dd>A {{domxref("WebGLSampler")}} object.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to return. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to return. Possible values:
     <ul>
-      <li><code>gl.TEXTURE_COMPARE_FUNC</code>: Returns a {{domxref("GLenum")}} indicating
+      <li><code>gl.TEXTURE_COMPARE_FUNC</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating
         the texture comparison function.</li>
-      <li><code>gl.TEXTURE_COMPARE_MODE</code>: Returns a {{domxref("GLenum")}} indicating
+      <li><code>gl.TEXTURE_COMPARE_MODE</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating
         the texture comparison mode.</li>
-      <li><code>gl.TEXTURE_MAG_FILTER</code>: Returns a {{domxref("GLenum")}} indicating
+      <li><code>gl.TEXTURE_MAG_FILTER</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating
         the texture magnification filter.</li>
-      <li><code>gl.TEXTURE_MAX_LOD</code>: Returns a {{domxref("GLfloat")}} indicating the
+      <li><code>gl.TEXTURE_MAX_LOD</code>: Returns a {{domxref("WebGL_API/Types", "GLfloat")}} indicating the
         maximum level-of-detail value.</li>
-      <li><code>gl.TEXTURE_MIN_FILTER</code>: Returns a {{domxref("GLenum")}} indicating
+      <li><code>gl.TEXTURE_MIN_FILTER</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating
         the texture minification filter</li>
-      <li><code>gl.TEXTURE_MIN_LOD</code>: Returns a {{domxref("GLfloat")}} indicating the
+      <li><code>gl.TEXTURE_MIN_LOD</code>: Returns a {{domxref("WebGL_API/Types", "GLfloat")}} indicating the
         minimum level-of-detail value.</li>
-      <li><code>gl.TEXTURE_WRAP_R</code>: Returns a {{domxref("GLenum")}} indicating the
+      <li><code>gl.TEXTURE_WRAP_R</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the
         texture wrapping function for the texture coordinate r.</li>
-      <li><code>gl.TEXTURE_WRAP_S</code>: Returns a {{domxref("GLenum")}} indicating the
+      <li><code>gl.TEXTURE_WRAP_S</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the
         texture wrapping function for the texture coordinate s.</li>
-      <li><code>gl.TEXTURE_WRAP_T</code>: Returns a {{domxref("GLenum")}} indicating the
+      <li><code>gl.TEXTURE_WRAP_T</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the
         texture wrapping function for the texture coordinate t.</li>
     </ul>
   </dd>
@@ -52,8 +52,8 @@ browser-compat: api.WebGL2RenderingContext.getSamplerParameter
 
 <h3 id="Return_value">Return value</h3>
 
-<p>Depends on the <code>pname</code> parameter, either a {{domxref("GLenum")}} or a
-  {{domxref("GLfloat")}}.</p>
+<p>Depends on the <code>pname</code> parameter, either a {{domxref("WebGL_API/Types", "GLenum")}} or a
+  {{domxref("WebGL_API/Types", "GLfloat")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.html
@@ -26,16 +26,16 @@ browser-compat: api.WebGL2RenderingContext.getSyncParameter
   <dt>sync</dt>
   <dd>A {{domxref("WebGLSync")}} object.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which information to return. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which information to return. Possible values:
     <ul>
-      <li><code>gl.OBJECT_TYPE</code>: Returns a {{domxref("GLenum")}} indicating the type
+      <li><code>gl.OBJECT_TYPE</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the type
         of the sync object (always <code>gl.SYNC_FENCE</code>).</li>
-      <li><code>gl.SYNC_STATUS</code>: Returns a {{domxref("GLenum")}} indicating the
+      <li><code>gl.SYNC_STATUS</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the
         status of the sync object (<code>gl.SIGNALED</code> or
         <code>gl.UNSIGNALED</code>).</li>
-      <li><code>gl.SYNC_CONDITION</code>: Returns a {{domxref("GLenum")}} indicating the
+      <li><code>gl.SYNC_CONDITION</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the
         sync objects' condition (always <code>gl.SYNC_GPU_COMMANDS_COMPLETE</code>).</li>
-      <li><code>gl.SYNC_FLAGS</code>: Returns a {{domxref("GLenum")}} indicating the flags
+      <li><code>gl.SYNC_FLAGS</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the flags
         with which the sync object was created (always 0 as no flags are supported).</li>
     </ul>
   </dd>
@@ -43,8 +43,8 @@ browser-compat: api.WebGL2RenderingContext.getSyncParameter
 
 <h3 id="Return_value">Return value</h3>
 
-<p>Depends on the <code>pname</code> parameter, either a {{domxref("GLenum")}} or a
-  {{domxref("GLbitfield")}}.</p>
+<p>Depends on the <code>pname</code> parameter, either a {{domxref("WebGL_API/Types", "GLenum")}} or a
+  {{domxref("WebGL_API/Types", "GLbitfield")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGL2RenderingContext.getTransformFeedbackVarying
   <dt>program</dt>
   <dd>A {{domxref("WebGLProgram")}}.</dd>
   <dt>index</dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the varying variable whose
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the varying variable whose
     information to retrieve<code>.</code></dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.html
@@ -32,7 +32,7 @@ browser-compat: api.WebGL2RenderingContext.getUniformBlockIndex
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLuint")}} indicating the uniform block index.</p>
+<p>A {{domxref("WebGL_API/Types", "GLuint")}} indicating the uniform block index.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.html
@@ -32,7 +32,7 @@ browser-compat: api.WebGL2RenderingContext.getUniformIndices
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An {{jsxref("Array")}} of {{domxref("GLuint")}} containing the uniform indices.</p>
+<p>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLuint")}} containing the uniform indices.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.invalidateFramebuffer
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>
@@ -34,7 +34,7 @@ browser-compat: api.WebGL2RenderingContext.invalidateFramebuffer
     </ul>
   </dd>
   <dt><code>attachments</code></dt>
-  <dd>An {{jsxref("Array")}} of {{domxref("GLenum")}} specifying the attachment points to
+  <dd>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLenum")}} specifying the attachment points to
     invalidate. Possible values:
     <ul>
       <li><code>gl.COLOR_ATTACHMENT{0-15}</code>: Invalidates one of the framebuffer's

--- a/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.invalidateSubFramebuffer
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>
@@ -34,7 +34,7 @@ browser-compat: api.WebGL2RenderingContext.invalidateSubFramebuffer
     </ul>
   </dd>
   <dt><code>attachments</code></dt>
-  <dd>An {{jsxref("Array")}} of {{domxref("GLenum")}} specifying the attachment points to
+  <dd>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLenum")}} specifying the attachment points to
     invalidate. Possible values:
     <ul>
       <li><code>gl.COLOR_ATTACHMENT{0-15}</code>: Invalidates one of the framebuffer's
@@ -48,16 +48,16 @@ browser-compat: api.WebGL2RenderingContext.invalidateSubFramebuffer
     </ul>
   </dd>
   <dt><code>x</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the left origin of the pixel rectangle to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the left origin of the pixel rectangle to
     invalidate.</dd>
   <dt><code>y</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the bottom origin of the pixel rectangle to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the bottom origin of the pixel rectangle to
     invalidate.</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the pixel rectangle to invalidate.
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the pixel rectangle to invalidate.
   </dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the pixel rectangle to invalidate.
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the pixel rectangle to invalidate.
   </dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGL2RenderingContext.isQuery
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether the given object is a valid
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given object is a valid
   {{domxref("WebGLQuery")}} object (<code>true</code>) or not (<code>false</code>).</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGL2RenderingContext.isSampler
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether the given object is a valid
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given object is a valid
   {{domxref("WebGLSampler")}} object (<code>true</code>) or not (<code>false</code>).</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGL2RenderingContext.isSync
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether the given object is a valid
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given object is a valid
   {{domxref("WebGLSync")}} object (<code>true</code>) or not (<code>false</code>).</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGL2RenderingContext.isTransformFeedback
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether the given object is a valid
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given object is a valid
   {{domxref("WebGLTransformFeedback")}} object (<code>true</code>) or not
   (<code>false</code>).</p>
 

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGL2RenderingContext.isVertexArray
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether the given object is a valid
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given object is a valid
   {{domxref("WebGLVertexArrayObject")}} object (<code>true</code>) or not
   (<code>false</code>).</p>
 

--- a/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.html
@@ -28,7 +28,7 @@ browser-compat: api.WebGL2RenderingContext.readBuffer
 
 <dl>
   <dt><code>src</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying a color buffer. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying a color buffer. Possible values:
     <ul>
       <li><code>gl.BACK</code>: Reads from the back color buffer.</li>
       <li><code>gl.NONE</code>: Reads from no color buffer.</li>

--- a/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.html
@@ -26,17 +26,17 @@ browser-compat: api.WebGL2RenderingContext.renderbufferStorageMultisample
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the target renderbuffer object. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target renderbuffer object. Possible values:
     <ul>
       <li><code>gl.RENDERBUFFER</code>: Buffer data storage for single images in a
         renderable internal format.</li>
     </ul>
   </dd>
   <dt>samples</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of samples to be used for the
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of samples to be used for the
     renderbuffer storage.</dd>
   <dt>internalFormat</dt>
-  <dd>A {{domxref("GLenum")}} specifying the internal format of the renderbuffer. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the internal format of the renderbuffer. Possible
     values (`gl.DEPTH_STENCIL` is not supported):
     <ul>
       <li><code>gl.R8</code></li>
@@ -77,9 +77,9 @@ browser-compat: api.WebGL2RenderingContext.renderbufferStorageMultisample
     </ul>
   </dd>
   <dt>width</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the renderbuffer in pixels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the renderbuffer in pixels.</dd>
   <dt>height</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the renderbuffer in pixels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the renderbuffer in pixels.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.html
@@ -27,30 +27,30 @@ void <var>gl</var>.samplerParameterf(<var>sampler</var>, <var>pname</var>, <var>
   <dt><code>sampler</code></dt>
   <dd>A {{domxref("WebGLSampler")}} object.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which parameter to set. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which parameter to set. Possible values:
     <ul>
-      <li><code>gl.TEXTURE_COMPARE_FUNC</code>: A {{domxref("GLenum")}} specifying the
+      <li><code>gl.TEXTURE_COMPARE_FUNC</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the
         texture comparison function.</li>
-      <li><code>gl.TEXTURE_COMPARE_MODE</code>: A {{domxref("GLenum")}} specifying the
+      <li><code>gl.TEXTURE_COMPARE_MODE</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the
         texture comparison mode.</li>
-      <li><code>gl.TEXTURE_MAG_FILTER</code>: A {{domxref("GLenum")}} specifying the
+      <li><code>gl.TEXTURE_MAG_FILTER</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the
         texture magnification filter.</li>
-      <li><code>gl.TEXTURE_MAX_LOD</code>: A {{domxref("GLfloat")}} specifying the maximum
+      <li><code>gl.TEXTURE_MAX_LOD</code>: A {{domxref("WebGL_API/Types", "GLfloat")}} specifying the maximum
         level-of-detail value.</li>
-      <li><code>gl.TEXTURE_MIN_FILTER</code>: A {{domxref("GLenum")}} specifying the
+      <li><code>gl.TEXTURE_MIN_FILTER</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the
         texture minification filter</li>
-      <li><code>gl.TEXTURE_MIN_LOD</code>: A {{domxref("GLfloat")}} specifying the minimum
+      <li><code>gl.TEXTURE_MIN_LOD</code>: A {{domxref("WebGL_API/Types", "GLfloat")}} specifying the minimum
         level-of-detail value.</li>
-      <li><code>gl.TEXTURE_WRAP_R</code>: A {{domxref("GLenum")}} specifying the texture
+      <li><code>gl.TEXTURE_WRAP_R</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture
         wrapping function for the texture coordinate r.</li>
-      <li><code>gl.TEXTURE_WRAP_S</code>: A {{domxref("GLenum")}} specifying the texture
+      <li><code>gl.TEXTURE_WRAP_S</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture
         wrapping function for the texture coordinate s.</li>
-      <li><code>gl.TEXTURE_WRAP_T</code>: A {{domxref("GLenum")}} specifying the texture
+      <li><code>gl.TEXTURE_WRAP_T</code>: A {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture
         wrapping function for the texture coordinate t.</li>
     </ul>
   </dd>
   <dt><code>param</code></dt>
-  <dd>A {{domxref("GLint")}} (<code>samplerParameteri</code>) or a {{domxref("GLfloat")}}
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} (<code>samplerParameteri</code>) or a {{domxref("WebGL_API/Types", "GLfloat")}}
     (<code>samplerParameterf</code>) specifying a value for <code>pname</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
@@ -32,7 +32,7 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_3D</code>: A three-dimensional texture.</li>
@@ -40,10 +40,10 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the color components in the texture. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the color components in the texture. Possible
     values:
     <ul>
       <li><code>gl.ALPHA</code>: Discards the red, green and blue components and reads the
@@ -82,20 +82,20 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
     </ul>
   </dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the depth of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the depth of the texture.</dd>
   <dt><code>border</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the width of the border. Must be 0.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the width of the border. Must be 0.</dd>
   <dt><code>format</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the format of the texel data. The correct
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the format of the texel data. The correct
     combinations with <code>internalformat</code> are listed in <a
       href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#TEXTURE_TYPES_FORMATS_FROM_DOM_ELEMENTS_TABLE">this
       table</a>.</dd>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of the texel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of the texel data. Possible values:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code>: 8 bits per channel for <code>gl.RGBA</code></li>
       <li><code>gl.UNSIGNED_SHORT_5_6_5</code>: 5 red bits, 6 green bits, 5 blue bits.
@@ -131,7 +131,7 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>A {{domxref("GLintptr")}} byte offset into the {{domxref("WebGLBuffer")}}'s data
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} byte offset into the {{domxref("WebGLBuffer")}}'s data
     store. Used to upload data to the currently bound {{domxref("WebGLTexture")}} from the
     <code>WebGLBuffer</code> bound to the <code>PIXEL_UNPACK_BUFFER</code> target.</dd>
 </dl>

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.texStorage2D
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -32,9 +32,9 @@ browser-compat: api.WebGL2RenderingContext.texStorage2D
     </ul>
   </dd>
   <dt><code>levels</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the number of texture levels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the number of texture levels.</dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the texture store format. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture store format. Possible values:
     <ul>
       <li><code>gl.R8</code></li>
       <li><code>gl.R16F</code></li>
@@ -81,9 +81,9 @@ browser-compat: api.WebGL2RenderingContext.texStorage2D
     </ul>
   </dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGL2RenderingContext.texStorage3D
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_3D</code>: A three-dimensional texture.</li>
@@ -32,9 +32,9 @@ browser-compat: api.WebGL2RenderingContext.texStorage3D
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the number of texture levels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the number of texture levels.</dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the texture store format. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture store format. Possible values:
     <ul>
       <li><code>gl.R8</code></li>
       <li><code>gl.R16F</code></li>
@@ -72,11 +72,11 @@ browser-compat: api.WebGL2RenderingContext.texStorage3D
     </ul>
   </dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the depth of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the depth of the texture.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.html
@@ -36,7 +36,7 @@ void <var>gl</var>.texSubImage3D(<var>target</var>, <var>level</var>, <var>xoffs
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_3D</code>: A three-dimensional texture.</li>
@@ -44,22 +44,22 @@ void <var>gl</var>.texSubImage3D(<var>target</var>, <var>level</var>, <var>xoffs
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>xoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the x offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the x offset within the texture image.</dd>
   <dt><code>yoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the y offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the y offset within the texture image.</dd>
   <dt><code>zoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the z offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the z offset within the texture image.</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the depth of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the depth of the texture.</dd>
   <dt><code>format</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the format of the texel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the format of the texel data. Possible values:
     <ul>
       <li><code>gl.ALPHA</code>: Discards the red, green and blue components and reads the
         alpha component.</li>
@@ -97,7 +97,7 @@ void <var>gl</var>.texSubImage3D(<var>target</var>, <var>level</var>, <var>xoffs
     </ul>
   </dd>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of the texel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of the texel data. Possible values:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code>: 8 bits per channel for <code>gl.RGBA</code></li>
       <li><code>gl.UNSIGNED_SHORT_5_6_5</code>: 5 red bits, 6 green bits, 5 blue bits.
@@ -144,7 +144,7 @@ void <var>gl</var>.texSubImage3D(<var>target</var>, <var>level</var>, <var>xoffs
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>A {{domxref("GLintptr")}} byte offset into the {{domxref("WebGLBuffer")}}'s data
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} byte offset into the {{domxref("WebGLBuffer")}}'s data
     store. Used to upload data to the currently bound {{domxref("WebGLTexture")}} from the
     <code>WebGLBuffer</code> bound to the <code>PIXEL_UNPACK_BUFFER</code> target.</dd>
 </dl>

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGL2RenderingContext.transformFeedbackVaryings
   <dd>An {{jsxref("Array")}} of {{domxref("DOMString")}} specifying the names of the
     varying variables to use.</dd>
   <dt><code>bufferMode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the mode to use when capturing the varying
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the mode to use when capturing the varying
     variables. Either <code>gl.INTERLEAVED_ATTRIBS</code> or
     <code>gl.SEPARATE_ATTRIBS</code>.</dd>
 </dl>

--- a/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.html
@@ -27,10 +27,10 @@ browser-compat: api.WebGL2RenderingContext.uniformBlockBinding
   <dd>A {{domxref("WebGLProgram")}} containing the active uniform block whose binding to
     assign.</dd>
   <dt><code>uniformBlockIndex</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the active uniform block within the
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the active uniform block within the
     program.</dd>
   <dt>uniformBlockBinding</dt>
-  <dd>A {{domxref("GLuint")}} specifying the binding point to which to bind the uniform
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the binding point to which to bind the uniform
     block.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
@@ -41,7 +41,7 @@ void gl.uniformMatrix4fv(location, transpose, data, optional srcOffset, optional
   <dd>A {{domxref("WebGLUniformLocation")}} object containing the location of the uniform
     attribute to modify.</dd>
   <dt>transpose</dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether to transpose the matrix. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether to transpose the matrix. Must be
     <code>false</code>.</dd>
   <dt>data</dt>
   <dd>A {{jsxref("Float32Array")}} of float values.</dd>

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.html
@@ -34,9 +34,9 @@ browser-compat: api.WebGL2RenderingContext.vertexAttribDivisor
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the generic vertex attributes.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the generic vertex attributes.</dd>
   <dt><code>divisor</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the number of instances that will pass between
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the number of instances that will pass between
     updates of the generic attribute.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
@@ -28,14 +28,14 @@ void <var>gl</var>.vertexAttribI4uiv(<var>index</var>, <var>value</var>);
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the position of the vertex attribute to be
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the position of the vertex attribute to be
     modified.</dd>
   <dt><code>v0, v1, v2, v3</code></dt>
   <dd>An integer {{jsxref("Number")}} for the vertex attribute value.</dd>
   <dt><code>value</code></dt>
   <dd>
-    <p>A {{jsxref("Uint32Array")}}/{{jsxref("Int32Array")}} or sequences of
-      {{domxref("GLuint")}}/ {{domxref("GLint")}} for integer vector vertex attribute
+    <p>A {{jsxref("Uint32Array")}}/{{jsxref("Int32Array")}} or sequences of
+      {{domxref("WebGL_API/Types", "GLuint")}}/ {{domxref("WebGL_API/Types", "GLint")}} for integer vector vertex attribute
       values.</p>
   </dd>
 </dl>

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.html
@@ -24,21 +24,21 @@ browser-compat: api.WebGL2RenderingContext.vertexAttribIPointer
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the vertex attribute that is to be
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute that is to be
     modified.</dd>
   <dt><code>size</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the number of components per vertex attribute.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the number of components per vertex attribute.
     Must be 1, 2, 3, or 4.</dd>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of each component in the array.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of each component in the array.
     Must be one of: <code>gl.BYTE</code>, <code>gl.UNSIGNED_BYTE</code>,
     <code>gl.SHORT</code>, <code>gl.UNSIGNED_SHORT</code>, <code>gl.INT</code>, or
     <code>gl.UNSIGNED_INT</code>.</dd>
   <dt><code>stride</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the offset in bytes between the beginning of
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the offset in bytes between the beginning of
     consecutive vertex attributes.</dd>
   <dt><code>offset</code></dt>
-  <dd>A {{domxref("GLintptr")}} specifying an offset in bytes of the first component in
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in bytes of the first component in
     the vertex attribute array. Must be a multiple of <code>type</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl2renderingcontext/waitsync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/waitsync/index.html
@@ -29,10 +29,10 @@ browser-compat: api.WebGL2RenderingContext.waitSync
   <dt><code>sync</code></dt>
   <dd>A {{domxref("WebGLSync")}} object on which to wait on.</dd>
   <dt>flags</dt>
-  <dd>A {{domxref("GLbitfield")}} specifying a bitwise combination of flags controlling
+  <dd>A {{domxref("WebGL_API/Types", "GLbitfield")}} specifying a bitwise combination of flags controlling
     the flushing behavior. Must be <code>0</code> (exists for extensions only).</dd>
   <dt>timeout</dt>
-  <dd>A {{domxref("GLint64")}} specifying a timeout the server should wait before
+  <dd>A {{domxref("WebGL_API/Types", "GLint64")}} specifying a timeout the server should wait before
     continuing. Must be <code>gl.TIMEOUT_IGNORED</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgl_api/constants/index.html
+++ b/files/en-us/web/api/webgl_api/constants/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{WebGLSidebar}}</div>
 
-<p>The <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> provides several constants that are passed into or returned by functions. All constants are of type {{domxref("GLenum")}}.</p>
+<p>The <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> provides several constants that are passed into or returned by functions. All constants are of type {{domxref("WebGL_API/Types", "GLenum")}}.</p>
 
 <p>Standard WebGL constants are installed on the {{domxref("WebGLRenderingContext")}} and {{domxref("WebGL2RenderingContext")}} objects, so that you use them as <code>gl.CONSTANT_NAME</code>:</p>
 
@@ -619,7 +619,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
   <tr>
    <td><code>BUFFER_USAGE</code></td>
    <td>0x8765</td>
-   <td>Passed to <code>getBufferParameter</code> to get the hint for the buffer passed in when it was created.</td>
+   <td>Passed to <code>getBufferParameter</code> to get the hint for the buffer passed in when it was created.</td>
   </tr>
  </tbody>
 </table>
@@ -1227,7 +1227,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Textures">Textures</h3>
 
-<p>Constants passed to {{domxref("WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
+<p>Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
 
 <table class="standard-table">
  <thead>
@@ -1881,7 +1881,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Textures_2">Textures</h3>
 
-<p>Constants passed to {{domxref("WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
+<p>Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
@@ -51,7 +51,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ETC1_WEBGL, 512, 51
 
 <ul>
  <li><a href="https://en.wikipedia.org/wiki/Ericsson_Texture_Compression">Ericsson Texture Compression – Wikipedia</a></li>
- <li>{{domxref("WEBGL_compressed_texture_es3")}} (ETC2 and EAC)</li>
+ <li>{{domxref("WEBGL_compressed_texture_etc")}} (ETC2 and EAC)</li>
  <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
  <li>{{domxref("WebGLRenderingContext.compressedTexImage2D()")}}</li>
  <li>{{domxref("WebGLRenderingContext.getParameter()")}}</li>

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.html
@@ -14,7 +14,7 @@ browser-compat: api.WEBGL_draw_buffers.drawBuffersWEBGL
   of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> and allows you to define
   the draw buffers to which all fragment colors are written.</p>
 
-<p>This method is part of the {{domxref("WEBGL_draw_buffers")}} extension.</p>
+<p>This method is part of the {{domxref("WEBGL_draw_buffers")}} extension.</p>
 
 <div class="note">
   <p><strong>Note:</strong> When using {{domxref("WebGL2RenderingContext", "WebGL2")}},
@@ -32,7 +32,7 @@ browser-compat: api.WEBGL_draw_buffers.drawBuffersWEBGL
 
 <dl>
   <dt>buffers</dt>
-  <dd>An {{jsxref("Array")}} of {{domxref("GLenum")}} constants defining drawing buffers.
+  <dd>An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLenum")}} constants defining drawing buffers.
     Possible values:
     <ul>
       <li><code>gl.NONE</code>: The fragment shader is not written to any color buffer.
@@ -88,9 +88,9 @@ browser-compat: api.WEBGL_draw_buffers.drawBuffersWEBGL
 <ul>
   <li>{{domxref("WEBGL_draw_buffers")}}</li>
   <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
-  <li>{{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}},</li>
-  <li>{{domxref("WebGLRenderingContext.framebufferTexture2D()")}},</li>
-  <li>{{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter()")}} </li>
+  <li>{{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}</li>
+  <li>{{domxref("WebGLRenderingContext.framebufferTexture2D()")}}</li>
+  <li>{{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter()")}}</li>
   <li>{{domxref("WebGLRenderingContext.getParameter()")}}</li>
   <li><a href="https://hacks.mozilla.org/2014/01/webgl-deferred-shading/">WebGL deferred
       shading - Mozilla Hacks blog</a></li>

--- a/files/en-us/web/api/webgl_draw_buffers/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/index.html
@@ -20,7 +20,7 @@ browser-compat: api.WEBGL_draw_buffers
 
 <h2 id="Constants">Constants</h2>
 
-<p>This extension exposes new constants, which can be used in the {{domxref("WebGLRenderingContext.framebufferRenderbuffer()", "gl.framebufferRenderbuffer()")}}, {{domxref("WebGLRenderingContext.framebufferTexture2D()", "gl.framebufferTexture2D()")}}, {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter()", "gl.getFramebufferAttachmentParameter()")}}  {{domxref("WEBGL_draw_buffers.drawBuffersWEBGL()", "ext.drawBuffersWEBGL()")}}, and {{domxref("WebGLRenderingContext.getParameter()", "gl.getParameter()")}} methods.</p>
+<p>This extension exposes new constants, which can be used in the {{domxref("WebGLRenderingContext.framebufferRenderbuffer()", "gl.framebufferRenderbuffer()")}}, {{domxref("WebGLRenderingContext.framebufferTexture2D()", "gl.framebufferTexture2D()")}}, {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter()", "gl.getFramebufferAttachmentParameter()")}} {{domxref("WEBGL_draw_buffers.drawBuffersWEBGL()", "ext.drawBuffersWEBGL()")}}, and {{domxref("WebGLRenderingContext.getParameter()", "gl.getParameter()")}} methods.</p>
 
 <dl>
  <dt><code>ext.COLOR_ATTACHMENT0_WEBGL<br>
@@ -39,7 +39,7 @@ browser-compat: api.WEBGL_draw_buffers
  ext.COLOR_ATTACHMENT13_WEBGL<br>
  ext.COLOR_ATTACHMENT14_WEBGL<br>
  ext.COLOR_ATTACHMENT15_WEBGL</code></dt>
- <dd>A {{domxref("GLenum")}} specifying a color buffer.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying a color buffer.</dd>
  <dt><code>ext.DRAW_BUFFER0_WEBGL<br>
  ext.DRAW_BUFFER1_WEBGL<br>
  ext.DRAW_BUFFER2_WEBGL<br>
@@ -56,11 +56,11 @@ browser-compat: api.WEBGL_draw_buffers
  ext.DRAW_BUFFER13_WEBGL<br>
  ext.DRAW_BUFFER14_WEBGL<br>
  ext.DRAW_BUFFER15_WEBGL</code></dt>
- <dd>A {{domxref("GLenum")}} returning a draw buffer.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLenum")}} returning a draw buffer.</dd>
  <dt><code>ext.MAX_COLOR_ATTACHMENTS_WEBGL</code></dt>
- <dd>A {{domxref("GLint")}} indicating the maximum number of framebuffer color attachment points.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLint")}} indicating the maximum number of framebuffer color attachment points.</dd>
  <dt><code>ext.MAX_DRAW_BUFFERS_WEBGL</code></dt>
- <dd>A {{domxref("GLint")}} indicating the maximum number of draw buffers.</dd>
+ <dd>A {{domxref("WebGL_API/Types", "GLint")}} indicating the maximum number of draw buffers.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>
@@ -81,7 +81,7 @@ browser-compat: api.WEBGL_draw_buffers
 <pre class="brush: js">var ext = gl.getExtension('WEBGL_draw_buffers');
 </pre>
 
-<p>Binding multiple textures (to a <code>tx[]</code> array)  to different framebuffer color attachments:</p>
+<p>Binding multiple textures (to a <code>tx[]</code> array) to different framebuffer color attachments:</p>
 
 <pre class="brush: js">var fb = gl.createFramebuffer();
 gl.bindFramebuffer(gl.FRAMEBUFFER, fb);

--- a/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.html
@@ -26,7 +26,7 @@ browser-compat: api.WebGLRenderingContext.bindAttribLocation
   <dt><code>program</code></dt>
   <dd>A {{domxref("WebGLProgram")}} object to bind.</dd>
   <dt>index</dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the generic vertex to bind.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the generic vertex to bind.</dd>
   <dt>name</dt>
   <dd>A {{domxref("DOMString")}} specifying the name of the variable to bind to the
     generic vertex index. This name cannot start with "webgl_" or "_webgl_", as these are

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.bindBuffer
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.ARRAY_BUFFER</code>: Buffer containing vertex attributes, such as
         vertex coordinates, texture coordinate data, or vertex color data.</li>

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.bindFramebuffer
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>

--- a/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.bindRenderbuffer
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.RENDERBUFFER</code>: Buffer data storage for single images in a
         renderable internal format.</li>

--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.bindTexture
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
       <li><code>gl.TEXTURE_CUBE_MAP</code>: A cube-mapped texture.</li>

--- a/files/en-us/web/api/webglrenderingcontext/blendcolor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendcolor/index.html
@@ -24,13 +24,13 @@ browser-compat: api.WebGLRenderingContext.blendColor
 
 <dl>
   <dt><code>red</code></dt>
-  <dd>A {{domxref("GLclampf")}} for the red component in the range of 0 to 1.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} for the red component in the range of 0 to 1.</dd>
   <dt><code>green</code></dt>
-  <dd>A {{domxref("GLclampf")}} for the green component in the range of 0 to 1.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} for the green component in the range of 0 to 1.</dd>
   <dt>blue</dt>
-  <dd>A {{domxref("GLclampf")}} for the blue component in the range of 0 to 1.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} for the blue component in the range of 0 to 1.</dd>
   <dt>alpha</dt>
-  <dd>A {{domxref("GLclampf")}} for the alpha component (transparency) in the range of 0
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} for the alpha component (transparency) in the range of 0
     to 1.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/blendequation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendequation/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.blendEquation
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying how source and destination colors are combined.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying how source and destination colors are combined.
     Must be either:
     <ul>
       <li><code>gl.FUNC_ADD</code>: source + destination,</li>

--- a/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.blendEquationSeparate
 
 <dl>
   <dt><code>modeRGB</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying how the red, green and blue components of source
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying how the red, green and blue components of source
     and destination colors are combined. Must be either:
     <ul>
       <li><code>gl.FUNC_ADD</code>: source + destination (default value),</li>
@@ -49,7 +49,7 @@ browser-compat: api.WebGLRenderingContext.blendEquationSeparate
     </ul>
   </dd>
   <dt><code>modeAlpha</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying how the alpha component (transparency) of source
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying how the alpha component (transparency) of source
     and destination colors are combined. Must be either:
     <ul>
       <li><code>gl.FUNC_ADD</code>: source + destination (default value),</li>

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.html
@@ -32,7 +32,7 @@ void gl.bufferData(target, ArrayBufferView srcData, usage, srcOffset, length);
 
 <dl>
 	<dt><code>target</code></dt>
-	<dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+	<dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
 		<ul>
 			<li><code>gl.ARRAY_BUFFER</code>: Buffer containing vertex attributes, such as
 				vertex coordinates, texture coordinate data, or vertex color data.</li>
@@ -58,15 +58,15 @@ void gl.bufferData(target, ArrayBufferView srcData, usage, srcOffset, length);
 		</ul>
 	</dd>
 	<dt><code>size</code></dt>
-	<dd>A {{domxref("GLsizeiptr")}} setting the size in bytes of the buffer object's data
+	<dd>A {{domxref("WebGL_API/Types", "GLsizeiptr")}} setting the size in bytes of the buffer object's data
 		store.</dd>
 	<dt><code>srcData</code> {{optional_inline}}</dt>
-	<dd>An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}} or one of the
+	<dd>An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}} or one of the
 		{{domxref("ArrayBufferView")}} typed array types that will be copied into the data
 		store. If <code>null</code>, a data store is still created, but the content is
 		uninitialized and undefined.</dd>
 	<dt><code>usage</code></dt>
-	<dd>A {{domxref("GLenum")}} specifying the intended usage pattern of the data store
+	<dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the intended usage pattern of the data store
 		for optimization purposes. Possible values:
 		<ul>
 			<li><code>gl.STATIC_DRAW</code>: The contents are intended to be specified
@@ -107,10 +107,10 @@ void gl.bufferData(target, ArrayBufferView srcData, usage, srcOffset, length);
 		</ul>
 	</dd>
 	<dt><code>srcOffset</code></dt>
-	<dd>A {{domxref("GLuint")}} specifying the element index offset where to start reading
+	<dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading
 		the buffer.</dd>
 	<dt><code>length</code> {{optional_inline}}</dt>
-	<dd>A {{domxref("GLuint")}} defaulting to 0.</dd>
+	<dd>A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.html
@@ -30,7 +30,7 @@ void gl.bufferSubData(target, dstByteOffset, ArrayBufferView srcData, srcOffset,
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.ARRAY_BUFFER</code>: Buffer containing vertex attributes, such as
         vertex coordinates, texture coordinate data, or vertex color data.</li>
@@ -54,17 +54,17 @@ void gl.bufferSubData(target, dstByteOffset, ArrayBufferView srcData, srcOffset,
     </ul>
   </dd>
   <dt>dstByteOffset</dt>
-  <dd>A {{domxref("GLintptr")}} specifying an offset in bytes where the data replacement
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in bytes where the data replacement
     will start.</dd>
   <dt>srcData {{optional_inline}}</dt>
-  <dd>An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}} or one of the
+  <dd>An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}} or one of the
     {{domxref("ArrayBufferView")}} typed array types that will be copied into the data
     store.</dd>
   <dt>srcOffset</dt>
-  <dd>A {{domxref("GLuint")}} specifying the element index offset where to start reading
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading
     the buffer.</dd>
   <dt><code>length</code> {{optional_inline}}</dt>
-  <dd>A {{domxref("GLuint")}} defaulting to 0.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.checkFramebufferStatus
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>
@@ -44,7 +44,7 @@ browser-compat: api.WebGLRenderingContext.checkFramebufferStatus
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLenum")}} indicating the completeness status of the framebuffer or
+<p>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the completeness status of the framebuffer or
   <code>0</code> if an error occurs. Possible enum return values:</p>
 
 <ul>

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.html
@@ -31,7 +31,7 @@ browser-compat: api.WebGLRenderingContext.clear
 
 <dl>
   <dt><code>mask</code></dt>
-  <dd>A {{domxref("GLbitfield")}} bitwise OR mask that indicates the buffers to be
+  <dd>A {{domxref("WebGL_API/Types", "GLbitfield")}} bitwise OR mask that indicates the buffers to be
     cleared. Possible values are:
     <ul>
       <li><code>gl.COLOR_BUFFER_BIT</code></li>

--- a/files/en-us/web/api/webglrenderingcontext/clearcolor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clearcolor/index.html
@@ -28,16 +28,16 @@ browser-compat: api.WebGLRenderingContext.clearColor
 
 <dl>
   <dt><code>red</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the red color value used when the color buffers
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the red color value used when the color buffers
     are cleared. Default value: 0.</dd>
   <dt><code>green</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the green color value used when the color
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the green color value used when the color
     buffers are cleared. Default value: 0.</dd>
   <dt><code>blue</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the blue color value used when the color
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the blue color value used when the color
     buffers are cleared. Default value: 0.</dd>
   <dt><code>alpha</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the alpha (transparency) value used when the
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the alpha (transparency) value used when the
     color buffers are cleared. Default value: 0.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/cleardepth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/cleardepth/index.html
@@ -28,7 +28,7 @@ browser-compat: api.WebGLRenderingContext.clearDepth
 
 <dl>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the depth value used when the depth buffer is
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the depth value used when the depth buffer is
     cleared. Default value: 1.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/clearstencil/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clearstencil/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.clearStencil
 
 <dl>
   <dt><code>s</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the index used when the stencil buffer is cleared.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the index used when the stencil buffer is cleared.
     Default value: 0.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/colormask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/colormask/index.html
@@ -24,16 +24,16 @@ browser-compat: api.WebGLRenderingContext.colorMask
 
 <dl>
   <dt><code>red</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether or not the red color component can be
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the red color component can be
     written into the frame buffer. Default value: <code>true</code>.</dd>
   <dt><code>green</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether or not the green color component can
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the green color component can
     be written into the frame buffer. Default value: <code>true</code>.</dd>
   <dt><code>blue</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether or not the blue color component can be
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the blue color component can be
     written into the frame buffer. Default value: <code>true</code>.</dd>
   <dt><code>alpha</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether or not the alpha (transparency)
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the alpha (transparency)
     component can be written into the frame buffer. Default value: <code>true</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.compileShader
 
 <dl>
   <dt><code>shader</code></dt>
-  <dd>A fragment or vertex {{domxref("WebGLShader")}}.</dd>
+  <dd>A fragment or vertex {{domxref("WebGLShader")}}.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
@@ -13,8 +13,8 @@ browser-compat: api.WebGLRenderingContext.compressedTexImage2D
 ---
 <div>{{APIRef("WebGL")}}</div>
 
-<p>The <strong><code>WebGLRenderingContext.compressedTexImage2D()</code></strong> 
-  and <strong><code>WebGL2RenderingContext.compressedTexImage3D()</code></strong> methods
+<p>The <strong><code>WebGLRenderingContext.compressedTexImage2D()</code></strong>
+  and <strong><code>WebGL2RenderingContext.compressedTexImage3D()</code></strong> methods
   of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API </a>specify a two- or
   three-dimensional texture image in a compressed format.</p>
 
@@ -43,7 +43,7 @@ void <var>gl</var>.compressedTexImage3D(<var>target</var>, <var>level</var>, <va
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values for <code>compressedTexImage2D</code>:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -68,10 +68,10 @@ void <var>gl</var>.compressedTexImage3D(<var>target</var>, <var>level</var>, <va
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the compressed image format. Compressed image
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the compressed image format. Compressed image
     formats must be enabled by <a
       href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">WebGL extensions</a> before
     using this method. All values are possible for <code>compressedTexImage2D</code>. See
@@ -171,19 +171,19 @@ void <var>gl</var>.compressedTexImage3D(<var>target</var>, <var>level</var>, <va
     </ul>
   </dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>depth</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the depth of the texture/the number of textures
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the depth of the texture/the number of textures
     in a <code>TEXTURE_2D_ARRAY</code>.</dd>
   <dt><code>border</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the width of the border. Must be 0.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the width of the border. Must be 0.</dd>
   <dt><code>imageSize</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of bytes to read from the buffer
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of bytes to read from the buffer
     bound to <code>gl.PIXEL_UNPACK_BUFFER</code>.</dd>
   <dt><code>offset</code></dt>
-  <dd>A {{domxref("GLintptr")}} specifying the offset in bytes from which to read from the
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying the offset in bytes from which to read from the
     buffer bound to <code>gl.PIXEL_UNPACK_BUFFER</code>.</dd>
   <dt><code>pixels</code></dt>
   <dd>An {{domxref("ArrayBufferView")}} that will be used as a data store for the

--- a/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.html
@@ -36,7 +36,7 @@ void gl.compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, 
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active
     compressed texture. Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -55,20 +55,20 @@ void gl.compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, 
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>xoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the horizontal offset within the compressed
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the horizontal offset within the compressed
     texture image.</dd>
   <dt><code>yoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the vertical offset within the compressed texture
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the vertical offset within the compressed texture
     image.</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the compressed texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the compressed texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the compressed texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the compressed texture.</dd>
   <dt><code>format</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the compressed image format. Compressed image
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the compressed image format. Compressed image
     formats must be enabled by <a
       href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">WebGL extensions</a> before
     using this method. Possible values:
@@ -162,10 +162,10 @@ void gl.compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, 
     </ul>
   </dd>
   <dt><code>imageSize</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of bytes to read from the buffer
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of bytes to read from the buffer
     bound to <code>gl.PIXEL_UNPACK_BUFFER</code>.</dd>
   <dt><code>offset</code></dt>
-  <dd>A {{domxref("GLintptr")}} specifying the offset in bytes from which to read from the
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying the offset in bytes from which to read from the
     buffer bound to <code>gl.PIXEL_UNPACK_BUFFER</code>.</dd>
   <dt><code>pixels</code></dt>
   <dd>An {{domxref("ArrayBufferView")}} that be used as a data store for the compressed

--- a/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.copyTexImage2D
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -44,10 +44,10 @@ browser-compat: api.WebGLRenderingContext.copyTexImage2D
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>internalformat</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the color components in the texture. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the color components in the texture. Possible
     values:
     <ul>
       <li><code>gl.ALPHA</code>: Discards the red, green and blue components and reads the
@@ -63,17 +63,17 @@ browser-compat: api.WebGLRenderingContext.copyTexImage2D
     </ul>
   </dd>
   <dt><code>x</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the x coordinate of the lower left corner where to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the x coordinate of the lower left corner where to
     start copying.</dd>
   <dt><code>y</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the y coordinate of the lower left corner where to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the y coordinate of the lower left corner where to
     start copying.</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>border</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the width of the border. Must be 0.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the width of the border. Must be 0.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.copyTexSubImage2D
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -44,23 +44,23 @@ browser-compat: api.WebGLRenderingContext.copyTexSubImage2D
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>xoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the horizontal offset within the texture image.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the horizontal offset within the texture image.
   </dd>
   <dt><code>yoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the vertical offset within the texture image.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the vertical offset within the texture image.</dd>
   <dt><code>x</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the x coordinate of the lower left corner where to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the x coordinate of the lower left corner where to
     start copying.</dd>
   <dt><code>y</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the y coordinate of the lower left corner where to
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the y coordinate of the lower left corner where to
     start copying.</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/cullface/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/cullface/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.cullFace
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying whether front- or back-facing polygons are
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying whether front- or back-facing polygons are
     candidates for culling. The default value is <code>gl.BACK</code>. Possible values
     are:
     <ul>

--- a/files/en-us/web/api/webglrenderingcontext/depthfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthfunc/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.depthFunc
 
 <dl>
   <dt><code>func</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the depth comparison function, which sets the
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the depth comparison function, which sets the
     conditions under which the pixel will be drawn. The default value is
     <code>gl.LESS</code>. Possible values are:
     <ul>

--- a/files/en-us/web/api/webglrenderingcontext/depthmask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthmask/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.depthMask
 
 <dl>
   <dt><code>flag</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether or not writing into the depth buffer
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not writing into the depth buffer
     is enabled. Default value: <code>true</code>, meaning that writing is enabled.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/depthrange/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthrange/index.html
@@ -24,12 +24,12 @@ browser-compat: api.WebGLRenderingContext.depthRange
 
 <dl>
   <dt><code>zNear</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the mapping of the near clipping plane to
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the mapping of the near clipping plane to
     window or viewport coordinates. Clamped to the range 0 to 1 and must be less than or
     equal to <code>zFar</code>. The default value i<code>s 0.</code></dd>
   <dt><code>zFar</code></dt>
-  <dd>A {{domxref("GLclampf")}} specifying the mapping of the far clipping plane to window
-    or viewport coordinates. Clamped to the range 0 to 1. The default value
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} specifying the mapping of the far clipping plane to window
+    or viewport coordinates. Clamped to the range 0 to 1. The default value
     i<code>s 1.</code></dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/disable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disable/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.disable
 <dl>
   <dt><code>cap</code></dt>
   <dd>
-    <p>A {{domxref("GLenum")}} specifying which WebGL capability to disable. Possible
+    <p>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which WebGL capability to disable. Possible
     values:</p>
     <table class="standard-table">
       <thead>

--- a/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.disableVertexAttribArray
 
 <dl>
   <dt>index</dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the vertex attribute to disable.
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute to disable.
   </dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.drawArrays
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the type primitive to render. Possible values
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type primitive to render. Possible values
     are:
     <ul>
       <li><code>gl.POINTS</code>: Draws a single dot.</li>
@@ -42,10 +42,10 @@ browser-compat: api.WebGLRenderingContext.drawArrays
     </ul>
   </dd>
   <dt>first</dt>
-  <dd>A {{domxref("GLint")}} specifying the starting index in the array of vector points.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the starting index in the array of vector points.
   </dd>
   <dt>count</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of indices to be rendered.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of indices to be rendered.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.drawElements
 
 <dl>
   <dt><code>mode</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the type primitive to render. Possible values
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type primitive to render. Possible values
     are:
     <ul>
       <li><code>gl.POINTS</code>: Draws a single dot.</li>
@@ -42,7 +42,7 @@ browser-compat: api.WebGLRenderingContext.drawElements
     </ul>
   </dd>
   <dt>count</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the number of elements of the bound element array
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the number of elements of the bound element array
     buffer to be rendered. For example, to draw a wireframe triangle with <code>gl.LINES</code>
     the count should be 2 endpoints per line &times; 3 lines = 6 elements. However to draw the
     same wireframe triangle with <code>gl.LINE_STRIP</code> the element array buffer does not
@@ -51,7 +51,7 @@ browser-compat: api.WebGLRenderingContext.drawElements
     triangle with <code>gl.LINE_LOOP</code> the element array buffer does not repeat the
     first/last vertex either so <code>count</code> will be three.</dd>
   <dt>type</dt>
-  <dd>A {{domxref("GLenum")}} specifying the type of the values in the element array
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the type of the values in the element array
     buffer. Possible values are:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code></li>
@@ -64,7 +64,7 @@ browser-compat: api.WebGLRenderingContext.drawElements
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>A {{domxref("GLintptr")}} specifying a byte offset in the element array buffer. Must
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying a byte offset in the element array buffer. Must
     be a valid multiple of the size of the given <code>type</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/enable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enable/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.enable
 <dl>
   <dt><code>cap</code></dt>
   <dd>
-    <p>A {{domxref("GLenum")}} specifying which WebGL capability to enable. Possible
+    <p>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which WebGL capability to enable. Possible
     values:</p>
     <table class="standard-table">
       <thead>

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
@@ -2,19 +2,19 @@
 title: WebGLRenderingContext.enableVertexAttribArray()
 slug: Web/API/WebGLRenderingContext/enableVertexAttribArray
 tags:
-- 3D
-- API
-- Attribute Array
-- Graphics
-- Method
-- Reference
-- Vertex Attributes
-- WebGL
-- WebGL API
-- WebGLRenderingContext
-- enableVertexAttribArray
-- vertex
-- vertex shader
+  - 3D
+  - API
+  - Attribute Array
+  - Graphics
+  - Method
+  - Reference
+  - Vertex Attributes
+  - WebGL
+  - WebGL API
+  - WebGLRenderingContext
+  - enableVertexAttribArray
+  - vertex
+  - vertex shader
 browser-compat: api.WebGLRenderingContext.enableVertexAttribArray
 ---
 <div>{{APIRef("WebGL")}}</div>
@@ -31,7 +31,7 @@ browser-compat: api.WebGLRenderingContext.enableVertexAttribArray
 </div>
 
 <p>In WebGL, values that apply to a specific vertex are stored in <a
-    href="/en-US/docs/Web/API/WebGL_API/Data#Attributes">attributes</a>. These are only
+    href="/en-US/docs/Web/API/WebGL_API/Data#attributes">attributes</a>. These are only
   available to the JavaScript code and the vertex shader. Attributes are referenced by an
   index number into the list of attributes maintained by the GPU. Some vertex attribute
   indices may have predefined purposes, depending on the platform and/or the GPU. Others
@@ -54,7 +54,7 @@ browser-compat: api.WebGLRenderingContext.enableVertexAttribArray
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index number that uniquely identifies the
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index number that uniquely identifies the
     vertex attribute to enable. If you know the name of the attribute but not its index,
     you can get the index by calling {{domxref("WebGLRenderingContext.getAttribLocation",
     "getAttribLocation()")}}.</dd>
@@ -97,7 +97,7 @@ gl.drawArrays(gl.TRIANGLES, 0, vertexCount);</pre>
 
 <div class="notecard note">
   <p><strong>Note:</strong> This code snippet is taken from <a
-    href="/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#Drawing_and_animating_the_scene">the
+    href="/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene">the
     function <code>animateScene()</code></a> in "A basic 2D WebGL animation example." See
   that article for the full sample and to see the resulting animation in action.</p>
 </div>

--- a/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.framebufferRenderbuffer
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) for the framebuffer.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) for the framebuffer.
     Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
@@ -42,7 +42,7 @@ browser-compat: api.WebGLRenderingContext.framebufferRenderbuffer
     </ul>
   </dd>
   <dt>attachment</dt>
-  <dd>A {{domxref("GLenum")}} specifying the attachment point for the render buffer.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the attachment point for the render buffer.
     Possible values:
     <ul>
       <li><code>gl.COLOR_ATTACHMENT0</code>: color buffer.</li>
@@ -94,7 +94,7 @@ browser-compat: api.WebGLRenderingContext.framebufferRenderbuffer
     </ul>
   </dd>
   <dt>renderbuffertarget</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) for the render buffer.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) for the render buffer.
     Possible values:
     <ul>
       <li><code>gl.RENDERBUFFER</code>: Buffer data storage for single images in a

--- a/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.framebufferTexture2D
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>
@@ -44,7 +44,7 @@ browser-compat: api.WebGLRenderingContext.framebufferTexture2D
     </ul>
   </dd>
   <dt>attachment</dt>
-  <dd>A {{domxref("GLenum")}} specifying the attachment point for the
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the attachment point for the
     <code>texture</code>. Possible values:
     <ul>
       <li><code>gl.COLOR_ATTACHMENT0</code>: Attaches the texture to the framebuffer's
@@ -105,7 +105,7 @@ browser-compat: api.WebGLRenderingContext.framebufferTexture2D
     </ul>
   </dd>
   <dt>textarget</dt>
-  <dd>A {{domxref("GLenum")}} specifying the texture target. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture target. Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A 2D image.</li>
       <li><code>gl.TEXTURE_CUBE_MAP_POSITIVE_X</code>: Image for the positive X face of
@@ -125,7 +125,7 @@ browser-compat: api.WebGLRenderingContext.framebufferTexture2D
   <dt>texture</dt>
   <dd>A {{domxref("WebGLTexture")}} object whose image to attach.</dd>
   <dt>level</dt>
-  <dd>A {{domxref("GLint")}} specifying the mipmap level of the texture image to be
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the mipmap level of the texture image to be
     attached. Must be 0.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.html
@@ -30,7 +30,7 @@ browser-compat: api.WebGLRenderingContext.generateMipmap
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture
     whose mipmaps will be generated. Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>

--- a/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.html
@@ -14,7 +14,7 @@ browser-compat: api.WebGLRenderingContext.getActiveAttrib
 <p>The <strong><code>WebGLRenderingContext.getActiveAttrib()</code></strong> method of the
   <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> returns a
   {{domxref("WebGLActiveInfo")}} object containing size, type, and name of a vertex
-  attribute. It is generally used when querying unknown attributes either for debugging or
+  attribute. It is generally used when querying unknown attributes either for debugging or
   generic library creation.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -28,9 +28,9 @@ browser-compat: api.WebGLRenderingContext.getActiveAttrib
   <dt>program</dt>
   <dd>A {{domxref("WebGLProgram")}} containing the vertex attribute.</dd>
   <dt>index</dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the vertex attribute to get. This
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute to get. This
     value is an index 0 to N - 1 as returned
-    by {{domxref("WebGLRenderingContext.getProgramParameter",
+    by {{domxref("WebGLRenderingContext.getProgramParameter",
     "gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES)")}}.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.html
@@ -29,9 +29,9 @@ browser-compat: api.WebGLRenderingContext.getActiveUniform
   <dd>A {{domxref("WebGLProgram")}} specifying the WebGL shader program from which to
     obtain the uniform variable's information.</dd>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the uniform attribute to get. This
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the uniform attribute to get. This
     value is an index 0 to N - 1 as returned
-    by {{domxref("WebGLRenderingContext.getProgramParameter",
+    by {{domxref("WebGLRenderingContext.getProgramParameter",
     "gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS)")}}.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.html
@@ -32,7 +32,7 @@ browser-compat: api.WebGLRenderingContext.getAttribLocation
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLint")}} number indicating the location of the variable name if found.
+<p>A {{domxref("WebGL_API/Types", "GLint")}} number indicating the location of the variable name if found.
   Returns -1 otherwise.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.getBufferParameter
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("Glenum")}} specifying the target buffer object. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target buffer object. Possible values:
     <ul>
       <li><code>gl.ARRAY_BUFFER</code>: Buffer containing vertex attributes, such as
         vertex coordinates, texture coordinate data, or vertex color data.</li>
@@ -48,11 +48,11 @@ browser-compat: api.WebGLRenderingContext.getBufferParameter
     </ul>
   </dd>
   <dt>pname</dt>
-  <dd>A {{domxref("Glenum")}} specifying information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying information to query. Possible values:
     <ul>
-      <li><code>gl.BUFFER_SIZE</code>: Returns a {{domxref("GLint")}} indicating the size
+      <li><code>gl.BUFFER_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} indicating the size
         of the buffer in bytes.</li>
-      <li><code>gl.BUFFER_USAGE</code>: Returns a {{domxref("GLenum")}} indicating the
+      <li><code>gl.BUFFER_USAGE</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating the
         usage pattern of the buffer. This is either:
         <ul>
           <li><code>gl.STATIC_DRAW</code>,</li>
@@ -78,7 +78,7 @@ browser-compat: api.WebGLRenderingContext.getBufferParameter
 <h3 id="Return_value">Return value</h3>
 
 <p>Depends on the requested information (as specified with <code>pname</code>). Either a
-  {{domxref("GLint")}} or a {{domxref("GLenum")}}.</p>
+  {{domxref("WebGL_API/Types", "GLint")}} or a {{domxref("WebGL_API/Types", "GLenum")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER</code>: Collection buffer data storage of color, alpha,
         depth and stencil buffers used to render an image.</li>
@@ -42,7 +42,7 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
     </ul>
   </dd>
   <dt>attachment</dt>
-  <dd>A {{domxref("GLenum")}} specifying the attachment point for the
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the attachment point for the
     <code>texture</code>. Possible values:
     <ul>
       <li><code>gl.COLOR_ATTACHMENT0</code>: Texture attachment for the framebuffer's
@@ -98,7 +98,7 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
     </ul>
   </dd>
   <dt>pname</dt>
-  <dd>A {{domxref("GLenum")}} specifying information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying information to query. Possible values:
     <ul>
       <li><code>gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE</code>: The type which contains the
         attached image.</li>
@@ -144,7 +144,7 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
 <h3 id="Return_value">Return value</h3>
 
 <p>Depends on the requested information (as specified with <code>pname</code>). Either a
-  {{domxref("GLint")}}, a {{domxref("GLenum")}}, a {{domxref("WebGLRenderbuffer")}}, or a
+  {{domxref("WebGL_API/Types", "GLint")}}, a {{domxref("WebGL_API/Types", "GLenum")}}, a {{domxref("WebGLRenderbuffer")}}, or a
   {{domxref("WebGLTexture")}}.</p>
 
 <table class="standard-table">
@@ -157,7 +157,7 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
   <tbody>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE</code></td>
-      <td>A {{domxref("GLenum")}} indicating the type of the texture. Either
+      <td>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the type of the texture. Either
         <code>gl.RENDERBUFFER</code>, <code>gl.TEXTURE</code>, or if no image is attached,
         <code>gl.NONE</code>.</td>
     </tr>
@@ -168,11 +168,11 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL</code></td>
-      <td>A {{domxref("GLint")}} indicating the mipmap level. Default value: 0.</td>
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the mipmap level. Default value: 0.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE</code></td>
-      <td>A {{domxref("GLenum")}} indicating the name of cube-map face of the texture.
+      <td>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the name of cube-map face of the texture.
         Possible values:
         <ul>
           <li><code>gl.TEXTURE_CUBE_MAP_POSITIVE_X</code>: Image for the positive X face
@@ -192,64 +192,64 @@ browser-compat: api.WebGLRenderingContext.getFramebufferAttachmentParameter
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of bits in the alpha component of
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits in the alpha component of
         the attachment.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of bits in the blue component of
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits in the blue component of
         the attachment.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code></td>
-      <td>A {{domxref("GLenum")}} indicating the encoding of components of the specified
+      <td>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the encoding of components of the specified
         attachment. Either <code>gl.LINEAR</code> or <code>gl.SRGB</code>.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE</code></td>
-      <td>A {{domxref("GLenum")}} indicating the format of the components of the specified
+      <td>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the format of the components of the specified
         attachment. Either <code>gl.FLOAT</code>, <code>gl.INT</code>,
         <code>gl.UNSIGNED_INT</code>, <code>gl.SIGNED_NORMALIZED</code>, or
         <code>gl.UNSIGNED_NORMALIZED</code>.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of bits in the depth component of
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits in the depth component of
         the attachment.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_GREEN_SIZE</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of bits in the green component of
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits in the green component of
         the attachment.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_RED_SIZE</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of bits in the red component of the
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits in the red component of the
         attachment.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of bits in the stencil component of
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of bits in the stencil component of
         the attachment.</td>
     </tr>
     <tr>
       <td><code>gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER</code></td>
-      <td>A {{domxref("GLint")}} indicating the number of the texture layer which contains
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the number of the texture layer which contains
         the attached image.</td>
     </tr>
     <tr>
       <td><code>ext.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT</code></td>
-      <td>A {{domxref("GLenum")}} indicating the framebuffer color encoding. Either
+      <td>A {{domxref("WebGL_API/Types", "GLenum")}} indicating the framebuffer color encoding. Either
         <code>gl.LINEAR</code> or <code>ext.SRGB_EXT</code>.</td>
     </tr>
     <tr>
       <td><code>ext.FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR</code></td>
-      <td>A {{domxref("GLsizei")}} indicating the number of views of the framebuffer
+      <td>A {{domxref("WebGL_API/Types", "GLsizei")}} indicating the number of views of the framebuffer
         object attachment.</td>
     </tr>
     <tr>
       <td><code>ext.FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR</code></td>
-      <td>A {{domxref("GLint")}} indicating the base view index of the framebuffer object
+      <td>A {{domxref("WebGL_API/Types", "GLint")}} indicating the base view index of the framebuffer object
         attachment.</td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.html
@@ -24,7 +24,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
 
 <dl>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying which parameter value to return. See below for
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which parameter value to return. See below for
     possible values.</dd>
 </dl>
 
@@ -50,7 +50,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
   <tbody>
     <tr>
       <td><code>gl.ACTIVE_TEXTURE</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -65,7 +65,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.ALPHA_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -75,7 +75,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.BLEND</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -85,42 +85,42 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.BLEND_DST_ALPHA</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLEND_DST_RGB</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLEND_EQUATION</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLEND_EQUATION_ALPHA</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLEND_EQUATION_RGB</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLEND_SRC_ALPHA</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLEND_SRC_RGB</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.BLUE_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -130,7 +130,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.COLOR_WRITEMASK</code></td>
-      <td>sequence&lt;{{domxref("GLboolean")}}&gt; (with 4 values)</td>
+      <td>sequence&lt;{{domxref("WebGL_API/Types", "GLboolean")}}&gt; (with 4 values)</td>
       <td></td>
     </tr>
     <tr>
@@ -217,12 +217,12 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.CULL_FACE</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.CULL_FACE_MODE</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td><code>gl.FRONT</code>, <code>gl.BACK</code> or <code>gl.FRONT_AND_BACK</code>.
         See also {{domxref("WebGLRenderingContext/cullFace", "cullFace")}}</td>
     </tr>
@@ -233,17 +233,17 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.DEPTH_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.DEPTH_CLEAR_VALUE</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.DEPTH_FUNC</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -253,17 +253,17 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.DEPTH_TEST</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.DEPTH_WRITEMASK</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.DITHER</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -279,84 +279,84 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.FRONT_FACE</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td><code>gl.CW</code> or <code>gl.CCW</code>. See also
         {{domxref("WebGLRenderingContext/frontFace", "frontFace")}}.</td>
     </tr>
     <tr>
       <td><code>gl.GENERATE_MIPMAP_HINT</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td><code>gl.FASTEST</code>, <code>gl.NICEST</code> or <code>gl.DONT_CARE</code>.
         See also {{domxref("WebGLRenderingContext/hint", "hint")}}.</td>
     </tr>
     <tr>
       <td><code>gl.GREEN_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.IMPLEMENTATION_COLOR_READ_FORMAT</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.IMPLEMENTATION_COLOR_READ_TYPE</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.LINE_WIDTH</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_CUBE_MAP_TEXTURE_SIZE</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_FRAGMENT_UNIFORM_VECTORS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_RENDERBUFFER_SIZE</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_TEXTURE_IMAGE_UNITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_TEXTURE_SIZE</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VARYING_VECTORS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VERTEX_ATTRIBS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VERTEX_UNIFORM_VECTORS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -366,27 +366,27 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.PACK_ALIGNMENT</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.POLYGON_OFFSET_FACTOR</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.POLYGON_OFFSET_FILL</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.POLYGON_OFFSET_UNITS</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.RED_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -402,22 +402,22 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.SAMPLE_BUFFERS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.SAMPLE_COVERAGE_INVERT</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.SAMPLE_COVERAGE_VALUE</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.SAMPLES</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -427,7 +427,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.SCISSOR_TEST</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -437,92 +437,92 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_FAIL</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_FUNC</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_PASS_DEPTH_FAIL</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_PASS_DEPTH_PASS</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_REF</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_VALUE_MASK</code></td>
-      <td>{{domxref("GLuint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLuint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BACK_WRITEMASK</code></td>
-      <td>{{domxref("GLuint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLuint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_CLEAR_VALUE</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_FAIL</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_FUNC</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_PASS_DEPTH_FAIL</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_PASS_DEPTH_PASS</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_REF</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_TEST</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_VALUE_MASK</code></td>
-      <td>{{domxref("GLuint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLuint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.STENCIL_WRITEMASK</code></td>
-      <td>{{domxref("GLuint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLuint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.SUBPIXEL_BITS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -537,22 +537,22 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.UNPACK_ALIGNMENT</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_COLORSPACE_CONVERSION_WEBGL</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_FLIP_Y_WEBGL</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -599,7 +599,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.DRAW_BUFFER<em>i</em></code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td><code>gl.BACK</code>, <code>gl.NONE</code> or
         <code>gl.COLOR_ATTACHMENT{0-15}</code>. See also
         {{domxref("WebGL2RenderingContext/drawBuffers", "drawBuffers")}}.</td>
@@ -612,163 +612,163 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.FRAGMENT_SHADER_DERIVATIVE_HINT</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td><code>gl.FASTEST</code>, <code>gl.NICEST</code> or <code>gl.DONT_CARE</code>.
         See also {{domxref("WebGLRenderingContext/hint", "hint")}}.</td>
     </tr>
     <tr>
       <td><code>gl.MAX_3D_TEXTURE_SIZE</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_ARRAY_TEXTURE_LAYERS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_CLIENT_WAIT_TIMEOUT_WEBGL</code></td>
-      <td>{{domxref("GLint64")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint64")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_COLOR_ATTACHMENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS</code></td>
-      <td>{{domxref("GLint64")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint64")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_COMBINED_UNIFORM_BLOCKS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS</code></td>
-      <td>{{domxref("GLint64")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint64")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_DRAW_BUFFERS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_ELEMENT_INDEX</code></td>
-      <td>{{domxref("GLint64")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint64")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_ELEMENTS_INDICES</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_ELEMENTS_VERTICES</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_FRAGMENT_INPUT_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_FRAGMENT_UNIFORM_BLOCKS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_FRAGMENT_UNIFORM_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_PROGRAM_TEXEL_OFFSET</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_SAMPLES</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_SERVER_WAIT_TIMEOUT</code></td>
-      <td>{{domxref("GLint64")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint64")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_TEXTURE_LOD_BIAS</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_UNIFORM_BLOCK_SIZE</code></td>
-      <td>{{domxref("GLint64")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint64")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_UNIFORM_BUFFER_BINDINGS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VARYING_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VERTEX_OUTPUT_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VERTEX_UNIFORM_BLOCKS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MAX_VERTEX_UNIFORM_COMPONENTS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.MIN_PROGRAM_TEXEL_OFFSET</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.PACK_ROW_LENGTH</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.PACK_SKIP_PIXELS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.PACK_SKIP_ROWS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
@@ -783,12 +783,12 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.RASTERIZER_DISCARD</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.READ_BUFFER</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -799,12 +799,12 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.SAMPLE_ALPHA_TO_COVERAGE</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.SAMPLE_COVERAGE</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -824,7 +824,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.TRANSFORM_FEEDBACK_ACTIVE</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -840,7 +840,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.TRANSFORM_FEEDBACK_PAUSED</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td></td>
     </tr>
     <tr>
@@ -850,32 +850,32 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_IMAGE_HEIGHT</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_ROW_LENGTH</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_SKIP_IMAGES</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_SKIP_PIXELS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
       <td><code>gl.UNPACK_SKIP_ROWS</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>See {{domxref("WebGLRenderingContext/pixelStorei", "pixelStorei")}}.</td>
     </tr>
     <tr>
@@ -904,26 +904,26 @@ browser-compat: api.WebGLRenderingContext.getParameter
   <tbody>
     <tr>
       <td><code>ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
       <td>{{domxref("EXT_texture_filter_anisotropic")}}</td>
       <td>Maximum available anisotropy.</td>
     </tr>
     <tr>
       <td><code>ext.FRAGMENT_SHADER_DERIVATIVE_HINT_OES</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td>{{domxref("OES_standard_derivatives")}}</td>
       <td>Accuracy of the derivative calculation for the GLSL built-in functions:
         <code>dFdx</code>, <code>dFdy</code>, and <code>fwidth</code>.</td>
     </tr>
     <tr>
       <td><code>ext.MAX_COLOR_ATTACHMENTS_WEBGL</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>{{domxref("WEBGL_draw_buffers")}}</td>
       <td>The maximum number of framebuffer color attachment points.</td>
     </tr>
     <tr>
       <td><code>ext.MAX_DRAW_BUFFERS_WEBGL</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>{{domxref("WEBGL_draw_buffers")}}</td>
       <td>The maximum number of draw buffers.</td>
     </tr>
@@ -944,19 +944,19 @@ browser-compat: api.WebGLRenderingContext.getParameter
     ext.DRAW_BUFFER13_WEBGL<br>
     ext.DRAW_BUFFER14_WEBGL<br>
     ext.DRAW_BUFFER15_WEBGL</code></td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td>{{domxref("WEBGL_draw_buffers")}}</td>
       <td>Drawing buffers.</td>
     </tr>
     <tr>
       <td><code>ext.VERTEX_ARRAY_BINDING_OES</code></td>
-      <td>{{domxref("WebGLVertexArrayObjectOES")}}</td>
+      <td>{{domxref("WebGLVertexArrayObject", "WebGLVertexArrayObjectOES")}}</td>
       <td>{{domxref("OES_vertex_array_object")}}</td>
       <td>Bound vertex array object (VAO).</td>
     </tr>
     <tr>
       <td><code>ext.TIMESTAMP_EXT</code></td>
-      <td>{{domxref("GLuint64EXT")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLuint64EXT")}}</td>
       <td>
         <p>{{domxref("EXT_disjoint_timer_query")}}</p>
       </td>
@@ -964,7 +964,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>ext.GPU_DISJOINT_EXT</code></td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td>{{domxref("EXT_disjoint_timer_query")}}</td>
       <td>
         <p>Returns whether or not the GPU performed any disjoint operation.</p>
@@ -972,7 +972,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
     </tr>
     <tr>
       <td><code>ext.MAX_VIEWS_OVR</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>{{domxref("OVR_multiview2")}}</td>
       <td>Maximum number of views.</td>
     </tr>

--- a/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.html
@@ -27,31 +27,31 @@ browser-compat: api.WebGLRenderingContext.getProgramParameter
   <dt>program</dt>
   <dd>A {{domxref("WebGLProgram")}} to get parameter information from.</dd>
   <dt>pname</dt>
-  <dd>A {{domxref("Glenum")}} specifying the information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the information to query. Possible values:
     <ul>
-      <li><code>gl.DELETE_STATUS</code>: Returns a {{domxref("GLboolean")}} indicating
+      <li><code>gl.DELETE_STATUS</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}} indicating
         whether or not the program is flagged for deletion.</li>
-      <li><code>gl.LINK_STATUS</code>: Returns a {{domxref("GLboolean")}} indicating
+      <li><code>gl.LINK_STATUS</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}} indicating
         whether or not the last link operation was successful.</li>
-      <li><code>gl.VALIDATE_STATUS</code>: Returns a {{domxref("GLboolean")}} indicating
+      <li><code>gl.VALIDATE_STATUS</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}} indicating
         whether or not the last validation operation was successful.</li>
-      <li><code>gl.ATTACHED_SHADERS</code>: Returns a {{domxref("GLint")}} indicating the
+      <li><code>gl.ATTACHED_SHADERS</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} indicating the
         number of attached shaders to a program.</li>
-      <li><code>gl.ACTIVE_ATTRIBUTES</code>: Returns a {{domxref("GLint")}} indicating the
+      <li><code>gl.ACTIVE_ATTRIBUTES</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} indicating the
         number of active attribute variables to a program.</li>
-      <li><code>gl.ACTIVE_UNIFORMS</code>: Returns a {{domxref("GLint")}} indicating the
+      <li><code>gl.ACTIVE_UNIFORMS</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} indicating the
         number of active uniform variables to a program.</li>
       <li>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
         the following values are available additionally:
         <ul>
           <li><code>gl.TRANSFORM_FEEDBACK_BUFFER_MODE</code>: Returns a
-            {{domxref("GLenum")}} indicating the buffer mode when transform feedback is
+            {{domxref("WebGL_API/Types", "GLenum")}} indicating the buffer mode when transform feedback is
             active. May be <code>gl.SEPARATE_ATTRIBS</code> or
             <code>gl.INTERLEAVED_ATTRIBS</code>.</li>
-          <li><code>gl.TRANSFORM_FEEDBACK_VARYINGS</code>: Returns a {{domxref("GLint")}}
+          <li><code>gl.TRANSFORM_FEEDBACK_VARYINGS</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}}
             indicating the number of varying variables to capture in transform feedback
             mode.</li>
-          <li><code>gl.ACTIVE_UNIFORM_BLOCKS</code>: Returns a {{domxref("GLint")}}
+          <li><code>gl.ACTIVE_UNIFORM_BLOCKS</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}}
             indicating the number of uniform blocks containing active uniforms.</li>
         </ul>
       </li>

--- a/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.html
@@ -24,20 +24,20 @@ browser-compat: api.WebGLRenderingContext.getRenderbufferParameter
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("Glenum")}} specifying the target renderbuffer object. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target renderbuffer object. Possible values:
     <ul>
       <li><code>gl.RENDERBUFFER</code>: Buffer data storage for single images in a
         renderable internal format.</li>
     </ul>
   </dd>
   <dt>pname</dt>
-  <dd>A {{domxref("Glenum")}} specifying the information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the information to query. Possible values:
     <ul>
-      <li><code>gl.RENDERBUFFER_WIDTH</code>: Returns a {{domxref("GLint")}} indicating
+      <li><code>gl.RENDERBUFFER_WIDTH</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} indicating
         the width of the image of the currently bound renderbuffer.</li>
-      <li><code>gl.RENDERBUFFER_HEIGHT</code>: Returns a {{domxref("GLint")}} indicating
+      <li><code>gl.RENDERBUFFER_HEIGHT</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} indicating
         the height of the image of the currently bound renderbuffer.</li>
-      <li><code>gl.RENDERBUFFER_INTERNAL_FORMAT</code>: Returns a {{domxref("GLenum")}}
+      <li><code>gl.RENDERBUFFER_INTERNAL_FORMAT</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}}
         indicating the internal format of the currently bound renderbuffer. The default is
         <code>gl.RGBA4</code>. Possible return values:
         <ul>
@@ -50,22 +50,22 @@ browser-compat: api.WebGLRenderingContext.getRenderbufferParameter
           <li><code>gl.STENCIL_INDEX8</code>: 8 stencil bits.</li>
         </ul>
       </li>
-      <li><code>gl.RENDERBUFFER_GREEN_SIZE</code>: Returns a {{domxref("GLint")}} that is
+      <li><code>gl.RENDERBUFFER_GREEN_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} that is
         the resolution size (in bits) for the green color.</li>
-      <li><code>gl.RENDERBUFFER_BLUE_SIZE</code>: Returns a {{domxref("GLint")}} that is
+      <li><code>gl.RENDERBUFFER_BLUE_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} that is
         the resolution size (in bits) for the blue color.</li>
-      <li><code>gl.RENDERBUFFER_RED_SIZE</code>: Returns a {{domxref("GLint")}} that is
+      <li><code>gl.RENDERBUFFER_RED_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} that is
         the resolution size (in bits) for the red color.</li>
-      <li><code>gl.RENDERBUFFER_ALPHA_SIZE</code>: Returns a {{domxref("GLint")}} that is
+      <li><code>gl.RENDERBUFFER_ALPHA_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} that is
         the resolution size (in bits) for the alpha component.</li>
-      <li><code>gl.RENDERBUFFER_DEPTH_SIZE</code>: Returns a {{domxref("GLint")}} that is
+      <li><code>gl.RENDERBUFFER_DEPTH_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} that is
         the resolution size (in bits) for the depth component.</li>
-      <li><code>gl.RENDERBUFFER_STENCIL_SIZE</code>: Returns a {{domxref("GLint")}} that
+      <li><code>gl.RENDERBUFFER_STENCIL_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}} that
         is the resolution size (in bits) for the stencil component.</li>
       <li>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
         the following value is available additionally:
         <ul>
-          <li><code>gl.RENDERBUFFER_SAMPLES</code>: Returns a {{domxref("GLint")}}
+          <li><code>gl.RENDERBUFFER_SAMPLES</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}}
             indicating the number of samples of the image of the currently bound
             renderbuffer.</li>
         </ul>
@@ -77,7 +77,7 @@ browser-compat: api.WebGLRenderingContext.getRenderbufferParameter
 <h3 id="Return_value">Return value</h3>
 
 <p>Depends on the requested information (as specified with <code>pname</code>). Either a
-  {{domxref("GLint")}} or a {{domxref("GLenum")}}.</p>
+  {{domxref("WebGL_API/Types", "GLint")}} or a {{domxref("WebGL_API/Types", "GLenum")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.html
@@ -26,13 +26,13 @@ browser-compat: api.WebGLRenderingContext.getShaderParameter
   <dt>shader</dt>
   <dd>A {{domxref("WebGLShader")}} to get parameter information from.</dd>
   <dt>pname</dt>
-  <dd>A {{domxref("GLenum")}} specifying the information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the information to query. Possible values:
     <ul>
-      <li><code>gl.DELETE_STATUS</code>: Returns a {{domxref("GLboolean")}} indicating
+      <li><code>gl.DELETE_STATUS</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}} indicating
         whether or not the shader is flagged for deletion.</li>
-      <li><code>gl.COMPILE_STATUS</code>: Returns a {{domxref("GLboolean")}} indicating
+      <li><code>gl.COMPILE_STATUS</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}} indicating
         whether or not the last shader compilation was successful.</li>
-      <li><code>gl.SHADER_TYPE</code>: Returns a {{domxref("GLenum")}} indicating whether
+      <li><code>gl.SHADER_TYPE</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}} indicating whether
         the shader is a vertex shader (<code>gl.VERTEX_SHADER</code>) or fragment shader
         (<code>gl.FRAGMENT_SHADER</code>) object.</li>
     </ul>

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
       <li><code>gl.TEXTURE_CUBE_MAP</code>: A cube-mapped texture.</li>
@@ -39,7 +39,7 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
     </ul>
   </dd>
   <dt>pname</dt>
-  <dd>A {{domxref("Glenum")}} specifying the information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the information to query. Possible values:
     <table class="standard-table">
       <thead>
         <tr>
@@ -55,13 +55,13 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
         </tr>
         <tr>
           <td><code>gl.TEXTURE_MAG_FILTER</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Texture magnification filter</td>
           <td><code>gl.LINEAR</code> (default value), <code>gl.NEAREST</code>.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_MIN_FILTER</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Texture minification filter</td>
           <td><code>gl.LINEAR</code>, <code>gl.NEAREST</code>,
             <code>gl.NEAREST_MIPMAP_NEAREST</code>, <code>gl.LINEAR_MIPMAP_NEAREST</code>,
@@ -70,14 +70,14 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
         </tr>
         <tr>
           <td><code>gl.TEXTURE_WRAP_S</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Wrapping function for texture coordinate <code>s</code></td>
           <td><code>gl.REPEAT</code> (default value), <code>gl.CLAMP_TO_EDGE</code>,
             <code>gl.MIRRORED_REPEAT</code>.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_WRAP_T</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Wrapping function for texture coordinate <code>t</code></td>
           <td><code>gl.REPEAT</code> (default value), <code>gl.CLAMP_TO_EDGE</code>,
             <code>gl.MIRRORED_REPEAT</code>.</td>
@@ -88,7 +88,7 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
         </tr>
         <tr>
           <td><code>ext.TEXTURE_MAX_ANISOTROPY_EXT</code></td>
-          <td>{{domxref("GLfloat")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
           <td>Maximum anisotropy for a texture</td>
           <td>Any float values.</td>
         </tr>
@@ -97,13 +97,13 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
         </tr>
         <tr>
           <td><code>gl.TEXTURE_BASE_LEVEL</code></td>
-          <td>{{domxref("GLint")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
           <td>Texture mipmap level</td>
           <td>Any int values.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_COMPARE_FUNC</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Comparison function</td>
           <td><code>gl.LEQUAL</code> (default value), <code>gl.GEQUAL</code>,
             <code>gl.LESS</code>, <code>gl.GREATER</code>, <code>gl.EQUAL</code>,
@@ -111,44 +111,44 @@ browser-compat: api.WebGLRenderingContext.getTexParameter
         </tr>
         <tr>
           <td><code>gl.TEXTURE_COMPARE_MODE</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Texture comparison mode</td>
           <td><code>gl.NONE</code> (default value),
             <code>gl.COMPARE_REF_TO_TEXTURE</code>.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_IMMUTABLE_FORMAT</code></td>
-          <td>{{domxref("GLboolean")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
           <td>Immutability of the texture format and size</td>
           <td>true or false.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_IMMUTABLE_LEVELS</code></td>
-          <td>{{domxref("GLuint")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLuint")}}</td>
           <td>?</td>
           <td>Any uint values.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_MAX_LEVEL</code></td>
-          <td>{{domxref("GLint")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
           <td>Maximum texture mipmap array level</td>
           <td>Any int values.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_MAX_LOD</code></td>
-          <td>{{domxref("GLfloat")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
           <td>Texture maximum level-of-detail value</td>
           <td>Any float values.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_MIN_LOD</code></td>
-          <td>{{domxref("GLfloat")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
           <td>Texture minimum level-of-detail value</td>
           <td>Any float values.</td>
         </tr>
         <tr>
           <td><code>gl.TEXTURE_WRAP_R</code></td>
-          <td>{{domxref("GLenum")}}</td>
+          <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
           <td>Wrapping function for texture coordinate <code>r</code></td>
           <td><code>gl.REPEAT</code> (default value), <code>gl.CLAMP_TO_EDGE</code>,
             <code>gl.MIRRORED_REPEAT</code>.</td>

--- a/files/en-us/web/api/webglrenderingcontext/getuniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getuniform/index.html
@@ -47,15 +47,15 @@ browser-compat: api.WebGLRenderingContext.getUniform
     </tr>
     <tr>
       <td><code>boolean</code></td>
-      <td>{{domxref("GLBoolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLBoolean")}}</td>
     </tr>
     <tr>
       <td><code>int</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
     </tr>
     <tr>
       <td><code>float</code></td>
-      <td>{{domxref("GLfloat")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLfloat")}}</td>
     </tr>
     <tr>
       <td><code>vec2</code></td>
@@ -67,7 +67,7 @@ browser-compat: api.WebGLRenderingContext.getUniform
     </tr>
     <tr>
       <td><code>bvec2</code></td>
-      <td>{{jsxref("Array")}} of {{domxref("GLBoolean")}} (with 2 elements)</td>
+      <td>{{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLBoolean")}} (with 2 elements)</td>
     </tr>
     <tr>
       <td><code>vec3</code></td>
@@ -79,7 +79,7 @@ browser-compat: api.WebGLRenderingContext.getUniform
     </tr>
     <tr>
       <td><code>bvec3</code></td>
-      <td>{{jsxref("Array")}} of {{domxref("GLBoolean")}} (with 3 elements)</td>
+      <td>{{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLBoolean")}} (with 3 elements)</td>
     </tr>
     <tr>
       <td><code>vec4</code></td>
@@ -91,7 +91,7 @@ browser-compat: api.WebGLRenderingContext.getUniform
     </tr>
     <tr>
       <td><code>bvec4</code></td>
-      <td>{{jsxref("Array")}} of {{domxref("GLBoolean")}} (with 4 elements)</td>
+      <td>{{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLBoolean")}} (with 4 elements)</td>
     </tr>
     <tr>
       <td><code>mat2</code></td>
@@ -107,18 +107,18 @@ browser-compat: api.WebGLRenderingContext.getUniform
     </tr>
     <tr>
       <td><code>sampler2D</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
     </tr>
     <tr>
       <td><code>samplerCube</code></td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
     </tr>
     <tr>
       <th colspan="2">Additionally available in WebGL 2</th>
     </tr>
     <tr>
       <td><code>uint</code></td>
-      <td>{{domxref("GLuint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLuint")}}</td>
     </tr>
     <tr>
       <td><code>uvec2</code></td>
@@ -158,7 +158,7 @@ browser-compat: api.WebGLRenderingContext.getUniform
     </tr>
     <tr>
       <td>any sampler type</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.html
@@ -24,21 +24,21 @@ browser-compat: api.WebGLRenderingContext.getVertexAttrib
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the vertex attribute.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute.</dd>
   <dt><code>pname</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the information to query. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the information to query. Possible values:
     <ul>
       <li><code>gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING</code>: Returns the currently bound
         {{domxref("WebGLBuffer")}}.</li>
-      <li><code>gl.VERTEX_ATTRIB_ARRAY_ENABLED</code>: Returns a {{domxref("GLboolean")}}
+      <li><code>gl.VERTEX_ATTRIB_ARRAY_ENABLED</code>: Returns a {{domxref("WebGL_API/Types", "GLboolean")}}
         that is <code>true</code> if the vertex attribute is enabled at this
         <code>index</code>. Otherwise <code>false</code>.</li>
-      <li><code>gl.VERTEX_ATTRIB_ARRAY_SIZE</code>: Returns a {{domxref("GLint")}}
+      <li><code>gl.VERTEX_ATTRIB_ARRAY_SIZE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}}
         indicating the size of an element of the vertex array.</li>
-      <li><code>gl.VERTEX_ATTRIB_ARRAY_STRIDE</code>: Returns a {{domxref("GLint")}}
+      <li><code>gl.VERTEX_ATTRIB_ARRAY_STRIDE</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}}
         indicating the number of bytes between successive elements in the array. 0 means
         that the elements are sequential.</li>
-      <li><code>gl.VERTEX_ATTRIB_ARRAY_TYPE</code>: Returns a {{domxref("GLenum")}}
+      <li><code>gl.VERTEX_ATTRIB_ARRAY_TYPE</code>: Returns a {{domxref("WebGL_API/Types", "GLenum")}}
         representing the array type. One of
         <ul>
           <li><code>gl.BYTE</code>,</li>
@@ -48,26 +48,26 @@ browser-compat: api.WebGLRenderingContext.getVertexAttrib
           <li><code>gl.FLOAT</code>.</li>
         </ul>
       </li>
-      <li><code>gl.VERTEX_ATTRIB_ARRAY_NORMALIZED</code>: Returns a
-        {{domxref("GLboolean")}} that is true if fixed-point data types are normalized for
+      <li><code>gl.VERTEX_ATTRIB_ARRAY_NORMALIZED</code>: Returns a
+        {{domxref("WebGL_API/Types", "GLboolean")}} that is true if fixed-point data types are normalized for
         the vertex attribute array at the given <code>index</code>.</li>
-      <li><code>gl.CURRENT_VERTEX_ATTRIB</code>: Returns a {{jsxref("Float32Array")}}
+      <li><code>gl.CURRENT_VERTEX_ATTRIB</code>: Returns a {{jsxref("Float32Array")}}
         (with 4 elements) representing the current value of the vertex attribute at the
         given <code>index</code>.</li>
       <li>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
         the following values are available additionally:
         <ul>
           <li><code>gl.VERTEX_ATTRIB_ARRAY_INTEGER</code>: Returns a
-            {{domxref("GLboolean")}} indicating whether or not an integer data type is in
+            {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not an integer data type is in
             the vertex attribute array at the given <code>index</code>.</li>
-          <li><code>gl.VERTEX_ATTRIB_ARRAY_DIVISOR</code>: Returns a {{domxref("GLint")}}
+          <li><code>gl.VERTEX_ATTRIB_ARRAY_DIVISOR</code>: Returns a {{domxref("WebGL_API/Types", "GLint")}}
             describing the frequency divisor used for instanced rendering.</li>
         </ul>
       </li>
       <li>When using the {{domxref("ANGLE_instanced_arrays")}} extension:
         <ul>
           <li><code>ext.VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE</code>: Returns a
-            {{domxref("GLint")}} describing the frequency divisor used for instanced
+            {{domxref("WebGL_API/Types", "GLint")}} describing the frequency divisor used for instanced
             rendering.</li>
         </ul>
       </li>

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.html
@@ -24,15 +24,15 @@ browser-compat: api.WebGLRenderingContext.getVertexAttribOffset
 
 <dl>
   <dt>index</dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the vertex attribute.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute.</dd>
   <dt>pname</dt>
-  <dd>A {{domxref("GLenum")}} which must be <code>gl.VERTEX_ATTRIB_ARRAY_POINTER</code>.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} which must be <code>gl.VERTEX_ATTRIB_ARRAY_POINTER</code>.
   </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLintptr")}} indicating the address of the vertex attribute.</p>
+<p>A {{domxref("WebGL_API/Types", "GLintptr")}} indicating the address of the vertex attribute.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/isbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isbuffer/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGLRenderingContext.isBuffer
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether or not the buffer is valid.</p>
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the buffer is valid.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/isenabled/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isenabled/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.isEnabled
 
 <dl>
   <dt><code>cap</code></dt>
-  <dd><p>A {{domxref("GLenum")}} specifying which WebGL capability to test. Possible values:</p>
+  <dd><p>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which WebGL capability to test. Possible values:</p>
     <table class="standard-table">
       <thead>
         <tr>
@@ -107,7 +107,7 @@ browser-compat: api.WebGLRenderingContext.isEnabled
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating if the capability <em>cap</em> is enabled
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating if the capability <em>cap</em> is enabled
   (<code>true</code>), or not (<code>false</code>).</p>
 
 <h2 id="Examples">Examples</h2>
@@ -117,7 +117,7 @@ browser-compat: api.WebGLRenderingContext.isEnabled
 </pre>
 
 <p>To activate or deactivate a specific capability, use the
-  {{domxref("WebGLRenderingContext.enable()")}} and 
+  {{domxref("WebGLRenderingContext.enable()")}} and
   {{domxref("WebGLRenderingContext.disable()")}} methods:</p>
 
 <pre class="brush: js">gl.enable(gl.STENCIL_TEST);

--- a/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGLRenderingContext.isFramebuffer
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether or not the frame buffer is valid.</p>
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the frame buffer is valid.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGLRenderingContext.isProgram
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether or not the program is valid.</p>
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the program is valid.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGLRenderingContext.isRenderbuffer
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether or not the renderbuffer is valid.</p>
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the renderbuffer is valid.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGLRenderingContext.isShader
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether or not the shader is valid.</p>
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the shader is valid.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/istexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/istexture/index.html
@@ -29,7 +29,7 @@ browser-compat: api.WebGLRenderingContext.isTexture
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("GLboolean")}} indicating whether or not the texture is valid.</p>
+<p>A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the texture is valid.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.html
@@ -36,7 +36,7 @@ browser-compat: api.WebGLRenderingContext.lineWidth
 
 <dl>
   <dt>width</dt>
-  <dd>A {{domxref("GLfloat")}} specifying the width of rasterized lines. Default value: 1.
+  <dd>A {{domxref("WebGL_API/Types", "GLfloat")}} specifying the width of rasterized lines. Default value: 1.
   </dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.html
@@ -24,10 +24,10 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
 
 <dl>
   <dt>pname</dt>
-  <dd>A {{domxref("Glenum")}} specifying which parameter to set. See below for possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying which parameter to set. See below for possible
     values.</dd>
   <dt>param</dt>
-  <dd>A {{domxref("GLint")}} specifying a value to set the <em><code>pname</code></em>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying a value to set the <em><code>pname</code></em>
     parameter to. See below for possible values.</dd>
 </dl>
 
@@ -52,7 +52,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.PACK_ALIGNMENT</code></td>
       <td>Packing of pixel data into memory</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>4</td>
       <td>1, 2, 4, 8</td>
       <td>OpenGL ES 2.0</td>
@@ -60,7 +60,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_ALIGNMENT</code></td>
       <td>Unpacking of pixel data from memory.</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>4</td>
       <td>1, 2, 4, 8</td>
       <td>OpenGL ES 2.0</td>
@@ -68,7 +68,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_FLIP_Y_WEBGL</code></td>
       <td>Flips the source data along its vertical axis if true.</td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td>false</td>
       <td>true, false</td>
       <td>WebGL</td>
@@ -76,7 +76,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL</code></td>
       <td>Multiplies the alpha channel into the other color channels</td>
-      <td>{{domxref("GLboolean")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLboolean")}}</td>
       <td>false</td>
       <td>true, false</td>
       <td>WebGL</td>
@@ -84,7 +84,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_COLORSPACE_CONVERSION_WEBGL</code></td>
       <td>Default color space conversion or no color space conversion.</td>
-      <td>{{domxref("GLenum")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLenum")}}</td>
       <td><code>gl.BROWSER_DEFAULT_WEBGL</code></td>
       <td><code>gl.BROWSER_DEFAULT_WEBGL</code>, <code>gl.NONE</code></td>
       <td>WebGL</td>
@@ -110,7 +110,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.PACK_ROW_LENGTH</code></td>
       <td>Number of pixels in a row.</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -119,7 +119,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
       <td><code>gl.PACK_SKIP_PIXELS</code></td>
       <td>Number of pixel locations skipped before the first pixel is written into memory.
       </td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -128,7 +128,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
       <td><code>gl.PACK_SKIP_ROWS</code></td>
       <td>Number of rows of pixel locations skipped before the first pixel is written into
         memory</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -136,7 +136,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_ROW_LENGTH</code></td>
       <td>Number of pixels in a row.</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -144,7 +144,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_IMAGE_HEIGHT</code></td>
       <td>Image height used for reading pixel data from memory</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -152,7 +152,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_SKIP_PIXELS</code></td>
       <td>Number of pixel images skipped before the first pixel is read from memory</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -161,7 +161,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
       <td><code>gl.UNPACK_SKIP_ROWS</code></td>
       <td>Number of rows of pixel locations skipped before the first pixel is read from
         memory</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>
@@ -169,7 +169,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
     <tr>
       <td><code>gl.UNPACK_SKIP_IMAGES</code></td>
       <td>Number of pixel images skipped before the first pixel is read from memory</td>
-      <td>{{domxref("GLint")}}</td>
+      <td>{{domxref("WebGL_API/Types", "GLint")}}</td>
       <td>0</td>
       <td>0 to <code>Infinity</code></td>
       <td>OpenGL ES 3.0</td>

--- a/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.html
@@ -27,10 +27,10 @@ browser-compat: api.WebGLRenderingContext.polygonOffset
 
 <dl>
   <dt>factor</dt>
-  <dd>A {{domxref("GLfloat")}} which sets the scale factor for the variable depth offset
+  <dd>A {{domxref("WebGL_API/Types", "GLfloat")}} which sets the scale factor for the variable depth offset
     for each polygon. The default value is 0.</dd>
   <dt>units</dt>
-  <dd>A {{domxref("GLfloat")}} which sets the multiplier by which an
+  <dd>A {{domxref("WebGL_API/Types", "GLfloat")}} which sets the multiplier by which an
     implementation-specific value is multiplied with to create a constant depth offset.
     The default value is 0.</dd>
 </dl>

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.html
@@ -30,17 +30,17 @@ void gl.readPixels(x, y, width, height, format, type, ArrayBufferView pixels, GL
 
 <dl>
   <dt>x</dt>
-  <dd>A {{domxref("GLint")}} specifying the first horizontal pixel that is read from the
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the first horizontal pixel that is read from the
     lower left corner of a rectangular block of pixels.</dd>
   <dt>y</dt>
-  <dd>A {{domxref("GLint")}} specifying the first vertical pixel that is read from the
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the first vertical pixel that is read from the
     lower left corner of a rectangular block of pixels.</dd>
   <dt>width</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the rectangle.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the rectangle.</dd>
   <dt>height</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the rectangle.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the rectangle.</dd>
   <dt>format</dt>
-  <dd>A {{domxref("GLenum")}} specifying the format of the pixel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the format of the pixel data. Possible values:
     <ul>
       <li><code>gl.ALPHA</code>: Discards the red, green and blue components and reads the
         alpha component.</li>
@@ -62,7 +62,7 @@ void gl.readPixels(x, y, width, height, format, type, ArrayBufferView pixels, GL
     </ul>
   </dd>
   <dt>type</dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of the pixel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of the pixel data. Possible values:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code></li>
       <li><code>gl.UNSIGNED_SHORT_5_6_5</code></li>

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.html
@@ -24,14 +24,14 @@ browser-compat: api.WebGLRenderingContext.renderbufferStorage
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("Glenum")}} specifying the target renderbuffer object. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the target renderbuffer object. Possible values:
     <ul>
       <li><code>gl.RENDERBUFFER</code>: Buffer data storage for single images in a
         renderable internal format.</li>
     </ul>
   </dd>
   <dt>internalFormat</dt>
-  <dd>A {{domxref("Glenum")}} specifying the internal format of the renderbuffer. Possible
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the internal format of the renderbuffer. Possible
     values:
     <ul>
       <li><code>gl.RGBA4</code>: 4 red bits, 4 green bits, 4 blue bits 4 alpha bits.</li>
@@ -102,9 +102,9 @@ browser-compat: api.WebGLRenderingContext.renderbufferStorage
     </ul>
   </dd>
   <dt>width</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the renderbuffer in pixels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the renderbuffer in pixels.</dd>
   <dt>height</dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the renderbuffer in pixels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the renderbuffer in pixels.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.html
@@ -24,10 +24,10 @@ browser-compat: api.WebGLRenderingContext.sampleCoverage
 
 <dl>
   <dt>value</dt>
-  <dd>A {{domxref("GLclampf")}} which sets a single floating-point coverage value clamped
+  <dd>A {{domxref("WebGL_API/Types", "GLclampf")}} which sets a single floating-point coverage value clamped
     to the range [0,1]. The default value is 1.0.</dd>
   <dt>invert</dt>
-  <dd>A {{domxref("GLboolean")}} which sets whether or not the coverage masks should be
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} which sets whether or not the coverage masks should be
     inverted. The default value is <code>false</code>.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/scissor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/scissor/index.html
@@ -24,16 +24,16 @@ browser-compat: api.WebGLRenderingContext.scissor
 
 <dl>
   <dt><code>x</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the horizontal coordinate for the lower left
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the horizontal coordinate for the lower left
     corner of the box. Default value: 0.</dd>
   <dt><code>y</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the vertical coordinate for the lower left corner
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the vertical coordinate for the lower left corner
     of the box. Default value: 0.</dd>
   <dt>width</dt>
-  <dd>A non-negative {{domxref("Glsizei")}} specifying the width of the scissor box.
+  <dd>A non-negative {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the scissor box.
     Default value: width of the canvas.</dd>
   <dt>height</dt>
-  <dd>A non-negative {{domxref("Glsizei")}} specifying the height of the scissor box.
+  <dd>A non-negative {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the scissor box.
     Default value: height of the canvas.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.html
@@ -27,31 +27,31 @@ browser-compat: api.WebGLRenderingContext.stencilFunc
 
 <dl>
   <dt><code>func</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the test function. The default function is
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the test function. The default function is
     <code>gl.ALWAYS</code>. The possible values are:
     <ul>
-      <li><code>gl.NEVER</code>:       Never pass.</li>
-      <li><code>gl.LESS</code>:         Pass if
-        <code>(ref &amp; mask) &lt;  (stencil &amp; mask)</code>.</li>
-      <li><code>gl.EQUAL</code>:       Pass if
-        <code>(ref &amp; mask) =  (stencil &amp; mask)</code>.</li>
-      <li><code>gl.LEQUAL</code>:     Pass if
+      <li><code>gl.NEVER</code>: Never pass.</li>
+      <li><code>gl.LESS</code>: Pass if
+        <code>(ref &amp; mask) &lt; (stencil &amp; mask)</code>.</li>
+      <li><code>gl.EQUAL</code>: Pass if
+        <code>(ref &amp; mask) = (stencil &amp; mask)</code>.</li>
+      <li><code>gl.LEQUAL</code>: Pass if
         <code>(ref &amp; mask) &lt;= (stencil &amp; mask)</code>.</li>
-      <li><code>gl.GREATER</code>:   Pass if
-        <code>(ref &amp; mask) &gt;  (stencil &amp; mask)</code>.</li>
+      <li><code>gl.GREATER</code>: Pass if
+        <code>(ref &amp; mask) &gt; (stencil &amp; mask)</code>.</li>
       <li><code>gl.NOTEQUAL</code>: Pass if
         <code>(ref &amp; mask) != (stencil &amp; mask)</code>.</li>
-      <li><code>gl.GEQUAL</code>:     Pass if
+      <li><code>gl.GEQUAL</code>: Pass if
         <code>(ref &amp; mask) &gt;= (stencil &amp; mask)</code>.</li>
-      <li><code>gl.ALWAYS</code>:     Always pass.</li>
+      <li><code>gl.ALWAYS</code>: Always pass.</li>
     </ul>
   </dd>
   <dt><code>ref</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the reference value for the stencil test. This
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the reference value for the stencil test. This
     value is clamped to the range 0 to 2^n - 1 where n is the number of bitplanes
     in the stencil buffer. The default value is 0.</dd>
   <dt><code>mask</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying a bit-wise mask that is used to AND the reference
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying a bit-wise mask that is used to AND the reference
     value and the stored stencil value when the test is done. The default value is all 1.
   </dd>
 </dl>

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.stencilFuncSeparate
 
 <dl>
   <dt>face</dt>
-  <dd>A {{domxref("GLenum")}} specifying whether the front and/or back stencil state is
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying whether the front and/or back stencil state is
     updated. The possible values are:
     <ul>
       <li><code>gl.FRONT</code></li>
@@ -36,31 +36,31 @@ browser-compat: api.WebGLRenderingContext.stencilFuncSeparate
     </ul>
   </dd>
   <dt><code>func</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the test function. The default function is
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the test function. The default function is
     <code>gl.ALWAYS</code>. The possible values are:
     <ul>
-      <li><code>gl.NEVER</code>:       Never pass.</li>
-      <li><code>gl.LESS</code>:         Pass if
-        <code>(ref &amp; mask) &lt;  (stencil &amp; mask)</code>.</li>
-      <li><code>gl.EQUAL</code>:       Pass if
-        <code>(ref &amp; mask) =  (stencil &amp; mask)</code>.</li>
-      <li><code>gl.LEQUAL</code>:     Pass if
+      <li><code>gl.NEVER</code>: Never pass.</li>
+      <li><code>gl.LESS</code>: Pass if
+        <code>(ref &amp; mask) &lt; (stencil &amp; mask)</code>.</li>
+      <li><code>gl.EQUAL</code>: Pass if
+        <code>(ref &amp; mask) = (stencil &amp; mask)</code>.</li>
+      <li><code>gl.LEQUAL</code>: Pass if
         <code>(ref &amp; mask) &lt;= (stencil &amp; mask)</code>.</li>
-      <li><code>gl.GREATER</code>:   Pass if
-        <code>(ref &amp; mask) &gt;  (stencil &amp; mask)</code>.</li>
+      <li><code>gl.GREATER</code>: Pass if
+        <code>(ref &amp; mask) &gt; (stencil &amp; mask)</code>.</li>
       <li><code>gl.NOTEQUAL</code>: Pass if
         <code>(ref &amp; mask) != (stencil &amp; mask)</code>.</li>
-      <li><code>gl.GEQUAL</code>:     Pass if
+      <li><code>gl.GEQUAL</code>: Pass if
         <code>(ref &amp; mask) &gt;= (stencil &amp; mask)</code>.</li>
-      <li><code>gl.ALWAYS</code>:     Always pass.</li>
+      <li><code>gl.ALWAYS</code>: Always pass.</li>
     </ul>
   </dd>
   <dt><code>ref</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the reference value for the stencil test. This
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the reference value for the stencil test. This
     value is clamped to the range 0 to 2^n - 1 where n is the number of bitplanes
     in the stencil buffer. The default value is 0.</dd>
   <dt><code>mask</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying a bit-wise mask that is used to AND the reference
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying a bit-wise mask that is used to AND the reference
     value and the stored stencil value when the test is done. The default value is all 1.
   </dd>
 </dl>

--- a/files/en-us/web/api/webglrenderingcontext/stencilmask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmask/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.stencilMask
 
 <dl>
   <dt><code>mask</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying a bit mask to enable or disable writing of
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying a bit mask to enable or disable writing of
     individual bits in the stencil planes. By default, the mask is all 1.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.stencilMaskSeparate
 
 <dl>
   <dt>face</dt>
-  <dd>A {{domxref("GLenum")}} specifying whether the front and/or back stencil writemask
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying whether the front and/or back stencil writemask
     is updated. The possible values are:
     <ul>
       <li><code>gl.FRONT</code></li>
@@ -36,7 +36,7 @@ browser-compat: api.WebGLRenderingContext.stencilMaskSeparate
     </ul>
   </dd>
   <dt><code>mask</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying a bit mask to enable or disable writing of
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying a bit mask to enable or disable writing of
     individual bits in the stencil planes. By default, the mask is all 1.</dd>
 </dl>
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.html
@@ -26,13 +26,13 @@ browser-compat: api.WebGLRenderingContext.stencilOp
 
 <dl>
   <dt><code>fail</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the function to use when the stencil test fails.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the function to use when the stencil test fails.
     The default value is <code>gl.KEEP</code>.</dd>
   <dt><code>zfail</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the function to use when the stencil test passes,
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the function to use when the stencil test passes,
     but the depth test fails. The default value is <code>gl.KEEP</code>.</dd>
   <dt><code>zpass</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the function to use when both the stencil test
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the function to use when both the stencil test
     and the depth test pass, or when the stencil test passes and there is no depth buffer
     or depth testing is disabled. The default value is <code>gl.KEEP</code>.</dd>
 </dl>

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.html
@@ -27,7 +27,7 @@ browser-compat: api.WebGLRenderingContext.stencilOpSeparate
 
 <dl>
   <dt>face</dt>
-  <dd>A {{domxref("GLenum")}} specifying whether the front and/or back stencil state is
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying whether the front and/or back stencil state is
     updated. The possible values are:
     <ul>
       <li><code>gl.FRONT</code></li>
@@ -36,13 +36,13 @@ browser-compat: api.WebGLRenderingContext.stencilOpSeparate
     </ul>
   </dd>
   <dt><code>fail</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the function to use when the stencil test fails.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the function to use when the stencil test fails.
     The default value is <code>gl.KEEP</code>.</dd>
   <dt><code>zfail</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the function to use when the stencil test passes,
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the function to use when the stencil test passes,
     but the depth test fails. The default value is <code>gl.KEEP</code>.</dd>
   <dt><code>zpass</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the function to use when both the stencil test
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the function to use when both the stencil test
     and the depth test pass, or when the stencil test passes and there is no depth buffer
     or depth testing is disabled. The default value is <code>gl.KEEP</code>.</dd>
 </dl>

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
@@ -40,7 +40,7 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -59,10 +59,10 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>internalformat</code></dt>
-  <dd><p>A {{domxref("GLenum")}} specifying the color components in the texture.</p>
+  <dd><p>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the color components in the texture.</p>
   <p>Possible values in both WebGL1 and WebGL2</p>
     <table>
       <thead>
@@ -124,8 +124,8 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
         </tr>
       </tbody>
     </table>
-  <p>Other possible values in WebGL2 for the versions of <code>texImage2D</code> that
-    take an <code>ArrayBufferView</code> or a <code>GLintptr offset</code></p>
+  <p>Other possible values in WebGL2 for the versions of <code>texImage2D</code> that
+    take an <code>ArrayBufferView</code> or a <code>GLintptr offset</code></p>
 
 <table>
   <thead>
@@ -693,7 +693,7 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
   </tbody>
 </table>
 
-<p>Possible values in WebGL2 for the versions of <code>texImage2D</code> that take a
+<p>Possible values in WebGL2 for the versions of <code>texImage2D</code> that take a
   texture an <code>HTMLImageElement</code>, <code>HTMLCanvasElement</code>,
   <code>HTMLVideoElement</code>, <code>ImageBitmap</code>, or <code>ImageData</code></p>
 
@@ -753,19 +753,19 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
 </ul>
 </dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture.</dd>
   <dt><code>border</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the width of the border. Must be 0.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the width of the border. Must be 0.</dd>
   <dt><code>format</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the format of the texel data. In WebGL 1, this
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the format of the texel data. In WebGL 1, this
     must be the same as <code>internalformat</code> (see above). in WebGL 2, the
     combinations are listed in <a
       href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#TEXTURE_TYPES_FORMATS_FROM_DOM_ELEMENTS_TABLE">this
       table</a>.</dd>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of the texel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of the texel data. Possible values:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code>: 8 bits per channel for <code>gl.RGBA</code></li>
       <li><code>gl.UNSIGNED_SHORT_5_6_5</code>: 5 red bits, 6 green bits, 5 blue bits.
@@ -837,7 +837,7 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>(WebGL 2 only) A {{domxref("GLintptr")}} byte offset into the
+  <dd>(WebGL 2 only) A {{domxref("WebGL_API/Types", "GLintptr")}} byte offset into the
     {{domxref("WebGLBuffer")}}'s data store. Used to upload data to the currently bound
     {{domxref("WebGLTexture")}} from the <code>WebGLBuffer</code> bound to the
     <code>PIXEL_UNPACK_BUFFER</code> target.</dd>

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.html
@@ -25,7 +25,7 @@ void <var>gl</var>.texParameteri(GLenum <var>target</var>, GLenum <var>pname</va
 
 <dl>
   <dt>target</dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target). Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
       <li><code>gl.TEXTURE_CUBE_MAP</code>: A cube-mapped texture.</li>
@@ -40,9 +40,9 @@ void <var>gl</var>.texParameteri(GLenum <var>target</var>, GLenum <var>pname</va
   </dd>
 </dl>
 
-<p>The <code>pname</code> parameter is a {{domxref("Glenum")}} specifying the texture
-  parameter to set. The <code>param</code> parameter is a {{domxref("GLfloat")}} or
-  {{domxref("GLint")}} specifying the value for the specified parameter
+<p>The <code>pname</code> parameter is a {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture
+  parameter to set. The <code>param</code> parameter is a {{domxref("WebGL_API/Types", "GLfloat")}} or
+  {{domxref("WebGL_API/Types", "GLint")}} specifying the value for the specified parameter
   <code>pname</code>.</p>
 
 <table class="standard-table">
@@ -89,7 +89,7 @@ void <var>gl</var>.texParameteri(GLenum <var>target</var>, GLenum <var>pname</va
     <tr>
       <td><code>ext.TEXTURE_MAX_ANISOTROPY_EXT</code></td>
       <td>Maximum anisotropy for a texture</td>
-      <td>A {{domxref("GLfloat")}} value.</td>
+      <td>A {{domxref("WebGL_API/Types", "GLfloat")}} value.</td>
     </tr>
     <tr>
       <th colspan="3">Additionally available when using a WebGL 2 context</th>

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.html
@@ -40,7 +40,7 @@ void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, ty
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the binding point (target) of the active texture.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
     Possible values:
     <ul>
       <li><code>gl.TEXTURE_2D</code>: A two-dimensional texture.</li>
@@ -59,20 +59,20 @@ void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, ty
     </ul>
   </dd>
   <dt><code>level</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the level of detail. Level 0 is the base image
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
     level and level <em>n</em> is the <em>n</em>th mipmap reduction level.</dd>
   <dt><code>xoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the lower left texel x coordinate of a width-wide
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the lower left texel x coordinate of a width-wide
     by height-wide rectangular subregion of the texture array.</dd>
   <dt><code>yoffset</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the lower left texel y coordinate of a width-wide
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the lower left texel y coordinate of a width-wide
     by height-wide rectangular subregion of the texture array..</dd>
   <dt><code>width</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the width of the texture in texels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the texture in texels.</dd>
   <dt><code>height</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the height of the texture in texels.</dd>
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the texture in texels.</dd>
   <dt><code>format</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the format of the texel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the format of the texel data. Possible values:
     <ul>
       <li><code>gl.ALPHA</code>: Discards the red, green and blue components and reads the
         alpha component.</li>
@@ -104,7 +104,7 @@ void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, ty
     </ul>
   </dd>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of the texel data. Possible values:
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of the texel data. Possible values:
     <ul>
       <li><code>gl.UNSIGNED_BYTE</code>: 8 bits per channel for <code>gl.RGBA</code></li>
       <li><code>gl.UNSIGNED_SHORT_5_6_5</code>: 5 red bits, 6 green bits, 5 blue bits.
@@ -166,7 +166,7 @@ void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, ty
     </ul>
   </dd>
   <dt>offset</dt>
-  <dd>(WebGL 2 only) A {{domxref("GLintptr")}} byte offset into the
+  <dd>(WebGL 2 only) A {{domxref("WebGL_API/Types", "GLintptr")}} byte offset into the
     {{domxref("WebGLBuffer")}}'s data store. Used to upload data to the currently bound
     {{domxref("WebGLTexture")}} from the <code>WebGLBuffer</code> bound to the
     <code>PIXEL_UNPACK_BUFFER</code> target.</dd>

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.uniformMatrix2fv
 
 <p>The three versions of this method (<code>uniformMatrix2fv()</code>,
   <code>uniformMatrix3fv()</code>, and <code>uniformMatrix4fv()</code>) take as the input
-  value 2-component, 3-component, and 4-component square matrices, respectively.  They are
+  value 2-component, 3-component, and 4-component square matrices, respectively. They are
   expected to have 4, 9 or 16 floats.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -43,7 +43,7 @@ browser-compat: api.WebGLRenderingContext.uniformMatrix2fv
     attribute to modify. The location is obtained using
     {{domxref("WebGLRenderingContext.getUniformLocation", "getUniformLocation()")}}.</dd>
   <dt><code>transpose</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether to transpose the matrix. Must be
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether to transpose the matrix. Must be
     <code>false</code>.</dd>
   <dt><code>value</code></dt>
   <dd>

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.html
@@ -32,7 +32,7 @@ void <var>gl</var>.vertexAttrib4fv(<var>index</var>, <var>value</var>);
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the position of the vertex attribute to be
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the position of the vertex attribute to be
     modified.</dd>
   <dt><code>v0, v1, v2, v3</code></dt>
   <dd>A floating point {{jsxref("Number")}} for the vertex attribute value.</dd>

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
@@ -26,13 +26,13 @@ browser-compat: api.WebGLRenderingContext.vertexAttribPointer
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>A {{domxref("GLuint")}} specifying the index of the vertex attribute that is to be
+  <dd>A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute that is to be
     modified.</dd>
   <dt><code>size</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the number of components per vertex attribute.
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the number of components per vertex attribute.
     Must be 1, 2, 3, or 4.</dd>
   <dt><code>type</code></dt>
-  <dd>A {{domxref("GLenum")}} specifying the data type of each component in the array.
+  <dd>A {{domxref("WebGL_API/Types", "GLenum")}} specifying the data type of each component in the array.
     Possible values:
     <ul>
       <li><code>gl.BYTE</code>: signed 8-bit integer, with values in [-128, 127]</li>
@@ -52,7 +52,7 @@ browser-compat: api.WebGLRenderingContext.vertexAttribPointer
     </ul>
   </dd>
   <dt><code>normalized</code></dt>
-  <dd>A {{domxref("GLboolean")}} specifying whether integer data values should be
+  <dd>A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether integer data values should be
     normalized into a certain range when being cast to a float.
     <ul>
       <li>For types <code>gl.BYTE</code> and <code>gl.SHORT</code>, normalizes the values
@@ -64,15 +64,15 @@ browser-compat: api.WebGLRenderingContext.vertexAttribPointer
     </ul>
   </dd>
   <dt><code>stride</code></dt>
-  <dd>A {{domxref("GLsizei")}} specifying the offset in bytes between the beginning of
+  <dd>A {{domxref("WebGL_API/Types", "GLsizei")}} specifying the offset in bytes between the beginning of
     consecutive vertex attributes. Cannot be larger than 255. If stride is 0, the
     attribute is assumed to be tightly packed, that is, the attributes are not interleaved
     but each attribute is in a separate block, and the next vertex' attribute follows
     immediately after the current vertex.</dd>
   <dt><code>offset</code></dt>
-  <dd>A {{domxref("GLintptr")}} specifying an offset in bytes of the first component in
+  <dd>A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in bytes of the first component in
     the vertex attribute array. Must be a multiple of the byte length
-    of <code>type</code>.</dd>
+    of <code>type</code>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/webglrenderingcontext/viewport/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/viewport/index.html
@@ -25,16 +25,16 @@ browser-compat: api.WebGLRenderingContext.viewport
 
 <dl>
   <dt><code>x</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the horizontal coordinate for the lower left
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the horizontal coordinate for the lower left
     corner of the viewport origin. Default value: 0.</dd>
   <dt><code>y</code></dt>
-  <dd>A {{domxref("GLint")}} specifying the vertical coordinate for the lower left corner
+  <dd>A {{domxref("WebGL_API/Types", "GLint")}} specifying the vertical coordinate for the lower left corner
     of the viewport origin. Default value: 0.</dd>
   <dt>width</dt>
-  <dd>A non-negative {{domxref("Glsizei")}} specifying the width of the viewport. Default
+  <dd>A non-negative {{domxref("WebGL_API/Types", "GLsizei")}} specifying the width of the viewport. Default
     value: width of the canvas.</dd>
   <dt>height</dt>
-  <dd>A non-negative {{domxref("Glsizei")}} specifying the height of the viewport. Default
+  <dd>A non-negative {{domxref("WebGL_API/Types", "GLsizei")}} specifying the height of the viewport. Default
     value: height of the canvas.</dd>
 </dl>
 

--- a/files/en-us/web/api/webgltexture/index.html
+++ b/files/en-us/web/api/webgltexture/index.html
@@ -54,6 +54,6 @@ var texture = gl.createTexture();
  <li>{{domxref("WebGLRenderingContext.getTexParameter()")}}</li>
  <li>{{domxref("WebGLRenderingContext.texImage2D()")}}</li>
  <li>{{domxref("WebGLRenderingContext.texSubImage2D()")}}</li>
- <li>{{domxref("WebGLRenderingContext.texParameterf()")}}</li>
- <li>{{domxref("WebGLRenderingContext.texParameteri()")}}</li>
+ <li>{{domxref("WebGLRenderingContext/texParameter", "WebGLRenderingContext.texParameterf()")}}</li>
+ <li>{{domxref("WebGLRenderingContext/texParameter", "WebGLRenderingContext.texParameteri()")}}</li>
 </ul>


### PR DESCRIPTION
Fixes the macros that make a redirect in WebGL. 

About 250 flaws less, and a quicker user experience.