### PR TITLE
[Markdown] [Web/API] Suppress GFM conversion of wide (>150 character) tables

### DIFF
--- a/files/en-us/web/api/aescbcparams/index.html
+++ b/files/en-us/web/api/aescbcparams/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/aesctrparams/index.html
+++ b/files/en-us/web/api/aesctrparams/index.html
@@ -51,7 +51,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/aesgcmparams/index.html
+++ b/files/en-us/web/api/aesgcmparams/index.html
@@ -45,7 +45,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/aeskeygenparams/index.html
+++ b/files/en-us/web/api/aeskeygenparams/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/audionode/channelcountmode/index.html
+++ b/files/en-us/web/api/audionode/channelcountmode/index.html
@@ -16,7 +16,7 @@ browser-compat: api.AudioNode.channelCountMode
 
 <p>The possible values of <code>channelCountMode</code> and their meanings are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Value</th>

--- a/files/en-us/web/api/audioprocessingevent/index.html
+++ b/files/en-us/web/api/audioprocessingevent/index.html
@@ -22,7 +22,7 @@ browser-compat: api.AudioProcessingEvent
 
 <p><em>The list below includes the properties inherited from its parent, {{domxref("Event")}}</em>.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Property</th>

--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -156,7 +156,7 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="no-markdown">
+<table>
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>The Barcode Detection API supports the following barcode formats:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Format</th>
@@ -156,7 +156,7 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/canvasimagesource/index.html
+++ b/files/en-us/web/api/canvasimagesource/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/closeevent/code/index.html
+++ b/files/en-us/web/api/closeevent/code/index.html
@@ -15,7 +15,7 @@ browser-compat: api.CloseEvent.code
 <h3>Value</h3>
 <p>A status code. As detailed in the following table, sourced from <a href="https://www.iana.org/assignments/websocket/websocket.xml#close-code-number">the IANA website</a>:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
      <th>Status code</th>

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -48,7 +48,7 @@ browser-compat: api.ConvolverNode.ConvolverNode
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/css_object_model/managing_screen_orientation/index.html
+++ b/files/en-us/web/api/css_object_model/managing_screen_orientation/index.html
@@ -105,7 +105,7 @@ li {
 
 <p>And here's the result</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Portrait</th>

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -37,7 +37,7 @@ browser-compat: api.CSSPrimitiveValue.getFloatValue
   <dt>unitType</dt>
   <dd>An <code>unsigned short</code> representing the code for the unit type, in which the
     value should be returned. Valid values are:
-    <table class="no-markdown">
+    <table>
       <thead>
         <tr>
           <th>Constant</th>

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -37,7 +37,7 @@ browser-compat: api.CSSPrimitiveValue.getFloatValue
   <dt>unitType</dt>
   <dd>An <code>unsigned short</code> representing the code for the unit type, in which the
     value should be returned. Valid values are:
-    <table class="standard-table">
+    <table class="no-markdown">
       <thead>
         <tr>
           <th>Constant</th>
@@ -129,7 +129,7 @@ browser-compat: api.CSSPrimitiveValue.getFloatValue
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col"><strong>Type</strong></th>

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
@@ -35,7 +35,7 @@ browser-compat: api.CSSPrimitiveValue.primitiveType
 <p>An <code>unsigned short</code> representing the type of the value. Possible values are:
 </p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Constant</th>

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -38,7 +38,7 @@ browser-compat: api.CSSPrimitiveValue.setFloatValue
   <dt>unitType</dt>
   <dd>An <code>unsigned short</code> representing the code for the unit type, in which the
     value should be returned. Valid values are:
-    <table class="standard-table">
+    <table class="no-markdown">
       <thead>
         <tr>
           <th>Constant</th>
@@ -132,7 +132,7 @@ browser-compat: api.CSSPrimitiveValue.setFloatValue
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col"><strong>Type</strong></th>

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -38,7 +38,7 @@ browser-compat: api.CSSPrimitiveValue.setFloatValue
   <dt>unitType</dt>
   <dd>An <code>unsigned short</code> representing the code for the unit type, in which the
     value should be returned. Valid values are:
-    <table class="no-markdown">
+    <table>
       <thead>
         <tr>
           <th>Constant</th>

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -38,7 +38,7 @@ browser-compat: api.CSSPrimitiveValue.setStringValue
   <dt>stringType</dt>
   <dd>An <code>unsigned short</code> representing the type of the value. Possible values
     are:
-    <table class="no-markdown">
+    <table>
       <thead>
         <tr>
           <th>Constant</th>

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -38,7 +38,7 @@ browser-compat: api.CSSPrimitiveValue.setStringValue
   <dt>stringType</dt>
   <dd>An <code>unsigned short</code> representing the type of the value. Possible values
     are:
-    <table class="standard-table">
+    <table class="no-markdown">
       <thead>
         <tr>
           <th>Constant</th>
@@ -75,7 +75,7 @@ browser-compat: api.CSSPrimitiveValue.setStringValue
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col"><strong>Type</strong></th>

--- a/files/en-us/web/api/cssrule/type/index.html
+++ b/files/en-us/web/api/cssrule/type/index.html
@@ -25,7 +25,7 @@ browser-compat: api.CSSRule.type
 <h3>Value</h3>
 <p>An integer which will be one of the type constants listed in the table below.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <tbody>
     <tr>
       <th>Type</th>

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -99,7 +99,7 @@ browser-compat: api.CSSStyleSheet
 
 <p>A (possibly incomplete) list of ways a stylesheet can be associated with a document follows:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Reason for the style sheet to be associated with the document</th>

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -37,7 +37,7 @@ browser-compat: api.CSSValue.cssValueType
 <p>An <code>unsigned short</code> representing a code defining the type of the value.
   Possible values are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Constant</th>

--- a/files/en-us/web/api/customelementregistry/define/index.html
+++ b/files/en-us/web/api/customelementregistry/define/index.html
@@ -53,7 +53,7 @@ browser-compat: api.CustomElementRegistry.define
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/customelementregistry/whendefined/index.html
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.html
@@ -39,7 +39,7 @@ browser-compat: api.CustomElementRegistry.whenDefined
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/decompressionstream/writable/index.html
+++ b/files/en-us/web/api/decompressionstream/writable/index.html
@@ -27,7 +27,7 @@ browser-compat: api.DecompressionStream.writable
 <pre class="brush:js">let stream = new DecompressionStream('gzip');
 console.log(stream.writeable); //a WritableStream</pre>
 
-<table class="standard-table">
+<table class="no-markdown">
   <tbody>
    <tr>
     <th scope="col">Specification</th>

--- a/files/en-us/web/api/directoryentrysync/index.html
+++ b/files/en-us/web/api/directoryentrysync/index.html
@@ -41,7 +41,7 @@ browser-compat: api.DirectoryEntrySync
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<tbody>
 		<tr>
 			<td><code>DirectoryReaderSync <a href="#createreader">createReader</a> () raises (<a href="/en-US/docs/Web/API/FileException">FileException</a>);</code></td>
@@ -82,7 +82,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>
@@ -118,7 +118,7 @@ browser-compat: api.DirectoryEntrySync
 	<dd>An object literal describing the behavior of the method. If the file does not exist, it is created.</dd>
 </dl>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Object literal</th>
@@ -171,7 +171,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>
@@ -227,7 +227,7 @@ browser-compat: api.DirectoryEntrySync
 	<dd>An object literal describing the behavior of the method if the file does not exist.</dd>
 </dl>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Object literal</th>
@@ -280,7 +280,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>
@@ -340,7 +340,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>

--- a/files/en-us/web/api/directoryentrysync/index.html
+++ b/files/en-us/web/api/directoryentrysync/index.html
@@ -82,7 +82,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="no-markdown">
+<table>
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>
@@ -171,7 +171,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="no-markdown">
+<table>
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>
@@ -280,7 +280,7 @@ browser-compat: api.DirectoryEntrySync
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="no-markdown">
+<table>
 	<thead>
 		<tr>
 			<th scope="col">Exception</th>

--- a/files/en-us/web/api/document/evaluate/index.html
+++ b/files/en-us/web/api/document/evaluate/index.html
@@ -98,7 +98,7 @@ alert(alertText); // Alerts the text of all h2 elements
 <p>These are supported values for the <code>resultType</code> parameter of the
 	<code>evaluate</code> method:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Result Type</th>

--- a/files/en-us/web/api/document/rootelement/index.html
+++ b/files/en-us/web/api/document/rootelement/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Specification</th>

--- a/files/en-us/web/api/domstring/index.html
+++ b/files/en-us/web/api/domstring/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/ecdhkeyderiveparams/index.html
+++ b/files/en-us/web/api/ecdhkeyderiveparams/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/ecdsaparams/index.html
+++ b/files/en-us/web/api/ecdsaparams/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/eckeygenparams/index.html
+++ b/files/en-us/web/api/eckeygenparams/index.html
@@ -35,7 +35,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/eckeyimportparams/index.html
+++ b/files/en-us/web/api/eckeyimportparams/index.html
@@ -33,7 +33,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/element/attachshadow/index.html
+++ b/files/en-us/web/api/element/attachshadow/index.html
@@ -93,7 +93,7 @@ browser-compat: api.Element.attachShadow
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/encoding_api/encodings/index.html
+++ b/files/en-us/web/api/encoding_api/encodings/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>The following table lists all encoding names and labels that user agents must support, as defined in the Encoding Spec. These are generally applicable anywhere character encodings are used.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
     <thead>
       <tr>
         <th scope="col">Label</th>

--- a/files/en-us/web/api/event/comparison_of_event_targets/index.html
+++ b/files/en-us/web/api/event/comparison_of_event_targets/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>There are five targets to consider:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
     <th>Property</th>
@@ -138,7 +138,7 @@ tags:
 
 <p>The <code>relatedTarget</code> property for the <code>mouseover</code> event holds the node that the mouse was previously over. For the <code>mouseout</code> event, it holds the node that the mouse moved to.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Event type</th>

--- a/files/en-us/web/api/event/comparison_of_event_targets/index.html
+++ b/files/en-us/web/api/event/comparison_of_event_targets/index.html
@@ -138,7 +138,7 @@ tags:
 
 <p>The <code>relatedTarget</code> property for the <code>mouseover</code> event holds the node that the mouse was previously over. For the <code>mouseout</code> event, it holds the node that the mouse moved to.</p>
 
-<table class="no-markdown">
+<table>
  <tbody>
   <tr>
    <th>Event type</th>

--- a/files/en-us/web/api/event/eventphase/index.html
+++ b/files/en-us/web/api/event/eventphase/index.html
@@ -33,7 +33,7 @@ browser-compat: api.Event.eventPhase
 
 <p>These values describe which phase the event flow is currently being evaluated.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/file/using_files_from_web_applications/index.html
+++ b/files/en-us/web/api/file/using_files_from_web_applications/index.html
@@ -479,7 +479,7 @@ URL.revokeObjectURL(obj_url);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/filereader/result/index.html
+++ b/files/en-us/web/api/filereader/result/index.html
@@ -31,7 +31,7 @@ browser-compat: api.FileReader.result
 
 <p>The result types are described below.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Method</th>

--- a/files/en-us/web/api/focusevent/relatedtarget/index.html
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.html
@@ -15,7 +15,7 @@ browser-compat: api.FocusEvent.relatedTarget
 <p>The <code><strong>FocusEvent.relatedTarget</strong></code> read-only property is the
   secondary target, depending on the type of event:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Event name</th>

--- a/files/en-us/web/api/gamepad_api/index.html
+++ b/files/en-us/web/api/gamepad_api/index.html
@@ -61,7 +61,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/geolocationpositionerror/code/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/code/index.html
@@ -25,7 +25,7 @@ browser-compat: api.GeolocationPositionError.code
 <p>An <code>unsigned short</code> representing the error code. The following values are
   possible:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Value</th>

--- a/files/en-us/web/api/history_api/index.html
+++ b/files/en-us/web/api/history_api/index.html
@@ -84,7 +84,7 @@ history.go(2)  // alerts "location: http://example.com/example.html?page=3, stat
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/hkdfparams/index.html
+++ b/files/en-us/web/api/hkdfparams/index.html
@@ -38,7 +38,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/hmacimportparams/index.html
+++ b/files/en-us/web/api/hmacimportparams/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/hmackeygenparams/index.html
+++ b/files/en-us/web/api/hmackeygenparams/index.html
@@ -33,7 +33,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/html_drag_and_drop_api/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.html
@@ -292,7 +292,7 @@ function drop_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th><strong>Specification</strong></th>

--- a/files/en-us/web/api/html_drag_and_drop_api/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>Each <a href="/en-US/docs/Web/API/DragEvent#event_types">drag event type</a> has an associated <a href="/en-US/docs/Web/API/DragEvent#globaleventhandlers">global event handler</a>:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Event</th>
@@ -292,7 +292,7 @@ function drop_handler(ev) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th><strong>Specification</strong></th>

--- a/files/en-us/web/api/html_sanitizer_api/index.html
+++ b/files/en-us/web/api/html_sanitizer_api/index.html
@@ -51,7 +51,7 @@ const result = new Sanitizer().sanitize(stringToClean);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/htmlfontelement/size/index.html
+++ b/files/en-us/web/api/htmlfontelement/size/index.html
@@ -23,7 +23,7 @@ browser-compat: api.HTMLFontElement.size
 
 <p>The format of the string must follow one of the following HTML microsyntaxes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Microsyntax</th>

--- a/files/en-us/web/api/htmlinputelement/stepup/index.html
+++ b/files/en-us/web/api/htmlinputelement/stepup/index.html
@@ -22,7 +22,7 @@ browser-compat: api.HTMLInputElement.stepUp
   <code><a href="/en-US/docs/Web/HTML/Attributes/step">step</a></code> defaults to the
   default value for <code>step</code> if not specified.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Input type</th>

--- a/files/en-us/web/api/htmlkeygenelement/index.html
+++ b/files/en-us/web/api/htmlkeygenelement/index.html
@@ -45,7 +45,7 @@ browser-compat: api.HTMLKeygenElement
 
 <h2 id="Methods">Methods</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Name &amp; Arguments</th>

--- a/files/en-us/web/api/htmlmediaelement/readystate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/readystate/index.html
@@ -23,7 +23,7 @@ browser-compat: api.HTMLMediaElement.readyState
 
 <p>An <code>unsigned short</code>. Possible values are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/htmltimeelement/datetime/index.html
+++ b/files/en-us/web/api/htmltimeelement/datetime/index.html
@@ -19,7 +19,7 @@ browser-compat: api.HTMLTimeElement.dateTime
 
 <p>The format of the string must follow one of the following HTML microsyntaxes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Microsyntax</th>

--- a/files/en-us/web/api/idbcursor/delete/index.html
+++ b/files/en-us/web/api/idbcursor/delete/index.html
@@ -39,7 +39,7 @@ browser-compat: api.IDBCursor.delete
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbcursor/direction/index.html
+++ b/files/en-us/web/api/idbcursor/direction/index.html
@@ -35,7 +35,7 @@ browser-compat: api.IDBCursor.direction
     enum</a>) indicating the direction in which the cursor is traversing the data.
   Possible values are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Value</th>

