### PR TITLE
[WebDriver] Add "webSocketUrl" capability

### DIFF
--- a/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.html
+++ b/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.html
@@ -4,8 +4,8 @@ slug: Web/WebDriver/Capabilities/acceptInsecureCerts
 tags:
   - Reference
   - WebDriver
-  - acceptInsecureCerts
   - capabilities
+  - acceptInsecureCerts
 ---
 <p>The <strong><code>acceptInsecureCerts</code> capability</strong> communicates whether expired or invalid <a href="/en-US/docs/Glossary/TLS">TLS certificates</a> are checked when <a href="/en-US/docs/Web/WebDriver/Commands/NavigateTo">navigating</a>. When the capability is false, an <a href="/en-US/docs/Web/WebDriver/Errors/InsecureCertificate">insecure certificate</a> error will be returned as navigation encounters domains with certificate problems. Otherwise, self-signed or otherwise invalid certificates will be implicitly trusted by the browser on navigation. The capability has effect for the lifetime of the session.</p>
 

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
@@ -2,10 +2,10 @@
 title: firefoxOptions
 slug: Web/WebDriver/Capabilities/firefoxOptions
 tags:
-  - Extension capabilities
   - Reference
   - WebDriver
   - capabilities
+  - Extension capabilities
   - firefoxOptions
 ---
 <p>The <a id="firefoxOptions"><strong><code>moz:firefoxOptions</code> capability</strong></a> is a namespaced set of

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
@@ -78,7 +78,7 @@ tags:
 <h5 id="args_array_of_strings"><code>args</code> (array of strings)</h5>
 
 <p>Command line arguments to pass to the Firefox binary. These must include the leading dash (<code>-</code>) where
-  required, e.g. <code>["<a href="/en-US/docs/Mozilla/Firefox/Headless_mode">-headless</a>"]</code>.</p>
+  required, e.g. <code>["<a href="https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/">-headless</a>"]</code>.</p>
 
 <p>To have geckodriver pick up an existing <a href="#profile">profile</a> on the local filesystem, you may pass
   <code>["-profile", "/path/to/profile"]</code>. But if a profile has to be transferred to a target machine it is
@@ -184,8 +184,8 @@ tags:
 
 <p>A JSON Object with one entry per preference to set. The preference will be written to the <a
     href="#profile">profile</a> before starting Firefox. A full list of available preferences is available from visiting
-  "<a>about:config</a>" in your Firefox browser. Some of these are documented on the <a
-    href="/en-US/docs/Mozilla/Preferences/Preference_reference">preference reference</a> page.</p>
+  "<a>about:config</a>" in your Firefox browser. Some of these are documented in <a
+    href="https://searchfox.org/mozilla-central/source/modules/libpref/init/all.js">this source</a> file.</p>
 
 <p>An example of a preference object:</p>
 
@@ -214,7 +214,7 @@ tags:
 
 <p>The following is an example of a full <a href="/en-US/docs/Web/WebDriver/Capabilities">capabilities object</a> that
   selects a specific Firefox binary to run with a prepared <a href="#profile">profile</a> from the filesystem in <a
