### PR TITLE
Remove mentions of ReadOnly in (Animation)EffectTiming

### DIFF
--- a/files/en-us/web/api/effecttiming/delay/index.html
+++ b/files/en-us/web/api/effecttiming/delay/index.html
@@ -2,37 +2,25 @@
 title: EffectTiming.delay
 slug: Web/API/EffectTiming/delay
 tags:
-- API
-- Animation
-- EffectTiming
-- Experimental
-- KeyframeEffect
-- Property
-- Reference
-- Web Animations
-- animate
-- delay
-- waapi
-- web animations api
+  - API
+  - Animation
+  - EffectTiming
+  - Experimental
+  - KeyframeEffect
+  - Property
+  - Reference
+  - Web Animations
+  - animate
+  - delay
+  - waapi
+  - web animations api
 browser-compat: api.EffectTiming.delay
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
-<p>The {{domxref("EffectTiming")}} dictionary's
-  <strong><code>delay</code></strong> property in the <a
-    href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> represents the
-  number of milliseconds to delay the start of the animation.</p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including
-    <code>delay</code>. The value of <code>delay</code> corresponds directly
-    to {{domxref("EffectTiming.delay")}} in {{domxref("AnimationEffectReadOnly.timing",
-    "timing")}} objects returned by {{domxref("AnimationEffectReadOnly")}},
-    {{domxref("KeyframeEffectReadOnly")}}, and {{domxref("KeyframeEffect")}}.</p>
-</div>
+<p>The {{domxref("EffectTiming")}} dictionary's <strong><code>delay</code></strong> property
+  in the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a>
+  represents the number of milliseconds to delay the start of the animation.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -47,30 +35,30 @@ browser-compat: api.EffectTiming.delay
 
 <p>A number specifying the delay, in milliseconds, from the start of the animation's play
   cycle to the beginning of its <strong>active interval</strong> (the time index at which
-  actual animation begins). Defaults to 0.</p>
+  actual animation begins). Defaults to 0.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the <a href="http://codepen.io/rachelnabors/pen/EPJdJx?editors=0010">Pool of
-    Tears</a> example, each tear is passed a random delay via its timing object:</p>
+<p>In the <a href="https://codepen.io/rachelnabors/pen/EPJdJx?editors=0010">Pool of
+    Tears</a> example, each tear is passed a random delay via its timing object:</p>
 
 <pre><code>// Randomizer function
 var getRandomMsRange = function(min, max) {
-  return Math.random() * (max - min) + min;
+  return Math.random() * (max - min) + min;
 }
 
 // Loop through each tear
 tears.forEach(function(el) {
 
   // Animate each tear
-  el.animate(
-    tearsFalling,
-    {
-      delay: getRandomMsRange(-1000, 1000), // randomized for each tear
-      duration: getRandomMsRange(2000, 6000), // randomized for each tear
-      iterations: Infinity,
-      easing: "cubic-bezier(0.6, 0.04, 0.98, 0.335)"
-    });
+  el.animate(
+    tearsFalling,
+    {
+      delay: getRandomMsRange(-1000, 1000), // randomized for each tear
+      duration: getRandomMsRange(2000, 6000), // randomized for each tear
+      iterations: Infinity,
+      easing: "cubic-bezier(0.6, 0.04, 0.98, 0.335)"
+    });
 });</code></pre>
 
 <h2 id="Specifications">Specifications</h2>
@@ -85,17 +73,11 @@ tears.forEach(function(el) {
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
-  <li>{{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including this one.
+  <li>{{domxref("Element.animate()")}} and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
+    both accept an object of timing properties including this one.
   </li>
-  <li>The value of this property corresponds to the one in {{domxref("EffectTiming")}}
-    (which is the {{domxref("AnimationEffectReadOnly.timing", "timing")}} object for
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}},
-    and {{domxref("KeyframeEffect")}}).</li>
   <li>CSS's
     <code><a href="/en-US/docs/Web/CSS/transition-delay">transition-delay</a></code>
-    and <code><a href="/en-US/docs/Web/CSS/animation-delay">animation-delay</a></code>
+    and <code><a href="/en-US/docs/Web/CSS/animation-delay">animation-delay</a></code>
   </li>
 </ul>

--- a/files/en-us/web/api/effecttiming/direction/index.html
+++ b/files/en-us/web/api/effecttiming/direction/index.html
@@ -2,38 +2,26 @@
 title: EffectTiming.direction
 slug: Web/API/EffectTiming/direction
 tags:
-- API
-- Animation
-- EffectTiming
-- Experimental
-- KeyframeEffect
-- Property
-- Reference
-- Web Animations
-- animate
-- direction
-- waapi
-- web animations api
+  - API
+  - Animation
+  - EffectTiming
+  - Experimental
+  - KeyframeEffect
+  - Property
+  - Reference
+  - Web Animations
+  - animate
+  - direction
+  - waapi
+  - web animations api
 browser-compat: api.EffectTiming.direction
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
-<p>The <strong><code>direction</code></strong> property of the <a
-    href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> dictionary
+<p>The <strong><code>direction</code></strong> property
+  of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> dictionary
   {{domxref("EffectTiming")}} indicates an animation's playback direction along its
   timeline, as well as its behavior when it reaches the end of an iteration</p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including
-    <code>direction.</code> The value of <code>direction</code> corresponds directly
-    to {{domxref("AnimationEffectTimingReadOnly.direction")}} in
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} objects returned by
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}}, and
-    {{domxref("KeyframeEffect")}}.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -69,8 +57,8 @@ browser-compat: api.EffectTiming.direction
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the <a href="http://codepen.io/rachelnabors/pen/bEPdQr?editors=0010">Forgotten
-    Key</a> example, Alice waves her arm up and down by passing her an
+<p>In the <a href="https://codepen.io/rachelnabors/pen/bEPdQr?editors=0010">Forgotten
+    Key</a> example, Alice waves her arm up and down by passing her an
   <code>alternate</code> value for her <code>direction</code> property:</p>
 
 <pre class="brush: js">// Get Alice's arm, and wave it up and down
