### PR TITLE
Reconstruct Global_Objects/Int32Array

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/index.md
@@ -3,6 +3,7 @@ title: Int32Array
 slug: Web/JavaScript/Reference/Global_Objects/Int32Array
 tags:
   - Class
+  - Int32Array
   - JavaScript
   - TypedArray
   - TypedArrays
@@ -11,52 +12,92 @@ browser-compat: javascript.builtins.Int32Array
 ---
 {{JSRef}}
 
-The **`Int32Array()`** typed array constructor creates an array
-of twos-complement 32-bit signed integers in the platform byte order. If control over
-byte order is needed, use {{jsxref("DataView")}} instead. The contents are initialized
-to `0`. Once established, you can reference elements in the array using the
-object's methods, or using standard array index syntax (that is, using bracket
-notation).
+The **`Int32Array`** typed array represents an array of twos-complement 32-bit signed integers in the platform byte order. If control over byte order is needed, use {{jsxref("DataView")}} instead. The contents are initialized to `0`. Once established, you can reference elements in the array using the object's methods, or using standard array index syntax (that is, using bracket notation).
 
-## Syntax
+## Constructor
 
-```js
-new Int32Array(); // new in ES2017
-new Int32Array(length);
-new Int32Array(typedArray);
-new Int32Array(object);
+- {{jsxref("Global_Objects/Int32Array/Int32Array", "Int32Array()")}}
+  - : Creates a new `Int32Array` object.
 
-new Int32Array(buffer);
-new Int32Array(buffer, byteOffset);
-new Int32Array(buffer, byteOffset, length);
-```
+## Static properties
 
