### PR TITLE
Remove tables from SVGAnimatedLength

### DIFF
--- a/files/en-us/web/api/svganimatedlength/index.md
+++ b/files/en-us/web/api/svganimatedlength/index.md
@@ -9,81 +9,25 @@ browser-compat: api.SVGAnimatedLength
 ---
 {{APIRef("SVG")}}
 
-## SVG animated length interface
-
-The `SVGAnimatedLength` interface is used for attributes of basic type [\<length>](/en-US/docs/SVG/Content_type#Length) which can be animated.
-
-### Interface overview
-
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="row">Also implement</th>
-      <td><em>None</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Methods</th>
-      <td><em>None</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Properties</th>
-      <td>
-        <ul>
-          <li>
-            readonly {{ domxref("SVGLength") }} <code>baseVal</code>
-          </li>
-          <li>
-            readonly {{ domxref("SVGLength") }} <code>animVal</code>
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Normative document</th>
-      <td>
-        <a
-          href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedLength"
-          >SVG 1.1 (2nd Edition)</a
-        >
-      </td>
-    </tr>
-  </tbody>
-</table>
+The `SVGAnimatedLength` interface represents attributes of type [\<length>](/en-US/docs/Web/SVG/Content_type#length) which can be animated.
 
 ## Properties
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>baseVal</code></td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        The base value of the given attribute before applying any animations.
-      </td>
-    </tr>
-    <tr>
-      <td><code>animVal</code></td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        If the given attribute or property is being animated, contains the
-        current animated value of the attribute or property. If the given
-        attribute or property is not currently being animated, contains the same
-        value as <code>baseVal</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
+- {{domxref("baseVal")}} {{ReadOnlyInline}}
+  - : A {{domxref("SVGLength")}} representing the base value of the given attribute before applying any animations.
+- {{domxref("animVal")}} {{ReadOnlyInline}}
+  - : If the given attribute or property is being animated, 
+    a {{domxref("SVGLength")}} containing the current animated value of the attribute or property. 
+    If the given attribute or property is not currently being animated, 
+    a {{domxref("SVGLength")}} containing the same value as <code>baseVal</code>.
 
 ## Methods
 
-The `SVGAnimatedLength` interface do not provide any specific methods.
+_This interface does not implement any specific methods._
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
Updated the interface structure so that it doesn't use table structure anymore