### PR TITLE
Replacing Broken Url in x-ms-acceleratorkey

### DIFF
--- a/files/en-us/web/html/global_attributes/x-ms-acceleratorkey/index.html
+++ b/files/en-us/web/html/global_attributes/x-ms-acceleratorkey/index.html
@@ -30,7 +30,7 @@ tags:
 <ul>
  <li><code>"Ctrl+B"</code> for a combination of the <kbd>Ctrl</kbd> and <kbd>B</kbd> keys.</li>
  <li><code>"J"</code> for just the <kbd>J</kbd> key.</li>
- <li><code>"Ctrl+; then K"</code> for a shortcut similar to <a href="https://help.manuscript.com/7558/fogbugz-keyboard-shortcuts#For_Your_Server_or_non-Ocelot_Keyboard_Shortcuts">FogBugz’s old keyboard mode</a>. This approach is more complicated, but does not override existing keyboard shortcuts provided by the user’s browser or operating system.</li>
+ <li><code>"Ctrl+; then K"</code> for a shortcut similar to <a href="https://support.fogbugz.com/hc/en-us/articles/360011254414-FogBugz-Keyboard-Shortcuts#:~:text=For%20Your%20Server%20or%20non-Ocelot%20Keyboard%20Shortcuts">FogBugz’s old keyboard mode</a>. This approach is more complicated, but does not override existing keyboard shortcuts provided by the user’s browser or operating system.</li>
 </ul>
 
 <h2 id="See_also">See also</h2>


### PR DESCRIPTION
https://help.manuscript.com/7558/fogbugz-keyboard-shortcuts#For_Your_Server_or_non-Ocelot_Keyboard_Shortcuts -> https://support.fogbugz.com/hc/en-us/articles/360011254414-FogBugz-Keyboard-Shortcuts#:~:text=For%20Your%20Server%20or%20non-Ocelot%20Keyboard%20Shortcuts

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
