### PR TITLE
Add interactive example for accent-color

### DIFF
--- a/files/en-us/web/css/accent-color/index.md
+++ b/files/en-us/web/css/accent-color/index.md
@@ -17,6 +17,8 @@ browser-compat: css.properties.accent-color
 
 The **`accent-color`** [CSS](/en-US/docs/Web/CSS) property sets the color of the elements {{Glossary("accent")}}. An accent appears in elements such as {{HTMLElement("input")}} of [`type="checkbox"`](/en-US/docs/Web/HTML/Element/input/checkbox), or [`type="radio"`](/en-US/docs/Web/HTML/Element/input/radio).
 
+{{EmbedInteractiveExample("pages/css/accent-color.html")}}
+
 ## Syntax
 
 ```css


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This adds an interactive example to the [accent-color](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color) page.


> Anything else that could help us review it

https://github.com/mdn/interactive-examples/pull/1864 - PR for the interactive example
