### PR TITLE
[Markdown] [Web/HTML] Remove DIV IDs from HTML elements, part 2

### DIFF
--- a/files/en-us/web/html/attributes/pattern/index.html
+++ b/files/en-us/web/html/attributes/pattern/index.html
@@ -14,14 +14,12 @@ tags:
 
 <p>The <code>pattern</code> attribute is an attribute of the {{HTMLElement("input/text", "text")}}, {{HTMLElement("input/tel", "tel")}}, {{HTMLElement("input/email", "email")}}, {{HTMLElement("input/url", "url")}}, {{HTMLElement("input/password", "password")}}, and {{HTMLElement("input/search", "search")}} input types.</p>
 
-<div id="pattern-include">
 <p>The <code>pattern</code> attribute, when specified, is a regular expression which the input's {{htmlattrxref("value")}} must match in order for the value to pass <a href="/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation">constraint validation</a>. It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">guide on regular expressions</a>; the <code>'u'</code> flag is specified when compiling the regular expression, so that the pattern is treated as a sequence of Unicode code points, instead of as ASCII. No forward slashes should be specified around the pattern text.</p>
 
 <p>If the specified pattern is not specified or is invalid, no regular expression is applied and this attribute is ignored.</p>
 
 <div class="note">
-<p><strong>Tip:</strong> Use the {{htmlattrxref("title", "input")}} attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You <strong>must not</strong> rely on the tooltip alone for an explanation. See below for more information on usability.</p>
-</div>
+<p><strong>Note:</strong> Use the {{htmlattrxref("title", "input")}} attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You <strong>must not</strong> rely on the tooltip alone for an explanation. See below for more information on usability.</p>
 </div>
 
 <p>Some of the input types supporting the pattern attribute, notably the {{HTMLElement("input/email", "email")}} and {{HTMLElement("input/url", "url")}} input types, have expected value syntaxes that must be matched. If the pattern attribute isn't present, and the value doesn't match the expected syntax for that value type, the {{domxref('ValidityState')}} object's read-only {{domxref('ValidityState.typeMismatch','typeMismatch')}} property will be true.</p>
@@ -37,12 +35,13 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
+<h3>Matching a phone number</h3>
+
 <p>Given the following:</p>
 
-<div id="example1">
 <pre class="brush: html">&lt;p&gt;
- &lt;label&gt;Enter your phone number in the format (123)456-7890
-  (&lt;input name="tel1" type="tel" pattern="[0-9]{3}" placeholder="###" aria-label="3-digit area code" size="2"/&gt;)-
+ &lt;label&gt;Enter your phone number in the format (123) - 456 - 7890
+  (&lt;input name="tel1" type="tel" pattern="[0-9]{3}" placeholder="###" aria-label="3-digit area code" size="2"/&gt;) -
    &lt;input name="tel2" type="tel" pattern="[0-9]{3}" placeholder="###" aria-label="3-digit prefix" size="2"/&gt; -
    &lt;input name="tel3" type="tel" pattern="[0-9]{4}" placeholder="####" aria-label="4-digit number" size="3"/&gt;
  &lt;/label&gt;
@@ -56,10 +55,9 @@ tags:
   border: red solid 3px;
 }</pre>
 
-<p>{{EmbedLiveSample("example1", 300, 40)}}</p>
-</div>
+<p>{{EmbedLiveSample("Matching_a_phone_number", 300, 80)}}</p>
 
-<p>Had we used <code><a href="/en-US/docs/Web/HTML/Attributes/minlength">minlength</a></code> and <code><a href="/en-US/docs/Web/HTML/Attributes/maxlength">maxlength</a></code> attributes instead, we may have seen {{domxref('validityState.tooLong')}} or {{domxref('validityState.tooShort')}} being true.</p>
+<p>If we had used <code><a href="/en-US/docs/Web/HTML/Attributes/minlength">minlength</a></code> and <code><a href="/en-US/docs/Web/HTML/Attributes/maxlength">maxlength</a></code> attributes instead, we may have seen {{domxref('validityState.tooLong')}} or {{domxref('validityState.tooShort')}} being true.</p>
 
 <h3 id="Specifying_a_pattern">Specifying a pattern</h3>
 

--- a/files/en-us/web/html/element/input/email/index.html
+++ b/files/en-us/web/html/element/input/email/index.html
@@ -230,7 +230,6 @@ browser-compat: html.elements.input.input-email
 <p>As always, you can provide a default value for an <code>email</code> input box by setting its {{htmlattrxref("value", "input")}} attribute:</p>
 
 <pre class="brush: html">&lt;input type="email" value="default@example.com"&gt;</pre>
-</div>
 
 <p>{{EmbedLiveSample("Providing_a_single_default_using_the_value_attribute", 600, 40)}}</p>
 

--- a/files/en-us/web/html/element/input/email/index.html
+++ b/files/en-us/web/html/element/input/email/index.html
@@ -145,7 +145,7 @@ browser-compat: html.elements.input.input-email
 <p>It's important, however, to note that this is not enough to ensure that the specified text is an e-mail address which actually exists, corresponds to the user of the site, or is acceptable in any other way. It ensures that the value of the field is properly formatted to be an e-mail address.</p>
 
 <div class="note">
