### PR TITLE
[Markdown] [Web/SVG] Remove hidden DIVs from SVG docs

### DIFF
--- a/files/en-us/web/svg/attribute/color/index.html
+++ b/files/en-us/web/svg/attribute/color/index.html
@@ -35,11 +35,9 @@ browser-compat: svg.attributes.presentation.color
 
 <h2 id="Example">Example</h2>
 
-<div class="hidden">
-<pre class="brush: css">html, body, svg {
+<pre class="brush: css hidden">html, body, svg {
   height: 100%;
 }</pre>
-</div>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;g color="green"&gt;

--- a/files/en-us/web/svg/attribute/cx/index.html
+++ b/files/en-us/web/svg/attribute/cx/index.html
@@ -103,9 +103,7 @@ tags:
 
 <h4 id="Example">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 34 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;

--- a/files/en-us/web/svg/attribute/cy/index.html
+++ b/files/en-us/web/svg/attribute/cy/index.html
@@ -103,9 +103,7 @@ tags:
 
 <h4 id="Example">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 34 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;

--- a/files/en-us/web/svg/attribute/d/index.html
+++ b/files/en-us/web/svg/attribute/d/index.html
@@ -162,9 +162,7 @@ tags:
 
 <h4 id="Examples">Examples</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;path fill="none" stroke="red"
@@ -253,9 +251,7 @@ tags:
 
 <h4 id="Examples_2">Examples</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- LineTo commands with absolute coordinates --&gt;
@@ -344,9 +340,7 @@ tags:
 
 <h4 id="Examples_3">Examples</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
 
@@ -467,9 +461,7 @@ tags:
 
 <h4 id="Examples_4">Examples</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
 
@@ -560,9 +552,7 @@ tags:
 
 <h4 id="Examples_5">Examples</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -609,9 +599,7 @@ tags:
 
 <h4 id="Examples_6">Examples</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 -1 30 11" xmlns="http://www.w3.org/2000/svg"&gt;
 

--- a/files/en-us/web/svg/attribute/dx/index.html
+++ b/files/en-us/web/svg/attribute/dx/index.html
@@ -161,9 +161,7 @@ tags:
 
 <h3 id="Example">Example</h3>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Lines materialized the position of the glyphs --&gt;

--- a/files/en-us/web/svg/attribute/dy/index.html
+++ b/files/en-us/web/svg/attribute/dy/index.html
@@ -161,9 +161,7 @@ tags:
 
 <h3 id="Example">Example</h3>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 150 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Horizontal lines --&gt;

--- a/files/en-us/web/svg/attribute/fill-rule/index.html
+++ b/files/en-us/web/svg/attribute/fill-rule/index.html
@@ -73,9 +73,7 @@ browser-compat: svg.attributes.presentation.fill-rule
 
 <h4 id="Example">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-10 -10 320 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of nonzero fill rule on crossing path segments --&gt;
@@ -109,9 +107,7 @@ browser-compat: svg.attributes.presentation.fill-rule
 
 <h4 id="Example_2">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-10 -10 320 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of evenodd fill rule on crossing path segments --&gt;

--- a/files/en-us/web/svg/attribute/points/index.html
+++ b/files/en-us/web/svg/attribute/points/index.html
@@ -61,9 +61,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- polyline is an open shape --&gt;
@@ -96,9 +94,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- polygon is an closed shape --&gt;

--- a/files/en-us/web/svg/attribute/preserveaspectratio/index.html
+++ b/files/en-us/web/svg/attribute/preserveaspectratio/index.html
@@ -13,39 +13,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: html">&lt;svg viewBox="-1 -1 162 92" xmlns="http://www.w3.org/2000/svg"&gt;
-  &lt;defs&gt;
-     &lt;path id="smiley" d="M50,10 A40,40,1,1,1,50,90 A40,40,1,1,1,50,10 M30,40 Q36,35,42,40 M58,40 Q64,35,70,40 M30,60 Q50,75,70,60 Q50,75,30,60" /&gt;
-  &lt;/defs&gt;
-
-  &lt;!-- (width&gt;height) meet --&gt;
-  &lt;svg preserveAspectRatio="xMidYMid meet"  x="0"   y="0"  viewBox="0 0 100 100" width="20"  height="10"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMinYMid meet"  x="25"  y="0"  viewBox="0 0 100 100" width="20"  height="10"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMaxYMid meet"  x="50"  y="0"  viewBox="0 0 100 100" width="20"  height="10"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-
-  &lt;!-- (width&gt;height) slice --&gt;
-  &lt;svg preserveAspectRatio="xMidYMin slice" x="0"   y="15" viewBox="0 0 100 100" width="20"  height="10"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMidYMid slice" x="25"  y="15" viewBox="0 0 100 100" width="20"  height="10"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMidYMax slice" x="50"  y="15" viewBox="0 0 100 100" width="20"  height="10"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-
-  &lt;!-- (width&lt;height) meet --&gt;
-  &lt;svg preserveAspectRatio="xMidYMin meet"  x="75"  y="0"  viewBox="0 0 100 100" width="10"  height="25"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMidYMid meet"  x="90"  y="0"  viewBox="0 0 100 100" width="10"  height="25"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMidYMax meet"  x="105" y="0"  viewBox="0 0 100 100" width="10"  height="25"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-
-  &lt;!-- (width&lt;height) slice --&gt;
-  &lt;svg preserveAspectRatio="xMinYMid slice" x="120" y="0"  viewBox="0 0 100 100" width="10"  height="25"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMidYMid slice" x="135" y="0"  viewBox="0 0 100 100" width="10"  height="25"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-  &lt;svg preserveAspectRatio="xMaxYMid slice" x="150" y="0"  viewBox="0 0 100 100" width="10"  height="25"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-
-  &lt;!-- none --&gt;
-  &lt;svg preserveAspectRatio="none"           x="0"   y="30" viewBox="0 0 100 100" width="160" height="60"&gt;&lt;use href="#smiley" /&gt;&lt;/svg&gt;
-&lt;/svg&gt;</pre>
-
-<div class="hidden">
-<h6 id="topExample">topExample</h6>
-
-<pre class="brush: css">html,body,svg { height:100% }
+<pre class="brush: css hidden">html,body,svg { height:100% }
 </pre>
 
 <pre class="brush: html">&lt;svg viewBox="-1 -1 162 92" xmlns="http://www.w3.org/2000/svg"&gt;
@@ -175,9 +143,8 @@ tags:
 rect:hover, rect:active {
   outline: 1px solid red;
 }</pre>
-</div>
 
-<p>{{EmbedLiveSample('topExample', '100%', 200)}}</p>
+<p>{{EmbedLiveSample('Example', '100%', 200)}}</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-linecap/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linecap/index.html
@@ -78,9 +78,7 @@ browser-compat: svg.attributes.presentation.stroke-linecap
 
 <h4 id="Example">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 4" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -111,9 +109,7 @@ browser-compat: svg.attributes.presentation.stroke-linecap
 
 <h4 id="Example_2">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 4" xmlns="http://www.w3.org/2000/svg"&gt;
 
@@ -144,9 +140,7 @@ browser-compat: svg.attributes.presentation.stroke-linecap
 
 <h4 id="Example_3">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 4" xmlns="http://www.w3.org/2000/svg"&gt;
 

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.html
@@ -115,9 +115,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <p>The <code>arcs</code> value indicates that an arcs corner is to be used to join path segments. The arcs shape is formed by extending the outer edges of the stroke at the join point with arcs that have the same curvature as the outer edges at the join point.</p>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of the "arcs" value --&gt;
@@ -143,9 +141,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <p>The <code>bevel</code> value indicates that a bevelled corner is to be used to join path segments.</p>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of the "bevel" value --&gt;
@@ -173,9 +169,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <div class="notecard note"><p><strong>Note:</strong> If the {{SVGAttr('stroke-miterlimit')}} is exceeded, the line join falls back to <code>bevel</code>.</p></div>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 -1 10 7" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of the "miter" value --&gt;
@@ -215,9 +209,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <p>If the {{SVGAttr('stroke-miterlimit')}} is exceeded, the miter is clipped at a distance equal to half the {{SVGAttr('stroke-miterlimit')}} value multiplied by the stroke width from the intersection of the path segments. This provides a better rendering than <code>miter</code> on very sharp join or in case of an animation.</p>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 -1 10 7" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of the "miter-clip" value --&gt;
@@ -252,9 +244,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <p>The <code>round</code> value indicates that a round corner is to be used to join path segments.</p>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- Effect of the "round" value --&gt;

--- a/files/en-us/web/svg/attribute/transform/index.html
+++ b/files/en-us/web/svg/attribute/transform/index.html
@@ -65,10 +65,7 @@ tags:
 
 <h4 id="Example">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
-</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="10" y="10" width="30" height="20" fill="green" /&gt;
@@ -115,10 +112,7 @@ tags:
 
 <h4 id="Example_2">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
-</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- No translation --&gt;
@@ -145,10 +139,7 @@ tags:
 
 <h4 id="Example_3">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
-</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-50 -50 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- uniform scale --&gt;
@@ -175,10 +166,7 @@ tags:
 
 <h4 id="Example_4">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
-</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-12 -2 34 14" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="0" y="0" width="10" height="10" /&gt;
@@ -200,10 +188,7 @@ tags:
 
 <h4 id="Example_5">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
-</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="-3" y="-3" width="6" height="6" /&gt;
@@ -220,10 +205,7 @@ tags:
 
 <h4 id="Example_6">Example</h4>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }
