### PR TITLE
fix: remove call to console.log to make 'frame' explanation less conf…

### DIFF
--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -38,7 +38,7 @@ function bar(x) {
   return foo(x * y)
 }
 
-console.log(bar(7)) //returns 42
+const baz = bar(7) // 42 is assigned to baz
 ```
 
 Order of operations:

--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -38,7 +38,7 @@ function bar(x) {
   return foo(x * y)
 }
 
-const baz = bar(7) // 42 is assigned to baz
+const baz = bar(7) // assigns 42 to baz
 ```
 
 Order of operations:


### PR DESCRIPTION
…using

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Resolves #8515 

> What was wrong/why is this fix needed? (quick summary only)

The related section explains function execution context with a semantic word 'frame,' and a simple code block containing two functions `foo` and `bar.` 

However, the code block also contains `console.log(bar(7))` which is a function and therefore should clarify whether it creates 'frame' or not.

Instead of adding `console.log` to the explanation, I deleted it.

> Anything else that could help us review it

- Please review whether this change makes the document more clear.

@VivianWang1993 Will this work for you?