### PR TITLE
CSS: Fix currentColor reference in box-shadow

### DIFF
--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -84,7 +84,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
   - : This is a fourth {{cssxref("&lt;length&gt;")}} value. Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be `0` (the shadow will be the same size as the element).
 - `<color>`
   - : See {{cssxref("&lt;color&gt;")}} values for possible keywords and notations.
-    If not specified, it defaults to {{cssxref("&lt;color&gt;","currentcolor","#currentcolor_keyword")}}.
+    If not specified, it defaults to {{cssxref("&lt;color&gt;","currentColor","#currentcolor_keyword")}}.
 
 ### Interpolation
 

--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -84,7 +84,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
   - : This is a fourth {{cssxref("&lt;length&gt;")}} value. Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be `0` (the shadow will be the same size as the element).
 - `<color>`
   - : See {{cssxref("&lt;color&gt;")}} values for possible keywords and notations.
-    If not specified, it defaults to {{cssxref("color_value#currentcolor_keyword")}}.
+    If not specified, it defaults to {{cssxref("&lt;color&gt;","currentcolor","#currentcolor_keyword")}}.
 
 ### Interpolation
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

Very small PR: The link to currentColot wasn't showing up right in this article. 
I fixed it to be the same as references to currentColor on other pages like [caret-color](https://developer.mozilla.org/en-US/docs/Web/CSS/caret-color)

