### PR TITLE
[Markdown] [Web/HTML] Fix HTML notes that aren't in a P

### DIFF
--- a/files/en-us/web/html/attributes/autocomplete/index.html
+++ b/files/en-us/web/html/attributes/autocomplete/index.html
@@ -45,7 +45,7 @@ tags:
 <dl>
 	<dt>"<code>off</code>"</dt>
 	<dd>The browser is not permitted to automatically enter or select a value for this field. It is possible that the document or application provides its own autocomplete feature, or that security concerns require that the field's value not be automatically entered.
-	<div class="note"><strong>Note:</strong> In most modern browsers, setting <code>autocomplete</code> to "<code>off</code>" will not prevent a password manager from asking the user if they would like to save username and password information, or from automatically filling in those values in a site's login form. See <a href="/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields">the autocomplete attribute and login fields</a>.</div>
+	<div class="note"><p><strong>Note:</strong> In most modern browsers, setting <code>autocomplete</code> to "<code>off</code>" will not prevent a password manager from asking the user if they would like to save username and password information, or from automatically filling in those values in a site's login form. See <a href="/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields">the autocomplete attribute and login fields</a>.</p></div>
 	</dd>
 	<dt>"<code>on</code>"</dt>
 	<dd>The browser is allowed to automatically complete the input. No guidance is provided as to the type of data expected in the field, so the browser may use its own judgement.</dd>

--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -96,7 +96,7 @@ tags:
    <td><code>background</code></td>
    <td>{{ HTMLElement("body") }}, {{ HTMLElement("table") }}, {{ HTMLElement("td") }}, {{ HTMLElement("th") }}</td>
    <td>Specifies the URL of an image file.
-    <div class="note"><strong>Note:</strong> Although browsers and email clients may still support this attribute, it is obsolete. Use CSS {{ Cssxref("background-image") }} instead.</div>
+    <div class="note"><p><strong>Note:</strong> Although browsers and email clients may still support this attribute, it is obsolete. Use CSS {{ Cssxref("background-image") }} instead.</p></div>
    </td>
   </tr>
   <tr>
@@ -456,7 +456,7 @@ tags:
    <td><code><a href="/en-US/docs/Web/HTML/Element/html#attr-manifest">manifest</a></code> {{deprecated_inline}}</td>
    <td>{{ HTMLElement("html") }}</td>
    <td>Specifies the URL of the document's cache manifest.
-    <div class="note"><strong>Note:</strong> This attribute is obsolete, use <a href="/en-US/docs/Web/Manifest"><code>&lt;link rel="manifest"&gt;</code></a> instead.</div>
+    <div class="note"><p><strong>Note:</strong> This attribute is obsolete, use <a href="/en-US/docs/Web/Manifest"><code>&lt;link rel="manifest"&gt;</code></a> instead.</p></div>
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/html/element/col/index.html
+++ b/files/en-us/web/html/element/col/index.html
@@ -109,7 +109,7 @@ browser-compat: html.elements.col
   <li>and <code>top</code>, which will put the text as close to the top of the cell as it is possible.</li>
  </ul>
 
- <div class="note"><strong>Note:</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <ul>
   <li>Do not try to set the {{cssxref("vertical-align")}} property on a selector giving a <code>&lt;col&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;col&gt;</code> element, they won't inherit it.</li>

--- a/files/en-us/web/html/element/colgroup/index.html
+++ b/files/en-us/web/html/element/colgroup/index.html
@@ -58,7 +58,7 @@ browser-compat: html.elements.colgroup
 <dl>
  <dt>{{htmlattrdef("span")}}</dt>
  <dd>This attribute contains a positive integer indicating the number of consecutive columns the <code>&lt;colgroup&gt;</code> element spans. If not present, its default value is <code>1</code>.
- <div class="note"><strong>Note:</strong> This attribute is applied on the attributes of the column group, it has no effect on the CSS styling rules associated with it or, even more, to the cells of the column's members of the group.
+ <div class="note"><p><strong>Note:</strong> This attribute is applied on the attributes of the column group, it has no effect on the CSS styling rules associated with it or, even more, to the cells of the column's members of the group.</p>
  <ul>
   <li>The <code>span</code> attribute is not permitted if there are one or more <code>&lt;col&gt;</code> elements within the <code>&lt;colgroup&gt;</code>.</li>
  </ul>
@@ -83,7 +83,7 @@ browser-compat: html.elements.colgroup
 
  <p>If this attribute is not set, the <code>left</code> value is assumed. The descendant {{HTMLElement("col")}} elements may override this value using their own {{htmlattrxref("align", "col")}} attribute.</p>
 
