### PR TITLE
Add technical reference for opengl.org

### DIFF
--- a/files/en-us/glossary/opengl/index.html
+++ b/files/en-us/glossary/opengl/index.html
@@ -15,3 +15,9 @@ tags:
 <ul>
  <li>{{Interwiki("wikipedia", "OpenGL")}} on Wikipedia</li>
 </ul>
+
+<h3 id="Technical_reference">Technical reference</h3>
+
+<ul>
+ <li><a href="https://www.opengl.org/">OpenGL</a></li>
+</ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The glossary entry "OpenGL" does not have a technical reference to its website opengl.org like other similar entries, e.g. [ECMAScript](https://developer.mozilla.org/en-US/docs/Glossary/ECMAScript).

This PR adds such a reference, to hopefully help those who seek technical references for OpenGL.