@@ -96,17 +84,10 @@ document.getElementById("alice_arm").animate([
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
-  <li>{{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including this one.
+  <li>{{domxref("Element.animate()")}} and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
+    both accept an object of timing properties including this one.
   </li>
-  <li>The value of this property corresponds to the one in
-    {{domxref("AnimationEffectTimingReadOnly")}} (which is the
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} object for
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}},
-    and {{domxref("KeyframeEffect")}}).</li>
   <li>
-    CSS's <code><a href="/en-US/docs/Web/CSS/animation-direction">animation-direction</a></code>
+    CSS's <code><a href="/en-US/docs/Web/CSS/animation-direction">animation-direction</a></code>
   </li>
 </ul>

--- a/files/en-us/web/api/effecttiming/duration/index.html
+++ b/files/en-us/web/api/effecttiming/duration/index.html
@@ -2,38 +2,26 @@
 title: EffectTiming.duration
 slug: Web/API/EffectTiming/duration
 tags:
-- API
-- Animation
-- EffectTiming
-- Experimental
-- KeyframeEffect
-- Property
-- Reference
-- Web Animations
-- animate
-- duration
-- waapi
-- web animations api
+  - API
+  - Animation
+  - EffectTiming
+  - Experimental
+  - KeyframeEffect
+  - Property
+  - Reference
+  - Web Animations
+  - animate
+  - duration
+  - waapi
+  - web animations api
 browser-compat: api.EffectTiming.duration
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
-<p>The <strong><code>duration</code></strong> property of the dictionary
+<p>The <strong><code>duration</code></strong> property of the dictionary
   {{domxref("EffectTiming")}} in the <a href="/en-US/docs/Web/API/Web_Animations_API">Web
     Animations API</a> specifies the duration in milliseconds that a single iteration
   (from beginning to end) the animation should take to complete.</p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including
-    <code>duration</code>. The value of <code>duration</code> corresponds directly
-    to {{domxref("AnimationEffectTimingReadOnly.duration")}} in
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} objects returned by
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}}, and
-    {{domxref("KeyframeEffect")}}.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -67,8 +55,8 @@ browser-compat: api.EffectTiming.duration
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the <a href="http://codepen.io/rachelnabors/pen/EPJdJx?editors=0010">Pool of
-    Tears</a> example, each tear is passed a random <code>duration</code> via its timing
+<p>In the <a href="https://codepen.io/rachelnabors/pen/EPJdJx?editors=0010">Pool of
+    Tears</a> example, each tear is passed a random <code>duration</code> via its timing
   object:</p>
 
 <pre class="brush: js">// Randomizer function
