### PR TITLE
Replace broken link in Proxy doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -380,12 +380,12 @@ console.log(products.number);      // 3
 
 ### A complete `traps` list example
 
-Now in order to create a complete sample `traps` list, for didactic purposes, we will try to proxify a _non-native_ object that is particularly suited to this type of operation: the `docCookies` global object created by [a simple cookie framework](https://reference.codeproject.com/Book/dom/document/cookie/simple_document.cookie_framework).
+Now in order to create a complete sample `traps` list, for didactic purposes, we will try to proxify a _non-native_ object that is particularly suited to this type of operation: the `docCookies` global object created by [a simple cookie framework](https://reference.codeproject.com/dom/document/cookie/simple_document.cookie_framework).
 
 ```js
 /*
   var docCookies = ... get the "docCookies" object here:
-  https://reference.codeproject.com/Book/dom/document/cookie/simple_document.cookie_framework
+  https://reference.codeproject.com/dom/document/cookie/simple_document.cookie_framework
 */
 
 var docCookies = new Proxy(docCookies, {


### PR DESCRIPTION
https://reference.codeproject.com/Book/dom/document/cookie/simple_document.cookie_framework (the book directory is probably removed) -> https://reference.codeproject.com/dom/document/cookie/simple_document.cookie_framework

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
