### PR TITLE
changing react 360 url in Getting started with React guide

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Hello_React">Hello React</h2>
 
-<p>As its official tagline states, <a href="https://reactjs.org/">React</a> is a library for building user interfaces. React is not a framework – it's not even exclusive to the web. It's used with other libraries to render to certain environments. For instance, <a href="https://reactnative.dev/">React Native</a> can be used to build mobile applications; <a href="https://facebook.github.io/react-360/">React 360</a> can be used to build virtual reality applications; and there are other possibilities besides.</p>
+<p>As its official tagline states, <a href="https://reactjs.org/">React</a> is a library for building user interfaces. React is not a framework – it's not even exclusive to the web. It's used with other libraries to render to certain environments. For instance, <a href="https://reactnative.dev/">React Native</a> can be used to build mobile applications; <a href="https://github.com/facebookarchive/react-360">React 360</a> can be used to build virtual reality applications; and there are other possibilities besides.</p>
 
 <p>To build for the web, developers use React in tandem with <a href="https://reactjs.org/docs/react-dom.html">ReactDOM</a>. React and ReactDOM are often discussed in the same spaces as — and utilized to solve the same problems as — other true web development frameworks. When we refer to React as a "framework", we’re working with that colloquial understanding.</p>
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Hello_React">Hello React</h2>
 
-<p>As its official tagline states, <a href="https://reactjs.org/">React</a> is a library for building user interfaces. React is not a framework – it's not even exclusive to the web. It's used with other libraries to render to certain environments. For instance, <a href="https://reactnative.dev/">React Native</a> can be used to build mobile applications; <a href="https://github.com/facebookarchive/react-360">React 360</a> can be used to build virtual reality applications; and there are other possibilities besides.</p>
+<p>As its official tagline states, <a href="https://reactjs.org/">React</a> is a library for building user interfaces. React is not a framework – it's not even exclusive to the web. It's used with other libraries to render to certain environments. For instance, <a href="https://reactnative.dev/">React Native</a> can be used to build mobile applications.</p>
 
 <p>To build for the web, developers use React in tandem with <a href="https://reactjs.org/docs/react-dom.html">ReactDOM</a>. React and ReactDOM are often discussed in the same spaces as — and utilized to solve the same problems as — other true web development frameworks. When we refer to React as a "framework", we’re working with that colloquial understanding.</p>
 


### PR DESCRIPTION
Facebook has stopped supporting the React 360 project since 2018 but it is still available to view and use.
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
