### PR TITLE
Partial rewrite of container queries doc for new draft spec

### DIFF
--- a/files/en-us/web/css/css_container_queries/index.md
+++ b/files/en-us/web/css/css_container_queries/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{CSSRef}}
 
-> **Note:** This document is an explanation of an early stage specification that is attracting a lot of interest from web developers. The examples and syntax below should be seen as an explainer to an evolving specification, in order to encourage experimentation and feedback. Once the specification matures, this will be the location of the full MDN documentation for container queries.
+> **Note:** This document is an explanation of an early stage specification that is attracting a lot of interest from web developers. The examples and syntax below should be seen as an explainer to an evolving specification, in order to encourage experimentation and feedback. Once the specification matures, this will be the location of the full MDN documentation for container queries. Last updated on 15 September 2021 to add details of the new properties `container-type`, `container-name`, and `container`.
 
 ## What problem do container queries solve?
 
@@ -31,13 +31,42 @@ It is this situation that container queries would solve. Instead of looking at t
 
 ## The container queries proposal
 
-The container queries specification is to become part of {{cssxref("CSS_Containment", "CSS Containment")}}, and add new values to the {{cssxref("contain")}} property. The `contain` property was initially designed to allow for performance optimizations. It provides a way for web developers to isolate parts of the DOM and declare to the browser these are independent from the rest of the document.
+The container queries specification is to become part of {{cssxref("CSS_Containment", "CSS Containment")}}. The initial CSS Containment draft defined the {{cssxref("contain")}} property to allow for performance optimizations. It provides a way for web developers to isolate parts of the DOM and declare to the browser these are independent from the rest of the document.
 
-For container queries, the `container-type` property describes the possible query types which can be used on a container. When `container-type` is defined on a parent container, the `@container` query can be used to apply conditional style rules to its descendants.
+The level 3 [draft specification](https://drafts.csswg.org/css-contain-3/) adds the `inline-size` and `block-size` keywords to `contain`.
 
-Using `container-type: size` indicates to the browser that the size of this area is known in both dimensions. A container that knows how big it is, is exactly what we need for container queries!
+In addition the draft specification proposes some new properties:
 
-However, we don't often know how big things are in both dimensions. When we use media queries, most of the time we care about the available width (or inline size). We define columns as a percentage or fraction of the space in that dimension. Therefore, container queries use the `container-type` property to allow size to be indicated in one dimension only. This is described as single-axis containment.
+- `container-type`
+  - : Defines an element as a **query container**. Descendents can query aspects of its sizing, layout, and style.
+- `container-name`
+  - : Specifies a list of **query container names** for `@container` rules to use to filter which query containers are targeted.
+- `container`:
+  - : A shorthand property to set both `container-type` and `container-name`.
+
+### `container-type`
+
+The `container-type` property can have the following values:
+
+- `size`
+  - : Establishes a query container for dimensional queries on the block and inline axis. Applies layout, style, and size containment to the element.
+- `inline-size`
+  - : Establishes a query container for dimensional queries on the inline axis of the container. Applies layout, style, and inline-size containment to the element.
+- `block-size`
+  - : Establishes a query container for dimensional queries on the the block axis of the container. Applies layout, style, and block-size containment to the element.
+- `style`
+  - : Establishes a query container for style queries.
+- `state`
+  - : Establishes a query container for state queries.
+
+
+> **Note:** to understand what happens when you apply layout, style, and size containment to a box, see the documentation for {{cssxref("contain")}}.
+
+#### Single-axis containment
+
+Using `container-type: size` indicates to the browser that the size of this area is known in both dimensions.
+
+However, we don't often know how big things are in both dimensions. When we use media queries, most of the time we care about the available width (or inline size). We define columns as a percentage or fraction of the space in that dimension. Therefore, container queries can use the `container-type` property to allow size to be indicated in one dimension only. This is described as single-axis containment.
 
 The following CSS creates a container with containment on the inline axis only. The content can grow to as large as it needs to be on the block axis.
 
@@ -46,6 +75,8 @@ The following CSS creates a container with containment on the inline axis only. 
   container-type: inline-size;
 }
 ```
+
+### `container-type`
 
 Adding the `container-type` property with a size value creates a **containment context** on that element. This means that the browser knows we might want to query this container later. You can then write a query which looks to this containment context rather than the viewport size, in order to make layout decisions for a component.
 
@@ -62,9 +93,31 @@ A container query is created using `@container`. This will query the nearest con
 
 If other areas of the layout are also containment contexts then we can drop the component into those areas and it will respond to the relevant containment context. This makes the various components that we might create in our pattern library truly reusable, without us needing to know the context that they are in.
 
-There are many things to be worked out, however this is the basic concept. The basic features as shown here can already be tested out in Chrome. Go to <kbd>chrome://flags</kbd>, search for Container Queries and enable that flag.
+### `container-name`
 
-You can then take a look at [my demo](https://codepen.io/rachelandrew/pen/NWdaxde) showing the above scenario, or [this growing collection of container queries demos](https://codepen.io/collection/XQrgJo).
+The previous example allows a component to query the nearest containment context, which is likely the most common use case. Sometimes however, you might want to query another container. This is where the `container-name` property will be useful. When creating your query container with `container-type`, add the `container-name` property. This takes a {{cssxref("custom-ident")}}, in the same way that you might name a {{cssxref("grid-area")}}.
+
+```css
+.sidebar {
+  container-type: inline-size;
+  container-name: sidebar;
+}
+```
+
+You can then target just that query container by adding the name to the container query:
+
+```css
+@container sidebar (min-width: 400px){
+  .card {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+  }
+}
+```
+
+There are many things to be worked out, however this is the basic concept. The basic features as shown here can already be tested out in Chrome. Go to `chrome://flags`, search for Container Queries and enable that flag.
+
+You can then take a look at [my demo](https://codepen.io/rachelandrew/pen/NWdaxde) showing a simple `inline-size` scenario, or [this growing collection of container queries demos](https://codepen.io/collection/XQrgJo).
 
 ## Share your feedback
 
@@ -82,5 +135,6 @@ Another solution is to rely on grid or flex layout. The component used in my dem
 
 ## See also
 
+- [Editor's Draft CSS Containment Level 3](https://drafts.csswg.org/css-contain-3/)
 - [Container Queries: a Quick Start Guide](https://www.oddbird.net/2021/04/05/containerqueries/)
 - [Collection of Container Queries articles](https://github.com/sturobson/Awesome-Container-Queries)


### PR DESCRIPTION
When we were talking about docs for experimental features on Monday, it reminded me I needed to update the Container Queries document for the new draft spec.

So this PR includes the relevant changes. I think this will slowly move towards something that we can turn into property pages once the spec is stable. 