### PR TITLE
FF93: Add onslotchange global handler

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -177,6 +177,8 @@ browser-compat: api.GlobalEventHandlers
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("selectionchange")}} event is raised, i.e. when the text selected on a web page changes.</dd>
  <dt>{{domxref("GlobalEventHandlers.onshow")}} {{Deprecated_Inline}}</dt>
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("show")}} event is raised.</dd>
+ <dt>{{domxref("GlobalEventHandlers.onslotchange")}}</dt>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("slotchange")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onstalled")}}</dt>
  <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("stalled")}} event is raised.</dd>
  <dt>{{domxref("GlobalEventHandlers.onsubmit")}}</dt>

--- a/files/en-us/web/api/globaleventhandlers/onslotchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onslotchange/index.html
@@ -1,0 +1,70 @@
+---
+title: GlobalEventHandlers.onslotchange
+slug: Web/API/GlobalEventHandlers/onslotchange
+tags:
+- API
+- Event Handler
+- Experimental
+- GlobalEventHandlers
+- Property
+- Reference
+- Shadow DOM API
+- slot
+- slotchange
+- onslotchange
+browser-compat: api.GlobalEventHandlers.onslotchange
+---
+<div>{{ApiRef('DOM')}}{{SeeCompatTable}}</div>
+
+<p>The <code><strong>onslotchange</strong></code> property of the {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes {{event("slotchange")}} events.</p>
+
+<p>The <code>slotchange</code> event is fired on {{DOMxRef("HTMLSlotElement")}} instances ({{HTMLElement("slot")}} elements) when the node(s) contained in the slot change.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">object.onslotchange = functionRef;
+</pre>
+
+<h3 id="Value">Value</h3>
+
+<p><code>functionRef</code> is a function name or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>.
+  The function receives an {{domxref("Event")}} object as its sole argument.</p>
+
+  <h2 id="Examples">Examples</h2>
+
+<p>The following snippet is a slightly modified version of our <a href="https://github.com/mdn/web-components-examples/tree/master/slotchange">slotchange example</a> which uses <code>onslotchange</code> rather than adding a listener for the <code>slotchange</code> event.</p>
+
+<p>First the code gets an array of all the <code>&lt;slot&gt;</code>s and then assigns a handler function to the <code>onslotchange</code> property on the template's second slot — this second slot is the one that has its contents changed in the example.
+Every time the element in the slot changes, we log a report to the console saying which slot has changed, and what the new node inside the slot is.</p>
+
+<pre class="brush: js">let slots = this.shadowRoot.querySelectorAll('slot');
+slots[1].onslotchange = function(e) {
+  let nodes = slots[1].assignedNodes();
+  console.log('Element in Slot "' + slots[1].name + '" changed to "' + nodes[0].outerHTML + '".');
+};</pre>
+
+<p>We might alternatively handle the event at a higher level. 
+  The snippet below shows the equivalent code if the handler is assigned to <code>onslotchange</code> on the <code>shadowRoot</code>:</p>
+
+<pre class="brush: js">this.shadowRoot.onslotchange = function(e) {
+  const nodes = e.originalTarget.assignedNodes();
+  console.log(`Element in Slot "${e.originalTarget.name}" changed to "${nodes[0].outerHTML}".`);
+};</pre>
+
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/Web_Components/Using_templates_and_slots">Using templates and slots</a></li>
+  <li>{{event("slotchange")}} event</li>
+  <li>{{domxref("HTMLSlotElement")}}</li>
+</ul>

--- a/files/en-us/web/api/globaleventhandlers/onslotchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onslotchange/index.html
@@ -44,7 +44,8 @@ slots[1].onslotchange = function(e) {
 };</pre>
 
 <p>We might alternatively handle the event at a higher level. 
-  The snippet below shows the equivalent code if the handler is assigned to <code>onslotchange</code> on the <code>shadowRoot</code>:</p>
+  The snippet below shows the equivalent code if the handler is assigned to <code>onslotchange</code> on the <code>shadowRoot</code>.
+  Every time the element in any slot changes, we log a report to the console saying which slot has changed, and what the new node inside the slot is.</p>
 
 <pre class="brush: js">this.shadowRoot.onslotchange = function(e) {
   const nodes = e.originalTarget.assignedNodes();

--- a/files/en-us/web/api/globaleventhandlers/onslotchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onslotchange/index.html
@@ -20,17 +20,7 @@ browser-compat: api.GlobalEventHandlers.onslotchange
 
 <p>The <code>slotchange</code> event is fired on {{DOMxRef("HTMLSlotElement")}} instances ({{HTMLElement("slot")}} elements) when the node(s) contained in the slot change.</p>
 
-<h2 id="Syntax">Syntax</h2>
-
-<pre class="brush: js">object.onslotchange = functionRef;
-</pre>
-
-<h3 id="Value">Value</h3>
-
-<p><code>functionRef</code> is a function name or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>.
-  The function receives an {{domxref("Event")}} object as its sole argument.</p>
-
-  <h2 id="Examples">Examples</h2>
+<h2 id="Examples">Examples</h2>
 
 <p>The following snippet is a slightly modified version of our <a href="https://github.com/mdn/web-components-examples/tree/master/slotchange">slotchange example</a> which uses <code>onslotchange</code> rather than adding a listener for the <code>slotchange</code> event.</p>
 
@@ -51,7 +41,6 @@ slots[1].onslotchange = function(e) {
   const nodes = e.originalTarget.assignedNodes();
   console.log(`Element in Slot "${e.originalTarget.name}" changed to "${nodes[0].outerHTML}".`);
 };</pre>
-
 
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/shadowroot/index.html
+++ b/files/en-us/web/api/shadowroot/index.html
@@ -39,6 +39,14 @@ browser-compat: api.ShadowRoot
  <dd>Returns a {{domxref('StyleSheetList')}} of {{domxref('CSSStyleSheet')}} objects for stylesheets explicitly linked into, or embedded in a shadow tree.</dd>
 </dl>
 
+<h3 id="event_handlers">Event handlers</h3>
+
+<dl>
+ <dt>{{domxref("ShadowRoot.onslotchange")}}</dt>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> representing the code to be called when the {{event("slotchange")}} event is raised.</dd>
+</dl>
+
+
 <h2 id="Methods">Methods</h2>
 
 <dl>

--- a/files/en-us/web/api/shadowroot/onslotchange/index.html
+++ b/files/en-us/web/api/shadowroot/onslotchange/index.html
@@ -20,16 +20,8 @@ browser-compat: api.ShadowRoot.onslotchange
 
 <p>The <code>slotchange</code> event is fired on {{DOMxRef("HTMLSlotElement")}} instances ({{HTMLElement("slot")}} elements) when the node(s) contained in the slot change.</p>
 
-<h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">this.ShadowRoot.onslotchange = functionRef;</pre>
-
-<h3 id="Value">Value</h3>
-
-<p><code>functionRef</code> is a function name or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>.
-  The function receives an {{domxref("Event")}} object as its sole argument.</p>
-
-  <h2 id="Examples">Examples</h2>
+<h2 id="Examples">Examples</h2>
 
 <p>The following snippet is a slightly modified version of our <a href="https://github.com/mdn/web-components-examples/tree/master/slotchange">slotchange example</a> which uses the <code>ShadowRoot.onslotchange</code> property rather than adding a listener for the <code>slotchange</code> event.</p>
 

--- a/files/en-us/web/api/shadowroot/onslotchange/index.html
+++ b/files/en-us/web/api/shadowroot/onslotchange/index.html
@@ -1,0 +1,59 @@
+---
+title: ShadowRoot.onslotchange
+slug: Web/API/ShadowRoot/onslotchange
+tags:
+- API
+- Event Handler
+- Experimental
+- ShadowRoot
+- Property
+- Reference
+- Shadow DOM API
+- slot
+- slotchange
+- onslotchange
+browser-compat: api.ShadowRoot.onslotchange
+---
+<div>{{ApiRef('DOM')}}{{SeeCompatTable}}</div>
+
+<p>The <code><strong>onslotchange</strong></code> property of the {{domxref("ShadowRoot")}} is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that processes {{event("slotchange")}} events.</p>
+
+<p>The <code>slotchange</code> event is fired on {{DOMxRef("HTMLSlotElement")}} instances ({{HTMLElement("slot")}} elements) when the node(s) contained in the slot change.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">this.ShadowRoot.onslotchange = functionRef;</pre>
+
+<h3 id="Value">Value</h3>
+
+<p><code>functionRef</code> is a function name or a <a href="/en-US/docs/Web/JavaScript/Reference/Operators/function">function expression</a>.
+  The function receives an {{domxref("Event")}} object as its sole argument.</p>
+
+  <h2 id="Examples">Examples</h2>
+
+<p>The following snippet is a slightly modified version of our <a href="https://github.com/mdn/web-components-examples/tree/master/slotchange">slotchange example</a> which uses the <code>ShadowRoot.onslotchange</code> property rather than adding a listener for the <code>slotchange</code> event.</p>
+
+<p>Every time the element in any slot changes, we log a report to the console saying which slot has changed, and what the new node inside the slot is.</p>
+
+<pre class="brush: js">this.shadowRoot.onslotchange = function(e) {
+  const nodes = e.originalTarget.assignedNodes();
+  console.log(`Element in Slot "${e.originalTarget.name}" changed to "${nodes[0].outerHTML}".`);
+};</pre>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/Web_Components/Using_templates_and_slots">Using templates and slots</a></li>
+  <li>{{event("slotchange")}} event</li>
+  <li>{{domxref("HTMLSlotElement")}}</li>
+  <li>{{domxref("GlobalEventHandlers.onslotchange")}}</li>
+</ul>


### PR DESCRIPTION
The Global event handler `onslotchange` was added by https://bugzilla.mozilla.org/show_bug.cgi?id=1501983. This just adds the doc for the handler. Note this is only in FF so is "experimental". 

Other docs work (e.g. BCD) can be tracked in: #8624

