### PR TITLE
[Markdown] Remove hidden no-code elements from HTML docs

### DIFF
--- a/files/en-us/web/html/element/rb/index.html
+++ b/files/en-us/web/html/element/rb/index.html
@@ -15,8 +15,6 @@ browser-compat: html.elements.rb
 
 <p>The <strong><code>&lt;rb&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is used to delimit the base text component of a  {{HTMLElement("ruby") }} annotation, i.e. the text that is being annotated. One <code>&lt;rb&gt;</code> element should wrap each separate atomic segment of the base text.</p>
 
-<div class="hidden">\{{EmbedInteractiveExample("pages/tabbed/rb.html", "tabbed-standard")}}</div>
-
 <table class="properties">
  <tbody>
   <tr>

--- a/files/en-us/web/html/global_attributes/accesskey/index.html
+++ b/files/en-us/web/html/global_attributes/accesskey/index.html
@@ -14,8 +14,6 @@ browser-compat: html.global_attributes.accesskey
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-accesskey.html","tabbed-shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <div class="note">
 <p><strong>Note</strong>: In the WHATWG spec, it says you can specify multiple space-separated characters, and the browser will use the first one it supports. However, this does not work in most browsers. IE/Edge uses the first one it supports without problems, provided there are no conflicts with other commands.</p>
 </div>

--- a/files/en-us/web/html/global_attributes/class/index.html
+++ b/files/en-us/web/html/global_attributes/class/index.html
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.class
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-class.html","tabbed-standard")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</div>
-
 <p>Though the specification doesn't put requirements on the name of classes, web developers are encouraged to use names that describe the semantic purpose of the element, rather than the presentation of the element. For example, <em>attribute</em> to describe an attribute rather than <em>italics</em>, although an element of this class may be presented by <em>italics</em>. Semantic names remain logical even if the presentation of the page changes.</p>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/global_attributes/contenteditable/index.html
+++ b/files/en-us/web/html/global_attributes/contenteditable/index.html
@@ -18,8 +18,6 @@ browser-compat: html.global_attributes.contenteditable
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-contenteditable.html","tabbed-shorter")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <p>The attribute must take one of the following values:</p>
 
 <ul>

--- a/files/en-us/web/html/global_attributes/data-_star_/index.html
+++ b/files/en-us/web/html/global_attributes/data-_star_/index.html
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.data_attributes
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-data.html","tabbed-standard")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</div>
-
 <p>All such custom data are available via the {{domxref("HTMLElement")}} interface of the element the attribute is set on. The {{domxref("HTMLElement.dataset")}} property gives access to them.<br>
  The <code>*</code> may be replaced by any name following <a href="https://www.w3.org/TR/REC-xml/#NT-Name">the production rule of XML names</a> with the following restrictions:</p>
 

--- a/files/en-us/web/html/global_attributes/dir/index.html
+++ b/files/en-us/web/html/global_attributes/dir/index.html
@@ -14,8 +14,6 @@ browser-compat: html.global_attributes.dir
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-dir.html","tabbed-standard")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <p>It can have the following values:</p>
 
 <ul>

--- a/files/en-us/web/html/global_attributes/hidden/index.html
+++ b/files/en-us/web/html/global_attributes/hidden/index.html
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.hidden
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-hidden.html","tabbed-shorter")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <p>The <code>hidden</code> attribute must not be used to hide content just from one presentation. If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.</p>
 
 <p>Hidden elements shouldn't be linked from non-hidden elements, and elements that are descendants of a hidden element are still active, which means that script elements can still execute and form elements can still submit. Elements and scripts may, however, refer to elements that are hidden in other contexts.</p>

--- a/files/en-us/web/html/global_attributes/id/index.html
+++ b/files/en-us/web/html/global_attributes/id/index.html
@@ -15,8 +15,6 @@ browser-compat: html.global_attributes.id
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-id.html","tabbed-shorter")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <div class="notecard warning">
 <p>This attribute's value is an opaque string: this means that web authors should not rely on it to convey human-readable information (although having your IDs somewhat human-readable can be useful for code comprehension, e.g. consider <code>ticket-18659</code> versus <code>r45tgfe-freds&amp;$@</code>).</p>
 </div>

--- a/files/en-us/web/html/global_attributes/lang/index.html
+++ b/files/en-us/web/html/global_attributes/lang/index.html
@@ -15,8 +15,6 @@ browser-compat: html.global_attributes.lang
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <p>If the attribute value is the <em>empty string</em> (<code>lang=""</code>), the language is set to <em>unknown</em>; if the language tag is not valid according to BCP47, it is set to <em>invalid</em>.</p>
 
 <p>Even if the <strong>lang</strong> attribute is set, it may not be taken into account, as the <a href="/en-US/docs/Web/HTML/Global_attributes#attr-xml:lang"><strong>xml:lang</strong></a> attribute has priority.</p>

--- a/files/en-us/web/html/global_attributes/spellcheck/index.html
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.html
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.spellcheck
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-spellcheck.html","tabbed-shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</div>
-
 <p>It may have the following values:</p>
 
 <ul>

--- a/files/en-us/web/html/global_attributes/style/index.html
+++ b/files/en-us/web/html/global_attributes/style/index.html
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.style
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-style.html","tabbed-shorter")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <div class="note">
 <p><strong>Usage note:</strong> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the <a href="/en-US/docs/Web/HTML/Global_attributes/hidden"><code>hidden</code></a> attribute.</p>
 </div>

--- a/files/en-us/web/html/global_attributes/tabindex/index.html
+++ b/files/en-us/web/html/global_attributes/tabindex/index.html
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.tabindex
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-tabindex.html","tabbed-standard")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
-
 <p>It accepts an integer as a value, with different results depending on the integer's value:</p>
 
 <ul>

--- a/files/en-us/web/html/global_attributes/title/index.html
+++ b/files/en-us/web/html/global_attributes/title/index.html
@@ -14,8 +14,6 @@ browser-compat: html.global_attributes.title
 
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-title.html","tabbed-shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</div>
-
 <p>Some typical uses:</p>
 
 <ul>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961 .

This PR removes hidden "no-code" elements from the HTML docs.

"no-code" means that the element is not itself a `<pre>` block and does not contain any `<pre>` blocks. These are probably part of some live sample and need different treatment.

These are all comments to editors except one, which "comments out" an interactive example showing a deprecated feature not supported in Chrome, so I just removed the example too.
