### PR TITLE
Use https for links in XML introduction

### DIFF
--- a/files/en-us/web/xml/xml_introduction/index.html
+++ b/files/en-us/web/xml/xml_introduction/index.html
@@ -151,9 +151,9 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a class="external" href="http://www.xml.com/">XML.com</a></li>
-	<li><a class="external" href="https://www.w3.org/XML/">Extensible Markup Language (XML) @ W3.org</a></li>
-	<li><a class="external" href="http://www.alistapart.com/articles/usingxml/">Using XML: A List Apart</a></li>
+  <li><a class="external" href="https://www.xml.com/">XML.com</a></li>
+  <li><a class="external" href="https://www.w3.org/XML/">Extensible Markup Language (XML) @ W3.org</a></li>
+  <li><a class="external" href="https://alistapart.com/article/usingxml/">Using XML: A List Apart</a>
+    <ul><li>This article is a great resource for transforming and creating your own language.</li></ul>
+  </li>
 </ul>
-
-<p>The <a href="http://www.alistapart.com/articles/usingxml/">Using XML</a> article above is a great resource on information for transforming and creating your own language.</p>


### PR DESCRIPTION
Also move a description closer to the link it's for.

This fixes three broken link flaws.