### PR TITLE
Fix exception table for SourceBuffer.trackDefaults

### DIFF
--- a/files/en-us/web/api/sourcebuffer/trackdefaults/index.md
+++ b/files/en-us/web/api/sourcebuffer/trackdefaults/index.md
@@ -37,30 +37,12 @@ A {{domxref("TrackDefaultList")}} object.
 
 The following exceptions may be thrown when setting a new value for this property.
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        One or more of the {{domxref("SourceBuffer")}} objects in
-        {{domxref("MediaSource.sourceBuffers")}} are being updated
-        (i.e. their {{domxref("SourceBuffer.updating")}} property is
-        currently <code>true</code>), or this <code>SourceBuffer</code> has been
-        removed from the {{domxref("MediaSource")}}.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-## Example
-
-TBD
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown when one or more of the {{domxref("SourceBuffer")}} objects 
+      in {{domxref("MediaSource.sourceBuffers")}} are being updated
+      (i.e. their {{domxref("SourceBuffer.updating")}} property is
+      currently <code>true</code>), or
+      this <code>SourceBuffer</code> has been removed from the {{domxref("MediaSource")}}.
 
 ## Browser compatibility
 


### PR DESCRIPTION
We don't use tables anymore for exceptions.