### PR TITLE
fix spec tables in box alignment properties

### DIFF
--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -249,7 +249,7 @@ display.addEventListener('change', function (evt) {
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.align-content.grid_context")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -232,7 +232,7 @@ display.addEventListener('change', function (evt) {
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.align-items.grid_context")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/align-self/index.md
+++ b/files/en-us/web/css/align-self/index.md
@@ -135,7 +135,7 @@ div:nth-child(3) {
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.align-self.grid_context")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -153,7 +153,7 @@ The `column-gap` property is specified as one of the values listed below.
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.column-gap.grid_context")}}
 
 ## Browser compatibility
 
@@ -162,5 +162,5 @@ The `column-gap` property is specified as one of the values listed below.
 ## See also
 
 - Related CSS properties: {{CSSxRef("row-gap")}}, {{CSSxRef("gap")}}
-- Grid Layout Guide: _[Basic concepts of grid layout - Gutters](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#Gutters)_
+- Grid Layout Guide: _[Basic concepts of grid layout - Gutters](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#gutters)_
 - Multi-column Layout Guide: _[Styling Columns](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns)_

--- a/files/en-us/web/css/gap/index.md
+++ b/files/en-us/web/css/gap/index.md
@@ -177,7 +177,7 @@ This property is specified as a value for `<'row-gap'>` followed optionally by a
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.gap.grid_context")}}
 
 ## Browser compatibility
 
@@ -186,4 +186,4 @@ This property is specified as a value for `<'row-gap'>` followed optionally by a
 ## See also
 
 - Related CSS properties: {{CSSxRef("row-gap")}}, {{CSSxRef("column-gap")}}
-- Grid Layout Guide: _[Basic concepts of grid layout - Gutters](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#Gutters)_
+- Grid Layout Guide: _[Basic concepts of grid layout - Gutters](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#gutters)_

--- a/files/en-us/web/css/justify-content/index.md
+++ b/files/en-us/web/css/justify-content/index.md
@@ -163,11 +163,11 @@ justifyContent.addEventListener("change", function (evt) {
 
 #### Result
 
-{{EmbedLiveSample("Setting_flex_item_distribution", "100%", 140)}}
+{{EmbedLiveSample("Setting_flex_item_distribution", "100%", 180)}}
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.justify-content.grid_context")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/justify-items/index.md
+++ b/files/en-us/web/css/justify-items/index.md
@@ -187,7 +187,7 @@ article {
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.justify-items.grid_context")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/justify-self/index.md
+++ b/files/en-us/web/css/justify-self/index.md
@@ -190,7 +190,7 @@ article {
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.justify-self.grid_context")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -124,7 +124,7 @@ row-gap: unset;
 
 ## Specifications
 
-{{Specifications}}
+{{Specifications("css.properties.row-gap.grid_context")}}
 
 ## Browser compatibility
 
@@ -133,4 +133,4 @@ row-gap: unset;
 ## See also
 
 - Related CSS properties: {{CSSxRef("column-gap")}}, {{CSSxRef("gap")}}
-- Grid Layout Guide: _[Basic concepts of grid layout - Gutters](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#Gutters)_
+- Grid Layout Guide: _[Basic concepts of grid layout - Gutters](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#gutters)_


### PR DESCRIPTION
All of these pages were missing a spec table after the change to how tables were displayed, this PR puts them back.
