### PR TITLE
Fix a link name in Global_Objects/Number/toLocaleString

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -43,7 +43,7 @@ A string with a language-sensitive representation of the given number.
 
 When formatting large numbers of numbers, it is better to create a
 {{jsxref("Intl.NumberFormat")}} object and use the function provided by its
-{{jsxref("Intl/NumberFormat/format")}} property.
+{{jsxref("Intl/NumberFormat/format", "format")}} property.
 
 ## Examples
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

The property name shouldn't include its directory name.

> Anything else that could help us review it
