### PR TITLE
Add brush: plain to pre blocks in server side

### DIFF
--- a/files/en-us/learn/server-side/configuring_server_mime_types/index.html
+++ b/files/en-us/learn/server-side/configuring_server_mime_types/index.html
@@ -114,11 +114,9 @@ tags:
 </ul>
 
 <p>Regardless of what server system you use, the effect you need to achieve is to set a response header with the name {{httpheader("Content-Type")}}, followed by a colon and space, followed by a MIME type. High-level environments often allow such headers to be set when generating the page. For example, in a PHP environment, you could set the response header for PDF resources like this:
-<pre>
-<code>header('Content-Type: application/pdf')</code>
-</pre>
+<pre class="brush: php">header('Content-Type: application/pdf')</pre>
 
-<p>Trying to instead set it with just <code>header('application/pdf')</code> won’t work .</p>
+<p>Trying to instead set it with just <code>header('application/pdf')</code> won’t work.</p>
 
 <h2 id="Related_Links">Related Links</h2>
 

--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -253,7 +253,7 @@ DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 <ol>
  <li>Copy your Django application into this folder (all the files at the same level as <strong>manage.py</strong> and below, <strong>not</strong> their containing locallibrary folder).</li>
  <li>Open the <strong>.gitignore</strong> file, copy the following lines into the bottom of it, and then save (this file is used to identify files that should not be uploaded to git by default).
-  <pre># Text backup files
+  <pre class="brush: plain"># Text backup files
 *.bak
 
 # Database
@@ -264,7 +264,7 @@ DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 </pre>
  </li>
  <li>Use the <code>status</code> command to check that all files you are about to <code>commit</code> are correct (you want to include source files, not binaries, temporary files etc.). It should look a bit like the listing below.
-  <pre>&gt; git status
+  <pre class="brush: plain">&gt; git status
 On branch main
 Your branch is up-to-date with 'origin/main'.
 Changes to be committed:
@@ -281,7 +281,7 @@ Changes to be committed:
   <pre class="brush: bash">git commit -m "First version of application moved into github"</pre>
  </li>
  <li>At this point, the remote repository has not been changed. Synchronise (<code>push</code>) your local repository to the remote Github repository using the following command:
-  <pre>git push origin main</pre>
+  <pre class="brush: bash">git push origin main</pre>
  </li>
 </ol>
 
@@ -307,7 +307,7 @@ Changes to be committed:
 
 <p>Create the file <code>Procfile</code> (no extension) in the root of your GitHub repository to declare the application's process types and entry points. Copy the following text into it:</p>
 
-<pre>web: gunicorn locallibrary.wsgi --log-file -</pre>
+<pre class="brush: plain">web: gunicorn locallibrary.wsgi --log-file -</pre>
 
 <p>The "<code>web:</code>" tells Heroku that this is a web dyno and can be sent HTTP traffic. The process to start in this dyno is <em>gunicorn</em>, which is a popular web application server that Heroku recommends. We start Gunicorn using the configuration information in the module <code>locallibrary.wsgi</code> (created with our application skeleton: <strong>/locallibrary/wsgi.py</strong>).</p>
 
@@ -338,14 +338,13 @@ Changes to be committed:
 
 <p>Install <em>dj-database-url</em> locally so that it becomes part of our <a href="#requirements">requirements</a> for Heroku to set up on the remote server:</p>
 
-<pre>$ pip3 install dj-database-url
-</pre>
+<pre class="brush: bash">$ pip3 install dj-database-url</pre>
 
 <h5 id="settings.py">settings.py</h5>
 
 <p>Open <strong>/locallibrary/settings.py</strong> and copy the following configuration into the bottom of the file:</p>
 
-<pre># Heroku: Update database configuration from $DATABASE_URL.
+<pre class="brush: plain"># Heroku: Update database configuration from $DATABASE_URL.
 import dj_database_url
 db_from_env = dj_database_url.config(conn_max_age=500)
 DATABASES['default'].update(db_from_env)</pre>
