### PR TITLE
Fix a typo: "of the of the"

### DIFF
--- a/files/en-us/web/css/place-items/index.md
+++ b/files/en-us/web/css/place-items/index.md
@@ -83,7 +83,7 @@ place-items: unset;
 - `self-end`
   - : The item is packed flush to the edge of the alignment container of the end side of the item, in the appropriate axis.
 - `center`
-  - : The items are packed flush to each other toward the center of the of the alignment container.
+  - : The items are packed flush to each other toward the center of the alignment container.
 - `left`
   - : The items are packed flush to each other toward the left edge of the alignment container. If the property’s axis is not parallel with the inline axis, this value behaves like `start`.
 - `right`


### PR DESCRIPTION
Repetition of "of the" in section "Values". 

