### PR TITLE
[Markdown] [Web/SVG] Fix SVG top example live samples

### DIFF
--- a/files/en-us/web/svg/attribute/attributename/index.html
+++ b/files/en-us/web/svg/attribute/attributename/index.html
@@ -19,12 +19,11 @@ tags:
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 250 250" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="50" y="50" width="100" height="100"&gt;
@@ -33,8 +32,7 @@ tags:
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "400", "250")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "400", "250")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/attributetype/index.html
+++ b/files/en-us/web/svg/attribute/attributetype/index.html
@@ -20,12 +20,11 @@ tags:
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 250 250" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="50" y="50" width="100" height="100"&gt;
@@ -34,8 +33,7 @@ tags:
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "400", "250")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "400", "250")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/azimuth/index.html
+++ b/files/en-us/web/svg/attribute/azimuth/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feDistantLight.azimuth
   <li>{{SVGElement("feDistantLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,9]">&lt;svg viewBox="0 0 440 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="distantLight1"&gt;
@@ -40,8 +39,7 @@ browser-compat: svg.elements.feDistantLight.azimuth
   &lt;circle cx="100" cy="100" r="80" style="filter: url(#distantLight2); transform: translateX(240px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/basefrequency/index.html
+++ b/files/en-us/web/svg/attribute/basefrequency/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feTurbulence.baseFrequency
   <li>{{SVGElement("feTurbulence")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="noise1" x="0" y="0" width="100%" height="100%"&gt;
@@ -36,8 +35,7 @@ browser-compat: svg.elements.feTurbulence.baseFrequency
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#noise2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/by/index.html
+++ b/files/en-us/web/svg/attribute/by/index.html
@@ -21,12 +21,11 @@ browser-compat: svg.elements.animate.by
   <li>{{SVGElement("animateTransform")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="10" y="10" width="100" height="100"&gt;
@@ -34,8 +33,7 @@ browser-compat: svg.elements.animate.by
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/clip-path/index.html
+++ b/files/en-us/web/svg/attribute/clip-path/index.html
@@ -36,10 +36,9 @@ browser-compat: svg.attributes.presentation.clip-path
   <li>{{SVGElement('use')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;clipPath id="myClip" clipPathUnits="objectBoundingBox"&gt;
@@ -67,8 +66,7 @@ browser-compat: svg.attributes.presentation.clip-path
         clip-path="circle() view-box" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/clip/index.html
+++ b/files/en-us/web/svg/attribute/clip/index.html
@@ -23,10 +23,9 @@ browser-compat: svg.attributes.presentation.clip
   <li>{{ SVGElement("marker") }}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Auto clipping --&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.attributes.presentation.clip
   &lt;/svg&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/clippathunits/index.html
+++ b/files/en-us/web/svg/attribute/clippathunits/index.html
@@ -15,10 +15,9 @@ tags:
   <li>{{SVGElement('clipPath')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100"&gt;
   &lt;clipPath id="myClip1" clipPathUnits="userSpaceOnUse"&gt;
@@ -44,8 +43,7 @@ tags:
   &lt;use clip-path="url(#myClip2)" xlink:href="#r4" fill="red" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="clipPath">clipPath</h2>
 

--- a/files/en-us/web/svg/attribute/color-rendering/index.html
+++ b/files/en-us/web/svg/attribute/color-rendering/index.html
@@ -48,12 +48,11 @@ browser-compat: svg.attributes.presentation.color-rendering
   <li>{{SVGElement("use")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[9,10,12,14">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -71,8 +70,7 @@ browser-compat: svg.attributes.presentation.color-rendering
   &lt;text x="290" y="50%" color-rendering="optimizeSpeed"&gt;speed-optimized&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/cx/index.html
+++ b/files/en-us/web/svg/attribute/cx/index.html
@@ -17,10 +17,9 @@ tags:
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;radialGradient cx="25%" id="myGradient"&gt;
@@ -33,8 +32,7 @@ tags:
   &lt;rect x="205" y="5" width="90" height="90" fill="url(#myGradient)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', 100, 100)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", 100, 100)}}</p>
 
 <h2 id="circle">circle</h2>
 

--- a/files/en-us/web/svg/attribute/cy/index.html
+++ b/files/en-us/web/svg/attribute/cy/index.html
@@ -17,10 +17,9 @@ tags:
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;radialGradient cy="25%" id="myGradient"&gt;
@@ -33,8 +32,7 @@ tags:
   &lt;rect x="5" y="205" width="90" height="90" fill="url(#myGradient)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 300)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 300)}}</p>
 
 <h2 id="circle">circle</h2>
 

--- a/files/en-us/web/svg/attribute/diffuseconstant/index.html
+++ b/files/en-us/web/svg/attribute/diffuseconstant/index.html
@@ -19,12 +19,11 @@ browser-compat: svg.elements.feDiffuseLighting.diffuseConstant
   <li>{{SVGElement("feDiffuseLighting")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.feDiffuseLighting.diffuseConstant
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#diffuseLighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/direction/index.html
+++ b/files/en-us/web/svg/attribute/direction/index.html
@@ -26,12 +26,11 @@ browser-compat: svg.attributes.presentation.direction
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 600 72" xmlns="http://www.w3.org/2000/svg"
     direction="rtl" lang="fa"&gt;

--- a/files/en-us/web/svg/attribute/direction/index.html
+++ b/files/en-us/web/svg/attribute/direction/index.html
@@ -39,8 +39,6 @@ browser-compat: svg.attributes.presentation.direction
 &lt;/svg&gt;
 </pre>
 
-</div>
-
 <h2 id="Usage_notes">Usage notes</h2>
 
 <table class="properties">

--- a/files/en-us/web/svg/attribute/display/index.html
+++ b/files/en-us/web/svg/attribute/display/index.html
@@ -30,12 +30,11 @@ browser-compat: svg.attributes.presentation.display
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 220 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Here the yellow rectangle is displayed --&gt;
@@ -47,8 +46,7 @@ browser-compat: svg.attributes.presentation.display
   &lt;rect x="140" y="20" width="60" height="60" fill="yellow" display="none"&gt;&lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "240", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "240", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/divisor/index.html
+++ b/files/en-us/web/svg/attribute/divisor/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feConvolveMatrix.divisor
   <li>{{SVGElement("feConvolveMatrix")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="convolveMatrix1" x="0" y="0" width="100%" height="100%"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.feConvolveMatrix.divisor
       style="filter:url(#convolveMatrix2); transform:translateX(220px);"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/dominant-baseline/index.html
+++ b/files/en-us/web/svg/attribute/dominant-baseline/index.html
@@ -35,16 +35,15 @@ browser-compat: svg.attributes.presentation.dominant-baseline
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }
 
 text {
   font: bold 14px Verdana, Helvetica, Arial, sans-serif;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 120" xmlns="http://www.w3.org/2000/svg"&gt;
     &lt;path d="M20,20 L180,20 M20,50 L180,50 M20,80 L180,80" stroke="grey" /&gt;
@@ -54,8 +53,7 @@ text {
     &lt;text dominant-baseline="hanging" x="30" y="80"&gt;Hanging&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/dur/index.html
+++ b/files/en-us/web/svg/attribute/dur/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.animate.dur
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,8]">&lt;svg viewBox="0 0 220 150" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="0" y="0" width="100" height="100"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.animate.dur
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "150")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "150")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/dx/index.html
+++ b/files/en-us/web/svg/attribute/dx/index.html
@@ -21,10 +21,9 @@ tags:
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Lines materialized the position of the glyphs --&gt;
@@ -45,8 +44,7 @@ tags:
   stroke-dasharray: 3px;
 }</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="altGlyph">altGlyph</h2>
 

--- a/files/en-us/web/svg/attribute/dy/index.html
+++ b/files/en-us/web/svg/attribute/dy/index.html
@@ -21,10 +21,9 @@ tags:
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Lines materialized the position of the glyphs --&gt;
@@ -45,8 +44,7 @@ tags:
   stroke-dasharray: 3px;
 }</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="altGlyph">altGlyph</h2>
 

--- a/files/en-us/web/svg/attribute/elevation/index.html
+++ b/files/en-us/web/svg/attribute/elevation/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feDistantLight.elevation
   <li>{{SVGElement("feDistantLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,9]">&lt;svg viewBox="0 0 440 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="distantLight1"&gt;
@@ -40,8 +39,7 @@ browser-compat: svg.elements.feDistantLight.elevation
   &lt;circle cx="100" cy="100" r="80" style="filter: url(#distantLight2); transform: translateX(240px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/exponent/index.html
+++ b/files/en-us/web/svg/attribute/exponent/index.html
@@ -19,12 +19,11 @@ tags:
   <li>{{SVGElement("feFuncR")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[13-15,20-22]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -57,8 +56,7 @@ tags:
       style="filter: url(#componentTransfer2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/fill-opacity/index.html
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.html
@@ -28,10 +28,9 @@ browser-compat: svg.attributes.presentation.fill-opacity
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Default fill opacity: 1 --&gt;
@@ -50,8 +49,7 @@ browser-compat: svg.attributes.presentation.fill-opacity
           style="fill-opacity: .25;" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/fill-rule/index.html
+++ b/files/en-us/web/svg/attribute/fill-rule/index.html
@@ -25,10 +25,9 @@ browser-compat: svg.attributes.presentation.fill-rule
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-10 -10 220 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Default value for fill-rule --&gt;
@@ -45,8 +44,7 @@ browser-compat: svg.attributes.presentation.fill-rule
    points="150,0 121,90 198,35 102,35 179,90"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/fill/index.html
+++ b/files/en-us/web/svg/attribute/fill/index.html
@@ -28,10 +28,9 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For animation, these elements are using this attribute: {{SVGElement('animate')}}, {{SVGElement('animateColor')}}, {{SVGElement('animateMotion')}}, {{SVGElement('animateTransform')}}, and {{SVGElement('set')}}.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Simple color fill --&gt;
@@ -60,8 +59,7 @@ browser-compat: svg.attributes.presentation.fill
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="altGlyph">altGlyph</h2>
 

--- a/files/en-us/web/svg/attribute/filter/index.html
+++ b/files/en-us/web/svg/attribute/filter/index.html
@@ -15,12 +15,11 @@ browser-compat: svg.attributes.presentation.filter
 
 <p>As a presentation attribute, it can be applied to any element but it only has effect on <a href="/en-US/docs/Web/SVG/Element#Container_elements">container elements</a> without the {{SVGElement("defs")}} element, all <a href="/en-US/docs/Web/SVG/Element#Graphics_elements">graphics elements</a> and the {{SVGElement("use")}} element.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="blur"&gt;
@@ -30,8 +29,7 @@ browser-compat: svg.attributes.presentation.filter
   &lt;rect x="10" y="10" width="80" height="80" filter="url(#blur)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/flood-color/index.html
+++ b/files/en-us/web/svg/attribute/flood-color/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.attributes.presentation.flood-color
   <li>{{SVGElement("feDropShadow")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="flood1"&gt;
@@ -39,8 +38,7 @@ browser-compat: svg.attributes.presentation.flood-color
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#flood2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/flood-opacity/index.html
+++ b/files/en-us/web/svg/attribute/flood-opacity/index.html
@@ -19,12 +19,11 @@ browser-compat: svg.attributes.presentation.flood-opacity
   <li>{{SVGElement("feFlood")}} and {{SVGElement("feDropShadow")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="flood1"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.attributes.presentation.flood-opacity
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#flood2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/font-family/index.html
+++ b/files/en-us/web/svg/attribute/font-family/index.html
@@ -22,20 +22,18 @@ browser-compat: svg.attributes.presentation.font-family
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-family="Arial, Helvetica, sans-serif"&gt;Sans serif&lt;/text&gt;
   &lt;text x="100" y="20" font-family="monospace"&gt;Monospace&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "30")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "30")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/font-size-adjust/index.html
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.attributes.presentation.font-size-adjust
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[9]">&lt;svg width="600" height="80" viewBox="0 0 500 80"
     xmlns="http://www.w3.org/2000/svg"&gt;
@@ -40,8 +39,7 @@ browser-compat: svg.attributes.presentation.font-size-adjust
   &lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "600", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "600", "100")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/font-size/index.html
+++ b/files/en-us/web/svg/attribute/font-size/index.html
@@ -22,20 +22,18 @@ browser-compat: svg.attributes.presentation.font-size
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-size="smaller"&gt;smaller&lt;/text&gt;
   &lt;text x="100" y="20" font-size="2em"&gt;2em&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "30")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "30")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/font-style/index.html
+++ b/files/en-us/web/svg/attribute/font-style/index.html
@@ -29,20 +29,18 @@ browser-compat: svg.attributes.presentation.font-style
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-style="normal"&gt;Normal font style&lt;/text&gt;
   &lt;text x="150" y="20" font-style="italic"&gt;Italic font style&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "250", "30")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "250", "30")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/font-variant/index.html
+++ b/files/en-us/web/svg/attribute/font-variant/index.html
@@ -22,20 +22,18 @@ browser-compat: svg.attributes.presentation.font-variant
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-variant="normal"&gt;Normal text&lt;/text&gt;
   &lt;text x="100" y="20" font-variant="small-caps"&gt;Small-caps text&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "250", "30")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "250", "30")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/font-weight/index.html
+++ b/files/en-us/web/svg/attribute/font-weight/index.html
@@ -22,20 +22,18 @@ browser-compat: svg.attributes.presentation.font-weight
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-weight="normal"&gt;Normal text&lt;/text&gt;
   &lt;text x="100" y="20" font-weight="bold"&gt;Bold text&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "30")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "30")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/fr/index.html
+++ b/files/en-us/web/svg/attribute/fr/index.html
@@ -16,12 +16,11 @@ browser-compat: svg.elements.radialGradient.fr
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,9]">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -41,8 +40,7 @@ browser-compat: svg.elements.radialGradient.fr
   &lt;circle cx="100" cy="100" r="100" fill="url(#gradient2)" style="transform: translateX(240px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/from/index.html
+++ b/files/en-us/web/svg/attribute/from/index.html
@@ -19,12 +19,11 @@ browser-compat: svg.elements.animate.from
   <li>{{SVGElement("animateTransform")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="10" y="10" height="100"&gt;
@@ -32,8 +31,7 @@ browser-compat: svg.elements.animate.from
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/fx/index.html
+++ b/files/en-us/web/svg/attribute/fx/index.html
@@ -16,12 +16,11 @@ browser-compat: svg.elements.radialGradient.fx
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,9]">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -41,8 +40,7 @@ browser-compat: svg.elements.radialGradient.fx
   &lt;circle cx="100" cy="100" r="100" fill="url(#gradient2)" style="transform: translateX(240px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/fy/index.html
+++ b/files/en-us/web/svg/attribute/fy/index.html
@@ -16,12 +16,11 @@ browser-compat: svg.elements.radialGradient.fy
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,9]">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -41,8 +40,7 @@ browser-compat: svg.elements.radialGradient.fy
   &lt;circle cx="100" cy="100" r="100" fill="url(#gradient2)" style="transform: translateX(240px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/gradienttransform/index.html
+++ b/files/en-us/web/svg/attribute/gradienttransform/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.linearGradient.gradientTransform
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[10]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;radialGradient id="gradient1" gradientUnits="userSpaceOnUse"
@@ -43,8 +42,7 @@ browser-compat: svg.elements.linearGradient.gradientTransform
   &lt;rect x="0" y="0" width="200" height="200" fill="url(#gradient2)" style="transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/height/index.html
+++ b/files/en-us/web/svg/attribute/height/index.html
@@ -39,10 +39,9 @@ tags:
   <li>{{SVGElement('use')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- With a height of 0 or less, nothing will be rendered --&gt;
@@ -51,8 +50,7 @@ tags:
   &lt;rect y="0" x="200" width="90" height="100%"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="feBlend">feBlend</h2>
 

--- a/files/en-us/web/svg/attribute/href/index.html
+++ b/files/en-us/web/svg/attribute/href/index.html
@@ -34,19 +34,17 @@ browser-compat: svg.attributes.href
   <li>{{SVGElement("use")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;a href="https://developer.mozilla.org/"&gt;&lt;text x="10" y="25"&gt;MDN Web Docs&lt;/text&gt;&lt;/a&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "320", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "320", "100")}}</p>
 
 <h2 id="In_SVG">In SVG</h2>
 

--- a/files/en-us/web/svg/attribute/id/index.html
+++ b/files/en-us/web/svg/attribute/id/index.html
@@ -12,7 +12,8 @@ browser-compat: svg.attributes.core.id
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
+<h2>Example</h2>
+
 <pre class="brush: html">&lt;svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;style type="text/css"&gt;
     &lt;![CDATA[

--- a/files/en-us/web/svg/attribute/id/index.html
+++ b/files/en-us/web/svg/attribute/id/index.html
@@ -28,7 +28,7 @@ browser-compat: svg.attributes.core.id
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample("topExample", "120", "120")}}</p>
+<p>{{EmbedLiveSample("Example", "120", "120")}}</p>
 </div>
 
 <h2 id="Usage_notes">Usage notes</h2>

--- a/files/en-us/web/svg/attribute/id/index.html
+++ b/files/en-us/web/svg/attribute/id/index.html
@@ -29,7 +29,6 @@ browser-compat: svg.attributes.core.id
 </pre>
 
 <p>{{EmbedLiveSample("Example", "120", "120")}}</p>
-</div>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/intercept/index.html
+++ b/files/en-us/web/svg/attribute/intercept/index.html
@@ -19,12 +19,11 @@ tags:
   <li>{{SVGElement("feFuncR")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[13-15,20-22]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -57,8 +56,7 @@ tags:
       style="filter: url(#componentTransfer2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/k1/index.html
+++ b/files/en-us/web/svg/attribute/k1/index.html
@@ -21,12 +21,11 @@ browser-compat: svg.elements.feComposite.k1
   <li>{{SVGElement("feComposite")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="composite1" x="0" y="0" width="100%" height="100%"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.feComposite.k1
       width="200" height="200" style="filter: url(#composite2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/k2/index.html
+++ b/files/en-us/web/svg/attribute/k2/index.html
@@ -21,12 +21,11 @@ browser-compat: svg.elements.feComposite.k2
   <li>{{SVGElement("feComposite")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="composite1" x="0" y="0" width="100%" height="100%"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.feComposite.k2
       width="200" height="200" style="filter: url(#composite2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/k3/index.html
+++ b/files/en-us/web/svg/attribute/k3/index.html
@@ -21,12 +21,11 @@ browser-compat: svg.elements.feComposite.k3
   <li>{{SVGElement("feComposite")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="composite1" x="0" y="0" width="100%" height="100%"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.feComposite.k3
       width="200" height="200" style="filter: url(#composite2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/k4/index.html
+++ b/files/en-us/web/svg/attribute/k4/index.html
@@ -21,12 +21,11 @@ browser-compat: svg.elements.feComposite.k4
   <li>{{SVGElement("feComposite")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="composite1" x="0" y="0" width="100%" height="100%"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.feComposite.k4
       width="200" height="200" style="filter: url(#composite2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/kernelmatrix/index.html
+++ b/files/en-us/web/svg/attribute/kernelmatrix/index.html
@@ -19,12 +19,11 @@ browser-compat: svg.elements.feConvolveMatrix.kernelMatrix
   <li>{{SVGElement("feConvolveMatrix")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="convolveMatrix1" x="0" y="0" width="100%" height="100%"&gt;
@@ -40,8 +39,7 @@ browser-compat: svg.elements.feConvolveMatrix.kernelMatrix
       style="filter:url(#convolveMatrix2); transform:translateX(220px);"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/kerning/index.html
+++ b/files/en-us/web/svg/attribute/kerning/index.html
@@ -23,13 +23,12 @@ browser-compat: svg.attributes.presentation.kerning
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
   font: 36px Verdana, Helvetica, Arial, sans-serif;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 150 125" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text x="10" y="30" kerning="auto"&gt;auto&lt;/text&gt;
@@ -37,8 +36,7 @@ browser-compat: svg.attributes.presentation.kerning
   &lt;text x="10" y="110" kerning="20px"&gt;length&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/keypoints/index.html
+++ b/files/en-us/web/svg/attribute/keypoints/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.animateMotion.keyPoints
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[10]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.animateMotion.keyPoints
   &lt;/circle&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/keysplines/index.html
+++ b/files/en-us/web/svg/attribute/keysplines/index.html
@@ -23,12 +23,11 @@ browser-compat: svg.elements.animate.keySplines
   <li>{{SVGElement("animateTransform")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[5,8]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;circle cx="60" cy="10" r="10"&gt;
@@ -41,8 +40,7 @@ browser-compat: svg.elements.animate.keySplines
   &lt;/circle&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/keytimes/index.html
+++ b/files/en-us/web/svg/attribute/keytimes/index.html
@@ -19,12 +19,11 @@ browser-compat: svg.elements.animate.keyTimes
   <li>{{SVGElement("animateTransform")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,6]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;circle cx="60" cy="10" r="10"&gt;
@@ -35,8 +34,7 @@ browser-compat: svg.elements.animate.keyTimes
   &lt;/circle&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/lang/index.html
+++ b/files/en-us/web/svg/attribute/lang/index.html
@@ -16,7 +16,8 @@ browser-compat: svg.attributes.core.lang
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
+<h2>Example</h2>
+
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text lang="en-US"&gt;This is some English text&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/lang/index.html
+++ b/files/en-us/web/svg/attribute/lang/index.html
@@ -21,7 +21,6 @@ browser-compat: svg.attributes.core.lang
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text lang="en-US"&gt;This is some English text&lt;/text&gt;
 &lt;/svg&gt;</pre>
-</div>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/lengthadjust/index.html
+++ b/files/en-us/web/svg/attribute/lengthadjust/index.html
@@ -19,12 +19,11 @@ browser-compat: svg.elements.text.lengthAdjust
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3-6]">&lt;svg width="300" height="150" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;g font-face="sans-serif"&gt;
@@ -43,8 +42,7 @@ browser-compat: svg.elements.text.lengthAdjust
   &lt;/g&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/letter-spacing/index.html
+++ b/files/en-us/web/svg/attribute/letter-spacing/index.html
@@ -26,20 +26,18 @@ browser-compat: svg.attributes.presentation.letter-spacing
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" letter-spacing="2"&gt;Bigger letter-spacing&lt;/text&gt;
   &lt;text x="200" y="20" letter-spacing="-0.5"&gt;Smaller letter-spacing&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "30")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "30")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/lighting-color/index.html
+++ b/files/en-us/web/svg/attribute/lighting-color/index.html
@@ -18,12 +18,11 @@ browser-compat: svg.attributes.presentation.lighting-color
   <li>{{SVGElement("feSpecularLighting")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
@@ -41,8 +40,7 @@ browser-compat: svg.attributes.presentation.lighting-color
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#diffuseLighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/limitingconeangle/index.html
+++ b/files/en-us/web/svg/attribute/limitingconeangle/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feSpotLight.limitingConeAngle
   <li>{{SVGElement("feSpotLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,9]">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="spotLight1" x="0" y="0" width="100%" height="100%"&gt;
@@ -40,8 +39,7 @@ browser-compat: svg.elements.feSpotLight.limitingConeAngle
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#spotLight2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/marker-end/index.html
+++ b/files/en-us/web/svg/attribute/marker-end/index.html
@@ -26,12 +26,11 @@ browser-compat: svg.attributes.presentation.marker-end
   <li>{{SVGElement("rect")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[12]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -48,8 +47,7 @@ browser-compat: svg.attributes.presentation.marker-end
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/marker-mid/index.html
+++ b/files/en-us/web/svg/attribute/marker-mid/index.html
@@ -26,12 +26,11 @@ browser-compat: svg.attributes.presentation.marker-mid
   <li>{{SVGElement("rect")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[8]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -44,8 +43,7 @@ browser-compat: svg.attributes.presentation.marker-mid
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/marker-start/index.html
+++ b/files/en-us/web/svg/attribute/marker-start/index.html
@@ -26,12 +26,11 @@ browser-compat: svg.attributes.presentation.marker-start
   <li>{{SVGElement("rect")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[12]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -48,8 +47,7 @@ browser-compat: svg.attributes.presentation.marker-start
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/mask/index.html
+++ b/files/en-us/web/svg/attribute/mask/index.html
@@ -36,10 +36,9 @@ browser-compat: svg.attributes.presentation.mask
   <li>{{SVGElement('use')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;mask id="myMask" maskContentUnits="objectBoundingBox"&gt;
@@ -56,8 +55,7 @@ browser-compat: svg.attributes.presentation.mask
           mask="url(#myMask)"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <p>Since SVG2, the {{cssxref('mask')}} attribute is defined as a css property and is a shorthand for many other properties: {{cssxref('mask-image')}}, {{cssxref('mask-mode')}}, {{cssxref('mask-repeat')}}, {{cssxref('mask-position')}}, {{cssxref('mask-clip')}}, {{cssxref('mask-origin')}}, {{cssxref('mask-size')}}, and {{cssxref('mask-composite')}}.</p>
 

--- a/files/en-us/web/svg/attribute/maskcontentunits/index.html
+++ b/files/en-us/web/svg/attribute/maskcontentunits/index.html
@@ -16,10 +16,9 @@ browser-compat: svg.elements.mask.maskContentUnits
   <li>{{SVGElement('mask')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;mask id="myMask1" maskContentUnits="userSpaceOnUse"&gt;
@@ -47,8 +46,7 @@ browser-compat: svg.elements.mask.maskContentUnits
   &lt;use mask="url(#myMask2)" xlink:href="#r4" fill="red" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="mask">mask</h2>
 

--- a/files/en-us/web/svg/attribute/maskunits/index.html
+++ b/files/en-us/web/svg/attribute/maskunits/index.html
@@ -16,10 +16,9 @@ browser-compat: svg.elements.mask.maskUnits
   <li>{{SVGElement('mask')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;mask id="myMask1" maskUnits="userSpaceOnUse"
@@ -49,8 +48,7 @@ browser-compat: svg.elements.mask.maskUnits
   &lt;use mask="url(#myMask2)" xlink:href="#r4" fill="red" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="mask">mask</h2>
 

--- a/files/en-us/web/svg/attribute/max/index.html
+++ b/files/en-us/web/svg/attribute/max/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.animate.max
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,5]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;circle cx="60" cy="10" r="10"&gt;
@@ -36,8 +35,7 @@ browser-compat: svg.elements.animate.max
   &lt;/circle&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/media/index.html
+++ b/files/en-us/web/svg/attribute/media/index.html
@@ -16,12 +16,11 @@ browser-compat: svg.elements.style.media
   <li>{{SVGElement("style")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[5]">&lt;svg viewBox="0 0 240 220" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;style&gt;
@@ -35,8 +34,7 @@ browser-compat: svg.elements.style.media
   &lt;rect y="20" width="200" height="200" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/min/index.html
+++ b/files/en-us/web/svg/attribute/min/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.animate.min
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,5]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;circle cx="60" cy="10" r="10"&gt;
@@ -36,8 +35,7 @@ browser-compat: svg.elements.animate.min
   &lt;/circle&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/mode/index.html
+++ b/files/en-us/web/svg/attribute/mode/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feBlend.mode
   <li>{{SVGElement("feBlend")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[5,10]">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="blending1" x="0" y="0" width="100%" height="100%"&gt;
@@ -42,8 +41,7 @@ browser-compat: svg.elements.feBlend.mode
       style="filter:url(#blending2); transform:translateX(220px);"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/numoctaves/index.html
+++ b/files/en-us/web/svg/attribute/numoctaves/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.feTurbulence.numOctaves
   <li>{{SVGElement("feTurbulence")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="noise1" x="0" y="0" width="100%" height="100%"&gt;
@@ -39,8 +38,7 @@ browser-compat: svg.elements.feTurbulence.numOctaves
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#noise2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/onclick/index.html
+++ b/files/en-us/web/svg/attribute/onclick/index.html
@@ -53,20 +53,18 @@ browser-compat: svg.attributes.events.global.onclick
   <li>{{SVGElement("view")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
   margin: 0;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;circle cx="100" cy="100" r="100" onclick="alert('You have clicked the circle.')" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/opacity/index.html
+++ b/files/en-us/web/svg/attribute/opacity/index.html
@@ -41,12 +41,11 @@ browser-compat: svg.attributes.presentation.opacity
   <li>{{SVGElement("video")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -60,8 +59,7 @@ browser-compat: svg.attributes.presentation.opacity
   &lt;circle cx="150" cy="50" r="40" fill="black" opacity="0.3" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/operator/index.html
+++ b/files/en-us/web/svg/attribute/operator/index.html
@@ -38,7 +38,6 @@ tags:
   &lt;text x="0" y="65" filter="url(#dilate)"&gt;Fat text&lt;/text&gt;
 &lt;/svg&gt;
 </pre>
-</div>
 
 <p>{{EmbedLiveSample("Example", "240", "200")}}</p>
 

--- a/files/en-us/web/svg/attribute/operator/index.html
+++ b/files/en-us/web/svg/attribute/operator/index.html
@@ -18,13 +18,12 @@ tags:
   <li>{{SVGElement("feMorphology")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
   font: 20px Arial, Helvetica, sans-serif;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 120 70" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="erode"&gt;
@@ -41,7 +40,7 @@ tags:
 </pre>
 </div>
 
-<p>{{EmbedLiveSample("topExample", "240", "200")}}</p>
+<p>{{EmbedLiveSample("Example", "240", "200")}}</p>
 
 <h2 id="feComposite">feComposite</h2>
 

--- a/files/en-us/web/svg/attribute/order/index.html
+++ b/files/en-us/web/svg/attribute/order/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feConvolveMatrix.order
   <li>{{SVGElement("feConvolveMatrix")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="emboss1" x="0" y="0" width="100%" height="100%"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.feConvolveMatrix.order
   &lt;rect x="0" y="0" width="200" height="200" style="filter:url(#emboss2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/orient/index.html
+++ b/files/en-us/web/svg/attribute/orient/index.html
@@ -16,12 +16,11 @@ browser-compat: svg.elements.marker.orient
   <li>{{SVGElement("marker")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[5,11]">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -46,8 +45,7 @@ browser-compat: svg.elements.marker.orient
       marker-end="url(#dataArrow)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/path/index.html
+++ b/files/en-us/web/svg/attribute/path/index.html
@@ -16,12 +16,11 @@ tags:
   <li>{{SVGElement("textPath")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[6]">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;path id="MyPath" fill="none" stroke="silver"
@@ -34,8 +33,7 @@ tags:
   &lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "220")}}</p>
 
 <h2 id="animateMotion">animateMotion</h2>
 

--- a/files/en-us/web/svg/attribute/pathlength/index.html
+++ b/files/en-us/web/svg/attribute/pathlength/index.html
@@ -23,10 +23,9 @@ tags:
   <li>{{SVGElement('rect')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;style&gt;
@@ -54,8 +53,7 @@ tags:
   &lt;path d="M 0,50 h100" pathLength="10"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="circle">circle</h2>
 

--- a/files/en-us/web/svg/attribute/patterntransform/index.html
+++ b/files/en-us/web/svg/attribute/patterntransform/index.html
@@ -16,10 +16,9 @@ browser-compat: svg.elements.pattern.patternTransform
   <li>{{SVGElement('pattern')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Apply a transform on the tile --&gt;
@@ -35,8 +34,7 @@ browser-compat: svg.elements.pattern.patternTransform
         fill="url(#p1)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 300)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 300)}}</p>
 
 <h2 id="pattern">pattern</h2>
 

--- a/files/en-us/web/svg/attribute/patternunits/index.html
+++ b/files/en-us/web/svg/attribute/patternunits/index.html
@@ -16,10 +16,9 @@ browser-compat: svg.elements.pattern.patternUnits
   <li>{{SVGElement('pattern')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- All geometry properties are relative to the current user space --&gt;
@@ -43,8 +42,7 @@ browser-compat: svg.elements.pattern.patternUnits
         fill="url(#p2)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="pattern">pattern</h2>
 

--- a/files/en-us/web/svg/attribute/pointer-events/index.html
+++ b/files/en-us/web/svg/attribute/pointer-events/index.html
@@ -40,10 +40,9 @@ browser-compat: svg.attributes.presentation.pointer-events
   <li>{{SVGElement('use')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--
@@ -77,8 +76,7 @@ browser-compat: svg.attributes.presentation.pointer-events
   e.target.style.fill = fill
 })</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/points/index.html
+++ b/files/en-us/web/svg/attribute/points/index.html
@@ -61,8 +61,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -97,8 +95,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/points/index.html
+++ b/files/en-us/web/svg/attribute/points/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{SVGElement("polygon")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-10 -10 220 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- polyline is an open shape --&gt;
@@ -37,8 +36,7 @@ tags:
   --&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="polyline">polyline</h2>
 

--- a/files/en-us/web/svg/attribute/pointsatx/index.html
+++ b/files/en-us/web/svg/attribute/pointsatx/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feSpotLight.pointsAtX
   <li>{{SVGElement("feSpotLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -41,8 +40,7 @@ browser-compat: svg.elements.feSpotLight.pointsAtX
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#lighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/pointsaty/index.html
+++ b/files/en-us/web/svg/attribute/pointsaty/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feSpotLight.pointsAtY
   <li>{{SVGElement("feSpotLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -41,8 +40,7 @@ browser-compat: svg.elements.feSpotLight.pointsAtY
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#lighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/pointsatz/index.html
+++ b/files/en-us/web/svg/attribute/pointsatz/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feSpotLight.pointsAtZ
   <li>{{SVGElement("feSpotLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -41,8 +40,7 @@ browser-compat: svg.elements.feSpotLight.pointsAtZ
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#lighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/preservealpha/index.html
+++ b/files/en-us/web/svg/attribute/preservealpha/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feConvolveMatrix.preserveAlpha
   <li>{{SVGElement("feConvolveMatrix")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="convolveMatrix1" x="0" y="0" width="100%" height="100%"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.feConvolveMatrix.preserveAlpha
       style="filter:url(#convolveMatrix2); transform:translateX(220px);"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/r/index.html
+++ b/files/en-us/web/svg/attribute/r/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{SVGElement("radialGradient")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;radialGradient r="0" id="myGradient000"&gt;
@@ -44,8 +43,7 @@ tags:
   &lt;rect x="220" y="120" width="60" height="60" fill="url(#myGradient100)" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="circle">circle</h2>
 

--- a/files/en-us/web/svg/attribute/repeatcount/index.html
+++ b/files/en-us/web/svg/attribute/repeatcount/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.animate.repeatCount
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,8]">&lt;svg viewBox="0 0 220 150" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="0" y="0" width="100" height="100"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.animate.repeatCount
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "150")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "150")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/repeatdur/index.html
+++ b/files/en-us/web/svg/attribute/repeatdur/index.html
@@ -20,12 +20,11 @@ browser-compat: svg.elements.animate.repeatDur
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,8]">&lt;svg viewBox="0 0 220 150" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="0" y="0" width="100" height="100"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.animate.repeatDur
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "150")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "150")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/requiredfeatures/index.html
+++ b/files/en-us/web/svg/attribute/requiredfeatures/index.html
@@ -50,9 +50,9 @@ browser-compat: svg.attributes.conditional_processing.requiredFeatures
   <li>{{SVGElement("use")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }
 
@@ -60,7 +60,6 @@ text {
   fill: white;
 }
 </pre>
-</div>
 
 <pre class="brush: html; highlight[4,7]">&lt;svg viewBox="0 0 250 45" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;g&gt;
@@ -73,8 +72,7 @@ text {
   &lt;/g&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "250", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "250", "100")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/restart/index.html
+++ b/files/en-us/web/svg/attribute/restart/index.html
@@ -20,9 +20,9 @@ browser-compat: svg.elements.animate.restart
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }
 
@@ -31,7 +31,6 @@ a {
   text-decoration: underline;
   cursor: pointer;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,8]">&lt;svg viewBox="0 0 220 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect y="30" width="100" height="100"&gt;
@@ -51,8 +50,7 @@ a {
   });
 });</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "150")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "150")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/result/index.html
+++ b/files/en-us/web/svg/attribute/result/index.html
@@ -32,12 +32,11 @@ tags:
   <li>{{SVGElement("feTurbulence")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4]">&lt;svg viewBox="0 0 220 220" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="displacementFilter"&gt;
@@ -51,8 +50,7 @@ tags:
       style="filter: url(#displacementFilter)"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", 220, 220)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", 220, 220)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/rx/index.html
+++ b/files/en-us/web/svg/attribute/rx/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{SVGElement("rect")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;ellipse cx="50"  cy="50" rx="0"  ry="25" /&gt;
@@ -31,8 +30,7 @@ tags:
   &lt;rect x="220" y="120" width="60" height="60" rx="150" ry="15"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="ellipse">ellipse</h2>
 

--- a/files/en-us/web/svg/attribute/ry/index.html
+++ b/files/en-us/web/svg/attribute/ry/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{SVGElement("rect")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;ellipse cx="50"  cy="50" ry="0"  rx="25" /&gt;
@@ -31,8 +30,7 @@ tags:
   &lt;rect x="220" y="120" width="60" height="60" ry="150" rx="15"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="ellipse">ellipse</h2>
 

--- a/files/en-us/web/svg/attribute/scale/index.html
+++ b/files/en-us/web/svg/attribute/scale/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feDisplacementMap.scale
   <li>{{SVGElement("feDisplacementMap")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,8]">&lt;svg viewBox="0 0 480 220" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="displacementFilter" x="-20%" y="-20%" width="140%" height="140%"&gt;
@@ -38,8 +37,7 @@ browser-compat: svg.elements.feDisplacementMap.scale
   &lt;circle cx="100" cy="100" r="80" style="filter: url(#displacementFilter2); transform: translateX(240px);""/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/seed/index.html
+++ b/files/en-us/web/svg/attribute/seed/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feTurbulence.seed
   <li>{{SVGElement("feTurbulence")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4,7]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="noise1" x="0" y="0" width="100%" height="100%"&gt;
@@ -36,8 +35,7 @@ browser-compat: svg.elements.feTurbulence.seed
   &lt;rect x="0" y="0" width="200" height="200" style="filter:url(#noise2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "220", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "220", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/shape-rendering/index.html
+++ b/files/en-us/web/svg/attribute/shape-rendering/index.html
@@ -24,20 +24,18 @@ browser-compat: svg.attributes.presentation.shape-rendering
   <li>{{SVGElement("rect")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;circle cx="100" cy="100" r="100" shape-rendering="geometricPrecision"/&gt;
   &lt;circle cx="320" cy="100" r="100" shape-rendering="crispEdges"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/side/index.html
+++ b/files/en-us/web/svg/attribute/side/index.html
@@ -16,16 +16,15 @@ browser-compat: svg.elements.textPath.side
   <li>{{SVGElement("textPath")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }
 
 text {
   font: 25px Arial, Helvetica, sans-serif;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text&gt;
@@ -39,8 +38,7 @@ text {
   &lt;circle id="circle2" cx="320" cy="100" r="70" fill="transparent" stroke="silver"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/specularconstant/index.html
+++ b/files/en-us/web/svg/attribute/specularconstant/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feSpecularLighting.specularConstant
   <li>{{SVGElement("feSpecularLighting")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="specularLighting1" x="0" y="0" width="100%" height="100%"&gt;
@@ -41,8 +40,7 @@ browser-compat: svg.elements.feSpecularLighting.specularConstant
       style="filter: url(#specularLighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/specularexponent/index.html
+++ b/files/en-us/web/svg/attribute/specularexponent/index.html
@@ -17,12 +17,11 @@ tags:
   <li>{{SVGElement("feSpotLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
@@ -41,8 +40,7 @@ tags:
       style="filter: url(#diffuseLighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="feSpecularLighting">feSpecularLighting</h2>
 

--- a/files/en-us/web/svg/attribute/stddeviation/index.html
+++ b/files/en-us/web/svg/attribute/stddeviation/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feGaussianBlur.stdDeviation
   <li>{{SVGElement("feGaussianBlur")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,6,9]">&lt;svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="gaussianBlur1"&gt;
@@ -40,8 +39,7 @@ browser-compat: svg.elements.feGaussianBlur.stdDeviation
   &lt;circle cx="100" cy="100" r="50" style="filter: url(#gaussianBlur3); transform: translateX(280px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stitchtiles/index.html
+++ b/files/en-us/web/svg/attribute/stitchtiles/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feTurbulence.stitchTiles
   <li>{{SVGElement("feTurbulence")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="noise1" x="0" y="0" width="100%" height="100%"&gt;
@@ -43,8 +42,7 @@ browser-compat: svg.elements.feTurbulence.stitchTiles
   &lt;rect x="0" y="0" width="100" height="100" style="filter: url(#noise2); transform: translate(320px, 100px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "220")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "220")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.html
@@ -29,10 +29,9 @@ browser-compat: svg.attributes.presentation.stroke-dasharray
  <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- No dashes nor gaps --&gt;
@@ -56,8 +55,7 @@ browser-compat: svg.attributes.presentation.stroke-dasharray
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
@@ -29,10 +29,9 @@ browser-compat: svg.attributes.presentation.stroke-dashoffset
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-3 0 33 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- No dash array --&gt;
@@ -75,8 +74,7 @@ browser-compat: svg.attributes.presentation.stroke-dashoffset
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-linecap/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linecap/index.html
@@ -25,10 +25,9 @@ browser-compat: svg.attributes.presentation.stroke-linecap
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -52,8 +51,7 @@ browser-compat: svg.attributes.presentation.stroke-linecap
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.html
@@ -28,10 +28,9 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 18 12" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--
@@ -89,8 +88,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 400)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 400)}}</p>
 
 <h2 id="Usage_context">Usage context</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.html
@@ -115,8 +115,6 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <p>The <code>arcs</code> value indicates that an arcs corner is to be used to join path segments. The arcs shape is formed by extending the outer edges of the stroke at the join point with arcs that have the same curvature as the outer edges at the join point.</p>
 
-<h4 id="Example">Example</h4>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -144,8 +142,6 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 <h3 id="bevel">bevel</h3>
 
 <p>The <code>bevel</code> value indicates that a bevelled corner is to be used to join path segments.</p>
-
-<h4 id="Example_2">Example</h4>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
@@ -176,8 +172,6 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 <p>The <code>miter</code> value indicates that a sharp corner is to be used to join path segments. The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect.</p>
 
 <div class="notecard note"><strong>Note:</strong> If the {{SVGAttr('stroke-miterlimit')}} is exceeded, the line join falls back to <code>bevel</code>.</div>
-
-<h4 id="Example_3">Example</h4>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
@@ -221,8 +215,6 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <p>If the {{SVGAttr('stroke-miterlimit')}} is exceeded, the miter is clipped at a distance equal to half the {{SVGAttr('stroke-miterlimit')}} value multiplied by the stroke width from the intersection of the path segments. This provides a better rendering than <code>miter</code> on very sharp join or in case of an animation.</p>
 
-<h4 id="Example_4">Example</h4>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -259,8 +251,6 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 <h3 id="round">round</h3>
 
 <p>The <code>round</code> value indicates that a round corner is to be used to join path segments.</p>
-
-<h4 id="Example_5">Example</h4>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
+++ b/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
@@ -26,10 +26,9 @@ browser-compat: svg.attributes.presentation.stroke-miterlimit
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 38 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Impact of the default miter limit --&gt;
@@ -65,8 +64,7 @@ browser-compat: svg.attributes.presentation.stroke-miterlimit
            M1,29 l7,-3 l7,3 m2,0 l3.5,-3 l3.5,3 m2,0 l2,-3 l2,3 m2,0 l0.75,-3 l0.75,3 m2,0 l0.5,-3 l0.5,3" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 400)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 400)}}</p>
 
 <p>When two line segments meet at a sharp angle and <code>miter</code> joins have been specified for {{ SVGAttr("stroke-linejoin") }}, it is possible for the miter to extend far beyond the thickness of the line stroking the path. The <code>stroke-miterlimit</code> ratio is used to define when the limit is exceeded, if so the join is converted from a miter to a bevel.</p>
 

--- a/files/en-us/web/svg/attribute/stroke-opacity/index.html
+++ b/files/en-us/web/svg/attribute/stroke-opacity/index.html
@@ -29,10 +29,9 @@ browser-compat: svg.attributes.presentation.stroke-opacity
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 40 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Default stroke opacity: 1 --&gt;
@@ -51,8 +50,7 @@ browser-compat: svg.attributes.presentation.stroke-opacity
           style="stroke-opacity: .3;" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-width/index.html
+++ b/files/en-us/web/svg/attribute/stroke-width/index.html
@@ -27,10 +27,9 @@ browser-compat: svg.attributes.presentation.stroke-width
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Default stroke width: 1 --&gt;
@@ -45,8 +44,7 @@ browser-compat: svg.attributes.presentation.stroke-width
           stroke-width="2%" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 150)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 150)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/stroke/index.html
+++ b/files/en-us/web/svg/attribute/stroke/index.html
@@ -29,10 +29,9 @@ browser-compat: svg.attributes.presentation.stroke
   <li>{{SVGElement('tspan')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Simple color stroke --&gt;
@@ -52,8 +51,7 @@ browser-compat: svg.attributes.presentation.stroke
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/style/index.html
+++ b/files/en-us/web/svg/attribute/style/index.html
@@ -12,10 +12,9 @@ browser-compat: svg.attributes.style.style
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html; highlight[3]">&lt;svg viewbox="0 0 100 60" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect width="80"  height="40" x="10" y="10"
@@ -23,8 +22,7 @@ browser-compat: svg.attributes.style.style
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/surfacescale/index.html
+++ b/files/en-us/web/svg/attribute/surfacescale/index.html
@@ -18,12 +18,11 @@ tags:
   <li>{{SVGElement("feSpecularLighting")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
@@ -41,8 +40,7 @@ tags:
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#diffuseLighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="feSpecularLighting">feSpecularLighting</h2>
 

--- a/files/en-us/web/svg/attribute/tabindex/index.html
+++ b/files/en-us/web/svg/attribute/tabindex/index.html
@@ -12,13 +12,12 @@ browser-compat: svg.attributes.core.tabindex
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;?xml version="1.0"?&gt;
 &lt;svg viewBox="0 0 260 260" xmlns="http://www.w3.org/2000/svg"&gt;
@@ -28,8 +27,7 @@ browser-compat: svg.attributes.core.tabindex
     &lt;circle cx="160" cy="160" r="60" tabindex="4" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "260", "260")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "260", "260")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/tablevalues/index.html
+++ b/files/en-us/web/svg/attribute/tablevalues/index.html
@@ -18,12 +18,11 @@ tags:
   <li>{{SVGElement("feFuncR")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[13-15,20-22]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -56,8 +55,7 @@ tags:
       style="filter: url(#componentTransfer2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/target/index.html
+++ b/files/en-us/web/svg/attribute/target/index.html
@@ -16,9 +16,9 @@ browser-compat: svg.elements.a.target
   <li>{{SVGElement("a")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }
 
@@ -27,7 +27,6 @@ text {
   fill: blue;
   text-decoration: underline;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,5,8]">&lt;svg viewBox="0 0 300 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;a href="https://developer.mozilla.org" target="_self"&gt;
@@ -41,8 +40,7 @@ text {
   &lt;/a&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "300", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "300", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/text-anchor/index.html
+++ b/files/en-us/web/svg/attribute/text-anchor/index.html
@@ -24,12 +24,11 @@ browser-compat: svg.attributes.presentation.text-anchor
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[6-8]">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Materialization of anchors --&gt;
@@ -52,8 +51,7 @@ browser-compat: svg.attributes.presentation.text-anchor
   ]]&gt;&lt;/style&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "120", "120")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "120", "120")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/text-decoration/index.html
+++ b/files/en-us/web/svg/attribute/text-decoration/index.html
@@ -26,20 +26,18 @@ browser-compat: svg.attributes.presentation.text-decoration
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" text-decoration="underline"&gt;Underlined text&lt;/text&gt;
   &lt;text x="0" y="40" text-decoration="line-through"&gt;Struck-through text&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "250", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "250", "100")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/text-rendering/index.html
+++ b/files/en-us/web/svg/attribute/text-rendering/index.html
@@ -18,20 +18,18 @@ browser-compat: svg.attributes.presentation.text-rendering
   <li>{{SVGElement("text")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 140 40" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="15" text-rendering="geometricPrecision"&gt;Geometric precision&lt;/text&gt;
   &lt;text y="35" text-rendering="optimizeLegibility"&gt;Optimized legibility&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "140")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "140")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/textlength/index.html
+++ b/files/en-us/web/svg/attribute/textlength/index.html
@@ -39,7 +39,6 @@ browser-compat: svg.attributes.textLength
   &lt;text y="20" textLength="6em"&gt;Small text length&lt;/text&gt;
   &lt;text y="40" textLength="120%"&gt;Big text length&lt;/text&gt;
 &lt;/svg&gt;</pre>
-</div>
 
 <p>{{EmbedLiveSample("Example", "200", "100")}}</p>
 
@@ -69,11 +68,10 @@ browser-compat: svg.attributes.textLength
  <dd>A numeric value outlines a length referring to the units of the current coordinate system.</dd>
 </dl>
 
-<h2 id="Example">Example</h2>
+<h2>Interactive example</h2>
 
 <p>Let's create a simple example that presents text you can resize using an {{HTMLElement("input")}} element of type <code><a href="/en-US/docs/Web/HTML/Element/input/range">"range"</a></code>.</p>
 
-<div class="hidden">
 <h3 id="CSS">CSS</h3>
 
 <pre class="brush: css">.controls {
@@ -140,7 +138,7 @@ widthSlider.dispatchEvent(new Event("input"));
 
 <p>Here's what the example looks like. Try dragging the slider around to get a feel for what it does.</p>
 
-<p>{{EmbedLiveSample("Example", 650, 160)}}</p>
+<p>{{EmbedLiveSample("Interactive_example", 650, 160)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/textlength/index.html
+++ b/files/en-us/web/svg/attribute/textlength/index.html
@@ -29,12 +29,11 @@ browser-compat: svg.attributes.textLength
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 60" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" textLength="6em"&gt;Small text length&lt;/text&gt;
@@ -42,7 +41,7 @@ browser-compat: svg.attributes.textLength
 &lt;/svg&gt;</pre>
 </div>
 
-<p>{{EmbedLiveSample("topExample", "200", "100")}}</p>
+<p>{{EmbedLiveSample("Example", "200", "100")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 
@@ -80,7 +79,6 @@ browser-compat: svg.attributes.textLength
 <pre class="brush: css">.controls {
   font: 16px "Open Sans", "Arial", sans-serif;
 }</pre>
-</div>
 
 <h3 id="SVG">SVG</h3>
 

--- a/files/en-us/web/svg/attribute/to/index.html
+++ b/files/en-us/web/svg/attribute/to/index.html
@@ -20,12 +20,11 @@ tags:
   <li>{{SVGElement("set")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[4]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="10" y="10" width="100" height="100"&gt;
@@ -34,8 +33,7 @@ tags:
   &lt;/rect&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="animate_animateColor_animateMotion_animateTransform">animate, animateColor, animateMotion, animateTransform</h2>
 

--- a/files/en-us/web/svg/attribute/transform/index.html
+++ b/files/en-us/web/svg/attribute/transform/index.html
@@ -13,10 +13,9 @@ tags:
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-40 0 150 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
   &lt;g fill="grey"
@@ -31,8 +30,7 @@ tags:
 &lt;/svg&gt;
 </pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <p>In SVG 1.1, only these 16 elements were allowed to use it: {{SVGElement('a')}}, {{SVGElement('circle')}}, {{SVGElement('clipPath')}}, {{SVGElement('defs')}}, {{SVGElement('ellipse')}}, {{SVGElement('foreignObject')}}, {{SVGElement('g')}}, {{SVGElement('image')}}, {{SVGElement('line')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('switch')}}, {{SVGElement('text')}}, and {{SVGElement('use')}}).</p>
 

--- a/files/en-us/web/svg/attribute/viewbox/index.html
+++ b/files/en-us/web/svg/attribute/viewbox/index.html
@@ -21,11 +21,10 @@ tags:
   <li>{{SVGElement("view")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }
 svg:not(:root) { display: inline-block; }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--
@@ -73,8 +72,7 @@ svg:not(:root) { display: inline-block; }</pre>
   &lt;circle cx="50%" cy="50%" r="4" fill="white"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <p>The exact effect of this attribute is influenced by the {{ SVGAttr("preserveAspectRatio") }} attribute.</p>
 

--- a/files/en-us/web/svg/attribute/visibility/index.html
+++ b/files/en-us/web/svg/attribute/visibility/index.html
@@ -40,12 +40,11 @@ browser-compat: svg.attributes.presentation.visibility
   <li>{{SVGElement("video")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[5,6]">&lt;svg viewBox="0 0 220 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="10" y="10" width="200" height="100" stroke="black"
@@ -56,8 +55,7 @@ browser-compat: svg.attributes.presentation.visibility
   &lt;/g&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "250", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "250", "100")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/width/index.html
+++ b/files/en-us/web/svg/attribute/width/index.html
@@ -39,10 +39,9 @@ tags:
   <li>{{SVGElement('use')}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- With a width of 0 or less, nothing will be rendered --&gt;
@@ -51,8 +50,7 @@ tags:
   &lt;rect x="0" y="200" width="100%" height="90"/&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="feBlend">feBlend</h2>
 

--- a/files/en-us/web/svg/attribute/word-spacing/index.html
+++ b/files/en-us/web/svg/attribute/word-spacing/index.html
@@ -26,20 +26,18 @@ browser-compat: svg.attributes.presentation.word-spacing
   <li>{{SVGElement("tspan")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" word-spacing="2"&gt;Bigger spacing between words&lt;/text&gt;
   &lt;text x="0" y="40" word-spacing="-0.5"&gt;Smaller spacing between words&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "250", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "250", "100")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/x/index.html
+++ b/files/en-us/web/svg/attribute/x/index.html
@@ -53,10 +53,9 @@ tags:
   <li>{{SVGElement("use")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="20"  y="20" width="60" height="60" /&gt;
@@ -64,8 +63,7 @@ tags:
   &lt;rect x="220" y="20" width="60" height="60" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="altGlyph">altGlyph</h2>
 

--- a/files/en-us/web/svg/attribute/x/index.html
+++ b/files/en-us/web/svg/attribute/x/index.html
@@ -793,8 +793,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -876,8 +874,6 @@ line {
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/x1/index.html
+++ b/files/en-us/web/svg/attribute/x1/index.html
@@ -21,10 +21,9 @@ tags:
   <li>{{ SVGElement("linearGradient") }}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="1" x2="5" y1="1" y2="9" stroke="red" /&gt;
@@ -32,8 +31,7 @@ tags:
   &lt;line x1="9" x2="5" y1="1" y2="9" stroke="blue" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="line">line</h2>
 

--- a/files/en-us/web/svg/attribute/x1/index.html
+++ b/files/en-us/web/svg/attribute/x1/index.html
@@ -54,8 +54,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -88,8 +86,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/x2/index.html
+++ b/files/en-us/web/svg/attribute/x2/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{ SVGElement("linearGradient") }}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="5" x2="1" y1="1" y2="9" stroke="red" /&gt;
@@ -27,8 +26,7 @@ tags:
   &lt;line x1="5" x2="9" y1="1" y2="9" stroke="blue" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="line">line</h2>
 

--- a/files/en-us/web/svg/attribute/x2/index.html
+++ b/files/en-us/web/svg/attribute/x2/index.html
@@ -49,8 +49,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -83,8 +81,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/xchannelselector/index.html
+++ b/files/en-us/web/svg/attribute/xchannelselector/index.html
@@ -18,12 +18,11 @@ browser-compat: svg.elements.feDisplacementMap.xChannelSelector
   <li>{{SVGElement("feDisplacementMap")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[6,12]">&lt;svg viewBox="0 0 440 160" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="displacementFilter"&gt;
@@ -45,8 +44,7 @@ browser-compat: svg.elements.feDisplacementMap.xChannelSelector
       filter="url(#displacementFilter2)"&gt;Some displaced text&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/xlink_colon_href/index.html
+++ b/files/en-us/web/svg/attribute/xlink_colon_href/index.html
@@ -40,19 +40,17 @@ tags:
   <li>{{SVGElement("use")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;a xlink:href="https://developer.mozilla.org/"&gt;&lt;text x="10" y="25"&gt;MDN Web Docs&lt;/text&gt;&lt;/a&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "320", "100")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "320", "100")}}</p>
 
 <h2 id="a">a</h2>
 

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.html
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.html
@@ -21,7 +21,6 @@ browser-compat: svg.attributes.core.xml_lang
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text xml:lang="en-US"&gt;This is some English text&lt;/text&gt;
 &lt;/svg&gt;</pre>
-</div>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.html
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.html
@@ -16,7 +16,8 @@ browser-compat: svg.attributes.core.xml_lang
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
+<h2>Example</h2>
+
 <pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text xml:lang="en-US"&gt;This is some English text&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/xml_colon_space/index.html
+++ b/files/en-us/web/svg/attribute/xml_colon_space/index.html
@@ -18,20 +18,18 @@ browser-compat: svg.attributes.core.xml_space
 
 <p>You can use this attribute with any SVG element.</p>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 140 50" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" xml:space="default"&gt;Default   spacing&lt;/text&gt;
   &lt;text y="40" xml:space="preserve"&gt;Preserved   spacing&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "120", "50")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "120", "50")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/y/index.html
+++ b/files/en-us/web/svg/attribute/y/index.html
@@ -53,10 +53,9 @@ tags:
   <li>{{SVGElement("use")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect y="20"  x="20" width="60" height="60" /&gt;
@@ -64,8 +63,7 @@ tags:
   &lt;rect y="220" x="20" width="60" height="60" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="altGlyph">altGlyph</h2>
 

--- a/files/en-us/web/svg/attribute/y/index.html
+++ b/files/en-us/web/svg/attribute/y/index.html
@@ -793,8 +793,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -876,8 +874,6 @@ line {
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/y1/index.html
+++ b/files/en-us/web/svg/attribute/y1/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{ SVGElement("linearGradient") }}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="1" x2="9" y1="1" y2="5" stroke="red" /&gt;
@@ -27,8 +26,7 @@ tags:
   &lt;line x1="1" x2="9" y1="9" y2="5" stroke="blue" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="line">line</h2>
 

--- a/files/en-us/web/svg/attribute/y1/index.html
+++ b/files/en-us/web/svg/attribute/y1/index.html
@@ -49,8 +49,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -83,8 +81,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/y2/index.html
+++ b/files/en-us/web/svg/attribute/y2/index.html
@@ -16,10 +16,9 @@ tags:
   <li>{{ SVGElement("linearGradient") }}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="1" x2="9" y1="5" y2="1" stroke="red"   /&gt;
@@ -27,8 +26,7 @@ tags:
   &lt;line x1="1" x2="9" y1="5" y2="9" stroke="blue"  /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", '100%', 200)}}</p>
 
 <h2 id="line">line</h2>
 

--- a/files/en-us/web/svg/attribute/y2/index.html
+++ b/files/en-us/web/svg/attribute/y2/index.html
@@ -49,8 +49,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Example">Example</h3>
-
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>
 </div>
@@ -83,8 +81,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<h3 id="Example_2">Example</h3>
 
 <div class="hidden">
 <pre class="brush: css">html,body,svg { height:100% }</pre>

--- a/files/en-us/web/svg/attribute/ychannelselector/index.html
+++ b/files/en-us/web/svg/attribute/ychannelselector/index.html
@@ -17,12 +17,11 @@ browser-compat: svg.elements.feDisplacementMap.yChannelSelector
   <li>{{SVGElement("feDisplacementMap")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[6,12]">&lt;svg viewBox="0 0 440 160" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="displacementFilter"&gt;
@@ -44,8 +43,7 @@ browser-compat: svg.elements.feDisplacementMap.yChannelSelector
       filter="url(#displacementFilter2)"&gt;Some displaced text&lt;/text&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "480", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "480", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 

--- a/files/en-us/web/svg/attribute/z/index.html
+++ b/files/en-us/web/svg/attribute/z/index.html
@@ -17,12 +17,11 @@ tags:
   <li>{{SVGElement("feSpotLight")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
@@ -40,8 +39,7 @@ tags:
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#diffuseLighting2); transform: translateX(220px);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "420", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "420", "200")}}</p>
 
 <h2 id="fePointLight">fePointLight</h2>
 

--- a/files/en-us/web/svg/attribute/zoomandpan/index.html
+++ b/files/en-us/web/svg/attribute/zoomandpan/index.html
@@ -22,12 +22,11 @@ browser-compat: svg.elements.svg.zoomAndPan
   <li>{{SVGElement("view")}}</li>
 </ul>
 
-<div id="topExample">
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<h2>Example</h2>
+
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html; highlight[1]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" zoomAndPan="disable"&gt;
   &lt;filter id="diffuseLighting" x="0" y="0" width="100%" height="100%"&gt;
@@ -39,8 +38,7 @@ browser-compat: svg.elements.svg.zoomAndPan
   &lt;rect x="0" y="0" width="200" height="200" style="filter: url(#diffuseLighting);" /&gt;
 &lt;/svg&gt;</pre>
 
-<p>{{EmbedLiveSample("topExample", "200", "200")}}</p>
-</div>
+<p>{{EmbedLiveSample("Example", "200", "200")}}</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8969 .

The SVG docs often present a live sample at the top, using a `<div>` to provide an ID. This PR removes the `<div>` and adds an H2 "Example" which the live sample can refer to. 