- <div class="note"><strong>Note:</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <ul>
   <li>Do not try to set the {{cssxref("text-align")}} property on a selector giving a {{HTMLElement("colgroup")}} element. Because {{HTMLElement("td")}} elements are not descendant of the {{HTMLElement("colgroup")}} element, they won't inherit it.</li>

--- a/files/en-us/web/html/element/frameset/index.html
+++ b/files/en-us/web/html/element/frameset/index.html
@@ -13,7 +13,7 @@ browser-compat: html.elements.frameset
 
 <p>The <strong><code>&lt;frameset&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is used to contain {{HTMLElement("frame")}} elements.</p>
 
-<div class="note"><strong>Note:</strong> Because the use of frames is now discouraged in favor of using {{HTMLElement("iframe")}}, this element is not typically used by modern web sites.</div>
+<div class="note"><p><strong>Note:</strong> Because the use of frames is now discouraged in favor of using {{HTMLElement("iframe")}}, this element is not typically used by modern web sites.</p></div>
 
 <h2 id="Attributes">Attributes</h2>
 

--- a/files/en-us/web/html/element/input/file/index.html
+++ b/files/en-us/web/html/element/input/file/index.html
@@ -65,7 +65,7 @@ browser-compat: html.elements.input.input-file
 
 <p>A file input's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that represents the path to the selected file(s). If the user selected multiple files, the <code>value</code> represents the first file in the list of files they selected. The other files can be identified using the input's <code>HTMLInputElement.files</code> property.</p>
 
-<div class="note"><strong>Note:</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <ol>
  <li>If multiple files are selected, the string represents the first selected file. JavaScript can access the other files <a href="/en-US/docs/Web/API/File/Using_files_from_web_applications#getting_information_about_selected_files">through the input's <code>files</code> property</a>.</li>
@@ -118,7 +118,7 @@ browser-compat: html.elements.input.input-file
 
 <p>The <a href="/en-US/docs/Web/HTML/Attributes/capture"><code>capture</code></a> attribute value is a string that specifies which camera to use for capture of image or video data, if the <a href="/en-US/docs/Web/HTML/Attributes/accept"><code>accept</code></a> attribute indicates that the input should be of one of those types. A value of <code>user</code> indicates that the user-facing camera and/or microphone should be used. A value of <code>environment</code> specifies that the outward-facing camera and/or microphone should be used. If this attribute is missing, the {{Glossary("user agent")}} is free to decide on its own what to do. If the requested facing mode isn't available, the user agent may fall back to its preferred default mode.</p>
 
-<div class="note"><strong>Note:</strong> <code>capture</code> was previously a Boolean attribute which, if present, requested that the device's media capture device(s) such as camera or microphone be used instead of requesting a file input.</div>
+<div class="note"><p><strong>Note:</strong> <code>capture</code> was previously a Boolean attribute which, if present, requested that the device's media capture device(s) such as camera or microphone be used instead of requesting a file input.</p></div>
 
 <h3 id="attr-files"><code id="files">files</code></h3>
 

--- a/files/en-us/web/html/element/li/index.html
+++ b/files/en-us/web/html/element/li/index.html
@@ -67,7 +67,7 @@ browser-compat: html.elements.li
  </ul>
  This type overrides the one used by its parent {{HTMLElement("ol")}} element, if any.
 
- <div class="note"><strong>Note:</strong> This attribute has been deprecated; use the CSS {{cssxref("list-style-type")}} property instead.</div>
+ <div class="note"><p><strong>Note:</strong> This attribute has been deprecated; use the CSS {{cssxref("list-style-type")}} property instead.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/meta/name/index.html
+++ b/files/en-us/web/html/element/meta/name/index.html
@@ -21,7 +21,7 @@ browser-compat: html.elements.meta.name
  <li>
   <p><code>application-name</code>: the name of the application running in the web page.</p>
 
-  <div class="note"><strong>Note:</strong>
+  <div class="note"><p><strong>Note:</strong></p>
 
   <ul>
    <li>Browsers may use this to identify the application. It is different from the {{HTMLElement("title")}} element, which usually contain the application name, but may also contain information like the document name or a status.</li>

