### PR TITLE
[Markdown] [Web/SVG] Make SVG docs consistently use properties tables

### DIFF
--- a/files/en-us/web/svg/attribute/class/index.html
+++ b/files/en-us/web/svg/attribute/class/index.html
@@ -22,7 +22,7 @@ browser-compat: svg.attributes.style.class
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
 	<tbody>
 		<tr>
 			<th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/crossorigin/index.html
+++ b/files/en-us/web/svg/attribute/crossorigin/index.html
@@ -18,11 +18,13 @@ browser-compat: api.SVGImageElement.crossOrigin
 <p>This table shows all possible keywords and their meaning:</p>
 
 <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Keyword</th>
+      <th>Description</th>
+    </tr>
+  </thead>
 	<tbody>
-		<tr>
-			<td class="header">Keyword</td>
-			<td class="header">Description</td>
-		</tr>
 		<tr>
 			<td><code>anonymous</code></td>
 			<td>CORS requests for this element will have the credentials flag set to 'same-origin'.</td>

--- a/files/en-us/web/svg/attribute/cursor/index.html
+++ b/files/en-us/web/svg/attribute/cursor/index.html
@@ -16,7 +16,7 @@ browser-compat: svg.attributes.presentation.cursor
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/cy/index.html
+++ b/files/en-us/web/svg/attribute/cy/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>For {{SVGElement('circle')}}, <code>cy</code> defines the y-axis coordinate of the center of the shape.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -61,7 +61,7 @@ tags:
 
 <p>For {{SVGElement('ellipse')}}, <code>cy</code> defines the y-axis coordinate of the center of the shape.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -84,7 +84,7 @@ tags:
 
 <p>For {{SVGElement('radialGradient')}}, <code>cy</code> defines the y-axis coordinate of the end circle for the radial gradient.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/d/index.html
+++ b/files/en-us/web/svg/attribute/d/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>For {{SVGElement('path')}}, <code>d</code> is a string containing a series of path commands that define the path to be drawn.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -61,7 +61,7 @@ tags:
 
 <p>For {{SVGElement('glyph')}}, <code>d</code> is a string containing a series of path commands that define the outline shape of the glyph.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -86,7 +86,7 @@ tags:
 
 <p>For {{SVGElement('missing-glyph')}}, <code>d</code> is a string containing a series of path commands that define the outline shape of the glyph.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/dx/index.html
+++ b/files/en-us/web/svg/attribute/dx/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>If there are multiple values, <code>dx</code> defines a shift along the x-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -75,7 +75,7 @@ tags:
 
 <p>For {{SVGElement('feDropShadow')}}, <code>dx</code> defines the x offset of the dropped shadow. The unit used to resolve the value of the attribute is set by the {{SVGAttr('primitiveUnits')}} attribute of the {{SVGElement('filter')}} element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -96,7 +96,7 @@ tags:
 
 <p>For {{SVGElement('feOffset')}}, <code>dx</code> defines the x offset of the filter input graphic. The unit used to resolve the value of the attribute is set by the {{SVGAttr('primitiveUnits')}} attribute of the {{SVGElement('filter')}} element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -119,7 +119,7 @@ tags:
 
 <p>For {{SVGElement('glyphRef')}}, <code>dx</code> defines the x offset of the glyph, in the font metric system.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -142,7 +142,7 @@ tags:
 
 <p>If there are multiple values, <code>dx</code> defines a shift along the x-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -196,7 +196,7 @@ tags:
 
 <p>If there are multiple values, <code>dx</code> defines a shift along the x-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -219,7 +219,7 @@ tags:
 
 <p>If there are multiple values, <code>dx</code> defines a shift along the x-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/dy/index.html
