### PR TITLE
Fix PeriodicWave() name

### DIFF
--- a/files/en-us/web/api/periodicwave/index.md
+++ b/files/en-us/web/api/periodicwave/index.md
@@ -21,7 +21,7 @@ The **`PeriodicWave`** interface defines a periodic waveform that can be used to
 
 ## Constructor
 
-- {{domxref("PeriodicWave.PeriodicWave()")}}
+- {{domxref("PeriodicWave.PeriodicWave", "PeriodicWave()")}}
   - : Creates a new `PeriodicWave` object instance using the default values for all properties. If you wish to establish custom property values at the outset, use the {{domxref("BaseAudioContext.createPeriodicWave")}} factory method instead.
 
 ## Properties


### PR DESCRIPTION
Fix the `PeriodicWave()` ctor's name.