### PR TITLE
[Markdown] [Web/HTML] Remove ID attributes from HTML docs: everything except input

### DIFF
--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -17,9 +17,9 @@ tags:
 
 <p>Elements in HTML have <strong>attributes</strong>; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.</p>
 
-<h2 id="global_event_handlers">Global event handlers</h2>
+<h2 id="Global_event_handlers">Global event handlers</h2>
 
-<p>In addition to the attributes listed in the table below, the <a href="/en-US/docs/Web/API/GlobalEventHandlers"><code>GlobalEventHandlers</code></a> article lists global event handlers — such as <a href="/en-US/docs/Web/API/GlobalEventHandlers/onclick"><code>onclick</code></a> — than can also be specified as <a href="#content_versus_idl_attributes">content attributes</a> on all elements.</a></p>
+<p>In addition to the attributes listed in the table below, the <a href="/en-US/docs/Web/API/GlobalEventHandlers"><code>GlobalEventHandlers</code></a> article lists global event handlers — such as <a href="/en-US/docs/Web/API/GlobalEventHandlers/onclick"><code>onclick</code></a> — than can also be specified as <a href="#content_versus_idl_attributes">content attributes</a> on all elements.</p>
 
 <h2 id="Attribute_list">Attribute list</h2>
 
@@ -83,7 +83,7 @@ tags:
    <td>Indicates whether controls in this form can by default have their values automatically completed by the browser.</td>
   </tr>
   <tr>
-   <td id="attr-autofocus"><code><a href="/en-US/docs/Web/HTML/Attributes/autofocus">autofocus</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Attributes/autofocus">autofocus</a></code></td>
    <td>{{ HTMLElement("button") }}, {{ HTMLElement("input") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }}</td>
    <td>The element should be automatically focused after the page loaded.</td>
   </tr>
@@ -293,7 +293,7 @@ tags:
    <td>Describes elements which belongs to this one.</td>
   </tr>
   <tr>
-   <td id="attr-form"><code><a href="/en-US/docs/Web/HTML/Attributes/form">form</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Attributes/form">form</a></code></td>
    <td>{{ HTMLElement("button") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("input") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("label") }}, {{ HTMLElement("meter") }}, {{ HTMLElement("object") }}, {{ HTMLElement("output") }}, {{ HTMLElement("progress") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }}</td>
    <td>Indicates the form that is the owner of the element.</td>
   </tr>
@@ -692,7 +692,7 @@ tags:
   <tr>
    <td><code><a href="/en-US/docs/Web/HTML/Global_attributes/translate">translate</a></code></td>
    <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
-   <td>Specify whether an element’s attribute values and the values of its <code><a href="https://dom.spec.whatwg.org/#text" id="ref-for-text①⑦">Text</a></code> node children are to be translated when the page is localized, or whether to leave them unchanged.</td>
+   <td>Specify whether an element’s attribute values and the values of its <code><a href="https://dom.spec.whatwg.org/#text">Text</a></code> node children are to be translated when the page is localized, or whether to leave them unchanged.</td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/Web/HTML/Attributes/type">type</a></code></td>

--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>Elements in HTML have <strong>attributes</strong>; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.</p>
 
-<h2 id="Global_event_handlers">Global event handlers</h2>
+<h2>Global event handlers</h2>
 
 <p>In addition to the attributes listed in the table below, the <a href="/en-US/docs/Web/API/GlobalEventHandlers"><code>GlobalEventHandlers</code></a> article lists global event handlers — such as <a href="/en-US/docs/Web/API/GlobalEventHandlers/onclick"><code>onclick</code></a> — than can also be specified as <a href="#content_versus_idl_attributes">content attributes</a> on all elements.</p>
 

--- a/files/en-us/web/html/block-level_elements/index.html
+++ b/files/en-us/web/html/block-level_elements/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>The following example demonstrates the block-level element's influence:</p>
 
-<h2 id="Block-level_Example">Block-level elements</h2>
+<h2 id="Block-level_elements">Block-level elements</h2>
 
 <h3 id="HTML">HTML</h3>
 
