### PR TITLE
Basic docs for onsecuritypolicyviolation global handler et al

### DIFF
--- a/files/en-us/web/api/element/index.html
+++ b/files/en-us/web/api/element/index.html
@@ -328,6 +328,9 @@ browser-compat: api.Element
  <dt>{{domxref("Element/wheel_event","wheel")}}</dt>
  <dd>Fired when the user rotates a wheel button on a pointing device (typically a mouse).<br>
  Also available via the {{DOMxRef("GlobalEventHandlers.onwheel", "onwheel")}} property.</dd>
+ <dt>{{domxref("Element/securitypolicyviolation_event","securitypolicyviolation")}}</dt>
+ <dd>Fired when a <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> is violated.
+  Also available via the global {{DOMxRef("GlobalEventHandlers.onsecuritypolicyviolation", "onsecuritypolicyviolation")}} property, which available on elements and the {{domxref("Document")}} and {{domxref("Window")}} objects.</dd>
 </dl>
 
 <h3 id="Clipboard_events">Clipboard events</h3>

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.html
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.html
@@ -1,0 +1,65 @@
+---
+title: 'Element: securitypolicyviolation event'
+slug: Web/API/Element/securitypolicyviolation_event
+tags:
+  - ?
+  - Event
+  - Reference
+browser-compat: api.Element.securitypolicyviolation_event
+---
+<div>{{APIRef}}</div>
+
+<p>The <strong><code>securitypolicyviolation</code></strong> event is fired when a <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> is violated.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th scope="row">Bubbles</th>
+   <td>Yes</td>
+  </tr>
+  <tr>
+   <th scope="row">Cancelable</th>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Interface</th>
+   <td>{{domxref("SecurityPolicyViolationEvent")}}</td>
+  </tr>
+  <tr>
+   <th scope="row">Event handler property</th>
+   <td>{{domxref("GlobalEventHandlers/onsecuritypolicyviolation", "onsecuritypolicyviolation")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<p>The event bubbles and is normally handled by an event handler on the {{domxref("Window")}} or {{domxref("Document")}}.
+  The handler can be assigned using the {{domxref("GlobalEventHandlers.onsecuritypolicyviolation")}} property or using {{domxref("EventTarget.addEventListener()")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The code below shows how you might add an event handler function using the <code>onsecuritypolicyviolation</code> global event handler property or <code>addEventListener()</code> on the top level <code>Window</code> (you could use exactly the same approach on <code>Document</code>).</p>
+
+<pre class="brush: js">
+window.onsecuritypolicyviolation = function(e) {
+   // Handle SecurityPolicyViolationEvent e here
+ };
+
+window.addEventListener("securitypolicyviolation", (e) => {
+  // Handle SecurityPolicyViolationEvent e here
+});
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("GlobalEventHandlers.onsecuritypolicyviolation")}}</li>
+  <li><a href="/en-US/docs/Web/HTTP/CSP">HTTP > Content Security Policy</a></li>
+</ul>

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.html
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.html
@@ -2,7 +2,7 @@
 title: 'Element: securitypolicyviolation event'
 slug: Web/API/Element/securitypolicyviolation_event
 tags:
-  - ?
+  - CSP
   - Event
   - Reference
 browser-compat: api.Element.securitypolicyviolation_event

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.html
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.html
@@ -32,7 +32,7 @@ browser-compat: api.Element.securitypolicyviolation_event
  </tbody>
 </table>
 
-<p>The event bubbles and is normally handled by an event handler on the {{domxref("Window")}} or {{domxref("Document")}}.
+<p>The event bubbles and is normally handled by an event handler on the {{domxref("Window")}} or {{domxref("Document")}} object.
   The handler can be assigned using the {{domxref("GlobalEventHandlers.onsecuritypolicyviolation")}} property or using {{domxref("EventTarget.addEventListener()")}}.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -163,6 +163,8 @@ browser-compat: api.GlobalEventHandlers
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("resize")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onscroll")}}</dt>
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("scroll")}} event is raised.</dd>
+ <dt>{{domxref("GlobalEventHandlers.onsecuritypolicyviolation")}}</dt>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the <a href="/en-US/docs/Web/API/Element/securitypolicyviolation_event"><code>securitypolicyviolation</code></a> event is raised after a <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> violation.</dd>
  <dt>{{domxref("GlobalEventHandlers.onseeked")}}</dt>
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("seeked")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onseeking")}}</dt>

--- a/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
@@ -33,7 +33,7 @@ browser-compat: api.GlobalEventHandlers.onsecuritypolicyviolation
 
 <h2 id="Example">Example</h2>
 
-<p>This code shows a very simpler top level handler set on <code>Window</code> that logs a value in the event to a text area (the same approach will work with a <code>Document</code>).
+<p>This code shows a very simpler top-level handler set on <code>Window</code> that logs a value in the event to a text area (the same approach will work with a <code>Document</code>).
 Note that in this case the <code>Content-Security-Policy</code>, which is set using a meta tag, allows the <code>'unsafe-inline'</code> script to run, but the image cannot be loaded.</p>
 
 <pre class="brush: html">&lt;!DOCTYPE html&gt;

