### PR TITLE
[Markdown] [Web/HTML] Remove DIV IDs from HTML docs, part 1

### DIFF
--- a/files/en-us/web/html/applying_color/index.html
+++ b/files/en-us/web/html/applying_color/index.html
@@ -166,9 +166,7 @@ tags:
 
 <p>Here are some sample colors in HSL notation:</p>
 
-<div id="hsl-swatches">
-<div class="hidden">
-<pre class="brush: css">table {
+<pre class="brush: css hidden">table {
   border: 1px solid black;
   font: 16px "Open Sans", Helvetica, Arial, sans-serif;
   border-spacing: 0;
@@ -219,13 +217,11 @@ th {
   &lt;/tr&gt;
  &lt;/tbody&gt;
 &lt;/table&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("hsl-swatches", 300, 260)}}</p>
-</div>
+<p>{{EmbedLiveSample("HSL_functional_notation", 300, 260)}}</p>
 
 <div class="note">
-<p>Note that when you omit the hue's unit, it's assumed to be in degrees (<code>deg</code>).</p>
+<p><strong>Note:</strong> When you omit the hue's unit, it's assumed to be in degrees (<code>deg</code>).</p>
 </div>
 
 <h2 id="Using_color">Using color</h2>

--- a/files/en-us/web/html/attributes/accept/index.html
+++ b/files/en-us/web/html/attributes/accept/index.html
@@ -36,24 +36,22 @@ tags:
 
 <p>When set on a file input type, the native file picker that opens up should only enable selecting files of the correct file type. Most operating systems lighten the files that don't match the criteria and aren't selectable.</p>
 
-<div id="simple_example">
 <pre class="brush: html">&lt;p&gt;
-	&lt;label for="soundFile"&gt;Select an audio file:&lt;/label&gt;
-	&lt;input type="file" id="soundFile" accept="audio/*"&gt;
-	&lt;/p&gt;
-	&lt;p&gt;
-	&lt;label for="videoFile"&gt;Select a video file:&lt;/label&gt;
-	&lt;input type="file" id="videoFile" accept="video/*"&gt;
-	&lt;/p&gt;
-	&lt;p&gt;
-	&lt;label for="imageFile"&gt;Select some images:&lt;/label&gt;
-	&lt;input type="file" id="imageFile" accept="image/*" multiple&gt;
-	&lt;/p&gt;</pre>
+  &lt;label for="soundFile"&gt;Select an audio file:&lt;/label&gt;
+  &lt;input type="file" id="soundFile" accept="audio/*"&gt;
+&lt;/p&gt;
+&lt;p&gt;
+  &lt;label for="videoFile"&gt;Select a video file:&lt;/label&gt;
+  &lt;input type="file" id="videoFile" accept="video/*"&gt;
+&lt;/p&gt;
+&lt;p&gt;
+  &lt;label for="imageFile"&gt;Select some images:&lt;/label&gt;
+  &lt;input type="file" id="imageFile" accept="image/*" multiple&gt;
+&lt;/p&gt;</pre>
 
-<p>{{EmbedLiveSample('simple_example', '100%', 200)}}</p>
+<p>{{EmbedLiveSample('Examples', '100%', 200)}}</p>
 
 <p>Note the last example allows you to select multiple images. See the <code><a href="multiple">multiple</a></code> attribute for more information.</p>
-</div>
 
 <h2 id="Unique_file_type_specifiers">Unique file type specifiers</h2>
 

--- a/files/en-us/web/html/element/bdi/index.html
+++ b/files/en-us/web/html/element/bdi/index.html
@@ -93,19 +93,17 @@ browser-compat: html.elements.bdi
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="No_&lt;bdi&gt;_with_only_LTR">No &lt;bdi&gt; with only LTR</h3>
+<h3 id="No_bdi_with_only_LTR">No bdi with only LTR</h3>
 
 <p>This example lists the winners of a competition using {{HTMLElement("span")}} elements only. When the names only contain LTR text the results look fine:</p>
 
-<div id="bdi-sample-1">
 <pre class="brush: html">&lt;ul&gt;
  &lt;li&gt;&lt;span class="name"&gt;Henrietta Boffin&lt;/span&gt; - 1st place&lt;/li&gt;
  &lt;li&gt;&lt;span class="name"&gt;Jerry Cruncher&lt;/span&gt; - 2nd place&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   border: 1px solid #3f87a6;
   max-width: calc(100% - 40px - 6px);
   padding: 20px;
@@ -113,24 +111,20 @@ browser-compat: html.elements.bdi
   border-width: 1px 1px 1px 5px;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('bdi-sample-1','','120','','','bdi-example') }}</p>
+<p>{{ EmbedLiveSample('No_bdi_with_only_LTR','','120','','','bdi-example') }}</p>
 
-<h3 id="No_&lt;bdi&gt;_with_RTL_text">No &lt;bdi&gt; with RTL text</h3>
+<h3 id="No_bdi_with_RTL_text">No bdi with RTL text</h3>
 
 <p>This example lists the winners of a competition using {{HTMLElement("span")}} elements only, and one of the winners has a name consisting of RTL text. In this case the "<code>- 1</code>", which consists of characters with neutral or weak directionality, will adopt the directionality of the RTL text, and the result will be garbled:</p>
 
-<div id="bdi-sample-2">
 <pre class="brush: html">&lt;ul&gt;
  &lt;li&gt;&lt;span class="name"&gt;اَلأَعْشَى&lt;/span&gt; - 1st place&lt;/li&gt;
  &lt;li&gt;&lt;span class="name"&gt;Jerry Cruncher&lt;/span&gt; - 2nd place&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   border: 1px solid #3f87a6;
   max-width: calc(100% - 40px - 6px);
   padding: 20px;
@@ -138,24 +132,20 @@ browser-compat: html.elements.bdi
   border-width: 1px 1px 1px 5px;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('bdi-sample-2','','120','','','bdi-example') }}</p>
+<p>{{ EmbedLiveSample('No_bdi_with_RTL_text','','120','','','bdi-example') }}</p>
 
