### PR TITLE
Remove mention of XUL in History API

### DIFF
--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.md
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.md
@@ -58,8 +58,6 @@ But `pushState()` has a few advantages:
 
 Note that `pushState()` never causes a `hashchange` event to be fired, even if the new URL differs from the old URL only in its hash.
 
-In a [XUL](/en-US/docs/Mozilla/Tech/XUL) document, it creates the specified XUL element.
-
 In other documents, it creates an element with a `null` namespace URI.
 
 ### The replaceState() method


### PR DESCRIPTION
XUL is dead (on MDN), so let's not obfuscate a page with what happens in XUL.