### PR TITLE
Add files/en-us/web/mathml/fonts • /en-US/docs/Web/MathML/Fonts

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5720,6 +5720,7 @@
 /en-US/docs/Mozilla/Firefox/Releases/Firefox_41_for_developers	/en-US/docs/Mozilla/Firefox/Releases/41
 /en-US/docs/Mozilla/Firefox/Releases/Firefox_47_for_developers	/en-US/docs/Mozilla/Firefox/Releases/47
 /en-US/docs/Mozilla/Firefox/Releases/developers	/en-US/docs/Mozilla/Firefox/Releases/63
+/en-US/docs/Mozilla/MathML_Project/Fonts	/en-US/docs/Web/MathML/Fonts
 /en-US/docs/Mozilla/Performance/Scroll-linked_effects	https://firefox-source-docs.mozilla.org/performance/scroll-linked_effects.html
 /en-US/docs/Mozilla/QA/Bug_writing_guidelines	https://bugzilla.mozilla.org/page.cgi?id=bug-writing.html
 /en-US/docs/Mozilla/Virtualenv	https://github.com/mdn/archived-content/tree/main/files/en-us/mozilla/virtualenv

--- a/files/en-us/web/mathml/fonts/index.html
+++ b/files/en-us/web/mathml/fonts/index.html
@@ -1,0 +1,136 @@
+---
+title: Fonts for Mozilla's MathML engine
+slug: Web/MathML/Fonts
+tags:
+  - Fonts
+  - MathML
+  - Project
+---
+<p>Fonts with appropriate Unicode coverage and Open Font Format features are required for good math rendering. This wiki page describes how users can install and use such math fonts with Mozilla&apos;s MathML engine. Note that most of these instructions may as well apply to other Web rendering engines.</p>
+
+<h2 id="Installation_Instructions">Installation Instructions</h2>
+
+<h3 id="Windows">Windows</h3>
+
+<p>Install the <em>Latin Modern Math</em> and <em>STIX</em> fonts as follows:</p>
+
+<ol>
+ <li>Download <a href="http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip">latinmodern-math-1959.zip</a>.</li>
+ <li>Open the ZIP archive, move inside the <code>latinmodern-math-1959</code> directory and then inside the <code>otf</code> directory. You will find a <code>latinmodern-math</code> font file.</li>
+ <li>Open the <code>latinmodern-math</code> font file and click the <code>Install</code> button.</li>
+ <li>Download <a href="https://github.com/stipub/stixfonts/raw/master/zipfiles/static_otf.zip">static_otf.zip</a>.</li>
+ <li>Open the <code>static_otf.zip</code> ZIP archive, and then move inside the <code>static_otf</code> directory. Among the files there, you will find a <code>STIXTwoMath-Regular</code> file.</li>
+ <li>Open the <code>STIXTwoMath-Regular</code> file and click the <code>Install</code> button. If desired, you may also do the same for the other font files.</li>
+</ol>
+
+<div class="note notecard">
+<p><strong>Note</strong>:<em>Cambria Math</em> is installed by default on Windows 7 and later versions and should ensure relatively good MathML rendering. <a href="https://windows.uservoice.com/forums/265757-windows-feature-suggestions/suggestions/9727281-add-new-math-fonts-latin-modern-math-and-stix-2">An enhancement request has been submitted to Microsoft to install Latin Modern Math and STIX by default</a>.</p>
+</div>
+
+<h3 id="OS_X">OS X</h3>
+
+<p>Install the <em>Latin Modern Math</em> and <em>STIX</em> fonts as follows:</p>
+
+<ol>
+ <li>Download <a href="http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip">latinmodern-math-1959.zip</a>.</li>
+ <li>Extract the ZIP archive, move inside the <code>latinmodern-math-1959</code> directory and then inside the <code>otf</code> directory. You will find a <code>latinmodern-math</code> font file.</li>
+ <li>Double-click the <code>latinmodern-math</code> font file click the &quot;Install the font&quot; button from the window that opens.</li>
+ <li>Download <a href="https://github.com/stipub/stixfonts/raw/master/zipfiles/static_otf.zip">static_otf.zip</a>.</li>
+ <li>Open the <code>static_otf.zip</code> ZIP archive, and then move inside the <code>static_otf</code> directory. Among the files there, you will find a <code>STIXTwoMath-Regular.otf</code> file.</li>
+ <li>Open the <code>STIXTwoMath-Regular.otf</code> file and click the <strong>Install Font</strong> button from the window that opens. If desired, you may also do the same for the other font files.</li>
+</ol>
+
+<div class="note notecard">
+<p><strong>Note</strong>: A deprecated version of STIX is preinstalled starting with OS X Lion and should ensure relatively good MathML rendering. Enhancement requests have been submitted to Apple to ship OpenType MATH fonts <span class="probNo" id="displayFullDetailsProblemID">in the default installation. If you have a developer account, these are problems </span><span class="probNo" id="displayFullDetailsProblemID">16841023</span> and <span class="probNo" id="displayFullDetailsProblemID">17021145.</span></p>
+</div>
+
+<h3 id="Linux">Linux</h3>
+
+<p>Install the <em>Latin Modern Math</em>, <em>STIX</em> or <em>XITS</em> fonts, which are generally available from your package manager.</p>
+
+<p>On Debian/Ubuntu/Mint and other Debian-based distributions, use the following command:</p>
+
+<pre class="notranslate">sudo apt-get install <code>fonts-lmodern fonts-stix</code></pre>
+
+<p>On Fedora and other Fedora-based distributions, use the following command (<code>stix-math-fonts</code> is often already installed):</p>
+
+<pre class="notranslate">sudo dnf install <code>texlive-lm-math stix-math-fonts</code></pre>
+
+<p>On openSUSE and other openSUSE-based distributions, use the following command:</p>
+
+<pre class="notranslate">sudo zypper install texlive-lm-math stix-fonts</pre>
+
+<p>On other Linux distributions, consider installing appropriate <code>texlive</code> packages, which includes <em>Latin Modern Math</em> and <em>XITS</em>:</p>
+
+<pre class="notranslate">sudo pacman -S texlive-core texlive-fontsextra # Arch Linux
+sudo urpmi texlive-dist texlive-fontsextra # Mageia
+</pre>
+
+<p>However, you might need to ensure that the fonts are known by your system. Typically,  use a fontconfig configuration <code>/etc/fonts/conf.avail/09-texlive-fonts.conf</code> that points to the <code>opentype</code> directory of TeXLive, such as:</p>
+
+<pre class="lang-tex prettyprint prettyprinted notranslate"><code><span class="pln">&lt;?xml version</span><span class="pun">=</span><span class="pln">&quot;1.0&quot;?&gt;
+&lt;!DOCTYPE fontconfig SYSTEM &quot;fonts.dtd&quot;&gt;
+&lt;fontconfig&gt;
+  &lt;dir&gt;/your/path/to/texmf-dist/fonts/opentype&lt;/dir&gt;
+&lt;/fontconfig&gt;</span></code></pre>
+
+<p>Finally, add this configuration file to the system font location list and regenerate the fontconfig cache:</p>
+
+<pre class="notranslate">ln -sf /etc/fonts/conf.avail/09-texlive-fonts.conf /etc/fonts/conf.d/
+fc-cache -sf
+</pre>
+
+<h3 id="Android">Android</h3>
+
+<p>You must use the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>.</p>
+
+<div class="note notecard">
+<p><strong>Note</strong>: There is an <a href="https://github.com/googlei18n/noto-fonts/issues/330">enhancement request</a> opened on the Noto bug tracker to improve math support.</p>
+</div>
+
+<h3 id="Firefox_OS">Firefox OS</h3>
+
+<p>You must use the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>.</p>
+
+<div class="note notecard">
+<p><strong>Note</strong>: We <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=775060">plan to bundle</a> a <a href="#math_fonts">MATH font</a> in the default installation.</p>
+</div>
+
+<h3 id="Other_systems">Other systems</h3>
+
+<p>On other systems, consider installing a <a href="#math_fonts">MATH font</a> using your package manager. Note that these fonts are generally delivered with TeX distributions such as <a href="https://www.tug.org/texlive/">TeX Live</a>, but you might need to follow specific instructions so that your system is aware of the fonts. As a last resort, install the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML fonts add-on</a>.</p>
+
+<h2 id="Advanced_setup">Advanced setup</h2>
+
+<h3 id="Arabic_Mathematical_Alphabetic_Symbols">Arabic Mathematical Alphabetic Symbols</h3>
+
+<p>Currently, very few fonts have appropriate glyphs for the Arabic Mathematical Alphabetic Symbols. If you are likely to need these characters, we recommend to install the XITS or <a href="https://www.amirifont.org/">Amiri</a> fonts.</p>
+
+<h3 id="Installation_without_Administrator_Privilege">Installation without Administrator Privilege</h3>
+
+<p>If you need to install fonts on a system without adminstrator privilege, the easiest option is to use math font the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>. Note that using the add-on is not optimal since it forces your Gecko browser to load a CSS stylesheet on each page you visit as well as Web math fonts on all pages with MathML content. A better alternative on UNIX systems is to install the OTF files for <a href="http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip">Latin Modern Math</a> and <a href="https://github.com/stipub/stixfonts">STIX</a> into some local font folder and (if necessary) to run <code>fc-cache</code> on it. On OS X and Linux, the standard paths are <code>~/Library/Fonts/</code> and <code>~/.fonts</code>.</p>
+
+<h3 id="Fonts_with_a_MATH_table"><span id="MATH_fonts"></a>Fonts with a MATH table</span></h3>
+
+<p>You can actually render MathML using any font with a MATH table and related Open Font Format features. A list of such math fonts is provided below. You can use the <em>advanced font preference menu</em> to configure the default font for mathematics. Alternatively, you can try the <a href="https://addons.mozilla.org/en-US/firefox/addon/mathml-font-settings/">MathML-fontsettings add-on</a>.</p>
+
+<ul>
+ <li><a href="https://www.ctan.org/tex-archive/fonts/Asana-Math/">Asana Math</a></li>
+ <li><a href="https://www.microsoft.com/typography/fonts/family.aspx?FID=360">Cambria Math</a></li>
+ <li><a href="https://sourceforge.net/projects/dejavu/files/dejavu/">DejaVu Math TeX Gyre</a></li>
+ <li><a href="https://github.com/YuanshengZhao/Garamond-Math">Garamond Math</a> (under development)</li>
+ <li><a href="http://www.gust.org.pl/projects/e-foundry/lm-math">Latin Modern Math</a></li>
+ <li><a href="https://github.com/khaledhosny/libertinus">Libertinus Math</a></li>
+ <li><a href="https://github.com/stipub/stixfonts">STIX Math</a></li>
+ <li><a href="http://www.gust.org.pl/projects/e-foundry/tg-math/download/index_html#Bonum_Math">TeX Gyre Bonum Math</a></li>
+ <li><a href="http://www.gust.org.pl/projects/e-foundry/tg-math/download/index_html#Pagella_Math">TeX Gyre Pagella Math</a></li>
+ <li><a href="http://www.gust.org.pl/projects/e-foundry/tg-math/download/index_html#Schola_Math">TeX Gyre Schola Math</a></li>
+ <li><a href="http://www.gust.org.pl/projects/e-foundry/tg-math/download/index_html#Termes_Math">TeX Gyre Termes Math</a></li>
+ <li><a href="https://github.com/khaledhosny/xits-math/releases">XITS Math</a></li>
+ <li><a href="https://github.com/firamath/firamath">Fira Math</a> (sans-serif typeface, under development)</li>
+ <li><a href="https://greekfontsociety-gfs.gr/typefaces/Math">GFS Neohellenic Math</a> (sans-serif typeface)</li>
+</ul>
+
+<h3 id="Using_mathematical_fonts_on_Web_pages">Using mathematical fonts on Web pages</h3>
+
+<p>Starting with Gecko 31.0 (Firefox 31.0 / Thunderbird 31.0 / SeaMonkey 2.28), it is now easy to set up the CSS style (and optional WOFF fonts) to use on your Web site. See the <a href="/en-US/docs/Web/MathML/Authoring#mathematical_fonts">Authoring MathML page</a> for details. You can use <a href="https://github.com/behdad/fonttools">FontTools</a> to edit the MATH table and create your own mathematical fonts.</p>

