### PR TITLE
Fix HierarchyRequestError DOMException

### DIFF
--- a/files/en-us/web/api/characterdata/after/index.md
+++ b/files/en-us/web/api/characterdata/after/index.md
@@ -29,8 +29,8 @@ after(... nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/characterdata/before/index.md
+++ b/files/en-us/web/api/characterdata/before/index.md
@@ -29,8 +29,8 @@ before(... nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -28,8 +28,8 @@ replaceWith(...nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -48,23 +48,23 @@ stylesheet.insertRule(rule [, index])
 
 The newly inserted rule's index within the stylesheet's rule-list.
 
-### Restrictions
+### Exceptions
 
 CSS has some intuitive and not-so-intuitive restrictions affecting where rules can be
-inserted. Violating them will likely raise a {{domxref("DOMException")}}.
+inserted. Violating them will raise an exception.
 
 - If `index` >
   `{{domxref("CSSRuleList", "", "", "1")}}.length`, the method aborts with an
-  `IndexSizeError`.
+  `IndexSizeError` {{domxref("DOMException")}}.
 - If `rule` cannot be inserted at `index` `0` due to
   some CSS constraint, the method aborts with a `HierarchyRequestError` {{domxref("DOMException")}}.
 - If more than one rule is given in the `rule` parameter, the method aborts
-  with a `SyntaxError`.
+  with a `SyntaxError`{{domxref("DOMException")}}.
 - If trying to insert an {{cssxref("@import")}} at-rule after a style rule, the method
   aborts with a `HierarchyRequestError`  {{domxref("DOMException")}}.
 - If `rule` is {{cssxref("@namespace")}} and the rule-list has more than
   just `@import` at-rules and/or `@namespace` at-rules, the method
-  aborts with an `InvalidStateError`.
+  aborts with an `InvalidStateError` {{domxref("DOMException")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -57,11 +57,11 @@ inserted. Violating them will likely raise a {{domxref("DOMException")}}.
   `{{domxref("CSSRuleList", "", "", "1")}}.length`, the method aborts with an
   `IndexSizeError`.
 - If `rule` cannot be inserted at `index` `0` due to
-  some CSS constraint, the method aborts with a `HierarchyRequestError`.
+  some CSS constraint, the method aborts with a `HierarchyRequestError` {{domxref("DOMException")}}.
 - If more than one rule is given in the `rule` parameter, the method aborts
   with a `SyntaxError`.
 - If trying to insert an {{cssxref("@import")}} at-rule after a style rule, the method
-  aborts with a `HierarchyRequestError`.
+  aborts with a `HierarchyRequestError`  {{domxref("DOMException")}}.
 - If `rule` is {{cssxref("@namespace")}} and the rule-list has more than
   just `@import` at-rules and/or `@namespace` at-rules, the method
   aborts with an `InvalidStateError`.

--- a/files/en-us/web/api/document/append/index.md
+++ b/files/en-us/web/api/document/append/index.md
@@ -32,7 +32,8 @@ append(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point
   in the hierarchy.
 
 ## Examples
@@ -40,7 +41,7 @@ append(...nodesOrDOMStrings)
 ### Appending a root element to a document
 
 If you try to append an element to an existing HTML document,
-it might throw a {{domxref("HierarchyRequestError")}} given a {{HTMLElement("html")}} element already exists.
+it might throw a `HierarchyRequestError`{{domxref("DOMException")}} given a {{HTMLElement("html")}} element already exists.
 
 ```js
 let html = document.createElement("html");

--- a/files/en-us/web/api/document/append/index.md
+++ b/files/en-us/web/api/document/append/index.md
@@ -33,8 +33,7 @@ append(...nodesOrDOMStrings)
 ### Exceptions
 
 - `HierarchyRequestError` {{DOMxRef("DOMException")}}
-  - : Thrown when the node cannot be inserted at the specified point
-  in the hierarchy.
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/document/prepend/index.md
+++ b/files/en-us/web/api/document/prepend/index.md
@@ -32,15 +32,15 @@ prepend(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 
 ### Prepending a root element to a document
 
 If you try to prepend an element to an existing HTML document,
-it might throw a {{domxref("HierarchyRequestError")}} given a {{HTMLElement("html")}} element already exists.
+it might throw a `HierarchyRequestError' {{domxref("DOMException")}} given a {{HTMLElement("html")}} element already exists.
 
 ```js
 let html = document.createElement("html");

--- a/files/en-us/web/api/document/replacechildren/index.md
+++ b/files/en-us/web/api/document/replacechildren/index.md
@@ -31,8 +31,8 @@ replaceChildren(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: The [constraints of the node
-  tree](https://dom.spec.whatwg.org/#concept-node-tree) are violated.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown if the [constraints of the node tree](https://dom.spec.whatwg.org/#concept-node-tree) are violated.
 
 ## Examples
 

--- a/files/en-us/web/api/documentfragment/append/index.md
+++ b/files/en-us/web/api/documentfragment/append/index.md
@@ -32,8 +32,8 @@ append(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/documentfragment/prepend/index.md
+++ b/files/en-us/web/api/documentfragment/prepend/index.md
@@ -32,8 +32,8 @@ prepend(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/documentfragment/replacechildren/index.md
+++ b/files/en-us/web/api/documentfragment/replacechildren/index.md
@@ -32,8 +32,8 @@ replaceChildren(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: The [constraints of the node
-  tree](https://dom.spec.whatwg.org/#concept-node-tree) are violated.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the nhe [constraints of the node tree](https://dom.spec.whatwg.org/#concept-node-tree) are violated.
 
 ## Examples
 

--- a/files/en-us/web/api/documenttype/after/index.md
+++ b/files/en-us/web/api/documenttype/after/index.md
@@ -29,12 +29,10 @@ after(... nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
-
-###
 
 ```js
 let docType = document.implementation.createDocumentType("html", "", "");

--- a/files/en-us/web/api/documenttype/before/index.md
+++ b/files/en-us/web/api/documenttype/before/index.md
@@ -33,8 +33,8 @@ before(... nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/documenttype/replacewith/index.md
+++ b/files/en-us/web/api/documenttype/replacewith/index.md
@@ -26,8 +26,8 @@ replaceWith(...nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/element/after/index.md
+++ b/files/en-us/web/api/element/after/index.md
@@ -29,8 +29,8 @@ after(... nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/element/append/index.md
+++ b/files/en-us/web/api/element/append/index.md
@@ -40,8 +40,8 @@ append(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/element/before/index.md
+++ b/files/en-us/web/api/element/before/index.md
@@ -29,8 +29,8 @@ before(... nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/element/prepend/index.md
+++ b/files/en-us/web/api/element/prepend/index.md
@@ -27,7 +27,7 @@ prepend(...nodesOrDOMStrings);
 ### Parameters
 
 - `nodesOrDOMStrings`
-  - : A set of {{domxref("Node")}} or {{domxref("DOMString")}} objects to insert.
+  - : A set of {{domxref("Node")}} or {{domxref("DOMString")}} objects to insert.
 
 ### Return value
 
@@ -35,8 +35,8 @@ prepend(...nodesOrDOMStrings);
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/element/replacechildren/index.md
+++ b/files/en-us/web/api/element/replacechildren/index.md
@@ -32,8 +32,8 @@ replaceChildren(...nodesOrDOMStrings)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: The [constraints of the node
-  tree](https://dom.spec.whatwg.org/#concept-node-tree) are violated.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the [constraints of the node tree](https://dom.spec.whatwg.org/#concept-node-tree) are violated.
 
 ## Examples
 

--- a/files/en-us/web/api/element/replacewith/index.md
+++ b/files/en-us/web/api/element/replacewith/index.md
@@ -29,8 +29,8 @@ replaceWith(...nodes)
 
 ### Exceptions
 
-- {{domxref("HierarchyRequestError")}}: Node cannot be inserted at the specified point
-  in the hierarchy.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlselectelement/add/index.md
+++ b/files/en-us/web/api/htmlselectelement/add/index.md
@@ -31,9 +31,8 @@ collection.add(item[, before]);
 
 ### Exceptions
 
-- A {{domxref("DOMError")}} of the type `HierarchyRequestError` if the
-  _item_ passed to the method is an ancestor of the
-  `{{domxref("HTMLSelectElement")}}`.
+- `HierarchyRequestError` {{DOMxRef("DOMException")}}
+  - : Thrown if the _item_ passed to the method is an ancestor of the`{{domxref("HTMLSelectElement")}}`.
 
 ## Examples
 


### PR DESCRIPTION
`HierarchyRequestError` is neither an interface nor a JS exception.

It is one of the possible `name` values of a `DOMException`.

Fixes all the cases where it wasn't explicit. This is something a lot of beginners have trouble understanding (and pushes them to ignore exceptions).