### PR TITLE
Make the note less ambiguous

### DIFF
--- a/files/en-us/web/css/border-image/index.md
+++ b/files/en-us/web/css/border-image/index.md
@@ -15,7 +15,7 @@ The **`border-image`** [CSS](/en-US/docs/Web/CSS) property draws an image around
 
 {{EmbedInteractiveExample("pages/css/border-image.html")}}
 
-> **Note:** You should specify a separate {{cssxref("border-style")}} in case the border image fails to load. Indeed, this is required according to the specification, although not all browsers implement this requirement.
+> **Note:** You should specify a separate {{cssxref("border-style")}} in case the border image fails to load. Although the specification doesn't strictly require it, some browsers don't render the border image if {{cssxref("border-style")}} is `none` or {{cssxref("border-width")}} is `0`.
 
 ## Constituent properties
 


### PR DESCRIPTION
The specification actually doesn't _require_ `border-style` and/or `border-width` for `border-image` to be rendered (https://github.com/w3c/csswg-drafts/issues/655#issuecomment-365454403). However, some browsers indeed would not render it without them (although this is technically a bug and is being fixed), so specifying them is a reasonable practical requirement at the moment (and providing fallbacks is a good practice anyway).

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
