### PR TITLE
Fix "event implements interface" phrasing

### DIFF
--- a/files/en-us/web/api/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.md
@@ -11,7 +11,7 @@ browser-compat: api.OfflineAudioCompletionEvent
 ---
 {{APIRef("Web Audio API")}}
 
-The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `OfflineAudioCompletionEvent` interface represents events that occur when the processing of an {{domxref("OfflineAudioContext")}} is terminated. The {{event("complete")}} event implements this interface.
+The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `OfflineAudioCompletionEvent` interface represents events that occur when the processing of an {{domxref("OfflineAudioContext")}} is terminated. The {{event("complete")}} event uses this interface.
 
 > **Note:** This interface is marked as deprecated; it is still supported for legacy reasons, but it will soon be superseded when the promise version of {{domxref("OfflineAudioContext.startRendering")}} is supported in browsers, which will no longer need it.
 

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -186,7 +186,7 @@ It is possible to process/render an audio graph very quickly in the background â
 - {{event("complete")}} (event)
   - : The `complete` event is fired when the rendering of an {{domxref("OfflineAudioContext")}} is terminated.
 - {{domxref("OfflineAudioCompletionEvent")}}
-  - : The `OfflineAudioCompletionEvent` represents events that occur when the processing of an {{domxref("OfflineAudioContext")}} is terminated. The {{event("complete")}} event implements this interface.
+  - : The `OfflineAudioCompletionEvent` represents events that occur when the processing of an {{domxref("OfflineAudioContext")}} is terminated. The {{event("complete")}} event uses this interface.
 
 ## Guides and tutorials
 


### PR DESCRIPTION
It's not correct to say that the "complete" event implements the
OfflineAudioCompletionEvent interface. To be pedantically correct, an
OfflineAudioCompletionEvent is fired with the type "complete", but just
say that the interface is used.