### PR TITLE
Marking literals as inline codes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -25,7 +25,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "BigInt64Array.BYTES_PER_ELEMENT")}}
   - : Returns a number value of the element size. `8` in the case of a `BigInt64Array`.
 - {{jsxref("TypedArray.name", "BigInt64Array.name")}}
-  - : Returns the string value of the constructor name. In the case of the `BigInt64Array` type, this is "BigInt64Array".
+  - : Returns the string value of the constructor name. In the case of the `BigInt64Array` type, this is "`BigInt64Array`".
 
 ## Static methods
 
@@ -56,23 +56,23 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.fill", "BigInt64Array.prototype.fill()")}}
   - : Fills all the elements of an array from a start index to an end index with a static value. See also {{jsxref("Array.prototype.fill()")}}.
 - {{jsxref("TypedArray.filter", "BigInt64Array.prototype.filter()")}}
-  - : Creates a new array with all of the elements of this array for which the provided filtering function returns true. See also {{jsxref("Array.prototype.filter()")}}.
+  - : Creates a new array with all of the elements of this array for which the provided filtering function returns `true`. See also {{jsxref("Array.prototype.filter()")}}.
 - {{jsxref("TypedArray.find", "BigInt64Array.prototype.find()")}}
   - : Returns the found value in the array if an element in the array satisfies the provided testing function, or `undefined` if not found. See also {{jsxref("Array.prototype.find()")}}.
 - {{jsxref("TypedArray.findIndex", "BigInt64Array.prototype.findIndex()")}}
-  - : Returns the found index in the array if an element in the array satisfies the provided testing function, or -1 if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
+  - : Returns the found index in the array if an element in the array satisfies the provided testing function, or `-1` if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
 - {{jsxref("TypedArray.forEach", "BigInt64Array.prototype.forEach()")}}
   - : Calls a function for each element in the array. See also {{jsxref("Array.prototype.forEach()")}}.
 - {{jsxref("TypedArray.includes", "BigInt64Array.prototype.includes()")}}
   - : Determines whether a typed array includes a certain element, returning `true` or `false` as appropriate. See also {{jsxref("Array.prototype.includes()")}}.
 - {{jsxref("TypedArray.indexOf", "BigInt64Array.prototype.indexOf()")}}
-  - : Returns the first (least) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
+  - : Returns the first (least) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
 - {{jsxref("TypedArray.join", "BigInt64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "BigInt64Array.prototype.keys()")}}
   - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "BigInt64Array.prototype.lastIndexOf()")}}
-  - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
+  - : Returns the last (greatest) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "BigInt64Array.prototype.map()")}}
   - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
 - {{jsxref("TypedArray.reduce", "BigInt64Array.prototype.reduce()")}}
@@ -80,17 +80,17 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 - {{jsxref("TypedArray.reduceRight", "BigInt64Array.prototype.reduceRight()")}}
   - : Applies a function against an accumulator and each value of the array (from right-to-left) so as to reduce it to a single value. See also {{jsxref("Array.prototype.reduceRight()")}}.
 - {{jsxref("TypedArray.reverse", "BigInt64Array.prototype.reverse()")}}
-  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
+  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
 - {{jsxref("TypedArray.set", "BigInt64Array.prototype.set()")}}
   - : Stores multiple values in the typed array, reading input values from a specified array.
 - {{jsxref("TypedArray.slice", "BigInt64Array.prototype.slice()")}}
   - : Extracts a section of an array and returns a new array. See also {{jsxref("Array.prototype.slice()")}}.
 - {{jsxref("TypedArray.some", "BigInt64Array.prototype.some()")}}
-  - : Returns true if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
+  - : Returns `true` if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
 - {{jsxref("TypedArray.sort", "BigInt64Array.prototype.sort()")}}
   - : Sorts the elements of an array in place and returns the array. See also {{jsxref("Array.prototype.sort()")}}.
 - {{jsxref("TypedArray.subarray", "BigInt64Array.prototype.subarray()")}}
