### PR TITLE
Remove mention of XUL Node.baseURIObject

### DIFF
--- a/files/en-us/web/api/node/baseuri/index.html
+++ b/files/en-us/web/api/node/baseuri/index.html
@@ -2,12 +2,12 @@
 title: Node.baseURI
 slug: Web/API/Node/baseURI
 tags:
-- API
-- HTML
-- NeedsSpecTable
-- Node
-- Property
-- Read-only
+  - API
+  - HTML
+  - NeedsSpecTable
+  - Node
+  - Property
+  - Read-only
 browser-compat: api.Node.baseURI
 ---
 <div>{{APIRef("DOM")}}</div>
@@ -21,7 +21,7 @@ browser-compat: api.Node.baseURI
 
 <p>In most cases the base URL is the location of the document, but it can be affected by
   many factors, including the {{HTMLElement("base")}} element in HTML and the
-  <code><a href="/en-US/docs/XML/xml:base">xml:base</a></code> attribute in XML.</p>
+  <code><a href="/en-US/docs/Web/XML/xml:base">xml:base</a></code> attribute in XML.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -47,7 +47,7 @@ browser-compat: api.Node.baseURI
   <li>When the document is new (created dynamically)</li>
 </ul>
 
-<p>See the <a href="http://developers.whatwg.org/urls.html#base-urls">Base URLs section of
+<p>See the <a href="https://developers.whatwg.org/urls.html#base-urls">Base URLs section of
     the HTML Living standard</a> for details.</p>
 
 <p>You can use <code>{{domxref("document")}}.baseURI</code> to obtain the base URL of a
@@ -59,11 +59,11 @@ browser-compat: api.Node.baseURI
 <p>The base URL of an <em>element</em> in HTML normally equals the base URL of the
   document the node is in.</p>
 
-<p>If the document contains <code><a href="/en-US/docs/XML/xml:base">xml:base</a></code>
+<p>If the document contains <code><a href="/en-US/docs/Web/XML/xml:base">xml:base</a></code>
   attributes (which you shouldn't do in HTML documents), the
   <code><em>element</em>.baseURI</code> takes the <code>xml:base</code> attributes of
   element's parents into account when computing the base URL. See <a
-    href="/en-US/docs/XML/xml:base">xml:base</a> for details.</p>
+    href="/en-US/docs/Web/XML/xml:base">xml:base</a> for details.</p>
 
 <p>You can use <code>{{domxref("element")}}.baseURI</code> to obtain the base URL of an
   element.</p>
@@ -80,8 +80,6 @@ browser-compat: api.Node.baseURI
 
 <ul>
   <li>{{HTMLElement("base")}} element (HTML)</li>
-  <li><code><a href="/en-US/docs/XML/xml:base">xml:base</a></code> attribute (XML
+  <li><code><a href="/en-US/docs/Web/XML/xml:base">xml:base</a></code> attribute (XML
     documents).</li>
-  <li>{{domxref("Node.baseURIObject")}} - a variant of this API for Mozilla add-ons and
-    internal code. Returns the base URL as an {{interface("nsIURI")}}.</li>
 </ul>


### PR DESCRIPTION
`Node.baseURIObject` was deleted. There was a mention there. (I also fixed some broken links)