### PR TITLE
Update authorisation header and extend www-auth with digest

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -75,6 +75,8 @@ Proxy-Authorization: <type> <credentials>
 
 ### Authentication schemes
 
+<!--   Some of the more common types are (case-insensitive): [Basic](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) | Digest | Bearer | HOBA | Mutual | Negotiate | OAuth | SCRAM-SHA-1 | SCRAM-SHA-256 | vapid -->
+
 The general HTTP authentication framework is used by several authentication schemes.
 Schemes can differ in security strength and in their availability in client or server software.
 

--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -94,7 +94,8 @@ Common authentication schemes include:
 - **Mutual**
   - : See {{rfc(8120)}}
 - **AWS4-HMAC-SHA256**
-  - : See [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html)
+  - : See [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html). This scheme is used for AWS3 server authentication.
+
 
 ## Basic authentication scheme
 

--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -25,7 +25,11 @@ The challenge and response flow works like this:
 
 ![A sequence diagram illustrating HTTP messages between a client and a server lifeline.](http-auth-sequence-diagram.png "Sequence Diagram of Client-server HTTP Authentication")
 
-In the case of a "Basic" authentication like shown in the figure, the exchange **must** happen over an HTTPS (TLS) connection to be secure.
+The general message flow above is the same for most (if not all) [authentication schemes](#authentication_schemes).
+The actual information in the headers and the way it is encoded does change!
+
+> **Warning:** The "Basic" authentication scheme used in the diagram above sends the credentials encoded but not encrypted.
+> This would be completely insecure unless the exchange was over a secure connection (HTTPS/TLS).
 
 ### Proxy authentication
 
@@ -73,17 +77,13 @@ Authorization: <type> <credentials>
 Proxy-Authorization: <type> <credentials>
 ```
 
-### Authentication schemes
+## Authentication schemes
 
-<!--   Some of the more common types are (case-insensitive): [Basic](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) | Digest | Bearer | HOBA | Mutual | Negotiate | OAuth | SCRAM-SHA-1 | SCRAM-SHA-256 | vapid -->
+The general HTTP authentication framework is the base for a number of authentication schemes.
 
-The general HTTP authentication framework is used by several authentication schemes.
-Schemes can differ in security strength and in their availability in client or server software.
-
-The most common authentication scheme is the "Basic" authentication scheme, which is introduced in more detail below.
 IANA maintains a [list of authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml), but there are other schemes offered by host services, such as Amazon AWS.
 
-Common authentication schemes include:
+Some common authentication schemes include:
 
 - **Basic**
   - : See {{rfc(7617)}}, base64-encoded credentials. More information below.
@@ -95,8 +95,19 @@ Common authentication schemes include:
   - : See {{rfc(7486)}}, Section 3, **H**TTP **O**rigin-**B**ound **A**uthentication, digital-signature-based
 - **Mutual**
   - : See {{rfc(8120)}}
+- **Negotiate** / **NTLM**
+  - : See [RFC4599](https://www.ietf.org/rfc/rfc4559.txt)
+- **VAPID**
+  - : See {{rfc(8292)}}
+- **SCRAM**
+  - : See {{rfc(7804)}} 
 - **AWS4-HMAC-SHA256**
   - : See [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html). This scheme is used for AWS3 server authentication.
+
+Schemes can differ in security strength and in their availability in client or server software.
+
+The "Basic" authentication scheme offers very poor security, but is widely supported and easy to set up.
+It is introduced in more detail below.
 
 
 ## Basic authentication scheme

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -6,14 +6,22 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  - header
+  - Header
+  - Authorization
+  - Authentication
+browser-compat: http.headers.Authorization
 ---
 {{HTTPSidebar}}
 
-The HTTP **`Authorization`** request header contains the
-credentials to authenticate a user agent with a server, usually, but not
-necessarily, after the server has responded with a {{HTTPStatus("401")}}
-`Unauthorized` status and the {{HTTPHeader("WWW-Authenticate")}} header.
+The HTTP **`Authorization`** request header can be used to provide credentials that authenticate a user agent with a server, allowing access to a protected resource.
+
+The **`Authorization`** header is usually, but not always, sent after the user agent first attempts to request a protected resource without credentials.
+The server responds with a {{HTTPStatus("401")}} `Unauthorized` message that includes at least one {{HTTPHeader("WWW-Authenticate")}} header.
+This header indicates what authentication schemes can be used to access the resource (and any additional information needed by the client to use them). 
+The user-agent should select the most secure authentication scheme that it supports from those offered, prompt the user for their credentials, and then re-request the resource (including the encoded credentials in the **`Authorization`** header). 
+
+> **Note:** This header is part of the [General HTTP authentication framework](/en-US/docs/Web/HTTP/Authentication#the_general_http_authentication_framework).
+> It can be used with a number of [authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
 
 <table class="properties">
   <tbody>
@@ -31,42 +39,37 @@ necessarily, after the server has responded with a {{HTTPStatus("401")}}
 ## Syntax
 
 ```
-Authorization: <type> <credentials>
+Authorization: <auth-scheme> <credentials>
 ```
 
 ## Directives
 
-- \<type>
-
-  - : The [Authentication type](/en-US/docs/Web/HTTP/Authentication#authentication_schemes), that is which algorithm will be used for authentication. A common type is [`"Basic"`](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme).
-
-    Other types common types can be found at the [IANA registry of Authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
-
-    > **Note:** AWS S3 servers use a specific authentication,
-    > [`AWS4-HMAC-SHA256`](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html).
+- `<auth-scheme>`
+  - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes) that defines how the credentials are encoded.
+    Some of the more common types are (case-insensitive): [Basic](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) | Digest | Bearer | HOBA | Mutual | Negotiate | OAuth | SCRAM-SHA-1 | SCRAM-SHA-256 | vapid
+    > **Note:** For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
 
 - \<credentials>
 
-  - : If the `"Basic"` authentication scheme is used,
-    the credentials are constructed
-    by first combining the username and the password with a colon (`aladdin:opensesame`),
-    then by encoding the resulting string in [`base64`](/en-US/docs/Glossary/Base64) (`YWxhZGRpbjpvcGVuc2VzYW1l`).
+  - : The credentials, encoded according to the specified scheme.
 
-    > **Note:** {{Glossary("Base64")}}-encoding does not mean encryption or hashing!
-    > As base64 is a reversible encoding,
-    > this method is equally (in)secure
-    > as sending the credentials in clear text.
-    > So you should alwaysuse {{Glossary("HTTPS")}} in conjunction with `Basic` authentication.
+    > **Note:** For information about the encoding algorithm, see the examples: below, in {{HTTPHeader("WWW-Authenticate")}}, in [HTTP Authentication](/en-US/docs/Web/HTTP/Authentication), and in the relevant specifications.
+
 
 ## Examples
 
-```
+### Basic authentication
+
+For `"Basic"` authentication the credentials are constructed by first combining the username and the password with a colon (`aladdin:opensesame`), and then by encoding the resulting string in [`base64`](/en-US/docs/Glossary/Base64) (`YWxhZGRpbjpvcGVuc2VzYW1l`).
+
+```https
 Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 ```
 
-See also [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) for
-examples on how to configure Apache or nginx servers to password protect your site with
-HTTP basic authentication.
+> **Warning:** {{Glossary("Base64")}}-encoding can easily be reversed to obtain the original name and password, so Basic authentication is completely insecure.
+> {{Glossary("HTTPS")}} is always recommended when using authentication, but is even more so when using `Basic` authentication.
+
+See also [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) for examples on how to configure Apache or nginx servers to password protect your site with HTTP basic authentication.
 
 ## Specifications
 
@@ -74,6 +77,14 @@ HTTP basic authentication.
 | ---------------------------------------------------- | -------------------------------------- |
 | {{RFC("7235", "Authorization", "4.2")}} | HTTP/1.1: Authentication               |
 | {{RFC("7617")}}                                 | The 'Basic' HTTP Authentication Scheme |
+| {{RFC("7616")}}                                 | HTTP Digest Access Authentication |
+
+<!-- {{Specifications}} -->
+
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -38,22 +38,88 @@ The user-agent should select the most secure authentication scheme that it suppo
 
 ## Syntax
 
+```http
+Authorization: <auth-scheme> <authorisation-parameters>
 ```
-Authorization: <auth-scheme> <credentials>
+
+Basic authentication
+
+```http
+Authorization: Basic <credentials>
 ```
+
+Digest authentication
+
+```http
+Authorization: Digest username=<username>,
+    realm="<realm>",
+    uri="<url>",
+    algorithm=<algorithm>,
+    nonce="<nonce>",
+    nc=<nc>,
+    cnonce="<cnonce>",
+    qop=<qop>,
+    response="<response>",
+    opaque="<opaque>"
+```
+
 
 ## Directives
 
 - `<auth-scheme>`
   - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes) that defines how the credentials are encoded.
