### PR TITLE
[Markdown] [Web/SVG] Remove SVG attribute IDs

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -551,7 +551,7 @@ tags:
 
 <h3 id="Presentation_attribute">Presentation attribute: d</h3>
 
-<p>The SVG {{SVGAttr('d')}} attribute, used to define a path to be drawn, is now a <a href="/en-US/docs/Web/SVG/Attribute/Presentation#attr-d">presentation attribute</a>. It can be used as a property in CSS and accepts the values <a href="/en-US/docs/Web/CSS/path()">path()</a> or <code>none</code>. (See {{bug(1340422)}} for more details.)</p>
+<p>The SVG {{SVGAttr('d')}} attribute, used to define a path to be drawn, is now a <a href="/en-US/docs/Web/SVG/Attribute/Presentation">presentation attribute</a>. It can be used as a property in CSS and accepts the values <a href="/en-US/docs/Web/CSS/path()">path()</a> or <code>none</code>. (See {{bug(1340422)}} for more details.)</p>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/svg/attribute/conditional_processing/index.html
+++ b/files/en-us/web/svg/attribute/conditional_processing/index.html
@@ -22,13 +22,13 @@ browser-compat: svg.attributes.conditional_processing
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-requiredextensions">{{SVGAttr('requiredExtensions')}}</dt>
+ <dt>{{SVGAttr('requiredExtensions')}}</dt>
  <dd>List all the browser specific capabilities that must be supported by the browser to be allowed to render the associated element.<br>
  <small><em>Value</em>: A list of space-separated URI; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-requiredfeatures">{{SVGAttr('requiredFeatures')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('requiredFeatures')}} {{deprecated_inline}}</dt>
  <dd>List all the features, <a href="https://www.w3.org/TR/SVG11/feature.html">as defined is the SVG 1.1 specification</a>, that must be supported by the browser to be allowed to render the associated element..<br>
  <small><em>Value</em>: A list of space-separated URI; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-systemlanguage">{{SVGAttr('systemLanguage')}}</dt>
+ <dt>{{SVGAttr('systemLanguage')}}</dt>
  <dd>Indicates which language the user must have chosen to render the associated element.<br>
  <small><em>Value</em>: <a href="http://www.ietf.org/rfc/bcp/bcp47.txt">A list of comma-separated language ID</a>; <em>Animatable</em>: <strong>No</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/attribute/core/index.html
+++ b/files/en-us/web/svg/attribute/core/index.html
@@ -24,10 +24,10 @@ browser-compat: svg.attributes.core
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-id">{{SVGAttr('id')}}</dt>
+ <dt>{{SVGAttr('id')}}</dt>
  <dd>Defines a unique identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a fragment identifier), scripting, or styling (with CSS).<br>
  <small><em>Value</em>: Any valid ID string; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-lang">{{SVGAttr('lang')}}</dt>
+ <dt>{{SVGAttr('lang')}}</dt>
  <dd>
  <p>Participates in defining the language of the element, the language that non-editable elements are written in or the language that editable elements should be written in. The tag contains one single entry value in the format defined in the <a href="https://www.ietf.org/rfc/bcp/bcp47.txt">Tags for Identifying Languages (BCP47) IETF document</a>.</p>
 
@@ -37,13 +37,13 @@ browser-compat: svg.attributes.core
 
  <p><small><em>Value</em>: Any valid language ID; <em>Animatable</em>: <strong>No</strong></small></p>
  </dd>
- <dt id="attr-tabindex">{{SVGAttr('tabindex')}}</dt>
+ <dt>{{SVGAttr('tabindex')}}</dt>
  <dd>The tabindex SVG attribute allows you to control whether an element is focusable and to define the relative order of the element for the purposes of sequential focus navigation.<br>
  <small><em>Value type</em>: <a href="/docs/Web/SVG/Content_type#Integer">&lt;integer&gt;</a>; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-xml:base">{{SVGAttr('xml:base')}}</dt>
+ <dt>{{SVGAttr('xml:base')}}</dt>
  <dd>Specifies a base IRI other than the base IRI of the document.<br>
  <small><em>Value type</em>: <a href="/docs/Web/SVG/Content_type#IRI">&lt;IRI&gt;</a>; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-xml:lang">{{SVGAttr('xml:lang')}}</dt>
+ <dt>{{SVGAttr('xml:lang')}}</dt>
  <dd>
  <p>It is a universal attribute allowed in all XML dialects to mark up the natural human language that an element contains. It's almost identical in usage to HTML's <a href="/en-US/docs/Web/HTML/Global_attributes/lang">lang</a>, but in conforming XML 1.0 documents, it does not allow the use of a null attribute value (<code>xml:lang=""</code>) to indicate an unknown language. Instead, use <code>xml:lang="und"</code>.</p>
 
@@ -53,7 +53,7 @@ browser-compat: svg.attributes.core
 
  <p><small><em>Value</em>: Any valid language ID; <em>Animatable</em>: <strong>No</strong></small></p>
  </dd>
- <dt id="attr-xml:space">{{SVGAttr('xml:space')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('xml:space')}} {{deprecated_inline}}</dt>
  <dd>
  <p>SVG supports the standard XML attribute <code>xml:space</code> to specify the handling of white space characters within a given {{ SVGElement("text") }} element's character data.</p>
 

--- a/files/en-us/web/svg/attribute/d/index.html
+++ b/files/en-us/web/svg/attribute/d/index.html
@@ -646,7 +646,7 @@ tags:
 <p>{{EmbedLiveSample('ClosePath', '100%', 200)}}</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> As a <a href="/en-US/docs/Web/SVG/Attribute/Presentation#attr-d">presentation attribute</a> <code>d</code> can be used as a CSS property</p>
