### PR TITLE
getBoundingClientRect : target purple example

### DIFF
--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -142,9 +142,8 @@ element, in each case.
 This example demonstrates how bounding client rect is changing when document is scrolled.
 
 ```html
-<div></div>
-    <div id="example"></div>
-    <div id="controls"></div>
+<div id="example"></div>
+<div id="controls"></div>
 ```
 
 ```css
@@ -163,7 +162,7 @@ p { margin: 0; }
 ```js
 function update() {
   const container = document.getElementById("controls");
-  const elem = document.querySelector('div');
+  const elem = document.getElementById("example");
   const rect = elem.getBoundingClientRect();
 
   container.innerHTML = '';


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Might be wrong, but, in the [getBoundingClientRect documentation page](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect), I would expect the 2nd live example to show the bounding rectangle of the purple example `div` (just like the 1st live example) instead of the empty `div` before it. Unsure where this empty `div` is coming from but without it, the JavaScript would actually target the correct one. Wondering if it was added by mistake at some point.

> Anything else that could help us review it

Nope