-  - : Returns a new `BigUint64Array` from the given start and end element index.
+  - : Returns a new `BigInt64Array` from the given start and end element index.
 - {{jsxref("TypedArray.values", "BigInt64Array.prototype.values()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
 - {{jsxref("TypedArray.toLocaleString", "BigInt64Array.prototype.toLocaleString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
@@ -25,7 +25,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "BigUint64Array.BYTES_PER_ELEMENT")}}
   - : Returns a number value of the element size. `8` in the case of a `BigUint64Array`.
 - {{jsxref("TypedArray.name", "BigUint64Array.name")}}
-  - : Returns the string value of the constructor name. In the case of the `BigUint64Array` type this is "BigUint64Array".
+  - : Returns the string value of the constructor name. In the case of the `BigUint64Array` type this is "`BigUint64Array`".
 
 ## Static methods
 
@@ -56,23 +56,23 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.fill", "BigUint64Array.prototype.fill()")}}
   - : Fills all the elements of an array from a start index to an end index with a static value. See also {{jsxref("Array.prototype.fill()")}}.
 - {{jsxref("TypedArray.filter", "BigUint64Array.prototype.filter()")}}
-  - : Creates a new array with all of the elements of this array for which the provided filtering function returns true. See also {{jsxref("Array.prototype.filter()")}}.
+  - : Creates a new array with all of the elements of this array for which the provided filtering function returns `true`. See also {{jsxref("Array.prototype.filter()")}}.
 - {{jsxref("TypedArray.find", "BigUint64Array.prototype.find()")}}
   - : Returns the found value in the array if an element in the array satisfies the provided testing function, or `undefined` if not found. See also {{jsxref("Array.prototype.find()")}}.
 - {{jsxref("TypedArray.findIndex", "BigUint64Array.prototype.findIndex()")}}
-  - : Returns the found index in the array if an element in the array satisfies the provided testing function, or -1 if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
+  - : Returns the found index in the array if an element in the array satisfies the provided testing function, or `-1` if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
 - {{jsxref("TypedArray.forEach", "BigUint64Array.prototype.forEach()")}}
   - : Calls a function for each element in the array. See also {{jsxref("Array.prototype.forEach()")}}.
 - {{jsxref("TypedArray.includes", "BigUint64Array.prototype.includes()")}}
   - : Determines whether a typed array includes a certain element, returning `true` or `false` as appropriate. See also {{jsxref("Array.prototype.includes()")}}.
 - {{jsxref("TypedArray.indexOf", "BigUint64Array.prototype.indexOf()")}}
-  - : Returns the first (least) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
+  - : Returns the first (least) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
 - {{jsxref("TypedArray.join", "BigUint64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "BigUint64Array.prototype.keys()")}}
   - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "BigUint64Array.prototype.lastIndexOf()")}}
-  - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
+  - : Returns the last (greatest) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "BigUint64Array.prototype.map()")}}
   - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
 - {{jsxref("TypedArray.reduce", "BigUint64Array.prototype.reduce()")}}
@@ -80,7 +80,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 - {{jsxref("TypedArray.reduceRight", "BigUint64Array.prototype.reduceRight()")}}
   - : Applies a function against an accumulator and each value of the array (from right-to-left) so as to reduce it to a single value. See also {{jsxref("Array.prototype.reduceRight()")}}.
 - {{jsxref("TypedArray.reverse", "BigUint64Array.prototype.reverse()")}}
-  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
+  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
 - {{jsxref("TypedArray.set", "BigUint64Array.prototype.set()")}}
   - : Stores multiple values in the typed array, reading input values from a specified array.
 - {{jsxref("TypedArray.slice", "BigUint64Array.prototype.slice()")}}

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -23,7 +23,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Float32Array.BYTES_PER_ELEMENT")}}
   - : Returns a number value of the element size. `4` in the case of an `Float32Array`.
 - {{jsxref("TypedArray.name", "Float32Array.name")}}
