### PR TITLE
Add missing backtick to line 50

### DIFF
--- a/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
@@ -47,7 +47,7 @@ When adding such a tag, you serve the same content for both domains, telling sea
 
 ```html
 <link href="http://example.org/whaddup" rel="canonical">
-``
+```
 
 Unlike the previous case, browser history will consider non-www and www URLs as independent entries.
 


### PR DESCRIPTION
The missing backtick causes the remaining portions of the page to render as a codeblock.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'
none found


> What was wrong/why is this fix needed? (quick summary only)
The missing backtick at line 50 (two instead of three) causes the remaining portions of the page to render as a codeblock.


> Anything else that could help us review it
