### PR TITLE
docs: use simpler language for row- and column-reverse descriptions

### DIFF
--- a/files/en-us/web/css/flex-direction/index.md
+++ b/files/en-us/web/css/flex-direction/index.md
@@ -46,11 +46,11 @@ The following values are accepted:
 - `row`
   - : The flex container's main-axis is defined to be the same as the text direction. The **main-start** and **main-end** points are the same as the content direction.
 - `row-reverse`
-  - : Behaves the same as `row` but the **main-start** and **main-end** points are permuted.
+  - : Behaves the same as `row` but the **main-start** and **main-end** points are opposite to the content direction.
 - `column`
   - : The flex container's main-axis is the same as the block-axis. The **main-start** and **main-end** points are the same as the **before** and **after** points of the writing-mode.
 - `column-reverse`
-  - : Behaves the same as `column` but the **main-start** and **main-end** are permuted.
+  - : Behaves the same as `column` but the **main-start** and **main-end** are opposite to the content direction.
 
 ## Accessibility concerns
 


### PR DESCRIPTION
The word "permuted" was being used. This tripped me up so much while reading that I had to stop and open this PR.

This is not very approachable language. It's not a commonly used word, so let's try to improve the reading level for these descriptions. 

Open to suggestions or improvements for my proposed change! 🙂

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

The wording used to describe `row-reverse` and `column-reverse` was unnecessarily complex. I tried to simplify it without using the word "reversed". 

> Anything else that could help us review it

I'm guessing the original author didn't want to use "reversed" to describe these property values. I continued this tradition.
