### PR TITLE
update return type of ShadowRoot.host

### DIFF
--- a/files/en-us/web/api/shadowroot/host/index.html
+++ b/files/en-us/web/api/shadowroot/host/index.html
@@ -23,7 +23,7 @@ browser-compat: api.ShadowRoot.host
 
 <h3 id="Value">Value</h3>
 
-<p>A  DOM {{domxref('Element')}}.</p>
+<p>A  DOM {{domxref('HTMLElement')}}.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A

> What was wrong/why is this fix needed? (quick summary only)

Aren't ShadowRoot hosts only allowed to be `HTMLElement`s? For example, we can't add roots to `SVGElement`s.

> Anything else that could help us review it

`attachShadow` exists on non HTMLElement instances, but it just throws when called on those instances.

Does it need to be `Element` in case we work out how to attach shadows to non HTMLElement instances later (and the spec gets updated)?