@@ -394,7 +393,7 @@ pip3 install psycopg2-binary
 
 <p>Open <strong>/locallibrary/settings.py</strong> and copy the following configuration into the bottom of the file. The <code>BASE_DIR</code> should already have been defined in your file (the <code>STATIC_URL</code> may already have been defined within the file when it was created. While it will cause no harm, you might as well delete the duplicate previous reference).</p>
 
-<pre># Static files (CSS, JavaScript, Images)
+<pre class="brush: python"># Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 # The absolute path to the directory where collectstatic will collect static files for deployment.
@@ -429,7 +428,7 @@ STATIC_URL = '/static/'
 
 <p>To install <em>WhiteNoise</em> into your Django application, open <strong>/locallibrary/settings.py</strong>, find the <code>MIDDLEWARE</code> setting and add the <code>WhiteNoiseMiddleware</code> near the top of the list, just below the <code>SecurityMiddleware</code>:</p>
 
-<pre>MIDDLEWARE = [
+<pre class="brush: python">MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -443,7 +442,7 @@ STATIC_URL = '/static/'
 
 <p>Optionally, you can reduce the size of the static files when they are served (this is more efficient). Just add the following to the bottom of <strong>/locallibrary/settings.py</strong>:</p>
 
-<pre># Simplified static file serving.
+<pre class="brush: python"># Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 </pre>
@@ -457,7 +456,7 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 <p>After installing all the different dependencies above, your <strong>requirements.txt</strong> file should have <em>at least</em> these items listed (though the version numbers may be different).
 Please delete any other dependencies not listed below, unless you've explicitly added them for this application.</p>
 
-<pre>dj-database-url==0.5.0
+<pre class="brush: plain">dj-database-url==0.5.0
 Django==3.1.2
 gunicorn==20.0.4
 psycopg2-binary==2.8.6
@@ -472,7 +471,7 @@ whitenoise==5.2.0
 
 <p>The <strong>runtime.txt</strong> file, if defined, tells Heroku which programming language to use. Create the file in the root of the repo and add the following text:</p>
 
-<pre>python-3.8.6</pre>
+<pre class="brush: plain">python-3.8.6</pre>
 
 <div class="notecard note">
   <p><strong>Note:</strong> Heroku only supports a small number of <a href="https://devcenter.heroku.com/articles/python-support#supported-python-runtimes">Python runtimes</a> (at time of writing, this includes the one above). Heroku will use a supported runtime irrespective of the value specified in this file.</p>

--- a/files/en-us/learn/server-side/django/development_environment/index.html
+++ b/files/en-us/learn/server-side/django/development_environment/index.html
@@ -294,7 +294,7 @@ nano .bash_profile # Open the file in the nano text editor, within the terminal
 
 <p>Installing <a href="https://pypi.python.org/pypi/virtualenvwrapper-win">virtualenvwrapper-win</a> is even simpler than setting up <em>virtualenvwrapper</em> because you don't need to configure where the tool stores virtual environment information (there is a default value). All you need to do is run the following command in the command prompt:</p>
 
-<pre><code>pip3 install virtualenvwrapper-win</code></pre>
+<pre class="brush: bash">pip3 install virtualenvwrapper-win</pre>
 
 <p>Now you can create a new virtual environment with the <code>mkvirtualenv</code> command</p>
 
@@ -304,12 +304,12 @@ nano .bash_profile # Open the file in the nano text editor, within the terminal
 
 <p>Now you can create a new virtual environment with the <code>mkvirtualenv</code> command. As this command runs you'll see the environment being set up (what you see is slightly platform-specific). When the command completes the new virtual environment will be active — you can see this because the start of the prompt will be the name of the environment in brackets (below we show this for Ubuntu, but the final line is similar for Windows/macOS).</p>
 
-<pre><code>$ mkvirtualenv my_django_environment
+<pre class="brush: bash">$ mkvirtualenv my_django_environment
 
 Running virtualenv with interpreter /usr/bin/python3
 ...
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/t_env7/bin/get_env_details
-(my_django_environment) ubuntu@ubuntu:~$</code>
+(my_django_environment) ubuntu@ubuntu:~$
 </pre>
 
 <p>Now you're inside the virtual environment you can install Django and start developing.</p>

--- a/files/en-us/learn/server-side/django/generic_views/index.html
+++ b/files/en-us/learn/server-side/django/generic_views/index.html
@@ -423,10 +423,10 @@ def book_detail_view(request, primary_key):
   Once the detail page exists we can get its URL with either of these two approaches:</p>
   <ul>
     <li>Use the <code>url</code> template tag to reverse the 'author-detail' URL (defined in the URL mapper), passing it the author instance for the book: 
-      <pre>&lt;a href="{% url 'author-detail' book.author.pk %}"&gt;\{{ book.author }}&lt;/a&gt;</pre>
+      <pre class="brush: python">&lt;a href="{% url 'author-detail' book.author.pk %}"&gt;\{{ book.author }}&lt;/a&gt;</pre>
     </li>
     <li>Call the author model's <code>get_absolute_url()</code> method (this performs the same reversing operation):
-      <pre>&lt;a href="\{{ book.author.get_absolute_url }}"&gt;\{{ book.author }}&lt;/a&gt;</pre>
+      <pre class="brush: plain">&lt;a href="\{{ book.author.get_absolute_url }}"&gt;\{{ book.author }}&lt;/a&gt;</pre>
     </li>
   </ul>
   <p>While both methods effectively do the same thing, <code>get_absolute_url()</code> is preferred because it helps you write more consistent and maintainable code (any changes only need to be done in one place: the author model).</p>
@@ -454,7 +454,7 @@ def book_detail_view(request, primary_key):
 
   <p>Beware also that if you don't define an order (on your class-based view or model), you will also see errors from the development server like this one:</p>
 
-  <pre>[29/May/2017 18:37:53] "GET /catalog/books/?page=1 HTTP/1.1" 200 1637
+  <pre class="brush: plain">[29/May/2017 18:37:53] "GET /catalog/books/?page=1 HTTP/1.1" 200 1637
 /foo/local_library/venv/lib/python3.5/site-packages/django/views/generic/list.py:99: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: &lt;QuerySet [&lt;Author: Ortiz, David&gt;, &lt;Author: H. McRaven, William&gt;, &lt;Author: Leigh, Melinda&gt;]&gt;
   allow_empty_first_page=allow_empty_first_page, **kwargs)
 </pre>