--- a/files/en-us/web/mathml/fonts/index.html
+++ b/files/en-us/web/mathml/fonts/index.html
@@ -6,7 +6,9 @@ tags:
   - MathML
   - Project
 ---
-<p>Fonts with appropriate Unicode coverage and Open Font Format features are required for good math rendering. This wiki page describes how users can install and use such math fonts with Mozilla&apos;s MathML engine. Note that most of these instructions may as well apply to other Web rendering engines.</p>
+<p>Fonts with appropriate Unicode coverage and Open Font Format features are required for good math rendering.
+  This page describes how users can install and use such math fonts with Mozilla's MathML engine.
+  Note that most of these instructions may as well apply to other Web rendering engines.</p>
 
 <h2 id="Installation_Instructions">Installation Instructions</h2>
 
@@ -24,7 +26,7 @@ tags:
 </ol>
 
 <div class="note notecard">
-<p><strong>Note</strong>:<em>Cambria Math</em> is installed by default on Windows 7 and later versions and should ensure relatively good MathML rendering. <a href="https://windows.uservoice.com/forums/265757-windows-feature-suggestions/suggestions/9727281-add-new-math-fonts-latin-modern-math-and-stix-2">An enhancement request has been submitted to Microsoft to install Latin Modern Math and STIX by default</a>.</p>
+<p><strong>Note:</strong> <em>Cambria Math</em> is installed by default on Windows 7 and later versions and should ensure relatively good MathML rendering. <a href="https://windows.uservoice.com/forums/265757-windows-feature-suggestions/suggestions/9727281-add-new-math-fonts-latin-modern-math-and-stix-2">An enhancement request has been submitted to Microsoft to install Latin Modern Math and STIX by default</a>.</p>
 </div>
 
 <h3 id="OS_X">OS X</h3>