--- a/files/en-us/web/html/element/meter/index.html
+++ b/files/en-us/web/html/element/meter/index.html
@@ -56,7 +56,7 @@ browser-compat: html.elements.meter
 <dl>
  <dt>{{htmlattrdef("value")}}</dt>
  <dd>The current numeric value. This must be between the minimum and maximum values (<code>min</code> attribute and <code>max</code> attribute) if they are specified. If unspecified or malformed, the value is <code>0</code>. If specified, but not within the range given by the <code>min</code> attribute and <code>max</code> attribute, the value is equal to the nearest end of the range.
- <div class="note"><strong>Note:</strong> Unless the <code>value</code> attribute is between <code>0</code> and <code>1</code> (inclusive), the <code>min</code> and <code>max</code> attributes should define the range so that the <code>value</code> attribute's value is within it.</div>
+ <div class="note"><p><strong>Note:</strong> Unless the <code>value</code> attribute is between <code>0</code> and <code>1</code> (inclusive), the <code>min</code> and <code>max</code> attributes should define the range so that the <code>value</code> attribute's value is within it.</p></div>
  </dd>
  <dt>{{htmlattrdef("min")}}</dt>
  <dd>The lower numeric bound of the measured range. This must be less than the maximum value (<code>max</code> attribute), if specified. If unspecified, the minimum value is <code>0</code>.</dd>

--- a/files/en-us/web/html/element/plaintext/index.html
+++ b/files/en-us/web/html/element/plaintext/index.html
@@ -15,7 +15,7 @@ browser-compat: html.elements.plaintext
 
 <p>The <strong><code>&lt;plaintext&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element renders everything following the start tag as raw text, ignoring any following HTML. There is no closing tag, since everything after it is considered raw text.</p>
 
-<div class="note"><strong>Note:</strong> Do not use this element.
+<div class="note"><p><strong>Note:</strong> Do not use this element.</p>
 
 <ul>
  <li><code>&lt;plaintext&gt;</code> is deprecated since HTML 2, and not all browsers implemented it. Browsers that did implement it didn't do so consistently.</li>

--- a/files/en-us/web/html/element/select/index.html
+++ b/files/en-us/web/html/element/select/index.html
@@ -51,7 +51,7 @@ browser-compat: html.elements.select
  <dd>
  <p>If the control is presented as a scrolling list box (e.g. when <code>multiple</code> is specified), this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is <code>0</code>.</p>
 
- <div class="note"><strong>Note:</strong> According to the HTML5 specification, the default value for size should be <code>1</code>; however, in practice, this has been found to break some web sites, and no other browser currently does that, so Mozilla has opted to continue to return <code>0</code> for the time being with Firefox.</div>
+ <div class="note"><p><strong>Note:</strong> According to the HTML5 specification, the default value for size should be <code>1</code>; however, in practice, this has been found to break some web sites, and no other browser currently does that, so Mozilla has opted to continue to return <code>0</code> for the time being with Firefox.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/tbody/index.html
+++ b/files/en-us/web/html/element/tbody/index.html
@@ -75,7 +75,7 @@ browser-compat: html.elements.tbody
 
  <p>As this attribute is deprecated, use the CSS {{cssxref("text-align")}} property instead.</p>
 
- <div class="note"><strong>Note:</strong> The equivalent <code>text-align</code> property for the <code>align="char"</code> is not implemented in any browsers yet. See the <a href="/en-US/docs/Web/CSS/text-align#browser_compatibility"><code>text-align</code>'s browser compatibility section</a> for the <code>&lt;string&gt;</code> value.</div>
+ <div class="note"><p><strong>Note:</strong> The equivalent <code>text-align</code> property for the <code>align="char"</code> is not implemented in any browsers yet. See the <a href="/en-US/docs/Web/CSS/text-align#browser_compatibility"><code>text-align</code>'s browser compatibility section</a> for the <code>&lt;string&gt;</code> value.</p></div>
  </dd>
  <dt>{{htmlattrdef("bgcolor")}} {{Deprecated_inline}}</dt>
  <dd>

--- a/files/en-us/web/html/element/td/index.html
+++ b/files/en-us/web/html/element/td/index.html
@@ -76,7 +76,7 @@ browser-compat: html.elements.td
  <dt>{{htmlattrdef("abbr")}} {{deprecated_inline}}</dt>
  <dd>
  <p>This attribute contains a short abbreviated description of the cell's content. Some user-agents, such as speech readers, may present this description before the content itself.</p>
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard. Alternatively, you can put the abbreviated description inside the cell and place the long content in the <strong>title</strong> attribute.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard. Alternatively, you can put the abbreviated description inside the cell and place the long content in the <strong>title</strong> attribute.</p></div>
  </dd>
  <dt>{{htmlattrdef("align")}} {{deprecated_inline}}</dt>
  <dd>