--- a/files/en-us/web/api/idbcursor/update/index.html
+++ b/files/en-us/web/api/idbcursor/update/index.html
@@ -47,7 +47,7 @@ browser-compat: api.IDBCursor.update
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.html
@@ -47,7 +47,7 @@ browser-compat: api.IDBDatabase.createObjectStore
     <p>An options object whose attributes are optional parameters to the method. It
       includes the following properties:</p>
 
-    <table class="standard-table">
+    <table class="no-markdown">
       <thead>
         <tr>
           <th scope="col">Attribute</th>
@@ -86,7 +86,7 @@ browser-compat: api.IDBDatabase.createObjectStore
 <p>This method may raise a {{domxref("DOMException")}} with a {{domxref("DOMError")}} of
   one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.html
@@ -42,7 +42,7 @@ browser-compat: api.IDBDatabase.deleteObjectStore
 
 <p>This method may raise a {{domxref("DOMException")}}  of one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbdatabase/transaction/index.html
+++ b/files/en-us/web/api/idbdatabase/transaction/index.html
@@ -105,7 +105,7 @@ var transaction = db.transaction('my-store-name');</pre>
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbindexsync/index.html
+++ b/files/en-us/web/api/idbindexsync/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <td><code>any <a href="#add">add</a> (in any value, in optional any key) raises (<a href="/IDBDatabaseException">IDBDatabaseException</a>);</code></td>
@@ -47,7 +47,7 @@ tags:
 
 <h2 id="Attributes">Attributes</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Attribute</th>

