### PR TITLE
Inconsistent "In this module" section on debugging page

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/debugging_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/debugging_html/index.html
@@ -178,6 +178,7 @@ tags:
  <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks">Creating hyperlinks</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting">Advanced text formatting</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure">Document and website structure</a></li>
+ <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML" aria-current="page">Debugging HTML</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter">Marking up a letter</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content">Structuring a page of content</a></li>
 </ul>


### PR DESCRIPTION
The page https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML
should conform the style on page https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). NA

> What was wrong/why is this fix needed? (quick summary only)
Found inconsistency between pages

> Anything else 

Here is an example of the style which is followed [throughout](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML)
<img src="https://user-images.githubusercontent.com/29653551/132891218-747399e3-bf64-477d-b544-2723807b0491.png" height=300>

Here is the [inconsistency](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML):
<img src="https://user-images.githubusercontent.com/29653551/132891315-2a7ce971-3393-43c4-9dc8-150c7e802db5.png" height=300>
