### PR TITLE
Fix typos and redirected links in WebRTC

### DIFF
--- a/files/en-us/web/api/rtcicecandidatepairstats/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/index.html
@@ -36,7 +36,7 @@ browser-compat: api.RTCIceCandidatePairStats
  <dd>Provides an informative value representing the available inbound capacity of the network by reporting the total number of bits per second available for all of the candidate pair's incoming {{Glossary("RTP")}} streams. This does not take into account the size of the {{Glossary("IP")}} overhead, nor any other transport layers such as {{Glossary("TCP")}} or {{Glossary("UDP")}}.</dd>
  <dt>{{domxref("RTCIceCandidatePairStats.availableOutgoingBitrate", "availableOutgoingBitrate")}} {{optional_inline}}</dt>
  <dd>Provides an informative value representing the available outbound capacity of the network by reporting the total number of bits per second available for all of the candidate pair's outoing {{Glossary("RTP")}} streams. This does not take into account the size of the {{Glossary("IP")}} overhead, nor any other transport layers such as {{Glossary("TCP")}} or {{Glossary("UDP")}}.</dd>
- <dt>{{domxref("RTCIceCandidatePairStats.bytesReceieved", "bytesReceieved")}} {{optional_inline}}</dt>
+ <dt>{{domxref("RTCIceCandidatePairStats/bytesReceived", "bytesReceived")}} {{optional_inline}}</dt>
  <dd>The total number of payload bytes received (that is, the total number of bytes received minus any headers, padding, or other administrative overhead) on this candidate pair so far.</dd>
  <dt>{{domxref("RTCIceCandidatePairStats.bytesSent", "bytesSent")}} {{optional_inline}}</dt>
  <dd>The total number of payload bytes sent (that is, the total number of bytes sent minus any headers, padding, or other administrative overhead) so far on this candidate pair.</dd>

--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
@@ -2,16 +2,16 @@
 title: RTCRtpReceiver.getStats()
 slug: Web/API/RTCRtpReceiver/getStats
 tags:
-- API
-- Media
-- Method
-- RTCRtpReceiver
-- Reference
-- WebRTC
-- WebRTC API
-- WebRTC Statistics
-- WebRTC Statistics API
-- getStats
+  - API
+  - Media
+  - Method
+  - RTCRtpReceiver
+  - Reference
+  - WebRTC
+  - WebRTC API
+  - WebRTC Statistics
+  - WebRTC Statistics API
+  - getStats
 browser-compat: api.RTCRtpReceiver.getStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
@@ -39,7 +39,7 @@ browser-compat: api.RTCRtpReceiver.getStats
 <h2 id="Example">Example</h2>
 
 <p>This simple example obtains the statistics for an <code>RTCRtpReceiver</code> and
-  updates an element's {{domxref("Node.innerText", "innerText")}} to display the number of
+  updates an element's {{domxref("HTMLElement/innerText", "innerText")}} to display the number of
   packets lost.</p>
 
 <pre class="brush: js">receiver.getStats().then(function(stats) {

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.html
@@ -2,15 +2,15 @@
 title: RTCRtpSender.getStats()
 slug: Web/API/RTCRtpSender/getStats
 tags:
-- API
-- Media
-- Method
-- RTCRtpSender
-- Reference
-- WebRTC
-- WebRTC Statistics
-- WebRTC Statistics API
-- getStats
+  - API
+  - Media
+  - Method
+  - RTCRtpSender
+  - Reference
+  - WebRTC
+  - WebRTC Statistics
+  - WebRTC Statistics API
+  - getStats
 browser-compat: api.RTCRtpSender.getStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
@@ -39,7 +39,7 @@ browser-compat: api.RTCRtpSender.getStats
 <h2 id="Example">Example</h2>
 
 <p>This simple example obtains the statistics for an <code>RTCRtpSender</code> and updates
-  an element's {{domxref("Node.innerText", "innerText")}} to display the current round
+  an element's {{domxref("HTMLElement/innerText", "innerText")}} to display the current round
   trip time for requests on the sender.</p>
 
 <pre class="brush: js">sender.getStats().then(function(stats) {
@@ -59,7 +59,7 @@ browser-compat: api.RTCRtpSender.getStats
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/Guide/API/WebRTC_API">WebRTC</a></li>
+  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC API</a></li>
   <li>{{domxref("RTCStatsReport")}}</li>
   <li>{{domxref("RTCRtpReceiver.getStats()")}}</li>
   <li>{{domxref("RTCPeerConnection.getStats()")}}</li>

--- a/files/en-us/web/api/rtctrackevent/receiver/index.html
+++ b/files/en-us/web/api/rtctrackevent/receiver/index.html
@@ -2,19 +2,19 @@
 title: RTCTrackEvent.receiver
 slug: Web/API/RTCTrackEvent/receiver
 tags:
-- API
-- Media
-- Property
-- RTCRtpReceiver
-- RTCTrackEvent
-- RTP
-- Read-only
-- Reference
-- WebRTC
-- WebRTC API
-- events
-- receiver
-- track
+  - API
+  - Media
+  - Property
+  - RTCRtpReceiver
+  - RTCTrackEvent
+  - RTP
+  - Read-only
+  - Reference
+  - WebRTC
+  - WebRTC API
+  - events
+  - receiver
+  - track
 browser-compat: api.RTCTrackEvent.receiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
@@ -32,7 +32,7 @@ browser-compat: api.RTCTrackEvent.receiver
 <h3 id="Value">Value</h3>
 
 <p>The {{domxref("RTCRtpTransceiver")}} which pairs the <code>receiver</code> with a
-  sender and other properties which establish a single bidirectional {{Glossary("SRTP")}}
+  sender and other properties which establish a single bidirectional {{Glossary("RTP", "SRTP")}}
   stream for use by the {{domxref("RTCTrackEvent.track", "track")}} associated with the
   <code>RTCTrackEvent</code>.</p>
 

--- a/files/en-us/web/api/rtctrackevent/transceiver/index.html
+++ b/files/en-us/web/api/rtctrackevent/transceiver/index.html
@@ -2,16 +2,16 @@
 title: RTCTrackEvent.transceiver
 slug: Web/API/RTCTrackEvent/transceiver
 tags:
-- API
-- Media
-- Property
-- RTCTrackEvent
-- RTP
-- Reference
-- Transceiver
-- WebRTC
-- WebRTC API
-- events
+  - API
+  - Media
+  - Property
+  - RTCTrackEvent
+  - RTP
+  - Reference
+  - Transceiver
+  - WebRTC
+  - WebRTC API
+  - events
 browser-compat: api.RTCTrackEvent.transceiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
@@ -33,7 +33,7 @@ browser-compat: api.RTCTrackEvent.transceiver
 <h3 id="Value">Value</h3>
 
 <p>The {{domxref("RTCRtpTransceiver")}} which pairs the <code>receiver</code> with a
-  sender and other properties which establish a single bidirectional {{Glossary("SRTP")}}
+  sender and other properties which establish a single bidirectional {{Glossary("RTP", "SRTP")}}
   stream for use by the {{domxref("RTCTrackEvent.track", "track")}} associated with the
   <code>RTCTrackEvent</code>.</p>
 


### PR DESCRIPTION
Fixed some typo, and a few links in WebRTC that were broken but the relevant pages are existing.