@@ -102,15 +90,7 @@ tears.forEach(function(el) {
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
-  <li>{{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including this one.
+  <li>{{domxref("Element.animate()")}} and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
+    both accept an object of timing properties including this one.
   </li>
-  <li>The value of this property corresponds to property of the same name in
-    {{domxref("AnimationEffectReadOnly.timing")}},
-    {{domxref("KeyframeEffectReadOnly.timing")}},
-    and {{domxref("KeyframeEffect.timing")}}).</li>
-  <li>CSS's {{cssxref("transition-duration")}} and {{cssxref("animation-duration")}}
-    properties</li>
 </ul>

--- a/files/en-us/web/api/effecttiming/easing/index.html
+++ b/files/en-us/web/api/effecttiming/easing/index.html
@@ -20,22 +20,9 @@ browser-compat: api.EffectTiming.easing
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
 <p>The {{domxref("EffectTiming")}} dictionary's
-  <strong><code>easing</code></strong> property in the <a
-    href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> specifies the
-  timing function used to scale the time to produce easing effects, where <em>easing</em>
+  <strong><code>easing</code></strong> property in the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a>
+  specifies the timing function used to scale the time to produce easing effects, where <em>easing</em>
   is the rate of the animation's change over time.</p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffect/KeyframeEffect",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including
-    <code>easing</code>. The value of easing corresponds directly
-    to {{domxref("AnimationEffectTimingReadOnly.easing")}} in
-    {{domxref("AnimationEffect/getTiming", "timing")}} objects returned by
-    {{domxref("AnimationEffect")}}, {{domxref("KeyframeEffect")}}, and
-    {{domxref("KeyframeEffect")}}.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -49,14 +36,14 @@ browser-compat: api.EffectTiming.easing
 <h3 id="Value">Value</h3>
 
 <p>A string defining the timing function to use for easing transitions during the
-  animation process. Accepts several pre-defined {{domxref("DOMString")}} values, a
+  animation process. Accepts several pre-defined {{domxref("DOMString")}} values, a
   <code>steps()</code> timing function like <code>steps(5, end)</code>, or a custom
   <code>cubic-bezier</code> value like <code>cubic-bezier(0.42, 0, 0.58, 1)</code>.
   Defaults to <code>linear</code>. Available values include:</p>
 
 <dl>
   <dt><code>linear</code></dt>
-  <dd>A constant rate of change, neither accelerating nor deccelerating. </dd>
+  <dd>A constant rate of change, neither accelerating nor deccelerating.</dd>
   <dt>
     <code>cubic-bezier(&lt;number&gt;, &lt;number&gt;, &lt;number&gt;, &lt;number&gt;)</code>
   </dt>
@@ -68,27 +55,17 @@ browser-compat: api.EffectTiming.easing
     as (x1, y1, x2, y2). Both x values must be in the range [0, 1] or the definition is
     invalid.</dd>
   <dt><code>ease</code></dt>
-  <dd>A decelerated rate of change, going from fast to slow. Equivalent to
-    <code>cubic-bezier(0.25, 0.1, 0.25, 1)</code>.</dd>
+  <dd>A decelerated rate of change, going from fast to slow.
+    Equivalent to <code>cubic-bezier(0.25, 0.1, 0.25, 1)</code>.</dd>
   <dt><code>ease-in</code></dt>
-  <dd>An accelerated rate of change, going from slow to fast. Equivalent to
-    <code>cubic-bezier(0.42, 0, 1, 1)</code>.</dd>
+  <dd>An accelerated rate of change, going from slow to fast.
+    Equivalent to <code>cubic-bezier(0.42, 0, 1, 1)</code>.</dd>
   <dt><code>ease-out</code></dt>
-  <dd>Another decelerated rate of change, going from fast to slow. Equivalent to
-    <code>cubic-bezier(0, 0, 0.58, 1)</code>.</dd>
+  <dd>Another decelerated rate of change, going from fast to slow.
+    Equivalent to <code>cubic-bezier(0, 0, 0.58, 1)</code>.</dd>
   <dt><code>ease-in-out</code></dt>
-  <dd>This rate of change speeds up in the middle. Equivalent to
-    <code>cubic-bezier(0.42, 0, 0.58, 1)</code>.</dd>
-  <dt class="hidden"><code>frames(&lt;integer&gt;)</code></dt>
-  <dd class="hidden">Specifies a <a
-      href="https://www.w3.org/TR/css-timing-1/#frames-timing-functions">frames timing
-      function</a>, which breaks the animation down into a number of equal time intervals
-    but also displays the start (0%) and end (100%) states for an equal amount of time to
-    the other intervals. The browser flips to a different static frame when each interval
-    is reached, rather than animating smoothly. See GitHub for a <a
-      href="https://mdn.github.io/css-examples/animation-frames-timing-function/index-waa.html">simple
-      example</a> that illustrates the difference between <code>steps()</code> and
-    <code>frames()</code>.</dd>
+  <dd>This rate of change speeds up in the middle.
+    Equivalent to <code>cubic-bezier(0.42, 0, 0.58, 1)</code>.</dd>
   <dt><code>steps(&lt;integer&gt;[, [ start | end ] ]?)</code></dt>
   <dd><img alt="A diagram of the various steps timing functions."
       src="step-timing-func-examples.svg"><br>
@@ -108,9 +85,8 @@ browser-compat: api.EffectTiming.easing
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the <a href="http://codepen.io/rachelnabors/pen/PNGGaV?editors=0010">Red Queen's
-    Race</a> example, we animate Alice and the Red Queen by passing an easing
-  <code>of steps(7, end)</code> to <code>animate()</code>:</p>
+<p>In the <a href="http://codepen.io/rachelnabors/pen/PNGGaV?editors=0010">Red Queen's Race</a> example,
+  we animate Alice and the Red Queen by passing an easing of <code>steps(7, end)</code> to <code>animate()</code>:</p>
 
 <pre class="brush: js">// Define the key frames
 var spriteFrames = [
@@ -144,9 +120,9 @@ spriteFrames, {
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
   <li>{{domxref("Element.animate()")}}, {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}}, and {{domxref("AnimationEffect.updateTiming()")}} all accept an
+    "KeyframeEffect()")}}, and {{domxref("AnimationEffect.updateTiming()")}} all accept an
     object of timing properties including this one.</li>
-  <li>The value of this property corresponds to the one in {{domxref("EffectTiming")}}
+  <li>The value of this property corresponds to the one in {{domxref("EffectTiming")}}
     (which is returned from {{domxref("AnimationEffect.getTiming()")}} and
     {{domxref("AnimationEffect.getComputedTiming()")}}).</li>
   <li>CSS's

--- a/files/en-us/web/api/effecttiming/enddelay/index.html
+++ b/files/en-us/web/api/effecttiming/enddelay/index.html
@@ -23,27 +23,15 @@ browser-compat: api.EffectTiming.endDelay
     API</a>) indicates the number of milliseconds to delay after the active period of an
   animation sequence. The animation's <strong>end time</strong>—the time at which an
   iteration is considered to have finished—is the time at which the animation finishes an
