### PR TITLE
Add return statements to "Clearing the cache" example code

### DIFF
--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -178,9 +178,9 @@ self.addEventListener('install', (e) =&gt; {
 
 <pre class="brush: js">self.addEventListener('activate', (e) =&gt; {
   e.waitUntil(caches.keys().then((keyList) =&gt; {
-    Promise.all(keyList.map((key) =&gt; {
+    return Promise.all(keyList.map((key) =&gt; {
       if (key === cacheName) { return; }
-      caches.delete(key);
+      return caches.delete(key);
     }))
   }));
 });</pre>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #8695

> What was wrong/why is this fix needed? (quick summary only)

`waitUntil()` and `Promise.all()` each expect to be given a (or an array of) Promise(s), but the missing `return`s meant that wasn't happening.

> Anything else that could help us review it

This page has the same code but with the returns:
https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/keys