### PR TITLE
Remove non-standard non-implemented method in BluetoothDevice

### DIFF
--- a/files/en-us/web/api/bluetoothdevice/index.html
+++ b/files/en-us/web/api/bluetoothdevice/index.html
@@ -38,9 +38,6 @@ browser-compat: api.BluetoothDevice
     an error if advetisments can’t shown for any reason.</dd>
   <dt>{{DOMxRef("BluetoothDevice.unwatchAdvertisments()")}} {{Experimental_Inline}}</dt>
   <dd>Stops watching for advertisments.</dd>
-  <dt>{{DOMxRef("BluetoothDevice.connectGATT()")}} {{Non-standard_Inline}} {{deprecated_inline}}</dt>
-  <dd>A {{jsxref("Promise")}} that resolves to an instance
-    of {{DOMxRef("BluetoothRemoteGATTServer")}}.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
The linked page has already been deleted long ago.