### PR TITLE
fix: correct where max-content can be applied

### DIFF
--- a/files/en-us/web/css/max-content/index.md
+++ b/files/en-us/web/css/max-content/index.md
@@ -9,7 +9,7 @@ tags:
   - sizing
 browser-compat: css.properties.width.max-content
 ---
-The `max-content` sizing keyword represents the intrinsic maximum width of the content. For text content this means that the content will not wrap at all even if it causes overflows.
+The `max-content` sizing keyword represents the intrinsic maximum width or height of the content. For text content this means that the content will not wrap at all even if it causes overflows.
 
 ## Syntax
 


### PR DESCRIPTION
- max-content css value can be applied to both width and height css properties. But the description text was saying only width
