### PR TITLE
add reportValidity

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.html
+++ b/files/en-us/learn/forms/form_validation/index.html
@@ -411,10 +411,11 @@ input:focus:invalid {
  <li><code>willValidate</code>: Returns <code>true</code> if the element will be validated when the form is submitted; <code>false</code> otherwise.</li>
 </ul>
 
-<p id="Constraint_validation_API_methods">The Constraint Validation API also makes the following methods available on the above elements.</p>
+<p id="Constraint_validation_API_methods">The Constraint Validation API also makes the following methods available on the above elements and the <code><a href="/en-US/docs/Web/HTML/Element/form">form</a></code> element.</p>
 
 <ul>
  <li><code>checkValidity()</code>: Returns <code>true</code> if the element's value has no validity problems; <code>false</code> otherwise. If the element is invalid, this method also fires an <a href="/en-US/docs/Web/API/HTMLInputElement/invalid_event"><code>invalid</code> event</a> on the element.</li>
+ <li><code>reportValidity()</code>: Report the invalid field(s) using the browser native messages. Useful in combination with <code>preventDefault()</code> in an <code>onSubmit</code> event handler</li>
  <li><code>setCustomValidity(<em>message</em>)</code>: Adds a custom error message to the element; if you set a custom error message, the element is considered to be invalid, and the specified error is displayed. This lets you use JavaScript code to establish a validation failure other than those offered by the standard HTML5 validation constraints. The message is shown to the user when reporting the problem.</li>
 </ul>
 

--- a/files/en-us/learn/forms/form_validation/index.html
+++ b/files/en-us/learn/forms/form_validation/index.html
@@ -415,7 +415,7 @@ input:focus:invalid {
 
 <ul>
  <li><code>checkValidity()</code>: Returns <code>true</code> if the element's value has no validity problems; <code>false</code> otherwise. If the element is invalid, this method also fires an <a href="/en-US/docs/Web/API/HTMLInputElement/invalid_event"><code>invalid</code> event</a> on the element.</li>
- <li><code>reportValidity()</code>: Report the invalid field(s) using the browser native messages. Useful in combination with <code>preventDefault()</code> in an <code>onSubmit</code> event handler</li>
+ <li><code>reportValidity()</code>: Reports invalid field(s) using events. Useful in combination with <code>preventDefault()</code> in an <code>onSubmit</code> event handler</li>
  <li><code>setCustomValidity(<em>message</em>)</code>: Adds a custom error message to the element; if you set a custom error message, the element is considered to be invalid, and the specified error is displayed. This lets you use JavaScript code to establish a validation failure other than those offered by the standard HTML5 validation constraints. The message is shown to the user when reporting the problem.</li>
 </ul>
 


### PR DESCRIPTION
I was missing information on how to trigger the native browser validation messages while dealing with a form onSubmit handler. Additionally, these methods are available to form elements as well beside the form fields

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
Not related to an open issue. 

> What was wrong/why is this fix needed? (quick summary only)
Felt like the page was missing reference to  'reportValidity' method

> Anything else that could help us review it
Found this method on a stackoverflow post and decided an attempt to improve MDN