### PR TITLE
fix a link name in Object.defineProperty

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -249,7 +249,7 @@ it but doesn't throw an error either.
 
 The `enumerable` property attribute defines whether the property is picked
 by {{jsxref("Object.assign()")}} or [spread
-](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)operator. For non-{{jsxref("Global_Objects/Symbol")}} properties it also defines whether it shows
+](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)operator. For non-{{jsxref("Global_Objects/Symbol", "Symbol")}} properties it also defines whether it shows
 up in a {{jsxref("Statements/for...in", "for...in")}} loop and
 {{jsxref("Object.keys()")}} or not.
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

"Global_Objects/Symbol" should be just "Symbol".

> Anything else that could help us review it
