### PR TITLE
Fix a dl closing tag

### DIFF
--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
@@ -66,7 +66,7 @@ new KeyframeEffect(source)
 
     <dt>{{domxref("KeyframeEffect/iterationComposite", "iterationComposite")}}</dt>
     <dd>Determines how values build from iteration to iteration in the current animation.</dd>
- <dl>
+ </dl>
  </dd>
 </dl>
 


### PR DESCRIPTION
Fixes a broken `dl` introduced in https://github.com/mdn/content/pull/8572, that was breaking Markdown conversion.