@@ -41,7 +43,7 @@ tags:
 </ol>
 
 <div class="note notecard">
-<p><strong>Note</strong>: A deprecated version of STIX is preinstalled starting with OS X Lion and should ensure relatively good MathML rendering. Enhancement requests have been submitted to Apple to ship OpenType MATH fonts <span class="probNo" id="displayFullDetailsProblemID">in the default installation. If you have a developer account, these are problems </span><span class="probNo" id="displayFullDetailsProblemID">16841023</span> and <span class="probNo" id="displayFullDetailsProblemID">17021145.</span></p>
+<p><strong>Note:</strong> A deprecated version of STIX is preinstalled starting with OS X Lion and should ensure relatively good MathML rendering. Enhancement requests have been submitted to Apple to ship OpenType MATH fonts <span class="probNo" id="displayFullDetailsProblemID">in the default installation. If you have a developer account, these are problems </span><span class="probNo" id="displayFullDetailsProblemID">16841023</span> and <span class="probNo" id="displayFullDetailsProblemID">17021145.</span></p>
 </div>
 
 <h3 id="Linux">Linux</h3>
@@ -50,33 +52,33 @@ tags:
 
 <p>On Debian/Ubuntu/Mint and other Debian-based distributions, use the following command:</p>
 
-<pre class="notranslate">sudo apt-get install <code>fonts-lmodern fonts-stix</code></pre>
+<pre class="brush: bash">sudo apt-get install <code>fonts-lmodern fonts-stix</code></pre>
 
 <p>On Fedora and other Fedora-based distributions, use the following command (<code>stix-math-fonts</code> is often already installed):</p>
 
