### PR TITLE
Add .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: | # runs during either prebuild (if enabled) or first startup
+      git remote add mdn https://github.com/mdn/content.git
+      yarn
+    command: | # runs every startup
+      yarn start
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 5000
+    onOpen: open-preview


### PR DESCRIPTION
This should help Gitpod set things up as described in README.md
(assuming Gitpod is opened on the user's own fork).

Unfortunately, there doesn't seem to be a way to refer to a user's fork
unless you already know where it is, so it doesn't look like we can
add a link to open Gitpod in this way to README.md.