### PR TITLE
Add IDB to list of IndexedDB libraries

### DIFF
--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -1334,6 +1334,7 @@ input {
 <ul>
  <li><a href="https://localforage.github.io/localForage/">localForage</a>: A Polyfill providing a simple name:value syntax for client-side data storage, which uses IndexedDB in the background, but falls back to WebSQL and then localStorage in browsers that don't support IndexedDB.</li>
  <li><a href="http://www.dexie.org/">dexie.js</a>: A wrapper for IndexedDB that allows much faster code development via nice, simple syntax.</li>
+ <li><a href="https://github.com/jakearchibald/idb">IDB</a>: A tiny library that mostly mirrors the IndexedDB API but with small usability improvements.</li>
  <li><a href="https://github.com/erikolson186/zangodb">ZangoDB</a>: A MongoDB-like interface for IndexedDB that supports most of the familiar filtering, projection, sorting, updating and aggregation features of MongoDB.</li>
  <li><a href="http://jsstore.net/">JsStore</a>: A simple and advanced IndexedDB wrapper having SQL like syntax. </li>
 </ul>


### PR DESCRIPTION
I placed it third in the list, as the list was already arranged in descending order by number of GitHub stars.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A

> What was wrong/why is this fix needed? (quick summary only)

I just figured that as long as a list of popular IndexedDB libraries existed, IDB may as well be included.

> Anything else that could help us review it

Nothing else I can think of.