### PR TITLE
Release notes and a small update to the ResizeObserver page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -47,6 +47,7 @@ tags:
 
 <ul>
   <li>{{domxref("ElementInternals.shadowRoot")}} is now supported ({{bug(1723521)}}).</li>
+  <li>The value <code>device-pixel-content-box</code> is now supported for {{domxref("ResizeObserver.Observe()")}} ({{bug(1587973)}}).</li>
 </ul>
 
 <h4 id="DOM">DOM</h4>

--- a/files/en-us/web/api/resizeobserver/observe/index.html
+++ b/files/en-us/web/api/resizeobserver/observe/index.html
@@ -38,6 +38,7 @@ browser-compat: api.ResizeObserver.observe
           <li><code>content-box</code> (the default): Size of the content area as defined in CSS.</li>
           <li><code>border-box</code>: Size of the box border area as defined in CSS.</li>
           <li><code>device-pixel-content-box</code>: The size of the content area as defined in CSS, in device pixels, before applying any CSS transforms on the element or its ancestors.</li>
+        </ul>
       </dd>
     </dl>
   </dd>

--- a/files/en-us/web/api/resizeobserver/observe/index.html
+++ b/files/en-us/web/api/resizeobserver/observe/index.html
@@ -33,9 +33,12 @@ browser-compat: api.ResizeObserver.observe
     only has one possible option that can be set:
     <dl>
       <dt><code>box</code></dt>
-      <dd>Sets which box model the observer will observe changes to. Possible values are
-        <code>content-box</code> (the default), <code>border-box</code>, and
-        <code>device-pixel-content-box</code>.</dd>
+      <dd>Sets which box model the observer will observe changes to. Possible values are:
+        <ul>
+          <li><code>content-box</code> (the default): Size of the content area as defined in CSS.</li>
+          <li><code>border-box</code>: Size of the box border area as defined in CSS.</li>
+          <li><code>device-pixel-content-box</code>: The size of the content area as defined in CSS, in device pixels, before applying any CSS transforms on the element or its ancestors.</li>
+      </dd>
     </dl>
   </dd>
 </dl>


### PR DESCRIPTION
Part of #8622 

Adds release notes and also expands the definitions in the docs.

Spec: https://drafts.csswg.org/resize-observer/#resize-observer-interface