### PR TITLE
remove superfluous language in Using Web Workers

### DIFF
--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -235,7 +235,7 @@ The exception to this is if the worker script's origin is a globally unique iden
 
 Data passed between the main page and workers is **copied**, not shared. Objects are serialized as they're handed to the worker, and subsequently, de-serialized on the other end. The page and worker **do not share the same instance**, so the end result is that **a duplicate** is created on each end. Most browsers implement this feature as [structured cloning](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 
-To illustrate this, let's create for didactical purpose a function named `emulateMessage()`, which will simulate the behavior of a value that is _cloned and not shared_ during the passage from a `worker` to the main page or vice versa:
+To illustrate this, let's create a function named `emulateMessage()`, which will simulate the behavior of a value that is _cloned and not shared_ during the passage from a `worker` to the main page or vice versa:
 
 ```js
 function emulateMessage(vVal) {


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

In the sentence `To illustrate this, let's create for didactical purpose a function named emulateMessage()`, "for didactical purpose" is an unusual and confusing phrase. luckily it's also unnecessary, since the beginning of the sentence "To illustrate this" conveys the same meaning already, ie "for example". I think this edit makes the sentence easier to read, (especially for non-native speakers, I imagine).

