### PR TITLE
Add variable for swtich statement.

### DIFF
--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -269,6 +269,7 @@ following `switch`. If `break` were omitted, the statement for
 `case 'Cherries'` would also be executed.
 
 ```js
+var fruittype = 'Apples';
 switch (fruittype) {
   case 'Oranges':
     console.log('Oranges are $0.59 a pound.');


### PR DESCRIPTION
When a reader copy-pastes the whole code with the icon, the reader has to explicitly add the `fruittype` variable, otherwise a `ReferenceError` is thrown.
Added the variable to avoid the error.