### PR TITLE
fixed a typo

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 
 <h3 id="Firefox_Gecko_properties">Firefox (Gecko) properties</h3>
 
-<p>Firefox stores is browser specific settings in the <code>gecko</code> subkey, which has the following properties:</p>
+<p>Firefox stores its browser specific settings in the <code>gecko</code> subkey, which has the following properties:</p>
 
 <dl>
 	<dt id="browser_specific_settings_gecko_id"><code>id</code></dt>


### PR DESCRIPTION
I think this is a typo but sorry to bother you, whoever is reading this, if it wasn't and I'm wrong:

old: "Firefox stores `is` browser specific settings in..."

new: "Firefox stores `its` browser specific settings in..."