-<pre class="notranslate">sudo dnf install <code>texlive-lm-math stix-math-fonts</code></pre>
+<pre class="brush: bash">sudo dnf install <code>texlive-lm-math stix-math-fonts</code></pre>
 
 <p>On openSUSE and other openSUSE-based distributions, use the following command:</p>
 
-<pre class="notranslate">sudo zypper install texlive-lm-math stix-fonts</pre>
+<pre class="brush: plain">sudo zypper install texlive-lm-math stix-fonts</pre>
 
 <p>On other Linux distributions, consider installing appropriate <code>texlive</code> packages, which includes <em>Latin Modern Math</em> and <em>XITS</em>:</p>
 
-<pre class="notranslate">sudo pacman -S texlive-core texlive-fontsextra # Arch Linux
+<pre class="brush: bash">sudo pacman -S texlive-core texlive-fontsextra # Arch Linux
 sudo urpmi texlive-dist texlive-fontsextra # Mageia
 </pre>
 
 <p>However, you might need to ensure that the fonts are known by your system. Typically,  use a fontconfig configuration <code>/etc/fonts/conf.avail/09-texlive-fonts.conf</code> that points to the <code>opentype</code> directory of TeXLive, such as:</p>
 
-<pre class="lang-tex prettyprint prettyprinted notranslate"><code><span class="pln">&lt;?xml version</span><span class="pun">=</span><span class="pln">&quot;1.0&quot;?&gt;
+<pre class="brush: tex">&lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!DOCTYPE fontconfig SYSTEM &quot;fonts.dtd&quot;&gt;
 &lt;fontconfig&gt;
   &lt;dir&gt;/your/path/to/texmf-dist/fonts/opentype&lt;/dir&gt;
