### PR TITLE
Create Layout Instability API sidebar

### DIFF
--- a/files/en-us/web/api/layoutshift/index.html
+++ b/files/en-us/web/api/layoutshift/index.html
@@ -11,7 +11,9 @@ tags:
   - Web Performance
 browser-compat: api.LayoutShift
 ---
-<p>The <code>LayoutShift</code> interface of the Layout Instability API provides insights into the stability of web pages based on movements of the elements on the page.</p>
+<div>{{APIRef("Layout Instability API")}}</div>
+
+<p>The <code>LayoutShift</code> interface of the <a href="/en-US/docs/Web/API/Layout_Instability_API">Layout Instability API</a> provides insights into the stability of web pages based on movements of the elements on the page.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/layoutshiftattribution/currentrect/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/currentrect/index.html
@@ -9,7 +9,7 @@ tags:
   - LayoutShiftAttribution
 browser-compat: api.LayoutShiftAttribution.currentRect
 ---
-<div><div>{{APIRef("Layout Instability API")}}</div></div>
+<div>{{APIRef("Layout Instability API")}}</div>
 
 <p>The <strong><code>currentRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
 

--- a/files/en-us/web/api/layoutshiftattribution/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/index.html
@@ -14,7 +14,7 @@ browser-compat: api.LayoutShiftAttribution
 ---
 <div>{{APIRef("Layout Instability API")}}</div>
 
-<p>The <code>LayoutShiftAttribution</code> interface of the {{domxref("Layout Instability API")}} provides debugging information about elements which have shifted.</p>
+<p>The <code>LayoutShiftAttribution</code> interface of the <a href="/en-US/docs/Web/API/Layout_Instability_API">Layout Instability API</a> provides debugging information about elements which have shifted.</p>
 
 <p>Instances of <code>LayoutShiftAttribution</code> are returned in an array by calling {{domxref("LayoutShift.sources")}}.</p>
 

--- a/files/en-us/web/api/layoutshiftattribution/node/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/node/index.html
@@ -9,7 +9,7 @@ tags:
   - LayoutShiftAttribution
 browser-compat: api.LayoutShiftAttribution.node
 ---
-<div><div>{{APIRef("Layout Instability API")}}</div></div>
+<div>{{APIRef("Layout Instability API")}}</div>
 
 <p>The <strong><code>node</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("node")}} representing the object that has shifted.</p>
 

--- a/files/en-us/web/api/layoutshiftattribution/previousrect/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/previousrect/index.html
@@ -9,7 +9,7 @@ tags:
   - LayoutShiftAttribution
 browser-compat: api.LayoutShiftAttribution.previousRect
 ---
-<div><div>{{APIRef("Layout Instability API")}}</div></div>
+<div>{{APIRef("Layout Instability API")}}</div>
 
 <p>The <strong><code>previousRect</code></strong> read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.</p>
 

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.html
@@ -9,7 +9,7 @@ tags:
   - LayoutShiftAttribution
 browser-compat: api.LayoutShiftAttribution.toJSON
 ---
-<div><div>{{APIRef("Layout Instability API")}}</div></div>
+<div>{{APIRef("Layout Instability API")}}</div>
 
 <p>The <strong><code>toJSON()</code></strong> method of the {{domxref("LayoutShiftAttribution")}} interface is a <em>serializer</em> that returns a JSON representation of the <code>LayoutShiftAttribution</code> object.</p>
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -839,6 +839,16 @@
       "properties": [],
       "events": []
     },
+    "Layout Instability API": {
+      "overview": ["Layout Instability API"],
+      "interfaces: ": [
+        "LayoutShift",
+        "LayoutShiftAttribution"
+      ],
+      "methods": [],
+      "properties": [],
+      "events": []
+    },
     "Long Tasks API": {
       "overview": ["Long Tasks API"],
       "interfaces": ["PerformanceLongTaskTiming", "TaskAttributionTiming"],


### PR DESCRIPTION
Fixes #8794

- Add the entry in `GroupData.json`. This allows the API to appear in the Web/API list of APIs and allows the use of sidebars.
- Normalize the use of the sidebar in the different reference and overview pages for this API.