### PR TITLE
add indexed-cache js in indexed_db_api, `see also` section.

### DIFF
--- a/files/en-us/web/api/indexeddb_api/index.html
+++ b/files/en-us/web/api/indexeddb_api/index.html
@@ -147,5 +147,6 @@ tags:
  <li><a href="https://www.npmjs.com/package/@sifrr/storage">sifrr-storage:</a> A small (~2kB) promise based library for client side key-value storage. Works with IndexedDB, localStorage, WebSQL, Cookies. Can automatically use supported storage available based on priority.</li>
  <li><a href="https://github.com/google/lovefield">lovefield</a>: Lovefield is a relational database for web apps. Written in JavaScript, works cross-browser. Provides SQL-like APIs that are fast, safe, and easy to use.</li>
  <li><a href="https://github.com/hyoo-ru/mam_mol/tree/master/db">$mol_db</a>: Tiny (~1.3kB) TypeScript facade with promise-based api and automatic migrations.</li>
+ <li><a href="https://github.com/knadh/indexed-cache">indexed-cache</a>: indexed-cache is a tiny Javascript library that "sideloads" static assets (script, link, and img tags) on webpages using the fetch() API and caches them in an IndexedDB store to eliminate the dependency on the standard browser static asset cache, and to eliminate HTTP requests on subsequent page loads. Javascript, CSS, and image assets are stored in IndexedDB as Blob()s.
 
 </ul>


### PR DESCRIPTION
I have added the indexed-cache js library in _see also_ section of indexedb_api.

https://github.com/knadh/indexed-cache

Useful if at least a few of these are true:

* There are large static files (JS, CSS) that rarely change.
* High traffic from a large number of returning users who access web pages with the same assets regularly and frequently.
* The pages are mostly inside mobile web views where browser cache gets evicted (OS pressure) causing the same assets to be fetched afresh over and over wasting bandwidth.
* Bandwidth is a concern.