### PR TITLE
Added very important yet missing information.

### DIFF
--- a/files/en-us/web/css/transform-function/rotate()/index.md
+++ b/files/en-us/web/css/transform-function/rotate()/index.md
@@ -32,8 +32,9 @@ rotate(a)
 ### Values
 
 - _a_
-  - : Is an {{ cssxref("&lt;angle&gt;") }} representing the angle of the rotation. A positive angle denotes a clockwise
-    rotation, a negative angle a counter-clockwise one.
+  - : Is an {{ cssxref("&lt;angle&gt;") }} representing the angle of the rotation. The direction of rotation depends on the writing direction. 
+      In a left-to-right context, a positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one. In a right-to-left context, 
+      a positive angle denotes a counter-clockwise rotation, a negative angle a clockwise one.
 
 <table class="standard-table">
   <thead>


### PR DESCRIPTION
The writing direction sensitivity of the direction of rotation seems to be an unspecified feature whose practical implications are so obviously appropriate that it seems to have been consistently yet silently implemented. Tested in Chrome and Firefox. However, its effect is sometimes unexpected, like when angle quotation marks are repurposed as twisties (and their bidi-mirrored=yes property does not fix it).

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None.

> What was wrong/why is this fix needed? (quick summary only)

Missing information.

> Anything else that could help us review it

Same problem in https://developer.mozilla.org/en-US/docs/Web/CSS/angle