### PR TITLE
Fix typo in onclick documentation

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.html
@@ -36,7 +36,7 @@ browser-compat: api.GlobalEventHandlers.onclick
     href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function
     expression</a>. The function receives a {{domxref("MouseEvent")}} object as its sole
   argument. Within the function, {{jsxref("Operators/this", "this")}} will be the object
-  that <code>onclick</code> was bound too (which will also match
+  that <code>onclick</code> was bound to (which will also match
   <code>event.currentTarget</code>)</p>
 
 <p>Only one <code>onclick</code> handler can be assigned to an object at a time. You may


### PR DESCRIPTION
fix: changed 'too' to 'to'

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
Typo


> Anything else that could help us review it