-    Some of the more common types are (case-insensitive): [Basic](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) | Digest | Bearer | HOBA | Mutual | Negotiate | OAuth | SCRAM-SHA-1 | SCRAM-SHA-256 | vapid
+    Some of the more common types are (case-insensitive): [`Basic`](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme), `Digest`, `Negotiate` and `AWS4-HMAC-SHA256`.
+
     > **Note:** For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
+
+
+Other than `<auth-scheme>` the remaining directives are specific to each [authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
+Generally you will need to check the relevant specifications for these (keys for a small subset of schemes are listed below).
+
+### Basic
 
 - \<credentials>
 
   - : The credentials, encoded according to the specified scheme.
 
     > **Note:** For information about the encoding algorithm, see the examples: below, in {{HTTPHeader("WWW-Authenticate")}}, in [HTTP Authentication](/en-US/docs/Web/HTTP/Authentication), and in the relevant specifications.
+
+### Digest
+
+
+- \<response>
+  - : A string of the hex digits that proves that the user knows a password.
+      The algorithm encodes the username and password, realm, cnonce, qop, nc, and so on.
+      It is described in detail in the specification. 
+- **`username`**
+  - : A quoted string containing user's name for the specified `realm` in either plain text or the hash code in hexadecimal notation.
+      If the name contains characters that aren't allowed in the field, then `username*` can be used instead (not "as well").
+- **`username*`**
+  - : The user's name formatted using an extended notation defined in RFC5987.
+      This should be used only if the name can't be encoded in `username` and if `userhash` is set `"false"`.
+- **`uri`**
+  - : The _Effective Request URI_. See the specification for more information.
+- **`realm`**
+  - : Realm of the requested username/password (again, should match the value in the corresponding {{HTTPHeader("WWW-Authenticate")}} response for the resource being requested).
+- **`opaque`**
+  - : The value in the corresponding {{HTTPHeader("WWW-Authenticate")}} response for the resource being requested.
+- **`algorithm`**
+  - : The algorithm used to calculate the digest. Must be a supported algorithm from the {{HTTPHeader("WWW-Authenticate")}} response for the resource being requested.
+- **`qop`**
+  - : A token indicating the _quality of protection_ applied to the message.
+      Must match the one value in the set specified in the {{HTTPHeader("WWW-Authenticate")}} response for the resource being requested.
+      - `"auth"`: Authentication
+      - `"auth-int"`: Authentication with integrity protection
+- **`cnonce`**
+  - : An quoted ASCII-only string value provided by the client.
+      This is used by both the client and server to provide mutual authentication, provide some message integrity protection, and avoid "chosen plaintext 
+      attacks".
+      See the specification for additional information. 
+- **`nc`**
+  - : Nonce count. The hexadecimal count of requests in which the client has sent the current `cnonce` value (including the current request).
+      The server can use duplicate `nc` values to recognise replay requests.
+- **`userhash`** {{optional_inline}}
+  - : `"true` if the username has been hashed. `"false"` by default.
 
 
 ## Examples

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -25,7 +25,7 @@ Multiple challenges are allowed in one `WWW-Authenticate` header, and multiple `
 A server may also include the `WWW-Authenticate` header in other response messages to indicate that supplying credentials might affect the response.
 
 After receiving the `WWW-Authenticate` header, a client will typically prompt the user for credentials, and then re-request the resource.
-This request uses the {{HTTPHeader("Authorization")}} header to supply the credentials to the server, encoded appropriately for the selected "challenge" authentication method.
+This new request uses the {{HTTPHeader("Authorization")}} header to supply the credentials to the server, encoded appropriately for the selected "challenge" authentication method.
 The client is expected to select the most secure of the challenges it understands (note that in some cases the "most secure" method is debatable).
 
 <table class="properties">
@@ -82,7 +82,8 @@ WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
 ## Directives
 
 - `<auth-scheme>`
-  - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). Some of the more common types are (case-insensitive): [Basic](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) | Digest | Bearer | HOBA | Mutual | Negotiate | OAuth | SCRAM-SHA-1 | SCRAM-SHA-256 | vapid
+  - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). Some of the more common types are (case-insensitive): [`Basic`](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme), `Digest`, `Negotiate` and `AWS4-HMAC-SHA256`.
+
     > **Note:** For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
 - **realm=**\<realm> {{optional_inline}}
   - : A string describing a protected area.
@@ -92,9 +93,9 @@ WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
   - : A token that may be useful for some schemes. The token allows the 66 unreserved URI characters plus a few others.
     According to the specification, it can hold a base64, base64url, base32, or base16 (hex) encoding, with or without padding, but excluding whitespace.
 
-Authorization parameter keys that are specific to each [authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
-These are listed below for some schemes.
-For others you may need to check the specifications:
+Other than `<auth-scheme>` and the key `realm`, authorization parameters are specific to each [authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
+Generally you will need to check the relevant specifications for these (keys for a small subset of schemes are listed below).
+
 
 ### Basic
 
@@ -110,34 +111,34 @@ For others you may need to check the specifications:
 - **`<realm>`** {{optional_inline}}
   - : String indicating which username/password to use.
       Minimally should include the host name, but might indicate the users or group that have access.
-- **`domain=`** `<list of URIs>` {{optional_inline}}
+- **`domain`** {{optional_inline}}
   - : A quoted, space-separated list of URI prefixes that define all the locations where the authentication information may be be used.
       If this key is not is not specified then the authentication information may be used anywhere on the web root.
-- **`nonce=`** `"<server specified string>`
-  - : A server-specified quoted string that is used to control the lifetime in which particular credentials will be considered valid.
+- **`nonce`**
+  - : A server-specified quoted string that the server can use to control the lifetime in which particular credentials will be considered valid.
     This must be uniquely generated each time a 401 response is made, and may be regenerated more often (for example, allowing a digest to be used only once).
-    The specification has advice on possible algorithms for generating this value, which is opaque to the client.
-- **`opaque=`** `"<server specified string>`
+    The specification contains advice on possible algorithms for generating this value.
+    The nonce value is opaque to the client.
+- **`opaque`**
   - : A server-specified quoted string that should be returned unchanged in the {{HTTPHeader("Authorization")}}. 
     This is opaque to the client. The server is recommended to include Base64 or hexadecimal data.
-- **`stale=`** `true` or some other flag {{optional_inline}}
+- **`stale`** {{optional_inline}}
   - : A case-insensitive flag indicating that the previous request from the client was rejected because the `nonce` used is too old (stale).
       If this is `true` the request can be re-tried using the same username/password encrypted using the new `nonce`.
       If it is any other value then the username/password are invalid and must be re-requested from the user.
-- **`algorithm=`** `"MD5"` | `"SHA-256"`  | `"SHA-512"`  {{optional_inline}}
-  - : Algorithm used to produce the digest (default if not specified is `"MD5"`).
-     There are session and non-session variants.
-     The session variants have the same name but are suffixed with "-sess".
-     For example: `"MD5-sess"`.
-- **`qop=`**
+- **`algorithm`**   {{optional_inline}}
+  - : Algorithm used to produce the digest.
+      Valid non-session values are: `"MD5"` (default if not specified), `"SHA-256"`, `"SHA-512"`.
+      Valid session values are: `"MD5-sess"`, `"SHA-256-sess"`, `"SHA-512-sess"`.
+- **`qop`**
   - : Quoted string indicating the quality of protection supported by the server. This must be supplied, and unrecognised options must be ignored.
       - `"auth"`: Authentication
       - `"auth-int"`: Authentication with integrity protection
 - **`charset="UTF-8"`** {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.
       The only allowed value is the case-insensitive string "UTF-8".
-- **`userhash=`** `"true"` | `"false"` {{optional_inline}}
-  - : A server may use this to indicate that it supports username hashing (default is `"false"`)
+- **`userhash`** {{optional_inline}}
+  - : A server may specify `"true"` to indicate that it supports username hashing (default is `"false"`)
 
 
 ## Examples
@@ -160,6 +161,67 @@ Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 For `"Basic"` authentication the credentials are constructed by first combining the username and the password with a colon (`aladdin:opensesame`), and then by encoding the resulting string in [`base64`](/en-US/docs/Glossary/Base64) (`YWxhZGRpbjpvcGVuc2VzYW1l`).
 
 > **Note:** See also [HTTP authentication](/en-US/docs/Web/HTTP/Authentication) for examples on how to configure Apache or nginx servers to password protect your site with HTTP basic authentication.
+
+
+### Digest authentication with SHA-256 and MD5
+
+> **Note:** This example is taken from {{RFC("7616")}} "HTTP Digest Access Authentication" (other examples in the specification show the use of `SHA-512`, `charset`, and `userhash`).
+
+The client attempts to access a document at URI "http://www.example.org/dir/index.html" that is protected via digest authentication.
+The username for this document is "Mufasa" and the password is "Circle of Life" (note the single space between each of the words).
+
+The first time the client requests the document, no {{HTTPHeader("Authorization")}} header field is sent.
+Here the server responds with an HTTP 401 message that includes a challenge for each digest algorithm it supports, in its order of preference (`SHA256` and then `MD5`)
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Digest
+    realm="http-auth@example.org",
+    qop="auth, auth-int",
+    algorithm=SHA-256,
+    nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+    opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
+WWW-Authenticate: Digest
+    realm="http-auth@example.org",
+    qop="auth, auth-int",
+    algorithm=MD5,
+    nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+    opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
+```
+
+The client prompts the user for their username and password, and then responds with a new request that encodes the credentials in the {{HTTPHeader("Authorization")}} header field.
+If the client chose the MD5 digest the {{HTTPHeader("Authorization")}} header field might look as shown below:
+
+```http
+Authorization: Digest username="Mufasa",
+    realm="http-auth@example.org",
+    uri="/dir/index.html",
+    algorithm=MD5,
+    nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+    nc=00000001,
+    cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ",
+    qop=auth,
+    response="8ca523f5e9506fed4657c9700eebdbec",
+    opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
+```
+
+If the client chose the SHA-256 digest the {{HTTPHeader("Authorization")}} header field might look as shown below:
+
+```http
+Authorization: Digest username="Mufasa",
+    realm="http-auth@example.org",
+    uri="/dir/index.html",
+    algorithm=SHA-256,
+    nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+    nc=00000001,
+    cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ",
+    qop=auth,
+    response="753927fa0e85d155564e2e272a28d1802ca10daf449
+        6794697cf8db5856cb6c1",
+    opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
+```
+
+
 
 ## Specifications
 


### PR DESCRIPTION
This is continued update or HTTP authorisation docs for #8682

This updates the  `WWW-Authenticate` and `Authorization` header docs with additional information. These headers are part of a framework, so the directives depend on the authentication method used. Prior to these updates the headers were written as though only the `Basic` authentication existed.

What I have tried to do is make this framework more obvious by including the directives and examples for both `Basic` and `Digest` authentication. 

Part of the way though though I realised that it is very difficult to do justice to the Digest authentication -  yes I could capture the entire algorithm, but the spec is pretty dense. I don't think we want to go to the point where people think this replaces the spec. What I want to do is give an overview that gives a good flavour of how it works, but makes it pretty clear that you do need to go to the spec if you're going to do anything more than superficial. 

In other words, I don't think this is perfect, but I think it is better. Thoughts?

This part is pretty much done for now. I am planning on updating the BCD https://github.com/mdn/browser-compat-data/pull/12446 to give better links into the spec. That is actually likely to be the most valuable part of this effort :-0