### PR TITLE
securitypolicyviolation events only work on Window/Document

### DIFF
--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.html
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.html
@@ -33,8 +33,15 @@ browser-compat: api.Element.securitypolicyviolation_event
  </tbody>
 </table>
 
-<p>The event bubbles and is normally handled by an event handler on the {{domxref("Window")}} or {{domxref("Document")}} object.
-  The handler can be assigned using the {{domxref("GlobalEventHandlers.onsecuritypolicyviolation")}} property or using {{domxref("EventTarget.addEventListener()")}}.</p>
+<p>The event is fired on the element that violates the policy and bubbles.
+  It is normally handled by an event handler on the {{domxref("Window")}} or {{domxref("Document")}} object.</p>
+  
+  <p>The handler can be assigned using the {{domxref("GlobalEventHandlers.onsecuritypolicyviolation")}} property or using {{domxref("EventTarget.addEventListener()")}}.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> You must add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
+    While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.</p>
+</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsecuritypolicyviolation/index.html
@@ -17,6 +17,11 @@ browser-compat: api.GlobalEventHandlers.onsecuritypolicyviolation
 
 <p>The <code>securitypolicyviolation</code> event fires when there is a <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> violation.</p>
 
+<div class="notecard note">
+  <p><strong>Note:</strong> In practice you must use the implementation of this property in a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
+    While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">onsecuritypolicyviolation = functionRef</pre>


### PR DESCRIPTION
Updates the securitypolicyviolation event and onsecuritypolicyviolation event handlers to note that they can in practice only be used on Document and Window. This is because while the handler property exists in any element, you can't assign a handler to the property until after the content is loaded, by which time the event will already have fired. I.e. you will miss it. 

This is part of delivering #8614