-&lt;/fontconfig&gt;</span></code></pre>
+&lt;/fontconfig&gt;</pre>
 
 <p>Finally, add this configuration file to the system font location list and regenerate the fontconfig cache:</p>
 
-<pre class="notranslate">ln -sf /etc/fonts/conf.avail/09-texlive-fonts.conf /etc/fonts/conf.d/
+<pre class="brush: plain">ln -sf /etc/fonts/conf.avail/09-texlive-fonts.conf /etc/fonts/conf.d/
 fc-cache -sf
 </pre>
 
@@ -85,7 +87,7 @@ fc-cache -sf
 <p>You must use the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>.</p>
 
 <div class="note notecard">
-<p><strong>Note</strong>: There is an <a href="https://github.com/googlei18n/noto-fonts/issues/330">enhancement request</a> opened on the Noto bug tracker to improve math support.</p>
+<p><strong>Note:</strong> There is an <a href="https://github.com/googlei18n/noto-fonts/issues/330">enhancement request</a> opened on the Noto bug tracker to improve math support.</p>
 </div>
 
 <h3 id="Firefox_OS">Firefox OS</h3>
@@ -93,7 +95,7 @@ fc-cache -sf
 <p>You must use the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>.</p>
 
 <div class="note notecard">
-<p><strong>Note</strong>: We <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=775060">plan to bundle</a> a <a href="#math_fonts">MATH font</a> in the default installation.</p>
+<p><strong>Note:</strong> We <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=775060">plan to bundle</a> a <a href="#math_fonts">MATH font</a> in the default installation.</p>
 </div>
 
 <h3 id="Other_systems">Other systems</h3>
@@ -110,7 +112,8 @@ fc-cache -sf
 
 <p>If you need to install fonts on a system without adminstrator privilege, the easiest option is to use math font the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>. Note that using the add-on is not optimal since it forces your Gecko browser to load a CSS stylesheet on each page you visit as well as Web math fonts on all pages with MathML content. A better alternative on UNIX systems is to install the OTF files for <a href="http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip">Latin Modern Math</a> and <a href="https://github.com/stipub/stixfonts">STIX</a> into some local font folder and (if necessary) to run <code>fc-cache</code> on it. On OS X and Linux, the standard paths are <code>~/Library/Fonts/</code> and <code>~/.fonts</code>.</p>
 
