### PR TITLE
Additional explanation regarding views not matched

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
@@ -43,7 +43,7 @@ browser-compat: webextensions.api.extension.getViews
   <dt><code>type</code>{{optional_inline}}</dt>
   <dd><code>string</code>. An {{WebExtAPIRef('extension.ViewType')}} indicating the type of view to get. If omitted, this function returns all views.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>
-  <dd><code>integer</code>. The window to restrict the search to. If omitted, this function returns all views. In Firefox version 92 and earlier, sidebar details are not returned.</dd>
+  <dd><code>integer</code>. The window to restrict the search to. If omitted, this function returns all views. In Firefox version 92 and earlier, sidebar views are not matched and, therefore, not returned.</dd>
  </dl>
  </dd>
 </dl>


### PR DESCRIPTION
Addresses feedback on [Sidebars included in extension.getViews when windowId specified #8399](https://github.com/mdn/content/pull/8399) made after the merge.