-  - : Returns the string value of the constructor name. In the case of the `Float32Array` type: "Float32Array".
+  - : Returns the string value of the constructor name. In the case of the `Float32Array` type: "`Float32Array`".
 
 ## Static methods
 
@@ -54,23 +54,23 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.fill", "Float32Array.prototype.fill()")}}
   - : Fills all the elements of an array from a start index to an end index with a static value. See also {{jsxref("Array.prototype.fill()")}}.
 - {{jsxref("TypedArray.filter", "Float32Array.prototype.filter()")}}
-  - : Creates a new array with all of the elements of this array for which the provided filtering function returns true. See also {{jsxref("Array.prototype.filter()")}}.
+  - : Creates a new array with all of the elements of this array for which the provided filtering function returns `true`. See also {{jsxref("Array.prototype.filter()")}}.
 - {{jsxref("TypedArray.find", "Float32Array.prototype.find()")}}
   - : Returns the found value in the array, if an element in the array satisfies the provided testing function or `undefined` if not found. See also {{jsxref("Array.prototype.find()")}}.
 - {{jsxref("TypedArray.findIndex", "Float32Array.prototype.findIndex()")}}
-  - : Returns the found index in the array, if an element in the array satisfies the provided testing function or -1 if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
+  - : Returns the found index in the array, if an element in the array satisfies the provided testing function or `-1` if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
 - {{jsxref("TypedArray.forEach", "Float32Array.prototype.forEach()")}}
   - : Calls a function for each element in the array. See also {{jsxref("Array.prototype.forEach()")}}.
 - {{jsxref("TypedArray.includes", "Float32Array.prototype.includes()")}}
   - : Determines whether a typed array includes a certain element, returning `true` or `false` as appropriate. See also {{jsxref("Array.prototype.includes()")}}.
 - {{jsxref("TypedArray.indexOf", "Float32Array.prototype.indexOf()")}}
-  - : Returns the first (least) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
+  - : Returns the first (least) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
 - {{jsxref("TypedArray.join", "Float32Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "Float32Array.prototype.keys()")}}
   - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "Float32Array.prototype.lastIndexOf()")}}
-  - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
+  - : Returns the last (greatest) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float32Array.prototype.map()")}}
   - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
 - {{jsxref("TypedArray.reduce", "Float32Array.prototype.reduce()")}}
@@ -78,13 +78,13 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 - {{jsxref("TypedArray.reduceRight", "Float32Array.prototype.reduceRight()")}}
   - : Apply a function against an accumulator and each value of the array (from right-to-left) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduceRight()")}}.
 - {{jsxref("TypedArray.reverse", "Float32Array.prototype.reverse()")}}
-  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
+  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
 - {{jsxref("TypedArray.set", "Float32Array.prototype.set()")}}
   - : Stores multiple values in the typed array, reading input values from a specified array.
 - {{jsxref("TypedArray.slice", "Float32Array.prototype.slice()")}}
   - : Extracts a section of an array and returns a new array. See also {{jsxref("Array.prototype.slice()")}}.
 - {{jsxref("TypedArray.some", "Float32Array.prototype.some()")}}
-  - : Returns true if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
+  - : Returns `true` if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
 - {{jsxref("TypedArray.sort", "Float32Array.prototype.sort()")}}
   - : Sorts the elements of an array in place and returns the array. See also {{jsxref("Array.prototype.sort()")}}.
 - {{jsxref("TypedArray.subarray", "Float32Array.prototype.subarray()")}}

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -23,7 +23,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Float64Array.BYTES_PER_ELEMENT")}}
   - : Returns a number value of the element size. `8` in the case of an `Float64Array`.
 - {{jsxref("TypedArray.name", "Float64Array.name")}}
