### PR TITLE
“Firefox user agent string reference”: Fix iPad/iPod/iPhone info

### DIFF
--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -214,7 +214,7 @@ Firefox for iOS uses the default Mobile Safari UA string, with an additional **F
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | iPod        | Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) **FxiOS/1.0** Mobile/12F69 Safari/600.1.4 |
 | iPhone      | Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) **FxiOS/1.0** Mobile/12F69 Safari/600.1.4     |
-| iPad        | Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) **FxiOS/1.0** Mobile/12F69 Safari/600.1.4       |
+| iPad        | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15                       |
 
 ## Firefox Web Runtime
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -208,13 +208,15 @@ Firefox OS has a four-digit version number: `X.X.X.Y`. The first two digits are 
 
 ## Firefox for iOS
 
-Firefox for iOS uses the default Mobile Safari UA string, with an additional **FxiOS/\<version>** token, similar to how [Chrome for iOS identifies itself](https://developer.chrome.com/multidevice/user-agent#chrome_for_ios_user_agent).
+Firefox for iOS uses the default Mobile Safari UA string, with an additional **FxiOS/\<version>** token on iPod and iPhone, similar to how [Chrome for iOS identifies itself](https://developer.chrome.com/multidevice/user-agent#chrome_for_ios_user_agent). 
 
 | Form factor | Firefox for iOS user agent string                                                                                                           |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | iPod        | Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) **FxiOS/1.0** Mobile/12F69 Safari/600.1.4 |
 | iPhone      | Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) **FxiOS/1.0** Mobile/12F69 Safari/600.1.4     |
 | iPad        | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15                       |
+
+Regarding the deviation on iPad form factor, see this [issue](https://github.com/mozilla-mobile/firefox-ios/issues/6620).
 
 ## Firefox Web Runtime
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #4779

> What was wrong/why is this fix needed? (quick summary only)

The userAgent string was incorrect. Updated as requested and verified from Firefox on iPad

> Anything else that could help us review it
