### PR TITLE
fix small flaws in Object.entries

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
@@ -16,7 +16,7 @@ object's own enumerable string-keyed property
 `[key, value]` pairs. This is the same as iterating
 with a {{jsxref("Statements/for...in", "for...in")}} loop, except that a
 `for...in` loop enumerates properties in the prototype
-chain as well).
+chain as well.
 
 The order of the array returned by **`Object.entries()`** is
 the same as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop. If
@@ -24,7 +24,7 @@ there is a need for different ordering, then
 the array should be sorted first, like
 `Object.entries(obj).sort((a, b) => b[0].localeCompare(a[0]));`.
 
-{{EmbedInteractiveExample("pages/js/object-entries.html", "taller")}}
+{{EmbedInteractiveExample("pages/js/object-entries.html")}}
 
 ## Syntax
 


### PR DESCRIPTION
> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

There was a orphaned ")" in this article.
And it looks "taller" shouldn't be needed in the Interactive Example.

> Anything else that could help us review it
