### PR TITLE
navigator.share() resolves at different point for Windows

### DIFF
--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -15,7 +15,8 @@ The **`navigator.share()`** method of the [Web Share API](/en-US/docs/Web/API/We
 
 This method requires that the current document have the [web-share](/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share) permission policy and {{Glossary("transient activation")}}. (It must be triggered off a UI event like a button click and cannot be launched at arbitrary points by a script.) Further, the method must specify valid data that is supported for sharing by the native implementation.
 
-The method resolves a {{jsxref("Promise")}} with `undefined` as soon as the data is successfully passed to the _share target_.
+The method resolves a {{jsxref("Promise")}} with `undefined`.
+On Windows this happens when the share popup is launched, while on Android the promise resolves once the data has successfully been passed to the _share target_.
 
 ## Syntax
 
@@ -41,7 +42,7 @@ navigator.share(data)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with `undefined` once the data has been sent to the share target, or rejected with one of the [Exceptions](#exceptions) given below.
+A {{jsxref("Promise")}} that resolves with `undefined`, or rejected with one of the [Exceptions](#exceptions) given below.
 
 ### Exceptions
 


### PR DESCRIPTION
As clarified with @saschanaz in https://github.com/mdn/browser-compat-data/pull/12194#issuecomment-921353584 , the `navigator.share()` promise always resolves with `undefined`. On Windows it resolves when the popup is launched. On Android it resolves later - when the information is passed to the share target. Other platforms may behave differently, so I have not commented specifically on those.
