### PR TITLE
fixed typo "complies and executes" to "compiles.."

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -75,7 +75,7 @@ tags:
 <ul>
   <li>The browser parses the HTML file first, and that leads to the browser recognizing any <code>&lt;link&gt;</code>-element references to external CSS stylesheets and any <code>&lt;script&gt;</code>-element references to scripts.</li>
   <li>As the browser parses the HTML, it sends requests back to the server for any CSS files it has found from <code>&lt;link&gt;</code> elements, and any JavaScript files it has found from <code>&lt;script&gt;</code> elements, and from those, then parses the CSS and JavaScript.</li>
-  <li>The browser generates an in-memory <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> tree from the parsed HTML, generates an in-memory <a href="/en-US/docs/Glossary/CSSOM">CSSOM</a> structure from the parsed CSS, and <a href="/en-US/docs/Web/Performance/How_browsers_work#javascript_compilation">complies and executes</a> the parsed JavaScript</a>.</li>
+  <li>The browser generates an in-memory <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> tree from the parsed HTML, generates an in-memory <a href="/en-US/docs/Glossary/CSSOM">CSSOM</a> structure from the parsed CSS, and <a href="/en-US/docs/Web/Performance/How_browsers_work#javascript_compilation">compiles and executes</a> the parsed JavaScript</a>.</li>
   <li>As the browser builds the DOM tree and applies the styles from the CSSOM tree and executes the JavaScript, a visual representation of the page is painted to the screen, and the user sees the page content and can begin to interact with it.</li>
 </ul>
 


### PR DESCRIPTION
## Page : 

[Order in which component files are parsed](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works#order_in_which_component_files_are_parsed)

