### PR TITLE
Enter key in <length> css ref

### DIFF
--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -106,7 +106,7 @@ When animated, values of the `<length>` data type are interpolated as real, floa
 
 ### Length unit comparison
 
-The following demo provides you with an input field in which you can enter a `<length>` value (e.g. `300px`, `50%`, `30vw`) to set the width of a result bar that will appear below it once you've pressed <kbd>Return</kbd>.
+The following demo provides you with an input field in which you can enter a `<length>` value (e.g. `300px`, `50%`, `30vw`) to set the width of a result bar that will appear below it once you've pressed <kbd>Enter/Return</kbd>.
 
 This allows you to compare and contrast the effect of different length units.
 

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -106,7 +106,7 @@ When animated, values of the `<length>` data type are interpolated as real, floa
 
 ### Length unit comparison
 
-The following demo provides you with an input field in which you can enter a `<length>` value (e.g. `300px`, `50%`, `30vw`) to set the width of a result bar that will appear below it once you've pressed <kbd>Enter/Return</kbd>.
+The following demo provides you with an input field in which you can enter a `<length>` value (e.g. `300px`, `50%`, `30vw`) to set the width of a result bar that will appear below it once you've pressed the <kbd>Enter</kbd> or the <kbd>Return</kbd> key.
 
 This allows you to compare and contrast the effect of different length units.
 


### PR DESCRIPTION
I just want to say that the Enter key is a more popular name than the Return key except in Norway.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