--- a/files/en-us/web/api/idbobjectstore/clear/index.html
+++ b/files/en-us/web/api/idbobjectstore/clear/index.html
@@ -42,7 +42,7 @@ browser-compat: api.IDBObjectStore.clear
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbobjectstore/delete/index.html
+++ b/files/en-us/web/api/idbobjectstore/delete/index.html
@@ -50,7 +50,7 @@ var <em>request</em> = <em>objectStore</em>.delete(<em>KeyRange</em>);
 
 <p>This method may raise a {{domxref("DOMException")}} of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbobjectstore/deleteindex/index.html
+++ b/files/en-us/web/api/idbobjectstore/deleteindex/index.html
@@ -46,7 +46,7 @@ browser-compat: api.IDBObjectStore.deleteIndex
 
 <p>This method may raise a {{domxref("DOMException")}} of one of the following types:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/idbobjectstoresync/index.html
+++ b/files/en-us/web/api/idbobjectstoresync/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <td><code>any <a href="#add">add</a> (in any value, in optional any key) raises (<a href="/en-US/docs/Web/API/IDBDatabaseException">IDBDatabaseException</a>);</code></td>
@@ -49,7 +49,7 @@ tags:
 
 <h2 id="Attributes">Attributes</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Attribute</th>
@@ -85,7 +85,7 @@ tags:
 
 <h3 id="Mode_constants">Mode constants</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant</th>

--- a/files/en-us/web/api/idbobjectstoresync/index.html
+++ b/files/en-us/web/api/idbobjectstoresync/index.html
@@ -85,7 +85,7 @@ tags:
 
 <h3 id="Mode_constants">Mode constants</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant</th>

--- a/files/en-us/web/api/idbrequest/error/index.html
+++ b/files/en-us/web/api/idbrequest/error/index.html
@@ -34,7 +34,7 @@ browser-compat: api.IDBRequest.error
   removed from the DOM standard. The following error codes are returned under certain
   conditions:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Error</th>

--- a/files/en-us/web/api/idbtransaction/mode/index.html
+++ b/files/en-us/web/api/idbtransaction/mode/index.html
@@ -34,7 +34,7 @@ browser-compat: api.IDBTransaction.mode
 <p>An {{domxref("IDBTransactionMode")}} object defining the mode for isolating access to
   data in the current object stores:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Value</th>