-  iteration (its initial delay, {{domxref("AnimationEffectTimingReadOnly.delay")}}, plus
-  its duration,{{domxref("AnimationEffectTimingReadOnly.duration", "duration")}}, plus its
-  end delay.</p>
+  iteration (its initial delay, {{domxref("EffectTiming.delay", "delay")}}, plus
+  its duration,{{domxref("EffectTiming.duration", "duration")}}, plus its
+  end delay).</p>
 
 <p>This is useful for sequencing animations based on the end time of another animation;
   note, however, that many of the sequence effects that will benefit most from this
   property have not been defined in the specification yet. For now, its main purpose is to
   represent the value of the <a href="/en-US/docs/Web/SVG">SVG</a> {{SVGAttr("min")}}
   attribute.</p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including
-    <code>endDelay.</code> The value of <code>endDelay</code> corresponds directly
-    to {{domxref("AnimationEffectTimingReadOnly.endDelay")}} in
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} objects returned by
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}}, and
-    {{domxref("KeyframeEffect")}}.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -71,14 +59,7 @@ timingProperties.endDelay = delayInMilliseconds;
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
-  <li>{{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including this one.
+  <li>{{domxref("Element.animate()")}}, and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
+    both accept an object of timing properties including this one.
   </li>
-  <li>The value of this property corresponds to the one in
-    {{domxref("AnimationEffectTimingReadOnly")}} (which is the
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} object for
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}},
-    and {{domxref("KeyframeEffect")}}).</li>
 </ul>

--- a/files/en-us/web/api/effecttiming/fill/index.html
+++ b/files/en-us/web/api/effecttiming/fill/index.html
@@ -2,27 +2,27 @@
 title: EffectTiming.fill
 slug: Web/API/EffectTiming/fill
 tags:
-- API
-- Animation
-- EffectTiming
-- Experimental
-- KeyframeEffect
-- Property
-- Reference
-- Web Animations
-- animate
-- fill
-- web animations api
+  - API
+  - Animation
+  - EffectTiming
+  - Experimental
+  - KeyframeEffect
+  - Property
+  - Reference
+  - Web Animations
+  - animate
+  - fill
+  - web animations api
 browser-compat: api.EffectTiming.fill
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
 <p>The <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a>'s
-  {{domxref("EffectTiming")}} dictionary's <strong><code>fill</code></strong> property
+  {{domxref("EffectTiming")}} dictionary's <strong><code>fill</code></strong> property
   specifies a <strong>fill mode</strong>, which defines how the element to which the
   animation is applied should look when the animation sequence is not actively running,
   such as before the time specified by
-  {{domxref("AnimationEffectTimingProperties.iterationStart", "iterationStart")}} or after
+  {{domxref("EffectTiming/iterationStart", "iterationStart")}} or after
   animation's end time.</p>
 
 <p>For example, setting fill to <code>"none"</code> means the animation's effects are not
@@ -38,8 +38,8 @@ browser-compat: api.EffectTiming.fill
 <div class="note">
   <p><strong>Note:</strong> {{domxref("Element.animate()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
     "KeyframeEffect()")}} accept an object of timing properties including
-    <code>fill.</code> The value of <code>fill</code> corresponds directly
-    to {{domxref("EffectTiming.fill", "fill")}} in {{domxref("EffectTiming")}} objects
+    <code>fill.</code> The value of <code>fill</code> corresponds directly
+    to {{domxref("EffectTiming.fill", "fill")}} in {{domxref("EffectTiming")}} objects
     returned by {{domxref("AnimationEffect.getTiming()", "getTiming()")}} in
     {{domxref("AnimationEffect")}} and {{domxref("KeyframeEffect")}}.</p>
 </div>
@@ -61,34 +61,34 @@ browser-compat: api.EffectTiming.fill
   <dt><code>"none"</code></dt>
   <dd>The animation's effects are only visible while the animation is iterating or its
     playhead is positioned over an iteration. The animation's effects are not visible when
-    its {{domxref("Animation.playState", "playState")}} is <code>pending</code> with
-    a {{domxref("AnimationEffectTimingReadOnly.delay", "delay")}}, when its
-    <code>playState</code> is <code>finished</code>, or during its
-    {{domxref("AnimationEffectTimingReadOnly.endDelay", "endDelay")}} or
-     {{domxref("AnimationEffectTimingReadOnly.delay", "delay")}}. In other words, if the
+    its {{domxref("Animation.playState", "playState")}} is <code>pending</code> with
+    a {{domxref("EffectTiming.delay", "delay")}}, when its
+    <code>playState</code> is <code>finished</code>, or during its
+    {{domxref("EffectTiming.endDelay", "endDelay")}} or
+    {{domxref("EffectTiming.delay", "delay")}}. In other words, if the
     animation isn't in its active interval, the affected element is not visible.</dd>
   <dt><code>"forwards"</code></dt>
   <dd>The affected element will continue to be rendered in the state of the final
-    animation framecontinue to be applied to the  after the animation has completed
-    playing, in spite of and during any
-    {{domxref("AnimationEffectTimingReadOnly.endDelay", "endDelay")}} or when its
-    <code>playState</code> is <code>finished</code>.</dd>
+    animation framecontinue to be applied to the after the animation has completed
+    playing, in spite of and during any
+    {{domxref("EffectTiming.endDelay", "endDelay")}} or when its
+    <code>playState</code> is <code>finished</code>.</dd>
   <dt><code>"backwards"</code></dt>
   <dd>The animation's effects should be reflected by the element(s) state prior to
