### PR TITLE
WebXR createProjectionLayer: fix options listing

### DIFF
--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -44,7 +44,7 @@ The `options` object can have the following optional properties:
     - `gl.SRGB8`
     - `gl.RGB8_ALPHA8`
    The default value is `gl.RGBA`.
-- `depthFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture (in that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`).
+- `depthFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture. (In that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`.)
   Possible values within {{domxref("WebGLRenderingContext")}} contexts with the {{domxref("WEBGL_depth_texture")}} extension enabled, or within {{domxref("WebGL2RenderingContext")}} contexts (no extension required):
     - `gl.DEPTH_COMPONENT`
     - `gl.DEPTH_STENCIL`
@@ -52,7 +52,7 @@ The `options` object can have the following optional properties:
     - `gl.DEPTH_COMPONENT24`
     - `gl.DEPTH24_STENCIL24`
    The default value is `gl.DEPTH_COMPONENT`.
-- `scaleFactor` {{optional_inline}}: A floating-point value which is used to scale the layer during compositing. A value of `1.0` represents the default pixel size for the frame buffer. See also {{domxref("XRWebGLLayer.getNativeFramebufferScaleFactor()")}}. Unlike other layers, the `XRProjectionLayer` can't be created with an explicit pixel width and height, because the size is inferred by the hardware (projection layers fill the observer's entire view).
+- `scaleFactor` {{optional_inline}}: A floating-point value which is used to scale the layer during compositing. A value of `1.0` represents the default pixel size for the frame buffer. (See also {{domxref("XRWebGLLayer.getNativeFramebufferScaleFactor()")}}.) Unlike other layers, the `XRProjectionLayer` can't be created with an explicit pixel width and height, because the size is inferred by the hardware. (Projection layers fill the observer's entire view.)
 
 ### Return value
 

--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -44,7 +44,7 @@ The `options` object can have the following optional properties:
     - `gl.SRGB8`
     - `gl.RGB8_ALPHA8`
    The default value is `gl.RGBA`.
-- `colorFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture (in that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`).
+- `depthFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture (in that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`).
   Possible values within {{domxref("WebGLRenderingContext")}} contexts with the {{domxref("WEBGL_depth_texture")}} extension enabled, or within {{domxref("WebGL2RenderingContext")}} contexts (no extension required):
     - `gl.DEPTH_COMPONENT`
     - `gl.DEPTH_STENCIL`

--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -28,14 +28,12 @@ createProjectionLayer(options)
 
 The `options` object can have the following optional properties:
 
-- `textureType` {{optional_inline}}
-  - : An string defining the type of texture the layer will have. Possible values:
+- `textureType` {{optional_inline}}: An string defining the type of texture the layer will have. Possible values:
     - `texture`: The textures of {{domxref("XRWebGLSubImage")}} will be of type `gl.TEXTURE_2D`.
     - `texture-array`: the textures of {{domxref("XRWebGLSubImage")}} will be of type `gl.TEXTURE_2D_ARRAY` (WebGL 2 contexts only).
     The default value is `texture`.
-- `colorFormat` {{optional_inline}}
-  - : A {{domxref("GLenum")}} defining the data type of the color texture data. Possible values:
-    - `gl.RGBA`
+- `colorFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the color texture data. Possible values:
+    - `gl.RGB`
     - `gl.RGBA`
     Additionally, for contexts with the {{domxref("EXT_sRGB")}} extension enabled:
     - `ext.SRGB_EXT`
@@ -46,17 +44,15 @@ The `options` object can have the following optional properties:
     - `gl.SRGB8`
     - `gl.RGB8_ALPHA8`
    The default value is `gl.RGBA`.
-- `colorFormat` {{optional_inline}}
-  - : A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture (in that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`).
-  Possible values within {{domxref("WebGLRenderingContext")}} contexts with the {{domxref("WEBGL_depth_texture")}} or within {{domxref("WebGLRenderingContext")}} contexts:
+- `colorFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture (in that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`).
+  Possible values within {{domxref("WebGLRenderingContext")}} contexts with the {{domxref("WEBGL_depth_texture")}} extension enabled, or within {{domxref("WebGL2RenderingContext")}} contexts (no extension required):
     - `gl.DEPTH_COMPONENT`
     - `gl.DEPTH_STENCIL`
     Additionally, for {{domxref("WebGL2RenderingContext")}} contexts:
     - `gl.DEPTH_COMPONENT24`
     - `gl.DEPTH24_STENCIL24`
    The default value is `gl.DEPTH_COMPONENT`.
-- `scaleFactor` {{optional_inline}}
-  - : A floating-point value which is used to scale the layer during compositing. A value of `1.0` represents the default pixel size for the frame buffer. See also {{domxref("XRWebGLLayer.getNativeFramebufferScaleFactor()")}}. Unlike other layers, the `XRProjectionLayer` can't be created with an explicit pixel width and height, because the size is inferred by the hardware (projection layers fill the observer's entire view).
+- `scaleFactor` {{optional_inline}}: A floating-point value which is used to scale the layer during compositing. A value of `1.0` represents the default pixel size for the frame buffer. See also {{domxref("XRWebGLLayer.getNativeFramebufferScaleFactor()")}}. Unlike other layers, the `XRProjectionLayer` can't be created with an explicit pixel width and height, because the size is inferred by the hardware (projection layers fill the observer's entire view).
 
 ### Return value
 


### PR DESCRIPTION
Definition lists don't really work with nested lists, falling back to just lists.