### PR TITLE
FF93 First changes for digest SHA256 support

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -10,7 +10,8 @@ tags:
 ---
 {{HTTPSidebar}}
 
-HTTP provides a general framework for access control and authentication. This page is an introduction to the HTTP framework for authentication, and shows how to restrict access to your server using the HTTP "Basic" schema.
+HTTP provides a general framework for access control and authentication.
+This page is an introduction to the HTTP framework for authentication, and shows how to restrict access to your server using the HTTP "Basic" schema.
 
 ## The general HTTP authentication framework
 
@@ -28,7 +29,8 @@ In the case of a "Basic" authentication like shown in the figure, the exchange *
 
 ### Proxy authentication
 
-The same challenge and response mechanism can be used for _proxy authentication_. As both resource authentication and proxy authentication can coexist, a different set of headers and status codes is needed. In the case of proxies, the challenging status code is {{HTTPStatus("407")}} (Proxy Authentication Required), the {{HTTPHeader("Proxy-Authenticate")}} response header contains at least one challenge applicable to the proxy, and the {{HTTPHeader("Proxy-Authorization")}} request header is used for providing the credentials to the proxy server.
+The same challenge and response mechanism can be used for _proxy authentication_.
+As both resource authentication and proxy authentication can coexist, a different set of headers and status codes is needed. In the case of proxies, the challenging status code is {{HTTPStatus("407")}} (Proxy Authentication Required), the {{HTTPHeader("Proxy-Authenticate")}} response header contains at least one challenge applicable to the proxy, and the {{HTTPHeader("Proxy-Authorization")}} request header is used for providing the credentials to the proxy server.
 
 ### Access forbidden
 
@@ -40,7 +42,8 @@ In all cases, the server may prefer returning a {{HTTPStatus("404")}} `Not Found
 
 ### Authentication of cross-origin images
 
-A potential security hole recently been fixed by browsers is authentication of cross-site images. From [Firefox 59](/en-US/docs/Mozilla/Firefox/Releases/59) onwards, image resources loaded from different origins to the current document are no longer able to trigger HTTP authentication dialogs ({{bug(1423146)}}), preventing user credentials being stolen if attackers were able to embed an arbitrary image into a third-party page.
+A potential security hole (that has since been fixed in browsers) was authentication of cross-site images.
+From [Firefox 59](/en-US/docs/Mozilla/Firefox/Releases/59) onwards, image resources loaded from different origins to the current document are no longer able to trigger HTTP authentication dialogs ({{bug(1423146)}}), preventing user credentials being stolen if attackers were able to embed an arbitrary image into a third-party page.
 
 ### Character encoding of HTTP authentication
 
@@ -54,7 +57,7 @@ The {{HTTPHeader("WWW-Authenticate")}} and {{HTTPHeader("Proxy-Authenticate")}} 
 
 The syntax for these headers is the following:
 
-```
+```http
 WWW-Authenticate: <type> realm=<realm>
 Proxy-Authenticate: <type> realm=<realm>
 ```
