### PR TITLE
Fix typo: Plural vs Singular

### DIFF
--- a/files/en-us/web/api/touch/index.html
+++ b/files/en-us/web/api/touch/index.html
@@ -29,7 +29,7 @@ browser-compat: api.Touch
 
 <h2 id="Properties">Properties</h2>
 
-<p><em>This interface has no parent, and doesn't inherits or implements any other property.</em></p>
+<p><em>This interface has no parent, and doesn't inherit or implement other properties.</em></p>
 
 <h3 id="Basic_properties">Basic properties</h3>
 
@@ -69,7 +69,7 @@ browser-compat: api.Touch
 
 <h2 id="Methods">Methods</h2>
 
-<p><em>This interface has no method and no parent, and doesn't inherits or implements any method.</em></p>
+<p><em>This interface has no methods and no parent, and doesn't inherit or implement any methods.</em></p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fix plural nouns that should be singular or vice versa.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None.


> What was wrong/why is this fix needed? (quick summary only)

Typos. Plural nouns that should be singular or vice versa.


> Anything else that could help us review it

Don't think so! Thanks!
