### PR TITLE
WebXR transient input hit test: fix typo space -> profile

### DIFF
--- a/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
@@ -42,7 +42,7 @@ An array of {{domxref("XRTransientInputHitTestResult")}} objects.
 
  let transientHitTestSource = null;
  xrSession.requestHitTestSourceForTransientInput({
-   space : "generic-touchscreen",
+   profile : "generic-touchscreen",
    offsetRay : new XRRay()
  }).then((touchScreenHitTestSource) => {
    transientHitTestSource = touchScreenHitTestSource;

--- a/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
@@ -69,7 +69,7 @@ const xrSession = navigator.xr.requestSession("immersive-ar", {
 let transientHitTestSource = null;
 
 xrSession.requestHitTestSourceForTransientInput({
-  space : "generic-touchscreen",
+  profile : "generic-touchscreen",
   offsetRay : new XRRay()
 }).then((touchScreenHitTestSource) => {
   transientHitTestSource = touchScreenHitTestSource;

--- a/files/en-us/web/api/xrtransientinputhittestsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/index.md
@@ -40,7 +40,7 @@ const xrSession = navigator.xr.requestSession("immersive-ar", {
 let transientHitTestSource = null;
 
 xrSession.requestHitTestSourceForTransientInput({
-  space : "generic-touchscreen",
+  profile : "generic-touchscreen",
   offsetRay : new XRRay()
 }).then((touchScreenHitTestSource) => {
   transientHitTestSource = touchScreenHitTestSource;


### PR DESCRIPTION
I made a typo. This dictionary has the `profile` option, not `space` https://immersive-web.github.io/hit-test/#transient-input-hit-test-options-dictionary (the other hit test dictionary has `space`)