### PR TITLE
[Markdown] Fix unconvertible <dl> elements in HTML

### DIFF
--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -329,7 +329,7 @@ tags:
 <h3 id="Non-standard_values">Non-standard values</h3>
 
 <dl>
-	<dt>apple-touch-icon</dt>
+	<dt>{{htmlattrdef("apple-touch-icon")}}</dt>
 	<dd>Specifies the icon for a web application on an iOS device.</dd>
 </dl>
 

--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -329,19 +329,8 @@ tags:
 <h3 id="Non-standard_values">Non-standard values</h3>
 
 <dl>
-	<dt>apple-touch-icon-precomposed</dt>
-	<dd>
-	<pre class="brush: html"> &lt;!-- third-generation iPad with high-resolution Retina display: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" sizes="144x144" href="/static/img/favicon144.e7e21ca263ca.png"&gt;
-  &lt;!-- iPhone with high-resolution Retina display: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" sizes="114x114" href="/static/img/favicon114.d526f38b09c5.png"&gt;
-  &lt;!-- first- and second-generation iPad: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" sizes="72x72" href="/static/img/favicon72.cc65d1d762a0.png"&gt;
-  &lt;!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --&gt;
-  &lt;link rel="apple-touch-icon-precomposed" href="/static/img/favicon57.de33179910ae.png"&gt;
-  &lt;!-- basic favicon --&gt;
-  &lt;link rel="icon" href="/static/img/favicon32.7f3da72dcea1.png"&gt;</pre>
-	</dd>
+	<dt>apple-touch-icon</dt>
+	<dd>Specifies the icon for a web application on an iOS device.</dd>
 </dl>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -27,8 +27,7 @@ browser-compat: html.elements.a
 
 <dl>
  <dt id="download">{{HTMLAttrDef("download")}}</dt>
- <dd>Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:</dd>
- <dd>
+ <dd><p>Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:</p>
  <ul>
   <li>Without a value, the browser will suggest a filename/extension, generated from various sources:
    <ul>