-    playing, in spite of and during any {{domxref("AnimationEffectTimingReadOnly.delay",
-    "delay")}} and <code>pending</code> {{domxref("Animation.playState", "playState")}}.
+    playing, in spite of and during any {{domxref("EffectTiming.delay",
+    "delay")}} and <code>pending</code> {{domxref("Animation.playState", "playState")}}.
   </dd>
   <dt><code>"both"</code></dt>
-  <dd>Combining the effects of <strong>both </strong><code>forwards</code> and
-    <code>backwards</code>: The animation's effects should be reflected by the element(s)
-    state prior to playing and retained after the animation has completed playing, in
-    spite of and during any {{domxref("AnimationEffectTimingReadOnly.endDelay",
-    "endDelay")}}, {{domxref("AnimationEffectTimingReadOnly.delay", "delay")}} and/or
-    <code>pending</code> or <code>finished</code> {{domxref("Animation.playState",
+  <dd>Combining the effects of <strong>both </strong><code>forwards</code> and
+    <code>backwards</code>: The animation's effects should be reflected by the element(s)
+    state prior to playing and retained after the animation has completed playing, in
+    spite of and during any {{domxref("EffectTiming.endDelay",
+    "endDelay")}}, {{domxref("EffectTiming.delay", "delay")}} and/or
+    <code>pending</code> or <code>finished</code> {{domxref("Animation.playState",
     "playState")}}.</dd>
   <dt><code>"auto"</code></dt>
   <dd>If the animation effect the fill mode is being applied to is a keyframe effect
-    ({{domxref("KeyframeEffect")}} or {{domxref("KeyframeEffectReadOnly")}}),
+    ({{domxref("KeyframeEffect")}} or {{domxref("KeyframeEffect")}}),
     <code>"auto"</code> is equivalent to <code>"none"</code>. Otherwise, the result is
     <code>"both"</code>.</dd>
 </dl>
@@ -108,12 +108,12 @@ browser-compat: api.EffectTiming.fill
 </p>
 
 <pre class="brush: html">&lt;div class="main"&gt;
-  &lt;div id="box"&gt;
-    &lt;div id="text"&gt;Look! A box!&lt;/div&gt;
-  &lt;/div&gt;
+  &lt;div id="box"&gt;
+    &lt;div id="text"&gt;Look! A box!&lt;/div&gt;
+  &lt;/div&gt;
 &lt;/div&gt;
 &lt;div class="button" id="animateButton"&gt;
-  Animate!
+  Animate!
 &lt;/div&gt;
 </pre>
 
@@ -124,17 +124,17 @@ browser-compat: api.EffectTiming.fill
 }
 
 .button {
-  cursor: pointer;
-  width: 300px;
-  border: 1px solid black;
-  font-size: 16px;
-  text-align: center;
-  margin-top: 0px;
-  padding-top: 2px;
-  padding-bottom: 4px;
-  color: white;
-  background-color: darkgreen;
-  font: 14px "Open Sans", "Arial", sans-serif;
+  cursor: pointer;
+  width: 300px;
+  border: 1px solid black;
+  font-size: 16px;
+  text-align: center;
+  margin-top: 0px;
+  padding-top: 2px;
+  padding-bottom: 4px;
+  color: white;
+  background-color: darkgreen;
+  font: 14px "Open Sans", "Arial", sans-serif;
 }
 
 #text {
@@ -147,7 +147,7 @@ browser-compat: api.EffectTiming.fill
   font: bold 2em "Lucida Grande", "Open Sans", sans-serif;
 }</pre>
 
-<p>While there's other CSS involved in this example, the part that really matters for our
+<p>While there's other CSS involved in this example, the part that really matters for our
   purposes is the CSS that styles the <code>"box"</code> element that we'll be animating.
   That CSS looks like this:</p>
 
@@ -213,10 +213,10 @@ browser-compat: api.EffectTiming.fill
   in its natural, unaltered condition anytime the animation isn't actively running.</p>
 
 <pre class="brush: js">document.getElementById("animateButton").addEventListener("click", event =&gt; {
-  document.getElementById("box").animate(
-    boxRotationKeyframes,
-    boxRotationTiming
-  );
+  document.getElementById("box").animate(
+    boxRotationKeyframes,
+    boxRotationTiming
+  );
 }, false);</pre>
 
 <p>The rest of the code is pretty simple: it adds an event listener to the "Animate"
@@ -239,11 +239,11 @@ browser-compat: api.EffectTiming.fill
 
 <h3 id="Follow_the_White_Rabbit_example">Follow the White Rabbit example</h3>
 
-<p>In the <a href="http://codepen.io/rachelnabors/pen/eJyWzm?editors=0010">Follow the
-    White Rabbit</a> example, the White Rabbit's animation is formed by coupling a
-  <code>KeyframeEffect</code> with an <code>Animation</code> object. The
+<p>In the <a href="https://codepen.io/rachelnabors/pen/eJyWzm?editors=0010">Follow the
+    White Rabbit</a> example, the White Rabbit's animation is formed by coupling a
+  <code>KeyframeEffect</code> with an <code>Animation</code> object. The
   <code>keyframeEffect</code> takes an object of <a
-    href="/en-US/docs/Web/API/Web_Animations_API/Animation_timing_options">timing
+    href="/en-US/docs/Web/API/EffectTiming">timing
     properties</a>, which is where we pass in <code>fill</code>. <code>Forwards</code>
   makes the rabbit retain its last keyframe rather than reverting to its unanimated state:
 </p>
@@ -275,7 +275,7 @@ var rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
   <li>The forwards fill of an animation (or backwards fill if the animation is playing in
     reverse) will continue to override any changes to specified style indefinitely which
     can lead to confusing behavior. This is because animations take priority in the <a
-      href="/en-US/docs/Web/CSS/Cascade#Cascading_order">CSS cascade</a> over normal
+      href="/en-US/docs/Web/CSS/Cascade#cascading_order">CSS cascade</a> over normal
     author styles.</li>
   <li>In order to avoid leaking memory when many filling animations overlap, the browser
     is required to remove overlapped animations which can lead to surprising results in
@@ -286,7 +286,7 @@ var rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
   final value of the animation effect directly in specified style:</p>
 
 <pre class="brush: js">elem.animate({ transform: 'translateY(100px)' }, 200).finished.then(() =&gt; {
-  elem.style.transform = 'translateY(100px)';
+  elem.style.transform = 'translateY(100px)';
 });
 </pre>
 
@@ -304,15 +304,15 @@ elem.animate({ transform: 'none', offset: 0 }, 200);
   before canceling it.</p>
 
 <pre class="brush: js">elem.addEventListener('click', async evt =&gt; {
-  const animation = elem.animate(
-    { transform: `translate(${evt.clientX}px, ${evt.clientY}px)` },
-    { duration: 800, fill: 'forwards' }
-  );
-  await animation.finished;
-  // commitStyles will record the style up to and including `animation` and
-  // update elem’s specified style with the result.
-  animation.commitStyles();
-  animation.cancel();
+  const animation = elem.animate(
+    { transform: `translate(${evt.clientX}px, ${evt.clientY}px)` },
+    { duration: 800, fill: 'forwards' }
+  );
+  await animation.finished;
+  // commitStyles will record the style up to and including `animation` and
+  // update elem's specified style with the result.
+  animation.commitStyles();
+  animation.cancel();
 });
 </pre>
 
@@ -334,6 +334,6 @@ elem.animate({ transform: 'none', offset: 0 }, 200);
     returned by {{domxref("AnimationEffect.getTiming()", "getTiming()")}} in
     {{domxref("AnimationEffect")}} and {{domxref("KeyframeEffect")}}.</li>
   <li>
-    CSS's <code><a href="/en-US/docs/Web/CSS/animation-fill-mode">animation-fill-mode</a></code>
+    CSS's <code><a href="/en-US/docs/Web/CSS/animation-fill-mode">animation-fill-mode</a></code>
   </li>
 </ul>

--- a/files/en-us/web/api/effecttiming/index.html
+++ b/files/en-us/web/api/effecttiming/index.html
@@ -17,31 +17,30 @@ browser-compat: api.EffectTiming
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
-<p>The <strong><code>EffectTiming</code></strong> dictionary, part of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a>, is used by {{domxref("Element.animate()")}}, 
-  {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly", "KeyframeEffectReadOnly()")}},
+<p>The <strong><code>EffectTiming</code></strong> dictionary, part of the <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a>, is used by {{domxref("Element.animate()")}},
    and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}} to describe timing properties for animation effects. These properties are all optional, although without setting a <code>duration</code> the animation will not play.</p>
 
