### PR TITLE
Regular expressions: link to multipage ES spec

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/assertions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/assertions/index.md
@@ -303,4 +303,4 @@ console.log(ripe_oranges); // [ 'ripe orange A ', 'ripe orange C' ]
   - [Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)
 
 - [The `RegExp()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
-- [Assertions in the ECMAScript specification](https://tc39.es/ecma262/#sec-assertion)
+- [Assertions in the ECMAScript specification](https://tc39.es/ecma262/multipage/text-processing.html#sec-assertion)

--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -305,4 +305,4 @@ console.table(nonEnglishText.match(regexpBMPWord));
   - [Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)
 
 - [The `RegExp()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
-- [CharacterClass in the ECMAScript specification](https://tc39.es/ecma262/#sec-characterclass)
+- [CharacterClass in the ECMAScript specification](https://tc39.es/ecma262/multipage/text-processing.html#sec-characterclass)

--- a/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -746,10 +746,10 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` s
 ```
 
 - UnicodeBinaryPropertyName
-  - : The name of a [binary property](https://tc39.es/ecma262/#table-binary-unicode-properties). E.g.: [`ASCII`](https://unicode.org/reports/tr18/#General_Category_Property), [`Alpha`](https://unicode.org/reports/tr44/#Alphabetic), `Math`, [`Diacritic`](https://unicode.org/reports/tr44/#Diacritic), [`Emoji`](https://unicode.org/reports/tr51/#Emoji_Properties), [`Hex_Digit`](https://unicode.org/reports/tr44/#Hex_Digit), `Math`, [`White_space`](https://unicode.org/reports/tr44/#White_Space), etc. See [Unicode Data PropList.txt ](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt)for more info.
+  - : The name of a [binary property](https://tc39.es/ecma262/multipage/text-processing.html#table-binary-unicode-properties). E.g.: [`ASCII`](https://unicode.org/reports/tr18/#General_Category_Property), [`Alpha`](https://unicode.org/reports/tr44/#Alphabetic), `Math`, [`Diacritic`](https://unicode.org/reports/tr44/#Diacritic), [`Emoji`](https://unicode.org/reports/tr51/#Emoji_Properties), [`Hex_Digit`](https://unicode.org/reports/tr44/#Hex_Digit), `Math`, [`White_space`](https://unicode.org/reports/tr44/#White_Space), etc. See [Unicode Data PropList.txt ](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt)for more info.
 - UnicodePropertyName
 
-  - : The name of a [non-binary](https://tc39.es/ecma262/#table-nonbinary-unicode-properties) property:
+  - : The name of a [non-binary](https://tc39.es/ecma262/multipage/text-processing.html#table-nonbinary-unicode-properties) property:
 
     - [General_Category](https://unicode.org/reports/tr18/#General_Category_Property) (`gc`)
     - [Script](https://unicode.org/reports/tr24/#Script) (`sc`)

--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.md
@@ -248,4 +248,4 @@ do {
   - [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes)
 
 - [The `RegExp()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
-- [ClassRanges in the ECMAScript specification](https://tc39.es/ecma262/#sec-classranges)
+- [ClassRanges in the ECMAScript specification](https://tc39.es/ecma262/multipage/text-processing.html#sec-classranges)

--- a/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -215,4 +215,4 @@ console.log(text.match(nonGreedyRegexp));
   - [Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)
 
 - [The `RegExp()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
-- [Quantifiers in the ECMAScript specification](https://tc39.es/ecma262/#sec-quantifier)
+- [Quantifiers in the ECMAScript specification](https://tc39.es/ecma262/multipage/text-processing.html#sec-quantifier)

--- a/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
@@ -41,9 +41,9 @@ tags:
 See also [PropertyValueAliases.txt](https://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt)
 
 - UnicodeBinaryPropertyName
-  - : The name of a [binary property](https://tc39.es/ecma262/#table-binary-unicode-properties). E.g.: [`ASCII`](https://unicode.org/reports/tr18/#General_Category_Property), [`Alpha`](https://unicode.org/reports/tr44/#Alphabetic), `Math`, [`Diacritic`](https://unicode.org/reports/tr44/#Diacritic), [`Emoji`](https://unicode.org/reports/tr51/#Emoji_Properties), [`Hex_Digit`](https://unicode.org/reports/tr44/#Hex_Digit), `Math`, [`White_space`](https://unicode.org/reports/tr44/#White_Space), etc. See [Unicode Data PropList.txt ](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt)for more info.
+  - : The name of a [binary property](https://tc39.es/ecma262/multipage/text-processing.html#table-binary-unicode-properties). E.g.: [`ASCII`](https://unicode.org/reports/tr18/#General_Category_Property), [`Alpha`](https://unicode.org/reports/tr44/#Alphabetic), `Math`, [`Diacritic`](https://unicode.org/reports/tr44/#Diacritic), [`Emoji`](https://unicode.org/reports/tr51/#Emoji_Properties), [`Hex_Digit`](https://unicode.org/reports/tr44/#Hex_Digit), `Math`, [`White_space`](https://unicode.org/reports/tr44/#White_Space), etc. See [Unicode Data PropList.txt ](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt)for more info.
 - UnicodePropertyName
-  - : The name of a [non-binary](https://tc39.es/ecma262/#table-nonbinary-unicode-properties) property:
+  - : The name of a [non-binary](https://tc39.es/ecma262/multipage/text-processing.html#table-nonbinary-unicode-properties) property:
 - UnicodePropertyValue
   - : One of the tokens listed in the Values section, below. Many values have aliases or shorthand (e.g. the value `Decimal_Number` for the `General_Category` property may be written `Nd`, `digit`, or `Decimal_Number`). For most values, the *`UnicodePropertyName`* part and equals sign may be omitted. If a *`UnicodePropertyName`* is specified, the value must correspond to the property type given.
 
@@ -97,7 +97,7 @@ mixedCharacters.match(/\p{Script=Greek}/u); // ε
 mixedCharacters.match(/\p{Sc=Cyrillic}/u); // Л
 ```
 
-For more details, please refer to [the Unicode specification](https://unicode.org/reports/tr24/#Script) and the [Scripts table in the ECMAScript specification](https://tc39.es/ecma262/#table-unicode-script-values).
+For more details, please refer to [the Unicode specification](https://unicode.org/reports/tr24/#Script) and the [Scripts table in the ECMAScript specification](https://tc39.es/ecma262/multipage/text-processing.html#table-unicode-script-values).
 
 If a character is used in a limited set of scripts, the `Script` property will only match for the "predominant" used script. If we want to match characters based on a "non-predominant" script, we could use the `Script_Extensions` property (`Scx` for short).
 
@@ -147,4 +147,4 @@ console.table(nonEnglishText.match(regexpUPE));
 - [Unicode character property — Wikipedia](https://en.wikipedia.org/wiki/Unicode_character_property)
 - [A blog post from Axel Rauschmayer about Unicode property escapes](https://2ality.com/2017/07/regexp-unicode-property-escapes.html)
 - [The Unicode document for Unicode properties](https://unicode.org/reports/tr18/#Categories)
-- [UnicodeMatchProperty in the ECMAScript specification](https://tc39.es/ecma262/#sec-runtime-semantics-unicodematchproperty-p)
+- [UnicodeMatchProperty in the ECMAScript specification](https://tc39.es/ecma262/multipage/text-processing.html#sec-runtime-semantics-unicodematchproperty-p)


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The ECMAScript specification is a huge document and takes non-trivial amount of time to load.

Its multipage variant is a lot more user friendly when referring to specific chapters.
