### PR TITLE
Remove XMLSerializer's serializeToStream() method

### DIFF
--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -22,8 +22,6 @@ The `XMLSerializer` interface provides the {{domxref("XMLSerializer.serializeToS
 
 - {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}
   - : Returns the serialized subtree of a string.
-- {{domxref("XMLSerializer.serializeToStream", "serializeToStream()")}} {{ non-standard_inline }}{{ deprecated_inline }}
-  - : The subtree rooted by the specified element is serialized to a byte stream using the character set specified.
 
 ## Examples
 


### PR DESCRIPTION
This was removed in Firefox 20.

BCD removal: https://github.com/mdn/browser-compat-data/pull/12417