### PR TITLE
[Markdown] [Web/SVG] Fix live sample ID arguments for SVG

### DIFF
--- a/files/en-us/web/svg/attribute/in/index.html
+++ b/files/en-us/web/svg/attribute/in/index.html
@@ -70,7 +70,7 @@ tags:
   <dd>This value is an assigned name for the filter primitive in the form of a {{cssxref("custom-ident")}}. If supplied, then graphics that result from processing this filter primitive can be referenced by an in attribute on a subsequent filter primitive within the same filter element. If no value is provided, the output will only be available for re-use as the implicit input into the next filter primitive if that filter primitive provides no value for its in attribute.</dd>
 </dl>
 
-<h2 id="Workaround_for_backgroundImage">Workaround for BackgroundImage</h2>
+<h2>Workaround for BackgroundImage</h2>
 
 <p><code>BackgroundImage</code> is not supported as a filter source in modern browsers (see the <a href="/en-US/docs/Web/SVG/Element/feComposite#browser_compatibility">feComposite compatibility table</a>). We therefore need to import one of the images to blend inside the filter itself, using an <code>&lt;feImage&gt;</code> element.</p>
 
@@ -107,7 +107,7 @@ tags:
 
 <h3 id="Result">Result</h3>
 
-<p>{{EmbedLiveSample("Workaround_for_backgroundImage")}}</p>
+<p>{{EmbedLiveSample("Workaround_for_BackgroundImage")}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/transform-origin/index.html
+++ b/files/en-us/web/svg/attribute/transform-origin/index.html
@@ -65,7 +65,7 @@ browser-compat: svg.attributes.presentation.transform-origin
  </li>
 </ul>
 
-<h2 id="example">Example</h2>
+<h2>Example</h2>
 
 <p>This example shows the code for one PNG image and three SVG images:</p>
 
@@ -208,7 +208,7 @@ browser-compat: svg.attributes.presentation.transform-origin
 
 <h3 id="result">Result</h3>
 
-<p>{{ EmbedLiveSample('example', 700, 1350) }}</p>
+<p>{{ EmbedLiveSample('Example', 700, 1350) }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/tutorial/gradients/index.html
+++ b/files/en-us/web/svg/tutorial/gradients/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>There are two types of gradients: linear and radial. You <strong>must</strong> give the gradient an <code>id</code> attribute; otherwise it can't be referenced by other elements inside the file.  Gradients are defined in a defs section as opposed to on a shape itself to promote reusability.</p>
 
-<h2 id="SVGLinearGradient">Linear Gradient</h2>
+<h2>Linear Gradient</h2>
 
 <p>Linear gradients change along a straight line. To insert one, you create a {{SVGElement('linearGradient')}} node inside the definitions section of your SVG file.</p>
 
@@ -43,7 +43,7 @@ tags:
 
 &lt;/svg&gt;</pre>
 
-<p>{{ EmbedLiveSample('SVGLinearGradient','120','240','/files/722/SVG_Linear_Gradient_Example.png') }}</p>
+<p>{{ EmbedLiveSample('Linear_Gradient','120','240','/files/722/SVG_Linear_Gradient_Example.png') }}</p>
 
 <p>Above is an example of a linear gradient being applied to a <code>&lt;rect&gt;</code> element. Inside the linear gradient are several {{SVGElement('stop')}} nodes. These nodes tell the gradient what color it should be at certain positions by specifying an <code>offset</code> attribute for the position, and a <code>stop-color</code> attribute. This can be assigned directly or through CSS. The two methods have been intermixed for the purposes of this example. For instance, this one tells the gradient to start at the color red, change to transparent-black in the middle, and end at the color blue. You can insert as many stop colors as you like to create a blend that's as beautiful or hideous as you need, but the offsets should always increase from 0% (or 0 if you want to drop the % sign) to 100% (or 1). Duplicate values will use the stop that is assigned furthest down the XML tree. Also, like with fill and stroke, you can specify a <code>stop-opacity</code> attribute to set the opacity at that position (again, in FF3 you can also use rgba values to do this).</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8969.

This fixes up the places in the SVG docs where a heading ID is different from the generated heading ID, and a live sample uses that ID. This will break in Markdown because in Markdown all heading IDs are always generated.