--- a/files/en-us/web/api/idbtransactionsync/index.html
+++ b/files/en-us/web/api/idbtransactionsync/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <td><code>void <a href="#abort">abort</a>() raises (<a href="/en-US/docs/Web/API/IDBDatabaseException">IDBDatabaseException</a>); </code></td>
@@ -35,7 +35,7 @@ tags:
 
 <h2 id="Attributes">Attributes</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Attribute</th>

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -146,7 +146,7 @@ request.onupgradeneeded = function(event) {
 
 <p>The following table shows the different ways the keys are supplied:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Key Path (<code>keyPath</code>)</th>

--- a/files/en-us/web/api/keyboardevent/key/key_values/index.html
+++ b/files/en-us/web/api/keyboardevent/key/key_values/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>Values of <code>key</code> which have special meanings other than identifying a specific key or character.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -65,7 +65,7 @@ tags:
 
 <p><em>Modifiers</em> are special keys which are used to generate special characters or cause special actions when used in combination with other keys. Examples include the <kbd>Shift</kbd> and <kbd>Control</kbd> keys, and lock keys such as <kbd>Caps Lock</kbd> and <kbd>NumLock</kbd>.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -247,7 +247,7 @@ tags:
 
 <h2 id="Whitespace_keys">Whitespace keys</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -309,7 +309,7 @@ tags:
 
 <h2 id="Navigation_keys">Navigation keys</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -411,7 +411,7 @@ tags:
 
 <h2 id="Editing_keys">Editing keys</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -545,7 +545,7 @@ tags:
 
 <h2 id="UI_keys">UI keys</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -718,7 +718,7 @@ tags:
 
 <h2 id="Device_keys">Device keys</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -848,7 +848,7 @@ tags:
 
 <h4 id="Common_IME_keys">Common IME keys</h4>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -1033,7 +1033,7 @@ tags:
 
 <p>These keys are only available on Korean keyboards. There are other keys defined by various platforms for Korean keyboards, but these are the most common and are the ones identified by the UI Events specification.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -1084,7 +1084,7 @@ tags:
 
 <p>These keys are only available on Japanese keyboards.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -1217,7 +1217,7 @@ tags:
 
 <p>The value of {{domxref("CompositionEvent.data", "data")}} will be one of the following:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col"><strong><code>CompositionEvent.data</code></strong> value</th>
@@ -1494,7 +1494,7 @@ tags:
 
 <p>If more function keys are available, their names continue the pattern here by continuing to increment the numeric portion of each key's name, so that, for example, <code>"F24"</code> is a valid key value.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> value</th>
@@ -1732,7 +1732,7 @@ tags:
 
 <p>These keys represent buttons which commonly exist on modern smartphones.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -1852,7 +1852,7 @@ tags:
 
 <p>The multimedia keys are extra buttons or keys for controlling media devices, found on some keyboards.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -1983,7 +1983,7 @@ tags:
 
 <p>These media keys are used specifically for controlling audio.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -2166,7 +2166,7 @@ tags:
 
 <p>These key values represent buttons or keys present on television devices, or computers or phones which have TV support.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -2445,7 +2445,7 @@ tags:
 <p><strong>Note:</strong> Remote controls typically include keys whose values are already defined elsewhere, such as under {{anch("Multimedia keys")}} or {{anch("Audio control keys")}}. Those keys' values will match what's documented in those tables.</p>
 </div>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -3051,7 +3051,7 @@ tags:
 
 <p>These special multimedia keys are used to control speech recognition features.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -3093,7 +3093,7 @@ tags:
 
 <p>These keys control documents. In the specification, they're included in other sets of keys (such as the media keys), but they are more sensibly considered to be their own category.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -3196,7 +3196,7 @@ tags:
 
 <p>Some keyboards offer special keys for launching or switching to certain common applications. Key values for those are listed here.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -3494,7 +3494,7 @@ tags:
 
 <p>Some keyboards include special keys for controlling Web browsers. Those keys follow.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>
@@ -3593,7 +3593,7 @@ tags:
 <p><strong>Note:</strong> The <kbd>10</kbd> key, if present, generates events with the <code>key</code> value of <code>"0"</code>.</p>
 </div>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th rowspan="2" scope="col"><code>KeyboardEvent.key</code> Value</th>

--- a/files/en-us/web/api/keyboardevent/keycode/index.html
+++ b/files/en-us/web/api/keyboardevent/keycode/index.html
@@ -112,7 +112,7 @@ browser-compat: api.KeyboardEvent.keyCode
  </li>
 </ol>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by printable keys in standard position</caption>
  <thead>
   <tr>
@@ -616,7 +616,7 @@ browser-compat: api.KeyboardEvent.keyCode
  </tfoot>
 </table>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by printable keys in standard position (punctuations in US layout):</caption>
  <thead>
   <tr>
@@ -1060,7 +1060,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <h3 id="Non-printable_keys_function_keys">Non-printable keys (function keys)</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by modifier keys:</caption>
  <thead>
   <tr>
@@ -1222,7 +1222,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <p>[3] When the Japanese keyboard layout is active, pressing the <kbd>"CapsLock"</kbd> key without pressing <kbd>Shift</kbd> raises <code>0x00 (0)</code>. The key works as the <kbd>"Alphanumeric"</kbd> key whose label is <code>"英数"</code>.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by non-printable keys:</caption>
  <thead>
   <tr>
@@ -1489,7 +1489,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <p >[6] <kbd>Pause</kbd> key with <kbd>Control</kbd> generates <code>0x03 (3)</code>.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by function keys:</caption>
  <thead>
   <tr>
@@ -1817,7 +1817,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <h3 id="Numpad_keys">Numpad keys</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by keys in numpad in NumLock state</caption>
  <thead>
   <tr>
@@ -2096,7 +2096,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <p >[1] <code>"NumLock"</code> key works as <code>"Clear"</code> key on Mac.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>keyCode values of each browser's keydown event caused by keys in numpad without NumLock state</caption>
  <thead>
   <tr>
@@ -2228,7 +2228,7 @@ browser-compat: api.KeyboardEvent.keyCode
 
 <p>Gecko defines a lot of <code>keyCode</code> values in <code>KeyboardEvent</code> for making the mapping table explicitly. These values are useful for add-on developers of Firefox, but not so useful in public web pages.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Constant</th>

--- a/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
+++ b/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
@@ -36,7 +36,7 @@ browser-compat: api.KeyframeEffect.setKeyframes
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -66,7 +66,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <td><code>void <a href="#requestfilesystem">requestFileSystem</a> (in unsigned short <em>type</em>, in unsigned long long <em>size</em>, in FileSystemCallback <em>successCallback</em>, in optional ErrorCallback <em>errorCallback</em>); </code></td>
@@ -79,7 +79,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant</th>
@@ -142,7 +142,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileError">FileError</a> with the following code:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>
@@ -185,7 +185,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileError">FileError</a> with the following code:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -185,7 +185,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileError">FileError</a> with the following code:</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/localfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/index.html
@@ -43,7 +43,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Method_overview">Method overview</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <td><code>FileSystemSync <a href="#requestfilesystemsync">requestFileSystemSync</a> (in unsigned short <em>type</em>, in long long <em>size</em>) raises <a href="/en-US/docs/Web/API/FileException">FileException</a>; </code></td>
@@ -56,7 +56,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant</th>
@@ -111,7 +111,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following code:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>
@@ -150,7 +150,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <p>This method can raise a <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following codes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/localfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/index.html
@@ -56,7 +56,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Constants">Constants</h2>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant</th>
@@ -111,7 +111,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following code:</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
@@ -40,7 +40,7 @@ browser-compat: api.LocalFileSystemSync.requestFileSystemSync
 
 <p>This method can raise an <a href="/en-US/docs/Web/API/FileException">FileException</a> with the following code:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/media_streams_api/constraints/index.html
+++ b/files/en-us/web/api/media_streams_api/constraints/index.html
@@ -532,7 +532,7 @@ function handleError(reason) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<tbody>
 		<tr>
 			<th scope="col">Specification</th>

--- a/files/en-us/web/api/mediaerror/code/index.html
+++ b/files/en-us/web/api/mediaerror/code/index.html
@@ -33,7 +33,7 @@ browser-compat: api.MediaError.code
 
 <h4 id="Media_error_code_constants">Media error code constants</h4>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Name</th>

--- a/files/en-us/web/api/mediasource/duration/index.html
+++ b/files/en-us/web/api/mediasource/duration/index.html
@@ -33,7 +33,7 @@ var <em>myDuration</em> = <em>mediaSource</em>.duration;</pre>
 
 <p>The following exceptions may be thrown when setting a new value for this property.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/mediasource/endofstream/index.html
+++ b/files/en-us/web/api/mediasource/endofstream/index.html
@@ -54,7 +54,7 @@ browser-compat: api.MediaSource.endOfStream
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.html
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.html
@@ -16,7 +16,7 @@ browser-compat: api.MouseEvent.relatedTarget
 <p>The <strong><code>MouseEvent.relatedTarget</code></strong> read-only property is the
   secondary target for the mouse event, if there is one. That is:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Event name</th>

--- a/files/en-us/web/api/mousewheelevent/index.html
+++ b/files/en-us/web/api/mousewheelevent/index.html
@@ -21,7 +21,7 @@ browser-compat: api.MouseWheelEvent
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Attribute</th>

--- a/files/en-us/web/api/mssitemodeevent/index.html
+++ b/files/en-us/web/api/mssitemodeevent/index.html
@@ -18,7 +18,7 @@ slug: Web/API/MSSiteModeEvent
 
 <h3 id="Methods">Methods</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Method</th>
@@ -47,7 +47,7 @@ slug: Web/API/MSSiteModeEvent
 
 <h3 id="Properties">Properties</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Property</th>

--- a/files/en-us/web/api/node/nodetype/index.html
+++ b/files/en-us/web/api/node/nodetype/index.html
@@ -27,7 +27,7 @@ browser-compat: api.Node.nodeType
 
 <h3 id="Node_type_constants">Node type constants</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/nodefilter/acceptnode/index.html
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.html
@@ -17,7 +17,7 @@ browser-compat: api.NodeFilter.acceptNode
   }} iteration algorithm. This method is expected to be written by the user of a
   <code>NodeFilter</code>. Possible return values are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Constant</th>

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.html
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.html
@@ -21,7 +21,7 @@ browser-compat: api.NodeIterator.whatToShow
 
 <p>The values that can be combined to form the bitmask are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
     <tr>
       <th>Constant</th>

