### PR TITLE
Remove link to CSSMatrix

### DIFF
--- a/files/en-us/web/api/dommatrix/index.html
+++ b/files/en-us/web/api/dommatrix/index.html
@@ -132,7 +132,7 @@ browser-compat: api.DOMMatrix
 <p>Here are The positions of the 16 elements (m_11 through m_44) which comprise the 4×4 abstract matrix:</p>
 <p><math display="block"><semantics><mrow><mo>[</mo><mtable rowspacing="0.5ex"><mtr><mtd><msub><mi>m</mi><mn>11</mn></msub></mtd><mtd><msub><mi>m</mi><mn>21</mn></msub></mtd><mtd><msub><mi>m</mi><mn>31</mn></msub></mtd><mtd><msub><mi>m</mi><mn>41</mn></msub></mtd></mtr><mtr><mtd><msub><mi>m</mi><mn>12</mn></msub></mtd><mtd><msub><mi>m</mi><mn>22</mn></msub></mtd><mtd><msub><mi>m</mi><mn>32</mn></msub></mtd><mtd><msub><mi>m</mi><mn>42</mn></msub></mtd></mtr><mtr><mtd><msub><mi>m</mi><mn>13</mn></msub></mtd><mtd><msub><mi>m</mi><mn>23</mn></msub></mtd><mtd><msub><mi>m</mi><mn>33</mn></msub></mtd><mtd><msub><mi>m</mi><mn>43</mn></msub></mtd></mtr><mtr><mtd><msub><mi>m</mi><mn>14</mn></msub></mtd><mtd><msub><mi>m</mi><mn>24</mn></msub></mtd><mtd><msub><mi>m</mi><mn>34</mn></msub></mtd><mtd><msub><mi>m</mi><mn>44</mn></msub></mtd></mtr></mtable><mo>]</mo></mrow><annotation encoding="TeX">\left [ \begin{matrix} m_{11} &amp; m_{21} &amp; m_{31} &amp; m_{41} \\ m_{12} &amp; m_{22} &amp; m_{32} &amp; m_{42} \\ m_{13} &amp; m_{23} &amp; m_{33} &amp; m_{43} \\ m_{14} &amp; m_{24} &amp; m_{34} &amp; m_{44} \end{matrix} \right ]</annotation></semantics></math></p>
 
-<p>The <code>DOMMatrix</code> interface is designed with the intent that it will be used for all matrices within markup, supplanting the {{domxref("SVGMatrix")}} and {{domxref("CSSMatrix")}} interfaces.</p>
+<p>The <code>DOMMatrix</code> interface is designed with the intent that it will be used for all matrices within markup, supplanting the {{domxref("SVGMatrix")}} and <code>CSSMatrix</code> interfaces.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
`CSSMatrix` info has been merged into this page. So the link is useless. Removed, kept as a mention of the original name.