### PR TITLE
Remove unrelated comment in EventListener.handleEvent

### DIFF
--- a/files/en-us/web/api/eventlistener/handleevent/index.md
+++ b/files/en-us/web/api/eventlistener/handleevent/index.md
@@ -39,7 +39,7 @@ eventListener.handleEvent(event);
 
 ### Return value
 
-`undefined`. If you return a value, the browser will ignore it.
+None.
 
 ## Specifications
 


### PR DESCRIPTION
The sentence is unrelated to the section. This is about the method handleEvent, not the handler called.