### PR TITLE
FF93: Relnote: SHA256 available for HTTP Digest Authentication

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -38,6 +38,7 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
+  <li>The SHA-256 algorithm is now supported for <a href="/en-US/docs/Web/HTTP/Authentication">HTTP Authentication</a> using digests. This allows much more secure authentication than previously available using the MD5 algorithm ({{bug(1682995)}}).</li>
   <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> image format). ({{bug(1682995)}}).</li>
 </ul>
 


### PR DESCRIPTION
Release note for #8682