-<h3 id="Fonts_with_a_MATH_table"><span id="MATH_fonts"></a>Fonts with a MATH table</span></h3>
+<a id="MATH_fonts"></a>
+<h3 id="Fonts_with_a_MATH_table">Fonts with a MATH table</h3>
 
 <p>You can actually render MathML using any font with a MATH table and related Open Font Format features. A list of such math fonts is provided below. You can use the <em>advanced font preference menu</em> to configure the default font for mathematics. Alternatively, you can try the <a href="https://addons.mozilla.org/en-US/firefox/addon/mathml-font-settings/">MathML-fontsettings add-on</a>.</p>
 
@@ -133,4 +136,6 @@ fc-cache -sf
 
 <h3 id="Using_mathematical_fonts_on_Web_pages">Using mathematical fonts on Web pages</h3>
 
-<p>Starting with Gecko 31.0 (Firefox 31.0 / Thunderbird 31.0 / SeaMonkey 2.28), it is now easy to set up the CSS style (and optional WOFF fonts) to use on your Web site. See the <a href="/en-US/docs/Web/MathML/Authoring#mathematical_fonts">Authoring MathML page</a> for details. You can use <a href="https://github.com/behdad/fonttools">FontTools</a> to edit the MATH table and create your own mathematical fonts.</p>
+<p>Starting with Gecko 31.0 (Firefox 31.0 / Thunderbird 31.0 / SeaMonkey 2.28), it is now easy to set up the CSS style (and optional WOFF fonts) to use on your Web site.
+  See the <a href="/en-US/docs/Web/MathML/Authoring#mathematical_fonts">Authoring MathML page</a> for details.
+  You can use <a href="https://github.com/behdad/fonttools">FontTools</a> to edit the MATH table and create your own mathematical fonts.</p>

--- a/files/en-us/web/mathml/fonts/test/index.html
+++ b/files/en-us/web/mathml/fonts/test/index.html
@@ -1,0 +1,92 @@
+---
+title: Test
+slug: Web/MathML/Fonts/Test
+---
+<p style="width: 500px; background: white;">You should see a grid with perfectly straight black lines. If not, please consider installing some <a href="/en-US/docs/Web/MathML/Fonts">MathML fonts</a>.</p>
+<div style="width: 540px; height: 540px; background: #eef;">
+  <div style="position: absolute;">
+    <div style="position: absolute; left: 20px; top: 20px;">
+      <div style="position: absolute;">
+        <div style="position: absolute; top: 0; left: 0;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 30px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 60px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 90px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 120px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 150px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 180px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 210px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 240px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 270px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 300px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 330px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 360px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 390px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 420px;">
+          <math><mo minsize="500px">√</mo></math></div>
+        <div style="position: absolute; top: 0; left: 450px;">
+          <math><mo minsize="500px">√</mo></math></div>
+      </div>
+      <div style="position: absolute;">
+        <div style="position: absolute; top: 0; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 30px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 60px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 90px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 120px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 150px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 180px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 210px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 240px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 270px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 300px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 330px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 360px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 390px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 420px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+        <div style="position: absolute; top: 450px; left: 0;">
+          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
+      </div>
+      <div style="position: absolute;">
+        <div style="position: absolute; background: #eef; top: -20px; height: 40px; width: 500px;">
+           </div>
+        <div style="position: absolute; background: #eef; top: 480px; height: 40px; width: 500px;">
+           </div>
+      </div>
+      <div style="position: absolute;">
+        <div style="position: absolute; background: #eef; left: -20px; width: 40px; height: 500px;">
+           </div>
+        <div style="position: absolute; background: #eef; left: 480px; width: 40px; height: 500px;">
+           </div>
+      </div>
+    </div>
+  </div>
+</div>
+<p> </p>


### PR DESCRIPTION
Also, redirect `/en-US/docs/Mozilla/MathML_Project/Fonts` to `/en-US/docs/Web/MathML/Fonts`. Fixes https://github.com/mdn/content/issues/4259.