### PR TITLE
Fix method invocation in “Beginning our Angular todo list app”

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.html
@@ -174,7 +174,7 @@ What would you like to do today?
 
 <p>In <code>app.component.ts</code>, add the following method to the class:</p>
 
-<pre class="brush: js">addItem(description) {
+<pre class="brush: js">addItem(description: string) {
   this.allItems.unshift({
     description,
     done: false


### PR DESCRIPTION
Fixes #6763
The angular CLI defaults to strict mode in the tsconfig, this includes a "no implicit any" rule.  
Setting up this method as instructed will get an error due to the implicit any type of the parameter.

```
Error: src/app/app.component.ts:28:11 - error TS7006: Parameter 'description' implicitly has an 'any' type.

28   addItem(description) {
             ~~~~~~~~~~~
```

---

This PR fixes the issue by adding a type to the parameter.