+  <p><strong>Note:</strong> As a <a href="/en-US/docs/Web/SVG/Attribute/Presentation">presentation attribute</a> <code>d</code> can be used as a CSS property</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/svg/attribute/presentation/index.html
+++ b/files/en-us/web/svg/attribute/presentation/index.html
@@ -84,196 +84,196 @@ browser-compat: svg.attributes.presentation
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-alignment-baseline">{{SVGAttr('alignment-baseline')}}</dt>
+ <dt>{{SVGAttr('alignment-baseline')}}</dt>
  <dd>It specifies how an object is aligned along the font baseline with respect to its parent.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|<code>baseline</code>|<code>before-edge</code>|<code>text-before-edge</code>|<code>middle</code>|<code>central</code>|<code>after-edge</code>|<code>text-after-edge</code>|<code>ideographic</code>|<code>alphabetic</code>|<code>hanging</code>|<code>mathematical</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-baseline-shift">{{SVGAttr('baseline-shift')}}</dt>
+ <dt>{{SVGAttr('baseline-shift')}}</dt>
  <dd>It allows repositioning of the dominant-baseline relative to the dominant-baseline of the parent text content element.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|<code>baseline</code>|<code>super</code>|<code>sub</code>|<a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-clip">{{SVGAttr('clip')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('clip')}} {{deprecated_inline}}</dt>
  <dd>It defines what portion of an element is visible.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|{{cssxref("shape")}}|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-clip-path">{{SVGAttr('clip-path')}}</dt>
+ <dt>{{SVGAttr('clip-path')}}</dt>
  <dd>It binds the element it is applied to with a given {{SVGElement('clipPath')}} element.<br>
  <small><em>Value</em>: <strong><code>none</code></strong>|<a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-clip-rule">{{SVGAttr('clip-rule')}}</dt>
+ <dt>{{SVGAttr('clip-rule')}}</dt>
  <dd>It indicates how to determine what side of a path is inside a shape in order to know how a {{SVGElement('clipPath')}} should clip its target.<br>
  <small><em>Value</em>: <strong><code>nonezero</code></strong>|<code>evenodd</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-color">{{SVGAttr('color')}}</dt>
+ <dt>{{SVGAttr('color')}}</dt>
  <dd>It provides a potential indirect value (<code>currentcolor</code>) for the <code>fill</code>, <code>stroke</code>, <code>stop-color</code>, <code>flood-color</code> and <code>lighting-color</code> presentation attributes.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#color">&lt;color&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-color-interpolation">{{SVGAttr('color-interpolation')}}</dt>
+ <dt>{{SVGAttr('color-interpolation')}}</dt>
  <dd>It specifies the color space for gradient interpolations, color animations, and alpha compositing.<br>
  <small><em>Value</em>: <code>auto</code>|<strong><code>sRGB</code></strong>|<code>linearRGB</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-color-interpolation-filters">{{SVGAttr('color-interpolation-filters')}}</dt>
+ <dt>{{SVGAttr('color-interpolation-filters')}}</dt>
  <dd>It specifies the color space for imaging operations performed via filter effects.<br>
  <small><em>Value</em>: <code>auto</code>|<code>sRGB</code>|<strong><code>linearRGB</code></strong>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-color-profile">{{SVGAttr('color-profile')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('color-profile')}} {{deprecated_inline}}</dt>
  <dd>It defines which color profile a raster image included through the {{SVGElement('image')}} element should use.<br>
  <small><em>Value</em>: <code>auto</code>|<code>sRGB</code>|<code>linearRGB</code>|<a href="/en-US/docs/Web/SVG/Content_type#name">&lt;name&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#iri">&lt;IRI&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-color-rendering">{{SVGAttr('color-rendering')}}</dt>
+ <dt>{{SVGAttr('color-rendering')}}</dt>
  <dd>It provides a hint to the browser about how to optimize its color interpolation and compositing operations.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|<code>optimizeSpeed</code>|<code>optimizeQuality</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-cursor">{{SVGAttr('cursor')}}</dt>
+ <dt>{{SVGAttr('cursor')}}</dt>
  <dd>It specifies the mouse cursor displayed when the mouse pointer is over an element.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a>|<a href="/en-US/docs/Web/CSS/cursor#values">&lt;keywords&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-d">{{SVGAttr('d')}}</dt>
+ <dt>{{SVGAttr('d')}}</dt>
  <dd>It defines a path to be drawn.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/CSS/path()">path()</a>|<code>none</code></small></dd>
- <dt id="attr-direction">{{SVGAttr('direction')}}</dt>
+ <dt>{{SVGAttr('direction')}}</dt>
  <dd>It specifies the base writing direction of text.<br>
  <small><em>Value</em>: <strong><code>ltr</code></strong>|<code>rtl</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-display">{{SVGAttr('display')}}</dt>
+ <dt>{{SVGAttr('display')}}</dt>
  <dd>It allows to control the rendering of graphical or container elements.<br>
  <small><em>Value</em>: see css {{cssxref('display')}}; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-dominant-baseline">{{SVGAttr('dominant-baseline')}}</dt>
+ <dt>{{SVGAttr('dominant-baseline')}}</dt>
  <dd>It defines the baseline used to align the box’s text and inline-level contents.<br>
  <small><em>Value</em>: <code>auto</code>|<code>text-bottom</code>|<code>alphabetic</code>|<code>ideographic</code>|<code>middle</code>|<code>central</code>| <code>mathematical</code>|<code>hanging</code>|<code>text-top</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-enable-background">{{SVGAttr('enable-background')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('enable-background')}} {{deprecated_inline}}</dt>
  <dd>It tells the browser how to manage the accumulation of the background image.<br>
  <small><em>Value</em>: <strong><code>accumulate</code></strong>|<code>new</code>|<code>inherit</code>; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-fill">{{SVGAttr('fill')}}</dt>