-    href="/en-US/docs/Mozilla/Firefox/Headless_mode">headless mode</a>. It also increases the number of IPC processes
+    href="https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/">headless mode</a>. It also increases the number of IPC processes
   through a preference, turns off chrome errors/warnings in the console, and enables more verbose logging:</p>
 
 <pre class="brush: json">{
@@ -283,7 +283,7 @@ tags:
   <li><a
       href="https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Capabilities.html#capabilities-example">geckodriver’s
       documentation on supported Firefox capabilities</a></li>
-  <li><a href="/en-US/docs/Web/WebDriver/Capabilities/goog/chromeOptions">Chrome-specific WebDriver capabilities</a>
+  <li><a href="https://chromedriver.chromium.org/capabilities">Chrome-specific WebDriver capabilities</a>
     (<code>goog:chromeOptions)</code></li>
   <li><a href="/en-US/docs/Web/WebDriver/Capabilities">List of WebDriver capabilities</a></li>
   <li><a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> command</li>

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.html
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>With the <code>webSocketUrl</code> capability set to <code>true</code> a WebSocket server will be started in the browser, supporting bidirectional communication by using the <a href="https://w3c.github.io/webdriver-bidi/">WebDriver BiDi protocol</a>.
 
-When the <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> request has the <code>webSocketUrl</code> capability set to <code>true</code>, and the session starts successfully, the value of the capabilities field in the response will have a <code>webSocketUrl</code> property set to the URL of the WebSocket server.
+When the <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> request has the <code>webSocketUrl</code> capability set to <code>true</code>, and the session starts successfully, the value of the <code>capabilities</code> field in the response will have a <code>webSocketUrl</code> property set to the URL of the WebSocket server.
 
 <h2 id="Example">Example</h2>
 <p>Requesting the WebSocket URL by setting the <code>webSocketUrl</code> capability to <code>true</code>:</p>

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.html
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.html
@@ -7,9 +7,9 @@ tags:
   - capabilities
   - webSocketUrl
 ---
-<p>With the <code>webSocketUrl</code> capability set to <code>true</code> a WebSocket server will be started in the browser, supporting bidirectional communication by using the <a href="https://w3c.github.io/webdriver-bidi/">WebDriver BiDi protocol</a>. This capability defaults to <code>false</code>, and has effect for the lifetime of the session.</p>
+<p>With the <code>webSocketUrl</code> capability set to <code>true</code> a WebSocket server will be started in the browser, supporting bidirectional communication by using the <a href="https://w3c.github.io/webdriver-bidi/">WebDriver BiDi protocol</a>.
 
-When the capability is set to <code>true</code> the returned capabilities from the <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> command will then have the same capability but with its value replaced by the WebSocket URL of the current WebDriver session.
+When the <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> request has the <code>webSocketUrl</code> capability set to <code>true</code>, and the session starts successfully, the value of the capabilities field in the response will have a <code>webSocketUrl</code> property set to the URL of the WebSocket server.
 
 <h2 id="Example">Example</h2>
 <p>Requesting the WebSocket URL by setting the <code>webSocketUrl</code> capability to <code>true</code>:</p>

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.html
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.html
@@ -29,4 +29,5 @@ Response:
 <ul>
  <li><a href="/en-US/docs/Web/WebDriver/Capabilities">List of WebDriver capabilities</a></li>
  <li><a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> command</li>
+ <li><a href="https://w3c.github.io/webdriver-bidi/#establishing">Establishing a WebDriver BiDi connection</a></li>
 </ul>

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.html
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.html
@@ -1,0 +1,32 @@
+---
+title: webSocketUrl
+slug: Web/WebDriver/Capabilities/webSocketUrl
+tags:
+  - Reference
+  - WebDriver
+  - capabilities
+  - webSocketUrl
+---
+<p>With the <strong><code>webSocketUrl</code> capability</strong> set to <code>true</code> a WebSocket server will be started in the browser, supporting bidirectional communication by using the <a href="https://w3c.github.io/webdriver-bidi/">WebDriver BiDi protocol</a>. This capability defaults to <code>false</code>, and has effect for the lifetime of the session.</p>
+
+When the capability is set to <code>true</code> the returned capabilities from the <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> command will then have the same capability but with its value replaced by the WebSocket URL of the current WebDriver session.
+
+<h2 id="Example">Example</h2>
+<p>Requesting the WebSocket URL by setting the <code>webSocketUrl</code> capability to <code>true</code>:</p>
+
+Request:
+<pre class="brush: json">POST /session HTTP/1.1
+{"capabilities": {"alwaysMatch": {"webSocketUrl": true}}}
+</pre>
+
+Response:
+<pre>
+{"value":{"sessionId":"571f206f-c3fe-794c-9218-77fa89595eb9","capabilities":{[..], "webSocketUrl":"ws://localhost:9222/session/571f206f-c3fe-794c-9218-77fa89595eb9"}}}
+</pre>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/WebDriver/Capabilities">List of WebDriver capabilities</a></li>
+ <li><a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> command</li>
+</ul>

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.html
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.html
@@ -7,7 +7,7 @@ tags:
   - capabilities
   - webSocketUrl
 ---
-<p>With the <strong><code>webSocketUrl</code> capability</strong> set to <code>true</code> a WebSocket server will be started in the browser, supporting bidirectional communication by using the <a href="https://w3c.github.io/webdriver-bidi/">WebDriver BiDi protocol</a>. This capability defaults to <code>false</code>, and has effect for the lifetime of the session.</p>
+<p>With the <code>webSocketUrl</code> capability set to <code>true</code> a WebSocket server will be started in the browser, supporting bidirectional communication by using the <a href="https://w3c.github.io/webdriver-bidi/">WebDriver BiDi protocol</a>. This capability defaults to <code>false</code>, and has effect for the lifetime of the session.</p>
 
 When the capability is set to <code>true</code> the returned capabilities from the <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">New Session</a> command will then have the same capability but with its value replaced by the WebSocket URL of the current WebDriver session.
 
@@ -21,7 +21,7 @@ Request:
 
 Response:
 <pre>
-{"value":{"sessionId":"571f206f-c3fe-794c-9218-77fa89595eb9","capabilities":{[..], "webSocketUrl":"ws://localhost:9222/session/571f206f-c3fe-794c-9218-77fa89595eb9"}}}
+{"value":{"capabilities":{"webSocketUrl":"ws://localhost:9222/session/571f206f-c3fe-794c-9218-77fa89595eb9", [..]}, "sessionId":"571f206f-c3fe-794c-9218-77fa89595eb9"}}
 </pre>
 
 <h2 id="See_also">See also</h2>


### PR DESCRIPTION
This PR adds documentation for the `webSocketUrl` capability that is provided by the [WebDriver BiDi specification](https://w3c.github.io/webdriver-bidi/#establishing).