### PR TITLE
[Markdown] [Web/HTML] Fix notes in HTML pages that have misplaced colons

### DIFF
--- a/files/en-us/web/html/attributes/accept/index.html
+++ b/files/en-us/web/html/attributes/accept/index.html
@@ -94,7 +94,7 @@ tags:
 <p>{{EmbedLiveSample('A_basic_example', 650, 60)}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/simple-file.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/simple-file.html">see it running live</a>.</p>
+<p><strong>Note:</strong> You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/simple-file.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/simple-file.html">see it running live</a>.</p>
 </div>
 
 <p>Regardless of the user's device or operating system, the file input provides a button that opens up a file picker dialog that allows the user to choose a file.</p>

--- a/files/en-us/web/html/element/br/index.html
+++ b/files/en-us/web/html/element/br/index.html
@@ -18,7 +18,7 @@ browser-compat: html.elements.br
 <p>As you can see from the above example, a <code>&lt;br&gt;</code> element is included at each point where we want the text to break. The text after the <code>&lt;br&gt;</code> begins again at the start of the next line of the text block.</p>
 
 <div class="note">
-<p><strong>Note</strong>: Do not use <code>&lt;br&gt;</code> to create margins between paragraphs; wrap them in {{htmlelement("p")}} elements and use the <a href="/en-US/docs/Web/CSS">CSS</a> {{cssxref('margin')}} property to control their size.</p>
+<p><strong>Note:</strong> Do not use <code>&lt;br&gt;</code> to create margins between paragraphs; wrap them in {{htmlelement("p")}} elements and use the <a href="/en-US/docs/Web/CSS">CSS</a> {{cssxref('margin')}} property to control their size.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>

--- a/files/en-us/web/html/element/canvas/index.html
+++ b/files/en-us/web/html/element/canvas/index.html
@@ -119,7 +119,7 @@ browser-compat: html.elements.canvas
 </table>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Exceeding the maximum dimensions or area renders the canvas unusable — drawing commands will not work.</p>
+<p><strong>Note:</strong> Exceeding the maximum dimensions or area renders the canvas unusable — drawing commands will not work.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/html/element/input/color/index.html
+++ b/files/en-us/web/html/element/input/color/index.html
@@ -54,7 +54,7 @@ browser-compat: html.elements.input.input-color
 <p>The {{htmlattrxref("value", "input")}} of an {{HTMLElement("input")}} element of type <code>color</code> is always a {{domxref("DOMString")}} which contains a 7-character string specifying an RGB color in hexadecimal format. While you can input the color in either upper- or lower-case, it will be stored in lower-case form. The value is never in any other form, and is never empty.</p>
 
 <div class="note">
-<p><strong>Note</strong>: Setting the value to anything that isn't a valid, fully-opaque, RGB color <em>in hexadecimal notation</em> will result in the value being set to <code>#000000</code>. In particular, you can't use CSS's standardized color names, or any CSS function syntax, to set the value. This makes sense when you keep in mind that HTML and CSS are separate languages and specifications. In addition, colors with an alpha channel are not supported; specifying a color in 9-character hexadecimal notation (e.g. <code>#009900aa</code>) will also result in the color being set to <code>#000000</code>.</p>
+<p><strong>Note:</strong> Setting the value to anything that isn't a valid, fully-opaque, RGB color <em>in hexadecimal notation</em> will result in the value being set to <code>#000000</code>. In particular, you can't use CSS's standardized color names, or any CSS function syntax, to set the value. This makes sense when you keep in mind that HTML and CSS are separate languages and specifications. In addition, colors with an alpha channel are not supported; specifying a color in 9-character hexadecimal notation (e.g. <code>#009900aa</code>) will also result in the color being set to <code>#000000</code>.</p>
 </div>
 
 <h2 id="Using_color_inputs">Using color inputs</h2>

--- a/files/en-us/web/html/element/input/date/index.html
+++ b/files/en-us/web/html/element/input/date/index.html
@@ -169,7 +169,7 @@ console.log(dateControl.valueAsNumber); // prints 1496275200000, a JavaScript ti
 <p>The result is that only days in April 2017 can be selected — the month and year parts of the textbox will be uneditable, and dates outside April 2017 can't be selected in the picker widget.</p>
 
 <div class="note">
-<p><strong>Note</strong>: You <em>should</em> be able to use the {{htmlattrxref("step", "input")}} attribute to vary the number of days jumped each time the date is incremented (e.g. to only make Saturdays selectable). However, this does not seem to be in any implementation at the time of writing.</p>
+<p><strong>Note:</strong> You <em>should</em> be able to use the {{htmlattrxref("step", "input")}} attribute to vary the number of days jumped each time the date is incremented (e.g. to only make Saturdays selectable). However, this does not seem to be in any implementation at the time of writing.</p>
 </div>
 
 <h3 id="Controlling_input_size">Controlling input size</h3>
@@ -470,7 +470,7 @@ daySelect.onchange = function() {
 }</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
+<p><strong>Note:</strong> Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/element/input/datetime-local/index.html
+++ b/files/en-us/web/html/element/input/datetime-local/index.html
@@ -168,7 +168,7 @@ dateControl.value = '2017-06-01T08:30';</pre>
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: You should be able to use the {{htmlattrxref("step", "input")}} attribute to vary the number of days jumped each time the date is incremented (e.g. maybe you only want to make Saturdays selectable). However, this does not seem to work effectively in any implementation at the time of writing.</p>
+<p><strong>Note:</strong> You should be able to use the {{htmlattrxref("step", "input")}} attribute to vary the number of days jumped each time the date is incremented (e.g. maybe you only want to make Saturdays selectable). However, this does not seem to work effectively in any implementation at the time of writing.</p>
 </div>
 
 <h3 id="Controlling_input_size">Controlling input size</h3>
@@ -572,7 +572,7 @@ daySelect.onchange = function() {
 }</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
+<p><strong>Note:</strong> Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/element/input/file/index.html
+++ b/files/en-us/web/html/element/input/file/index.html
@@ -179,7 +179,7 @@ browser-compat: html.elements.input.input-file
 <p>{{EmbedLiveSample('A_basic_example', 650, 90)}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/simple-file.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/simple-file.html">see it running live</a>.</p>
+<p><strong>Note:</strong> You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/simple-file.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/simple-file.html">see it running live</a>.</p>
 </div>
 
 <p>Regardless of the user's device or operating system, the file input provides a button that opens up a file picker dialog that allows the user to choose a file.</p>
@@ -208,7 +208,7 @@ browser-compat: html.elements.input.input-file
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: You can set as well as get the value of <code>HTMLInputElement.files</code> in all modern browsers; this was most recently added to Firefox, in version 57 (see {{bug(1384030)}}).</p>
+<p><strong>Note:</strong> You can set as well as get the value of <code>HTMLInputElement.files</code> in all modern browsers; this was most recently added to Firefox, in version 57 (see {{bug(1384030)}}).</p>
 </div>
 
 <h3 id="Limiting_accepted_file_types">Limiting accepted file types</h3>
@@ -248,7 +248,7 @@ browser-compat: html.elements.input.input-file
 <p>{{EmbedLiveSample('Limiting_accepted_file_types', 650, 90)}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/file-with-accept.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/file-with-accept.html">see it running live</a>.</p>
+<p><strong>Note:</strong> You can find this example on GitHub too — see the <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/file-with-accept.html">source code</a>, and also <a href="https://mdn.github.io/learning-area/html/forms/file-examples/file-with-accept.html">see it running live</a>.</p>
 </div>
 
 <p>It may look similar, but if you try selecting a file with this input, you'll see that the file picker only lets you select the file types specified in the <code>accept</code> value (the exact interface differs across browsers and operating systems).</p>
@@ -277,7 +277,7 @@ input.value = "foo";
 <p>In this example, we'll present a slightly more advanced file chooser that takes advantage of the file information available in the <code>HTMLInputElement.files</code> property, as well as showing off a few clever tricks.</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can see the complete source code for this example on GitHub — <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/file-example.html">file-example.html</a> (<a href="https://mdn.github.io/learning-area/html/forms/file-examples/file-example.html">see it live also</a>). We won't explain the CSS; the JavaScript is the main focus.</p>
+<p><strong>Note:</strong> You can see the complete source code for this example on GitHub — <a href="https://github.com/mdn/learning-area/blob/master/html/forms/file-examples/file-example.html">file-example.html</a> (<a href="https://mdn.github.io/learning-area/html/forms/file-examples/file-example.html">see it live also</a>). We won't explain the CSS; the JavaScript is the main focus.</p>
 </div>
 
 <p>First of all, let's look at the HTML:</p>

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -1199,7 +1199,7 @@ nameInput.addEventListener('invalid', () =&gt; {
 </div>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Firefox supported a proprietary error attribute — <code>x-moz-errormessage</code> — for many versions, which allowed you set custom error messages in a similar way. This has been removed as of version 66 (see {{bug(1513890)}}).</p>
+<p><strong>Note:</strong> Firefox supported a proprietary error attribute — <code>x-moz-errormessage</code> — for many versions, which allowed you set custom error messages in a similar way. This has been removed as of version 66 (see {{bug(1513890)}}).</p>
 </div>
 
 <h3 id="Localization">Localization</h3>

--- a/files/en-us/web/html/element/input/month/index.html
+++ b/files/en-us/web/html/element/input/month/index.html
@@ -455,7 +455,7 @@ function populateYears() {
 }</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
+<p><strong>Note:</strong> Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/element/input/number/index.html
+++ b/files/en-us/web/html/element/input/number/index.html
@@ -150,7 +150,7 @@ browser-compat: html.elements.input.input-number
 </div>
 
 <div class="note">
-<p><strong>Note</strong>: It's crucial to remember that a user can tinker with your HTML behind the scenes, so your site <em>must not</em> use simple client-side validation for any security purposes. You <em>must</em> verify on the server side any transaction in which the provided value may have security implications of any kind.</p>
+<p><strong>Note:</strong> It's crucial to remember that a user can tinker with your HTML behind the scenes, so your site <em>must not</em> use simple client-side validation for any security purposes. You <em>must</em> verify on the server side any transaction in which the provided value may have security implications of any kind.</p>
 </div>
 
 <p>Mobile browsers further help with the user experience by showing a special keyboard more suited for entering numbers when the user tries to enter a value.</p>
@@ -167,7 +167,7 @@ browser-compat: html.elements.input.input-number
 <p>A number input is considered valid when empty and when a single number is entered, but is otherwise invalid. If the {{htmlattrxref("required", "input")}} attribute is used, the input is no longer considered valid when empty.</p>
 
 <div class="note">
-<p><strong>Note</strong>: Any number is an acceptable value, as long as it is a <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#valid-floating-point-number">valid floating point number</a> (that is, not <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a>).</p>
+<p><strong>Note:</strong> Any number is an acceptable value, as long as it is a <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#valid-floating-point-number">valid floating point number</a> (that is, not <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a>).</p>
 </div>
 
 <h3 id="Placeholders">Placeholders</h3>

--- a/files/en-us/web/html/element/input/radio/index.html
+++ b/files/en-us/web/html/element/input/radio/index.html
@@ -108,7 +108,7 @@ browser-compat: html.elements.input.input-radio
 <p>If you omit the <code>value</code> attribute in the HTML, the submitted form data assigns the value <code>on</code> to the group. In this scenario, if the user clicked on the "Phone" option and submitted the form, the resulting form data would be <code>contact=on</code>, which isn't helpful. So don't forget to set your <code>value</code> attributes!</p>
 
 <div class="note">
-<p><strong>Note</strong>: If no radio button is selected when the form is submitted, the radio group is not included in the submitted form data at all, since there is no value to report.</p>
+<p><strong>Note:</strong> If no radio button is selected when the form is submitted, the radio group is not included in the submitted form data at all, since there is no value to report.</p>
 </div>
 
 <p>It's fairly uncommon to actually want to allow the form to be submitted without any of the radio buttons in a group selected, so it is usually wise to have one default to the <code>checked</code> state. See {{anch("Selecting a radio button by default")}} below.</p>
@@ -221,7 +221,7 @@ form.addEventListener("submit", function(event) {
 <p>In this case, the first radio button is now selected by default.</p>
 
 <div class="note">
-<p><strong>Note</strong>: If you put the <code>checked</code> attribute on more than one radio button, later instances will override earlier ones; that is, the last <code>checked</code> radio button will be the one that is selected. This is because only one radio button in a group can ever be selected at once, and the user agent automatically deselects others each time a new one is marked as checked.</p>
+<p><strong>Note:</strong> If you put the <code>checked</code> attribute on more than one radio button, later instances will override earlier ones; that is, the last <code>checked</code> radio button will be the one that is selected. This is because only one radio button in a group can ever be selected at once, and the user agent automatically deselects others each time a new one is marked as checked.</p>
 </div>
 
 <h3 id="Providing_a_bigger_hit_area_for_your_radio_buttons">Providing a bigger hit area for your radio buttons</h3>

--- a/files/en-us/web/html/element/input/search/index.html
+++ b/files/en-us/web/html/element/input/search/index.html
@@ -311,7 +311,7 @@ browser-compat: html.elements.input.input-search
 <p>There is no visual difference from the previous example, but screenreader users have way more information available to them.</p>
 
 <div class="note">
-<p><strong>Note</strong>: See <a href="/en-US/docs/Learn/Accessibility/WAI-ARIA_basics#signpostslandmarks">Signposts/Landmarks</a> for more information about such accessibility features.</p>
+<p><strong>Note:</strong> See <a href="/en-US/docs/Learn/Accessibility/WAI-ARIA_basics#signpostslandmarks">Signposts/Landmarks</a> for more information about such accessibility features.</p>
 </div>
 
 <h3 id="Physical_input_element_size">Physical input element size</h3>
@@ -335,7 +335,7 @@ browser-compat: html.elements.input.input-search
 <p><code>&lt;input&gt;</code> elements of type <code>search</code> have the same validation features available to them as regular <code>text</code> inputs. It is less likely that you'd want to use validation features in general for search boxes. In many cases, users should just be allowed to search for anything, but there are a few cases to consider, such as searches against data of a known format.</p>
 
 <div class="note">
-<p><strong>Note</strong>: HTML form validation is <em>not</em> a substitute for scripts that ensure that the entered data is in the proper format. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
+<p><strong>Note:</strong> HTML form validation is <em>not</em> a substitute for scripts that ensure that the entered data is in the proper format. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
 </div>
 
 <h3 id="A_note_on_styling">A note on styling</h3>

--- a/files/en-us/web/html/element/input/text/index.html
+++ b/files/en-us/web/html/element/input/text/index.html
@@ -280,7 +280,7 @@ browser-compat: html.elements.input.input-text
 <p><code>&lt;input&gt;</code> elements of type <code>text</code> have no automatic validation applied to them (since a basic text input needs to be capable of accepting any arbitrary string), but there are some client-side validation options available, which we'll discuss below.</p>
 
 <div class="note">
-<p><strong>Note</strong>: HTML form validation is <em>not</em> a substitute for server-scripts that ensure the entered data is in the proper format. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
+<p><strong>Note:</strong> HTML form validation is <em>not</em> a substitute for server-scripts that ensure the entered data is in the proper format. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.</p>
 </div>
 
 <h3 id="A_note_on_styling">A note on styling</h3>

--- a/files/en-us/web/html/element/input/week/index.html
+++ b/files/en-us/web/html/element/input/week/index.html
@@ -370,7 +370,7 @@ function populateWeeks() {
 }</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
+<p><strong>Note:</strong> Remember that some years have 53 weeks in them (see <a href="https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year">Weeks per year</a>)! You'll need to take this into consideration when developing production apps.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/element/script/index.html
+++ b/files/en-us/web/html/element/script/index.html
@@ -107,7 +107,7 @@ browser-compat: html.elements.script
  </ul>
 
  <div class="notecard note">
- <p><strong>Note</strong>: An empty string value (<code>""</code>) is both the default value, and a fallback value if <code>referrerpolicy</code> is not supported. If <code>referrerpolicy</code> is not explicitly specified on the <code>&lt;script&gt;</code> element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to <code>strict-origin-when-cross-origin</code>.</p>
+ <p><strong>Note:</strong> An empty string value (<code>""</code>) is both the default value, and a fallback value if <code>referrerpolicy</code> is not supported. If <code>referrerpolicy</code> is not explicitly specified on the <code>&lt;script&gt;</code> element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to <code>strict-origin-when-cross-origin</code>.</p>
  </div>
  </dd>
  <dt>{{htmlattrdef("src")}}</dt>

--- a/files/en-us/web/html/element/slot/index.html
+++ b/files/en-us/web/html/element/slot/index.html
@@ -93,7 +93,7 @@ browser-compat: html.elements.slot
 &lt;/template&gt;</pre>
 
 <div class="note">
-<p><strong>Note</strong>: You can see this complete example in action at <a class="external external-icon" href="https://github.com/mdn/web-components-examples/tree/master/element-details" rel="noopener">element-details</a> (see it <a class="external external-icon" href="https://mdn.github.io/web-components-examples/element-details/" rel="noopener">running live</a>). In addition, you can find an explanation at <a href="/en-US/docs/Web/Web_Components/Using_templates_and_slots">Using templates and slots</a>.</p>
+<p><strong>Note:</strong> You can see this complete example in action at <a class="external external-icon" href="https://github.com/mdn/web-components-examples/tree/master/element-details" rel="noopener">element-details</a> (see it <a class="external external-icon" href="https://mdn.github.io/web-components-examples/element-details/" rel="noopener">running live</a>). In addition, you can find an explanation at <a href="/en-US/docs/Web/Web_Components/Using_templates_and_slots">Using templates and slots</a>.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/element/table/index.html
+++ b/files/en-us/web/html/element/table/index.html
@@ -312,7 +312,7 @@ document.querySelector('table').tBodies[0].sort(function(a, b){
 <p>The following example adds an event handler to every <code>&lt;th&gt;</code> element of every <code>&lt;table&gt;</code> in the <code>document</code>; it sorts all the <code>&lt;tbody&gt;</code>'s rows, basing the sorting on the <code>td</code> cells contained in the rows.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: This solution assumes that the <code>&lt;td&gt;</code> elements are populated by raw text with no descendant elements.</p>
+<p><strong>Note:</strong> This solution assumes that the <code>&lt;td&gt;</code> elements are populated by raw text with no descendant elements.</p>
 </div>
 
 <h5 id="HTML_2">HTML</h5>

--- a/files/en-us/web/html/global_attributes/accesskey/index.html
+++ b/files/en-us/web/html/global_attributes/accesskey/index.html
@@ -15,7 +15,7 @@ browser-compat: html.global_attributes.accesskey
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-accesskey.html","tabbed-shorter")}}</div>
 
 <div class="note">
-<p><strong>Note</strong>: In the WHATWG spec, it says you can specify multiple space-separated characters, and the browser will use the first one it supports. However, this does not work in most browsers. IE/Edge uses the first one it supports without problems, provided there are no conflicts with other commands.</p>
+<p><strong>Note:</strong> In the WHATWG spec, it says you can specify multiple space-separated characters, and the browser will use the first one it supports. However, this does not work in most browsers. IE/Edge uses the first one it supports without problems, provided there are no conflicts with other commands.</p>
 </div>
 
 <p>The way to activate the accesskey depends on the browser and its platform:</p>

--- a/files/en-us/web/html/global_attributes/itemscope/index.html
+++ b/files/en-us/web/html/global_attributes/itemscope/index.html
@@ -243,7 +243,7 @@ browser-compat: html.global_attributes.itemscope
 </table>
 
 <div class="note">
-<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://search.google.com/test/rich-results">Rich Results Testing Tool</a>. Try it on the HTML shown above.</p>
+<p><strong>Note:</strong> A handy tool for extracting microdata structures from HTML is Google's <a href="https://search.google.com/test/rich-results">Rich Results Testing Tool</a>. Try it on the HTML shown above.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/global_attributes/itemtype/index.html
+++ b/files/en-us/web/html/global_attributes/itemtype/index.html
@@ -208,7 +208,7 @@ browser-compat: html.global_attributes.itemtype
 </table>
 
 <div class="note">
-<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/structured-data/testing-tool/">Structured Data Testing Tool</a>. Try it on the HTML shown above</p>
+<p><strong>Note:</strong> A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/structured-data/testing-tool/">Structured Data Testing Tool</a>. Try it on the HTML shown above</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/html/link_types/preload/index.html
+++ b/files/en-us/web/html/link_types/preload/index.html
@@ -85,11 +85,11 @@ before browsers' main rendering machinery kicks in. This ensures they are availa
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: <code>video</code> preloading is included in the Preload spec, but is not currently implemented by browsers.</p>
+<p><strong>Note:</strong> <code>video</code> preloading is included in the Preload spec, but is not currently implemented by browsers.</p>
 </div>
 
 <div class="note">
-<p><strong>Note</strong>: There's more detail about these values and the web features they expect to be consumed by in the Preload spec — see <a href="https://w3c.github.io/preload/#link-element-extensions">link element extensions</a>. Also note that the full list of values the <code>as</code> attribute can take is governed by the Fetch spec — see <a href="https://fetch.spec.whatwg.org/#concept-request-destination">request destinations</a>.</p>
+<p><strong>Note:</strong> There's more detail about these values and the web features they expect to be consumed by in the Preload spec — see <a href="https://w3c.github.io/preload/#link-element-extensions">link element extensions</a>. Also note that the full list of values the <code>as</code> attribute can take is governed by the Fetch spec — see <a href="https://fetch.spec.whatwg.org/#concept-request-destination">request destinations</a>.</p>
 </div>
 
 <h2 id="Including_a_MIME_type">Including a MIME type</h2>

--- a/files/en-us/web/html/microdata/index.html
+++ b/files/en-us/web/html/microdata/index.html
@@ -148,7 +148,7 @@ tags:
 <p>{{ EmbedLiveSample('HTML', '', '100', '', 'Web/HTML/Microdata') }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/search/docs/guides/intro-structured-data">Structured Data Testing Tool</a>. Try it on the HTML shown above.</p>
+<p><strong>Note:</strong> A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/search/docs/guides/intro-structured-data">Structured Data Testing Tool</a>. Try it on the HTML shown above.</p>
 </div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This PR fixes all notes in the HTML docs where the colon was outside the `<strong>Note</strong>` part.
