### PR TITLE
FF93 KeyboardEvent.initKeyEvent() hidden behind preference

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -51,7 +51,15 @@ tags:
 
 <h4 id="DOM">DOM</h4>
 
+
+
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
+
+<h4 id="Events">Events</h4>
+<ul>
+  <li>{{domxref("KeyboardEvent.initKeyEvent()")}} has been moved behind the preference <code>dom.keyboardevent.init_key_event.enabled</code> and is disabled by default.
+    The method is not present in any current specification or supported in other current browsers ({{bug(1717760)}}).</li>
+</ul>
 
 <h4 id="removals_media">Removals</h4>
 

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.html
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.html
@@ -8,8 +8,18 @@ tags:
   - KeyboardEvent
   - Method
   - Reference
+  - Non Standard
 ---
-<p>{{ ApiRef("DOM Events") }}{{non-standard_header}}{{deprecated_header}}</p>
+<p>{{ ApiRef("DOM Events") }}</p>
+
+<div class="notecard warning">
+  <p><strong>Warning:</strong> Do NOT use this method; Use the {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}} constructor instead!</p>
+      
+  <p>The method has been removed from the DOM specification and is not supported by any current browser.
+    Firefox hides this method behind the preference (<code>dom.keyboardevent.init_key_event.enabled</code>) from version 93 and plans to remove it shortly afterwards.</p>
+</div>
+
+<p>{{deprecated_header}}</p>
 
 <p>The <strong><code>KeyboardEvent.initKeyEvent()</code></strong> method is used to
   initialize the value of an event created using
@@ -19,17 +29,6 @@ tags:
   <code>initKeyEvent()</code> must be called to set the event before it is <a
     href="/en-US/docs/Web/API/EventTarget/dispatchEvent">dispatched</a>.</p>
 
-<div class="warning">
-  <p><strong>Warning:</strong> Do not use this method. Use the
-      {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}} constructor
-      instead.<br>
-    <br>
-    This method is based on the key events spec in the <a class="external"
-    href="https://www.w3.org/TR/1999/WD-DOM-Level-2-19990923/events.html">early versions
-    of DOM 2 Events</a>, later removed from that spec. Prefer the modern constructor structure as
-    the only cross-browser way of building events.
-  </p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
[KeyboardEvent.initKeyEvent()](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent)  is not in any spec and Gecko is only remaining browser to support. FF93 hides it behind a preference with intent to remove in FF99. 

This
-  notes the preference and intent, and makes the warning not to use this first in the page
- add release note

Any other work with this can be tracked in https://github.com/mdn/content/issues/8623