### PR TITLE
Fixes #2645: adds overview entry to groupdata.json for Screen Orienta…

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1222,6 +1222,7 @@
       "events": []
     },
     "Screen Orientation API": {
+      "overview": ["Screen Orientation API"],
       "guides": ["/docs/Web/API/CSS_Object_Model/Managing_screen_orientation"],
       "interfaces": ["ScreenOrientation"],
       "methods": [],


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #2645

> What was wrong/why is this fix needed? (quick summary only)

There was no Overview Entry for Screen Orientation API even though the Overview page exists

> Anything else that could help us review it

1. I have verified that that the page starts showing https://developer.mozilla.org/en-US/docs/Web/API#Specifications but not sure how to check the sidebar. 
2. The target page shows in Draft . Is that still true or can the Draft status be removed?