### PR TITLE
Replacing Url in scroll-snap-points-y

### DIFF
--- a/files/en-us/web/css/scroll-snap-points-y/index.md
+++ b/files/en-us/web/css/scroll-snap-points-y/index.md
@@ -104,4 +104,4 @@ Not part of any standard.
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/)

--- a/files/en-us/web/css/scroll-snap-points-y/index.md
+++ b/files/en-us/web/css/scroll-snap-points-y/index.md
@@ -104,4 +104,4 @@ Not part of any standard.
 ## See also
 
 - [CSS Scroll Snap](/en-US/docs/Web/CSS/CSS_Scroll_Snap)
-- [Well-Controlled Scrolling with CSS Scroll Snap](https://web.dev/css-scroll-snap/p)
+- [Well-Controlled Scrolling with CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap)


### PR DESCRIPTION
https://web.dev/css-scroll-snap/p (404) -> https://developers.google.com/web/updates/2018/07/css-scroll-snap (200)

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
