### PR TITLE
Add note about initKeyEvent deprecation to Firefox release notes for 93

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -59,6 +59,10 @@ tags:
 
 <h4 id="removals_webext">Removals</h4>
 
+<ul>
+  <li>Use of the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent">KeyboardEvent.initKeyEvent</a></code> to initiate a <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent">KeyboardEvent</a></code> object is now deprecated. We expect to remove <code>initKeyEvent</code> from Firefox in version 96. Extension developers should use a <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent">KeyboardEvent</a></code> constructor to initiate a KeyboardEvent object instead.</li>
+</ul> 
+
 <h2 id="Older_versions">Older versions</h2>
 
 <p>{{Firefox_for_developers(92)}}</p>

--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -60,7 +60,7 @@ tags:
 <h4 id="removals_webext">Removals</h4>
 
 <ul>
-  <li>Use of the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent">KeyboardEvent.initKeyEvent</a></code> to initiate a <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent">KeyboardEvent</a></code> object is now deprecated. We expect to remove <code>initKeyEvent</code> from Firefox in version 96. Extension developers should use a <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent">KeyboardEvent</a></code> constructor to initiate a KeyboardEvent object instead.</li>
+  <li>Use of the <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent">KeyboardEvent.initKeyEvent</a></code> to initiate a <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent">KeyboardEvent</a></code> object is now deprecated (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1727024">Bug 1727024</a>). We expect to remove <code>initKeyEvent</code> from Firefox in version 96. Extension developers should use a <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent">KeyboardEvent</a></code> constructor to initiate a KeyboardEvent object instead. </li>
 </ul> 
 
 <h2 id="Older_versions">Older versions</h2>


### PR DESCRIPTION
Adds item to Firefox 93 release notes that .initKeyEvent has been deprecated and that extension developers who want to initiate a KeyboardEvent object should use a KeyboardEvent constructor instead. 

Related bugs: 

https://bugzilla.mozilla.org/show_bug.cgi?id=1727024
https://bugzilla.mozilla.org/show_bug.cgi?id=1727502
https://bugzilla.mozilla.org/show_bug.cgi?id=1717760

// cc @rpl 

