### PR TITLE
added </progress> in :indeterminate css ref

### DIFF
--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -90,8 +90,8 @@ progress {
 }
 
 progress:indeterminate {
-width:80vw; 
-height:40px;
+  width:80vw;
+  height:40px;
 }
 ```
 

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -91,7 +91,7 @@ progress {
 
 progress:indeterminate {
   width:80vw;
-  height:40px;
+  height:20px;
 }
 ```
 

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -90,9 +90,8 @@ progress {
 }
 
 progress:indeterminate {
-  opacity: 0.5;
-  background-color: lightgray;
-  box-shadow: 0 0 2px 1px red;
+width:80vw; 
+height:40px;
 }
 ```
 

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -79,7 +79,7 @@ for (var i = 0; i < inputs.length; i++) {
 #### HTML
 
 ```html
-<progress>
+<progress></progress>
 ```
 
 #### CSS


### PR DESCRIPTION
It seems that &lt;/progress&gt; has left &lt;progress&gt; alone. 🙂

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
