### PR TITLE
Clarify CSS injection timing

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -78,9 +78,9 @@ browser-compat: webextensions.manifest.content_scripts
    <td><a id="css"><code>css</code></a></td>
    <td><code>Array</code></td>
    <td>
-    <p>An array of paths, relative to <code>manifest.json</code>, referencing CSS files that will be injected into matching pages.</p>
+    <p>An array of paths, relative to the manifest.json file, referencing CSS files that will be injected into matching pages.</p>
 
-    <p>Files are injected in the order given, and before the DOM is loaded.</p>
+    <p>Files are injected in the order given, and at the time specified by <code><a href="#run_at">run_at</a></code>.</p>
 
     <div class="notecard note">
     <p><strong>Note:</strong> Firefox resolves URLs in injected CSS files relative to the CSS file itself, rather than to the page it's injected into.</p>
@@ -115,7 +115,7 @@ browser-compat: webextensions.manifest.content_scripts
 
     <p>...then <code>"my-content-script.js"</code> can use jQuery.</p>
 
-    <p>Files are injected at the time specified by <code><a href="#run_at">run_at</a></code>.</p>
+    <p>The files are injected after any files in <code><a href="#css">css</a></code>, and at the time specified by <code><a href="#run_at">run_at</a></code>.</p>
    </td>
   </tr>
   <tr>
@@ -160,7 +160,7 @@ browser-compat: webextensions.manifest.content_scripts
    <td><a id="run_at"><code>run_at</code></a></td>
    <td><code>String</code></td>
    <td>
-    <p>This option determines when the scripts specified in <code><a href="#js">js</a></code> are injected. You can supply one of three strings here, each of which identifies a state in the process of loading a document. The states directly correspond to {{domxref("Document/readyState", "Document.readyState")}}:</p>
+    <p>This option determines when the files specified in <code><a href="#css">css</a></code> and <code><a href="#js">js</a></code> are injected. You can supply one of three strings here, each of which identifies a state in the process of loading a document. The states directly correspond to {{domxref("Document/readyState", "Document.readyState")}}:</p>
 
     <dl>
      <dt><code>"document_start"</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -78,7 +78,7 @@ browser-compat: webextensions.manifest.content_scripts
    <td><a id="css"><code>css</code></a></td>
    <td><code>Array</code></td>
    <td>
-    <p>An array of paths, relative to the manifest.json file, referencing CSS files that will be injected into matching pages.</p>
+    <p>An array of paths, relative to <code>manifest.json</code>, referencing CSS files that will be injected into matching pages.</p>
 
     <p>Files are injected in the order given, and at the time specified by <code><a href="#run_at">run_at</a></code>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -106,7 +106,7 @@ browser-compat: webextensions.manifest.content_scripts
    <td><a id="js"><code>js</code></a></td>
    <td><code>Array</code></td>
    <td>
-    <p>An array of paths, relative to the manifest.json file, referencing JavaScript files that will be injected into matching pages.</p>
+    <p>An array of paths, relative to <code>manifest.json</code>, referencing JavaScript files that will be injected into matching pages.</p>
 
     <p>Files are injected in the order given. This means that, for example, if you include jQuery here followed by another content script, like this...</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -90,17 +90,17 @@ browser-compat: webextensions.manifest.content_scripts
   <tr>
    <td><a id="exclude_globs"><code>exclude_globs</code></a></td>
    <td><code>Array</code></td>
-   <td>An array of strings containing wildcards. See <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#matching_url_patterns">Matching URL patterns</a> below.</td>
+   <td>An array of strings containing wildcards. See <a href="#matching_url_patterns">Matching URL patterns</a> below.</td>
   </tr>
   <tr>
    <td><a id="exclude_matches"><code>exclude_matches</code></a></td>
    <td><code>Array</code></td>
-   <td>An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>. See <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#matching_url_patterns">Matching URL patterns</a> below.</td>
+   <td>An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>. See <a href="#matching_url_patterns">Matching URL patterns</a> below.</td>
   </tr>
   <tr>
    <td><a id="include_globs"><code>include_globs</code></a></td>
    <td><code>Array</code></td>
-   <td>An array of strings containing wildcards. See <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#matching_url_patterns">Matching URL patterns</a> below.</td>
+   <td>An array of strings containing wildcards. See <a href="#matching_url_patterns">Matching URL patterns</a> below.</td>
   </tr>
   <tr>
    <td><a id="js"><code>js</code></a></td>
@@ -122,7 +122,7 @@ browser-compat: webextensions.manifest.content_scripts
    <td><code><a id="match_about_blank">match_about_blank</a></code></td>
    <td><code>Boolean</code></td>
    <td>
-    <p>Insert the content scripts into pages whose URL is <code>"about:blank"</code> or <code>"about:srcdoc"</code>, if the URL of the page that opened or created this page <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#matching_url_patterns">matches the patterns</a> specified in the rest of the <code>content_scripts</code> key.</p>
+    <p>Insert the content scripts into pages whose URL is <code>"about:blank"</code> or <code>"about:srcdoc"</code>, if the URL of the page that opened or created this page <a href="#matching_url_patterns">matches the patterns</a> specified in the rest of the <code>content_scripts</code> key.</p>
 
     <p>This is especially useful to run scripts in empty iframes , whose URL is <code>"about:blank"</code>. To do this you should also set the <code>all_frames</code> key.</p>
 
@@ -143,7 +143,7 @@ browser-compat: webextensions.manifest.content_scripts
     <div class="notecard note">
     <p><strong>Note: </strong><code>match_about_blank</code> is supported in Firefox from version 52. </p>
 
-    <p>Note that in Firefox, content scripts won't be injected into empty iframes at <code>"document_start"</code>, even if you specify that value in <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#run_at">run_at</a></code> .</p>
+    <p>Note that in Firefox, content scripts won't be injected into empty iframes at <code>"document_start"</code>, even if you specify that value in <code><a href="#run_at">run_at</a></code> .</p>
     </div>
    </td>
   </tr>
@@ -151,7 +151,7 @@ browser-compat: webextensions.manifest.content_scripts
    <td><a id="matches"><code>matches</code></a></td>
    <td><code>Array</code></td>
    <td>
-    <p>An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>. See <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#matching_url_patterns">Matching URL patterns</a> below.</p>
+    <p>An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>. See <a href="#matching_url_patterns">Matching URL patterns</a> below.</p>
 
     <p>This is the only mandatory key.</p>
    </td>


### PR DESCRIPTION
Fixes #8914

The [content_scripts page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) was unclear regarding the timing of CSS file injection. The [css](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#css) section said they were injected before the DOM was loaded, and it wasn't clear that the [run_at](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#run_at) key controlled when the CSS would be injected.