-<h3 id="Using_&lt;bdi&gt;_with_LTR_and_RTL_text">Using &lt;bdi&gt; with LTR and RTL text</h3>
+<h3 id="Using_bdi_with_LTR_and_RTL_text">Using bdi with LTR and RTL text</h3>
 
 <p>This example lists the winners of a competition using <code> &lt;bdi&gt;</code> elements. These elements instruct the browser to treat the name in isolation from its embedding context, so the example output is properly ordered:</p>
 
-<div id="bdi-sample-3">
 <pre class="brush: html">&lt;ul&gt;
  &lt;li&gt;&lt;bdi class="name"&gt;اَلأَعْشَى&lt;/bdi&gt; - 1st place&lt;/li&gt;
  &lt;li&gt;&lt;bdi class="name"&gt;Jerry Cruncher&lt;/bdi&gt; - 2nd place&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   border: 1px solid #3f87a6;
   max-width: calc(100% - 40px - 6px);
   padding: 20px;
@@ -163,10 +153,8 @@ browser-compat: html.elements.bdi
   border-width: 1px 1px 1px 5px;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('bdi-sample-3','','120','','','bdi-example') }}</p>
+<p>{{ EmbedLiveSample('Using_bdi_with_LTR_and_RTL_text','','120','','','bdi-example') }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/big/index.html
+++ b/files/en-us/web/html/element/big/index.html
@@ -25,9 +25,8 @@ browser-compat: html.elements.big
 
 <p>Here we see examples showing the use of <code>&lt;big&gt;</code> followed by an example showing how to accomplish the same results using modern CSS syntax instead.</p>
 
-<h3 id="Using_&lt;big&gt;">Using <code>&lt;big&gt;</code></h3>
+<h3 id="Using_big">Using big</h3>
 
-<div id="Using_big">
 <p>This example uses the obsolete <code>&lt;big&gt;</code> element to increase the size of some text.</p>
 
 <h4 id="HTML">HTML</h4>
@@ -36,7 +35,6 @@ browser-compat: html.elements.big
   This is the first sentence. &lt;big&gt;This whole
   sentence is in bigger letters.&lt;/big&gt;
 &lt;/p&gt;</pre>
-</div>
 
 <h4 id="Result">Result</h4>
 

--- a/files/en-us/web/html/element/cite/index.html
+++ b/files/en-us/web/html/element/cite/index.html
@@ -61,7 +61,6 @@ browser-compat: html.elements.cite
 
 <p>In the context of the <code>&lt;cite&gt;</code> element, a creative work that might be cited could be, for example, one of the following:</p>
 
-<div class="threecolumns" id="creative-works">
 <ul>
  <li>A book</li>
  <li>A research paper</li>
@@ -91,7 +90,6 @@ browser-compat: html.elements.cite
  <li>A written or oral statement</li>
  <li>And so forth.</li>
 </ul>
-</div>
 
 <p>It's worth noting that the W3C specification says that a reference to a creative work, as included within a <code>&lt;cite&gt;</code> element, may include the name of the work’s author. However, the WHATWG specification for <code>&lt;cite&gt;</code> says the opposite: that a person’s name must <em>never</em> be included, under any circumstances.</p>
 

--- a/files/en-us/web/html/element/input/button/index.html
+++ b/files/en-us/web/html/element/input/button/index.html
@@ -20,7 +20,7 @@ browser-compat: html.elements.input.input-button
 <div>{{EmbedInteractiveExample("pages/tabbed/input-button.html", "tabbed-shorter")}}</div>
 
 <div class="note">
-<p><strong>Note</strong>: While <code>&lt;input&gt;</code> elements of type <code>button</code> are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}’s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.</p>
+<p><strong>Note:</strong> While <code>&lt;input&gt;</code> elements of type <code>button</code> are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}’s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.</p>
 </div>
 
 <table class="properties">
@@ -50,21 +50,21 @@ browser-compat: html.elements.input.input-button
 
 <h2 id="Value">Value</h2>
 
+<h3>Button with a value</h3>
+
 <p>An <code>&lt;input type="button"&gt;</code> elements' {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that is used as the button's label.</p>
 
-<div id="summary-example3">
 <pre class="brush: html">&lt;input type="button" value="Click Me"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("summary-example3", 650, 30)}}</p>
+<p>{{EmbedLiveSample("Button_with_a_value", 650, 30)}}</p>
+
+<h3>Button without a value</h3>
 
 <p>If you don't specify a <code>value</code>, you get an empty button:</p>
 
-<div id="summary-example1">
 <pre class="brush: html">&lt;input type="button"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("summary-example1", 650, 30)}}</p>
+<p>{{EmbedLiveSample("Button_without_a_value", 650, 30)}}</p>
 
 <h2 id="Using_buttons">Using buttons</h2>
 
