### PR TITLE
Minor change

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/search/index.md
+++ b/files/en-us/web/api/htmlanchorelement/search/index.md
@@ -45,7 +45,7 @@ Alternatively, [`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examp
 
 ```js
 let params = new URLSearchParams(queryString);
-let q = parseInt(params.get("q"); // returns the number 123
+let q = parseInt(params.get("q")); // returns the number 123
 ```
 
 ## Specifications


### PR DESCRIPTION
Missing closing parenthesis on parseInt example

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

Small error syntax of parseInt example

> Anything else that could help us review it