-### Parameters
+- {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Int32Array.BYTES_PER_ELEMENT")}}
+  - : Returns a number value of the element size. `4` in the case of an `Int32Array`.
+- {{jsxref("TypedArray.name", "Int32Array.name")}}
+  - : Returns the string value of the constructor name. In the case of the `Int32Array` type: "`Int32Array`".
 
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+## Static methods
+
+- {{jsxref("TypedArray.from", "Int32Array.from()")}}
+  - : Creates a new `Int32Array` from an array-like or iterable object. See also {{jsxref("Array.from()")}}.
+- {{jsxref("TypedArray.of", "Int32Array.of()")}}
+  - : Creates a new `Int32Array` with a variable number of arguments. See also {{jsxref("Array.of()")}}.
+
+## Instance properties
+
+- {{jsxref("TypedArray.prototype.buffer", "Int32Array.prototype.buffer")}}
+  - : Returns the {{jsxref("ArrayBuffer")}} referenced by the `Int32Array`. Fixed at construction time and thus **read only**.
+- {{jsxref("TypedArray.prototype.byteLength", "Int32Array.prototype.byteLength")}}
+  - : Returns the length (in bytes) of the `Int32Array` from the start of its {{jsxref("ArrayBuffer")}}. Fixed at construction time and thus **read only.**
+- {{jsxref("TypedArray.prototype.byteOffset", "Int32Array.prototype.byteOffset")}}
+  - : Returns the offset (in bytes) of the `Int32Array` from the start of its {{jsxref("ArrayBuffer")}}. Fixed at construction time and thus **read only.**
+- {{jsxref("TypedArray.prototype.length", "Int32Array.prototype.length")}}
+  - : Returns the number of elements held in the `Int32Array`. Fixed at construction time and thus **read only.**
+
+## Instance methods
+
+- {{jsxref("TypedArray.copyWithin", "Int32Array.prototype.copyWithin()")}}
+  - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
+- {{jsxref("TypedArray.entries", "Int32Array.prototype.entries()")}}
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
+- {{jsxref("TypedArray.every", "Int32Array.prototype.every()")}}
+  - : Tests whether all elements in the array pass the test provided by a function. See also {{jsxref("Array.prototype.every()")}}.
+- {{jsxref("TypedArray.fill", "Int32Array.prototype.fill()")}}
+  - : Fills all the elements of an array from a start index to an end index with a static value. See also {{jsxref("Array.prototype.fill()")}}.
+- {{jsxref("TypedArray.filter", "Int32Array.prototype.filter()")}}
+  - : Creates a new array with all of the elements of this array for which the provided filtering function returns `true`. See also {{jsxref("Array.prototype.filter()")}}.
+- {{jsxref("TypedArray.find", "Int32Array.prototype.find()")}}
+  - : Returns the found value in the array, if an element in the array satisfies the provided testing function or `undefined` if not found. See also {{jsxref("Array.prototype.find()")}}.
+- {{jsxref("TypedArray.findIndex", "Int32Array.prototype.findIndex()")}}
+  - : Returns the found index in the array, if an element in the array satisfies the provided testing function or `-1` if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
+- {{jsxref("TypedArray.forEach", "Int32Array.prototype.forEach()")}}
+  - : Calls a function for each element in the array. See also {{jsxref("Array.prototype.forEach()")}}.
+- {{jsxref("TypedArray.includes", "Int32Array.prototype.includes()")}}
+  - : Determines whether a typed array includes a certain element, returning `true` or `false` as appropriate. See also {{jsxref("Array.prototype.includes()")}}.
+- {{jsxref("TypedArray.indexOf", "Int32Array.prototype.indexOf()")}}
+  - : Returns the first (least) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
+- {{jsxref("TypedArray.join", "Int32Array.prototype.join()")}}
+  - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
+- {{jsxref("TypedArray.keys", "Int32Array.prototype.keys()")}}
+  - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+- {{jsxref("TypedArray.lastIndexOf", "Int32Array.prototype.lastIndexOf()")}}
+  - : Returns the last (greatest) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
+- {{jsxref("TypedArray.map", "Int32Array.prototype.map()")}}
+  - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
+- {{jsxref("TypedArray.reduce", "Int32Array.prototype.reduce()")}}
+  - : Apply a function against an accumulator and each value of the array (from left-to-right) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduce()")}}.
+- {{jsxref("TypedArray.reduceRight", "Int32Array.prototype.reduceRight()")}}
+  - : Apply a function against an accumulator and each value of the array (from right-to-left) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduceRight()")}}.
+- {{jsxref("TypedArray.reverse", "Int32Array.prototype.reverse()")}}
+  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
+- {{jsxref("TypedArray.set", "Int32Array.prototype.set()")}}
+  - : Stores multiple values in the typed array, reading input values from a specified array.
+- {{jsxref("TypedArray.slice", "Int32Array.prototype.slice()")}}
+  - : Extracts a section of an array and returns a new array. See also {{jsxref("Array.prototype.slice()")}}.
+- {{jsxref("TypedArray.some", "Int32Array.prototype.some()")}}
+  - : Returns `true` if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
+- {{jsxref("TypedArray.sort", "Int32Array.prototype.sort()")}}
+  - : Sorts the elements of an array in place and returns the array. See also {{jsxref("Array.prototype.sort()")}}.
+- {{jsxref("TypedArray.subarray", "Int32Array.prototype.subarray()")}}
+  - : Returns a new `Int32Array` from the given start and end element index.
+- {{jsxref("TypedArray.values", "Int32Array.prototype.values()")}}
+  - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
+- {{jsxref("TypedArray.toLocaleString", "Int32Array.prototype.toLocaleString()")}}
+  - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
+- {{jsxref("TypedArray.toString", "Int32Array.prototype.toString()")}}
+  - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
+- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]()")}}
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples
 
@@ -96,23 +137,6 @@ var int32 = new Int32Array(iterable);
 ## Browser compatibility
 
 {{Compat}}
-
-### Compatibility notes
-
-Starting with ECMAScript 2015, `Int32Array` constructors require to be
-constructed with a {{jsxref("Operators/new", "new")}} operator. Calling a
-`Int32Array` constructor as a function without `new`, will throw a
-{{jsxref("TypeError")}} from now on.
-
-```js example-bad
-var dv = Int32Array([1, 2, 3]);
-// TypeError: calling a builtin Int32Array constructor
-// without new is forbidden
-```
-
-```js example-good
-var dv = new Int32Array([1, 2, 3]);
-```
 
 ## See also
 


### PR DESCRIPTION
The content is for the Int32Array() constructor rather than Int32Array class.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none.

> What was wrong/why is this fix needed? (quick summary only)

The content is the same to the Int32Array() constructor.
This article should be for the Int32Array class.


> Anything else that could help us review it