@@ -419,7 +418,7 @@ document.querySelector('a').addEventListener('click', event =&gt;
   &lt;/header&gt;
 
   &lt;main id="content"&gt; &lt;/main&gt; &lt;!-- The skip link jumps to here --&gt;
-  
+
 &lt;/body&gt;
 </pre>
 

--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -95,7 +95,7 @@ browser-compat: html.elements.area
  <dt>{{htmlattrdef("rel")}}</dt>
  <dd>For anchors containing the {{htmlattrxref("href", "area")}} attribute, this attribute specifies the relationship of the target object to the link object. The value is a space-separated list of <a href="/en-US/docs/Web/HTML/Link_types">link types values</a>. The values and their semantics will be registered by some authority that might have meaning to the document author. The default relationship, if no other is given, is void. Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.</dd>
  <dt>{{htmlattrdef("shape")}}</dt>
- <dd><p>The shape of the associated hot spot. The specifications for HTML defines the values <code>rect</code>, which defines a rectangular region; <code>circle</code>, which defines a circular region; <code>poly</code>, which defines a polygon; and <code>default</code>, which indicates the entire region beyond any defined shapes.</p>
+ <dd>The shape of the associated hot spot. The specifications for HTML defines the values <code>rect</code>, which defines a rectangular region; <code>circle</code>, which defines a circular region; <code>poly</code>, which defines a polygon; and <code>default</code>, which indicates the entire region beyond any defined shapes.</dd>
  <dt>{{htmlattrdef("target")}}</dt>
  <dd>A keyword or author-defined name of the {{Glossary("browsing context")}} to display the linked resource. The following keywords have special meanings:
  <ul>

--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -61,8 +61,7 @@ browser-compat: html.elements.area
  <dt>{{htmlattrdef("alt")}}</dt>
  <dd>A text string alternative to display on browsers that do not display images. The text should be phrased so that it presents the user with the same kind of choice as the image would offer when displayed without the alternative text. This attribute is required only if the {{htmlattrxref("href", "area")}} attribute is used.</dd>
  <dt>{{htmlattrdef("coords")}}</dt>
- <dd>The <code>coords</code> attribute details the coordinates of the <code><a href="#attr-shape">shape</a></code> attribute in size, shape, and placement of an <code>&lt;area&gt;</code>.</dd>
- <dd>
+ <dd><p>The <code>coords</code> attribute details the coordinates of the <code><a href="#attr-shape">shape</a></code> attribute in size, shape, and placement of an <code>&lt;area&gt;</code>.</p>
  <ul>
   <li><code>rect</code>: the value is <code><var>x1,y1,x2,y2</var></code>. Value specifies the coordinates of the top-left and bottom-right corner of the rectangle.<br>
    For example: <code>&lt;area shape="rect" coords="0,0,253,27" href="#" target="_blank" alt="Mozilla"&gt;</code> The coords in the above example specify: 0,0 as the top-left corner and 253,27 as the bottom-right corner of the rectangle.</li>
@@ -96,19 +95,16 @@ browser-compat: html.elements.area
  <dt>{{htmlattrdef("rel")}}</dt>
  <dd>For anchors containing the {{htmlattrxref("href", "area")}} attribute, this attribute specifies the relationship of the target object to the link object. The value is a space-separated list of <a href="/en-US/docs/Web/HTML/Link_types">link types values</a>. The values and their semantics will be registered by some authority that might have meaning to the document author. The default relationship, if no other is given, is void. Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.</dd>
  <dt>{{htmlattrdef("shape")}}</dt>
- <dd>The shape of the associated hot spot. The specifications for HTML defines the values <code>rect</code>, which defines a rectangular region; <code>circle</code>, which defines a circular region; <code>poly</code>, which defines a polygon; and <code>default</code>, which indicates the entire region beyond any defined shapes.</dd>
- <dd>Many browsers, notably Internet Explorer 4 and higher, support <code>circ</code>, <code>polygon</code>, and <code>rectangle</code> as valid values for {{htmlattrxref("shape", "area")}}, but these values are non-standard.</dd>
+ <dd><p>The shape of the associated hot spot. The specifications for HTML defines the values <code>rect</code>, which defines a rectangular region; <code>circle</code>, which defines a circular region; <code>poly</code>, which defines a polygon; and <code>default</code>, which indicates the entire region beyond any defined shapes.</p>
  <dt>{{htmlattrdef("target")}}</dt>
- <dd>A keyword or author-defined name of the {{Glossary("browsing context")}} to display the linked resource.</dd>
- <dd>The following keywords have special meanings:
+ <dd>A keyword or author-defined name of the {{Glossary("browsing context")}} to display the linked resource. The following keywords have special meanings:
  <ul>
   <li><code>_self</code> (default): Show the resource in the current browsing context.</li>
   <li><code>_blank</code>: Show the resource in a new, unnamed browsing context.</li>
   <li><code>_parent</code>: Show the resource in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as <code>_self</code>.</li>
   <li><code>_top</code>: Show the resource in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as <code>_self</code>.</li>
  </ul>
- </dd>
- <dd>Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.
+ <p>Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.</p>
  <div class="notecard note">
  <h4>Note</h4>
  <p>Setting <code>target="_blank"</code> on <code>&lt;area&gt;</code> elements implicitly provides the same <code>rel</code> behavior as setting <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> which does not set <code>window.opener</code>. See <a href="#browser_compatibility">browser compatibility</a> for support status.</p>

--- a/files/en-us/web/html/element/base/index.html
+++ b/files/en-us/web/html/element/base/index.html
@@ -60,8 +60,7 @@ browser-compat: html.elements.base
  <dt>{{htmlattrdef("href")}}</dt>
  <dd>The base URL to be used throughout the document for relative URLs. Absolute and relative URLs are allowed.</dd>
  <dt>{{htmlattrdef("target")}}</dt>
- <dd>A <strong>keyword</strong> or <strong>author-defined name</strong> of the default {{Glossary("browsing context")}} to show the results of navigation from {{HTMLElement("a")}}, {{HTMLElement("area")}}, or {{HTMLElement("form")}} elements without explicit <code>target</code> attributes.</dd>
- <dd>The following keywords have special meanings:
+ <dd><p>A <strong>keyword</strong> or <strong>author-defined name</strong> of the default {{Glossary("browsing context")}} to show the results of navigation from {{HTMLElement("a")}}, {{HTMLElement("area")}}, or {{HTMLElement("form")}} elements without explicit <code>target</code> attributes. The following keywords have special meanings:</p>
  <ul>
   <li><code>_self</code> (default): Show the result in the current browsing context.</li>
   <li><code>_blank</code>: Show the result in a new, unnamed browsing context.</li>

--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -65,8 +65,8 @@ browser-compat: html.elements.button
  <p>Firefox, unlike other browsers, <a href="https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing">persists the dynamic disabled state</a> of a {{HTMLElement("button")}} across page loads. Use the {{htmlattrxref("autocomplete","button")}} attribute to control this feature.</p>
  </dd>
  <dt>{{htmlattrdef("form")}}</dt>
- <dd>The {{HTMLElement("form")}} element to associate the button with (its <em>form owner</em>). The value of this attribute must be the <code>id</code> of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;button&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</dd>
- <dd>This attribute lets you associate <code>&lt;button&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.</dd>
+ <dd><p>The {{HTMLElement("form")}} element to associate the button with (its <em>form owner</em>). The value of this attribute must be the <code>id</code> of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;button&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</p>
+ <p>This attribute lets you associate <code>&lt;button&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.</p></dd>
  <dt>{{htmlattrdef("formaction")}}</dt>
  <dd>The URL that processes the information submitted by the button. Overrides the {{htmlattrxref("action","form")}} attribute of the button's form owner. Does nothing if there is no form owner.</dd>
  <dt>{{htmlattrdef("formenctype")}}</dt>
@@ -89,8 +89,8 @@ browser-compat: html.elements.button
  <p>If specified, this attribute overrides the {{htmlattrxref("method","form")}} attribute of the button's form owner.</p>
  </dd>
  <dt>{{htmlattrdef("formnovalidate")}}</dt>
- <dd>If the button is a submit button, this Boolean attribute specifies that the form is not to be <a href="/en-US/docs/Learn/Forms/Form_validation">validated</a> when it is submitted. If this attribute is specified, it overrides the {{htmlattrxref("novalidate","form")}} attribute of the button's form owner.</dd>
- <dd>This attribute is also available on <code><a href="/en-US/docs/Web/HTML/Element/input/image">&lt;input type="image"&gt;</a></code> and <code><a href="/en-US/docs/Web/HTML/Element/input/submit">&lt;input type="submit"&gt;</a></code> elements.</dd>
+ <dd><p>If the button is a submit button, this Boolean attribute specifies that the form is not to be <a href="/en-US/docs/Learn/Forms/Form_validation">validated</a> when it is submitted. If this attribute is specified, it overrides the {{htmlattrxref("novalidate","form")}} attribute of the button's form owner.</p>
+ <p>This attribute is also available on <code><a href="/en-US/docs/Web/HTML/Element/input/image">&lt;input type="image"&gt;</a></code> and <code><a href="/en-US/docs/Web/HTML/Element/input/submit">&lt;input type="submit"&gt;</a></code> elements.</p></dd>
  <dt>{{htmlattrdef("formtarget")}}</dt>
  <dd>If the button is a submit button, this attribute is a author-defined name or standardized, underscore-prefixed keyword indicating where to display the response from submitting the form. This is the <code>name</code> of, or keyword for, a <em>browsing context</em> (a tab, window, or {{HTMLElement("iframe")}}). If this attribute is specified, it overrides the {{htmlattrxref("target", "form")}} attribute of the button's form owner. The following keywords have special meanings:
  <ul>

--- a/files/en-us/web/html/element/iframe/index.html
+++ b/files/en-us/web/html/element/iframe/index.html
@@ -67,17 +67,14 @@ browser-compat: html.elements.iframe
 
 <dl>
  <dt>{{htmlattrdef("allow")}}</dt>
- <dd>Specifies a <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature policy</a> for the <code>&lt;iframe&gt;</code>. The policy defines what features are available to the <code>&lt;iframe&gt;</code> based on the origin of the request (e.g. access to the microphone, camera, battery, web-share API, etc.).<br>
- <br>
- For more information and examples see: <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> &gt; <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute">The iframe allow attribute</a>.</dd>
+ <dd><p>Specifies a <a href="/en-US/docs/Web/HTTP/Feature_Policy">feature policy</a> for the <code>&lt;iframe&gt;</code>. The policy defines what features are available to the <code>&lt;iframe&gt;</code> based on the origin of the request (e.g. access to the microphone, camera, battery, web-share API, etc.).</p>
+ <p>For more information and examples see: <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> &gt; <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute">The iframe allow attribute</a>.</p></dd>
  <dt>{{htmlattrdef("allowfullscreen")}}</dt>
- <dd>Set to <code>true</code> if the <code>&lt;iframe&gt;</code> can activate fullscreen mode by calling the {{domxref("Element.requestFullscreen", "requestFullscreen()")}} method.</dd>
- <dd>
+ <dd><p>Set to <code>true</code> if the <code>&lt;iframe&gt;</code> can activate fullscreen mode by calling the {{domxref("Element.requestFullscreen", "requestFullscreen()")}} method.</p>
  <div class="note">This attribute is considered a legacy attribute and redefined as <code>allow="fullscreen"</code>.</div>
  </dd>
  <dt>{{htmlattrdef("allowpaymentrequest")}}</dt>
- <dd>Set to <code>true</code> if a cross-origin <code>&lt;iframe&gt;</code> should be allowed to invoke the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a>.</dd>
- <dd>
+ <dd><p>Set to <code>true</code> if a cross-origin <code>&lt;iframe&gt;</code> should be allowed to invoke the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a>.</p>
  <div class="note">This attribute is considered a legacy attribute and redefined as <code>allow="payment"</code>.</div>
  </dd>
  <dt>{{htmlattrdef("csp")}} {{experimental_inline}}</dt>

--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -122,8 +122,6 @@ browser-compat: html.elements.img
 	<dt>{{htmlattrdef("decoding")}}</dt>
 	<dd>
 	<p>Provides an image decoding hint to the browser. Allowed values:</p>
-	</dd>
-	<dd>
 	<dl>
 		<dt><code>sync</code></dt>
 		<dd>Decode the image synchronously, for atomic presentation with other content.</dd>
@@ -215,8 +213,7 @@ browser-compat: html.elements.img
 
 <dl>
 	<dt>{{htmlattrdef("align")}} {{deprecated_inline}}</dt>
-	<dd>Aligns the image with its surrounding context. Use the {{cssxref('float')}} and/or {{cssxref('vertical-align')}} {{glossary("CSS")}} properties instead of this attribute. Allowed values:</dd>
-	<dd>
+	<dd>Aligns the image with its surrounding context. Use the {{cssxref('float')}} and/or {{cssxref('vertical-align')}} {{glossary("CSS")}} properties instead of this attribute. Allowed values:
 	<dl>
 		<dt><code>top</code></dt>
 		<dd>Equivalent to <code style="white-space: nowrap;">vertical-align: top</code> or <code style="white-space: nowrap;">vertical-align: text-top</code></dd>

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -609,8 +609,6 @@ browser-compat: html.elements.input
  <dd>
  <p>A string specifying a name for the input control. This name is submitted along with the control's value when the form data is submitted.</p>
 
- <h5 id="Whats_in_a_name">What's in a name</h5>
-
  <p>Consider the <code>name</code> a required attribute (even though it's not). If an input has no <code>name</code> specified, or <code>name</code> is empty, the input's value is not submitted with the form! (Disabled controls, unchecked radio buttons, unchecked checkboxes, and reset buttons are also not sent.)</p>
 
  <p>There are two special cases:</p>
@@ -620,8 +618,6 @@ browser-compat: html.elements.input
   <li><code>isindex</code>: For historical reasons, the name <code><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name">isindex</a></code> is not allowed.</li>
  </ol>
 
- <h5 id="name_and_radio_buttons">name and radio buttons</h5>
-
  <p>The <a href="#htmlattrdefname"><code>name</code></a> attribute creates a unique behavior for radio buttons.</p>
 
  <p>Only one radio button in a same-named group of radio buttons can be checked at a time. Selecting any radio button in that group automatically deselects any currently-selected radio button in the same group. The value of that one checked radio button is sent along with the name if the form is submitted,</p>
@@ -629,8 +625,6 @@ browser-compat: html.elements.input
  <p>When tabbing into a series of same-named group of radio buttons, if one is checked, that one will receive focus. If they aren't grouped together in source order, if one of the group is checked, tabbing into the group starts when the first one in the group is encountered, skipping all those that aren't checked. In other words, if one is checked, tabbing skips the unchecked radio buttons in the group. If none are checked, the radio button group receives focus when the first button in the same name group is reached.</p>
 
  <p>Once one of the radio buttons in a group has focus, using the arrow keys will navigate through all the radio buttons of the same name, even if the radio buttons are not grouped together in the source order.</p>
-
- <h5 id="HTMLFormElement.elements">HTMLFormElement.elements</h5>
 
  <p>When an input element is given a <code>name</code>, that name becomes a property of the owning form element's {{domxref("HTMLFormElement.elements")}} property. If you have an input whose <code>name</code> is set to <code>guest</code> and another whose <code>name</code> is <code>hat-size</code>, the following code can be used:</p>
 
@@ -648,14 +642,12 @@ let hatSize = form.elements["hat-size"];
  </dd>
  <dt id="htmlattrdefpattern">{{htmlattrdef("pattern")}}</dt>
  <dd>
- <div id="pattern-include">
  <p>The <code>pattern</code> attribute, when specified, is a regular expression that the input's {{htmlattrxref("value", "input")}} must match in order for the value to pass <a href="/en-US/docs/Web/Guide/HTML/Constraint_validation">constraint validation</a>. It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">guide on regular expressions</a>; the <code>'u'</code> flag is specified when compiling the regular expression, so that the pattern is treated as a sequence of Unicode code points, instead of as ASCII. No forward slashes should be specified around the pattern text.</p>
 
  <p>If the <code>pattern</code> attribute is present but is not specified or is invalid, no regular expression is applied and this attribute is ignored completely. If the pattern attribute is valid and a non-empty value does not match the pattern, constraint validation will prevent form submission.</p>
 
  <div class="note">
  <p><strong>Tip:</strong> If using the <code>pattern</code> attribute, inform the user about the expected format by including explanatory text nearby. You can also include a {{htmlattrxref("title", "input")}} attribute to explain what the requirements are to match the pattern; most browsers will display this title as a tooltip. The visible explanation is required for accessibility. The tooltip is an enhancement.</p>
- </div>
  </div>
 
  <p>See {{anch("Client-side validation")}} for more information.</p>
@@ -688,7 +680,6 @@ let hatSize = form.elements["hat-size"];
  </dd>
  <dt id="htmlattrdefstep">{{htmlattrdef("step")}}</dt>
  <dd>
- <div id="step-include">
  <p>Valid for the numeric input types, including <code>number</code>, date/time input types, and <code>range</code>, the <code><a href="/en-US/docs/Web/HTML/Attributes/step">step</a></code> attribute is a number that specifies the granularity that the value must adhere to.</p>
 
  <p>If not explicitly included:</p>
@@ -706,7 +697,6 @@ let hatSize = form.elements["hat-size"];
 
  <div class="note">
  <p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the value is considered invalid in contraint validation and will match the <code>:invalid</code> pseudoclass.</p>
- </div>
  </div>
 
  <p>See {{anch("Client-side validation")}} for more information.</p>

--- a/files/en-us/web/html/element/link/index.html
+++ b/files/en-us/web/html/element/link/index.html
@@ -63,8 +63,7 @@ browser-compat: html.elements.link
 
 <dl>
  <dt>{{HTMLAttrDef("as")}}</dt>
- <dd>This attribute is only used when <code>rel="preload"</code> or <code>rel="prefetch"</code> has been set on the <code>&lt;link&gt;</code> element. It specifies the type of content being loaded by the <code>&lt;link&gt;</code>, which is necessary for request matching, application of correct <a href="/en-US/docs/Web/HTTP/CSP">content security policy</a>, and setting of correct {{HTTPHeader("Accept")}} request header. Furthermore, <code>rel="preload"</code> uses this as a signal for request prioritization. The table below lists the valid values for this attribute and the elements or resources they apply to.</dd>
- <dd>
+ <dd><p>This attribute is only used when <code>rel="preload"</code> or <code>rel="prefetch"</code> has been set on the <code>&lt;link&gt;</code> element. It specifies the type of content being loaded by the <code>&lt;link&gt;</code>, which is necessary for request matching, application of correct <a href="/en-US/docs/Web/HTTP/CSP">content security policy</a>, and setting of correct {{HTTPHeader("Accept")}} request header. Furthermore, <code>rel="preload"</code> uses this as a signal for request prioritization. The table below lists the valid values for this attribute and the elements or resources they apply to.</p>
  <table class="standard-table">
   <thead>
    <tr>
@@ -214,8 +213,7 @@ browser-compat: html.elements.link
  <div class="note"><strong>Usage note:</strong> To produce the same effect as this obsolete attribute, use the {{HTTPHeader("Content-Type")}} HTTP header on the linked resource.</div>
  </dd>
  <dt>{{HTMLAttrDef("rev")}} {{deprecated_inline}}</dt>
- <dd>The value of this attribute shows the relationship of the current document to the linked document, as defined by the {{HTMLAttrxRef("href", "link")}} attribute. The attribute thus defines the reverse relationship compared to the value of the <code>rel</code> attribute. <a href="/en-US/docs/Web/HTML/Link_types">Link type values</a> for the attribute are similar to the possible values for {{HTMLAttrxRef("rel", "link")}}.</dd>
- <dd>
+ <dd><p>The value of this attribute shows the relationship of the current document to the linked document, as defined by the {{HTMLAttrxRef("href", "link")}} attribute. The attribute thus defines the reverse relationship compared to the value of the <code>rel</code> attribute. <a href="/en-US/docs/Web/HTML/Link_types">Link type values</a> for the attribute are similar to the possible values for {{HTMLAttrxRef("rel", "link")}}.</p>
  <div class="notecard note">
  <p><strong>Note:</strong> This attribute is considered obsolete by the WHATWG HTML living standard (which is the specification MDN treats as canonical). However, it's worth noting that <code>rev</code> is <em>not</em> considered obsolete in the W3C specification. That said, given the uncertainty, relying on <code>rev</code> is unwise.</p>
 

--- a/files/en-us/web/html/element/output/index.html
+++ b/files/en-us/web/html/element/output/index.html
@@ -56,8 +56,9 @@ browser-compat: html.elements.output
  <dt>{{htmlattrdef("for")}}</dt>
  <dd>A space-separated list of other elements’ {{htmlattrxref("id")}}s, indicating that those elements contributed input values to (or otherwise affected) the calculation.</dd>
  <dt>{{htmlattrdef("form")}}</dt>
- <dd>The {{HTMLElement("form")}} element to associate the output with (its <em>form owner</em>). The value of this attribute must be the {{htmlattrxref("id")}} of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;output&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</dd>
- <dd>This attribute lets you associate <code>&lt;output&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.</dd>
+ <dd><p>The {{HTMLElement("form")}} element to associate the output with (its <em>form owner</em>). The value of this attribute must be the {{htmlattrxref("id")}} of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;output&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</p>
+ <p>This attribute lets you associate <code>&lt;output&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.</p>
+ </dd>
  <dt>{{htmlattrdef("name")}}</dt>
  <dd>The element's name. Used in the {{domxref("HTMLFormElement.elements", "form.elements")}} API.</dd>
 </dl>

--- a/files/en-us/web/html/element/select/index.html
+++ b/files/en-us/web/html/element/select/index.html
@@ -38,8 +38,9 @@ browser-compat: html.elements.select
  <dt>{{htmlattrdef("disabled")}}</dt>
  <dd>This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example {{htmlelement("fieldset")}}; if there is no containing element with the <code>disabled</code> attribute set, then the control is enabled.</dd>
  <dt>{{htmlattrdef("form")}}</dt>
- <dd>The {{HTMLElement("form")}} element to associate the <code>&lt;select&gt;</code> with (its <em>form owner</em>). The value of this attribute must be the {{htmlattrxref("id")}} of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;select&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</dd>
- <dd>This attribute lets you associate <code>&lt;select&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.</dd>
+ <dd><p>The {{HTMLElement("form")}} element to associate the <code>&lt;select&gt;</code> with (its <em>form owner</em>). The value of this attribute must be the {{htmlattrxref("id")}} of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;select&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</p>
+ <p>This attribute lets you associate <code>&lt;select&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.
+ </p></dd>
  <dt>{{htmlattrdef("multiple")}}</dt>
  <dd>This Boolean attribute indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When <code>multiple</code> is specified, most browsers will show a scrolling list box instead of a single line dropdown.</dd>
  <dt>{{htmlattrdef("name")}}</dt>

--- a/files/en-us/web/html/element/slot/index.html
+++ b/files/en-us/web/html/element/slot/index.html
@@ -58,8 +58,8 @@ browser-compat: html.elements.slot
 
 <dl>
  <dt>{{htmlattrdef("name")}}</dt>
- <dd>The slot's name.</dd>
- <dd>A <strong><dfn>named slot</dfn></strong> is a <code>&lt;slot&gt;</code> element with a <code>name</code> attribute.</dd>
+ <dd><p>The slot's name.</p>
+ <p>A <strong><dfn>named slot</dfn></strong> is a <code>&lt;slot&gt;</code> element with a <code>name</code> attribute.</p></dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/html/element/time/index.html
+++ b/files/en-us/web/html/element/time/index.html
@@ -91,19 +91,19 @@ browser-compat: html.elements.time
  <dt>a valid week string</dt>
  <dd><code>2011-W47</code></dd>
  <dt>a valid time string</dt>
- <dd><code>14:54</code></dd>
- <dd><code>14:54:39</code></dd>
- <dd><code>14:54:39.929</code></dd>
+ <dd><p><code>14:54</code></p>
+ <p><code>14:54:39</code></p>
+ <p><code>14:54:39.929</code></p></dd>
  <dt>a valid local date and time string</dt>
- <dd><code>2011-11-18T14:54:39.929</code></dd>
- <dd><code>2011-11-18 14:54:39.929</code></dd>
+ <dd><p><code>2011-11-18T14:54:39.929</code></p>
+ <p><code>2011-11-18 14:54:39.929</code></p></dd>
  <dt>a valid global date and time string</dt>
- <dd><code>2011-11-18T14:54:39.929Z</code></dd>
- <dd><code>2011-11-18T14:54:39.929-0400</code></dd>
- <dd><code>2011-11-18T14:54:39.929-04:00</code></dd>
- <dd><code>2011-11-18 14:54:39.929Z</code></dd>
- <dd><code>2011-11-18 14:54:39.929-0400</code></dd>
- <dd><code>2011-11-18 14:54:39.929-04:00</code></dd>
+ <dd><p><code>2011-11-18T14:54:39.929Z</code></p>
+ <p><code>2011-11-18T14:54:39.929-0400</code></p>
+ <p><code>2011-11-18T14:54:39.929-04:00</code></p>
+ <p><code>2011-11-18 14:54:39.929Z</code></p>
+ <p><code>2011-11-18 14:54:39.929-0400</code></p>
+ <p><code>2011-11-18 14:54:39.929-04:00</code></p></dd>
  <dt>a valid duration string</dt>
  <dd><code>PT4H18M3S</code></dd>
 </dl>

--- a/files/en-us/web/html/element/ul/index.html
+++ b/files/en-us/web/html/element/ul/index.html
@@ -53,8 +53,7 @@ browser-compat: html.elements.ul
 
 <dl>
  <dt>{{ htmlattrdef("compact") }} {{Deprecated_inline}}</dt>
- <dd>This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the {{glossary("user agent")}}, and it doesn't work in all browsers.</dd>
- <dd>
+ <dd><p>This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the {{glossary("user agent")}}, and it doesn't work in all browsers.</p>
  <div class="warning"><strong>Warning:</strong> Do not use this attribute, as it has been deprecated: use <a href="/en-US/docs/Web/CSS">CSS</a> instead. To give a similar effect as the <code>compact</code> attribute, the CSS property {{cssxref("line-height")}} can be used with a value of <code>80%</code>.</div>
  </dd>
  <dt>{{ htmlattrdef("type") }} {{Deprecated_inline}}</dt>

--- a/files/en-us/web/html/element/video/index.html
+++ b/files/en-us/web/html/element/video/index.html
@@ -51,8 +51,7 @@ browser-compat: html.elements.video
  <dt>{{htmlattrdef("controls")}}</dt>
  <dd>If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.</dd>
  <dt>{{htmlattrdef("controlslist")}} {{experimental_inline}}</dt>
- <dd>The <code><a href="https://wicg.github.io/controls-list/html-output/multipage/embedded-content.html#attr-media-controlslist">controlslist</a></code> attribute, when specified, helps the browser select what controls to show on the media element whenever the browser shows its own set of controls (e.g. when the <code>controls</code> attribute is specified).</dd>
- <dd>
+ <dd><p>The <code><a href="https://wicg.github.io/controls-list/html-output/multipage/embedded-content.html#attr-media-controlslist">controlslist</a></code> attribute, when specified, helps the browser select what controls to show on the media element whenever the browser shows its own set of controls (e.g. when the <code>controls</code> attribute is specified).</p>
  <p>The allowed values are <code>nodownload</code>, <code>nofullscreen</code> and <code>noremoteplayback</code>.</p>
 
  <p>Use the <a href="#disable_pip"><code>disablepictureinpicture</code></a> attribute if you want to disable the Picture-In-Picture mode (and the control).</p>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This PR fixes all places in the HTML docs where `<dl>` elements weren't being converted into Markdown.

Mostly this is because if incorrect consecutive `<dd>` elements.

In a couple of places we have `<div id="thing">`, and I confirmed that "thing" is not being used as a link target.

In one place I made a substantive change to update the description of `apple-touch-icon` (https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html).