### PR TITLE
Unlink BCD from CryptoKeyPair

### DIFF
--- a/files/en-us/web/api/cryptokeypair/index.md
+++ b/files/en-us/web/api/cryptokeypair/index.md
@@ -7,7 +7,6 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
-browser-compat: api.CryptoKeyPair
 ---
 {{APIRef("Web Crypto API")}}
 
@@ -41,11 +40,9 @@ The examples for `SubtleCrypto` methods often use `CryptoKeyPair` objects. For e
 
 ## Specifications
 
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
+| Specification                        | Status                           | Comment         |
+| ------------------------------------ | -------------------------------- | --------------- |
+| {{SpecName('Web Crypto API')}} | {{Spec2('Web Crypto API')}} | |
 
 ## See also
 


### PR DESCRIPTION
Follow-up to #8846.  This PR removes the compatibility table for the `CryptoKeyPair` dictionary and switches the spec table to a manually generated one.  Correlates with the removal of the compat data in BCD, see https://github.com/mdn/browser-compat-data/pull/12346.
