### PR TITLE
Linkify Option() ctor and move it into the right section

### DIFF
--- a/files/en-us/web/api/htmloptionelement/index.md
+++ b/files/en-us/web/api/htmloptionelement/index.md
@@ -15,6 +15,11 @@ The **`HTMLOptionElement`** interface represents {{HTMLElement("option")}} eleme
 
 {{InheritanceDiagram(600, 120)}}
 
+## Constructor
+
+- {{domxref("HTMLOptionElement.Option", "Option()")}}
+  - : Returns a newly created `HTMLOptionElement` object. It has four parameters: the text to display, `text`, the value associated, `value`, the value of `defaultSelected`, and the value of `selected`. The last three parameters are optional.
+
 ## Properties
 
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
@@ -38,10 +43,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 ## Methods
 
-_Inherits methods from its parent, {{domxref("HTMLElement")}}._
+_Doesn't implement specific methods, but inherits methods from its parent, {{domxref("HTMLElement")}}._
 
-- Option()
-  - : Is a constructor creating an `HTMLOptionElement` object. It has four values: the text to display, `text`, the value associated, `value`, the value of `defaultSelected`, and the value of `selected`. The last three values are optional.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmloptionelement/index.md
+++ b/files/en-us/web/api/htmloptionelement/index.md
@@ -43,7 +43,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 ## Methods
 
-_Doesn't implement specific methods, but inherits methods from its parent, {{domxref("HTMLElement")}}._
+_Doesn't implement any specific method, but inherits methods from its parent, {{domxref("HTMLElement")}}._
 
 
 ## Specifications


### PR DESCRIPTION
The unusual `Option()` ctor was not a link and not under the Constructor section. This fixes this.