@@ -32,7 +32,7 @@ tags:
 <pre class="brush: css">p { background-color: #8ABB55; }
 </pre>
 
-<p>{{ EmbedLiveSample('Block-level_Example') }}</p>
+<p>{{ EmbedLiveSample('Block-level_elements') }}</p>
 
 <h2 id="Usage">Usage</h2>
 

--- a/files/en-us/web/html/block-level_elements/index.html
+++ b/files/en-us/web/html/block-level_elements/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>The following example demonstrates the block-level element's influence:</p>
 
-<h2 id="Block-level_elements">Block-level elements</h2>
+<h2>Block-level elements</h2>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/web/html/date_and_time_formats/index.html
+++ b/files/en-us/web/html/date_and_time_formats/index.html
@@ -382,21 +382,21 @@ tags:
   </tr>
   <tr>
    <td><code>1986-01-28 11:38:00.010</code></td>
-   <td><code>1986-01-28T11:38:00.01</code> (See <a href="#datetime-local-footnote1">note 1</a>.)</td>
+   <td>
+     <p><code>1986-01-28T11:38:00.01</code></p>
+     <p>Note that after normalization, this is the same string as the previous <code>datetime-local</code> string. The space has been replaced with the "<code>T</code>" character and the trailing zero in the fraction of a second has been removed to make the string as short as possible.</p>
+   </td>
    <td>January 28, 1986 at 11:38:00.01 AM</td>
   </tr>
   <tr>
    <td><code>0170-07-31T22:00:00</code></td>
-   <td><code>0170-07-31T22:00</code> (See <a href="#datetime-local-footnote2">note 2</a>.)</td>
+   <td><p><code>0170-07-31T22:00</code></p>
+     <p>Note that the normalized form of this date drops the "<code>:00</code>" indicating the number of seconds to be zero, because the seconds are optional when zero, and the normalized string minimizes the length of the string.</p>
+   </td>
    <td>July 31, 170 at 10:00 PM</td>
   </tr>
  </tbody>
 </table>
-
-<ol>
- <li>Notice that <a id="datetime-local-footnote1">after normalization</a>, this is the same string as the previous <code>datetime-local</code> string. The space has been replaced with the "<code>T</code>" character and the trailing zero in the fraction of a second has been removed to make the string as short as possible.</li>
- <li>Note that the <a id="datetime-local-footnote2">normalized form</a> of this date drops the "<code>:00</code>" indicating the number of seconds to be zero, because the seconds are optional when zero, and the normalized string minimizes the length of the string.</li>
-</ol>
 
 <h2 id="Global_date_and_time_strings">Global date and time strings</h2>
 

--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -28,7 +28,7 @@ browser-compat: html.elements.a
 <p>This element's attributes include the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
 <dl>
- <dt id="download">{{HTMLAttrDef("download")}}</dt>
+ <dt>{{HTMLAttrDef("download")}}</dt>
  <dd><p>Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:</p>
  <ul>
   <li>Without a value, the browser will suggest a filename/extension, generated from various sources:
@@ -61,7 +61,7 @@ browser-compat: html.elements.a
  </ul>
  </div>
  </dd>
- <dt id="href">{{HTMLAttrDef("href")}}</dt>
+ <dt>{{HTMLAttrDef("href")}}</dt>
  <dd>
  <p>The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers:</p>
 
@@ -73,11 +73,11 @@ browser-compat: html.elements.a
   <li>While web browsers may not support other URL schemes, web sites can with <code><a href="/en-US/docs/Web/API/Navigator/registerProtocolHandler">registerProtocolHandler()</a></code></li>
  </ul>
  </dd>
- <dt id="hreflang">{{HTMLAttrDef("hreflang")}}</dt>
+ <dt>{{HTMLAttrDef("hreflang")}}</dt>
  <dd>Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as <a href="/en-US/docs/Web/HTML/Global_attributes/lang">the global <code>lang</code> attribute</a>.</dd>
- <dt id="ping">{{HTMLAttrDef("ping")}}</dt>
+ <dt>{{HTMLAttrDef("ping")}}</dt>
  <dd>A space-separated list of URLs. When the link is followed, the browser will send {{HTTPMethod("POST")}} requests with the body <code>PING</code> to the URLs. Typically for tracking.</dd>
- <dt id="referrerpolicy">{{HTMLAttrDef("referrerpolicy")}}</dt>
+ <dt>{{HTMLAttrDef("referrerpolicy")}}</dt>
  <dd>How much of the <a href="/en-US/docs/Web/HTTP/Headers/Referer">referrer</a> to send when following the link.
 
   <ul>
@@ -90,9 +90,9 @@ browser-compat: html.elements.a
     <li><code>strict-origin-when-cross-origin</code> (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</li>
     <li><code>unsafe-url</code>: The referrer will include the origin <em>and</em> the path (but not the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hash">fragment</a>, <a href="/en-US/docs/Web/API/HTMLAnchorElement/password">password</a>, or <a href="/en-US/docs/Web/API/HTMLAnchorElement/username">username</a>). <strong>This value is unsafe</strong>, because it leaks origins and paths from TLS-protected resources to insecure origins.</li>
    </ul></dd>
- <dt id="rel">{{HTMLAttrDef("rel")}}</dt>
+ <dt>{{HTMLAttrDef("rel")}}</dt>
  <dd>The relationship of the linked URL as space-separated <a href="/en-US/docs/Web/HTML/Link_types">link types</a>.</dd>
- <dt id="target">{{HTMLAttrDef("target")}}</dt>
+ <dt>{{HTMLAttrDef("target")}}</dt>
  <dd>Where to display the linked URL, as the name for a <em>browsing context</em> (a tab, window, or {{HTMLElement("iframe")}}). The following keywords have special meanings for where to load the URL:
  <ul>
   <li><code>_self</code>: the current browsing context. (Default)</li>
@@ -106,32 +106,32 @@ browser-compat: html.elements.a
  <p>Setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements implicitly provides the same <code>rel</code> behavior as setting <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> which does not set <code>window.opener</code>. See <a href="#browser_compatibility">browser compatibility</a> for support status.</p>
  </div>
  </dd>
- <dt id="type">{{HTMLAttrDef("type")}}</dt>
+ <dt>{{HTMLAttrDef("type")}}</dt>
  <dd>Hints at the linked URL’s format with a {{Glossary("MIME type")}}. No built-in functionality.</dd>
 </dl>
 
 <h3 id="Deprecated_attributes">Deprecated attributes</h3>
 
 <dl>
- <dt id="charset">{{HTMLAttrDef("charset")}}{{Deprecated_Inline}}</dt>
+ <dt>{{HTMLAttrDef("charset")}}{{Deprecated_Inline}}</dt>
  <dd>Hinted at the {{Glossary("character encoding")}} of the linked URL.
  <div class="notecard note">
  <h4>Note</h4>
  <p>This attribute is deprecated and <strong>should not be used by authors</strong>. Use the HTTP {{HTTPHeader("Content-Type")}} header on the linked URL.</p>
  </div>
  </dd>
- <dt id="coords">{{HTMLAttrDef("coords")}}{{Deprecated_Inline}}</dt>
+ <dt>{{HTMLAttrDef("coords")}}{{Deprecated_Inline}}</dt>
  <dd>Used with <a href="#shape">the <code>shape</code> attribute</a>. A comma-separated list of coordinates.</dd>
- <dt id="name">{{HTMLAttrDef("name")}}{{Deprecated_Inline}}</dt>
+ <dt>{{HTMLAttrDef("name")}}{{Deprecated_Inline}}</dt>
  <dd>Was required to define a possible target location in a page. In HTML 4.01, <code>id</code> and <code>name</code> could both be used on <code>&lt;a&gt;</code>, as long as they had identical values.
  <div class="notecard note">
  <h4>Note</h4>
  <p>Use the global attribute {{HTMLAttrxRef("id")}} instead.</p>
  </div>
  </dd>
- <dt id="rev">{{HTMLAttrDef("rev")}}{{Deprecated_Inline}}</dt>
+ <dt>{{HTMLAttrDef("rev")}}{{Deprecated_Inline}}</dt>
  <dd>Specified a reverse link; the opposite of <a href="#rel">the <code>rel</code> attribute</a>. Deprecated for being very confusing.</dd>
- <dt id="shape">{{HTMLAttrDef("shape")}}{{Deprecated_Inline}}</dt>
+ <dt>{{HTMLAttrDef("shape")}}{{Deprecated_Inline}}</dt>
  <dd>The shape of the hyperlink’s region in an image map.
  <div class="notecard note">
  <h4>Note</h4>
@@ -269,7 +269,7 @@ browser-compat: html.elements.a
 
 <p>See {{RFC(3966)}} for syntax, additional features, and other details about the <code>tel:</code> URL scheme.</p>
 
-<h3 id="Using_the_download_attribute_to_save_a_&lt;canvas&gt;_as_a_PNG">Using the download attribute to save a &lt;canvas&gt; as a PNG</h3>
+<h3>Using the download attribute to save a &lt;canvas&gt; as a PNG</h3>
 
 <p>To save a {{HTMLElement("canvas")}} element’s contents as an image, you can create a link with a <code>download</code> attribute and the canvas data as a <code>data:</code> URL:</p>
 

--- a/files/en-us/web/html/element/aside/index.html
+++ b/files/en-us/web/html/element/aside/index.html
@@ -64,7 +64,7 @@ browser-compat: html.elements.aside
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Using_&lt;aside&gt;">Using &lt;aside&gt;</h3>
+<h3>Using &lt;aside&gt;</h3>
 
 <p>This example uses <code>&lt;aside&gt;</code> to mark up a paragraph in an article. The paragraph is only indirectly related to the main article content:</p>
 
@@ -83,7 +83,7 @@ browser-compat: html.elements.aside
   &lt;/p&gt;
 &lt;/article&gt;</pre>
 
-<p>{{EmbedLiveSample("Examples")}}</p>
+<p>{{EmbedLiveSample("Using_aside")}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/audio/index.html
+++ b/files/en-us/web/html/element/audio/index.html
@@ -264,7 +264,7 @@ elem.audioTrackList.onremovetrack = function(event) {
 
 <p>For details on when autoplay works, how to get permission to use autoplay, and how and when it's appropriate to use autoplay, see our <a href="/en-US/docs/Web/Media/Autoplay_guide">autoplay guide</a>.</p>
 
-<h3 id="&lt;audio&gt;_element_with_&lt;source&gt;_element">&lt;audio&gt; element with &lt;source&gt; element</h3>
+<h3>&lt;audio&gt; element with &lt;source&gt; element</h3>
 
 <p>This example specifies which audio track to embed using the <code>src</code> attribute on a nested <code>&lt;source&gt;</code> element rather than directly on the <code>&lt;audio&gt;</code> element. It is always useful to include the file's MIME type inside the <code>type</code> attribute, as the browser is able to instantly tell if it can play that file, and not waste time on it if not.</p>
 
@@ -274,7 +274,7 @@ elem.audioTrackList.onremovetrack = function(event) {
 &lt;/audio&gt;
 </pre>
 
-<h3 id="&lt;audio&gt;_with_multiple_&lt;source&gt;_elements">&lt;audio&gt; with multiple &lt;source&gt; elements</h3>
+<h3>&lt;audio&gt; with multiple &lt;source&gt; elements</h3>
 
 <p>This example includes multiple <code>&lt;source&gt;</code> elements. The browser tries to load the first source element (Opus) if it is able to play it; if not it falls back to the second (Vorbis) and finally back to MP3:</p>
 

--- a/files/en-us/web/html/element/base/index.html
+++ b/files/en-us/web/html/element/base/index.html
@@ -72,7 +72,7 @@ browser-compat: html.elements.base
 
 <h2 id="Usage_notes">Usage notes</h2>
 
-<h3 id="Multiple_&lt;base&gt;_elements">Multiple &lt;base&gt; elements</h3>
+<h3>Multiple &lt;base&gt; elements</h3>
 
 <p>If multiple <code>&lt;base&gt;</code> elements are used, only the first <code>href</code> and first <code>target</code> are obeyed — all others are ignored.</p>
 

--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -179,7 +179,7 @@ browser-compat: html.elements.button
  <li><a href="https://axesslab.com/hand-tremors/">Hand tremors and the giant-button-problem - Axess Lab</a></li>
 </ul>
 
-<h3 id="ARIA">ARIA state information</h3>
+<h3>ARIA state information</h3>
 
 <p>To describe the state of a button the correct ARIA attribute to use is <code>aria-pressed</code> and not <code>aria-checked</code> or <code>aria-selected</code>. To find out more read  the information about the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">ARIA button role</a>.</p>
 

--- a/files/en-us/web/html/element/canvas/index.html
+++ b/files/en-us/web/html/element/canvas/index.html
@@ -67,7 +67,7 @@ browser-compat: html.elements.canvas
 
 <p>You should provide alternate content inside the <code>&lt;canvas&gt;</code> block. That content will be rendered both on older browsers that don't support canvas and in browsers with JavaScript disabled.</p>
 
-<h3 id="Required_&lt;canvas&gt;_tag">Required &lt;/canvas&gt; tag</h3>
+<h3>Required &lt;/canvas&gt; tag</h3>
 
 <p>Unlike the {{HTMLElement("img")}} element, the {{HTMLElement("canvas")}} element <strong>requires</strong> the closing tag (<code>&lt;/canvas&gt;</code>).</p>
 

--- a/files/en-us/web/html/element/center/index.html
+++ b/files/en-us/web/html/element/center/index.html
@@ -15,7 +15,7 @@ browser-compat: html.elements.center
 ---
 <div>{{deprecated_header}}</div>
 
-<p>The <strong><code>&lt;center&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is a <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level element</a> that displays its block-level or inline contents centered horizontally within its containing element.</span> The container is usually, but isn't required to be, {{HTMLElement("body")}}.</p>
+<p>The <strong><code>&lt;center&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is a <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level element</a> that displays its block-level or inline contents centered horizontally within its containing element. The container is usually, but isn't required to be, {{HTMLElement("body")}}.</p>
 
 <p>This tag has been deprecated in HTML 4 (and XHTML 1) in favor of the <a href="/en-US/docs/Web/CSS">CSS</a> {{Cssxref("text-align")}} property, which can be applied to the {{HTMLElement("div")}} element or to an individual {{HTMLElement("p")}}. For centering blocks, use other CSS properties like {{Cssxref("margin-left")}} and {{Cssxref("margin-right")}} and set them to <code>auto</code> (or set {{Cssxref("margin")}} to <code>0 auto</code>).</p>
 
@@ -33,19 +33,19 @@ browser-compat: html.elements.center
 &lt;p&gt;So will this paragraph.&lt;/p&gt;&lt;/center&gt;
 </pre>
 
-<h2 id="Example_2">Example 2 (CSS alternative)</h2>
+<h2>Example 2 (CSS alternative)</h2>
 
 <pre class="brush: html">&lt;div style="text-align:center"&gt;This text will be centered.
 &lt;p&gt;So will this paragraph.&lt;/p&gt;&lt;/div&gt;
 </pre>
 
-<h2 id="Example_3">Example 3 (CSS alternative)</h2>
+<h2>Example 3 (CSS alternative)</h2>
 
 <pre class="brush: html">&lt;p style="text-align:center"&gt;This line will be centered.&lt;br&gt;
 And so will this line.&lt;/p&gt;
 </pre>
 
-<h2 id="Notes">Note</h2>
+<h2>Note</h2>
 
 <p>Applying {{Cssxref("text-align")}}<code>:center</code> to a {{HTMLElement("div")}} or {{HTMLElement("p")}} element centers the <em>contents</em> of those elements while leaving their overall dimensions unchanged.</p>
 

--- a/files/en-us/web/html/element/dfn/index.html
+++ b/files/en-us/web/html/element/dfn/index.html
@@ -76,7 +76,7 @@ browser-compat: html.elements.dfn
 <p>If the <code>&lt;dfn&gt;</code> element has a <code>title</code> attribute, it <em>must</em> contain the term being defined and no other text.</p>
 </div>
 
-<h3 id="Links_to_&lt;dfn&gt;_elements">Links to <code>&lt;dfn&gt;</code> elements</h3>
+<h3>Links to <code>&lt;dfn&gt;</code> elements</h3>
 
 <p>If you include an {{htmlattrxref("id")}} attribute on the <code>&lt;dfn&gt;</code> element, you can then link to it using {{HTMLElement("a")}} elements. Such links should be uses of the term, with the intent being that the reader can quickly navigate to the term's definition if they're not already aware of it, by clicking on the term's link.</p>
 

--- a/files/en-us/web/html/element/dl/index.html
+++ b/files/en-us/web/html/element/dl/index.html
@@ -146,7 +146,7 @@ browser-compat: html.elements.dl
   content: ": ";
 }</pre>
 
-<h3 id="Wrapping_name-value_groups_in_HTMLElementdiv_elements">Wrapping name-value groups in <code>div</code> elements</h3>
+<h3>Wrapping name-value groups in <code>div</code> elements</h3>
 
 <p><a href="/en-US/docs/Glossary/WHATWG">WHATWG</a> HTML allows wrapping each name-value group in a {{HTMLElement("dl")}} element in a {{HTMLElement("div")}} element. This can be useful when using <a href="/en-US/docs/Web/HTML/Microdata">microdata</a>, or when <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a> apply to a whole group, or for styling purposes.</p>
 

--- a/files/en-us/web/html/element/em/index.html
+++ b/files/en-us/web/html/element/em/index.html
@@ -58,7 +58,7 @@ browser-compat: html.elements.em
 
 <p>Typically this element is displayed in italic type. However, it should not be used to apply italic styling; use the CSS {{cssxref("font-style")}} property for that purpose. Use the {{HTMLElement("cite")}} element to mark the title of a work (book, play, song, etc.). Use the {{HTMLElement("i")}} element to mark text that is in an alternate tone or mood, which covers many common situations for italics such as scientific names or words in other languages. Use the {{HTMLElement("strong")}} element to mark text that has greater importance than surrounding text.</p>
 
-<h3 id="&lt;i&gt;_vs._&lt;em&gt;">&lt;i&gt; vs. &lt;em&gt;</h3>
+<h3>&lt;i&gt; vs. &lt;em&gt;</h3>
 
 <p>New developers are often confused at seeing multiple elements that produce similar results. <code>&lt;em&gt;</code> and <code>&lt;i&gt;</code> are a common example, since they both italicize text. What's the difference? Which should you use?</p>
 

--- a/files/en-us/web/html/element/heading_elements/index.html
+++ b/files/en-us/web/html/element/heading_elements/index.html
@@ -65,7 +65,7 @@ browser-compat: html.elements.h1
  <li>Use only one <code>&lt;h1&gt;</code> per page or view. It should concisely describe the overall purpose of the content.</li>
 </ul>
 
-<h3 id="multiple_h1">Multiple <code>&lt;h1&gt;</code> elements on one page</h3>
+<h3>Multiple <code>&lt;h1&gt;</code> elements on one page</h3>
 
 <p>Using more than one <code>&lt;h1&gt;</code> is allowed by the HTML specification, but is not considered a best practice. Using only one <code>&lt;h1&gt;</code> is beneficial for screenreader users.</p>
 

--- a/files/en-us/web/html/element/iframe/index.html
+++ b/files/en-us/web/html/element/iframe/index.html
@@ -90,7 +90,7 @@ browser-compat: html.elements.iframe
  </dd>
  <dt>{{htmlattrdef("name")}}</dt>
  <dd>A targetable name for the embedded browsing context. This can be used in the <code>target</code> attribute of the {{HTMLElement("a")}}, {{HTMLElement("form")}}, or {{HTMLElement("base")}} elements; the <code>formtarget</code> attribute of the {{HTMLElement("input")}} or {{HTMLElement("button")}} elements; or the <code>windowName</code> parameter in the {{domxref("Window.open()","window.open()")}} method.</dd>
- <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
+ <dt>{{htmlattrdef("referrerpolicy")}}</dt>
  <dd>Indicates which <a href="/en-US/docs/Web/API/Document/referrer">referrer</a> to send when fetching the frame's resource:
  <ul>
   <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>
@@ -190,7 +190,7 @@ browser-compat: html.elements.iframe
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Example1">A simple &lt;iframe&gt;</h3>
+<h3>A simple &lt;iframe&gt;</h3>
 
 <p>This example embeds the page at <a href="https://example.org">https://example.org</a> in an iframe.</p>
 
@@ -202,7 +202,7 @@ browser-compat: html.elements.iframe
 
 <h4 id="Result">Result</h4>
 
-<p>{{ EmbedLiveSample('Example1', 640,400)}}</p>
+<p>{{ EmbedLiveSample('A_simple_iframe', 640,400)}}</p>
 
 <h2 id="Accessibility_concerns">Accessibility concerns</h2>
 

--- a/files/en-us/web/html/element/index.html
+++ b/files/en-us/web/html/element/index.html
@@ -64,7 +64,7 @@ tags:
 
 <p>{{HTMLRefTable({"include":["HTML embedded content"], "exclude":["multimedia"]})}}</p>
 
-<h2 id="SVG_and_Math">SVG and MathML</h2>
+<h2>SVG and MathML</h2>
 
 <p>You can embed <a href="/en-US/docs/Web/SVG">SVG</a> and <a href="/en-US/docs/Web/MathML">MathML</a> content directly into HTML documents, using the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements.</p>
 

--- a/files/en-us/web/html/element/main/index.html
+++ b/files/en-us/web/html/element/main/index.html
@@ -11,7 +11,7 @@ browser-compat: html.elements.main
 ---
 <div>{{HTMLRef}}</div>
 
-<p>The <strong><code>&lt;main&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element represents the dominant content of the {{HTMLElement("body")}} of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.</span></p>
+<p>The <strong><code>&lt;main&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element represents the dominant content of the {{HTMLElement("body")}} of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/main.html","tabbed-shorter")}}</div>
 
@@ -33,7 +33,7 @@ browser-compat: html.elements.main
   </tr>
   <tr>
    <th scope="row">Permitted parents</th>
-   <td>Where <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">flow content</a> is expected, but only if it is a <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#hierarchically-correct-main-element" id="the-main-element:hierarchically-correct-main-element">hierarchically correct <code>main</code> element</a>.</td>
+   <td>Where <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">flow content</a> is expected, but only if it is a <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#hierarchically-correct-main-element">hierarchically correct <code>main</code> element</a>.</td>
   </tr>
   <tr>
    <th scope="row">Implicit ARIA role</th>

--- a/files/en-us/web/html/element/portal/index.html
+++ b/files/en-us/web/html/element/portal/index.html
@@ -37,10 +37,10 @@ browser-compat: html.elements.portal
 <p>This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
 <dl>
-  <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
+  <dt>{{htmlattrdef("referrerpolicy")}}</dt>
   <dd>Sets the <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy">referrer policy</a> to use when requesting the page at the URL given as the value of the <code>src</code> attribute.
   </dd>
-  <dt id="attr-src">{{htmlattrdef("src")}}</dt>
+  <dt>{{htmlattrdef("src")}}</dt>
   <dd>The URL of the page to embed.</dd>
 </dl>
 

--- a/files/en-us/web/html/element/script/index.html
+++ b/files/en-us/web/html/element/script/index.html
@@ -93,7 +93,7 @@ browser-compat: html.elements.script
  <dd>This Boolean attribute is set to indicate that the script should not be executed in browsers that support<a href="https://hacks.mozilla.org/2015/08/es6-in-depth-modules/"> ES2015 modules</a> — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.</dd>
  <dt>{{htmlattrdef("nonce")}}</dt>
  <dd>A cryptographic nonce (number used once) to allow scripts in a <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src">script-src Content-Security-Policy</a>. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.</dd>
- <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
+ <dt>{{htmlattrdef("referrerpolicy")}}</dt>
  <dd>Indicates which <a href="/en-US/docs/Web/API/Document/referrer">referrer</a> to send when fetching the script, or resources fetched by the script:
   <ul>
   <li><code>no-referrer</code>: The {{HTTPHeader("Referer")}} header will not be sent.</li>

--- a/files/en-us/web/html/element/section/index.html
+++ b/files/en-us/web/html/element/section/index.html
@@ -68,9 +68,9 @@ browser-compat: html.elements.section
 
 <p>To reiterate, each <code>&lt;section&gt;</code> should be identified, typically by including a heading ({{HTMLElement('h1')}}-{{HTMLElement('h6')}} element) as a child of the <code>&lt;section&gt;</code> element, wherever possible. See below for examples of where you might see a <code>&lt;section&gt;</code> without a heading.</p>
 
-<h2 id="Example">Examples</h2>
+<h2>Examples</h2>
 
-<h3 id="simple_usage_example">Simple usage example</h3>
+<h3>Simple usage example</h3>
 
 <h4 id="Before">Before</h4>
 
@@ -87,7 +87,7 @@ browser-compat: html.elements.section
 &lt;/section&gt;
 </pre>
 
-<h3 id="using_a_section_without_a_heading">Using a section without a heading</h3>
+<h3>Using a section without a heading</h3>
 
 <p>Circumstances where you might see <code>&lt;section&gt;</code> used without a heading are typically found in web application/UI sections rather than in traditional document structures. In a document, it doesn't really make any sense to have a separate section of content without a heading to describe its contents. Such headings are useful for all readers, but particularly useful for users of assistive technologies like screenreaders, and they are also good for SEO.</p>
 

--- a/files/en-us/web/html/element/strike/index.html
+++ b/files/en-us/web/html/element/strike/index.html
@@ -36,7 +36,7 @@ browser-compat: html.elements.strike
 &amp;lt;s&amp;gt;:	&lt;s&gt;Today's Special: Salmon&lt;/s&gt; SOLD OUT
 </pre>
 
-<p id="Result">The result of this code is:</p>
+<p>The result of this code is:</p>
 
 <p>{{EmbedLiveSample("Example")}}</p>
 

--- a/files/en-us/web/html/element/strong/index.html
+++ b/files/en-us/web/html/element/strong/index.html
@@ -66,7 +66,7 @@ browser-compat: html.elements.strong
 
 <p>Another accepted use for <code>&lt;strong&gt;</code> is to denote the labels of paragraphs which represent notes or warnings within the text of a page.</p>
 
-<h3 id="&lt;b&gt;_vs._&lt;strong&gt;">&lt;b&gt; vs. &lt;strong&gt;</h3>
+<h3>&lt;b&gt; vs. &lt;strong&gt;</h3>
 
 <p>It is often confusing to new developers why there are so many ways to express the same thing on a rendered website. {{HTMLElement("b")}} and <code>&lt;strong&gt;</code> are perhaps one of the most common sources of confusion, causing developers to ask "Should I use <code>&lt;b&gt;</code> or <code>&lt;strong&gt;</code>? Don't they both do the same thing?"</p>
 
@@ -76,7 +76,7 @@ browser-compat: html.elements.strong
 
 <p>The intended meaning or purpose of the enclosed text should be what determines which element you use. Communicating meaning is what semantics are all about.</p>
 
-<h3 id="&lt;em&gt;_vs._&lt;strong&gt;">&lt;em&gt; vs. &lt;strong&gt;</h3>
+<h3>&lt;em&gt; vs. &lt;strong&gt;</h3>
 
 <p>Adding to the confusion is the fact that while HTML 4 defined <code>&lt;strong&gt;</code> as indicating a stronger emphasis, HTML 5 defines <code>&lt;strong&gt;</code> as representing "strong importance for its contents." This is an important distinction to make.</p>
 

--- a/files/en-us/web/html/element/time/index.html
+++ b/files/en-us/web/html/element/time/index.html
@@ -121,7 +121,7 @@ browser-compat: html.elements.time
 
 <p>{{EmbedLiveSample('Simple_example', 250, 60)}}</p>
 
-<h3 id="Datetime_example"><code>datetime</code> example</h3>
+<h3><code>datetime</code> example</h3>
 
 <h4 id="HTML_2">HTML</h4>
 
@@ -131,7 +131,7 @@ browser-compat: html.elements.time
 
 <h4 id="Output_2">Output</h4>
 
-<p>{{EmbedLiveSample('Datetime_example', 250, 60)}}</p>
+<p>{{EmbedLiveSample('datetime_example', 250, 60)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/u/index.html
+++ b/files/en-us/web/html/element/u/index.html
@@ -122,7 +122,7 @@ spelled word.&lt;/p&gt;</pre>
 
 <p>{{EmbedLiveSample("Indicating_a_spelling_error", 650, 80)}}</p>
 
-<h3 id="Avoiding_&lt;u&gt;">Avoiding &lt;u&gt;</h3>
+<h3>Avoiding &lt;u&gt;</h3>
 
 <p>Most of the time, you actually don't want to use <code>&lt;u&gt;</code>. Here are some examples that show what you should do instead in several cases.</p>
 

--- a/files/en-us/web/html/element/video/index.html
+++ b/files/en-us/web/html/element/video/index.html
@@ -54,7 +54,7 @@ browser-compat: html.elements.video
  <dd><p>The <code><a href="https://wicg.github.io/controls-list/html-output/multipage/embedded-content.html#attr-media-controlslist">controlslist</a></code> attribute, when specified, helps the browser select what controls to show on the media element whenever the browser shows its own set of controls (e.g. when the <code>controls</code> attribute is specified).</p>
  <p>The allowed values are <code>nodownload</code>, <code>nofullscreen</code> and <code>noremoteplayback</code>.</p>
 
- <p>Use the <a href="#disable_pip"><code>disablepictureinpicture</code></a> attribute if you want to disable the Picture-In-Picture mode (and the control).</p>
+ <p>Use the <a href="#attr-disablepictureinpicture"><code>disablepictureinpicture</code></a> attribute if you want to disable the Picture-In-Picture mode (and the control).</p>
  </dd>
  <dt>{{htmlattrdef("crossorigin")}}</dt>
  <dd>This enumerated attribute indicates whether to use CORS to fetch the related video. <a href="/en-US/docs/Web/HTML/CORS_enabled_image">CORS-enabled resources</a> can be reused in the {{HTMLElement("canvas")}} element without being <em>tainted</em>. The allowed values are:
@@ -65,9 +65,9 @@ browser-compat: html.elements.video
   <dd>Sends a cross-origin request with a credential. In other words, it sends the <code>Origin:</code> HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through <code>Access-Control-Allow-Credentials:</code> HTTP header), the image will be <em>tainted</em> and its usage restricted.</dd>
  </dl>
  When not present, the resource is fetched without a CORS request (i.e. without sending the <code>Origin:</code> HTTP header), preventing its non-tainted used in {{HTMLElement('canvas')}} elements. If invalid, it is handled as if the enumerated keyword <code>anonymous</code> was used. See <a href="/en-US/docs/Web/HTML/Attributes/crossorigin">CORS settings attributes</a> for additional information.</dd>
- <dt id="disable_pip"><a href="https://wicg.github.io/picture-in-picture/#disable-pip">{{htmlattrdef("disablepictureinpicture")}}</a> {{experimental_inline}}</dt>
+ <dt>{{htmlattrdef("disablepictureinpicture")}} {{experimental_inline}}</dt>
  <dd>Prevents the browser from suggesting a Picture-in-Picture context menu or to request Picture-in-Picture automatically in some cases.</dd>
- <dt><a href="https://www.w3.org/TR/remote-playback/#the-disableremoteplayback-attribute">{{htmlattrdef("disableremoteplayback")}}</a> {{experimental_inline}}</dt>
+ <dt>{{htmlattrdef("disableremoteplayback")}} {{experimental_inline}}</dt>
  <dd>A Boolean attribute used to disable the capability of remote playback in devices that are attached using wired (HDMI, DVI, etc.) and wireless technologies (Miracast, Chromecast, DLNA, AirPlay, etc).
  <p>In Safari, you can use <a href="https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AirPlayGuide/OptingInorOutofAirPlay/OptingInorOutofAirPlay.html"><code>x-webkit-airplay="deny"</code></a> as a fallback.</p>
  </dd>

--- a/files/en-us/web/html/global_attributes/itemprop/index.html
+++ b/files/en-us/web/html/global_attributes/itemprop/index.html
@@ -192,7 +192,7 @@ browser-compat: html.global_attributes.itemprop
 
 <h3 id="Same_structured_data_marked_up_in_two_different_ways">Same structured data marked up in two different ways</h3>
 
-<p id="There_is_no_semantic_difference_between_the_following_two_examples">There is no semantic difference between the following two examples</p>
+<p>There is no semantic difference between the following two examples</p>
 
 <pre class="brush: html">&lt;figure&gt;
  &lt;img src="castle.jpeg"&gt;

--- a/files/en-us/web/html/inline_elements/index.html
+++ b/files/en-us/web/html/inline_elements/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>HTML (<strong>Hypertext Markup Language</strong>) elements historically were categorized as either "block-level" elements or "inline-level" elements. Since this is a presentational characteristic it is nowadays specified by CSS in the <a href="/en-US/docs/Web/CSS/CSS_Flow_Layout">Flow Layout</a>.</p>
 
-<p>Inline elements are those which only occupy the space bounded by the tags defining the element, instead of breaking the flow of the content.</p> 
+<p>Inline elements are those which only occupy the space bounded by the tags defining the element, instead of breaking the flow of the content.</p>
 
 <div class="note">
 <p>An inline element does not start on a new line and only takes up as much width as necessary.</p>
@@ -97,7 +97,7 @@ the block-level element's influence.&lt;/div&gt;</pre>
  <dd>By default, inline elements do not force a new line to begin in the document flow. Block elements, on the other hand, typically cause a line break to occur (although, as usual, this can be changed using CSS).</dd>
 </dl>
 
-<h2 id="Elements">List of "inline" elements</h2>
+<h2>List of "inline" elements</h2>
 
 <p>The following elements are inline by default (although block and inline elements are no longer defined in HTML 5, use <a href="/en-US/docs/Web/Guide/HTML/Content_categories">content categories</a> instead):</p>
 

--- a/files/en-us/web/html/link_types/index.html
+++ b/files/en-us/web/html/link_types/index.html
@@ -110,7 +110,7 @@ browser-compat: html.elements.link.rel
    <td><em>None.</em></td>
   </tr>
   <tr>
-   <td id="icon"><code>icon</code></td>
+   <td><code>icon</code></td>
    <td>Defines a resource for representing the page in the user interface, usually an icon (auditory or visual). In the browser, it is usually referred to as the {{glossary("Favicon", "favicon")}}.<br>
     <br>
     If there are multiple <code>&lt;link rel="icon"&gt;</code>s, the browser uses their {{HTMLAttrxRef("media","link")}}, {{HTMLAttrxRef("type","link")}}, and {{HTMLAttrxRef("sizes","link")}} attributes to select the most appropriate icon. If several icons are equally appropriate, the last one is used. If the most appropriate icon is later found to be inappropriate, for example because it uses an unsupported format, the browser proceeds to the next-most appropriate, and so on.<br>

--- a/files/en-us/web/html/microformats/index.html
+++ b/files/en-us/web/html/microformats/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>There are <a href="https://microformats.org/wiki/microformats2#Parsers">open source parsing libraries for most languages</a> for microformats2.</p>
 
-<h2 id="How_Microformats_Work"><span id="How_do_Microformats_Work">How Microformats Work</span></h2>
+<h2>How Microformats Work</h2>
 
 <p>An author of a webpage can add microformats to their HTML. For example if they wanted to identify themselves they could use an <a href="https://microformats.org/wiki/h-card">h-card</a> such as:</p>
 

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>There are now three modes used by the layout engines in web browsers: quirks mode, almost standards mode, and full standards mode. In <strong>quirks mode</strong>, layout emulates nonstandard behavior in Navigator 4 and Internet Explorer 5. This is essential in order to support websites that were built before the widespread adoption of web standards. In <strong>full standards mode</strong>, the behavior is (hopefully) the behavior described by the HTML and CSS specifications. In <strong>almost standards mode</strong>, there are only a very small number of quirks implemented.</p>
 
-<h2 id="How_does_Mozilla_determine_which_mode_to_use.3F">How do browsers determine which mode to use?</h2>
+<h2>How do browsers determine which mode to use?</h2>
 
 <p>For <a href="/en-US/docs/HTML">HTML</a> documents, browsers use a DOCTYPE in the beginning of the document to decide whether to handle it in quirks mode or standards mode. To ensure that your page uses full standards mode, make sure that your page has a DOCTYPE like in this example:</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This remove ID attributes from the rest of the HTML docs, after https://github.com/mdn/content/pull/9124 and https://github.com/mdn/content/pull/9125 remove them from the `<input>` docs.

There are two main things here:
* removing `id="thing"`, and updating anywhere `#thing` is used
* adjusting any IDs that are attached to headings, where the ID doesn't match the one that would be derived from the heading text (and therefore might break a live sample in Markdown. Usually I just removed the heading ID entirely so we use the derived one immediately, and any potential breakages will be obvious.

In https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings I got rid of some footnotes.