@@ -104,7 +104,6 @@ function updateButton() {
 
 <p>In this example, <kbd>s</kbd> is specified as the access key (you'll need to press <kbd>s</kbd> plus the particular modifier keys for your browser/OS combination; see <a href="/en-US/docs/Web/HTML/Global_attributes/accesskey">accesskey</a> for a useful list of those).</p>
 
-<div id="accesskey-example1">
 <pre class="brush: html">&lt;form&gt;
   &lt;input type="button" value="Start machine" accesskey="s"&gt;
 &lt;/form&gt;
@@ -112,8 +111,7 @@ function updateButton() {
 </pre>
 </div>
 
-<div class="hidden">
-<pre class="brush: js">const button = document.querySelector('input');
+<pre class="brush: js hidden">const button = document.querySelector('input');
 const paragraph = document.querySelector('p');
 
 button.addEventListener('click', updateButton);
@@ -127,26 +125,22 @@ function updateButton() {
     paragraph.textContent = 'The machine is stopped.';
   }
 }</pre>
-</div>
 
 <p>{{EmbedLiveSample("Adding_keyboard_shortcuts_to_buttons", 650, 100)}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: The problem with the above example of course is that the user will not know what the access key is! In a real site, you'd have to provide this information in a way that doesn't intefere with the site design (for example by providing an easily accessible link that points to information on what the site accesskeys are).</p>
+<p><strong>Note:</strong> The problem with the above example of course is that the user will not know what the access key is! In a real site, you'd have to provide this information in a way that doesn't intefere with the site design (for example by providing an easily accessible link that points to information on what the site accesskeys are).</p>
 </div>
 
 <h3 id="Disabling_and_enabling_a_button">Disabling and enabling a button</h3>
 
 <p>To disable a button, specify the {{htmlattrxref("disabled")}} global attribute on it, like so:</p>
 
-<div id="disable-example1">
 <pre class="brush: html">&lt;input type="button" value="Disable me" disabled&gt;</pre>
-</div>
+
+<h4>Setting the disabled attribute</h4>
 
 <p>You can enable and disable buttons at run time by setting <code>disabled</code> to <code>true</code> or <code>false</code>. In this example our button starts off enabled, but if you press it, it is disabled using <code>button.disabled = true</code>. A {{domxref("setTimeout()")}} function is then used to reset the button back to its enabled state after two seconds.</p>
-
-<div class="hidden">
-<h6 id="Hidden_code_1">Hidden code 1</h6>
 
 <pre class="brush: html">&lt;input type="button" value="Enabled"&gt;</pre>
 
@@ -162,16 +156,14 @@ function disableButton() {
     button.value = 'Enabled';
   }, 2000);
 }</pre>
-</div>
 
-<p>{{EmbedLiveSample("Hidden_code_1", 650, 60)}}</p>
+<p>{{EmbedLiveSample("Setting_the_disabled_attribute", 650, 60)}}</p>
+
+<h4>Inheriting the disabled state</h4>
 
 <p>If the <code>disabled</code> attribute isn't specified, the button inherits its <code>disabled</code> state from its parent element. This makes it possible to enable and disable groups of elements all at once by enclosing them in a container such as a {{HTMLElement("fieldset")}} element, and then setting <code>disabled</code> on the container.</p>
 
 <p>The example below shows this in action. This is very similar to the previous example, except that the <code>disabled</code> attribute is set on the <code>&lt;fieldset&gt;</code> when the first button is pressed — this causes all three buttons to be disabled until the two second timeout has passed.</p>
-
-<div class="hidden">
-<h6 id="Hidden_code_2">Hidden code 2</h6>
 
 <pre class="brush: html">&lt;fieldset&gt;
   &lt;legend&gt;Button group&lt;/legend&gt;
@@ -191,12 +183,11 @@ function disableButton() {
     fieldset.disabled = false;
   }, 2000);
 }</pre>
-</div>
 