+ <dt>{{SVGAttr('fill')}}</dt>
  <dd>It defines the color of the inside of the graphical element it applies to.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#paint">&lt;paint&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-fill-opacity">{{SVGAttr('fill-opacity')}}</dt>
+ <dt>{{SVGAttr('fill-opacity')}}</dt>
  <dd>It specifies the opacity of the color or the content the current object is filled with.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#number">&lt;number&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-fill-rule">{{SVGAttr('fill-rule')}}</dt>
+ <dt>{{SVGAttr('fill-rule')}}</dt>
  <dd>It indicates how to determine what side of a path is inside a shape.<br>
  <small><em>Value</em>: <strong><code>nonzero</code></strong>|<code>evenodd</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-filter">{{SVGAttr('filter')}}</dt>
+ <dt>{{SVGAttr('filter')}}</dt>
  <dd>It defines the filter effects defined by the {{SVGElement('filter')}} element that shall be applied to its element.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a>|<strong><code>none</code></strong>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-flood-color">{{SVGAttr('flood-color')}}</dt>
+ <dt>{{SVGAttr('flood-color')}}</dt>
  <dd>It indicates what color to use to flood the current filter primitive subregion defined through the {{SVGElement('feFlood')}} or {{SVGElement('feDropShadow')}} element.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#color">&lt;color&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-flood-opacity">{{SVGAttr('flood-opacity')}}</dt>
+ <dt>{{SVGAttr('flood-opacity')}}</dt>
  <dd>It indicates the opacity value to use across the current filter primitive subregion defined through the {{SVGElement('feFlood')}} or {{SVGElement('feDropShadow')}} element.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#number">&lt;number&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-family">{{SVGAttr('font-family')}}</dt>
+ <dt>{{SVGAttr('font-family')}}</dt>
  <dd>It indicates which font family will be used to render the text of the element.<br>
  <small><em>Value</em>: see css {{cssxref('font-family')}}; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-size">{{SVGAttr('font-size')}}</dt>
+ <dt>{{SVGAttr('font-size')}}</dt>
  <dd>It specifies the size of the font.<br>
  <small><em>Value</em>: see css {{cssxref('font-size')}}; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-size-adjust">{{SVGAttr('font-size-adjust')}}</dt>
+ <dt>{{SVGAttr('font-size-adjust')}}</dt>
  <dd>It specifies that the font size should be chosen based on the height of lowercase letters rather than the height of capital letters.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#number">&lt;number&gt;</a>|<code><strong>none</strong></code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-stretch">{{SVGAttr('font-stretch')}}</dt>
+ <dt>{{SVGAttr('font-stretch')}}</dt>
  <dd>It selects a normal, condensed, or expanded face from a font.<br>
  <small><em>Value</em>: see css {{cssxref('font-stretch')}}; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-style">{{SVGAttr('font-style')}}</dt>
+ <dt>{{SVGAttr('font-style')}}</dt>
  <dd>It specifies whether a font should be styled with a normal, italic, or oblique face from its {{SVGAttr('font-family')}}.<br>
  <small><em>Value</em>: <strong><code>normal</code></strong>|<code>italic</code>|<code>oblique</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-variant">{{SVGAttr('font-variant')}}</dt>
+ <dt>{{SVGAttr('font-variant')}}</dt>
  <dd>It specifies whether a font should be used with some of their variation such as small caps or ligatures.<br>
  <small><em>Value</em>: see css {{cssxref('font-variant')}}; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-font-weight">{{SVGAttr('font-weight')}}</dt>
+ <dt>{{SVGAttr('font-weight')}}</dt>
  <dd>It specifies the weight (or boldness) of the font.<br>
  <small><em>Value</em>: <strong><code>normal</code></strong>|<code>bold</code>|<code>lighter</code>|<code>bolder</code>|<code>100</code>|<code>200</code>|<code>300</code>|<code>400</code>|<code>500</code>|<code>600</code>|<code>700</code>|<code>800</code>|<code>900</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-glyph-orientation-horizontal">{{SVGAttr('glyph-orientation-horizontal')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('glyph-orientation-horizontal')}} {{deprecated_inline}}</dt>
  <dd>It controls glyph orientation when the inline-progression-direction is horizontal.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#angle">&lt;angle&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-glyph-orientation-vertical">{{SVGAttr('glyph-orientation-vertical')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('glyph-orientation-vertical')}} {{deprecated_inline}}</dt>
  <dd>It controls glyph orientation when the inline-progression-direction is vertical.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|<a href="/en-US/docs/Web/SVG/Content_type#angle">&lt;angle&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>No</strong></small></dd>
- <dt id="attr-image-rendering">{{SVGAttr('image-rendering')}}</dt>
+ <dt>{{SVGAttr('image-rendering')}}</dt>
  <dd>It provides a hint to the browser about how to make speed vs. quality tradeoffs as it performs image processing.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|<code>optimizeQuality</code>|<code>optimizeSpeed</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-kerning">{{SVGAttr('kerning')}} {{deprecated_inline}}</dt>
+ <dt>{{SVGAttr('kerning')}} {{deprecated_inline}}</dt>
  <dd>It indicates whether the browser should adjust inter-glyph spacing.<br>
  <small><em>Value</em>: <strong><code>auto</code></strong>|<a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-letter-spacing">{{SVGAttr('letter-spacing')}}</dt>
+ <dt>{{SVGAttr('letter-spacing')}}</dt>
  <dd>It controls spacing between text characters.<br>
  <small><em>Value</em>: <strong><code>normal</code></strong>|<a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-lighting-color">{{SVGAttr('lighting-color')}}</dt>
