### PR TITLE
Fix typo in background and borders

### DIFF
--- a/files/en-us/learn/css/building_blocks/test_your_skills_backgrounds_and_borders/index.html
+++ b/files/en-us/learn/css/building_blocks/test_your_skills_backgrounds_and_borders/index.html
@@ -9,7 +9,7 @@ tags:
   - backgrounds
   - borders
 ---
-<p>This aim of this skill test is to get you working with CSS backgrounds and borders using the skills you have learned in the previous lesson.</p>
+<p>The aim of this skill test is to get you working with CSS backgrounds and borders using the skills you have learned in the previous lesson.</p>
 
 <div class="notecard note">
 <p><strong>Note</strong>: You can try out solutions in the interactive editors below, however it may be helpful to download the code and use an online tool such as <a href="https://codepen.io/">CodePen</a>, <a href="https://jsfiddle.net/">jsFiddle</a>, or <a href="https://glitch.com/">Glitch</a> to work on the tasks.<br>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A

> What was wrong/why is this fix needed? (quick summary only)

A word "the" is more appropriate than "this", since "aim" hasn't appeared in the document or the context yet.

> Anything else that could help us review it

I checked other "Test your skills" documents in "Building blocks" sections ([example 1](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Selectors_Tasks), [2](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Box_Model_Tasks)), and confirmed that they start with "The aim of this task is ..."