-<p>In other words, these properties describe how the {{Glossary("user agent")}} should go about making the transition from keyframe to keyframe, and how to behave when the animation begins and ends.</p>
+<p>In other words, these properties describe how the {{Glossary("user agent")}} should go about making the transition from keyframe to keyframe, and how to behave when the animation begins and ends.</p>
 
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref("EffectTiming.delay", "delay")}} {{optional_inline}}</dt>
- <dd>The number of milliseconds to delay the start of the animation. Defaults to 0.</dd>
- <dt>{{domxref("EffectTiming.direction", "direction")}} {{optional_inline}}</dt>
- <dd>Whether the animation runs forwards (<code>normal</code>), backwards (<code>reverse</code>), switches direction after each iteration (<code>alternate</code>), or runs backwards and switches direction after each iteration (<code>alternate-reverse</code>). Defaults to <code>"normal"</code>.</dd>
- <dt>{{domxref("EffectTiming.duration", "duration")}} {{optional_inline}}</dt>
- <dd>The number of milliseconds each iteration of the animation takes to complete. Defaults to 0. Although this is technically optional, keep in mind that your animation will not run if this value is 0.</dd>
- <dt>{{domxref("EffectTiming.easing", "easing")}} {{optional_inline}}</dt>
- <dd>The rate of the animation's change over time. Accepts the pre-defined values <code>"linear"</code>, <code>"ease"</code>, <code>"ease-in"</code>, <code>"ease-out"</code>, and <code>"ease-in-out"</code>, or a custom <code>"cubic-bezier"</code> value like <code>"cubic-bezier(0.42, 0, 0.58, 1)"</code>. Defaults to <code>"linear"</code>.</dd>
- <dt>{{domxref("EffectTiming.endDelay", "endDelay")}} {{optional_inline}}</dt>
- <dd>The number of milliseconds to delay after the end of an animation. This is primarily of use when sequencing animations based on the end time of another animation. Defaults to 0. </dd>
- <dt>{{domxref("EffectTiming.fill", "fill")}} {{optional_inline}}</dt>
- <dd>Dictates whether the animation's effects should be reflected by the element(s) prior to playing (<code>"backwards"</code>), retained after the animation has completed playing (<code>"forwards"</code>), or <code>both</code>. Defaults to <code>"none"</code>.</dd>
- <dt>{{domxref("EffectTiming.iterationStart", "iterationStart")}} {{optional_inline}}</dt>
- <dd>Describes at what point in the iteration the animation should start. 0.5 would indicate starting halfway through the first iteration for example, and with this value set, an animation with 2 iterations would end halfway through a third iteration. Defaults to 0.0.</dd>
- <dt>{{domxref("EffectTiming.iterations", "iterations")}} {{optional_inline}}</dt>
- <dd>The number of times the animation should repeat. Defaults to <code>1</code>, and can also take a value of {{jsxref("Infinity")}} to make it repeat for as long as the element exists.</dd>
+ <dt>{{domxref("EffectTiming.delay", "delay")}} {{optional_inline}}</dt>
+ <dd>The number of milliseconds to delay the start of the animation. Defaults to 0.</dd>
+ <dt>{{domxref("EffectTiming.direction", "direction")}} {{optional_inline}}</dt>
+ <dd>Whether the animation runs forwards (<code>normal</code>), backwards (<code>reverse</code>), switches direction after each iteration (<code>alternate</code>), or runs backwards and switches direction after each iteration (<code>alternate-reverse</code>). Defaults to <code>"normal"</code>.</dd>
+ <dt>{{domxref("EffectTiming.duration", "duration")}} {{optional_inline}}</dt>
+ <dd>The number of milliseconds each iteration of the animation takes to complete. Defaults to 0. Although this is technically optional, keep in mind that your animation will not run if this value is 0.</dd>
+ <dt>{{domxref("EffectTiming.easing", "easing")}} {{optional_inline}}</dt>
+ <dd>The rate of the animation's change over time. Accepts the pre-defined values <code>"linear"</code>, <code>"ease"</code>, <code>"ease-in"</code>, <code>"ease-out"</code>, and <code>"ease-in-out"</code>, or a custom <code>"cubic-bezier"</code> value like <code>"cubic-bezier(0.42, 0, 0.58, 1)"</code>. Defaults to <code>"linear"</code>.</dd>
+ <dt>{{domxref("EffectTiming.endDelay", "endDelay")}} {{optional_inline}}</dt>
+ <dd>The number of milliseconds to delay after the end of an animation. This is primarily of use when sequencing animations based on the end time of another animation. Defaults to 0.</dd>
+ <dt>{{domxref("EffectTiming.fill", "fill")}} {{optional_inline}}</dt>
+ <dd>Dictates whether the animation's effects should be reflected by the element(s) prior to playing (<code>"backwards"</code>), retained after the animation has completed playing (<code>"forwards"</code>), or <code>both</code>. Defaults to <code>"none"</code>.</dd>
+ <dt>{{domxref("EffectTiming.iterationStart", "iterationStart")}} {{optional_inline}}</dt>
+ <dd>Describes at what point in the iteration the animation should start. 0.5 would indicate starting halfway through the first iteration for example, and with this value set, an animation with 2 iterations would end halfway through a third iteration. Defaults to 0.0.</dd>
+ <dt>{{domxref("EffectTiming.iterations", "iterations")}} {{optional_inline}}</dt>
+ <dd>The number of times the animation should repeat. Defaults to <code>1</code>, and can also take a value of {{jsxref("Infinity")}} to make it repeat for as long as the element exists.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>
@@ -59,5 +58,4 @@ browser-compat: api.EffectTiming
  <li><a href="/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API">Using the Web Animations API</a></li>
  <li>{{domxref("Element.animate()")}}</li>
  <li>{{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}</li>
- <li>{{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly", "KeyframeEffectReadOnly()")}}</li> 
 </ul>

--- a/files/en-us/web/api/effecttiming/iterations/index.html
+++ b/files/en-us/web/api/effecttiming/iterations/index.html
@@ -2,40 +2,28 @@
 title: EffectTiming.iterations
 slug: Web/API/EffectTiming/iterations
 tags:
-- API
-- Animation
-- EffectTiming
-- Experimental
-- KeyframeEffect
-- Property
-- Reference
-- Web Animations
-- animate
-- iterations
-- waapi
-- web animations api
+  - API
+  - Animation
+  - EffectTiming
+  - Experimental
+  - KeyframeEffect
+  - Property
+  - Reference
+  - Web Animations
+  - animate
+  - iterations
+  - waapi
+  - web animations api
 browser-compat: api.EffectTiming.iterations
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
-<p>The <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> dictionary
-  {{domxref("EffectTiming")}}'s <strong><code>iterations</code></strong> property
+<p>The <a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> dictionary
+  {{domxref("EffectTiming")}}'s <strong><code>iterations</code></strong> property
   specifies the number of times the animation should repeat. The default value is 1,
   indicating that it should only play once, but you can set it to any floating-point value
   (including positive {{jsxref("Infinity")}} defaults to <code>1</code>, and can also take
-  a value of <code>Infinity</code> to make it loop infinitely. </p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including
-    <code>iterations</code>. The value of <code>iterations</code> corresponds directly
-    to {{domxref("AnimationEffectTimingReadOnly.iterations")}} in
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} objects returned by
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}}, and
-    {{domxref("KeyframeEffect")}}.</p>
-</div>
+  a value of <code>Infinity</code> to make it loop infinitely.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -63,9 +51,9 @@ browser-compat: api.EffectTiming.iterations
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the <a href="http://codepen.io/rachelnabors/pen/bEPdQr?editors=0010">Forgotten
-    Key</a> example, Alice waves her arm up and down the entire time the page is open by
-  passing <code>Infinity</code> as the value for her <code>iterations</code> property:</p>
+<p>In the <a href="https://codepen.io/rachelnabors/pen/bEPdQr?editors=0010">Forgotten
+    Key</a> example, Alice waves her arm up and down the entire time the page is open by
+  passing <code>Infinity</code> as the value for her <code>iterations</code> property:</p>
 
 <pre class="brush: js">// Get Alice's arm, and wave it up and down
 document.getElementById("alice_arm").animate([
@@ -91,14 +79,8 @@ document.getElementById("alice_arm").animate([
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
   <li>{{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including this one.
+    and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
+    both accept an object of timing properties including this one.
   </li>
-  <li>The value of this property corresponds to the one in
-    {{domxref("AnimationEffectTimingReadOnly")}} (which is the
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} object for
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}},
-    and {{domxref("KeyframeEffect")}}).</li>
   <li>CSS's {{cssxref("animation-iteration-count")}}</li>
 </ul>

--- a/files/en-us/web/api/effecttiming/iterationstart/index.html
+++ b/files/en-us/web/api/effecttiming/iterationstart/index.html
@@ -2,38 +2,26 @@
 title: EffectTiming.iterationStart
 slug: Web/API/EffectTiming/iterationStart
 tags:
-- API
-- Animation
-- EffectTiming
-- Experimental
-- KeyframeEffect
-- Property
-- Reference
-- Web Animations
-- animate
-- iterationStart
-- waapi
-- web animations api
+  - API
+  - Animation
+  - EffectTiming
+  - Experimental
+  - KeyframeEffect
+  - Property
+  - Reference
+  - Web Animations
+  - animate
+  - iterationStart
+  - waapi
+  - web animations api
 browser-compat: api.EffectTiming.iterationStart
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
 <p><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a>'s
-  {{domxref("EffectTiming")}} dictionary's 
-  <strong><code>iterationStart</code></strong> property specifies the repetition number
+  {{domxref("EffectTiming")}} dictionary's <strong><code>iterationStart</code></strong> property
+  specifies the repetition number
   which repetition the animation begins at and its progress through it.</p>
-
-<div class="note">
-  <p><strong>Note:</strong> {{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly()")}}, and
-    {{domxref("KeyframeEffect.KeyframeEffect()")}} all accept an object of timing
-    properties including <code>iterationStart.</code> The value of
-    <code>iterationStart</code> corresponds directly
-    to {{domxref("AnimationEffectTimingReadOnly.iterationStart")}} in
-    {{domxref("AnimationEffectReadOnly.timing", "timing")}} objects returned by
-    {{domxref("AnimationEffectReadOnly")}}, {{domxref("KeyframeEffectReadOnly")}}, and
-    {{domxref("KeyframeEffect")}}.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -49,7 +37,7 @@ browser-compat: api.EffectTiming.iterationStart
 <p>A floating-point value whose value is at least 0 and is not {{jsxref("Infinity",
   "+Infinity")}}, indicating the offset into the number of iterations the animation
   sequence is to run at which to start animating. <code>iterationStart</code>
-  represents the iteration index at which the animation effect begins as well as its
+  represents the iteration index at which the animation effect begins as well as its
   progress through that iteration.</p>
 
 <p>Usually you'll use a value between 0.0 and 1.0 to indicate an offset into the first run
@@ -62,7 +50,7 @@ browser-compat: api.EffectTiming.iterationStart
 <div class="note">
   <p><strong>Note:</strong> It's currently undefined what happens if you specify a value of
     <code>iterationStart</code> which is greater than the value of
-    {{domxref("AnimationEffectTimingProperties.iterations")}}. See <a
+    {{domxref("EffectTiming.iterations")}}. See <a
       href="https://github.com/w3c/web-animations/issues/170">issue 170 in the Web
       Animations API specification's issue tracker</a> for details and status of any
     changes to the specification in this regard.</p>
@@ -80,13 +68,8 @@ browser-compat: api.EffectTiming.iterationStart
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>
-  <li>{{domxref("Element.animate()")}},
-    {{domxref("KeyframeEffectReadOnly.KeyframeEffectReadOnly",
-    "KeyframeEffectReadOnly()")}}, and {{domxref("KeyframeEffect.KeyframeEffect",
-    "KeyframeEffect()")}} all accept an object of timing properties including this one.
+  <li>{{domxref("Element.animate()")}} and {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
+    both accept an object of timing properties including this one.
   </li>
-  <li>The value of this property corresponds to
-    {{domxref("AnimationEffectReadOnly.timing")}},
-    {{domxref("KeyframeEffectReadOnly.timing")}},
-    and {{domxref("KeyframeEffect.timing")}}).</li>
+
 </ul>


### PR DESCRIPTION
There is no more `AnimationEffectTiming`, `EffectTimingReadOnly`, and `AnimationEffectTimingReadOnly` in the spec.

And they were dictionaries so the name has never been visible to web devs.

Link to them in the docs were either redirects, or plain broken (red links).

I've fixed this (and cleaned the pages a bit). I kept `EffectTiming`, which may be one of these dictionaries we will keep documented on separate pages (or not)