### PR TITLE
Remove broken useless link to XUL Tutorial

### DIFF
--- a/files/en-us/web/api/selection/getrangeat/index.md
+++ b/files/en-us/web/api/selection/getrangeat/index.md
@@ -57,5 +57,3 @@ for(let i = 0; i < sel.rangeCount; i++) {
 ## See also
 
 - {{domxref("Selection")}}, the interface it belongs to.
-- [Tree Selection](/en-US/docs/XUL_Tutorial/Tree_Selection) (for the
-  `getRangeAt()` method on the `nsITreeSelection` interface)


### PR DESCRIPTION
XUL is gone and the link was broken and useless.