--- a/files/en-us/web/api/payment_request_api/concepts/index.html
+++ b/files/en-us/web/api/payment_request_api/concepts/index.html
@@ -90,7 +90,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/pbkdf2params/index.html
+++ b/files/en-us/web/api/pbkdf2params/index.html
@@ -44,7 +44,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/performanceentry/entrytype/index.html
+++ b/files/en-us/web/api/performanceentry/entrytype/index.html
@@ -31,7 +31,7 @@ browser-compat: api.PerformanceEntry.entryType
 
 <h3 id="Performance_entry_type_names">Performance entry type names</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Value</th>

--- a/files/en-us/web/api/performanceentry/name/index.html
+++ b/files/en-us/web/api/performanceentry/name/index.html
@@ -27,7 +27,7 @@ browser-compat: api.PerformanceEntry.name
 <p>The return value depends on the subtype of the <code>PerformanceEntry</code> object and
   the value of {{domxref("PerformanceEntry.entryType")}}, as shown by the table below.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Value</th>

--- a/files/en-us/web/api/performancenavigation/type/index.html
+++ b/files/en-us/web/api/performancenavigation/type/index.html
@@ -26,7 +26,7 @@ browser-compat: api.PerformanceNavigation.type
 
 <p>Possible values are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Value</th>

