### PR TITLE
Add Spring as Java server framework

### DIFF
--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.html
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.html
@@ -240,6 +240,7 @@ if __name__ == "__main__":
  <li><a href="/en-US/docs/Learn/Server-side/Express_Nodejs">Express</a> for Node.js.</li>
  <li><a href="https://laravel.com/">Laravel</a> for PHP.</li>
  <li><a href="https://rubyonrails.org/" rel="external">Ruby On Rails</a> for Ruby.</li>
+ <li><a href="https://spring.io/guides/gs/handling-form-submission/">Spring Boot</a> for Java.</li>
 </ul>
 
 <p>It's worth noting that even using these frameworks, working with forms isn't necessarily <em>easy</em>. But it's much easier than trying to write all the functionality yourself from scratch, and will save you a lot of time.</p>


### PR DESCRIPTION
This PR is in regard to the Sending and retrieving form data article, section "Other languages and frameworks" https://developer.mozilla.org/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#other_languages_and_frameworks

It seems to make sense to include a framework for Java since it's [one of the most used](https://insights.stackoverflow.com/survey/2021#technology-most-popular-technologies#:~:text=Java) languages in the world currently and is often taught in schools. 

Spring has a [quick-start tutorial](https://spring.io/guides/gs/handling-form-submission/) specifically about handling form submission which seems like a really good fit.

Let me know if there's anything you'd like changed!

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Not an issue, just an improvement.


> What was wrong/why is this fix needed? (quick summary only)

My addition includes a server-side framework for Java because it's a very popular language.


> Anything else that could help us review it

Nope!