### PR TITLE
Remove CSS referencing outdated/removed content

### DIFF
--- a/files/en-us/web/html/element/details/index.html
+++ b/files/en-us/web/html/element/details/index.html
@@ -209,10 +209,6 @@ details &gt; summary {
   list-style: none;
 }
 
-details &gt; summary::-webkit-details-marker {
-  display: none;
-}
-
 details &gt; p {
   border-radius: 0 0 10px 10px;
   background-color: #ddd;


### PR DESCRIPTION
Remove CSS that references an outdated note (already removed on issue #8398).

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Helps to fix issue #8398.

> What was wrong/why is this fix needed? (quick summary only)

The CSS code is related to some content that was removed.

> Anything else that could help us review it

The CSS was referencing this note: 

```Chrome doesn't support this yet, however, so we also need to use its non-standard ::-webkit-details-marker pseudo-element to customize the appearance in that browser.```

Since it's not present anymore, this CSS rule doesn't apply anymore.