@@ -65,7 +68,7 @@ Here, `<type>` is the authentication scheme ("Basic" is the most common scheme a
 
 The {{HTTPHeader("Authorization")}} and {{HTTPHeader("Proxy-Authorization")}} request headers contain the credentials to authenticate a user agent with a (proxy) server. Here, the `<type>` is needed again followed by the credentials, which can be encoded or encrypted depending on which authentication scheme is used.
 
-```
+```http
 Authorization: <type> <credentials>
 Proxy-Authorization: <type> <credentials>
 ```
@@ -123,7 +126,8 @@ user2:$apr1$O04r.y2H$/vEkesPhVInBByJUkXitA/
 
 ### Restricting access with nginx and basic authentication
 
-For nginx, you will need to specify a location that you are going to protect and the `auth_basic` directive that provides the name to the password-protected area. The `auth_basic_user_file` directive then points to a `.htpasswd` file containing the encrypted user credentials, just like in the Apache example above.
+For nginx, you will need to specify a location that you are going to protect and the `auth_basic` directive that provides the name to the password-protected area.
+The `auth_basic_user_file` directive then points to a `.htpasswd` file containing the encrypted user credentials, just like in the Apache example above.
 
 ```
 location /status {
@@ -140,7 +144,8 @@ Many clients also let you avoid the login prompt by using an encoded URL contain
 https://username:password@www.example.com/
 ```
 
-**The use of these URLs is deprecated**. In Chrome, the `username:password@` part in URLs is even [stripped out](https://bugs.chromium.org/p/chromium/issues/detail?id=82250#c7) for security reasons. In Firefox, it is checked if the site actually requires authentication and if not, Firefox will warn the user with a prompt "You are about to log in to the site “www\.example.com” with the username “username”, but the website does not require authentication. This may be an attempt to trick you."
+**The use of these URLs is deprecated**.
+In Chrome, the `username:password@` part in URLs is even [stripped out](https://bugs.chromium.org/p/chromium/issues/detail?id=82250#c7) for security reasons. In Firefox, it is checked if the site actually requires authentication and if not, Firefox will warn the user with a prompt "You are about to log in to the site “www\.example.com” with the username “username”, but the website does not require authentication. This may be an attempt to trick you."
 
 ## See also
 

--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -72,16 +72,20 @@ Proxy-Authorization: <type> <credentials>
 
 ### Authentication schemes
 
-The general HTTP authentication framework is used by several authentication schemes. Schemes can differ in security strength and in their availability in client or server software.
+The general HTTP authentication framework is used by several authentication schemes.
+Schemes can differ in security strength and in their availability in client or server software.
 
-The most common authentication scheme is the "Basic" authentication scheme, which is introduced in more detail below. IANA maintains a [list of authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml), but there are other schemes offered by host services, such as Amazon AWS. Common authentication schemes include:
+The most common authentication scheme is the "Basic" authentication scheme, which is introduced in more detail below.
+IANA maintains a [list of authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml), but there are other schemes offered by host services, such as Amazon AWS.
+
+Common authentication schemes include:
 
 - **Basic**
   - : See {{rfc(7617)}}, base64-encoded credentials. More information below.
 - **Bearer**
   - : See {{rfc(6750)}}, bearer tokens to access OAuth 2.0-protected resources
 - **Digest**
-  - : See {{rfc(7616)}}, only md5 hashing is supported in Firefox, see {{bug(472823)}} for SHA encryption support
+  - : See {{rfc(7616)}}. Firefox 93 and later support SHA-256 encryption. Previous versions only support MD5 hashing (not recommended).
 - **HOBA**
   - : See {{rfc(7486)}}, Section 3, **H**TTP **O**rigin-**B**ound **A**uthentication, digital-signature-based
 - **Mutual**

--- a/files/en-us/web/http/headers/digest/index.md
+++ b/files/en-us/web/http/headers/digest/index.md
@@ -4,25 +4,21 @@ slug: Web/HTTP/Headers/Digest
 tags:
   - HTTP
   - HTTP Header
+  - Digest
+  - Authentication
 browser-compat: http.headers.Digest
 ---
 {{HTTPSidebar}}
 
-The **`Digest`** response HTTP header provides a
-{{Glossary("digest")}} of the requested resource.
+The **`Digest`** response HTTP header provides a {{Glossary("digest")}} of the _selected representation_ of the requested resource.
 
-In [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231) terms,
-this is the _selected representation_ of a resource.
-The selected representation depends
-on the [`Content-Type`](/en-US/docs/Web/HTTP/Headers/Content-Type)
-and [`Content-Encoding`](/en-US/docs/Web/HTTP/Headers/Content-Encoding) header values,
-so a single resource may have multiple different digest values.
+Representations are different "versions" of a particular resource that might be returned from a request: for example, the same data resource might formatted in a particular media type such as XML or JSON, localised to a particular written language or geographical region, and/or compressed or otherwise encoded for transmission.
+The representation can be determined from the response's {{Glossary("Representation header","Representation headers")}}.
 
-The digest is calculated over the entire representation. The representation itself may be:
+The digest applies to the whole representation of a resource, not to a particular message.
+It can be used to verify that the representation has not been modified during transmission.
 
-- fully contained in the response message body,
-- not at all contained in the message body (for example, in a response to a [`HEAD`](/en-US/docs/Web/HTTP/Methods/HEAD) request),
-- or partially contained in the message body (for example, in a response to a [range request](/en-US/docs/Web/HTTP/Range_requests)).
+> **Note:** While a representation may be fully contained in the message body of a single response, it can also be sent using multiple messages in response to a [range request](/en-US/docs/Web/HTTP/Range_requests), or omitted altogether in response to a {{HTTPMethod("HEAD")}} request.
 
 <table class="properties">
   <tbody>
@@ -37,6 +33,7 @@ The digest is calculated over the entire representation. The representation itse
   </tbody>
 </table>
 
+
 ## Syntax
 
 ```
@@ -47,32 +44,23 @@ Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-value>
 ## Directives
 
 - `<digest-algorithm>`
-  - : Supported digest algorithms are defined in [RFC 3230](https://datatracker.ietf.org/doc/html/rfc3230) and [RFC 5843](https://datatracker.ietf.org/doc/html/rfc5843), and include
-    `SHA-256` and `SHA-512`. Some of the supported algorithms,
-    including `unixsum` and `MD5` are subject to collisions and are
-    thus not suitable for applications in which collision-resistance is important.
+  - : Digest algorithms are defined in [Digest Headers](https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers/). 
+    - Permitted digest algorithms values include: `unixsum`, `unixcksum`, `crc32c`, `sha-256` and `sha-512`, `id-sha-256`, `id-sha-512`
+    - Deprecated algorithms values include: `md5`, `sha`, `adler32`.
 - `<digest-value>`
-  - : The result of applying the digest algorithm to the resource representation and
-    encoding the result. The choice of digest algorithm also determines the encoding to
-    use: for example `SHA-256` uses base64 encoding.
+  - : The result of applying the digest algorithm to the resource representation and encoding the result.
+    The choice of digest algorithm also determines the encoding to use: for example `SHA-256` uses base64 encoding.
 
 ## Examples
 
-```
+```http
 Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,unixsum=30637
 ```
 
 ## Specifications
 
-| Specification                                                                                                  |
-| -------------------------------------------------------------------------------------------------------------- |
-| [draft-ietf-httpbis-digest-headers-latest](https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers) |
-
-This header was originally defined in [RFC 3230](https://datatracker.ietf.org/doc/html/rfc3230),
-but the definition of "selected representation" in [RFC 7231](https://www.rfc-editor.org/info/rfc7231) made the original definition inconsistent with current HTTP specifications.
-When released, The "Resource Digests for HTTP" draft therefore will obsolete RFC 3230
-and will update the standard to be consistent.
+{{Specifications("http.headers.Digest")}}
 
 ## Browser compatibility
 
@@ -81,5 +69,6 @@ and will update the standard to be consistent.
 ## See also
 
 - {{HTTPHeader("Want-Digest")}}
+
 - [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests)
 - [`206 Partial Content`](/en-US/docs/Web/HTTP/Status/206 "The HTTP 206 Partial Content success status response code indicates that the request has succeeded and has the body contains the requested ranges of data, as described in the Range header of the request.")

--- a/files/en-us/web/http/headers/want-digest/index.md
+++ b/files/en-us/web/http/headers/want-digest/index.md
@@ -10,26 +10,17 @@ browser-compat: http.headers.Want-Digest
 ---
 {{HTTPSidebar}}
 
-The **`Want-Digest`** HTTP header is primarily used in a HTTP
-request, to ask the responder to provide a {{Glossary("digest")}} of the requested
-resource using the [`Digest`](/en-US/docs/Web/HTTP/Headers/Digest)
-response header.
+The **`Want-Digest`** HTTP header is primarily used in a HTTP request, to ask the server to provide a {{Glossary("digest")}} of the requested resource using the {{HTTPHeader("Digest")}} response header.
 
-The header contains identifiers for one or more digest algorithms that the sender
-wishes the responder to use to create the digest. The sender may use [quality values](/en-US/docs/Glossary/Quality_values) to indicate its
-preference ordering among the choices it offers.
+The header contains identifiers for one or more digest algorithms that the sender wishes the server to use to create the digest.
+The request may use {{Glossary("quality values")}} to indicate its preference/order for particular digest algorithms.
 
-If `Want-Digest` does not include any digest algorithms that the server
-supports, the server may respond with:
+If `Want-Digest` does not include any digest algorithms that the server supports, the server may respond with:
 
 - a digest calculated using a different digest algorithm, or
-- a [`400 Bad Request`](/en-US/docs/Web/HTTP/Status/400) error,
-  and include another `Want-Digest` header with that response, listing the
-  algorithms that it does support.
+- a [`400 Bad Request`](/en-US/docs/Web/HTTP/Status/400) error, and include another `Want-Digest` header with that response, listing the algorithms that it does support.
 
-See the page for the
-[`Digest`](/en-US/docs/Web/HTTP/Headers/Digest) header for more
-information.
+See the page for the {{HTTPHeader("Digest")}} header for more information.
 
 <table class="properties">
   <tbody>
@@ -49,7 +40,7 @@ information.
 
 ## Syntax
 
-```
+```http
 Want-Digest: <digest-algorithm>
 
 // Multiple algorithms, weighted with the quality value syntax:
@@ -59,17 +50,16 @@ Want-Digest: <digest-algorithm><q-value>,<digest-algorithm><q-value>
 ## Directives
 
 - \<digest-algorithm>
-  - : Supported digest algorithms are defined in [RFC 3230](https://datatracker.ietf.org/doc/html/rfc3230) and [RFC 5843](https://datatracker.ietf.org/doc/html/rfc5843), and include
-    `SHA-256` and `SHA-512`. Some of the supported algorithms,
-    including `unixsum` and `MD5` are subject to collisions and are
-    thus not suitable for applications in which collision-resistance is important.
+  - : Digest algorithms are defined in [Digest Headers](https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers/). 
+    - Permitted digest algorithms values include: `unixsum`, `unixcksum`, `crc32c`, `sha-256` and `sha-512`, `id-sha-256`, `id-sha-512`
+    - Deprecated algorithms values include: `md5`, `sha`, `adler32`.    
 - \<q-value>
   - : The [quality value](/en-US/docs/Glossary/Quality_values) to apply to that
     option.
 
 ## Examples
 
-```
+```http
 Want-Digest: sha-256
 Want-Digest: SHA-512;q=0.3, sha-256;q=1, md5;q=0
 ```
@@ -81,67 +71,57 @@ uses one of them:
 
 Request:
 
-```
+```http
 GET /item
 Want-Digest: sha-256;q=0.3, sha;q=1
 ```
 
 Response:
 
-```
+```http
 HTTP/1.1 200 Ok
 Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 ```
 
 ### Unsupported digests
 
-The server does not support any of the requested digest algorithms, so uses a different
-algorithm:
+The server does not support any of the requested digest algorithms, so uses a different algorithm:
 
 Request:
 
-```
+```http
 GET /item
 Want-Digest: sha;q=1
 ```
 
 Response:
 
-```
+```http
 HTTP/1.1 200 Ok
 Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 ```
 
-The server does not support any of the requested digest algorithms, so responds with a
-400 error and includes another `Want-Digest` header, listing the algorithms
-that it does support:
+The server does not support any of the requested digest algorithms.
+In this case it responds with a 400 error and includes another `Want-Digest` header, listing the algorithms that it does support:
 
 Request:
 
-```
+```http
 GET /item
 Want-Digest: sha;q=1
 ```
 
 Response:
 
-```
+```http
 HTTP/1.1 400 Bad Request
 Want-Digest: sha-256, sha-512
 ```
 
 ## Specifications
 
-| Specification                                                                                                  |
-| -------------------------------------------------------------------------------------------------------------- |
-| [draft-ietf-httpbis-digest-headers-latest](https://datatracker.ietf.org/doc/draft-ietf-httpbis-digest-headers) |
+{{Specifications("http.headers.Want-Digest")}}
 
-This header was originally defined in [RFC 3230](https://datatracker.ietf.org/doc/html/rfc3230),
-but the definition of "selected representation"
-in [RFC 7231](https://www.rfc-editor.org/info/rfc7231)
-made the original definition inconsistent with current HTTP specifications.
-When released, The "Resource Digests for HTTP" draft therefore will obsolete RFC 3230
-and will update the standard to be consistent.
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -11,9 +11,20 @@ browser-compat: http.headers.WWW-Authenticate
 ---
 {{HTTPSidebar}}
 
-The HTTP **`WWW-Authenticate`** response header defines the authentication method that should be used to gain access to a resource.
+The HTTP **`WWW-Authenticate`** response header defines the [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) methods ("challenges") that might be used to gain access to a specific resource.
 
-The `WWW-Authenticate` header is sent along with a {{HTTPStatus("401")}} `Unauthorized` response.
+> **Note:** This header is part of the [General HTTP authentication framework](/en-US/docs/Web/HTTP/Authentication#the_general_http_authentication_framework), which can be used with a number of [authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes) .
+> Each "challenge" lists a scheme supported by the server and additional parameters that are defined for that scheme type. 
+
+A server using [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) will respond with {{HTTPStatus("401")}} `Unauthorized` response to a request for a protected resource.
+This response must include at least one `WWW-Authenticate` header and at least one {{Glossary("challenge")}}, to indicate what authentication schemes can be used to access the resource (and any additional data that each particular scheme needs).
+
+Multiple challenges are allowed in the one `WWW-Authenticate` header, and multiple `WWW-Authenticate` headers are allowed in the one response.
+A server may also include the `WWW-Authenticate` header in other response messages to indicate that supplying credentials might affect the response.
+
+After recieving `WWW-Authenticate` a client will typically prompt the user for credentials, and then re-request the resource.
+This request uses the {{HTTPHeader("Authorization")}} header to supply the credentials to the server, encoded appropriately for the selected "challenge" authentication method.
+The client is expected to select the most secure of the challenges it understands (note that in some cases the "most secure" method is debatable).
 
 <table class="properties">
   <tbody>
@@ -30,25 +41,82 @@ The `WWW-Authenticate` header is sent along with a {{HTTPStatus("401")}} `Unauth
 
 ## Syntax
 
+At least one challenge must be specified.
+Multiple challenges may be specified commas-separated in a single header, or in individual headers:
+```http
+// Challenges specified in single header
+WWW-Authenticate: challenge1, ..., challengeN
+
+// Challenges specified in multiple headers
+WWW-Authenticate: challenge1
+...
+WWW-Authenticate: challengeN
 ```
-WWW-Authenticate: <type> realm=<realm>[, charset="UTF-8"]
+
+A single challenge has the following format. Note that the scheme token (`<auth-scheme>`) is mandatory.
+The presence of `realm`, `token68` and any other parameters depends on the definition of the selected scheme.
+
+```http
+// Possible challenge formats (scheme dependent)
+WWW-Authenticate: <auth-scheme>
+WWW-Authenticate: <auth-scheme> realm=<realm>
+WWW-Authenticate: <auth-scheme> token68
+WWW-Authenticate: <auth-scheme> auth-param1=token1, ..., auth-paramN=auth-paramN-token    
+WWW-Authenticate: <auth-scheme> realm=<realm> token68
+WWW-Authenticate: <auth-scheme> realm=<realm> token68 auth-param1=auth-param1-token , ..., auth-paramN=auth-paramN-token 
+WWW-Authenticate: <auth-scheme> realm=<realm> auth-param1=auth-param1-token, ..., auth-paramN=auth-paramN-token 
+WWW-Authenticate: <auth-scheme> token68 auth-param1=auth-param1-token, ..., auth-paramN=auth-paramN-token
 ```
+
+For example, [Basic authentication](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) allows for optional `realm` and `charset` keys, but does not support `token68`.
+
+```http
+WWW-Authenticate: Basic
+WWW-Authenticate: Basic realm=<realm>
+WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
+```
+
 
 ## Directives
 
-- \<type>
-  - : [Authentication type](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). A common type is ["Basic"](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). IANA maintains a [list of Authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
-- realm=\<realm>
-  - : A description of the protected area. If no realm is specified, clients often display a formatted hostname instead.
-- charset=\<charset>
-  - : Tells the client the server's preferred encoding scheme when submitting a username and password. The only allowed value is the case insensitive string "UTF-8". This does not relate to the encoding of the realm string.
+- `<auth-scheme>`
+  - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). Some of the more common types are (case-insensitive): [Basic](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) | Digest | Bearer | HOBA | Mutual | Negotiate | OAuth | SCRAM-SHA-1 | SCRAM-SHA-256 | vapid
+    > **Note:** For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
+- **realm=**\<realm> {{optional_inline}}
+  - : A string describing a protected area.
+    A realm allows a server to partition up the areas it protects (if supported by a scheme that allows such partitioning).
+    If no realm is specified, clients often display a formatted hostname instead.
+- `<token68>` {{optional_inline}}
+  - : A token that may be useful for some schemes. The token allows the 66 unreserved URI characters plus a few others.
+    According to the specification, it can hold a base64, base64url, base32, or base16 (hex) encoding, with or without padding, but excluding whitespace.
+
+Authorization parameter keys that are specific to each [authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
+These are listed below for some schemes.
+For others you may need to check the specifications:
+
+### Basic
+
+- **`<realm>`** {{optional_inline}}
+  - : As above.
+- **`charset="UTF-8"`** {{optional_inline}}
+  - : Tells the client the server's preferred encoding scheme when submitting a username and password.
+      The only allowed value is the case insensitive string "UTF-8".
+      This does not relate to the encoding of the realm string.
 
 ## Examples
 
-Typically, a server response contains a `WWW-Authenticate` header that looks like this:
+### Basic authentication
 
-```
+A server that only supports basic authentication might have a `WWW-Authenticate` response header which looks like this:
+
+```http
 WWW-Authenticate: Basic realm="Access to the staging site", charset="UTF-8"
+```
+
+Both the realm and charset are optional, so it could instead look like this:
+
+```http
+WWW-Authenticate: Basic
 ```
 
 See also [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) for examples on how to configure Apache or nginx servers to password protect your site with HTTP basic authentication.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -22,7 +22,7 @@ This response must include at least one `WWW-Authenticate` header and at least o
 Multiple challenges are allowed in one `WWW-Authenticate` header, and multiple `WWW-Authenticate` headers are allowed in one response.
 A server may also include the `WWW-Authenticate` header in other response messages to indicate that supplying credentials might affect the response.
 
-After recieving `WWW-Authenticate` a client will typically prompt the user for credentials, and then re-request the resource.
+After receiving the `WWW-Authenticate` header, a client will typically prompt the user for credentials, and then re-request the resource.
 This request uses the {{HTTPHeader("Authorization")}} header to supply the credentials to the server, encoded appropriately for the selected "challenge" authentication method.
 The client is expected to select the most secure of the challenges it understands (note that in some cases the "most secure" method is debatable).
 

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -100,7 +100,7 @@ For others you may need to check the specifications:
   - : As above.
 - **`charset="UTF-8"`** {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.
-      The only allowed value is the case insensitive string "UTF-8".
+      The only allowed value is the case-insensitive string "UTF-8".
       This does not relate to the encoding of the realm string.
 
 ## Examples

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -19,7 +19,7 @@ The HTTP **`WWW-Authenticate`** response header defines the [HTTP authentication
 A server using [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) will respond with a {{HTTPStatus("401")}} `Unauthorized` response to a request for a protected resource.
 This response must include at least one `WWW-Authenticate` header and at least one {{Glossary("challenge")}}, to indicate what authentication schemes can be used to access the resource (and any additional data that each particular scheme needs).
 
-Multiple challenges are allowed in the one `WWW-Authenticate` header, and multiple `WWW-Authenticate` headers are allowed in the one response.
+Multiple challenges are allowed in one `WWW-Authenticate` header, and multiple `WWW-Authenticate` headers are allowed in one response.
 A server may also include the `WWW-Authenticate` header in other response messages to indicate that supplying credentials might affect the response.
 
 After recieving `WWW-Authenticate` a client will typically prompt the user for credentials, and then re-request the resource.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -16,7 +16,7 @@ The HTTP **`WWW-Authenticate`** response header defines the [HTTP authentication
 > **Note:** This header is part of the [General HTTP authentication framework](/en-US/docs/Web/HTTP/Authentication#the_general_http_authentication_framework), which can be used with a number of [authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes) .
 > Each "challenge" lists a scheme supported by the server and additional parameters that are defined for that scheme type. 
 
-A server using [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) will respond with {{HTTPStatus("401")}} `Unauthorized` response to a request for a protected resource.
+A server using [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) will respond with a {{HTTPStatus("401")}} `Unauthorized` response to a request for a protected resource.
 This response must include at least one `WWW-Authenticate` header and at least one {{Glossary("challenge")}}, to indicate what authentication schemes can be used to access the resource (and any additional data that each particular scheme needs).
 
 Multiple challenges are allowed in the one `WWW-Authenticate` header, and multiple `WWW-Authenticate` headers are allowed in the one response.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -42,7 +42,7 @@ The client is expected to select the most secure of the challenges it understand
 ## Syntax
 
 At least one challenge must be specified.
-Multiple challenges may be specified commas-separated in a single header, or in individual headers:
+Multiple challenges may be specified, comma-separated, in a single header, or in individual headers:
 ```http
 // Challenges specified in single header
 WWW-Authenticate: challenge1, ..., challengeN


### PR DESCRIPTION
FF93 supports SHA256 for digest authentication.  Docs work can be tracked in #8682

This is just the first part of the work. What I have discovered is that the HTTP Authorization stuff is overly focussed on basic authorization. This first fix is primarily to `WWW-Authenticate` to make it clear that this is part of a generic framework that may be modified for specific authorization schemes. 
Essentially with this change it still really only covers "Basic" but will be easy to extend for Digest when I do that (next).
If you're OK with that change I'll roll it out to the `Authorization` header. 

I will be adding more about schemas and what is supported but that is mostly going to be in one place - the HTTP authentication header OR BCD (in discussion). What I'd like to do is have in BCD along with the associated specs, but still in discussion. 

Following all this, I hope to actually be able to go in and add Digest information - and it will then be in a structure that anyone else can extend if they like.