### PR TITLE
Fix #8861: Update example code

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -541,7 +541,7 @@ multiply24(10) // 240
 if (!Array.prototype.mapUsingReduce) {
   Array.prototype.mapUsingReduce = function(callback, initialValue) {
     return this.reduce(function(mappedArray, currentValue, currentIndex, array) {
-      mappedArray[index] = callback.call(initialValue, currentValue, currentIndex, array)
+      mappedArray[currentIndex] = callback.call(initialValue, currentValue, currentIndex, array)
       return mappedArray
     }, [])
   }


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #8861 in  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#write_map_using_reduce



> What was wrong/why is this fix needed? (quick summary only)

The example code provided used a non-existing variable 'index', I have rectified the code to instead use the variable `currentIndex` from the parameter `currentIndex` defined in the function. This produces the intended result.