+ <dt>{{SVGAttr('lighting-color')}}</dt>
  <dd>It defines the color of the light source for filter primitives elements {{SVGElement('feDiffuseLighting')}} and {{SVGElement('feSpecularLighting')}}.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#color">&lt;color&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-marker-end">{{SVGAttr('marker-end')}}</dt>
+ <dt>{{SVGAttr('marker-end')}}</dt>
  <dd>It defines the arrowhead or polymarker that will be drawn at the final vertex of the given {{SVGElement('path')}} element or basic shape.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a>|<strong><code>none</code></strong>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-marker-mid">{{SVGAttr('marker-mid')}}</dt>
+ <dt>{{SVGAttr('marker-mid')}}</dt>
  <dd>It defines the arrowhead or polymarker that will be drawn at every vertex other than the first and last vertex of the given {{SVGElement('path')}} element or basic shape.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a>|<strong><code>none</code></strong>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-marker-start">{{SVGAttr('marker-start')}}</dt>
+ <dt>{{SVGAttr('marker-start')}}</dt>
  <dd>It defines the arrowhead or polymarker that will be drawn at the first vertex of the given {{SVGElement('path')}} element or basic shape.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a>|<strong><code>none</code></strong>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-mask">{{SVGAttr('mask')}}</dt>
+ <dt>{{SVGAttr('mask')}}</dt>
  <dd>It alters the visibility of an element by either masking or clipping the image at specific points.<br>
  <small><em>Value</em>: see css {{cssxref('mask')}}; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-opacity">{{SVGAttr('opacity')}}</dt>
+ <dt>{{SVGAttr('opacity')}}</dt>
  <dd>It specifies the transparency of an object or a group of objects.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#opacity_value">&lt;opacity-value&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-overflow">{{SVGAttr('overflow')}}</dt>
+ <dt>{{SVGAttr('overflow')}}</dt>
  <dd>Specifies whether the content of a block-level element is clipped when it overflows the element's box.<br>
  <small><em>Value</em>: <code><strong>visible</strong></code>|<code>hidden|scroll</code>|<code>auto</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-pointer-events">{{SVGAttr('pointer-events')}}</dt>
+ <dt>{{SVGAttr('pointer-events')}}</dt>
  <dd>Defines whether or when an element may be the target of a mouse event.<br>
  <small><em>Value</em>: <code>bounding-box</code>|<code><strong>visiblePainted</strong></code>|<code>visibleFil</code>|<code>visibleStroke</code>|<code>visible</code> |<code>painted</code>|<code>fill</code>|<code>stroke</code>|<code>all</code>|<code>none</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-shape-rendering">{{SVGAttr('shape-rendering')}}</dt>
+ <dt>{{SVGAttr('shape-rendering')}}</dt>
  <dd>Hints about what tradeoffs to make as the browser renders {{SVGElement('path')}} element or basic shapes.<br>
  <small><em>Value</em>: <code><strong>auto</strong></code>|<code>optimizeSpeed</code>|<code>crispEdges</code>|<code>geometricPrecision</code> |<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-solid-color">{{SVGAttr('solid-color')}}</dt>
+ <dt>{{SVGAttr('solid-color')}}</dt>
  <dd>-<br>
  <small><em>Value</em>:; <em>Animatable</em>: <strong>-</strong></small></dd>
- <dt id="attr-solid-opacity">{{SVGAttr('solid-opacity')}}</dt>
+ <dt>{{SVGAttr('solid-opacity')}}</dt>
  <dd>-<br>
  <small><em>Value</em>:; <em>Animatable</em>: <strong>-</strong></small></dd>
- <dt id="attr-stop-color">{{SVGAttr('stop-color')}}</dt>
+ <dt>{{SVGAttr('stop-color')}}</dt>
  <dd>Indicates what color to use at that gradient stop.<br>
  <small><em>Value</em>: <code>currentcolor</code>|<a href="/en-US/docs/Web/SVG/Content_type#color">&lt;color&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#icccolor">&lt;icccolor&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stop-opacity">{{SVGAttr('stop-opacity')}}</dt>
+ <dt>{{SVGAttr('stop-opacity')}}</dt>
  <dd>Defines the opacity of a given gradient stop.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#opacity_value">&lt;opacity-value&gt;</a>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke">{{SVGAttr('stroke')}}</dt>
+ <dt>{{SVGAttr('stroke')}}</dt>
  <dd>Defines the color used to paint the outline of the shape.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#paint">&lt;paint&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-dasharray">{{SVGAttr('stroke-dasharray')}}</dt>
+ <dt>{{SVGAttr('stroke-dasharray')}}</dt>
  <dd>Defines the pattern of dashes and gaps used to paint the outline of the shape.<br>
  <small><em>Value</em>: <code>none</code>|<code>&lt;dasharray&gt;</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-dashoffset">{{SVGAttr('stroke-dashoffset')}}</dt>
+ <dt>{{SVGAttr('stroke-dashoffset')}}</dt>
  <dd>Defines an offset on the rendering of the associated dash array.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-linecap"><strong>{{SVGAttr('stroke-linecap')}}</strong></dt>
+ <dt><strong>{{SVGAttr('stroke-linecap')}}</strong></dt>
  <dd>Defines the shape to be used at the end of open subpaths when they are stroked.<br>
  <small><em>Value</em>: <code><strong>butt</strong></code>|<code>round</code>|<code>square</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-linejoin"><strong>{{SVGAttr('stroke-linejoin')}}</strong></dt>
+ <dt><strong>{{SVGAttr('stroke-linejoin')}}</strong></dt>
  <dd>Defines the shape to be used at the corners of paths when they are stroked.<br>
  <small><em>Value</em>: <code>arcs</code>|<code>bevel</code>|<code><strong>miter</strong></code>|<code>miter-clip</code>|<code>round</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-miterlimit"><strong>{{SVGAttr('stroke-miterlimit')}}</strong></dt>