-</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="-3" y="-3" width="6" height="6" /&gt;

--- a/files/en-us/web/svg/attribute/x/index.html
+++ b/files/en-us/web/svg/attribute/x/index.html
@@ -793,9 +793,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- horizontal line to materialized the text base line --&gt;
@@ -875,9 +873,7 @@ line {
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- horizontal line to materialized the text base line --&gt;

--- a/files/en-us/web/svg/attribute/x1/index.html
+++ b/files/en-us/web/svg/attribute/x1/index.html
@@ -54,9 +54,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="1" x2="5" y1="1" y2="9" stroke="red"   /&gt;
@@ -87,9 +85,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--

--- a/files/en-us/web/svg/attribute/x2/index.html
+++ b/files/en-us/web/svg/attribute/x2/index.html
@@ -49,9 +49,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="5" x2="1" y1="1" y2="9" stroke="red"   /&gt;
@@ -82,9 +80,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--

--- a/files/en-us/web/svg/attribute/y/index.html
+++ b/files/en-us/web/svg/attribute/y/index.html
@@ -793,9 +793,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- horizontal line to materialized the text base line --&gt;
@@ -875,9 +873,7 @@ line {
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!-- horizontal line to materialized the text base line --&gt;

--- a/files/en-us/web/svg/attribute/y1/index.html
+++ b/files/en-us/web/svg/attribute/y1/index.html
@@ -49,9 +49,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="1" x2="9" y1="1" y2="5" stroke="red"   /&gt;
@@ -82,9 +80,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--

--- a/files/en-us/web/svg/attribute/y2/index.html
+++ b/files/en-us/web/svg/attribute/y2/index.html
@@ -49,9 +49,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;line x1="1" x2="9" y1="5" y2="1" stroke="red"   /&gt;
@@ -82,9 +80,7 @@ tags:
  </tbody>
 </table>
 
-<div class="hidden">
-<pre class="brush: css">html,body,svg { height:100% }</pre>
-</div>
+<pre class="brush: css hidden">html,body,svg { height:100% }</pre>
 
 <pre class="brush: html">&lt;svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;!--

--- a/files/en-us/web/svg/tutorial/texts/index.html
+++ b/files/en-us/web/svg/tutorial/texts/index.html
@@ -31,14 +31,6 @@ tags:
 
 <p>This element is used to mark up sub-portions of a larger text. It must be a child of a <code>text</code> element or another <code>tspan</code> element. A typical use case is to paint one word of a sentence bold red.</p>
 
-<pre class="brush:xml">&lt;text&gt;
-  This is &lt;tspan font-weight="bold" fill="red"&gt;bold and red&lt;/tspan&gt;
-&lt;/text&gt;
-</pre>
-
-<div class="hidden">
-<h6 id="Playable_code">Playable code</h6>
-
 <pre class="brush:html">&lt;svg width="350" height="60" xmlns="http://www.w3.org/2000/svg"&gt;
 &lt;text&gt;
   This is &lt;tspan font-weight="bold" fill="red"&gt;bold and red&lt;/tspan&gt;
@@ -52,9 +44,8 @@ tags:
 ]]&gt;&lt;/style&gt;
 &lt;/svg&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Playable_code', '100%', 100) }}</p>
