### PR TITLE
Use `onchange` instead of `addEventListener`

### DIFF
--- a/files/en-us/web/api/mediaquerylist/onchange/index.html
+++ b/files/en-us/web/api/mediaquerylist/onchange/index.html
@@ -30,7 +30,7 @@ browser-compat: api.MediaQueryList.onchange
 
 <pre class="brush: js">var mql = window.matchMedia('(max-width: 600px)');
 
-mql.addEventListener( "change", (e) =&gt; {
+mql.onchange = (e) =&gt; {
     if (e.matches) {
     /* the viewport is 600 pixels wide or less */
     console.log('This is a narrow screen — less than 600px wide.')
@@ -38,7 +38,7 @@ mql.addEventListener( "change", (e) =&gt; {
     /* the viewport is more than than 600 pixels wide */
     console.log('This is a wide screen — more than 600px wide.')
   }
-})
+}
 
 </pre>
 


### PR DESCRIPTION
The article is about `MediaQueryList.onchange`, but the example used `MediaQueryList.addEventListener`. I've corrected the example to use `onchange`.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #8693


> What was wrong/why is this fix needed? (quick summary only)

The article is about MediaQueryList.onchange, but the example doesn't use it. Instead the example uses MediaQueryList.addEventListener.


> Anything else that could help us review it

Nothing besides what I've already provided in issue #8693.