### PR TITLE
Fix RsaHashedImportParams in pkcs8 importKey example

### DIFF
--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -303,9 +303,6 @@ function importPrivateKey(pem) {
     binaryDer,
     {
       name: "RSA-PSS",
-      // Consider using a 4096-bit key for systems that require long-term security
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },
     true,


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Fixes the importKey example to correctly use [RsaHashedImportParams](https://developer.mozilla.org/en-US/docs/Web/API/RsaHashedImportParams). 
Passing `modulusLength` and `publicExponent` make no impact on the imported key and is rather computed from the key material.

> Anything else that could help us review it

https://w3c.github.io/webcrypto/#RsaHashedImportParams-dictionary
https://w3c.github.io/webcrypto/#rsa-pss-registration