### PR TITLE
Remove mention of TrustedTypePolicyOptions

### DIFF
--- a/files/en-us/web/api/trusted_types_api/index.md
+++ b/files/en-us/web/api/trusted_types_api/index.md
@@ -46,8 +46,6 @@ A policy is a factory for Trusted Types. Web developers can specify a set of pol
   - : Defines the functions used to create the above Trusted Type objects.
 - {{domxref("TrustedTypePolicyFactory")}}
   - : Creates policies and verifies that Trusted Type object instances were created via one of the policies.
-- {{domxref("TrustedTypePolicyOptions")}}
-  - : A dictionary that holds author-defined functions for converting string values into trusted values.
 
 ## Examples
 


### PR DESCRIPTION
1. The link was broken
2. We don't document `TrustedTypePolicyOptions` separately, so it will stay broken
3. It was listed under interfaces, and it is not.