+ <dt><strong>{{SVGAttr('stroke-miterlimit')}}</strong></dt>
  <dd>Defines a limit on the ratio of the miter length to the {{ SVGAttr("stroke-width") }} used to draw a miter join.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#number">&lt;number&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-opacity"><strong>{{SVGAttr('stroke-opacity')}}</strong></dt>
+ <dt><strong>{{SVGAttr('stroke-opacity')}}</strong></dt>
  <dd>Defines the opacity of the stroke of a shape.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#opacity_value">&lt;opacity-value&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#paint">&lt;percentage&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-stroke-width"><strong>{{SVGAttr('stroke-width')}}</strong></dt>
+ <dt><strong>{{SVGAttr('stroke-width')}}</strong></dt>
  <dd>Defines the width of the stroke to be applied to the shape.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a>|<a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-text-anchor"><strong>{{SVGAttr('text-anchor')}}</strong></dt>
+ <dt><strong>{{SVGAttr('text-anchor')}}</strong></dt>
  <dd>Defines the vertical alignment a string of text.<br>
  <small><em>Value</em>: <code>start</code>|<code>middle</code>|<code>end</code>|<code><strong>inherit</strong></code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-text-decoration"><strong>{{SVGAttr('text-decoration')}}</strong></dt>
+ <dt><strong>{{SVGAttr('text-decoration')}}</strong></dt>
  <dd>Sets the appearance of decorative lines on text.<br>
  <small><em>Value</em>: <code>none</code>|<code>underline</code>|<code>overline</code>|<code>line-through</code>|<code>blink</code>|<code><strong>inherit</strong></code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-text-rendering"><strong>{{SVGAttr('text-rendering')}}</strong></dt>
+ <dt><strong>{{SVGAttr('text-rendering')}}</strong></dt>
  <dd>Hints about what tradeoffs to make as the browser renders text.<br>
  <small><em>Value</em>: <code><strong>auto</strong></code>|<code>optimizeSpeed</code>|<code>optimizeLegibility</code>|<code>geometricPrecision</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-transform"><strong>{{SVGAttr('transform')}}</strong></dt>
+ <dt><strong>{{SVGAttr('transform')}}</strong></dt>
  <dd>Defines a list of transform definitions that are applied to an element and the element's children.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#transform-list">&lt;transform-list&gt;</a>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-unicode-bidi"><strong>{{SVGAttr('unicode-bidi')}}</strong></dt>
+ <dt><strong>{{SVGAttr('unicode-bidi')}}</strong></dt>
  <dd>-<br>
  <small><em>Value</em>:; <em>Animatable</em>: <strong>-</strong></small></dd>
- <dt id="attr-vector-effect"><strong>{{SVGAttr('vector-effect')}}</strong></dt>
+ <dt><strong>{{SVGAttr('vector-effect')}}</strong></dt>
  <dd>Specifies the vector effect to use when drawing an object.<br>
  <small><em>Value</em>: <code>default</code>|<code>non-scaling-stroke</code>|<code>inherit</code>|<code>&lt;uri&gt;</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-visibility"><strong>{{SVGAttr('visibility')}}</strong></dt>
+ <dt><strong>{{SVGAttr('visibility')}}</strong></dt>
  <dd>Lets you control the visibility of graphical elements.<br>
  <small><em>Value</em>: <strong><code>visible</code></strong>|<code>hidden</code>|<code>collapse</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-word-spacing"><strong>{{SVGAttr('word-spacing')}}</strong></dt>
+ <dt><strong>{{SVGAttr('word-spacing')}}</strong></dt>
  <dd>Specifies spacing behavior between words.<br>
  <small><em>Value</em>: <a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a>|<code><strong title="this is the default value">inherit</strong></code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-writing-mode"><strong>{{SVGAttr('writing-mode')}}</strong></dt>
+ <dt><strong>{{SVGAttr('writing-mode')}}</strong></dt>
  <dd>Specifies whether the initial inline-progression-direction for a {{SVGElement('text')}} element shall be left-to-right, right-to-left, or top-to-bottom.<br>
  <small><em>Value</em>: <strong><code>lr-tb</code></strong>|<code>rl-tb</code>|<code>tb-rl</code>|<code>lr</code>|<code>rl</code>|<code>tb</code>|<code>inherit</code>; <em>Animatable</em>: <strong>Yes</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/attribute/styling/index.html
+++ b/files/en-us/web/svg/attribute/styling/index.html
@@ -21,10 +21,10 @@ browser-compat: svg.attributes.style
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-class">{{SVGAttr('class')}}</dt>
+ <dt>{{SVGAttr('class')}}</dt>
  <dd>Assigns a class name or set of class names to an element. It functions identically to the {{htmlattrxref('class')}} attribute in HTML.<br>
  <small><em>Value</em>: Any valid ID string; <em>Animatable</em>: <strong>Yes</strong></small></dd>
- <dt id="attr-style">{{SVGAttr('style')}}</dt>
+ <dt>{{SVGAttr('style')}}</dt>
  <dd>It specifies style information for its element. It functions identically to the {{htmlattrxref('style')}} attribute in HTML.<br>
  <small><em>Value</em>: Any valid style string; <em>Animatable</em>: <strong>No</strong></small>
 

--- a/files/en-us/web/svg/element/animatemotion/index.html
+++ b/files/en-us/web/svg/element/animatemotion/index.html
@@ -40,13 +40,13 @@ browser-compat: svg.elements.animateMotion
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-keyPoints">{{SVGAttr("keyPoints")}}</dt>
+ <dt>{{SVGAttr("keyPoints")}}</dt>
  <dd>This attribute indicate, in the range [0,1], how far is the object along the path for each {{SVGAttr("keyTimes")}} associated values.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#number"><strong>&lt;number&gt;</strong></a>*; <em>Default value</em>: none; <em>Animatable</em>: <strong>no</strong></small></dd>
