### PR TITLE
Move relevant information to the top of the page

### DIFF
--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -59,6 +59,11 @@ These legacy pseudo-classes can be used to provide backwards compatibility.
 }
 ```
 
+### Difference between :is() and :where()
+
+The difference between the two is that `:is()` counts towards the specificity of the overall selector (it takes the specificity of its most specific argument), whereas [`:where()`](/en-US/docs/Web/CSS/:where) has a specificity value of 0. This is demonstrated by the [example on the `:where()` reference page](/en-US/docs/Web/CSS/:where#examples).
+
+
 ### Forgiving Selector Parsing
 
 The specification defines `:is()` and `:where()` as accepting a [forgiving selector list](https://drafts.csswg.org/selectors-4/#typedef-forgiving-selector-list).
@@ -238,10 +243,6 @@ h1 {
   font-size: 15px;
 }
 ```
-
-### Difference between :is() and :where()
-
-The difference between the two is that `:is()` counts towards the specificity of the overall selector (it takes the specificity of its most specific argument), whereas [`:where()`](/en-US/docs/Web/CSS/:where) has a specificity value of 0. This is demonstrated by the [example on the `:where()` reference page](/en-US/docs/Web/CSS/:where#examples).
 
 ## Syntax
 


### PR DESCRIPTION
_Difference between :is() and :where()_ Should appear at the top of the page instead of being at the bottom.