-<p><strong>Note</strong>: It's also crucial to remember that a user can tinker with your HTML behind the scenes, so your site <em>must not</em> use this validation for any security purposes. You <em>must</em> verify the e-mail address on the server side of any transaction in which the provided text may have any security implications of any kind.</p>
+<p><strong>Note:</strong> It's also crucial to remember that a user can tinker with your HTML behind the scenes, so your site <em>must not</em> use this validation for any security purposes. You <em>must</em> verify the e-mail address on the server side of any transaction in which the provided text may have any security implications of any kind.</p>
 </div>
 
 <h3 id="A_simple_email_input">A simple email input</h3>
@@ -169,7 +169,7 @@ browser-compat: html.elements.input.input-email
 <p>The input is now considered valid when a single e-mail address is entered, or when any number of e-mail addresses separated by commas and, optionally, some number of whitespace characters are present.</p>
 
 <div class="note">
-<p><strong>Note</strong>: When <code>multiple</code> is used, the value <em>is</em> allowed to be empty.</p>
+<p><strong>Note:</strong> When <code>multiple</code> is used, the value <em>is</em> allowed to be empty.</p>
 </div>
 
 <p>Some examples of valid strings when <code>multiple</code> is specified:</p>
@@ -225,17 +225,18 @@ browser-compat: html.elements.input.input-email
 
 <h3 id="Providing_default_options">Providing default options</h3>
 
+<h4>Providing a single default using the value attribute</h4>
+
 <p>As always, you can provide a default value for an <code>email</code> input box by setting its {{htmlattrxref("value", "input")}} attribute:</p>
 
-<div id="Default_value">
 <pre class="brush: html">&lt;input type="email" value="default@example.com"&gt;</pre>
 </div>
 