- <dt id="attr-path">{{SVGAttr("path")}}</dt>
+ <dt>{{SVGAttr("path")}}</dt>
  <dd>This attribute defines the path of the motion, using the same syntax as the {{SVGAttr('d')}} attribute.<br>
  <small><em>Value type</em>: <strong>&lt;string&gt;</strong>; <em>Default value</em>: none; <em>Animatable</em>: <strong>no</strong></small></dd>
- <dt id="attr-rotate">{{SVGAttr("rotate")}}</dt>
+ <dt>{{SVGAttr("rotate")}}</dt>
  <dd>This attribute defines a rotation applied to the element animated along a path, usually to make it pointing in the direction of the animation.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#number"><strong>&lt;number&gt;</strong></a>|<code>auto</code>|<code>auto-reverse</code>; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>no</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/circle/index.html
+++ b/files/en-us/web/svg/element/circle/index.html
@@ -28,13 +28,13 @@ browser-compat: svg.elements.circle
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-cx">{{SVGAttr("cx")}}</dt>
+ <dt>{{SVGAttr("cx")}}</dt>
  <dd>The x-axis coordinate of the center of the circle.<br>
  <small><em>Value type</em>: <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a></strong>|<strong><a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a></strong> ; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-cy">{{SVGAttr("cy")}}</dt>
+ <dt>{{SVGAttr("cy")}}</dt>
  <dd>The y-axis coordinate of the center of the circle.<br>
  <small><em>Value type</em>: <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&lt;length&gt;</a></strong>|<strong><a href="/en-US/docs/Web/SVG/Content_type#percentage">&lt;percentage&gt;</a></strong> ; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-r">{{SVGAttr("r")}}</dt>
+ <dt>{{SVGAttr("r")}}</dt>
  <dd>The radius of the circle. A value lower or equal to zero disables rendering of the circle.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#length"><strong>&lt;length&gt;</strong></a> ; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("pathLength")}}</dt>

--- a/files/en-us/web/svg/element/fedropshadow/index.html
+++ b/files/en-us/web/svg/element/fedropshadow/index.html
@@ -50,13 +50,13 @@ browser-compat: svg.elements.feDropShadow
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-dx">{{SVGAttr("dx")}}</dt>
+ <dt>{{SVGAttr("dx")}}</dt>
  <dd>This attribute defines the x offset of the drop shadow.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#number"><strong>&lt;number&gt;</strong></a>; <em>Default value</em>: <code>2</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-dy">{{SVGAttr("dy")}}</dt>
+ <dt>{{SVGAttr("dy")}}</dt>
  <dd>This attribute defines the y offset of the drop shadow.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#number"><strong>&lt;number&gt;</strong></a>; <em>Default value</em>: <code>2</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-stdDeviation">{{SVGAttr("stdDeviation")}}</dt>
+ <dt>{{SVGAttr("stdDeviation")}}</dt>
  <dd>This attribute defines the standard deviation for the blur operation in the drop shadow.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#number"><strong>&lt;number&gt;</strong></a>; <em>Default value</em>: <code>2</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/lineargradient/index.html
+++ b/files/en-us/web/svg/element/lineargradient/index.html
@@ -39,10 +39,10 @@ browser-compat: svg.elements.linearGradient
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-gradientUnits">{{SVGAttr("gradientUnits")}}</dt>
+ <dt>{{SVGAttr("gradientUnits")}}</dt>
  <dd>This attribute defines the coordinate system for attributes <code>x1</code>, <code>x2</code>, <code>y1</code>, <code>y2</code><br>
  <small><em>Value type</em>: <code>userSpaceOnUse</code>|<code>objectBoundingBox</code> ; <em>Default value</em>: <code>objectBoundingBox</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-gradientTransform">{{SVGAttr("gradientTransform")}}</dt>
+ <dt>{{SVGAttr("gradientTransform")}}</dt>
  <dd>This attribute provides additional <a href="/en-US/docs/Web/SVG/Attribute/transform">transformation</a> to the gradient coordinate system.<br>
  <small><em>Value type</em>: <strong><a href="/en-US/docs/Web/SVG/Content_type#transform-list">&lt;transform-list&gt;</a></strong> ; <em>Default value</em>: <em>identity transform</em>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("href")}}</dt>
@@ -57,7 +57,7 @@ browser-compat: svg.elements.linearGradient
  <dt>{{SVGAttr("x2")}}</dt>
  <dd>This attribute defines the x coordinate of the ending point of the vector gradient along which the linear gradient is drawn.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#length"><strong>&lt;length&gt;</strong></a> ; <em>Default value</em>: <code>100%</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-cx">{{SVGAttr("xlink:href")}}</dt>
+ <dt>{{SVGAttr("xlink:href")}}</dt>
  <dd>{{Deprecated_Header}}An <a href="/en-US/docs/Web/SVG/Content_type#iri">&lt;IRI&gt;</a> reference to another <code>&lt;linearGradient&gt;</code> element that will be used as a template.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#iri"><strong>&lt;IRI&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("y1")}}</dt>

--- a/files/en-us/web/svg/element/mask/index.html
+++ b/files/en-us/web/svg/element/mask/index.html
@@ -37,7 +37,7 @@ browser-compat: svg.elements.mask
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-height">{{SVGAttr("height")}}</dt>
+ <dt>{{SVGAttr("height")}}</dt>
  <dd>This attribute defines the height of the masking area.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#length"><strong>&lt;length&gt;</strong></a> ; <em>Default value</em>: <code>120%</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("maskContentUnits")}}</dt>
