### PR TITLE
Removing Broken Link in XML introduction

### DIFF
--- a/files/en-us/web/xml/xml_introduction/index.html
+++ b/files/en-us/web/xml/xml_introduction/index.html
@@ -153,7 +153,6 @@ tags:
 <ul>
 	<li><a class="external" href="http://www.xml.com/">XML.com</a></li>
 	<li><a class="external" href="https://www.w3.org/XML/">Extensible Markup Language (XML) @ W3.org</a></li>
-	<li><a class="external" href="http://www.alistapart.com/d/usingxml/xml_uses_a.html">XML Example: A List Apart</a></li>
 	<li><a class="external" href="http://www.alistapart.com/articles/usingxml/">Using XML: A List Apart</a></li>
 </ul>
 


### PR DESCRIPTION
maybe http://www.alistapart.com/d/usingxml/xml_uses_a.html URL is changed or removed.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