-<p>{{EmbedLiveSample("Default_value", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Providing_a_single_default_using_the_value_attribute", 600, 40)}}</p>
 
 <h4 id="Offering_suggested_values">Offering suggested values</h4>
 
-<p>Taking it a step farther, you can provide a list of default options from which the user can select by specifying the {{htmlattrxref("list", "input")}} attribute. This doesn't limit the user to those options, but does allow them to select commonly-used e-mail addresses more quickly. This also offers hints to {{htmlattrxref("autocomplete", "input")}}. The <code>list</code> attribute specifies the ID of a {{HTMLElement("datalist")}}, which in turn contains one {{HTMLElement("option")}} element per suggested value; each <code>option</code>'s <code>value</code> is the corresponding suggested value for the email entry box.</p>
+<p>Taking it a step further, you can provide a list of default options from which the user can select by specifying the {{htmlattrxref("list", "input")}} attribute. This doesn't limit the user to those options, but does allow them to select commonly-used e-mail addresses more quickly. This also offers hints to {{htmlattrxref("autocomplete", "input")}}. The <code>list</code> attribute specifies the ID of a {{HTMLElement("datalist")}}, which in turn contains one {{HTMLElement("option")}} element per suggested value; each <code>option</code>'s <code>value</code> is the corresponding suggested value for the email entry box.</p>
 
 <pre class="brush: html">&lt;input type="email" size="40" list="defaultEmails"&gt;
 
@@ -256,7 +257,7 @@ browser-compat: html.elements.input.input-email
 <p>There are two levels of content validation available for <code>email</code> inputs. First, there's the standard level of validation offered to all {{HTMLElement("input")}}s, which automatically ensures that the contents meet the requirements to be a valid e-mail address. But there's also the option to add additional filtering to ensure that your own specialized needs are met, if you have any.</p>
 
 <div class="warning">
-<p><strong>Important</strong>: HTML form validation is <em>not</em> a substitute for scripts that ensure that the entered data is in the proper format.It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it completely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
+<p><strong>Warning:</strong> HTML form validation is <em>not</em> a substitute for scripts that ensure that the entered data is in the proper format.It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it completely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
 </div>
 
 <h3 id="Basic_validation">Basic validation</h3>
@@ -270,7 +271,7 @@ browser-compat: html.elements.input.input-email
 <p>To learn more about how form validation works and how to take advantage of the {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS properties to style the input based on whether or not the current value is valid, see <a href="/en-US/docs/Learn/Forms/Form_validation">Form data validation</a>.</p>
 
 <div class="note">
-<p><strong>Note</strong>: There are known specification issues related to international domain names and the validation of e-mail addresses in HTML. See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=15489">W3C bug 15489</a> for details.</p>
+<p><strong>Note:</strong> There are known specification issues related to international domain names and the validation of e-mail addresses in HTML. See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=15489">W3C bug 15489</a> for details.</p>
 </div>
 
 <h3 id="Pattern_validation">Pattern validation</h3>
@@ -320,7 +321,7 @@ label::after {
 &lt;/form&gt;
 </pre>
 
-<p>{{EmbedLiveSample("Pattern_validation", 700, 275)}}</p>
+<p>{{EmbedLiveSample("Pattern_validation", 700, 300)}}</p>
 
 <p>Our {{HTMLElement("form")}} contains one {{HTMLElement("input")}} of type <code>email</code> for the user's e-mail address, a {{HTMLElement("textarea")}} to enter their message for IT into, and an <code>&lt;input&gt;</code> of type <code><a href="/en-US/docs/Web/HTML/Element/input/submit">"submit"</a></code>, which creates a button to submit the form. Each text entry box has a {{HTMLElement("label")}} associated with it to let the user know what's expected of them.</p>
 
@@ -341,7 +342,7 @@ label::after {
 <p><img alt="" src="email-pattern-match-bad.png"></p>
 
 <div class="note">
-<p><strong>Note</strong>: If you run into trouble while writing your validation regular expressions and they're not working properly, check your browser's console; there may be helpful error messages there to aid you in solving the problem.</p>
+<p><strong>Note:</strong> If you run into trouble while writing your validation regular expressions and they're not working properly, check your browser's console; there may be helpful error messages there to aid you in solving the problem.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>
@@ -362,7 +363,7 @@ label::after {
   &lt;option value="hulk@grrrrrrrr.arg"&gt;
 &lt;/datalist&gt;</pre>
 
-<p>{{EmbedLiveSample('Examples', 600, 50)}}</p>
+<p>{{EmbedLiveSample('Examples', 600, 80)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -768,13 +768,22 @@ let hatSize = form.elements["hat-size"];
  <dt>{{htmlattrdef("autocorrect")}} {{non-standard_inline}}</dt>
  <dd>{{page("/en-US/docs/Web/HTML/Element/input/text", "autocorrect-include")}}</dd>
  <dt>{{htmlattrdef("incremental")}} {{non-standard_inline}}</dt>
- <dd>{{page("/en-US/docs/Web/HTML/Element/input/search", "incremental-include")}}</dd>
+ <dd>
+   <p>The Boolean attribute <code>incremental</code> is a WebKit and Blink extension (so supported by Safari, Opera, Chrome, etc.) which, if present, tells the {{Glossary("user agent")}} to process the input as a live search. As the user edits the value of the field, the user agent sends {{event("search")}} events to the {{domxref("HTMLInputElement")}} object representing the search box. This allows your code to update the search results in real time as the user edits the search.</p>
+
+   <p>If <code>incremental</code> is not specified, the {{event("search")}} event is only sent when the user explicitly initiates a search (such as by pressing the <kbd>Enter</kbd> or <kbd>Return</kbd> key while editing the field).</p>
+
+   <p>The <code>search</code> event is rate-limited so that it is not sent more frequently than an implementation-defined interval.</p>
+ </dd>
  <dt>{{htmlattrdef("mozactionhint")}} {{non-standard_inline}}</dt>
  <dd>{{page("/en-US/docs/Web/HTML/Element/input/text", "mozactionhint-include")}}</dd>
  <dt>{{htmlattrdef("orient")}} {{non-standard_inline}}</dt>
  <dd>{{page("/en-US/docs/Web/HTML/Element/input/range", "orient-include")}}</dd>
  <dt>{{htmlattrdef("results")}} {{non-standard_inline}}</dt>
- <dd>{{page("/en-US/docs/Web/HTML/Element/input/search", "results-include")}}</dd>
+ <dd>
+   <p>The <code>results</code> attribute—supported only by Safari—is a numeric value that lets you override the maximum number of entries to be displayed in the {{HTMLElement("input")}} element's natively-provided drop-down menu of previous search queries.</p>
+
+   <p>The value must be a non-negative decimal number. If not provided, or an invalid value is given, the browser's default maximum number of entries is used.</p></dd>
  <dt>{{htmlattrdef("webkitdirectory")}} {{non-standard_inline}}</dt>
  <dd>{{page("/en-US/docs/Web/HTML/Element/input/file", "webkitdirectory-include")}}</dd>
 </dl>

--- a/files/en-us/web/html/element/input/search/index.html
+++ b/files/en-us/web/html/element/input/search/index.html
@@ -163,13 +163,11 @@ browser-compat: html.elements.input.input-search
 
 <h3 id="attr-incremental"><code id="incremental">incremental</code> {{non-standard_inline}}</h3>
 
-<div id="incremental-include">
 <p>The Boolean attribute <code>incremental</code> is a WebKit and Blink extension (so supported by Safari, Opera, Chrome, etc.) which, if present, tells the {{Glossary("user agent")}} to process the input as a live search. As the user edits the value of the field, the user agent sends {{event("search")}} events to the {{domxref("HTMLInputElement")}} object representing the search box. This allows your code to update the search results in real time as the user edits the search.</p>
 
 <p>If <code>incremental</code> is not specified, the {{event("search")}} event is only sent when the user explicitly initiates a search (such as by pressing the <kbd>Enter</kbd> or <kbd>Return</kbd> key while editing the field).</p>
 
 <p>The <code>search</code> event is rate-limited so that it is not sent more frequently than an implementation-defined interval.</p>
-</div>
 
 <h3 id="attr-mozactionhint"><code id="mozactionhint">mozactionhint</code> {{non-standard_inline}}</h3>
 
@@ -177,11 +175,9 @@ browser-compat: html.elements.input.input-search
 
 <h3 id="attr-results"><code id="results">results</code> {{non-standard_inline}}</h3>
 
-<div id="results-include">
 <p>The <code>results</code> attribute—supported only by Safari—is a numeric value that lets you override the maximum number of entries to be displayed in the {{HTMLElement("input")}} element's natively-provided drop-down menu of previous search queries.</p>
 
 <p>The value must be a non-negative decimal number. If not provided, or an invalid value is given, the browser's default maximum number of entries is used.</p>
-</div>
 
 <h2 id="Using_search_inputs">Using search inputs</h2>
 

--- a/files/en-us/web/html/element/input/submit/index.html
+++ b/files/en-us/web/html/element/input/submit/index.html
@@ -21,12 +21,6 @@ browser-compat: html.elements.input.input-submit
 
 <p>{{HTMLElement("input")}} elements of type <strong><code>submit</code></strong> are rendered as buttons. When the {{domxref("Element/click_event", "click")}} event occurs (typically because the user clicked the button), the {{Glossary("user agent")}} attempts to submit the form to the server.</p>
 
-<div id="summary-example2">
-<pre class="brush: html">&lt;input type="submit" value="Send Request"&gt;</pre>
-</div>
-
-<p>{{EmbedLiveSample("summary-example2", 650, 30)}}</p>
-
 <table class="properties">
  <tbody>
   <tr>
@@ -56,19 +50,19 @@ browser-compat: html.elements.input.input-submit
 
 <p>An <code>&lt;input type="submit"&gt;</code> element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} which is displayed as the button's label. Buttons do not have a true value otherwise.</p>
 
-<div id="summary-example3">
-<pre class="brush: html">&lt;input type="submit" value="Send Request"&gt;</pre>
-</div>
+<h3>Setting the value attribute</h3>
 
-<p>{{EmbedLiveSample("summary-example3", 650, 30)}}</p>
+<pre class="brush: html">&lt;input type="submit" value="Send Request"&gt;</pre>
+
+<p>{{EmbedLiveSample("Setting_the_value_attribute", 650, 30)}}</p>
+
+<h3>Omitting the value attribute</h3>
 
 <p>If you don't specify a <code>value</code>, the button will have a default label, chosen by the user agent. This label is likely to be something along the lines of "Submit" or "Submit Query." Here's an example of a submit button with a default label in your browser:</p>
 
-<div id="summary-example1">
 <pre class="brush: html">&lt;input type="submit"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("summary-example1", 650, 30)}}</p>
+<p>{{EmbedLiveSample("Omitting_the_value_attribute", 650, 30)}}</p>
 
 <h2 id="Additional_attributes">Additional attributes</h2>
 
@@ -226,14 +220,12 @@ browser-compat: html.elements.input.input-submit
 
 <p>To disable a submit button, specify the {{htmlattrxref("disabled")}} global attribute on it, like so:</p>
 
-<div id="disable-example1">
 <pre class="brush: html">&lt;input type="submit" value="Disabled" disabled&gt;</pre>
-</div>
 
 <p>You can enable and disable buttons at run time by setting <code>disabled</code> to <code>true</code> or <code>false</code>; in JavaScript this looks like <code>btn.disabled = true</code> or <code>btn.disabled = false</code>.</p>
 
 <div class="note">
-<p>See the <code><a href="/en-US/docs/Web/HTML/Element/input/button#disabling_and_enabling_a_button">&lt;input type="button"&gt;</a></code> page for more ideas about enabling and disabling buttons.</p>
+<p><strong>Note:</strong> See the <code><a href="/en-US/docs/Web/HTML/Element/input/button#disabling_and_enabling_a_button">&lt;input type="button"&gt;</a></code> page for more ideas about enabling and disabling buttons.</p>
 </div>
 
 <h2 id="Validation">Validation</h2>

--- a/files/en-us/web/html/element/input/tel/index.html
+++ b/files/en-us/web/html/element/input/tel/index.html
@@ -229,23 +229,23 @@ browser-compat: html.elements.input.input-tel
 <p>{{EmbedLiveSample("Element_value_length", 600, 40) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: The above attributes do affect {{anch("Validation")}} — the above example's inputs will count as invalid if the length of the value is less than 9 characters, or more than 14. Most browser won't even let you enter a value over the max length.</p>
+<p><strong>Note:</strong> The above attributes do affect {{anch("Validation")}} — the above example's inputs will count as invalid if the length of the value is less than 9 characters, or more than 14. Most browser won't even let you enter a value over the max length.</p>
 </div>
 
 <h3 id="Providing_default_options">Providing default options</h3>
 
+<h4>Providing a single default using the value attribute</h4>
+
 <p>As always, you can provide a default value for an <code>tel</code> input box by setting its {{htmlattrxref("value", "input")}} attribute:</p>
 
-<div id="Default_value">
 <pre class="brush: html">&lt;input id="telNo" name="telNo" type="tel"
        value="333-4444-4444"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("Default_value", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Providing_a_single_default_using_the_value_attribute", 600, 40)}}</p>
 
 <h4 id="Offering_suggested_values">Offering suggested values</h4>
 
-<p>Taking it a step farther, you can provide a list of default phone number values from which the user can select. To do this, use the {{htmlattrxref("list", "input")}} attribute. This doesn't limit the user to those options, but does allow them to select commonly-used telephone numbers more quickly. This also offers hints to {{htmlattrxref("autocomplete", "input")}}. The <code>list</code> attribute specifies the ID of a {{HTMLElement("datalist")}} element, which in turn contains one {{HTMLElement("option")}} element per suggested value; each <code>option</code>'s <code>value</code> is the corresponding suggested value for the telephone number entry box.</p>
+<p>Taking it a step further, you can provide a list of default phone number values from which the user can select. To do this, use the {{htmlattrxref("list", "input")}} attribute. This doesn't limit the user to those options, but does allow them to select commonly-used telephone numbers more quickly. This also offers hints to {{htmlattrxref("autocomplete", "input")}}. The <code>list</code> attribute specifies the ID of a {{HTMLElement("datalist")}} element, which in turn contains one {{HTMLElement("option")}} element per suggested value; each <code>option</code>'s <code>value</code> is the corresponding suggested value for the telephone number entry box.</p>
 
 <pre class="brush: html">&lt;label for="telNo"&gt;Phone number: &lt;/label&gt;
 &lt;input id="telNo" name="telNo" type="tel" list="defaultTels"&gt;
@@ -270,7 +270,7 @@ browser-compat: html.elements.input.input-tel
 <p>As we've touched on before, it's quite difficult to provide a one-size-fits-all client-side validation solution for phone numbers. So what can we do? Let's consider some options.</p>
 
 <div class="warning">
-<p><strong>Important</strong>: HTML form validation is <em>not</em> a substitute for server-side scripts that ensure the entered data is in the proper format before it is allowed into the database.  It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
+<p><strong>Warning:</strong> HTML form validation is <em>not</em> a substitute for server-side scripts that ensure the entered data is in the proper format before it is allowed into the database.  It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
 </div>
 
 <h3 id="Making_telephone_numbers_required">Making telephone numbers required</h3>

--- a/files/en-us/web/html/element/input/text/index.html
+++ b/files/en-us/web/html/element/input/text/index.html
@@ -125,7 +125,7 @@ browser-compat: html.elements.input.input-text
 <p>If the specified pattern is not specified or is invalid, no regular expression is applied and this attribute is ignored completely.</p>
 
 <div class="note">
-<p><strong>Tip:</strong> Use the {{htmlattrxref("title", "input")}} attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.</p>
+<p><strong>Note:</strong> Use the {{htmlattrxref("title", "input")}} attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.</p>
 </div>
 </div>
 

--- a/files/en-us/web/html/element/input/time/index.html
+++ b/files/en-us/web/html/element/input/time/index.html
@@ -76,14 +76,18 @@ browser-compat: html.elements.input.input-time
 
 <h2 id="Value">Value</h2>
 
-<div id="value-sample1">
-<p>A {{domxref("DOMString")}} containing the value of the time entered into the input. You can set a default value for the input by including a valid time in the {{htmlattrxref("value", "input")}} attribute when creating the <code>&lt;input&gt;</code> element, like so:</p>
+<p>A {{jsxref("String")}} containing the value of the time entered into the input.</p>
+
+<h3>Setting the value attribute</h3>
+
+<p>You can set a default value for the input by including a valid time in the {{htmlattrxref("value", "input")}} attribute when creating the <code>&lt;input&gt;</code> element, like so:</p>
 
 <pre class="brush: html">&lt;label for="appt-time"&gt;Choose an appointment time: &lt;/label&gt;
 &lt;input id="appt-time" type="time" name="appt-time" value="13:30"&gt;</pre>
-</div>
 
-<p>{{ EmbedLiveSample('value-sample1', 600, 60) }}</p>
+<p>{{ EmbedLiveSample('Setting_the_value_attribute', 600, 60) }}</p>
+
+<h3>Setting the value using JavaScript</h3>
 
 <p>You can also get and set the date value in JavaScript using the {{domxref("HTMLInputElement")}} <code>value</code> property, for example:</p>
 
@@ -156,8 +160,7 @@ startTime.addEventListener("input", function() {
 </table>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Unlike many data types, time values have a <strong>periodic domain</strong>, meaning that the values reach the highest possible value, then wrap back around to the beginning again. For example, specifying a <code>min</code> of <code>14:00</code> and a <code>max</code> of <code>2:00</code> means that the permitted time values start at 2:00 PM, run through midnight to the next day, ending at 2:00 AM. See more in the <a
+  <p><strong>Note:</strong> Unlike many data types, time values have a <strong>periodic domain</strong>, meaning that the values reach the highest possible value, then wrap back around to the beginning again. For example, specifying a <code>min</code> of <code>14:00</code> and a <code>max</code> of <code>2:00</code> means that the permitted time values start at 2:00 PM, run through midnight to the next day, ending at 2:00 AM. See more in the <a
     href="#making_min_and_max_cross_midnight">making min and max cross midnight</a> section of this article.</p>
 </div>
 
@@ -209,7 +212,7 @@ startTime.addEventListener("input", function() {
 <p>You can use the {{htmlattrxref("step", "input")}} attribute to vary the amount of time jumped whenever the time is incremented or decremented (for example, so the time moves by 10 minutes at a time when clicking the little arrow widgets).</p>
 
 <div class="note">
-<p>This property has some strange effects across browsers, so is not completely reliable.</p>
+<p><strong>Note:</strong> This property has some strange effects across browsers, so is not completely reliable.</p>
 </div>
 
 <p>It takes an integer value that equates to the number of seconds you want to increment by; the default value is 60 seconds, or one minute. If you specify a value of less than 60 seconds (1 minute), the <code>time</code> input will show a seconds input area alongside the hours and minutes:</p>
@@ -228,7 +231,7 @@ startTime.addEventListener("input", function() {
 <p>The steps value seems to have no effect in Edge.</p>
 
 <div class="note">
-<p>Using <code>step</code> seems to cause validation to not work properly (as seen in the next section).</p>
+<p><strong>Note:</strong> Using <code>step</code> seems to cause validation to not work properly (as seen in the next section).</p>
 </div>
 
 <h2 id="Validation">Validation</h2>

--- a/files/en-us/web/html/element/input/url/index.html
+++ b/files/en-us/web/html/element/input/url/index.html
@@ -172,7 +172,7 @@ browser-compat: html.elements.input.input-url
 <p>It's important, however, to note that this is not enough to ensure that the specified text is a URL which actually exists, corresponds to the user of the site, or is acceptable in any other way. It ensures that the value of the field is properly formatted to be a URL.</p>
 
 <div class="note">
-<p><strong>Note</strong>: It's also crucial to remember that a user can tinker with your HTML behind the scenes, so your site <em>must not</em> use this validation for any security purposes. You <em>must</em> verify the URL on the server-side of any transaction in which the provided text may have any security implications of any kind.</p>
+<p><strong>Note:</strong> A user can tinker with your HTML behind the scenes, so your site <em>must not</em> use this validation for any security purposes. You <em>must</em> verify the URL on the server-side of any transaction in which the provided text may have any security implications of any kind.</p>
 </div>
 
 <h3 id="A_simple_URL_input">A simple URL input</h3>
@@ -224,23 +224,23 @@ browser-compat: html.elements.input.input-url
 <p>{{EmbedLiveSample("Element_value_length", 600, 40) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: These attributes also affect validation; a value shorter or longer than the specified minimum/maximum lengths will be classified as invalid; in addition most browsers will refuse to let the user enter a value longer than the specified maximum length.</p>
+<p><strong>Note:</strong> These attributes also affect validation; a value shorter or longer than the specified minimum/maximum lengths will be classified as invalid; in addition most browsers will refuse to let the user enter a value longer than the specified maximum length.</p>
 </div>
 
 <h3 id="Providing_default_options">Providing default options</h3>
 
+<h4>Providing a single default using the value attribute</h4>
+
 <p>As always, you can provide a default value for a <code>url</code> input box by setting its {{htmlattrxref("value", "input")}} attribute:</p>
 
-<div id="Default_value">
 <pre class="brush: html">&lt;input id="myURL" name="myURL" type="url"
        value="http://www.example.com"&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("Default_value", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Providing_a_single_default_using_the_value_attribute", 600, 40)}}</p>
 
 <h4 id="Offering_suggested_values">Offering suggested values</h4>
 
-<p>Taking it a step farther, you can provide a list of default options from which the user can select by specifying the {{htmlattrxref("list", "input")}} attribute. This doesn't limit the user to those options, but does allow them to select commonly-used URLs more quickly. This also offers hints to {{htmlattrxref("autocomplete", "input")}}. The <code>list</code> attribute specifies the ID of a {{HTMLElement("datalist")}}, which in turn contains one {{HTMLElement("option")}} element per suggested value; each <code>option</code>'s <code>value</code> is the corresponding suggested value for the URL entry box.</p>
+<p>Taking it a step further, you can provide a list of default options from which the user can select by specifying the {{htmlattrxref("list", "input")}} attribute. This doesn't limit the user to those options, but does allow them to select commonly-used URLs more quickly. This also offers hints to {{htmlattrxref("autocomplete", "input")}}. The <code>list</code> attribute specifies the ID of a {{HTMLElement("datalist")}}, which in turn contains one {{HTMLElement("option")}} element per suggested value; each <code>option</code>'s <code>value</code> is the corresponding suggested value for the URL entry box.</p>
 
 <pre class="brush: html">&lt;input id="myURL" name="myURL" type="url"
        list="defaultURLs"&gt;
@@ -292,14 +292,12 @@ browser-compat: html.elements.input.input-url
 
 <p>As mentioned earlier, to make a URL entry required before the form can be submitted (you can't leave the field blank), you just need to include the {{htmlattrxref("required", "input")}} attribute on the input.</p>
 
-<div id="Making_a_URL_required_example">
 <pre class="brush: html">&lt;form&gt;
   &lt;input id="myURL" name="myURL" type="url" required&gt;
   &lt;button&gt;Submit&lt;/button&gt;
 &lt;/form&gt;</pre>
-</div>
 
-<p>{{EmbedLiveSample("Making_a_URL_required_example", 600, 40)}}</p>
+<p>{{EmbedLiveSample("Making_a_URL_required", 600, 40)}}</p>
 
 <p>Try submitting the above form with no value entered to see what happens.</p>
 
@@ -370,7 +368,7 @@ browser-compat: html.elements.input.input-url
 <p>That's why, instead, we specify the string "The URL must be in a myco domain". By doing that, the resulting full error message might be something like "The entered text doesn't match the required pattern. The URL should be in a myco domain."</p>
 
 <div class="note">
-<p><strong>Note</strong>: If you run into trouble while writing your validation regular expressions and they're not working properly, check your browser's console; there may be helpful error messages there to aid you in solving the problem.</p>
+<p><strong>Note:</strong> If you run into trouble while writing your validation regular expressions and they're not working properly, check your browser's console; there may be helpful error messages there to aid you in solving the problem.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/html/element/rb/index.html
+++ b/files/en-us/web/html/element/rb/index.html
@@ -58,6 +58,8 @@ browser-compat: html.elements.rb
 
 <h2 id="Examples">Examples</h2>
 
+<h3>Using rb</h3>
+
 <p>In this example, we provide an annotation for the original character equivalent of "Kanji":</p>
 
 <pre class="brush: html">&lt;ruby&gt;
@@ -67,6 +69,10 @@ browser-compat: html.elements.rb
 
 <p>Note how we've included two <code>&lt;rb&gt;</code> elements, to delimit the two separate parts of the ruby base text. The annotation on the other hand is delimited by two {{htmlelement("rt")}} elements.</p>
 
+<p>{{EmbedLiveSample("Using_rb", "100%", 60)}}</p>
+
+<h3>Separate annotations</h3>
+
 <p>Note that we could also write this example with the two base text parts annotated completely separately. In this case we don't need to include <code>&lt;rb&gt;</code> elements:</p>
 
 <pre class="brush: html">&lt;ruby&gt;
@@ -74,39 +80,7 @@ browser-compat: html.elements.rb
   字 &lt;rp&gt;(&lt;/rp&gt;&lt;rt&gt;ji&lt;/rt&gt;&lt;rp&gt;)&lt;/rp&gt;
 &lt;/ruby&gt;</pre>
 
-<div class="hidden">
-<div id="with-ruby">
-<pre class="brush: html">&lt;ruby&gt; &lt;rb&gt;漢&lt;rb&gt;字 &lt;rp&gt;(&lt;/rp&gt;&lt;rt&gt;kan&lt;rt&gt;ji&lt;rp&gt;)&lt;/rp&gt; &lt;/ruby&gt;
-</pre>
-
-<pre class="brush: css">body {
-  font-size: 22px;
-}</pre>
-</div>
-</div>
-
-<p>The output looks like so:</p>
-
-<p>{{EmbedLiveSample("with-ruby", "100%", 60)}}</p>
-
-<p>The HTML above might look something like this when rendered by a browser <em>without</em> ruby support:</p>
-
-<div id="without-ruby">
-<div class="hidden">
-<pre class="brush: html">漢字 (kan ji)</pre>
-
-<pre class="brush: css">body {
-  font-size: 22px;
-}
-</pre>
-</div>
-</div>
-
-<p>{{EmbedLiveSample("without-ruby", "100%", 60)}}</p>
-
-<div class="note">
-<p><strong>Note</strong>: See the article about the {{HTMLElement("ruby")}} element for further examples.</p>
-</div>
+<p>See the article about the {{HTMLElement("ruby")}} element for further examples.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/rp/index.html
+++ b/files/en-us/web/html/element/rp/index.html
@@ -62,41 +62,22 @@ browser-compat: html.elements.rp
 
 <h2 id="Examples">Examples</h2>
 
+<h3>Using ruby annotations</h3>
+
 <p>This example uses ruby annotations to display the {{interwiki("wikipedia", "Romaji")}} equivalents for each character.</p>
 
-<div id="with-ruby">
 <pre class="brush: html">&lt;ruby&gt;
   漢 &lt;rp&gt;(&lt;/rp&gt;&lt;rt&gt;Kan&lt;/rt&gt;&lt;rp&gt;)&lt;/rp&gt;
   字 &lt;rp&gt;(&lt;/rp&gt;&lt;rt&gt;ji&lt;/rt&gt;&lt;rp&gt;)&lt;/rp&gt;
 &lt;/ruby&gt;</pre>
 
-<div class="hidden">
-<h3 id="CSS">CSS</h3>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   font-size: 22px;
 }</pre>
-</div>
-</div>
 
 <p>The result looks like this in your browser:</p>
 
-<p>{{EmbedLiveSample("with-ruby", 600, 60)}}</p>
-
-<p>The HTML above rendered by a browser <em>without</em> ruby support might look like this:</p>
-
-<div id="without-ruby">
-<div class="hidden">
-<pre class="brush: html">漢 (Kan) 字 (ji)</pre>
-
-<pre class="brush: css">body {
-  font-size: 22px;
-}
-</pre>
-</div>
-</div>
-
-<p>{{EmbedLiveSample("without-ruby", 600, 60)}}</p>
+<p>{{EmbedLiveSample("Using_ruby_annotations", 600, 60)}}</p>
 
 <p>See the article about the {{HTMLElement("ruby")}} element for further examples.</p>
 

--- a/files/en-us/web/html/element/rt/index.html
+++ b/files/en-us/web/html/element/rt/index.html
@@ -58,41 +58,24 @@ browser-compat: html.elements.rt
 
 <h2 id="Examples">Examples</h2>
 
+<h3>Using ruby annotations</h3>
+
 <p>This simple example provides Romaji transliteration for the kanji characters within the {{HTMLElement("ruby")}} element:</p>
 
-<div id="with-ruby">
 <pre class="brush: html">&lt;ruby&gt;
   漢 &lt;rt&gt;Kan&lt;/rt&gt;
   字 &lt;rt&gt;ji&lt;/rt&gt;
 &lt;/ruby&gt;
 </pre>
 
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   font-size: 22px;
 }
 </pre>
-</div>
-</div>
 
 <p>The output looks like this in your browser:</p>
 
-<p>{{EmbedLiveSample("with-ruby", 600, 60)}}</p>
-
-<p>On a browser <em>without</em> ruby support, this example might look like this:</p>
-
-<div id="without-ruby">
-<div class="hidden">
-<pre class="brush: html">漢 Kan 字 ji</pre>
-
-<pre class="brush: css">body {
-  font-size: 22px;
-}
-</pre>
-</div>
-</div>
-
-<p>{{EmbedLiveSample("without-ruby", 600, 60)}}</p>
+<p>{{EmbedLiveSample("Using_ruby_annotations", 600, 60)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/table/index.html
+++ b/files/en-us/web/html/element/table/index.html
@@ -27,8 +27,7 @@ browser-compat: html.elements.table
   <tr>
    <th scope="row">Permitted content</th>
    <td>
-    <div class="content-models">
-    <div id="table-mdls">In this order:
+    In this order:
     <ol>
      <li>an optional {{HTMLElement("caption")}} element,</li>
      <li>zero or more {{HTMLElement("colgroup")}} elements,</li>
@@ -41,8 +40,6 @@ browser-compat: html.elements.table
      </li>
      <li>an optional {{HTMLElement("tfoot")}} element</li>
     </ol>
-    </div>
-    </div>
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/html/element/u/index.html
+++ b/files/en-us/web/html/element/u/index.html
@@ -17,10 +17,10 @@ browser-compat: html.elements.u
 ---
 <div>{{HTMLRef}}</div>
 
-<p>The <strong><code>&lt;u&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation.</span> This is rendered by default as a simple solid underline, but may be altered using CSS.</p>
+<p>The <strong><code>&lt;u&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS.</p>
 
 <div class="warning">
-<p>This element used to be called the "Underline" element in older versions of HTML, and is still sometimes misused in this way. To underline text, you should instead apply a style that includes the CSS {{cssxref("text-decoration")}} property set to <code>underline</code>.</p>
+<p><strong>Warning:</strong> This element used to be called the "Underline" element in older versions of HTML, and is still sometimes misused in this way. To underline text, you should instead apply a style that includes the CSS {{cssxref("text-decoration")}} property set to <code>underline</code>.</p>
 </div>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/u.html", "tabbed-shorter")}}</div>
@@ -69,7 +69,7 @@ browser-compat: html.elements.u
 <p>Along with other pure styling elements, the original HTML Underline (<code>&lt;u&gt;</code>) element was deprecated in HTML 4; however, <code>&lt;u&gt;</code> was restored in HTML 5 with a new, semantic, meaning: to mark text as having some form of non-textual annotation applied.</p>
 
 <div class="note">
-<p>Be careful to avoid using the <code>&lt;u&gt;</code> element with its default styling (of underlined text) in such a way as to be confused with a hyperlink, which is also underlined by default.</p>
+<p><strong>Note:</strong> Avoid using the <code>&lt;u&gt;</code> element with its default styling (of underlined text) in such a way as to be confused with a hyperlink, which is also underlined by default.</p>
 </div>
 
 <h3 id="Use_cases">Use cases</h3>
@@ -148,28 +148,26 @@ Chicken Noodle Soup With Carrots</pre>
 
 <h4 id="Presenting_a_book_title">Presenting a book title</h4>
 
-<div id="example-unstyled-cite">
 <p>Book titles should be presented using the {{HTMLElement("cite")}} element instead of <code>&lt;u&gt;</code> or even <code>&lt;i&gt;</code>.</p>
 
-<h5 id="HTML_3">HTML</h5>
+<h5>Using the cite element</h5>
 
 <pre class="brush: html">&lt;p&gt;The class read &lt;cite&gt;Moby Dick&lt;/cite&gt; in the first term.&lt;/p&gt;</pre>
 
-<h5 id="Result_with_default_style">Result with default style</h5>
+<p>{{EmbedLiveSample("Using_the_cite_element", 650, 80)}}</p>
 
-<p>{{EmbedLiveSample("example-unstyled-cite", 650, 80)}}</p>
-</div>
+<h5>Styling the cite element</h5>
 
-<p>Note that the default styling for the <code>&lt;cite&gt;</code> element renders the text in italics. You can, if you wish, override that using CSS:</p>
+<p>The default styling for the <code>&lt;cite&gt;</code> element renders the text in italics. You can override that using CSS:</p>
+
+<pre class="brush: html">&lt;p&gt;The class read &lt;cite&gt;Moby Dick&lt;/cite&gt; in the first term.&lt;/p&gt;</pre>
 
 <pre class="brush: css">cite {
   font-style: normal;
   text-decoration: underline;
 }</pre>
 
-<h5 id="Result_with_custom_style">Result with custom style</h5>
-
-<p>{{EmbedLiveSample("Presenting_a_book_title", 650, 80)}}</p>
+<p>{{EmbedLiveSample("Styling_the_cite_element", 650, 80)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This removes some more `<div id=` from the HTML docs. Almost all live samples.

I haven't yet addressed the heavy use of `{{page}}` in the input element docs. That's going to take some thought.