@@ -46,13 +46,13 @@ browser-compat: svg.elements.mask
  <dt>{{SVGAttr("maskUnits")}}</dt>
  <dd>This attribute defines the coordinate system for attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}} and {{SVGAttr("height")}} on the <code>&lt;mask&gt;</code>.<br>
  <small><em>Value type</em>: <code>userSpaceOnUse</code>|<code>objectBoundingBox</code> ; <em>Default value</em>: <code>objectBoundingBox</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-x">{{SVGAttr("x")}}</dt>
+ <dt>{{SVGAttr("x")}}</dt>
  <dd>This attribute defines the x-axis coordinate of the top-left corner of the masking area.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#coordinate"><strong>&lt;coordinate&gt;</strong></a> ; <em>Default value</em>: <code>-10%</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-cy">{{SVGAttr("y")}}</dt>
+ <dt>{{SVGAttr("y")}}</dt>
  <dd>This attribute defines the y-axis coordinate of the top-left corner of the masking area.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#coordinate"><strong>&lt;coordinate&gt;</strong></a> ; <em>Default value</em>: <code>-10%</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-width">{{SVGAttr("width")}}</dt>
+ <dt>{{SVGAttr("width")}}</dt>
  <dd>This attribute defines the width of the masking area.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#length"><strong>&lt;length&gt;</strong></a> ; <em>Default value</em>: <code>120%</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/path/index.html
+++ b/files/en-us/web/svg/element/path/index.html
@@ -31,7 +31,7 @@ browser-compat: svg.elements.path
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-cx">{{SVGAttr("d")}}</dt>
+ <dt>{{SVGAttr("d")}}</dt>
  <dd>This attribute defines the shape of the path.<br>
  <small><em>Value type</em>: <strong>&lt;string&gt;</strong> ; <em>Default value</em>: <code>''</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("pathLength")}}</dt>

--- a/files/en-us/web/svg/element/radialgradient/index.html
+++ b/files/en-us/web/svg/element/radialgradient/index.html
@@ -57,7 +57,7 @@ browser-compat: svg.elements.radialGradient
  <dt>{{SVGAttr("gradientUnits")}}</dt>
  <dd>This attribute defines the coordinate system for attributes <code>cx</code>, <code>cy</code>, <code>r</code>, <code>fx</code>, <code>fy</code>, <code>fr</code><br>
  <small><em>Value type</em>: <code>userSpaceOnUse</code>|<code>objectBoundingBox</code> ; <em>Default value</em>: <code>objectBoundingBox</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-cx">{{SVGAttr("gradientTransform")}}</dt>
+ <dt>{{SVGAttr("gradientTransform")}}</dt>
  <dd>This attribute provides additional <a href="/en-US/docs/Web/SVG/Attribute/transform">transformation</a> to the gradient coordinate system.<br>
  <small><em>Value type</em>: <strong><a href="/en-US/docs/Web/SVG/Content_type#transform-list">&lt;transform-list&gt;</a></strong> ; <em>Default value</em>: <em>identity transform</em>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("href")}}</dt>
@@ -69,7 +69,7 @@ browser-compat: svg.elements.radialGradient
  <dt>{{SVGAttr("spreadMethod")}}</dt>
  <dd>This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.<br>
  <small><em>Value type</em>: <code>pad</code>|<code>reflect</code>|<code>repeat</code> ; <em>Default value</em>: <code>pad</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-xlink">{{SVGAttr("xlink:href")}}</dt>
+ <dt>{{SVGAttr("xlink:href")}}</dt>
  <dd>{{Deprecated_Header}}An <a href="/en-US/docs/Web/SVG/Content_type#iri">&lt;IRI&gt;</a> reference to another <code>&lt;radialGradient&gt;</code> element that will be used as a template.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#iri"><strong>&lt;IRI&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/script/index.html
+++ b/files/en-us/web/svg/element/script/index.html
@@ -43,13 +43,13 @@ browser-compat: svg.elements.script
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-crossorigin">{{htmlattrxref("crossorigin", "script")}}</dt>
+ <dt>{{htmlattrxref("crossorigin", "script")}}</dt>
  <dd>This attribute defines <a href="/en-US/docs/Web/HTML/Attributes/crossorigin">CORS settings</a> as define for the HTML {{HTMLElement('script')}} element.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#string"><strong>&lt;string&gt;</strong></a>; <em>Default value</em>: <code>?</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("href")}}</dt>
  <dd>The {{Glossary("URL")}} to the script to load.<br>
  <small><em>Value type</em>: <strong><a href="/en-US/docs/Web/SVG/Content_type#url">&lt;URL&gt;</a></strong> ; <em>Default value</em>: <em>none</em>; <em>Animatable</em>: <strong>no</strong></small></dd>
- <dt id="attr-type">{{SVGAttr("type")}}</dt>
+ <dt>{{SVGAttr("type")}}</dt>
  <dd>This attribute defines type of the script language to use.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#string"><strong>&lt;string&gt;</strong></a>; <em>Default value</em>: <code>application/ecmascript</code>; <em>Animatable</em>: <strong>no</strong></small></dd>
  <dt>{{SVGAttr("xlink:href")}} {{deprecated_inline}}</dt>

--- a/files/en-us/web/svg/element/set/index.html
+++ b/files/en-us/web/svg/element/set/index.html
@@ -37,7 +37,7 @@ browser-compat: svg.elements.set
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-cx">{{SVGAttr("to")}}</dt>
+ <dt>{{SVGAttr("to")}}</dt>
  <dd>This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#anything"><strong>&lt;anything&gt;</strong></a>; <em>Default value</em>: none; <em>Animatable</em>: <strong>no</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/stop/index.html
