### PR TITLE
Fixes #2608: adds negative examples for path matching:

### DIFF
--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -120,11 +120,18 @@ For example, if `Domain=mozilla.org` is set, then cookies are available on subdo
 
 The `Path` attribute indicates a URL path that must exist in the requested URL in order to send the `Cookie` header. The `%x2F` ("/") character is considered a directory separator, and subdirectories match as well.
 
-For example, if `Path=/docs` is set, these paths match:
+For example, if `Path=/docs` is set, these request paths match:
 
 - `/docs`
+- `/docs/`
 - `/docs/Web/`
 - `/docs/Web/HTTP`
+
+But these request paths don't:
+
+- `/`
+- `/docsets`
+- `/fr/docs`
 
 #### SameSite attribute
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -120,7 +120,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     The forward slash (`/`) character is interpreted as a directory separator,
     and subdirectories will be matched as well:
-    for `Path=/docs`, `/docs`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
+    for `Path=/docs`, the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match, but none of `/`, `/docsets`, `/fr/docs` would.
 
 - `Secure` {{optional_inline}}
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -120,7 +120,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     The forward slash (`/`) character is interpreted as a directory separator,
     and subdirectories will be matched as well:
-    for `Path=/docs`, the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match, but none of `/`, `/docsets`, `/fr/docs` would.
+    for `Path=/docs`:
+    * the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match
+    * the request paths `/`, `/docsets`, `/fr/docs` will not match.
 
 - `Secure` {{optional_inline}}
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -121,8 +121,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     The forward slash (`/`) character is interpreted as a directory separator,
     and subdirectories will be matched as well:
     for `Path=/docs`:
-    * the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match
-    * the request paths `/`, `/docsets`, `/fr/docs` will not match.
+    - the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match
+    - the request paths `/`, `/docsets`, `/fr/docs` will not match.
 
 - `Secure` {{optional_inline}}
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #2608

> What was wrong/why is this fix needed? (quick summary only)

There were matching path examples but none for mismatch.

> Anything else that could help us review it
