### PR TITLE
Release notes for ElementInternals.shadowRoot

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -45,6 +45,10 @@ tags:
 
 <h3 id="APIs">APIs</h3>
 
+<ul>
+  <li>{{domxref("ElementInternals.shadowRoot")}} is now supported ({{bug(1723521)}}).</li>
+</ul>
+
 <h4 id="DOM">DOM</h4>
 
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>


### PR DESCRIPTION
Part of #8616 adds the release notes.