--- a/files/en-us/web/api/permissions/query/index.html
+++ b/files/en-us/web/api/permissions/query/index.html
@@ -44,7 +44,7 @@ browser-compat: api.Permissions.query
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Exception</th>

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -97,7 +97,7 @@ tags:
 
 <p>Below is a short description of each event type and its associated {{domxref("GlobalEventHandlers","Global Event Handler")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Event</th>
@@ -304,7 +304,7 @@ tags:
 
 <p>The following table provides the values of <code>button</code> and <code>buttons</code> for the various device button states.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Device Button State</th>
@@ -467,7 +467,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table>
+<table class="no-markdown">
   <tr>
    <th>Specification</th>
   </tr>

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -304,7 +304,7 @@ tags:
 
 <p>The following table provides the values of <code>button</code> and <code>buttons</code> for the various device button states.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Device Button State</th>
@@ -467,7 +467,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="no-markdown">
+<table>
   <tr>
    <th>Specification</th>
   </tr>

--- a/files/en-us/web/api/pointer_events/using_pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/using_pointer_events/index.html
@@ -218,7 +218,7 @@ Log: &lt;pre id="log" style="border: 1px solid #ccc;"&gt;&lt;/pre&gt;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/publickeycredentialcreationoptions/extensions/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/extensions/index.html
@@ -57,7 +57,7 @@ browser-compat: api.PublicKeyCredentialCreationOptions.extensions
       rel="noopener">future</a></p>
 </div>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Extension identifier</th>

--- a/files/en-us/web/api/request/request/index.html
+++ b/files/en-us/web/api/request/request/index.html
@@ -78,7 +78,7 @@ browser-compat: api.Request.Request
 
 <h2 id="Errors">Errors</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Type</th>

--- a/files/en-us/web/api/rsahashedimportparams/index.html
+++ b/files/en-us/web/api/rsahashedimportparams/index.html
@@ -33,7 +33,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/rsahashedkeygenparams/index.html
+++ b/files/en-us/web/api/rsahashedkeygenparams/index.html
@@ -39,7 +39,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/rsaoaepparams/index.html
+++ b/files/en-us/web/api/rsaoaepparams/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/rsapssparams/index.html
+++ b/files/en-us/web/api/rsapssparams/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/index.html
@@ -36,7 +36,7 @@ browser-compat: api.RTCSessionDescription
 
 <p>This enum defines strings that describe the current state of the session description, as used in the {{domxref("RTCSessionDescription.type", "type")}} property. The session description's type will be specified using one of these values.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Value</th>

--- a/files/en-us/web/api/sourcebuffer/abort/index.html
+++ b/files/en-us/web/api/sourcebuffer/abort/index.html
@@ -34,7 +34,7 @@ browser-compat: api.SourceBuffer.abort
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/sourcebuffer/appendwindowend/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendwindowend/index.html
@@ -40,7 +40,7 @@ browser-compat: api.SourceBuffer.appendWindowEnd
 
 <p>The following exceptions may be thrown when setting a new value for this property.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/sourcebuffer/appendwindowstart/index.html
+++ b/files/en-us/web/api/sourcebuffer/appendwindowstart/index.html
@@ -41,7 +41,7 @@ browser-compat: api.SourceBuffer.appendWindowStart
 
 <p>The following exceptions may be thrown when setting a new value for this property.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/sourcebuffer/mode/index.html
+++ b/files/en-us/web/api/sourcebuffer/mode/index.html
@@ -61,7 +61,7 @@ browser-compat: api.SourceBuffer.mode
 
 <p>The following exceptions may be thrown when setting a new value for this property.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/sourcebuffer/remove/index.html
+++ b/files/en-us/web/api/sourcebuffer/remove/index.html
@@ -43,7 +43,7 @@ browser-compat: api.SourceBuffer.remove
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/sourcebuffer/timestampoffset/index.html
+++ b/files/en-us/web/api/sourcebuffer/timestampoffset/index.html
@@ -37,7 +37,7 @@ browser-compat: api.SourceBuffer.timestampOffset
 
 <p>The following exceptions may be thrown when setting a new value for this property.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/sourcebuffer/trackdefaults/index.html
+++ b/files/en-us/web/api/sourcebuffer/trackdefaults/index.html
@@ -37,7 +37,7 @@ browser-compat: api.SourceBuffer.trackDefaults
 
 <p>The following exceptions may be thrown when setting a new value for this property.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Exception</th>

--- a/files/en-us/web/api/svganimatedangle/index.html
+++ b/files/en-us/web/api/svganimatedangle/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGAnimatedAngle
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -45,7 +45,7 @@ browser-compat: api.SVGAnimatedAngle
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedboolean/index.html
+++ b/files/en-us/web/api/svganimatedboolean/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGAnimatedBoolean
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -45,7 +45,7 @@ browser-compat: api.SVGAnimatedBoolean
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedenumeration/index.html
+++ b/files/en-us/web/api/svganimatedenumeration/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGAnimatedEnumeration
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -45,7 +45,7 @@ browser-compat: api.SVGAnimatedEnumeration
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedinteger/index.html
+++ b/files/en-us/web/api/svganimatedinteger/index.html
@@ -18,7 +18,7 @@ browser-compat: api.SVGAnimatedInteger
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -46,7 +46,7 @@ browser-compat: api.SVGAnimatedInteger
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedlength/index.html
+++ b/files/en-us/web/api/svganimatedlength/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGAnimatedLength
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -43,7 +43,7 @@ browser-compat: api.SVGAnimatedLength
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedlengthlist/index.html
+++ b/files/en-us/web/api/svganimatedlengthlist/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGAnimatedLengthList
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -45,7 +45,7 @@ browser-compat: api.SVGAnimatedLengthList
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatednumber/index.html
+++ b/files/en-us/web/api/svganimatednumber/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGAnimatedNumber
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -45,7 +45,7 @@ browser-compat: api.SVGAnimatedNumber
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedrect/index.html
+++ b/files/en-us/web/api/svganimatedrect/index.html
@@ -15,7 +15,7 @@ browser-compat: api.SVGAnimatedRect
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -43,7 +43,7 @@ browser-compat: api.SVGAnimatedRect
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svganimatedtransformlist/index.html
+++ b/files/en-us/web/api/svganimatedtransformlist/index.html
@@ -16,7 +16,7 @@ browser-compat: api.SVGAnimatedTransformList
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -44,7 +44,7 @@ browser-compat: api.SVGAnimatedTransformList
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgcomponenttransferfunctionelement/index.html
+++ b/files/en-us/web/api/svgcomponenttransferfunctionelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGComponentTransferFunctionElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfeblendelement/index.html
+++ b/files/en-us/web/api/svgfeblendelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGFEBlendElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfecolormatrixelement/index.html
+++ b/files/en-us/web/api/svgfecolormatrixelement/index.html
@@ -19,7 +19,7 @@ browser-compat: api.SVGFEColorMatrixElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfecompositeelement/index.html
+++ b/files/en-us/web/api/svgfecompositeelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGFECompositeElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfeconvolvematrixelement/index.html
+++ b/files/en-us/web/api/svgfeconvolvematrixelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGFEConvolveMatrixElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfedisplacementmapelement/index.html
+++ b/files/en-us/web/api/svgfedisplacementmapelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGFEDisplacementMapElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfegaussianblurelement/index.html
+++ b/files/en-us/web/api/svgfegaussianblurelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGFEGaussianBlurElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfemorphologyelement/index.html
+++ b/files/en-us/web/api/svgfemorphologyelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGFEMorphologyElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgfeturbulenceelement/index.html
+++ b/files/en-us/web/api/svgfeturbulenceelement/index.html
@@ -19,7 +19,7 @@ browser-compat: api.SVGFETurbulenceElement
 
 <h3 id="Turbulence_types">Turbulence types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>
@@ -46,7 +46,7 @@ browser-compat: api.SVGFETurbulenceElement
 
 <h3 id="Stitch_options">Stitch options</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svggradientelement/index.html
+++ b/files/en-us/web/api/svggradientelement/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGGradientElement
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svglength/index.html
+++ b/files/en-us/web/api/svglength/index.html
@@ -19,7 +19,7 @@ browser-compat: api.SVGLength
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -113,7 +113,7 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Name</th>
@@ -182,7 +182,7 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>
@@ -233,7 +233,7 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
 
 <h2 id="Methods">Methods</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name &amp; Arguments</th>

--- a/files/en-us/web/api/svgpreserveaspectratio/index.html
+++ b/files/en-us/web/api/svgpreserveaspectratio/index.html
@@ -18,7 +18,7 @@ browser-compat: api.SVGPreserveAspectRatio
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -70,7 +70,7 @@ browser-compat: api.SVGPreserveAspectRatio
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>
@@ -152,7 +152,7 @@ browser-compat: api.SVGPreserveAspectRatio
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgrect/the__x__property/index.html
+++ b/files/en-us/web/api/svgrect/the__x__property/index.html
@@ -6,7 +6,7 @@ slug: Web/API/SVGRect/The__X__property
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Name</th>

--- a/files/en-us/web/api/svgrenderingintent/index.html
+++ b/files/en-us/web/api/svgrenderingintent/index.html
@@ -21,7 +21,7 @@ browser-compat: api.SVGRenderingIntent
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgstringlist/index.html
+++ b/files/en-us/web/api/svgstringlist/index.html
@@ -18,7 +18,7 @@ browser-compat: api.SVGStringList
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -56,7 +56,7 @@ browser-compat: api.SVGStringList
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>
@@ -80,7 +80,7 @@ browser-compat: api.SVGStringList
 
 <h2 id="Methods">Methods</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name &amp; Arguments</th>

--- a/files/en-us/web/api/svgtextpathelement/index.html
+++ b/files/en-us/web/api/svgtextpathelement/index.html
@@ -19,7 +19,7 @@ browser-compat: api.SVGTextPathElement
 
 <h3 id="Method_types">Method types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>
@@ -46,7 +46,7 @@ browser-compat: api.SVGTextPathElement
 
 <h3 id="Spacing_types">Spacing types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgtransform/index.html
+++ b/files/en-us/web/api/svgtransform/index.html
@@ -18,7 +18,7 @@ browser-compat: api.SVGTransform
 
 <h3 id="Interface_overview">Interface overview</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="row">Also implement</th>
@@ -70,7 +70,7 @@ browser-compat: api.SVGTransform
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>
@@ -117,7 +117,7 @@ browser-compat: api.SVGTransform
 
 <h2 id="Properties">Properties</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>
@@ -158,7 +158,7 @@ browser-compat: api.SVGTransform
 
 <h2 id="Methods">Methods</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name &amp; Arguments</th>

--- a/files/en-us/web/api/svgunittypes/index.html
+++ b/files/en-us/web/api/svgunittypes/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGUnitTypes
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/svgzoomandpan/index.html
+++ b/files/en-us/web/api/svgzoomandpan/index.html
@@ -17,7 +17,7 @@ browser-compat: api.SVGZoomAndPan
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/treewalker/whattoshow/index.html
+++ b/files/en-us/web/api/treewalker/whattoshow/index.html
@@ -15,7 +15,7 @@ browser-compat: api.TreeWalker.whatToShow
   {{domxref("Node")}} that must to be presented. Non-matching nodes are skipped, but their
   children may be included, if relevant. The possible values are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Constant</th>

--- a/files/en-us/web/api/usvstring/index.html
+++ b/files/en-us/web/api/usvstring/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.html
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.html
@@ -131,7 +131,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>Each voice also has local controls, which allow you to manipulate the effects or parameters particular to each technique we are using to create those voices. The techniques we are using are:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Name of voice</th>

--- a/files/en-us/web/api/web_bluetooth_api/index.html
+++ b/files/en-us/web/api/web_bluetooth_api/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.html
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="Supported_types">Supported types</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Object type</th>

--- a/files/en-us/web/api/webgl_api/constants/index.html
+++ b/files/en-us/web/api/webgl_api/constants/index.html
@@ -42,7 +42,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.clear()")}} to clear buffer masks.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -628,7 +628,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.getVertexAttrib()")}}.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -776,7 +776,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants returned from {{domxref("WebGLRenderingContext.getError()")}}.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -822,7 +822,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.frontFace()")}}.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -882,7 +882,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Data_types">Data types</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -931,7 +931,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Pixel_formats">Pixel formats</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -975,7 +975,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Pixel_types">Pixel types</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1178,7 +1178,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.stencilOp()")}}.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1229,7 +1229,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1373,7 +1373,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Uniform_types">Uniform types</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1462,7 +1462,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Shader_precision-specified_types">Shader precision-specified types</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1506,7 +1506,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Framebuffers_and_renderbuffers">Framebuffers and renderbuffers</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1697,7 +1697,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.pixelStorei()")}}.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1732,7 +1732,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.getParameter()")}} to specify what information to return.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1883,7 +1883,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2217,7 +2217,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Pixel_types_2">Pixel types</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2276,7 +2276,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Queries">Queries</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2315,7 +2315,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Draw_buffers">Draw buffers</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2494,7 +2494,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Samplers">Samplers</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2583,7 +2583,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Buffers_2">Buffers</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2637,7 +2637,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Data_types_2">Data types</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2706,7 +2706,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Vertex_attributes_2">Vertex attributes</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2730,7 +2730,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Transform_feedback">Transform feedback</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2824,7 +2824,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Framebuffers_and_renderbuffers_2">Framebuffers and renderbuffers</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2933,7 +2933,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Uniforms">Uniforms</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3077,7 +3077,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Sync_objects">Sync objects</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3156,7 +3156,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Miscellaneous_constants">Miscellaneous constants</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3257,7 +3257,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(ANGLE_instanced_arrays)">{{domxref("ANGLE_instanced_arrays")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3276,7 +3276,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_debug_renderer_info)">{{domxref("WEBGL_debug_renderer_info")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3300,7 +3300,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_texture_filter_anisotropic)">{{domxref("EXT_texture_filter_anisotropic")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3422,7 +3422,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_compressed_texture_pvrtc)">{{domxref("WEBGL_compressed_texture_pvrtc")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3456,7 +3456,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_compressed_texture_etc1)">{{domxref("WEBGL_compressed_texture_etc1")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3475,7 +3475,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_depth_texture)">{{domxref("WEBGL_depth_texture")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3494,7 +3494,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(OES_texture_half_float)">{{domxref("OES_texture_half_float")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3513,7 +3513,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_color_buffer_float)">{{domxref("WEBGL_color_buffer_float")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3547,7 +3547,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_blend_minmax)">{{domxref("EXT_blend_minmax")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3571,7 +3571,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_sRGB)">{{domxref("EXT_sRGB")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3624,7 +3624,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_draw_buffers)">{{domxref("WEBGL_draw_buffers")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3808,7 +3808,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(OES_vertex_array_object)">{{domxref("OES_vertex_array_object")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3827,7 +3827,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_disjoint_timer_query)">{{domxref("EXT_disjoint_timer_query")}}</h3>
 
-<table class="no-markdown">
+<table>
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3876,7 +3876,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="no-markdown">
+<table>
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/webgl_api/constants/index.html
+++ b/files/en-us/web/api/webgl_api/constants/index.html
@@ -42,7 +42,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.clear()")}} to clear buffer masks.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -73,7 +73,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.drawElements()")}} or {{domxref("WebGLRenderingContext.drawArrays()")}} to specify what kind of primitive to render.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -124,7 +124,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.blendFunc()")}} or {{domxref("WebGLRenderingContext.blendFuncSeparate()")}} to specify the blending mode (for both, RBG and alpha, or separately).</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -215,7 +215,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.blendEquation()")}} or {{domxref("WebGLRenderingContext.blendEquationSeparate()")}} to control how the blending is calculated (for both, RBG and alpha, or separately).</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -246,7 +246,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.getParameter()")}} to specify what information to return.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -577,7 +577,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.bufferData()")}}, {{domxref("WebGLRenderingContext.bufferSubData()")}}, {{domxref("WebGLRenderingContext.bindBuffer()")}}, or {{domxref("WebGLRenderingContext.getBufferParameter()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -628,7 +628,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.getVertexAttrib()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -684,7 +684,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.cullFace()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -720,7 +720,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.enable()")}} or {{domxref("WebGLRenderingContext.disable()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -776,7 +776,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants returned from {{domxref("WebGLRenderingContext.getError()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -822,7 +822,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.frontFace()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -848,7 +848,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.hint()")}}</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -882,7 +882,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Data_types">Data types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -931,7 +931,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Pixel_formats">Pixel formats</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -975,7 +975,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Pixel_types">Pixel types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1011,7 +1011,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.createShader()")}} or {{domxref("WebGLRenderingContext.getShaderParameter()")}}</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1122,7 +1122,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.depthFunc()")}} or {{domxref("WebGLRenderingContext.stencilFunc()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1178,7 +1178,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.stencilOp()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1229,7 +1229,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1373,7 +1373,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Uniform_types">Uniform types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1462,7 +1462,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Shader_precision-specified_types">Shader precision-specified types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1506,7 +1506,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Framebuffers_and_renderbuffers">Framebuffers and renderbuffers</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1697,7 +1697,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.pixelStorei()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1732,7 +1732,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.getParameter()")}} to specify what information to return.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -1883,7 +1883,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <p>Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}, {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}, {{domxref("WebGLRenderingContext.bindTexture()")}}, {{domxref("WebGLRenderingContext.texImage2D()")}}, and others.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2217,7 +2217,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Pixel_types_2">Pixel types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2276,7 +2276,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Queries">Queries</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2315,7 +2315,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Draw_buffers">Draw buffers</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2494,7 +2494,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Samplers">Samplers</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2583,7 +2583,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Buffers_2">Buffers</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2637,7 +2637,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Data_types_2">Data types</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2706,7 +2706,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Vertex_attributes_2">Vertex attributes</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2730,7 +2730,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Transform_feedback">Transform feedback</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2824,7 +2824,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Framebuffers_and_renderbuffers_2">Framebuffers and renderbuffers</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -2933,7 +2933,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Uniforms">Uniforms</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3077,7 +3077,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Sync_objects">Sync objects</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3156,7 +3156,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="Miscellaneous_constants">Miscellaneous constants</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3257,7 +3257,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(ANGLE_instanced_arrays)">{{domxref("ANGLE_instanced_arrays")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3276,7 +3276,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_debug_renderer_info)">{{domxref("WEBGL_debug_renderer_info")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3300,7 +3300,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_texture_filter_anisotropic)">{{domxref("EXT_texture_filter_anisotropic")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3324,7 +3324,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_compressed_texture_s3tc)">{{domxref("WEBGL_compressed_texture_s3tc")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3358,7 +3358,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_compressed_texture_etc)">{{domxref("WEBGL_compressed_texture_etc")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3422,7 +3422,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_compressed_texture_pvrtc)">{{domxref("WEBGL_compressed_texture_pvrtc")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3456,7 +3456,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_compressed_texture_etc1)">{{domxref("WEBGL_compressed_texture_etc1")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3475,7 +3475,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_depth_texture)">{{domxref("WEBGL_depth_texture")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3494,7 +3494,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(OES_texture_half_float)">{{domxref("OES_texture_half_float")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3513,7 +3513,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_color_buffer_float)">{{domxref("WEBGL_color_buffer_float")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3547,7 +3547,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_blend_minmax)">{{domxref("EXT_blend_minmax")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3571,7 +3571,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_sRGB)">{{domxref("EXT_sRGB")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3605,7 +3605,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(OES_standard_derivatives)">{{domxref("OES_standard_derivatives")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3624,7 +3624,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(WEBGL_draw_buffers)">{{domxref("WEBGL_draw_buffers")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3808,7 +3808,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(OES_vertex_array_object)">{{domxref("OES_vertex_array_object")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3827,7 +3827,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h3 id="domxref(EXT_disjoint_timer_query)">{{domxref("EXT_disjoint_timer_query")}}</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant name</th>
@@ -3876,7 +3876,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/webgl_api/types/index.html
+++ b/files/en-us/web/api/webgl_api/types/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>These types are used within a {{domxref("WebGLRenderingContext")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Type</th>
@@ -100,7 +100,7 @@ tags:
 
 <p>These types are used within a {{domxref("WebGL2RenderingContext")}}. All WebGL 1 types are used as well.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Type</th>
@@ -121,7 +121,7 @@ tags:
 
 <p>These types are used within <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">WebGL extensions</a>.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Type</th>
@@ -140,7 +140,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/webgl_api/types/index.html
+++ b/files/en-us/web/api/webgl_api/types/index.html
@@ -100,7 +100,7 @@ tags:
 
 <p>These types are used within a {{domxref("WebGL2RenderingContext")}}. All WebGL 1 types are used as well.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
    <tr>
      <th>Type</th>
@@ -121,7 +121,7 @@ tags:
 
 <p>These types are used within <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">WebGL extensions</a>.</p>
 
-<table class="no-markdown">
+<table>
  <thead>
    <tr>
      <th>Type</th>

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.html
@@ -38,7 +38,7 @@ browser-compat: api.WEBGL_compressed_texture_astc
 
 <p>The compressed texture formats are exposed by 28 constants and can be used in two functions: {{domxref("WebGLRenderingContext.compressedTexImage2D", "compressedTexImage2D()")}} and {{domxref("WebGLRenderingContext.compressedTexSubImage2D", "compressedTexSubImage2D()")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
     <th>Constants</th>

--- a/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
@@ -59,7 +59,7 @@ browser-compat: api.WebGLRenderingContext.blendFunc
   Similarly, R<sub>C</sub>, G<sub>C</sub>, B<sub>C</sub>, A<sub>C</sub> represent respectively
   the <em>red</em>, <em>green</em>, <em>blue</em> and <em>alpha</em> component of a constant color. They are all values between 0 and 1, included.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
@@ -78,7 +78,7 @@ Similarly, R<sub>C</sub>, G<sub>C</sub>, B<sub>C</sub>, A<sub>C</sub> represent 
 the <em>red</em>, <em>green</em>, <em>blue</em> and <em>alpha</em> component of a constant color.
 They are all values between 0 and 1, included.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/webglrenderingcontext/geterror/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/geterror/index.html
@@ -25,7 +25,7 @@ browser-compat: api.WebGLRenderingContext.getError
 
 <h3 id="Return_value">Return value</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.html
@@ -39,7 +39,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
 <p>You can query the following <code>pname</code> parameters when using a
   {{domxref("WebGLRenderingContext")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>
@@ -578,7 +578,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
 <p>You can query the following <code>pname</code> parameters when using a
   {{domxref("WebGL2RenderingContext")}}.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>
@@ -892,7 +892,7 @@ browser-compat: api.WebGLRenderingContext.getParameter
 <p>You can query the following <code>pname</code> parameters when using <a
     href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">WebGL extensions</a>:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.html
@@ -37,7 +37,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
 
 <h2 id="Pixel_storage_parameters">Pixel storage parameters</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Parameter name (for <code>pname</code>)</th>
@@ -95,7 +95,7 @@ browser-compat: api.WebGLRenderingContext.pixelStorei
 <p>When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the
   following values are available additionally:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th scope="col">Constant</th>

--- a/files/en-us/web/api/window/showmodaldialog/index.html
+++ b/files/en-us/web/api/window/showmodaldialog/index.html
@@ -38,7 +38,7 @@ browser-compat: api.Window.showModalDialog
     dialog, using one or more semicolon delimited values:</li>
 </ul>
 
-<table class="standard-table">
+<table class="no-markdown">
   <tbody>
     <tr>
       <th>Syntax</th>

--- a/files/en-us/web/api/worklet/index.html
+++ b/files/en-us/web/api/worklet/index.html
@@ -19,7 +19,7 @@ browser-compat: api.Worklet
 
 <p>Worklets are restricted to specific use cases; they cannot be used for arbitrary computations like Web Workers. The <code>Worklet</code> interface abstracts properties and methods common to all kind of worklets, and cannot be created directly. Instead, you can use one of the following classes:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Name</th>

--- a/files/en-us/web/api/xmlhttprequest/upload/index.html
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.html
@@ -30,7 +30,7 @@ browser-compat: api.XMLHttpRequest.upload
 
 <p>The following events can be triggered on an upload object and used to monitor the upload:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Event</th>

--- a/files/en-us/web/api/xpathexception/index.html
+++ b/files/en-us/web/api/xpathexception/index.html
@@ -23,7 +23,7 @@ browser-compat: api.XPathException
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Constant</th>

--- a/files/en-us/web/api/xpathresult/index.html
+++ b/files/en-us/web/api/xpathresult/index.html
@@ -46,7 +46,7 @@ browser-compat: api.XPathResult
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
    <tr>
      <th>Result Type Defined Constant</th>

--- a/files/en-us/web/api/xpathresult/resulttype/index.html
+++ b/files/en-us/web/api/xpathresult/resulttype/index.html
@@ -30,7 +30,7 @@ browser-compat: api.XPathResult.resultType
 
 <h2 id="Constants">Constants</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
     <tr>
       <th>Result Type Defined Constant</th>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7898.

This PR adds a new class `"no-markdown"` to all tables under Web/API that:

* would have been converted to GFM, and
* whose GFM representation would have been more than 150 characters wide

The `"no-markdown"` class stops the converter from converting these tables to GFM.

The reasoning is that GFM tables are hard to read when they get above a certain width, and discussion in https://github.com/mdn/content/issues/7898#issuecomment-913896142 landed on 150 characters as a reasonable threshold.

Once conversion is done, we should probably remove the `"no-markdown"` class, as it serves no further purpose.

Note that this PR also removes `"standard-table"` from tables in all files it touches. This has no effect (`standard-table` is a no-op since https://github.com/mdn/mdn-minimalist/pull/681).
