### PR TITLE
Fixes links to Point -> WebKitPoint

### DIFF
--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.html
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.html
@@ -17,7 +17,7 @@ browser-compat: api.Window.convertPointFromNodeToPage
 
 <p>{{Non-standard_header}}</p>
 
-<p>Given a {{domxref("Point")}} specified in a particular DOM {{domxref("Node")}}'s
+<p>Given a {{domxref("WebKitPoint")}} specified in a particular DOM {{domxref("Node")}}'s
   coordinate system, the {{domxref("Window")}} method
   <code><strong>convertPointFromNodeToPage()</strong></code> returns a <code>Point</code>
   which specifies the same position in the page's coordinate system. This method is
@@ -25,7 +25,7 @@ browser-compat: api.Window.convertPointFromNodeToPage
 
 <div class="warning">
   <p><strong>Warning:</strong> Please review the {{anch("Browser compatibility")}} section before using this method,
-    as it's not widely supported (nor is the {{domxref("Point")}} object it uses).</p>
+    as it's not widely supported (nor is the {{domxref("WebKitPoint")}} object it uses).</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -40,13 +40,13 @@ browser-compat: api.Window.convertPointFromNodeToPage
   <dd>The {{domxref("Node")}} in whose coordinate system the <code>Point</code> specified
     by <code>nodePoint</code> is described.</dd>
   <dt><code>nodePoint</code></dt>
-  <dd>A {{domxref("Point")}} object describing a point in <code>node</code>'s coordinate
+  <dd>A {{domxref("WebKitPoint")}} object describing a point in <code>node</code>'s coordinate
     system; this point will be converted to the page's coordinate system.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("Point")}} object specifying a point in the page's coordinate system.</p>
+<p>A {{domxref("WebKitPoint")}} object specifying a point in the page's coordinate system.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -62,7 +62,7 @@ browser-compat: api.Window.convertPointFromNodeToPage
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>{{domxref("Window.convertPointFromPageToNode()")}}</li>
+  <li>{{domxref("Window.webkitConvertPointFromPageToNode")}}</li>
   <li>Mozilla implementation bug: {{bug(850806)}}</li>
   <li><a
       href="https://msdn.microsoft.com/en-us/library/ie/dn760734%28v=vs.85%29.aspx"><code>webkitConvertPointFromNodeToPage</code>

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.html
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.html
@@ -17,14 +17,14 @@ browser-compat: api.Window.convertPointFromPageToNode
 
 <p>{{Non-standard_header}}</p>
 
-<p>Given a {{domxref("Point")}} specified in the page's coordinate system, the
+<p>Given a {{domxref("WebKitPoint")}} specified in the page's coordinate system, the
   {{domxref("Window")}} method <strong><code>convertPointFromPageToNode()</code></strong>
   returns a <code>Point</code> object specifying the same location in the coordinate
   system of the specified DOM {{domxref("Node")}}.</p>
 
 <div class="warning">
   <p><strong>Warning:</strong> Please review the {{anch("Browser compatibility")}} section before using this method,
-    as it's not widely supported (nor is the {{domxref("Point")}} object it uses).</p>
+    as it's not widely supported (nor is the {{domxref("WebKitPoint")}} object it uses).</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -39,7 +39,7 @@ browser-compat: api.Window.convertPointFromPageToNode
   <dd>The {{domxref("Node")}} into whose coordinate system the point is to be converted.
   </dd>
   <dt><code>pagePoint</code></dt>
-  <dd>A {{domxref("Point")}} object specifying a point in the coordinate system of the
+  <dd>A {{domxref("WebKitPoint")}} object specifying a point in the coordinate system of the
     page, which is to be converted into the node's coordinate system.</dd>
 </dl>
 
@@ -62,7 +62,7 @@ browser-compat: api.Window.convertPointFromPageToNode
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>{{domxref("Window.convertPointFromNodeToPage()")}}</li>
+  <li>{{domxref("Window.webkitConvertPointFromNodeToPage")}}</li>
   <li>Mozilla implementation bug: {{bug(850808)}}</li>
   <li><a
       href="https://msdn.microsoft.com/en-us/library/ie/dn760735(v=vs.85).aspx"><code>webkitConvertPointFromPageToNode</code>


### PR DESCRIPTION
`Point` has been renamed `WebKitPoint`. This fixes macro to point directly to it (and using the prefixed version is clearer in these 2 pages)