### PR TITLE
Fix overriden formData in “Using Fetch” Uploading-files example

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -168,7 +168,7 @@ const photos = document.querySelector('input[type="file"][multiple]');
 
 formData.append('title', 'My Vegas Vacation');
 for (let i = 0; i < photos.files.length; i++) {
-  formData.append('photos', photos.files[i]);
+  formData.append(`photos_${i}`, photos.files[i]);
 }
 
 fetch('https://example.com/posts', {


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fix: #8603

> What was wrong/why is this fix needed? (quick summary only)

in `Uploading multiple files` section in `Using Fetch` page, example code override `photos` in `formData`.
I fixed example code so that code does not override `formData` with `photes_${i}` key

> Anything else that could help us review it

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#uploading_multiple_files