### PR TITLE
Remove onmozinterruptbegin/end from HTMLMediaElement page

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.html
+++ b/files/en-us/web/api/htmlmediaelement/index.html
@@ -130,15 +130,6 @@ browser-compat: api.HTMLMediaElement
  <dd>Returns a <code>double</code> representing the number of samples per second that will be played. For example, 44100 samples per second is the sample rate used by CD audio.</dd>
 </dl>
 
-<h3 id="Obsolete_event_handlers">Obsolete event handlers</h3>
-
-<dl>
- <dt>{{domxref("HTMLMediaElement.onmozinterruptbegin")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Sets the <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> called when the media element is interrupted because of the Audio Channel manager. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
- <dt>{{domxref("HTMLMediaElement.onmozinterruptend")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
- <dd>Sets the event handler called when the interruption is concluded. This was Firefox-specific, having been implemented for Firefox OS, and was removed in Firefox 55.</dd>
-</dl>
-
 <h2 id="Methods">Methods</h2>
 
 <p><em>This interface also inherits methods from its ancestors {{domxref("HTMLElement")}}, {{domxref("Element")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}.</em></p>


### PR DESCRIPTION
This PR removes the `onmozinterruptbegin` and `onmozinterruptend` obsolete event handlers from the `HTMLMediaElement` API documentation.  Their individual pages have been long since removed.  Corresponds with BCD removal work: https://github.com/mdn/browser-compat-data/pull/12094
