### PR TITLE
Remove XPCOM reference from Functions/getter

### DIFF
--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -7,6 +7,7 @@ tags:
   - Functions
   - JavaScript
   - Language feature
+  - Reference
 browser-compat: javascript.functions.get
 ---
 {{jsSidebar("Functions")}}
@@ -167,11 +168,6 @@ get notifier() {
 },
 ```
 
-For Firefox code, see also the `XPCOMUtils.jsm` code module, which defines
-the
-[`defineLazyGetter()`](</en-US/docs/Mozilla/JavaScript_code_modules/XPCOMUtils.jsm#defineLazyGetter()>)
-function.
-
 ### `get` vs. `defineProperty`
 
 While using the `get` keyword and {{jsxref("Object.defineProperty()")}} have
@@ -214,7 +210,7 @@ console.log(
 
 ## See also
 
-- [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set)
+- [Setter](/en-US/docs/Web/JavaScript/Reference/Functions/set)
 - {{jsxref("Operators/delete", "delete")}}
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Object.defineGetter", "__defineGetter__")}}

--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -6,6 +6,7 @@ tags:
   - Functions
   - JavaScript
   - Language feature
+  - Reference
 browser-compat: javascript.functions.set
 ---
 {{jsSidebar("Functions")}}
@@ -135,7 +136,7 @@ console.log(obj.baz);
 
 ## See also
 
-- [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get)
+- [Getter](/en-US/docs/Web/JavaScript/Reference/Functions/get)
 - {{jsxref("Operators/delete", "delete")}}
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Object.defineGetter", "__defineGetter__")}}


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

None.

> What was wrong/why is this fix needed? (quick summary only)

Outdated/dead link.

- Also added `Reference` tag.

> Anything else that could help us review it

None.