--- a/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
@@ -1,0 +1,75 @@
+---
+title: GlobalEventHandlers.onsecuritypolicyviolation
+slug: Web/API/GlobalEventHandlers/onsecuritypolicyviolation
+tags:
+- API
+- Event Handler
+- GlobalEventHandlers
+- HTML DOM
+- Property
+- Reference
+browser-compat: api.GlobalEventHandlers.onsecuritypolicyviolation
+---
+<div>{{ApiRef("HTML DOM")}}</div>
+
+<p>The <strong><code>onsecuritypolicyviolation</code></strong> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> for processing <a href="/en-US/docs/Web/API/Element/securitypolicyviolation_event">securitypolicyviolation</a> events.</p>
+
+<p>The <code>securitypolicyviolation</code> event fires when there is a <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> violation.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">onsecuritypolicyviolation = functionRef</pre>
+
+<h3 id="Value">Value</h3>
+
+<dl>
+  <dt><code>functionRef</code></dt>
+  <dd>A function name, or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>. The function receives a {{domxref("SecurityPolicyViolationEvent")}} object as its sole argument.</dd>
+</dl>
+
+<p>Only one <code>onsecuritypolicyviolation</code> handler can be assigned to an object at a time.</p>
+
+<p>For greater flexibility, you can pass a <a href="/en-US/docs/Web/API/Element/securitypolicyviolation_event">securitypolicyviolation</a> event to the {{domxref("EventTarget.addEventListener()")}} method instead.</p>
+
+<h2 id="Example">Example</h2>
+
+<p>This code shows a very simpler top level handler set on <code>Window</code> that logs a value in the event to a text area (the same approach will work with a <code>Document</code>).
+Note that in this case the <code>Content-Security-Policy</code>, which is set using a meta tag, allows the <code>'unsafe-inline'</code> script to run, but the image cannot be loaded.</p>
+
+<pre class="brush: html">&lt;!DOCTYPE html&gt;
+  &lt;html lang="en"&gt;
+   &lt;head&gt;
+     &lt;title&gt;Examples CSP error on page load&lt;/title&gt;
+     &lt;meta charset="UTF-8"&gt;
+     &lt;meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline';"&gt;
+     &lt;/head&gt;
+   &lt;script&gt;
+     //Assign function to onsecuritypolicyviolation global handler
+     window.onsecuritypolicyviolation = function(e) {
+       const log_area = document.getElementById("log");
+       log_area.textContent+=e.blockedURI+"\n";
+     };
+   &lt;/script&gt;
+   &lt;body&gt;
+    &lt;h1&gt;Image loading should fail&lt;/h1&gt;
+    &lt;label for="log"&gt;Blocked URI&lt;/label&gt;
+    &lt;textarea id="log" rows="2" cols="50"&gt;&lt;/textarea&gt;
+    &lt;img src="HTTPRevved_fix_typo.png"&gt;
+   &lt;/body&gt;
+  &lt;/html&gt;</pre>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/Element/securitypolicyviolation_event">Element: <code>securitypolicyviolation</code> event</a></li>
+  <li><a href="/en-US/docs/Web/HTTP/CSP">HTTP > Content Security Policy</a></li>
+</ul>

--- a/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
@@ -34,7 +34,7 @@ browser-compat: api.GlobalEventHandlers.onsecuritypolicyviolation
 <h2 id="Example">Example</h2>
 
 <p>This code shows a very simpler top-level handler set on <code>Window</code> that logs a value in the event to a text area (the same approach will work with a <code>Document</code>).
-Note that in this case the <code>Content-Security-Policy</code>, which is set using a meta tag, allows the <code>'unsafe-inline'</code> script to run, but the image cannot be loaded.</p>
+Note that in this case the <code>Content-Security-Policy</code> value, which is set using a meta tag, allows the <code>'unsafe-inline'</code> script to run, but the image cannot be loaded.</p>
 
 <pre class="brush: html">&lt;!DOCTYPE html&gt;
   &lt;html lang="en"&gt;

--- a/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
@@ -3,6 +3,7 @@ title: GlobalEventHandlers.onsecuritypolicyviolation
 slug: Web/API/GlobalEventHandlers/onsecuritypolicyviolation
 tags:
 - API
+- CSP
 - Event Handler
 - GlobalEventHandlers
 - HTML DOM


### PR DESCRIPTION
FF93 adds a global event handler for CSP security violations name `onsecuritypolicyviolation` - docs work tracked in #8614. 

This PR adds _basic docs_ for the global handler and the event fired off Element (which was missing). The event type was already documented.

The example is minimal because it relies on being able to invoke a CSP violation, which you can't do inside an MDN page. For the handler I've put some demo HTML someone could copy. In the event I just have some javascript showing assignment of event handlers. 

I say basic, because I am still exploring this in https://bugzilla.mozilla.org/show_bug.cgi?id=1727302#c5 and in [BDC](https://github.com/mdn/browser-compat-data/pull/12289).

There are two main aspects that are "missing:
- In theory this can be called on any element, but I don't see the point. If you attach the listener before loading the document the element is null (so you can't). If you wait until after the document is loaded you have already had the CSP event - and you missed it. If I'm right then you should only use the listener on the Document or Window.
- Event handlers exist of Window and Document, and predate the global event handler. Not sure if that means I need separate docs for those (?)