### PR TITLE
Refine HTTP req. examples in “Client-Server Overview”

### DIFF
--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -201,7 +201,7 @@ Content-Length: 0
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: The HTTP responses and requests shown in these examples were captured using the <a href="https://www.telerik.com/download/fiddler">Fiddler</a> application, but you can get similar information using web sniffers (e.g. <a href="https://websniffer.cc/">Websniffer</a>) or packet analyzer like <a href="https://www.wireshark.org/">Wireshark</a>. You can try this yourself. Use any of the linked tools, and then navigate through a site and edit profile information to see the different requests and responses. Most modern browsers also have tools that monitor network requests (for example, the <a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a> tool in Firefox).</p>
+<p><strong>Note</strong>: The HTTP responses and requests shown in these examples were captured using the <a href="https://www.telerik.com/download/fiddler">Fiddler</a> application, but you can get similar information using web sniffers (e.g. <a href="https://websniffer.cc/">Websniffer</a>) or packet analyzers like <a href="https://www.wireshark.org/">Wireshark</a>. You can try this yourself. Use any of the linked tools, and then navigate through a site and edit profile information to see the different requests and responses. Most modern browsers also have tools that monitor network requests (for example, the <a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a> tool in Firefox).</p>
 </div>
 
 <h2 id="Static_sites">Static sites</h2>

--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -78,7 +78,7 @@ tags:
 
 <p>Each line of the request contains information about it. The first part is called the <strong>header</strong>, and contains useful information about the request, in the same way that an <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML">HTML head</a> contains useful information about an HTML document (but not the actual content itself, which is in the body):</p>
 
-<pre class="brush: http">GET https://developer.mozilla.org/en-US/search?q=client+server+overview&amp;topic=apps&amp;topic=html&amp;topic=css&amp;topic=js&amp;topic=api&amp;topic=webdev HTTP/1.1
+<pre class="brush: http">GET /en-US/search?q=client+server+overview&amp;topic=apps&amp;topic=html&amp;topic=css&amp;topic=js&amp;topic=api&amp;topic=webdev HTTP/1.1
 Host: developer.mozilla.org
 Connection: keep-alive
 Pragma: no-cache
@@ -161,7 +161,7 @@ Content-Length: 41823
 
 <p>The text below shows the HTTP request made when a user submits new profile details on this site. The format of the request is almost the same as the <code>GET</code> request example shown previously, though the first line identifies this request as a <code>POST</code>. </p>
 
-<pre class="brush: http">POST https://developer.mozilla.org/en-US/profiles/hamishwillee/edit HTTP/1.1
+<pre class="brush: http">POST /en-US/profiles/hamishwillee/edit HTTP/1.1
 Host: developer.mozilla.org
 Connection: keep-alive
 Content-Length: 432
@@ -201,7 +201,7 @@ Content-Length: 0
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: The HTTP responses and requests shown in these examples were captured using the <a href="https://www.telerik.com/download/fiddler">Fiddler</a> application, but you can get similar information using web sniffers (e.g. <a href="https://websniffer.cc/">Websniffer</a>) or browser extensions like <a href="https://addons.mozilla.org/en-US/firefox/addon/httpfox/">HttpFox</a>. You can try this yourself. Use any of the linked tools, and then navigate through a site and edit profile information to see the different requests and responses. Most modern browsers also have tools that monitor network requests (for example, the <a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a> tool in Firefox).</p>
+<p><strong>Note</strong>: The HTTP responses and requests shown in these examples were captured using the <a href="https://www.telerik.com/download/fiddler">Fiddler</a> application, but you can get similar information using web sniffers (e.g. <a href="https://websniffer.cc/">Websniffer</a>) or packet analyzer like <a href="https://www.wireshark.org/">Wireshark</a>. You can try this yourself. Use any of the linked tools, and then navigate through a site and edit profile information to see the different requests and responses. Most modern browsers also have tools that monitor network requests (for example, the <a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a> tool in Firefox).</p>
 </div>
 
 <h2 id="Static_sites">Static sites</h2>


### PR DESCRIPTION
Hi,
Isn't it the the most common form of Request-URI is absolute path of the URI and full absolute URI is used for proxies?
HttpFox is discontinued, replaced with Wireshark.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