-  - : Returns the string value of the constructor name. In the case of the `Float64Array` type: "Float64Array".
+  - : Returns the string value of the constructor name. In the case of the `Float64Array` type: "`Float64Array`".
 
 ## Static methods
 
@@ -54,23 +54,23 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.fill", "Float64Array.prototype.fill()")}}
   - : Fills all the elements of an array from a start index to an end index with a static value. See also {{jsxref("Array.prototype.fill()")}}.
 - {{jsxref("TypedArray.filter", "Float64Array.prototype.filter()")}}
-  - : Creates a new array with all of the elements of this array for which the provided filtering function returns true. See also {{jsxref("Array.prototype.filter()")}}.
+  - : Creates a new array with all of the elements of this array for which the provided filtering function returns `true`. See also {{jsxref("Array.prototype.filter()")}}.
 - {{jsxref("TypedArray.find", "Float64Array.prototype.find()")}}
   - : Returns the found value in the array, if an element in the array satisfies the provided testing function or `undefined` if not found. See also {{jsxref("Array.prototype.find()")}}.
 - {{jsxref("TypedArray.findIndex", "Float64Array.prototype.findIndex()")}}
-  - : Returns the found index in the array, if an element in the array satisfies the provided testing function or -1 if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
+  - : Returns the found index in the array, if an element in the array satisfies the provided testing function or `-1` if not found. See also {{jsxref("Array.prototype.findIndex()")}}.
 - {{jsxref("TypedArray.forEach", "Float64Array.prototype.forEach()")}}
   - : Calls a function for each element in the array. See also {{jsxref("Array.prototype.forEach()")}}.
 - {{jsxref("TypedArray.includes", "Float64Array.prototype.includes()")}}
   - : Determines whether a typed array includes a certain element, returning `true` or `false` as appropriate. See also {{jsxref("Array.prototype.includes()")}}.
 - {{jsxref("TypedArray.indexOf", "Float64Array.prototype.indexOf()")}}
-  - : Returns the first (least) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
+  - : Returns the first (least) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
 - {{jsxref("TypedArray.join", "Float64Array.prototype.join()")}}
   - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
 - {{jsxref("TypedArray.keys", "Float64Array.prototype.keys()")}}
   - : Returns a new _array iterator_ that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
 - {{jsxref("TypedArray.lastIndexOf", "Float64Array.prototype.lastIndexOf()")}}
-  - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
+  - : Returns the last (greatest) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float64Array.prototype.map()")}}
   - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
 - {{jsxref("TypedArray.reduce", "Float64Array.prototype.reduce()")}}
@@ -84,7 +84,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 - {{jsxref("TypedArray.slice", "Float64Array.prototype.slice()")}}
   - : Extracts a section of an array and returns a new array. See also {{jsxref("Array.prototype.slice()")}}.
 - {{jsxref("TypedArray.some", "Float64Array.prototype.some()")}}
-  - : Returns true if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
+  - : Returns `true` if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
 - {{jsxref("TypedArray.sort", "Float64Array.prototype.sort()")}}
   - : Sorts the elements of an array in place and returns the array. See also {{jsxref("Array.prototype.sort()")}}.
 - {{jsxref("TypedArray.subarray", "Float64Array.prototype.subarray()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
@@ -23,7 +23,7 @@ The **`Uint32Array`** typed array represents an array of 32-bit unsigned integer
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Uint32Array.BYTES_PER_ELEMENT")}}
   - : Returns a number value of the element size. `4` in the case of an `Uint32Array`.
 - {{jsxref("TypedArray.name", "Uint32Array.name")}}
-  - : Returns the string value of the constructor name. In the case of the `Uint32Array` type: "Uint32Array".
+  - : Returns the string value of the constructor name. In the case of the `Uint32Array` type: "`Uint32Array`".
 
 ## Static methods
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none.

> What was wrong/why is this fix needed? (quick summary only)

Literals which appears in codes should be marked as a inline code.
I have fixed them in TypedArrays.

> Anything else that could help us review it
