### PR TITLE
Remove mentions of outdated mixins in worker global scopes

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.html
@@ -16,7 +16,7 @@ browser-compat: api.DedicatedWorkerGlobalScope
 
 <h2 id="Properties">Properties</h2>
 
-<p><em>This interface inherits properties from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}, and therefore implements properties from {{domxref("WindowTimers")}}, {{domxref("WindowBase64")}}, and {{domxref("WindowEventHandlers")}}.</em></p>
+<p><em>This interface inherits properties from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}.</em></p>
 
 <dl>
  <dt>{{domxref("DedicatedWorkerGlobalScope.name")}} {{readOnlyinline}}</dt>
@@ -40,7 +40,7 @@ browser-compat: api.DedicatedWorkerGlobalScope
 
 <h3 id="Event_handlers">Event handlers</h3>
 
-<p><em>This interface inherits event handlers from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}, and therefore implements event handlers from {{domxref("WindowTimers")}}, {{domxref("WindowBase64")}}, and {{domxref("WindowEventHandlers")}}.</em></p>
+<p><em>This interface inherits event handlers from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}.</em></p>
 
 <dl>
  <dt>{{domxref("DedicatedWorkerGlobalScope.onmessage")}}</dt>
@@ -51,7 +51,7 @@ browser-compat: api.DedicatedWorkerGlobalScope
 
 <h2 id="Methods">Methods</h2>
 
-<p><em>This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}, and therefore implements methods from {{domxref("WindowTimers")}}, {{domxref("WindowBase64")}}, and {{domxref("WindowEventHandlers")}}.</em></p>
+<p><em>This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}.</em></p>
 
 <dl>
  <dt>{{domxref("DedicatedWorkerGlobalScope.close()")}}</dt>

--- a/files/en-us/web/api/serviceworkerglobalscope/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.html
@@ -20,7 +20,7 @@ browser-compat: api.ServiceWorkerGlobalScope
 
 <p>Additionally, synchronous requests are not allowed from within a service worker — only asynchronous requests, like those initiated via the {{domxref("fetch()")}} method, can be used.</p>
 
-<p>This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}, and therefore implements properties from {{domxref("WindowTimers")}}, {{domxref("WindowBase64")}}, and {{domxref("WindowEventHandlers")}}.</p>
+<p>This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}.</p>
 
 <p>{{InheritanceDiagram(700, 85, 20)}}</p>
 
@@ -129,7 +129,7 @@ browser-compat: api.ServiceWorkerGlobalScope
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/ServiceWorker_API/Using_Service_Workers">Using Service Workers</a></li>
+ <li><a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using Service Workers</a></li>
  <li><a class="external external-icon" href="https://github.com/mdn/sw-test">Service workers basic code example</a></li>
  <li><a class="external external-icon" href="https://jakearchibald.github.io/isserviceworkerready/">Is ServiceWorker ready?</a></li>
  <li>{{jsxref("Promise")}}</li>


### PR DESCRIPTION
There were mentions of very old, outdated, no more on MDN, mixins in these two interface pages. Removed them.