### PR TITLE
FF92 relnote + glossary : HTTPS RR used for HTTPS connectiosn

### DIFF
--- a/files/en-us/glossary/https_rr/index.html
+++ b/files/en-us/glossary/https_rr/index.html
@@ -8,8 +8,10 @@ tags:
   - Infrastructure
   - Security
 ---
-<p><strong>HTTPS RR</strong> (<strong><em>HTTPS Resource Records</em></strong>) are a type of DNS record that delivers configuration information and parameters for how to access a service via {{Glossary("HTTPS")}}.
-  Among other things, the presence of an HTTPS RR record signals that all useful {{Glossary("HTTP")}} resources on the origin are reachable over HTTPS, which in turn means that a browser can upgrade connections to the domain from HTTP to HTTPS. </p>
+<p><strong>HTTPS RR</strong> (<strong><em>HTTPS Resource Records</em></strong>) are a type of DNS record that delivers configuration information and parameters for how to access a service via {{Glossary("HTTPS")}}.</p>
+
+<p>An <em>HTTPS RR</em> can be used to optimize the process of connecting to a service using HTTPS.
+  Further, the presence of an <em>HTTPS RR</em> signals that all useful {{Glossary("HTTP")}} resources on the origin are reachable over HTTPS, which in turn means that a browser can safely upgrade connections to the domain from HTTP to HTTPS. </p>
 
 <h3>See also</h3>
 

--- a/files/en-us/glossary/https_rr/index.html
+++ b/files/en-us/glossary/https_rr/index.html
@@ -1,0 +1,22 @@
+---
+title: HTTPS RR
+slug: Glossary/https_rr
+tags:
+  - Glossary
+  - HTTPS
+  - HTTPS RR
+  - Infrastructure
+  - Security
+---
+<p><strong>HTTPS RR</strong> (<strong><em>HTTPS Resource Records</em></strong>) are a type of DNS record that delivers configuration information and parameters for how to access a service via {{Glossary("HTTPS")}}.
+  Among other things, the presence of an HTTPS RR record signals that all useful {{Glossary("HTTP")}} resources on the origin are reachable over HTTPS, which in turn means that a browser can upgrade connections to the domain from HTTP to HTTPS. </p>
+
+<h3>See also</h3>
+
+<ul>
+  <li><a href="https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/00/">Service binding and parameter specification via the DNS (DNS SVCB and HTTPS RRs)</a> (Draft IETF specification: draft-ietf-dnsop-svcb-https-00)</li>
+  <li><a href="https://emilymstark.com/2020/10/24/strict-transport-security-vs-https-resource-records-the-showdown.html">Strict Transport Security vs. HTTPS Resource Records: the showdown</a> (Emily M. Stark blog)</li>
+  <li>{{glossary("SSL")}}</li>
+  <li>{{glossary("TLS")}}</li>
+</ul>
+

--- a/files/en-us/mozilla/firefox/releases/92/index.html
+++ b/files/en-us/mozilla/firefox/releases/92/index.html
@@ -38,6 +38,13 @@ tags:
   <li>{{jsxref("Object.hasOwn()")}} can be used to test whether a property was defined on an object or inherited ({{bug(1721149)}}).</li>
 </ul>
 
+<h3 id="HTTP">HTTP</h3>
+
+<ul>
+  <li>Firefox will automatically upgrade an HTTP request to HTTPS when a usable {{Glossary("HTTPS RR")}} is available.
+    It will also use information provided in an <em>HTTPS RR</em> to optimize the process of establishing HTTPS connections⁠—this is conceptually similar to using the {{HTTPHeader("Alt-Svc")}} header. 
+    ({{bug(1721132)}}).</li>
+</ul>
 
 <h3 id="APIs">APIs</h3>
 


### PR DESCRIPTION
FF92 will automatically upgrade a connection from HTTP to HTTPS if an HTTP Resource record ("HTTPS RR") is available (because the record indicates all HTTP resources on the domain can be accessed by HTTPS).

Further, if setting up a connection for HTTPS (i.e. maybe the first time, rather than upgrading), if it has the HTTPS RR it will use the information to optimise the connection.

I have added release notes and a glossary  that say this. 

This is part of delivering #8683