-<p>{{EmbedLiveSample("Hidden_code_2", 650, 60)}}</p>
+<p>{{EmbedLiveSample("Inheriting_the_disabled_state", 650, 100)}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: Firefox will, unlike other browsers, by default, <a href="https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing">persist the dynamic disabled state</a> of a {{HTMLElement("button")}} across page loads. Use the {{htmlattrxref("autocomplete","button")}} attribute to control this feature.</p>
+<p><strong>Note:</strong> Firefox will, unlike other browsers, by default, <a href="https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing">persist the dynamic disabled state</a> of a {{HTMLElement("button")}} across page loads. Use the {{htmlattrxref("autocomplete","button")}} attribute to control this feature.</p>
 </div>
 
 <h2 id="Validation">Validation</h2>

--- a/files/en-us/web/html/element/input/date/index.html
+++ b/files/en-us/web/html/element/input/date/index.html
@@ -113,7 +113,13 @@ console.log(dateControl.valueAsNumber); // prints 1496275200000, a JavaScript ti
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<p>{{page("/en-US/docs/Web/HTML/Element/input/number", "step-include")}}</p>
+<p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
+
+<p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
+
+<div class="note">
+<p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
+</div>
 
 <p>For <code>date</code> inputs, the value of <code>step</code> is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the <code>step</code> value (the underlying numeric value is in milliseconds). The default value of <code>step</code> is 1, indicating 1 day.</p>
 

--- a/files/en-us/web/html/element/input/datetime-local/index.html
+++ b/files/en-us/web/html/element/input/datetime-local/index.html
@@ -120,7 +120,13 @@ dateControl.value = '2017-06-01T08:30';</pre>
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<p>{{page("/en-US/docs/Web/HTML/Element/input/number", "step-include")}}</p>
+<p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
+
+<p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
+
+<div class="note">
+<p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
+</div>
 
 <p>For <code>datetime-local</code> inputs, the value of <code>step</code> is given in seconds, with a scaling factor of 1000 (since the underlying numeric value is in milliseconds). The default value of <code>step</code> is 60, indicating 60 seconds (or 1 minute, or 60,000 milliseconds).</p>
 

--- a/files/en-us/web/html/element/input/file/index.html
+++ b/files/en-us/web/html/element/input/file/index.html
@@ -132,30 +132,11 @@ browser-compat: html.elements.input.input-file
 
 <p>In addition to the attributes listed above, the following non-standard attributes are available on some browsers. You should try to avoid using them when possible, since doing so will limit the ability of your code to function in browsers that don't implement them.</p>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Attribute</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>{{anch("webkitdirectory")}}</code></td>
-   <td>A Boolean indicating whether or not to only allow the user to choose a directory (or directories, if <code>{{anch("multiple")}}</code> is also present)</td>
-  </tr>
- </tbody>
-</table>
+<h3><code>webkitdirectory</code></h3>
 
-<h3 id="attr-webkitdirectory"><code id="webkitdirectory">webkitdirectory</code> {{non-standard_inline}}</h3>
-
-<div id="webkitdirectory-include">
 <p>The Boolean <code>webkitdirectory</code> attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.</p>
 
-<div class="note">
-<p><strong>Note:</strong> Though originally implemented only for WebKit-based browsers, <code>webkitdirectory</code> is also usable in Microsoft Edge as well as Firefox 50 and later. However, even though it has relatively broad support, it is still not standard and should not be used unless you have no alternative.</p>
-</div>
-</div>
+<p>Though originally implemented only for WebKit-based browsers, <code>webkitdirectory</code> is also usable in Microsoft Edge as well as Firefox 50 and later. However, even though it has relatively broad support, it is still not standard and should not be used unless you have no alternative.</p>
 
 <h2 id="Unique_file_type_specifiers">Unique file type specifiers</h2>
 

--- a/files/en-us/web/html/element/input/hidden/index.html
+++ b/files/en-us/web/html/element/input/hidden/index.html
@@ -16,16 +16,6 @@ browser-compat: html.elements.input.input-hidden
 
 <p>{{HTMLElement("input")}} elements of type <strong><code>hidden</code></strong> let web developers include data that cannot be seen or modified by users when a form is submitted. For example, the ID of the content that is currently being ordered or edited, or a unique security token. Hidden inputs are completely invisible in the rendered page, and there is no way to make it visible in the page's content.</p>
 
-<div class="note">
-<p><strong>Note</strong>: There is a live example below the following line of code — if it is working correctly, you should see nothing!</p>
-</div>
-
-<div id="Basic_example">
-<pre class="brush: html">&lt;input id="prodId" name="prodId" type="hidden" value="xm234jq"&gt;</pre>
-
-<p>{{ EmbedLiveSample('Basic_example', 600, 40) }}</p>
-</div>
-
 <table class="properties">
  <tbody>
   <tr>
@@ -52,7 +42,7 @@ browser-compat: html.elements.input.input-hidden
 </table>
 
 <div class="note">
-<p><strong>Note</strong>: The {{domxref("HTMLElement/input_event", "input")}} and {{domxref("HTMLElement/change_event", "change")}} events do not apply to this input type. Hidden inputs cannot be focused even using JavaScript (e.g. <code>hiddenInput.focus()</code>).</p>
+<p><strong>Note:</strong> The {{domxref("HTMLElement/input_event", "input")}} and {{domxref("HTMLElement/change_event", "change")}} events do not apply to this input type. Hidden inputs cannot be focused even using JavaScript (e.g. <code>hiddenInput.focus()</code>).</p>
 </div>
 
 <h2 id="Value">Value</h2>
@@ -60,7 +50,7 @@ browser-compat: html.elements.input.input-hidden
 <p>The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute holds a {{domxref("DOMString")}} that contains the hidden data you want to include when the form is submitted to the server. This specifically can't be edited or seen by the user via the user interface, although you could edit the value via browser developer tools.</p>
 
 <div class="warning">
-<p><strong>Important:</strong> While the value isn't displayed to the user in the page's content, it is visible—and can be edited—using any browser's developer tools or "View Source" functionality. Do not rely on <code>hidden</code> inputs as a form of security.</p>
+<p><strong>Warning:</strong> While the value isn't displayed to the user in the page's content, it is visible—and can be edited—using any browser's developer tools or "View Source" functionality. Do not rely on <code>hidden</code> inputs as a form of security.</p>
 </div>
 
 <h2 id="Additional_attributes">Additional attributes</h2>
@@ -111,7 +101,7 @@ browser-compat: html.elements.input.input-hidden
 <p>This would stop a malicious user from creating a fake form, pretending to be a bank, and emailing the form to unsuspecting users to trick them into transferring money to the wrong place. This kind of attack is called a <a href="/en-US/docs/Learn/Server-side/First_steps/Website_security#cross-site_request_forgery_(csrf)">Cross Site Request Forgery (CSRF)</a>; pretty much any reputable server-side framework uses hidden secrets to prevent such attacks.</p>
 
 <div class="note">
-<p>As stated previously, placing the secret in a hidden input doesn't inherently make it secure. The key's composition and encoding would do that. The value of the hidden input is that it keeps the secret associated with the data and automatically includes it when the form is sent to the server. You need to use well-designed secrets to actually secure your website.</p>
+<p><strong>Note:</strong> Placing the secret in a hidden input doesn't inherently make it secure. The key's composition and encoding would do that. The value of the hidden input is that it keeps the secret associated with the data and automatically includes it when the form is sent to the server. You need to use well-designed secrets to actually secure your website.</p>
 </div>
 
 <h2 id="Validation">Validation</h2>
@@ -181,7 +171,7 @@ textarea {
 <p>{{ EmbedLiveSample('Examples', '100%', 200) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can also find the example on GitHub (see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/hidden-input-example/index.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/hidden-input-example/index.html">see it running live</a>).</p>
+<p><strong>Note:</strong> You can also find the example on GitHub (see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/hidden-input-example/index.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/hidden-input-example/index.html">see it running live</a>).</p>
 </div>
 
 <p>When submitted, the form data sent to the server will look something like this:</p>

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -647,7 +647,7 @@ let hatSize = form.elements["hat-size"];
  <p>If the <code>pattern</code> attribute is present but is not specified or is invalid, no regular expression is applied and this attribute is ignored completely. If the pattern attribute is valid and a non-empty value does not match the pattern, constraint validation will prevent form submission.</p>
 
  <div class="note">
- <p><strong>Tip:</strong> If using the <code>pattern</code> attribute, inform the user about the expected format by including explanatory text nearby. You can also include a {{htmlattrxref("title", "input")}} attribute to explain what the requirements are to match the pattern; most browsers will display this title as a tooltip. The visible explanation is required for accessibility. The tooltip is an enhancement.</p>
+ <p><strong>Note:</strong> If using the <code>pattern</code> attribute, inform the user about the expected format by including explanatory text nearby. You can also include a {{htmlattrxref("title", "input")}} attribute to explain what the requirements are to match the pattern; most browsers will display this title as a tooltip. The visible explanation is required for accessibility. The tooltip is an enhancement.</p>
  </div>
 
  <p>See {{anch("Client-side validation")}} for more information.</p>
@@ -884,11 +884,10 @@ let hatSize = form.elements["hat-size"];
  </tbody>
 </table>
 
-<h4 id="Examples">Examples</h4>
+<h4>Pseudo-classes example</h4>
 
 <p>We can style a checkbox label based on whether the checkbox is checked or not. In this example, we are styling the {{cssxref('color')}} and {{cssxref('font-weight')}} of the {{htmlelement('label')}} that comes immediately after a checked input. We haven't applied any styles if the <code>input</code> is not checked.</p>
 
-<div id="checkbox_label">
 <pre class="brush: html hidden">&lt;input id="checkboxInput" type="checkbox"&gt;
 &lt;label for="checkboxInput"&gt;Toggle the checkbox on and off&lt;/label&gt;
 </pre>
@@ -899,8 +898,7 @@ let hatSize = form.elements["hat-size"];
 }
 </pre>
 
-<p>{{EmbedLiveSample('checkbox_label', 500, 80)}}</p>
-</div>
+<p>{{EmbedLiveSample('Pseudo-classes_example', 500, 80)}}</p>
 
 <h3 id="Attribute_selectors">Attribute selectors</h3>
 

--- a/files/en-us/web/html/element/input/month/index.html
+++ b/files/en-us/web/html/element/input/month/index.html
@@ -62,32 +62,30 @@ browser-compat: html.elements.input.input-month
 
 <p>A {{domxref("DOMString")}} representing the value of the month and year entered into the input, in the form YYYY-MM (four or more digit year, then a hyphen ("<code>-</code>"), followed by the two-digit month). The format of the month string used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid local month string")}}.</p>
 
+<h3>Setting a default value</h3>
+
 <p>You can set a default value for the input control by including a month and year inside the {{htmlattrxref("value", "input")}} attribute, like so:</p>
 
-<div id="value-example-1">
 <pre class="brush: html">&lt;label for="bday-month"&gt;What month were you born in?&lt;/label&gt;
 &lt;input id="bday-month" type="month" name="bday-month" value="2017-06"&gt;</pre>
 
-<p>{{EmbedLiveSample('value-example-1', 600, 60)}}</p>
-</div>
+<p>{{EmbedLiveSample('Setting_a_default_value', 600, 60)}}</p>
 
 <p>One thing to note is that the displayed date format differs from the actual <code>value</code>; most {{Glossary("user agent", "user agents")}} display the month and year in a locale-appropriate form, based on the set locale of the user's operating system, whereas the date <code>value</code> is always formatted <code>yyyy-MM</code>.</p>
 
 <p>When the above value is submitted to the server, for example, it will look like <code>bday-month=1978-06</code>.</p>
 
+<h3>Setting the value using JavaScript</h3>
+
 <p>You can also get and set the date value in JavaScript using the {{domxref("HTMLInputElement.value")}} property, for example:</p>
 
-<div id="value-example-2">
-<div class="hidden">
 <pre class="brush: html">&lt;label for="bday-month"&gt;What month were you born in?&lt;/label&gt;
 &lt;input id="bday-month" type="month" name="bday-month" value="2017-06"&gt;</pre>
-</div>
 
 <pre class="brush: js">var monthControl = document.querySelector('input[type="month"]');
 monthControl.value = '1978-06';</pre>
 
-<p>{{EmbedLiveSample("value-example-2", 600, 60)}}</p>
-</div>
+<p>{{EmbedLiveSample("Setting_the_value_using_JavaScript", 600, 60)}}</p>
 
 <h2 id="Additional_attributes">Additional attributes</h2>
 
@@ -148,7 +146,13 @@ monthControl.value = '1978-06';</pre>
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<p>{{page("/en-US/docs/Web/HTML/Element/input/number", "step-include")}}</p>
+<p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
+
+<p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
+
+<div class="note">
+<p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
+</div>
 
 <p>For <code>month</code> inputs, the value of <code>step</code> is given in months, with a scaling factor of 1 (since the underlying numeric value is also in months). The default value of <code>step</code> is 1 month.</p>
 

--- a/files/en-us/web/html/element/input/number/index.html
+++ b/files/en-us/web/html/element/input/number/index.html
@@ -115,14 +115,12 @@ browser-compat: html.elements.input.input-number
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<div id="step-include">
 <p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
 
 <p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
 
 <div class="note">
 <p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
-</div>
 </div>
 
 <p>The default stepping value for <code>number</code> inputs is <code>1</code>, allowing only integers to be entered—<em>unless</em> the stepping base is not an integer.</p>

--- a/files/en-us/web/html/element/input/password/index.html
+++ b/files/en-us/web/html/element/input/password/index.html
@@ -162,12 +162,10 @@ browser-compat: html.elements.input.input-password
  <dd>Allow the browser or password manager to automatically enter a new password for the site; this is used on "change your password" and "new user" forms, on the field asking the user for a new password. The new password may be generated in a variety of ways, depending on the password manager in use. It may fill in a new suggested password, or it might show the user an interface for creating one.</dd>
 </dl>
 
-<div id="Autocomplete_sample1">
 <pre class="brush: html">&lt;label for="userPassword"&gt;Password:&lt;/label&gt;
 &lt;input id="userPassword" type="password" autocomplete="current-password"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("Autocomplete_sample1", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Allowing_autocomplete", 600, 40)}}</p>
 
 <h3 id="Making_the_password_mandatory">Making the password mandatory</h3>
 
@@ -227,14 +225,12 @@ browser-compat: html.elements.input.input-password
 
 <p>In this example, only values consisting of at least four and no more than eight hexadecimal digits are valid.</p>
 
-<div id="Validation_sample1">
 <pre class="brush: html">&lt;label for="hexId"&gt;Hex ID: &lt;/label&gt;
 &lt;input id="hexId" type="password" pattern="[0-9a-fA-F]{4,8}"
        title="Enter an ID consisting of 4-8 hexadecimal digits"
        autocomplete="new-password"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("Validation_sample1", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Validation", 600, 40)}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/html/element/input/radio/index.html
+++ b/files/en-us/web/html/element/input/radio/index.html
@@ -28,14 +28,12 @@ browser-compat: html.elements.input.input-radio
 
 <div>{{EmbedInteractiveExample("pages/tabbed/input-radio.html", "tabbed-standard")}}</div>
 
-<div id="Basic_example">
 <p>They are called radio buttons because they look and operate in a similar manner to the push buttons on old-fashioned radios, such as the one shown below.</p>
 
 <p><img alt="Shows what radio buttons looked like in the olden days." src="old-radio.jpg" title="Photo of an old-time radio"></p>
-</div>
 
 <div class="note">
-<p><strong>Note</strong>: <a href="/en-US/docs/Web/HTML/Element/input/checkbox">Checkboxes</a> are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off. Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.</p>
+<p><strong>Note:</strong> <a href="/en-US/docs/Web/HTML/Element/input/checkbox">Checkboxes</a> are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off. Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.</p>
 </div>
 
 <table class="properties">

--- a/files/en-us/web/html/element/input/range/index.html
+++ b/files/en-us/web/html/element/input/range/index.html
@@ -118,7 +118,13 @@ browser-compat: html.elements.input.input-range
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<p>{{page("/en-US/docs/Web/HTML/Element/input/number", "step-include")}}</p>
+<p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
+
+<p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
+
+<div class="note">
+<p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
+</div>
 
 <p>The default stepping value for <code>range</code> inputs is 1, allowing only integers to be entered, <em>unless</em> the stepping base is not an integer; for example, if you set <code>min</code> to -10 and <code>value</code> to 1.5, then a <code>step</code> of 1 will allow only values such as 1.5, 2.5, 3.5,... in the positive direction and -0.5, -1.5, -2.5,... in the negative direction. See the <a href="/en-US/docs/Web/HTML/Attributes/step">HTML <code>step</code> attribute</a>.</p>
 
@@ -144,7 +150,7 @@ browser-compat: html.elements.input.input-range
 <p id="orient-include">Similar to the -moz-orient non-standard CSS property impacting the {{htmlelement('progress')}} and {{htmlelement('meter')}} elements, the <code>orient</code> attribute defines the orientation of the range slider. Values include <code>horizontal</code>, meaning the range is rendered horizontally, and <code>vertical</code>, where the range is rendered vertically.</p>
 
 <div class="notecard note">
-<p>Note: The following input attributes do not apply to the input range: <code>accept</code>, <code>alt</code>, <code>checked</code>, <code>dirname</code>, <code>formaction</code>, <code>formenctype</code>, <code>formmethod</code>, <code>formnovalidate</code>, <code>formtarget</code>, <code>height</code>, <code>maxlength</code>, <code>minlength</code>, <code>multiple</code>, <code>pattern</code>, <code>placeholder</code>, <code>readonly</code>, <code>required</code>, <code>size</code>, <code>src</code>, and <code>width</code>. Any of these attributes, if included, will be ignored.</p>
+<p><strong>Note:</strong> The following input attributes do not apply to the input range: <code>accept</code>, <code>alt</code>, <code>checked</code>, <code>dirname</code>, <code>formaction</code>, <code>formenctype</code>, <code>formmethod</code>, <code>formnovalidate</code>, <code>formtarget</code>, <code>height</code>, <code>maxlength</code>, <code>minlength</code>, <code>multiple</code>, <code>pattern</code>, <code>placeholder</code>, <code>readonly</code>, <code>required</code>, <code>size</code>, <code>src</code>, and <code>width</code>. Any of these attributes, if included, will be ignored.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>
@@ -176,21 +182,21 @@ browser-compat: html.elements.input.input-range
 
 <p>By default, the granularity, is 1, meaning that the value is always an integer. You can change the {{htmlattrxref("step")}} attribute to control the granularity. For example, If you need a value between 5 and 10, accurate to two decimal places, you should set the value of <code>step</code> to 0.01:</p>
 
-<div id="Granularity_sample1">
+<h4>Setting the step attribute</h4>
+
 <pre class="brush: html">&lt;input type="range" min="5" max="10" step="0.01"&gt;</pre>
 
-<p>{{EmbedLiveSample("Granularity_sample1", 600, 40)}}</p>
-</div>
+<p>{{EmbedLiveSample("Setting_the_step_attribute", 600, 40)}}</p>
+
+<h4>Setting step to "any"</h4>
 
 <p>If you want to accept any value regardless of how many decimal places it extends to, you can specify a value of <code>any</code> for the {{htmlattrxref("step", "input")}} attribute:</p>
 
-<div id="Granularity_sample2">
 <pre class="brush: html">&lt;input type="range" min="0" max="3.14" step="any"&gt;</pre>
 
-<p>{{EmbedLiveSample("Granularity_sample2", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Setting_step_to_any", 600, 40)}}</p>
 
 <p>This example lets the user select any value between 0 and π without any restriction on the fractional part of the value selected.</p>
-</div>
 
 <h3 id="Adding_hash_marks_and_labels">Adding hash marks and labels</h3>
 
@@ -318,63 +324,49 @@ browser-compat: html.elements.input.input-range
 </table>
 
 <div class="note">
-<p><strong>Note</strong>: Currently, no browser fully supports these features. Firefox doesn't support hash marks and labels at all, for example, while Chrome supports hash marks but doesn't support labels. Version 66 (66.0.3359.181) of Chrome supports labels but the {{htmlelement("datalist")}} tag has to be styled with CSS as its {{cssxref("display")}} property is set to <code>none</code> by default, hiding the labels.</p>
+<p><strong>Note:</strong> Currently, no browser fully supports these features. Firefox doesn't support hash marks and labels at all, for example, while Chrome supports hash marks but doesn't support labels. Version 66 (66.0.3359.181) of Chrome supports labels but the {{htmlelement("datalist")}} tag has to be styled with CSS as its {{cssxref("display")}} property is set to <code>none</code> by default, hiding the labels.</p>
 </div>
 
-<h3 id="Change_the_orientation">Change the orientation</h3>
+<h3>Creating vertical range controls</h3>
 
-<div class="xhidden">
 <p>By default, if a browser renders a range input as a slider, it will render it so that the knob slides left and right. When supported, we will be able to make the range vertical, to slide up and down with CSS by declaring a height value greater than the width value. This is not actually implemented yet by any of the major browsers. (See Firefox {{bug(981916)}}, <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=341071">Chrome bug 341071</a>). It also, perhaps, may still be <a href="https://github.com/whatwg/html/issues/4177">under discussion</a>.</p>
 
 <p>In the meantime, we can make the range vertical by rotating it using CSS transforms, or, by targeting each browser engine with their own method, which includes setting the {{cssxref('appearance')}} to <code>slider-vertical</code>, by using a non-standard <code>orient</code> attribute in Firefox, or by changing the text direction for Internet Explorer and Edge.</p>
 
+<h4>Horizontal range control</h4>
+
 <p>Consider this range control:</p>
 
-<div id="Orientation_sample1">
 <pre class="brush: html">&lt;input type="range" id="volume" min="0" max="11" value="7" step="1"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("Orientation_sample1", 200, 200, "orientation_sample1.png")}}</p>
+<p>{{EmbedLiveSample("Horizontal_range_control", 200, 200, "orientation_sample1.png")}}</p>
 
 <p>This control is horizontal (at least on most if not all major browsers; others might vary).</p>
-</div>
 
-<h3 id="Standards">Standards</h3>
+<h4>Standards-based vertical range control</h4>
 
 <p>According to the specification, making it vertical requires adding CSS to change the dimensions of the control so that it's taller than it is wide, like this:</p>
-
-<div id="Orientation_sample2">
-<h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">#volume {
   height: 150px;
   width: 50px;
 }</pre>
 
-<h4 id="HTML">HTML</h4>
-
 <pre class="brush: html">&lt;input type="range" id="volume" min="0" max="11" value="7" step="1"&gt;</pre>
 
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Orientation_sample2", 200, 200, "orientation_sample2.png")}}</p>
-</div>
+<p>{{EmbedLiveSample("Standards-based_vertical_range_control", 200, 200, "orientation_sample2.png")}}</p>
 
 <p>Unfortunately, no major browsers currently support vertical range controls directly.</p>
 
-<h3 id="transform_rotate-90deg">transform: rotate(-90deg)</h3>
+<h4>Using transform</h4>
 
-<p>You can, however, create a vertical range control by drawing a horizontal range control on its side. The easiest way is to use CSS: by applying a {{cssxref("transform")}} to rotate the element, you can make it vertical. Let's take a look.</p>
-
-<h4 id="HTML_2">HTML</h4>
+<p>You can create a vertical range control by drawing a horizontal range control on its side. The easiest way is to use CSS: by applying a {{cssxref("transform")}} to rotate the element, you can make it vertical. Let's take a look.</p>
 
 <p>The HTML needs to be updated to wrap the {{HTMLElement("input")}} in a {{HTMLElement("div")}} to let us correct the layout after the transform is performed (since transforms don't automatically affect the layout of the page):</p>
 
 <pre class="brush: html">&lt;div class="slider-wrapper"&gt;
   &lt;input type="range" min="0" max="11" value="7" step="1"&gt;
 &lt;/div&gt;</pre>
-
-<h4 id="CSS_2">CSS</h4>
 
 <p>Now we need some CSS. First is the CSS for the wrapper itself; this specifies the display mode and size we want so that the page lays out correctly; in essence, it's reserving an area of the page for the slider so that the rotated slider fits into the reserved space without making a mess of things.</p>
 
@@ -398,20 +390,16 @@ browser-compat: html.elements.input.input-range
 
 <p>The size of the control is set to be 150 pixels long by 20 pixels tall. The margins are set to 0 and the {{cssxref("transform-origin")}} is shifted to the middle of the space the slider rotates through; since the slider is configured to be 150 pixels wide, it rotates through a box which is 150 pixels on each side. Offsetting the origin by 75px on each axis means we will rotate around the center of that space. Finally, we rotate counter-clockwise by 90°. The result: a range input which is rotated so the maximum value is at the top and the minimum value is at the bottom.</p>
 
-<p>{{EmbedLiveSample("transform_rotate-90deg", 200, 200, "orientation_sample3.png")}}</p>
+<p>{{EmbedLiveSample("Using_transform", 200, 200, "orientation_sample3.png")}}</p>
 
-<h3 id="appearance_property">appearance property</h3>
+<h4>Using the appearance property</h4>
 
 <p>The {{cssxref('appearance')}} property has a non-standard value of <code>slider-vertical</code> that, well, makes sliders vertical.</p>
-
-<h4 id="HTML_3">HTML</h4>
 
 <p>We use the same HTML as in the previous examples:</p>
 
 <pre class="brush: html">&lt;input type="range" min="0" max="11" value="7" step="1"&gt;
 </pre>
-
-<h4 id="CSS_3">CSS</h4>
 
 <p>We target just the inputs with a type of range:</p>
 
@@ -419,33 +407,27 @@ browser-compat: html.elements.input.input-range
   -webkit-appearance: slider-vertical;
 }</pre>
 
-<p>{{EmbedLiveSample("appearance_property", 200, 200)}}</p>
+<p>{{EmbedLiveSample("Using_the_appearance_property", 200, 200)}}</p>
 
-<h3 id="orient_attribute">orient attribute</h3>
+<h4>Using the orient attribute</h4>
 
 <p>In Firefox only, there is a non-standard <code>orient</code> property.</p>
-
-<h4 id="HTML_4">HTML</h4>
 
 <p>Use similar HTML as in the previous examples, we add the attribute with a value of <code>vertical</code>:</p>
 
 <pre class="brush: html">&lt;input type="range" min="0" max="11" value="7" step="1" orient="vertical"&gt;
 </pre>
 
-<p>{{EmbedLiveSample("orient_attribute", 200, 200)}}</p>
+<p>{{EmbedLiveSample("Using_the_orient_attribute", 200, 200)}}</p>
 
-<h3 id="writing-mode_bt-lr">writing-mode: bt-lr;</h3>
+<h4 id="writing-mode_bt-lr">writing-mode: bt-lr;</h4>
 
 <p>The {{cssxref('writing-mode')}} property should generally not be used to alter text direction for internationalization or localization purposes, but can be used for special effects. </p>
-
-<h4 id="HTML_5">HTML</h4>
 
 <p>We use the same HTML as in the previous examples:</p>
 
 <pre class="brush: html">&lt;input type="range" min="0" max="11" value="7" step="1"&gt;
 </pre>
-
-<h4 id="CSS_4">CSS</h4>
 
 <p>We target just the inputs with a type of range, changing the writing mode from the default to <code>bt-lr</code>, or bottom-to-top and left-to-right:</p>
 
@@ -455,18 +437,14 @@ browser-compat: html.elements.input.input-range
 
 <p>{{EmbedLiveSample("writing-mode_bt-lr", 200, 200)}}</p>
 
-<h3 id="Putting_it_all_together">Putting it all together</h3>
+<h4 id="Putting_it_all_together">Putting it all together</h4>
 
 <p>As each of the above examples works in different browsers, you can put all of them in a single example to make it work cross browser:</p>
-
-<h4 id="HTML_6">HTML</h4>
 
 <p>We keep the <code>orient</code> attribute with a value of <code>vertical</code> for Firefox:</p>
 
 <pre class="brush: html">&lt;input type="range" min="0" max="11" value="7" step="1" orient="vertical"&gt;
 </pre>
-
-<h4 id="CSS_5">CSS</h4>
 
 <p>We target just the inputs with a type of range, changing the writing mode from the default to <code>bt-lr</code>, or bottom-to-top and left-to-right, for Edge and Internet Explorer, and add <code>-webkit-appearance: slider-vertical</code> for all -webkit-based browsers:</p>
 

--- a/files/en-us/web/html/element/input/reset/index.html
+++ b/files/en-us/web/html/element/input/reset/index.html
@@ -54,19 +54,19 @@ browser-compat: html.elements.input.input-reset
 
 <p>An <code>&lt;input type="reset"&gt;</code> element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that is used as the button's label. Buttons such as <code>reset</code> don't have a value otherwise.</p>
 
-<div id="summary-example3">
-<pre class="brush: html">&lt;input type="reset" value="Reset the form"&gt;</pre>
-</div>
+<h3>Setting the value attribute</h3>
 
-<p>{{EmbedLiveSample("summary-example3", 650, 30)}}</p>
+<pre class="brush: html">&lt;input type="reset" value="Reset the form"&gt;</pre>
+
+<p>{{EmbedLiveSample("Setting_the_value_attribute", 650, 30)}}</p>
+
+<h3>Omitting the value attribute</h3>
 
 <p>If you don't specify a <code>value</code>, you get an button with the default label (typically "Reset," but this will vary depending on the {{Glossary("user agent")}}):</p>
 
-<div id="summary-example1">
 <pre class="brush: html">&lt;input type="reset"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("summary-example1", 650, 30)}}</p>
+<p>{{EmbedLiveSample("Omitting_the_value_attribute", 650, 30)}}</p>
 
 <h2 id="Using_reset_buttons">Using reset buttons</h2>
 
@@ -118,14 +118,12 @@ browser-compat: html.elements.input.input-reset
 
 <p>To disable a reset button, specify the {{htmlattrxref("disabled")}} global attribute on it, like so:</p>
 
-<div id="disable-example1">
 <pre class="brush: html">&lt;input type="reset" value="Disabled" disabled&gt;</pre>
-</div>
 
 <p>You can enable and disable buttons at run time by setting <code>disabled</code> to <code>true</code> or <code>false</code>; in JavaScript this looks like <code>btn.disabled = true</code> or <code>btn.disabled = false</code>.</p>
 
 <div class="note">
-<p><strong>Note</strong>: See the <code><a href="/en-US/docs/Web/HTML/Element/input/button#disabling_and_enabling_a_button">&lt;input type="button"&gt;</a></code> page for more ideas about enabling and disabling buttons.</p>
+<p><strong>Note:</strong> See the <code><a href="/en-US/docs/Web/HTML/Element/input/button#disabling_and_enabling_a_button">&lt;input type="button"&gt;</a></code> page for more ideas about enabling and disabling buttons.</p>
 </div>
 
 <h2 id="Validation">Validation</h2>

--- a/files/en-us/web/html/element/input/time/index.html
+++ b/files/en-us/web/html/element/input/time/index.html
@@ -175,7 +175,13 @@ startTime.addEventListener("input", function() {
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<p>{{page("/en-US/docs/Web/HTML/Element/input/number", "step-include")}}</p>
+<p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
+
+<p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
+
+<div class="note">
+<p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
+</div>
 
 <p>For <code>time</code> inputs, the value of <code>step</code> is given in seconds, with a scaling factor of 1000 (since the underlying numeric value is in milliseconds). The default value of <code>step</code> is 60, indicating 60 seconds (or 1 minute, or 60,000 milliseconds).</p>
 

--- a/files/en-us/web/html/element/input/week/index.html
+++ b/files/en-us/web/html/element/input/week/index.html
@@ -123,7 +123,13 @@ weekControl.value = '2017-W45';</pre>
 
 <h3 id="attr-step"><code id="step">step</code></h3>
 
-<p>{{page("/en-US/docs/Web/HTML/Element/input/number", "step-include")}}</p>
+<p>The <code>step</code> attribute is a number that specifies the granularity that the value must adhere to, or the special value <code>any</code>, which is described below. Only values which are equal to the basis for stepping (<code>{{anch("min")}}</code> if specified, {{htmlattrxref("value", "input")}} otherwise, and an appropriate default value if neither of those is provided) are valid.</p>
+
+<p>A string value of <code>any</code> means that no stepping is implied, and any value is allowed (barring other constraints, such as <code>{{anch("min")}}</code> and <code>{{anch("max")}}</code>).</p>
+
+<div class="note">
+<p><strong>Note:</strong> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.</p>
+</div>
 
 <p>For <code>week</code> inputs, the value of <code>step</code> is given in weeks, with a scaling factor of 604,800,000 (since the underlying numeric value is in milliseconds). The default value of <code>step</code> is 1, indicating 1week. The default stepping base is -259,200,000, which is the beginning of the first week of 1970 (<code>"1970-W01"</code>).</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This PR is the first of two to remove `<div id=` from the HTML documentation. Most of these are live samples.

I also removed a usage of the `{{page}}` macro to include some text that was marked up with `<div id="step-include">`.

The changes around making range controls vertical are a bit intricate - I think the original heading levels are wrong there (each sub-piece of the problem should be an h4).

I also snuck in a few fixes to notes and warnings.
