### PR TITLE
Use keydown instead of the deprecated keypress event

### DIFF
--- a/files/en-us/web/api/fullscreen_api/index.html
+++ b/files/en-us/web/api/fullscreen_api/index.html
@@ -132,10 +132,10 @@ tags:
 
 <p>When the page is loaded, this code is run to set up an event listener to watch for the <kbd>Enter</kbd> key.</p>
 
-<pre class="brush: js">document.addEventListener("keypress", function(e) {
-  if (e.keyCode === 13) {
-    toggleFullScreen();
-  }
+<pre class="brush: js">document.addEventListener("keydown", function(e) {
+  if (e.key === "Enter") {
+    toggleFullScreen();
+  }
 }, false);
 </pre>
 


### PR DESCRIPTION
Make the example code under the heading "Watching for the Enter key" at https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API work with `keydown` instead of the deprecated `keypress` event.
This will potentially prevent beginners or people otherwise learning from the example code from using a deprecated event, which is generally bad practice (it was not stated that the `keypress` event is deprecated within the example code).

<!-- Please provide the following information to help us review this PR: -->
Fixes: #None



> What was wrong/why is this fix needed? (quick summary only)

deprecated event, must be replaced

