### PR TITLE
Add closing `</p>` tag in example

### DIFF
--- a/files/en-us/web/html/element/sup/index.html
+++ b/files/en-us/web/html/element/sup/index.html
@@ -76,7 +76,7 @@ browser-compat: html.elements.sup
 <p>Exponents, or powers of a number, are among the most common uses of superscripted text. For example:</p>
 
 <pre class="brush: html">&lt;p&gt;One of the most common equations in all of physics is
-&lt;var&gt;E&lt;/var&gt;=&lt;var&gt;m&lt;/var&gt;&lt;var&gt;c&lt;/var&gt;&lt;sup&gt;2&lt;/sup&gt;.&lt;p&gt;</pre>
+&lt;var&gt;E&lt;/var&gt;=&lt;var&gt;m&lt;/var&gt;&lt;var&gt;c&lt;/var&gt;&lt;sup&gt;2&lt;/sup&gt;.&lt;/p&gt;</pre>
 
 <p>The resulting output looks like this:</p>
 


### PR DESCRIPTION
The closing paragraph tag in the example is missing the `/` to make it a closing `</p>` tag.

This replaces the open `<p>` tag with closing `</p>` tag by adding the `/` in the code example.