@@ -91,7 +91,7 @@ browser-compat: html.elements.td
 
  <p>The default value when this attribute is not specified is <code>left</code>.</p>
 
- <div class="note"><strong>Note:</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <ul>
   <li>To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values, apply the CSS {{cssxref("text-align")}} property to the element.</li>

--- a/files/en-us/web/html/element/textarea/index.html
+++ b/files/en-us/web/html/element/textarea/index.html
@@ -78,7 +78,7 @@ browser-compat: html.elements.textarea
  <dd>The name of the control.</dd>
  <dt>{{ htmlattrdef("placeholder") }}</dt>
  <dd>A hint to the user of what can be entered in the control. Carriage returns or line-feeds within the placeholder text must be treated as line breaks when rendering the hint.
- <div class="note"><strong>Note:</strong> Placeholders should only be used to show an example of the type of data that should be entered into a form; they are <em>not</em> a substitute for a proper {{HTMLElement("label")}} element tied to the input. See {{SectionOnPage("/en-US/docs/Web/HTML/Element/input", "Labels and placeholders")}} for a full explanation.</div>
+ <div class="note"><p><strong>Note:</strong> Placeholders should only be used to show an example of the type of data that should be entered into a form; they are <em>not</em> a substitute for a proper {{HTMLElement("label")}} element tied to the input. See {{SectionOnPage("/en-US/docs/Web/HTML/Element/input", "Labels and placeholders")}} for a full explanation.</p></div>
  </dd>
  <dt>{{ htmlattrdef("readonly") }}</dt>
  <dd>This Boolean attribute indicates that the user cannot modify the value of the control. Unlike the <code>disabled</code> attribute, the <code>readonly</code> attribute does not prevent the user from clicking or selecting in the control. The value of a read-only control is still submitted with the form.</dd>

--- a/files/en-us/web/html/element/tfoot/index.html
+++ b/files/en-us/web/html/element/tfoot/index.html
@@ -71,7 +71,7 @@ browser-compat: html.elements.tfoot
 
  <p>If this attribute is not set, the <code>left</code> value is assumed.</p>
 
- <div class="note"><strong>Note:</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <ul>
   <li>To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values, use the CSS {{cssxref("text-align")}} property on it.</li>
@@ -98,7 +98,7 @@ browser-compat: html.elements.tfoot
   <li>and <code>top</code>, which will put the text as close to the top of the cell as it is possible.</li>
  </ul>
 
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/th/index.html
+++ b/files/en-us/web/html/element/th/index.html
@@ -97,7 +97,7 @@ browser-compat: html.elements.th
 
  <p>The default value when this attribute is not specified is <code>left</code>.</p>
 
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard.
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard.</p>
 
  <ul>
   <li>To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values, apply the CSS {{cssxref("text-align")}} property to the element.</li>
@@ -107,7 +107,7 @@ browser-compat: html.elements.th
  </dd>
  <dt>{{htmlattrdef("axis")}} {{deprecated_inline}}</dt>
  <dd>This attribute contains a list of space-separated strings. Each string is the <code>id</code> of a group of cells that this header applies to.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the {{htmlattrxref("scope", "th")}} attribute instead.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the {{htmlattrxref("scope", "th")}} attribute instead.</p></div>
  </dd>
  <dt>{{htmlattrdef("bgcolor")}} {{Non-standard_inline}}</dt>
  <dd>This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in <a href="https://www.w3.org/Graphics/Color/sRGB">sRGB</a> and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings:
@@ -130,19 +130,19 @@ browser-compat: html.elements.th
      <li><code>aqua</code> = "#00FFFF"</li>
   </ul>
 