+++ b/files/en-us/web/svg/attribute/dy/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>If there are multiple values, <code>dy</code> defines a shift along the y-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -75,7 +75,7 @@ tags:
 
 <p>For {{SVGElement('feDropShadow')}}, <code>dy</code> defines the y offset of the dropped shadow. The unit used to resolve the value of the attribute is set by the {{SVGAttr('primitiveUnits')}} attribute of the {{SVGElement('filter')}} element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -96,7 +96,7 @@ tags:
 
 <p>For {{SVGElement('feOffset')}}, <code>dy</code> defines the y offset of the filter input graphic. The unit used to resolve the value of the attribute is set by the {{SVGAttr('primitiveUnits')}} attribute of the {{SVGElement('filter')}} element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -119,7 +119,7 @@ tags:
 
 <p>For {{SVGElement('glyphRef')}}, <code>dy</code> defines the y offset of the glyph, in the font metric system.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -142,7 +142,7 @@ tags:
 
 <p>If there are multiple values, <code>dy</code> defines a shift along the y-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -197,7 +197,7 @@ tags:
 
 <p>If there are multiple values, <code>dy</code> defines a shift along the y-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -220,7 +220,7 @@ tags:
 
 <p>If there are multiple values, <code>dy</code> defines a shift along the y-axis for each individual glyph relative to the preceding glyph. If there are less values than glyphs, the remaining glyphs use a value of <code>0</code>. If there are more values than glyphs, extra values are ignored.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/fill-opacity/index.html
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.html
@@ -53,7 +53,7 @@ browser-compat: svg.attributes.presentation.fill-opacity
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/fill-rule/index.html
+++ b/files/en-us/web/svg/attribute/fill-rule/index.html
@@ -48,7 +48,7 @@ browser-compat: svg.attributes.presentation.fill-rule
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/fill/index.html
+++ b/files/en-us/web/svg/attribute/fill/index.html
@@ -67,7 +67,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('altGlyph')}}, <code>fill</code> is a presentation attribute that defines the color of the glyph.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -90,7 +90,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('animate')}}, <code>fill</code> defines the final state of the animation.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -113,7 +113,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('animateColor')}}, <code>fill</code> defines the final state of the animation.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -134,7 +134,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('animateMotion')}}, <code>fill</code> defines the final state of the animation.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -155,7 +155,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('animateTransform')}}, <code>fill</code> defines the final state of the animation.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -176,7 +176,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('circle')}}, <code>fill</code> is a presentation attribute that defines the color of the circle.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -199,7 +199,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('ellipse')}}, <code>fill</code> is a presentation attribute that defines the color of the ellipse.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -222,7 +222,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('path')}}, <code>fill</code> is a presentation attribute that defines the color of the interior of the shape. (<em>Interior is define by the {{SVGAttr('fill-rule')}} attribute</em>)</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -245,7 +245,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('polygon')}}, <code>fill</code> is a presentation attribute that defines the color of the interior of the shape. (<em>Interior is define by the {{SVGAttr('fill-rule')}} attribute</em>)</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -268,7 +268,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('polyline')}}, <code>fill</code> is a presentation attribute that defines the color of the interior of the shape. (<em>Interior is define by the {{SVGAttr('fill-rule')}} attribute</em>)</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -291,7 +291,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('rect')}}, <code>fill</code> is a presentation attribute that defines the color of the rectangle.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -314,7 +314,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('set')}}, <code>fill</code> defines the final state of the animation.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -335,7 +335,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('text')}}, <code>fill</code> is a presentation attribute that defines what the color of the text.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -358,7 +358,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('textPath')}}, <code>fill</code> is a presentation attribute that defines the color of the text.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -383,7 +383,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('tref')}}, <code>fill</code> is a presentation attribute that defines the color of the text.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -406,7 +406,7 @@ browser-compat: svg.attributes.presentation.fill
 
 <p>For {{SVGElement('tspan')}}, <code>fill</code> is a presentation attribute that defines the color of the text.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/font-size-adjust/index.html
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.html
@@ -43,7 +43,7 @@ browser-compat: svg.attributes.presentation.font-size-adjust
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Default value</th>

