### PR TITLE
Remove HTML5 from internal URL

### DIFF
--- a/files/en-us/web/api/validitystate/stepmismatch/index.md
+++ b/files/en-us/web/api/validitystate/stepmismatch/index.md
@@ -33,6 +33,6 @@ If true, the element matches the {{cssxref(":invalid")}} and {{cssxref(":out-of-
 
 ## See also
 
-- [Constraint validation](/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation)
+- [Constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation)
 - [Forms: Data form validation](/en-US/docs/Learn/Forms/Form_validation)
 - [`step` attribute](/en-US/docs/Web/HTML/Attributes/step)


### PR DESCRIPTION
The internal link was mentioning HTML5, we removed this directory long ago. Fixing.