### PR TITLE
Fix typography and structure of PerformanceNavigationTiming.type

### DIFF
--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -16,16 +16,16 @@ The **`type`** read-only property returns a the type of navigation.
 
 A {{domxref("DOMString","string")}} containing one of the following values:
 
-- `navigate`
+- `"navigate"`
   - : Navigation started by clicking a link, entering the URL in the browser's address
     bar, form submission, or initializing through a script operation other than reload and
     back_forward as listed below.
-- `reload`
+- `"reload"`
   - : Navigation is through the browser's reload operation or
     {{domxref("location.reload()")}}.
-- `back_forward`
+- `"back_forward"`
   - : Navigation is through the browser's history traversal operation.
-- `prerender`
+- `"prerender"`
   - : Navigation is initiated by a [prerender hint](https://www.w3.org/TR/resource-hints/#prerender).
 
 ## Example

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -14,7 +14,7 @@ The **`type`** read-only property returns a the type of navigation.
 
 ## Value
 
-The value is one of the following strings:
+A {{domxref("DOMString","string")}} containing one of the following values:
 
 - `navigate`
   - : Navigation started by clicking a link, entering the URL in the browser's address

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -10,33 +10,23 @@ browser-compat: api.PerformanceNavigationTiming.type
 ---
 {{APIRef("Navigation Timing")}}{{SeeCompatTable}}
 
-The **`type`** read-only property returns a
-{{domxref("DOMString","string")}} representing the type of navigation. The value must be
-one of the following:
+The **`type`** read-only property returns a the type of navigation.
 
-- navigate
+## Value
+
+The value is one of the following strings:
+
+- `navigate`
   - : Navigation started by clicking a link, entering the URL in the browser's address
     bar, form submission, or initializing through a script operation other than reload and
     back_forward as listed below.
-- reload
+- `reload`
   - : Navigation is through the browser's reload operation or
     {{domxref("location.reload()")}}.
-- back_forward
+- `back_forward`
   - : Navigation is through the browser's history traversal operation.
-- prerender
+- `prerender`
   - : Navigation is initiated by a [prerender hint](https://www.w3.org/TR/resource-hints/#prerender).
-
-This property is {{readonlyInline}}.
-
-## Syntax
-
-```js
-perfEntry.type;
-```
-
-### Return Value
-
-A {{domxref("DOMString","string")}} which is one of the values listed above.
 
 ## Example
 


### PR DESCRIPTION
Strings were not in `<code>`. Read-only was mentioned twice. Fixed the structure to match the most recent property page template.

(Found when reviewing the _Giant MD Conversion PR™_.)