+++ b/files/en-us/web/svg/element/stop/index.html
@@ -36,13 +36,13 @@ browser-compat: svg.elements.stop
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-offset">{{SVGAttr("offset")}}</dt>
+ <dt>{{SVGAttr("offset")}}</dt>
  <dd>This attribute defines where the gradient stop is placed along the gradient vector.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#number"><strong>&lt;number&gt;</strong></a>|<a href="/en-US/docs/Web/SVG/Content_type#percentage"><strong>&lt;percentage&gt;</strong></a>; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-stop-color">{{SVGAttr("stop-color")}}</dt>
+ <dt>{{SVGAttr("stop-color")}}</dt>
  <dd>This attribute defines the color of the gradient stop. It can be used as a CSS property.<br>
  <small><em>Value type</em>: <code>currentcolor</code>|<a href="/en-US/docs/Web/SVG/Content_type#color"><strong>&lt;color&gt;</strong></a>|<a href="/en-US/docs/Web/SVG/Content_type#icccolor"><strong>&lt;icccolor&gt;</strong></a>; <em>Default value</em>: <code>black</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-stop-opacity">{{SVGAttr("stop-opacity")}}</dt>
+ <dt>{{SVGAttr("stop-opacity")}}</dt>
  <dd>This attribute defines the opacity of the gradient stop. It can be used as a CSS property.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#opacity_value"><strong>&lt;opacity&gt;</strong></a>; <em>Default value</em>: <code>1</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/style/index.html
+++ b/files/en-us/web/svg/element/style/index.html
@@ -36,13 +36,13 @@ browser-compat: svg.elements.style
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-type">{{SVGAttr("type")}}</dt>
+ <dt>{{SVGAttr("type")}}</dt>
  <dd>This attribute defines type of the style sheet language to use as a media type string.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#string"><strong>&lt;string&gt;</strong></a>; <em>Default value</em>: <code>text/css</code>; <em>Animatable</em>: <strong>no</strong></small></dd>
- <dt id="attr-media">{{SVGAttr("media")}}</dt>
+ <dt>{{SVGAttr("media")}}</dt>
  <dd>This attribute defines to which {{cssxref('@media', 'media')}} the style applies.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#string"><strong>&lt;string&gt;</strong></a>; <em>Default value</em>: <code>all</code>; <em>Animatable</em>: <strong>no</strong></small></dd>
- <dt id="attr-title">{{SVGAttr("title")}}</dt>
+ <dt>{{SVGAttr("title")}}</dt>
  <dd>This attribute the title of the style sheet which can be used to switch between alternate style sheets.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#string"><strong>&lt;string&gt;</strong></a>; <em>Default value</em>: <em>none</em>; <em>Animatable</em>: <strong>no</strong></small></dd>
 </dl>

--- a/files/en-us/web/svg/element/textpath/index.html
+++ b/files/en-us/web/svg/element/textpath/index.html
@@ -39,16 +39,16 @@ browser-compat: svg.elements.textPath
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-cx">{{SVGAttr("href")}}</dt>
+ <dt>{{SVGAttr("href")}}</dt>
  <dd>The URL to the path or basic shape on which to render the text. If the <code>path</code> attribute is set, <code>href</code> has no effect.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#url"><strong>&lt;URL&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("lengthAdjust")}}</dt>
  <dd>Where length adjustment should be applied to the text: the space between glyphs, or both the space and the glyphs themselves.<br>
  <small><em>Value type</em>: <code>spacing</code>|<code>spacingAndGlyphs</code>; <em>Default value</em>: <code>spacing</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-cy">{{SVGAttr("method")}}</dt>
+ <dt>{{SVGAttr("method")}}</dt>
  <dd>Which method to render individual glyphs along the path.<br>
  <small><em>Value type</em>: <code>align</code>|<code>stretch</code> ; <em>Default value</em>: <code>align</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-r">{{SVGAttr("path")}}</dt>
+ <dt>{{SVGAttr("path")}}</dt>
  <dd>The path on which the text should be rendered.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#path_data"><strong>&lt;path_data&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("side")}}</dt>

--- a/files/en-us/web/svg/element/use/index.html
+++ b/files/en-us/web/svg/element/use/index.html
@@ -47,19 +47,19 @@ That's why the circles have different x positions, but the same stroke value.
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
- <dt id="attr-cx">{{SVGAttr("href")}}</dt>
+ <dt>{{SVGAttr("href")}}</dt>
  <dd>The URL to an element/fragment that needs to be duplicated.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#url"><strong>&lt;URL&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-xlink">{{SVGAttr("xlink:href")}}</dt>
+ <dt>{{SVGAttr("xlink:href")}}</dt>
  <dd>{{Deprecated_Header}}An <a href="/en-US/docs/Web/SVG/Content_type#iri">&lt;IRI&gt;</a> reference to an element/fragment that needs to be duplicated.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#iri"><strong>&lt;IRI&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("x")}}</dt>
  <dd>The x coordinate of the use element.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#coordinate"><strong>&lt;coordinate&gt;</strong></a> ; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-cy">{{SVGAttr("y")}}</dt>
+ <dt>{{SVGAttr("y")}}</dt>
  <dd>The y coordinate of the use element.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#coordinate"><strong>&lt;coordinate&gt;</strong></a> ; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
- <dt id="attr-r">{{SVGAttr("width")}}</dt>
+ <dt>{{SVGAttr("width")}}</dt>
  <dd>The width of the use element.<br>
  <small><em>Value type</em>: <a href="/en-US/docs/Web/SVG/Content_type#length"><strong>&lt;length&gt;</strong></a> ; <em>Default value</em>: <code>0</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("height")}}</dt>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8969.

This PR removes ID attributes on references to SVG attributes. I only found a couple of places where they were being used, and updated the links in this PR too (the links now make more sense than before IMO).

