### PR TITLE
Link itemprop attribute to its respective section

### DIFF
--- a/files/en-us/web/guide/html/content_categories/index.html
+++ b/files/en-us/web/guide/html/content_categories/index.html
@@ -9,7 +9,7 @@ tags:
   - NeedsUpdate
   - Web
 ---
-<p><span class="seoSummary">Every <a href="/en-US/docs/Web/HTML">HTML</a> element is a member of one or more <strong>content categories</strong> — these categories group elements that share common characteristics.</span> This is a loose grouping (it doesn't actually create a relationship among elements of these categories), but they help define and describe the categories' shared behavior and their associated rules, especially when you come upon their intricate details. It's also possible for elements to not be a member of <em>any</em> of these categories.</p>
+<p>Every <a href="/en-US/docs/Web/HTML">HTML</a> element is a member of one or more <strong>content categories</strong> — these categories group elements that share common characteristics. This is a loose grouping (it doesn't actually create a relationship among elements of these categories), but they help define and describe the categories' shared behavior and their associated rules, especially when you come upon their intricate details. It's also possible for elements to not be a member of <em>any</em> of these categories.</p>
 
 <p>There are three types of content categories:</p>
 
@@ -45,7 +45,7 @@ tags:
 <ul>
  <li>{{HTMLElement("area")}}, if it is a descendant of a {{HTMLElement("map")}} element</li>
  <li>{{HTMLElement("link")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#attr-itemprop">itemprop</a> attribute is present</li>
- <li>{{HTMLElement("meta")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#attr-itemprop"><strong>itemprop</strong></a> attribute is present</li>
+ <li>{{HTMLElement("meta")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#attr-itemprop">itemprop</a> attribute is present</li>
  <li>{{HTMLElement("style")}}, if the {{deprecated_inline}}{{htmlattrxref("scoped","style")}} attribute is present</li>
 </ul>
 
@@ -87,9 +87,9 @@ tags:
  <li>{{HTMLElement("area")}}, if it is a descendant of a {{HTMLElement("map")}} element</li>
  <li>{{HTMLElement("del")}}, if it contains only phrasing content</li>
  <li>{{HTMLElement("ins")}}, if it contains only phrasing content</li>
- <li>{{HTMLElement("link")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#itemprop"><strong>itemprop</strong></a> attribute is present</li>
+ <li>{{HTMLElement("link")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#attr-itemprop">itemprop</a> attribute is present</li>
  <li>{{HTMLElement("map")}}, if it contains only phrasing content</li>
- <li>{{HTMLElement("meta")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#itemprop"><strong>itemprop</strong></a> attribute is present</li>
+ <li>{{HTMLElement("meta")}}, if the <a href="/en-US/docs/Web/HTML/Global_attributes#attr-itemprop">itemprop</a> attribute is present</li>
 </ul>
 
 <h3 id="Embedded_content">Embedded content</h3>


### PR DESCRIPTION
- link `itemprop` attribute to its respective section
- remove `seoSummary` class span
- make the link to be consistent with styling; remove strong tags
---
I can use `htmlattrxref`macro here right?
can anyone help me with the syntax?