--- a/files/en-us/web/svg/attribute/height/index.html
+++ b/files/en-us/web/svg/attribute/height/index.html
@@ -56,7 +56,7 @@ tags:
 
 <p>For {{SVGElement('feBlend')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -77,7 +77,7 @@ tags:
 
 <p>For {{SVGElement('feColorMatrix')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -98,7 +98,7 @@ tags:
 
 <p>For {{SVGElement('feComponentTransfer')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -119,7 +119,7 @@ tags:
 
 <p>For {{SVGElement('feComposite')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -140,7 +140,7 @@ tags:
 
 <p>For {{SVGElement('feConvolveMatrix')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -161,7 +161,7 @@ tags:
 
 <p>For {{SVGElement('feDiffuseLighting')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -182,7 +182,7 @@ tags:
 
 <p>For {{SVGElement('feDisplacementMap')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -203,7 +203,7 @@ tags:
 
 <p>For {{SVGElement('feDropShadow')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -224,7 +224,7 @@ tags:
 
 <p>For {{SVGElement('feFlood')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -245,7 +245,7 @@ tags:
 
 <p>For {{SVGElement('feGaussianBlur')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -266,7 +266,7 @@ tags:
 
 <p>For {{SVGElement('feImage')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -287,7 +287,7 @@ tags:
 
 <p>For {{SVGElement('feMerge')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -308,7 +308,7 @@ tags:
 
 <p>For {{SVGElement('feMorphology')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -329,7 +329,7 @@ tags:
 
 <p>For {{SVGElement('feOffset')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -350,7 +350,7 @@ tags:
 
 <p>For {{SVGElement('feSpecularLighting')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -371,7 +371,7 @@ tags:
 
 <p>For {{SVGElement('feTile')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -392,7 +392,7 @@ tags:
 
 <p>For {{SVGElement('feTurbulence')}}, <code>height</code> defines the vertical length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -413,7 +413,7 @@ tags:
 
 <p>For {{SVGElement('filter')}}, <code>height</code> defines the vertical length for the rendering area of the filter.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -434,7 +434,7 @@ tags:
 
 <p>For {{SVGElement('foreignObject')}}, <code>height</code> defines the vertical length for the rendering area for the referenced document.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -457,7 +457,7 @@ tags:
 
 <p>For {{SVGElement('image')}}, <code>height</code> defines the vertical length for the image.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -480,7 +480,7 @@ tags:
 
 <p>For {{SVGElement('mask')}}, <code>height</code> defines the vertical length of its area of effect. The exact effect of this attribute is influenced by the {{SVGAttr('maskUnits')}} attribute.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -501,7 +501,7 @@ tags:
 
 <p>For {{SVGElement('pattern')}}, <code>height</code> defines the vertical length of the tile pattern. The exact effect of this attribute is influenced by the {{SVGAttr('patternUnits')}} and {{SVGAttr('patternTransform')}} attributes.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -522,7 +522,7 @@ tags:
 
 <p>For {{SVGElement('rect')}}, <code>height</code> defines the vertical length for the rectangle.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -547,7 +547,7 @@ tags:
 
 <div class="note"><p><strong>Note:</strong> In an HTML document if both the {{SVGAttr('viewBox')}} and <code>height</code> attributes are omitted, <a href="https://svgwg.org/specs/integration/#svg-css-sizing">the svg element will be rendered with a height of <code>150px</code></a></p></div>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -570,7 +570,7 @@ tags:
 
 <p>For {{SVGElement('use')}}, <code>height</code> defines the vertical length for the referenced element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/order/index.html
+++ b/files/en-us/web/svg/attribute/order/index.html
@@ -41,7 +41,7 @@ browser-compat: svg.elements.feConvolveMatrix.order
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/overline-position/index.html
+++ b/files/en-us/web/svg/attribute/overline-position/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/overline-thickness/index.html
+++ b/files/en-us/web/svg/attribute/overline-thickness/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/pathlength/index.html
+++ b/files/en-us/web/svg/attribute/pathlength/index.html
@@ -59,7 +59,7 @@ tags:
 
 <p>For {{SVGElement('circle')}}, <code>pathLength</code> lets authors specify a total length for the circle, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -80,7 +80,7 @@ tags:
 
 <p>For {{SVGElement('ellipse')}}, <code>pathLength</code> lets authors specify a total length for the ellipse, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -101,7 +101,7 @@ tags:
 
 <p>For {{SVGElement('line')}}, <code>pathLength</code> lets authors specify a total length for the line, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -122,7 +122,7 @@ tags:
 
 <p>For {{SVGElement('path')}}, <code>pathLength</code> lets authors specify a total length for the path, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -143,7 +143,7 @@ tags:
 
 <p>For {{SVGElement('polygon')}}, <code>pathLength</code> lets authors specify a total length for the shape, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -164,7 +164,7 @@ tags:
 
 <p>For {{SVGElement('polyline')}}, <code>pathLength</code> lets authors specify a total length for the shape, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -185,7 +185,7 @@ tags:
 
 <p>For {{SVGElement('rect')}}, <code>pathLength</code> lets authors specify a total length for the rectangle, in user units.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/pointer-events/index.html
+++ b/files/en-us/web/svg/attribute/pointer-events/index.html
@@ -80,7 +80,7 @@ browser-compat: svg.attributes.presentation.pointer-events
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/preserveaspectratio/index.html
+++ b/files/en-us/web/svg/attribute/preserveaspectratio/index.html
@@ -226,7 +226,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('feImage')}}, <code>preserveAspectRatio</code> defines how the referenced image should fit in the rectangle define by the <code>&lt;feImage&gt;</code> element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -247,7 +247,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('image')}}, <code>preserveAspectRatio</code> defines how the referenced image should fit in the rectangle define by the <code>&lt;image&gt;</code> element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -268,7 +268,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('marker')}}, <code>preserveAspectRatio</code> indicates if a uniform scaling must be performed to fit the element viewport.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -289,7 +289,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('pattern')}}, <code>preserveAspectRatio</code> indicates if a uniform scaling must be performed to fit the element viewport.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -310,7 +310,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('svg')}}, <code>preserveAspectRatio</code> indicates if a uniform scaling must be performed to fit the element viewport.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -331,7 +331,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('symbol')}}, <code>preserveAspectRatio</code> indicates if a uniform scaling must be performed to fit the element viewport.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -352,7 +352,7 @@ rect:hover, rect:active {
 
 <p>For {{SVGElement('view')}}, <code>preserveAspectRatio</code> indicates if a uniform scaling must be performed to fit the element viewport.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/r/index.html
+++ b/files/en-us/web/svg/attribute/r/index.html
@@ -49,7 +49,7 @@ tags:
 
 <p>For {{SVGElement('circle')}}, <code>r</code> defines the radius of the circle and therefor its size. With a value lower or equal to zero the circle won't be drawn at all.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -74,7 +74,7 @@ tags:
 
 <p>The gradient will be drawn such that the <strong>100%</strong> gradient stop is mapped to the perimeter of this end circle. A value of lower or equal to zero will cause the area to be painted as a single color using the color and opacity of the last gradient {{ SVGElement("stop") }}.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/rx/index.html
+++ b/files/en-us/web/svg/attribute/rx/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>For {{SVGElement('ellipse')}}, <code>rx</code> defines the x-radius of the shape. With a value lower or equal to zero the ellipse won't be drawn at all.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -67,7 +67,7 @@ tags:
  <li>If <code>rx</code> is greater than half of the width of the rectangle, then the browser will consider the value for <code>rx</code> as half of the width of the rectangle.</li>
 </ul>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/ry/index.html
+++ b/files/en-us/web/svg/attribute/ry/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>For {{SVGElement('ellipse')}}, <code>ry</code> defines the y-radius of the shape. With a value lower or equal to zero the ellipse won't be drawn at all.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -67,7 +67,7 @@ tags:
  <li>If <code>ry</code> is greater than half of the width of the rectangle, then the browser will consider the value for <code>ry</code> as half of the width of the rectangle.</li>
 </ul>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/strikethrough-position/index.html
+++ b/files/en-us/web/svg/attribute/strikethrough-position/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/strikethrough-thickness/index.html
+++ b/files/en-us/web/svg/attribute/strikethrough-thickness/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.html
@@ -59,7 +59,7 @@ browser-compat: svg.attributes.presentation.stroke-dasharray
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
@@ -78,7 +78,7 @@ browser-compat: svg.attributes.presentation.stroke-dashoffset
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke-linecap/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linecap/index.html
@@ -55,7 +55,7 @@ browser-compat: svg.attributes.presentation.stroke-linecap
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.html
@@ -92,7 +92,7 @@ browser-compat: svg.attributes.presentation.stroke-linejoin
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
+++ b/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
@@ -76,7 +76,7 @@ browser-compat: svg.attributes.presentation.stroke-miterlimit
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke-opacity/index.html
+++ b/files/en-us/web/svg/attribute/stroke-opacity/index.html
@@ -54,7 +54,7 @@ browser-compat: svg.attributes.presentation.stroke-opacity
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke-width/index.html
+++ b/files/en-us/web/svg/attribute/stroke-width/index.html
@@ -48,7 +48,7 @@ browser-compat: svg.attributes.presentation.stroke-width
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/stroke/index.html
+++ b/files/en-us/web/svg/attribute/stroke/index.html
@@ -55,7 +55,7 @@ browser-compat: svg.attributes.presentation.stroke
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/transform/index.html
+++ b/files/en-us/web/svg/attribute/transform/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>Also, as a legacy from SVG 1.1, {{SVGElement('linearGradient')}} and {{SVGElement('radialGradient')}} support the <code>gradientTransform</code> attribute, and {{SVGElement('pattern')}} supports the <code>patternTransform</code> attribute, both of which act exactly like the <code>transform</code> attribute.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/type/index.html
+++ b/files/en-us/web/svg/attribute/type/index.html
@@ -38,7 +38,7 @@ tags:
 
 <h3 id="For_the_SVGElement(animateTransform)_elements">For the {{SVGElement("animateTransform")}} elements</h3>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>
@@ -61,7 +61,7 @@ tags:
 
 <h3 id="For_the_SVGElement(feColorMatrix)_element">For the {{ SVGElement("feColorMatrix") }} element</h3>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>
@@ -84,7 +84,7 @@ tags:
 
 <h3 id="For_the_SVGElement(feFuncR)_SVGElement(feFuncG)_SVGElement(feFuncB)_and_SVGElement(feFuncA)_elements">For the {{ SVGElement("feFuncR") }}, {{ SVGElement("feFuncG") }}, {{ SVGElement("feFuncB") }}, and {{ SVGElement("feFuncA") }} elements</h3>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>
@@ -107,7 +107,7 @@ tags:
 
 <h3 id="For_the_SVGElement(feTurbulence)_element">For the {{ SVGElement("feTurbulence") }} element</h3>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>
@@ -130,7 +130,7 @@ tags:
 
 <h3 id="For_the_SVGElement(style)_and_SVGElement(script)_elements">For the {{ SVGElement("style") }} and {{SVGElement("script")}} elements</h3>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/underline-position/index.html
+++ b/files/en-us/web/svg/attribute/underline-position/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/underline-thickness/index.html
+++ b/files/en-us/web/svg/attribute/underline-thickness/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Usage_context">Usage context</h2>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Categories</th>

--- a/files/en-us/web/svg/attribute/viewbox/index.html
+++ b/files/en-us/web/svg/attribute/viewbox/index.html
@@ -82,7 +82,7 @@ svg:not(:root) { display: inline-block; }</pre>
 
 <p>For {{SVGElement('marker')}}, <code>viewBox</code> defines the position and dimension for the content of the <code>&lt;marker&gt;</code> element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -103,7 +103,7 @@ svg:not(:root) { display: inline-block; }</pre>
 
 <p>For {{SVGElement('pattern')}}, <code>viewBox</code> defines the position and dimension for the content of the pattern tile.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -124,7 +124,7 @@ svg:not(:root) { display: inline-block; }</pre>
 
 <p>For {{SVGElement('svg')}}, <code>viewBox</code> defines the position and dimension for the content of the <code>&lt;svg&gt;</code> element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -145,7 +145,7 @@ svg:not(:root) { display: inline-block; }</pre>
 
 <p>For {{SVGElement('symbol')}}, <code>viewBox</code> defines the position and dimension for the content of the <code>&lt;symbol&gt;</code> element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -166,7 +166,7 @@ svg:not(:root) { display: inline-block; }</pre>
 
 <p>For {{SVGElement('view')}}, <code>viewBox</code> defines the position and dimension for the content of the <code>&lt;view&gt;</code> element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/width/index.html
+++ b/files/en-us/web/svg/attribute/width/index.html
@@ -56,7 +56,7 @@ tags:
 
 <p>For {{SVGElement('feBlend')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -77,7 +77,7 @@ tags:
 
 <p>For {{SVGElement('feColorMatrix')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -98,7 +98,7 @@ tags:
 
 <p>For {{SVGElement('feComponentTransfer')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -119,7 +119,7 @@ tags:
 
 <p>For {{SVGElement('feComposite')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -140,7 +140,7 @@ tags:
 
 <p>For {{SVGElement('feConvolveMatrix')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -161,7 +161,7 @@ tags:
 
 <p>For {{SVGElement('feDiffuseLighting')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -182,7 +182,7 @@ tags:
 
 <p>For {{SVGElement('feDisplacementMap')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -203,7 +203,7 @@ tags:
 
 <p>For {{SVGElement('feDropShadow')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -224,7 +224,7 @@ tags:
 
 <p>For {{SVGElement('feFlood')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -245,7 +245,7 @@ tags:
 
 <p>For {{SVGElement('feGaussianBlur')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -266,7 +266,7 @@ tags:
 
 <p>For {{SVGElement('feImage')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -287,7 +287,7 @@ tags:
 
 <p>For {{SVGElement('feMerge')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -308,7 +308,7 @@ tags:
 
 <p>For {{SVGElement('feMorphology')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -329,7 +329,7 @@ tags:
 
 <p>For {{SVGElement('feOffset')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -350,7 +350,7 @@ tags:
 
 <p>For {{SVGElement('feSpecularLighting')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -371,7 +371,7 @@ tags:
 
 <p>For {{SVGElement('feTile')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -392,7 +392,7 @@ tags:
 
 <p>For {{SVGElement('feTurbulence')}}, <code>width</code> defines the horizontal length for the rendering area of the primitive.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -413,7 +413,7 @@ tags:
 
 <p>For {{SVGElement('filter')}}, <code>width</code> defines the horizontal length for the rendering area of the filter.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -434,7 +434,7 @@ tags:
 
 <p>For {{SVGElement('foreignObject')}}, <code>width</code> defines the horizontal length for the rendering area for the referenced document.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -457,7 +457,7 @@ tags:
 
 <p>For {{SVGElement('image')}}, <code>width</code> defines the horizontal length for the image.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -480,7 +480,7 @@ tags:
 
 <p>For {{SVGElement('mask')}}, <code>width</code> defines the horizontal length of its area of effect. The exact effect of this attribute is influenced by the {{SVGAttr('maskUnits')}} attribute.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -501,7 +501,7 @@ tags:
 
 <p>For {{SVGElement('pattern')}}, <code>width</code> defines the horizontal length of the tile pattern. The exact effect of this attribute is influenced by the {{SVGAttr('patternUnits')}} and {{SVGAttr('patternTransform')}} attributes.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -522,7 +522,7 @@ tags:
 
 <p>For {{SVGElement('rect')}}, <code>width</code> defines the horizontal length for the rectangle.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -547,7 +547,7 @@ tags:
 
 <div class="note"><p><strong>Note:</strong> In an HTML document if both the {{SVGAttr('viewBox')}} and <code>width</code> attributes are omitted, <a href="https://svgwg.org/specs/integration/#svg-css-sizing">the svg element will be rendered with a width of <code>300px</code></a></p></div>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -570,7 +570,7 @@ tags:
 
 <p>For {{SVGElement('use')}}, <code>width</code> defines the horizontal length for the referenced element.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/x1/index.html
+++ b/files/en-us/web/svg/attribute/x1/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>For {{SVGElement('line')}}, <code>x1</code> defines the x coordinate of the starting point of the line.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -68,7 +68,7 @@ tags:
 
 <p>For {{SVGElement('linearGradient')}}, <code>x1</code> defines the  x coordinate of the starting point of the <em>gradient vector</em> used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/x2/index.html
+++ b/files/en-us/web/svg/attribute/x2/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>For {{SVGElement('line')}}, <code>x2</code> defines the x coordinate of the ending point of the line.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -63,7 +63,7 @@ tags:
 
 <p>For {{SVGElement('linearGradient')}}, <code>x2</code> defines the  x coordinate of the ending point of the <em>gradient vector</em> used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/y1/index.html
+++ b/files/en-us/web/svg/attribute/y1/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>For {{SVGElement('line')}}, <code>y1</code> defines the y coordinate of the starting point of the line.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -63,7 +63,7 @@ tags:
 
 <p>For {{SVGElement('linearGradient')}}, <code>y1</code> defines the y coordinate of the starting point of the <em>gradient vector</em> used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>

--- a/files/en-us/web/svg/attribute/y2/index.html
+++ b/files/en-us/web/svg/attribute/y2/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>For {{SVGElement('line')}}, <code>y2</code> defines the y coordinate of the ending point of the line.</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>
@@ -63,7 +63,7 @@ tags:
 
 <p>For {{SVGElement('linearGradient')}}, <code>y2</code> defines the y coordinate of the ending point of the <em>gradient vector</em> used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes</p>
 
-<table class="standard-table">
+<table class="properties">
  <tbody>
   <tr>
    <th scope="row">Value</th>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8969.

Many of the tables in the SVG docs are "properties" tables, and use the `properties` class. For example: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ascent#font-face .

Many other tables are also properties tables, but don't have `properties` set. For example: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength#circle.

This PR ensures that "properties" tables consistently use the "properties" class.