@@ -471,7 +471,7 @@ def book_detail_view(request, primary_key):
 
 <p>If you decide to go with a <code>class Meta</code> for the <code>Author</code> model (probably not as flexible as customizing the class-based view, but easy enough), you will end up with something like this:</p>
 
-<pre>class Author(models.Model):
+<pre class="brush: python">class Author(models.Model):
     first_name = models.CharField(max_length=100)
     last_name = models.CharField(max_length=100)
     date_of_birth = models.DateField(null=True, blank=True)

--- a/files/en-us/learn/server-side/django/home_page/index.html
+++ b/files/en-us/learn/server-side/django/home_page/index.html
@@ -86,7 +86,7 @@ tags:
 
 <p>The following code snippet from <strong>locallibrary/urls.py </strong>includes the <code>catalog.urls</code> module:</p>
 
-<pre>urlpatterns += [
+<pre class="brush: python">urlpatterns += [
     path('catalog/', include('catalog.urls')),
 ]
 </pre>

--- a/files/en-us/learn/server-side/django/skeleton_website/index.html
+++ b/files/en-us/learn/server-side/django/skeleton_website/index.html
@@ -273,7 +273,7 @@ If this pattern is targeted in an include(), ensure the include() pattern has a 
 
 <p>Add the following final block to the bottom of the file now:</p>
 
-<pre># Use static() to add url mapping to serve static files during development (only)
+<pre class="brush: python"># Use static() to add url mapping to serve static files during development (only)
 from django.conf import settings
 from django.conf.urls.static import static
 

--- a/files/en-us/learn/server-side/django/testing/index.html
+++ b/files/en-us/learn/server-side/django/testing/index.html
@@ -122,7 +122,7 @@ tags:
 
 <p>Django uses the unittest module’s <a href="https://docs.python.org/3/library/unittest.html#unittest-test-discovery" title="(in Python v3.5)">built-in test discovery</a>, which will discover tests under the current working directory in any file named with the pattern <strong>test*.py</strong>. Provided you name the files appropriately, you can use any structure you like. We recommend that you create a module for your test code, and have separate files for models, views, forms, and any other types of code you need to test. For example:</p>
 
-<pre>catalog/
+<pre class="brush: plain">catalog/
   /tests/
     __init__.py
     test_models.py

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.html
@@ -308,7 +308,7 @@ app.use(helmet());
 </pre>
  </li>
  <li>Use the status command to check all files that you are about to add are correct (you want to include source files, not binaries, temporary files etc.). It should look a bit like the listing below.
-  <pre>&gt; git status
+  <pre class="brush: bash">&gt; git status
 On branch main
 Your branch is up-to-date with 'origin/main'.
 Changes to be committed:

--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
@@ -94,7 +94,7 @@ tags:
 
 <p>The easiest way to install the most recent LTS version of Node 12.x is to use the <a href="https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions">package manager</a> to get it from the Ubuntu <em>binary distributions</em> repository. This can be done by running the following two commands on your terminal:</p>
 
-<pre>curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+<pre class="brush: bash">curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt-get install -y nodejs
 </pre>
 
@@ -293,7 +293,7 @@ npm run lint
 
 <p>The <a href="https://expressjs.com/en/starter/generator.html">Express Application Generator</a> tool generates an Express application "skeleton". Install the generator using NPM as shown:</p>
 
-<pre><code>npm install express-generator -g</code></pre>
+<pre class="brush: bash">npm install express-generator -g</pre>
 
 <div class="notecard note">
 <p><strong>Note:</strong> You may need to prefix this line with <code>sudo</code> on Ubuntu or macOS. The <code>-g</code> flag installs the tool globally so that you can call it from anywhere.</p>

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.html
@@ -55,7 +55,7 @@ exports.book_detail = function(req, res, next) {
 
 <p>Create <strong>/views/book_detail.pug</strong> and add the text below.</p>
 
-<pre>extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1 Title: #{book.title}
@@ -96,7 +96,7 @@ block content
 <div class="notecard note">
 <p><strong>Note:</strong> The list of genres associated with the book is implemented in the template as below. This adds a comma after every genre associated with the book except for the last one.</p>
 
-<pre>  p #[strong Genre:]
+<pre class="brush: plain">  p #[strong Genre:]
     each val, index in book.genre
       a(href=val.url) #{val.name}
       if index &lt; book.genre.length - 1

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/locallibrary_base_template/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/locallibrary_base_template/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>Open <strong>/views/layout.pug</strong> and replace the content with the code below.</p>
 
-<pre>doctype html
+<pre class="brush: plain">doctype html
 html(lang='en')
   head
     title= title

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/template_primer/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/template_primer/index.html
@@ -31,7 +31,7 @@ app.set('view engine', 'pug');</pre>
 <p>If you look in the views directory you will see the .pug files for the project's default views.
 These include the view for the home page (<strong>index.pug</strong>) and base template (<strong>layout.pug</strong>) that we will need to replace with our own content.</p>
 
-<pre>/express-locallibrary-tutorial  //the project root
+<pre class="brush: plain">/express-locallibrary-tutorial  //the project root
   /views
     error.pug
     index.pug
@@ -44,7 +44,7 @@ These include the view for the home page (<strong>index.pug</strong>) and base t
 
 <p>The first thing to notice is that the file maps the structure of a typical HTML file, with the first word in (almost) every line being an HTML element, and indentation being used to indicate nested elements. So for example, the <code>body</code> element is inside an <code>html</code> element, and paragraph elements (<code>p</code>) are within the <code>body</code> element, etc. Non-nested elements (e.g. individual paragraphs) are on separate lines.</p>
 
-<pre class="brush: html">doctype html
+<pre class="brush: plain">doctype html
 html(lang="en")
   head
     title= title
@@ -91,12 +91,12 @@ html(lang="en")
 
 <p>If a tag is followed by the equals sign, the following text is treated as a JavaScript <em>expression</em>. So for example, in the first line below, the content of the <code>h1</code> tag will be <em>variable</em> <code>title</code> (either defined in the file or passed into the template from Express). In the second line the paragraph content is a text string concatenated with the <code>title</code> variable. In both cases the default behavior is to <em>escape</em> the line.</p>
 
-<pre class="brush: html">h1= title
+<pre class="brush: plain">h1= title
 p= 'Evaluated and &lt;em&gt;escaped expression&lt;/em&gt;:' + title</pre>
 
 <p>If there is no equals symbol after the tag then the content is treated as plain text. Within the plain text you can insert escaped and unescaped data using the <code>#{}</code> and<code> !{}</code> syntax respectively, as shown below. You can also add raw HTML within the plain text.</p>
 
-<pre class="brush: html">p This is a line with #[em some emphasis] and #[strong strong text] markup.
+<pre class="brush: plain">p This is a line with #[em some emphasis] and #[strong strong text] markup.
 p This line has an un-escaped string: !{'&lt;em&gt; is emphasised&lt;/em&gt;'}, an escaped string: #{'&lt;em&gt; is not emphasised&lt;/em&gt;'}, and escaped variables: #{title}.</pre>
 
 <div class="notecard note">
@@ -105,19 +105,19 @@ p This line has an un-escaped string: !{'&lt;em&gt; is emphasised&lt;/em&gt;'}, 
 
 <p>You can use the pipe ('<strong>|</strong>') character at the beginning of a line to indicate "<a href="https://pugjs.org/language/plain-text.html" rel="noopener">plain text</a>". For example, the additional text shown below will be displayed on the same line as the preceding anchor, but will not be linked.</p>
 
-<pre class="brush: html">a(href='http://someurl/') Link text
+<pre class="brush: plain">a(href='http://someurl/') Link text
 | Plain text</pre>
 
 <p>Pug allows you to perform conditional operations using <code>if</code>, <code>else</code> , <code>else if</code> and <code>unless</code>—for example:</p>
 
-<pre class="brush: html">if title
+<pre class="brush: plain">if title
   p A variable named "title" exists
 else
   p A variable named "title" does not exist</pre>
 
 <p>You can also perform loop/iteration operations using <code>each-in</code> or <code>while</code> syntax. In the code fragment below we've looped through an array to display a list of variables (note the use of the 'li=' to evaluate the "val" as a variable below. The value you iterate across can also be passed into the template as a variable!</p>
 
-<pre class="brush: html">ul
+<pre class="brush: plain">ul
   each val in [1, 2, 3, 4, 5]
     li= val</pre>
 
@@ -129,7 +129,7 @@ else
 
 <p>For example, the base template <strong>layout.pug</strong> created in our <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/skeleton_website">skeleton project</a> looks like this:</p>
 
-<pre class="brush: html">doctype html
+<pre class="brush: plain">doctype html
 html
   head
     title= title
@@ -141,7 +141,7 @@ html
 
 <p>The default <strong>index.pug</strong> (created for our skeleton project) shows how we override the base template. The <code>extends</code> tag identifies the base template to use, and then we use <code>block <em>section_name</em></code> to indicate the new content of the section that we will override.</p>
 
-<pre class="brush: html">extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1= title

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_author_form/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_author_form/index.html
@@ -102,7 +102,7 @@ body('first_name').trim().isLength({ min: 1 }).escape().withMessage('First name 
 
 <p>Create <strong>/views/author_form.pug</strong> and copy in the text below.</p>
 
-<pre>extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1=title

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.html
@@ -148,7 +148,7 @@ for (let i = 0; i &lt; results.genres.length; i++) {
 
 <p>Create <strong>/views/book_form.pug</strong> and copy in the text below.</p>
 
-<pre>extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1= title

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.html
@@ -93,7 +93,7 @@ exports.bookinstance_create_post = [
 
 <p>Create <strong>/views/bookinstance_form.pug</strong> and copy in the text below.</p>
 
-<pre>extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1=title

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.html
@@ -22,7 +22,7 @@ tags:
 <div class="notecard note">
 <p><strong>Note:</strong> This syntax allows us to use <code>body</code> and <code>validationResult</code> as the associated middleware functions, as you will see in the post route section below. It is equivalent to:</p>
 
-<pre>validator = require("express-validator");
+<pre class="brush: js">validator = require("express-validator");
 body = validator.body();
 validationResult = validator.validationResult();
 </pre>

--- a/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.html
@@ -91,7 +91,7 @@ exports.author_delete_post = function(req, res, next) {
 
 <p>Create <strong>/views/author_delete.pug</strong> and copy in the text below.</p>
 
-<pre>extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1 #{title}: #{author.name}
@@ -137,7 +137,7 @@ block content
 
 <p>Open the <strong>author_detail.pug</strong> view and add the following lines at the bottom.</p>
 
-<pre class="brush: html">hr
+<pre class="brush: plain">hr
 p
   a(href=author.url+'/delete') Delete author</pre>
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.html
@@ -141,7 +141,7 @@ exports.book_update_post = [
 
 <p>Open <strong>/views/book_form.pug</strong> and update the section where the author form control is set to have the conditional code shown below.</p>
 
-<pre>    div.form-group
+<pre class="brush: plain">    div.form-group
       label(for='author') Author:
       select#author.form-control(type='select' placeholder='Select author' name='author' required='true' )
         - authors.sort(function(a, b) {let textA = a.family_name.toUpperCase(); let textB = b.family_name.toUpperCase(); return (textA &lt; textB) ? -1 : (textA &gt; textB) ? 1 : 0;});
@@ -166,7 +166,7 @@ exports.book_update_post = [
 
 <p>Open the <strong>book_detail.pug</strong> view and make sure there are links for both deleting and updating books at the bottom of the page, as shown below.</p>
 
-<pre class="brush: html">  hr
+<pre class="brush: plain">  hr
   p
     a(href=book.url+'/delete') Delete Book
   p

--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.html
@@ -53,7 +53,7 @@ tags:
 <ol>
  <li>Open Terminal (on Windows, open the command line utility)</li>
  <li>Create the folder where you want to save the program, for example, <code>test-node</code> and then enter it by entering the following command into your terminal:
-  <pre>cd test-node</pre>
+  <pre class="brush: bash">cd test-node</pre>
  </li>
  <li>Using your favorite text editor, create a file called <code>hello.js</code> and paste the following code into it:<br>
 
@@ -376,11 +376,11 @@ app.listen(3000);</pre>
 
 <p>Any files in the public directory are served by adding their filename (<em>relative</em> to the base "public" directory) to the base URL. So for example:</p>
 
-<pre><code>http://localhost:3000/images/dog.jpg
+<pre class="brush: plain">http://localhost:3000/images/dog.jpg
 http://localhost:3000/css/style.css
 http://localhost:3000/js/app.js
 http://localhost:3000/about.html
-</code></pre>
+</pre>
 
 <p>You can call <code>static()</code> multiple times to serve multiple directories. If a file cannot be found by one middleware function then it will be passed on to the subsequent middleware (the order that middleware is called is based on your declaration order).</p>
 
@@ -395,9 +395,9 @@ app.use(express.static('media'));
 
 <p>Now, you can load the files that are in the <code>public</code> directory from the <code>/media</code> path prefix.</p>
 
-<pre><code>http://localhost:3000/media/images/dog.jpg
+<pre class="brush: plain">http://localhost:3000/media/images/dog.jpg
 http://localhost:3000/media/video/cat.mp4
-http://localhost:3000/media/cry.mp3</code>
+http://localhost:3000/media/cry.mp3
 </pre>
 
 <div class="notecard note">

--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
@@ -636,7 +636,7 @@ db.on('error', console.error.bind(console, 'MongoDB connection error:'));</pre>
 <p>We will define a separate module for each model, as <a href="#one_schemamodel_per_file">discussed above</a>.
 Start by creating a folder for our models in the project root (<strong>/models</strong>) and then create separate files for each of the models:</p>
 
-<pre>/express-locallibrary-tutorial  //the project root
+<pre class="brush: plain">/express-locallibrary-tutorial  //the project root
   /models
     author.js
     book.js

--- a/files/en-us/learn/server-side/express_nodejs/routes/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/routes/index.html
@@ -203,7 +203,7 @@ app.use('/wiki', wiki);</pre>
 
 <p>Start by creating a folder for our controllers in the project root (<strong>/controllers</strong>) and then create separate controller files/modules for handling each of the models:</p>
 
-<pre>/express-locallibrary-tutorial  //the project root
+<pre class="brush: plain">/express-locallibrary-tutorial  //the project root
   /controllers
     authorController.js
     bookController.js
@@ -414,7 +414,7 @@ exports.book_update_post = function(req, res) {
 <p>The skeleton already has a <strong>./routes</strong> folder containing routes for the <em>index</em> and <em>users</em>.
 Create another route file — <strong>catalog.js</strong> — inside this folder, as shown.</p>
 
-<pre>/express-locallibrary-tutorial //the project root
+<pre class="brush: plain">/express-locallibrary-tutorial //the project root
   /routes
     index.js
     users.js

--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.html
@@ -287,7 +287,7 @@ This sets up some of the application error handling and then loads <strong>app.j
 The app routes are stored in separate modules under the <strong>routes/</strong> directory.
 The templates are stored under the /<strong>views</strong> directory.</p>
 
-<pre>/express-locallibrary-tutorial
+<pre class="brush: plain">express-locallibrary-tutorial
     app.js
     /bin
         www
@@ -497,7 +497,7 @@ router.get('/', function(req, res, next) {
 
 <p>The corresponding template for the above route is given below (<strong>index.pug</strong>). We'll talk more about the syntax later. All you need to know for now is that the <code>title</code> variable (with value <code>'Express'</code>) is inserted where specified in the template.</p>
 
-<pre>extends layout
+<pre class="brush: plain">extends layout
 
 block content
   h1= title

--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -78,7 +78,7 @@ tags:
 
 <p>Each line of the request contains information about it. The first part is called the <strong>header</strong>, and contains useful information about the request, in the same way that an <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML">HTML head</a> contains useful information about an HTML document (but not the actual content itself, which is in the body):</p>
 
-<pre>GET https://developer.mozilla.org/en-US/search?q=client+server+overview&amp;topic=apps&amp;topic=html&amp;topic=css&amp;topic=js&amp;topic=api&amp;topic=webdev HTTP/1.1
+<pre class="brush: http">GET https://developer.mozilla.org/en-US/search?q=client+server+overview&amp;topic=apps&amp;topic=html&amp;topic=css&amp;topic=js&amp;topic=api&amp;topic=webdev HTTP/1.1
 Host: developer.mozilla.org
 Connection: keep-alive
 Pragma: no-cache
@@ -129,7 +129,7 @@ Cookie: sessionid=6ynxs23n521lu21b1t136rhbv7ezngie; csrftoken=zIPUJsAZv6pcgCBJSC
 
 <p>At the end of the message we see the <strong>body</strong> content — which contains the actual HTML returned by the request.</p>
 
-<pre class="brush: html">HTTP/1.1 200 OK
+<pre class="brush: http">HTTP/1.1 200 OK
 Server: Apache
 X-Backend-Server: developer1.webapp.scl3.mozilla.com
 Vary: Accept,Cookie, Accept-Encoding
@@ -161,7 +161,7 @@ Content-Length: 41823
 
 <p>The text below shows the HTTP request made when a user submits new profile details on this site. The format of the request is almost the same as the <code>GET</code> request example shown previously, though the first line identifies this request as a <code>POST</code>. </p>
 
-<pre class="brush: html">POST https://developer.mozilla.org/en-US/profiles/hamishwillee/edit HTTP/1.1
+<pre class="brush: http">POST https://developer.mozilla.org/en-US/profiles/hamishwillee/edit HTTP/1.1
 Host: developer.mozilla.org
 Connection: keep-alive
 Content-Length: 432
@@ -185,7 +185,7 @@ csrfmiddlewaretoken=zIPUJsAZv6pcgCBJSCj1zU6pQZbfMUAT&amp;user-username=hamishwil
 
 <p>The response from the request is shown below. The status code of "<code>302 Found</code>" tells the browser that the post succeeded, and that it must issue a second HTTP request to load the page specified in the <code>Location</code> field. The information is otherwise similar to that for the response to a <code>GET</code> request.</p>
 
-<pre class="brush: html">HTTP/1.1 302 FOUND
+<pre class="brush: http">HTTP/1.1 302 FOUND
 Server: Apache
 X-Backend-Server: developer3.webapp.scl3.mozilla.com
 Vary: Cookie
@@ -286,8 +286,8 @@ urlpatterns = [
     url(r'^junior/$', views.junior),
 ]</pre>
 
-<div class="note">
-<p><strong>Note</strong>: The first parameters in the <code>url()</code> functions may look a bit odd (e.g. <code>r'^junior/$'</code>) because they use a pattern matching technique called "regular expressions" (RegEx, or RE). You don't need to know how regular expressions work at this point, other than that they allow us to match patterns in the URL (rather than the hard coded values above) and use them as parameters in our view functions. As an example, a really simple RegEx might say "match a single uppercase letter, followed by between 4 and 7 lower case letters."</p>
+<div class="notecard note">
+<p><strong>Note:</strong> The first parameters in the <code>url()</code> functions may look a bit odd (e.g. <code>r'^junior/$'</code>) because they use a pattern matching technique called "regular expressions" (RegEx, or RE). You don't need to know how regular expressions work at this point, other than that they allow us to match patterns in the URL (rather than the hard coded values above) and use them as parameters in our view functions. As an example, a really simple RegEx might say "match a single uppercase letter, followed by between 4 and 7 lower case letters."</p>
 </div>
 
 <p>The web framework also makes it easy for a view function to fetch information from the database. The structure of our data is defined in models, which are Python classes that define the fields to be stored in the underlying database. If we have a model named <em>Team</em> with a field of "<em>team_type</em>" then we can use a simple query syntax to get back all teams that have a particular type.</p>


### PR DESCRIPTION
Fixes #8561 

This adds `<pre class="brush: plain">` to all empty pre blocks in Learn/server side. This adds the copy content icon to rendered content, which is not present otherwise. I'm also hoping it simplifies markdown conversion :-)