### PR TITLE
fix: window typo

### DIFF
--- a/files/en-us/web/api/window/visualviewport/index.html
+++ b/files/en-us/web/api/window/visualviewport/index.html
@@ -16,10 +16,6 @@ browser-compat: api.Window.visualViewport
   {{domxref("Window")}} interface returns a {{domxref("VisualViewport")}} object
   representing the visual viewport for a given window.</p>
 
-<h2 id="Syntax">Syntax</h2>
-
-<pre class="brush: js">var <em>visualViewport</em> = window.visualViewport</pre>
-
 <h3 id="Value">Value</h3>
 
 <p>A {{domxref("VisualViewport")}} object.</p>

--- a/files/en-us/web/api/window/visualviewport/index.html
+++ b/files/en-us/web/api/window/visualviewport/index.html
@@ -18,7 +18,7 @@ browser-compat: api.Window.visualViewport
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>visualViewport</em> = Window.visualViewport</pre>
+<pre class="brush: js">var <em>visualViewport</em> = window.visualViewport</pre>
 
 <h3 id="Value">Value</h3>
 


### PR DESCRIPTION
Fix `Window` to `window` in the syntax example for better copy, paste.