+<p>{{ EmbedLiveSample('tspan', '100%', 100) }}</p>
 
 <p>The <code>tspan</code> element has the following custom attributes:</p>
 
@@ -75,16 +66,6 @@ tags:
 
 <p>This element fetches via its <code>xlink:href</code> attribute an arbitrary path and aligns the characters, that it encircles, along this path:</p>
 
-<pre class="brush:xml">&lt;path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" /&gt;
-&lt;text&gt;
-  &lt;textPath xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#my_path"&gt;
-    A curve.
-  &lt;/textPath&gt;
-&lt;/text&gt;</pre>
-
-<div class="hidden">
-<h6 id="Playable_code_2">Playable code 2</h6>
-
 <pre class="brush:html">&lt;svg width="200" height="100" xmlns="http://www.w3.org/2000/svg"&gt;
 &lt;path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" /&gt;
 &lt;text&gt;
@@ -101,8 +82,7 @@ tags:
 ]]&gt;&lt;/style&gt;
 &lt;/svg&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Playable_code_2', '100%', 100) }}</p>
+<p>{{ EmbedLiveSample('textPath', '100%', 100) }}</p>
 
 <div>{{PreviousNext("Web/SVG/Tutorial/Patterns", "Web/SVG/Tutorial/Basic_Transformations")}}</div>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8969.

This PR removes `<div class="hidden">` from the SVG docs, and transfers "hidden" to the code blocks they contained.

In a couple of pages the hidden `<div>` also wrapped a heading that was used by a live sample, so I adjusted things a bit there.