- <div class="note"><strong>Note:</strong> Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The {{HTMLElement("th")}} element should be styled using <a href="/en-US/docs/Web/CSS">CSS</a>. To create a similar effect use the {{cssxref("background-color")}} property in <a href="/en-US/docs/Web/CSS">CSS</a> instead.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The {{HTMLElement("th")}} element should be styled using <a href="/en-US/docs/Web/CSS">CSS</a>. To create a similar effect use the {{cssxref("background-color")}} property in <a href="/en-US/docs/Web/CSS">CSS</a> instead.</p></div>
  </dd>
  <dt>{{htmlattrdef("char")}} {{deprecated_inline}}</dt>
  <dd>The content in the cell element is aligned to a character. Typical values include a period (.) to align numbers or monetary values. If {{htmlattrxref("align", "th")}} is not set to <code>char</code>, this attribute is ignored.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard. To achieve the same effect, you can specify the character as the first value of the {{cssxref("text-align")}} property.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard. To achieve the same effect, you can specify the character as the first value of the {{cssxref("text-align")}} property.</p></div>
  </dd>
  <dt>{{htmlattrdef("charoff")}} {{deprecated_inline}}</dt>
  <dd>This attribute is used to shift column data to the right of the character specified by the <strong>char</strong> attribute. Its value specifies the length of this shift.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard.</p></div>
  </dd>
  <dt>{{htmlattrdef("height")}} {{deprecated_inline}}</dt>
  <dd>This attribute is used to define a recommended cell height.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the CSS {{cssxref("height")}} property instead.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the CSS {{cssxref("height")}} property instead.</p></div>
  </dd>
  <dt>{{htmlattrdef("valign")}} {{deprecated_inline}}</dt>
  <dd>This attribute specifies how a text is vertically aligned inside a cell. Possible values for this attribute are:
@@ -153,11 +153,11 @@ browser-compat: html.elements.th
   <li>and <code>top</code>: Positions the text near the top of the cell.</li>
  </ul>
 
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the CSS {{cssxref("vertical-align")}} property instead.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the CSS {{cssxref("vertical-align")}} property instead.</p></div>
  </dd>
  <dt>{{htmlattrdef("width")}} {{deprecated_inline}}</dt>
  <dd>This attribute is used to define a recommended cell width. Additional space can be added with the {{domxref("HTMLTableElement.cellSpacing", "cellspacing")}} and {{domxref("HTMLTableElement.cellPadding", "cellpadding")}} properties and the width of the {{HTMLElement("col")}} element can also create extra width. But, if a column's width is too narrow to show a particular cell properly, it will be widened when displayed.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the CSS {{cssxref("width")}} property instead.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete in the latest standard: use the CSS {{cssxref("width")}} property instead.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/thead/index.html
+++ b/files/en-us/web/html/element/thead/index.html
@@ -68,7 +68,7 @@ browser-compat: html.elements.thead
 
  <p>If this attribute is not set, the <code>left</code> value is assumed.</p>
 
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (not supported) in the latest standard.
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete (not supported) in the latest standard.</p>
 
  <ul>
   <li>To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values, use the CSS {{cssxref("text-align")}} property on it.</li>
@@ -101,11 +101,11 @@ browser-compat: html.elements.thead
  </dd>
  <dt>{{htmlattrdef("char")}} {{deprecated_inline}}</dt>
  <dd>This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If {{htmlattrxref("align", "thead")}} is not set to <code>char</code>, this attribute is ignored.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the {{htmlattrxref("char", "thead")}}, in CSS3, you can use the character set using the {{htmlattrxref("char", "thead")}} attribute as the value of the {{cssxref("text-align")}} property.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the {{htmlattrxref("char", "thead")}}, in CSS3, you can use the character set using the {{htmlattrxref("char", "thead")}} attribute as the value of the {{cssxref("text-align")}} property.</p></div>
  </dd>
  <dt>{{htmlattrdef("charoff")}} {{deprecated_inline}}</dt>
  <dd>This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the <strong>char</strong> attribute.
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard.</p></div>
  </dd>
  <dt>{{htmlattrdef("valign")}} {{deprecated_inline}}</dt>
  <dd>This attribute specifies the vertical alignment of the text within each row of cells of the table header. Possible values for this attribute are:
@@ -116,7 +116,7 @@ browser-compat: html.elements.thead
   <li><code>top</code>, which will put the text as close to the top of the cell as it is possible.</li>
  </ul>
 
- <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/xmp/index.html
+++ b/files/en-us/web/html/element/xmp/index.html
@@ -15,7 +15,7 @@ browser-compat: html.elements.xmp
 
 <p>The <strong><code>&lt;xmp&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element renders text between the start and end tags without interpreting the HTML in between and using a monospaced font. The HTML2 specification recommended that it should be rendered wide enough to allow 80 characters per line.</p>
 
-<div class="note"><strong>Note:</strong> Do not use this element.
+<div class="note"><p><strong>Note:</strong> Do not use this element.</p>
 
 <ul>
  <li>It has been deprecated since HTML3.2 and was not implemented in a consistent way. It was completely removed from the language in HTML5.</li>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This PR ensures the `<strong>Note:</strong>` is wrapped in P tags, which the converter expects.