### PR TITLE
Fix or remove cases of "HTML5 media"

### DIFF
--- a/files/en-us/web/api/audionode/connect/index.md
+++ b/files/en-us/web/api/audionode/connect/index.md
@@ -77,7 +77,7 @@ If the destination is an `AudioParam`, `connect()` returns
 The most obvious use of the `connect()` method is to direct the audio output
 from one node into the audio input of another node for further processing. For example,
 you might send the audio from a {{domxref("MediaElementAudioSourceNode")}}—that is, the
-audio from an HTML5 media element such as {{HTMLElement("audio")}}—through a band pass
+audio from an HTML media element such as {{HTMLElement("audio")}}—through a band pass
 filter implemented using a {{domxref("BiquadFilterNode")}} to reduce noise before then
 sending the audio along to the speakers.
 

--- a/files/en-us/web/api/htmlmediaelement/canplay_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplay_event/index.md
@@ -39,15 +39,6 @@ The `canplay` event is fired when the user agent can play the media, but estimat
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.oncanplay")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.md
@@ -41,15 +41,6 @@ The `canplaythrough` event is fired when the user agent can play the media, and 
         {{domxref("GlobalEventHandlers.oncanplaythrough")}}
       </td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/durationchange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/durationchange_event/index.md
@@ -41,15 +41,6 @@ The `durationchange` event is fired when the `duration` attribute has been updat
         {{domxref("GlobalEventHandlers.ondurationchange")}}
       </td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/emptied_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/emptied_event/index.md
@@ -39,15 +39,6 @@ The `emptied` event is fired when the media has become empty; for example, this 
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onemptied")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.md
@@ -46,15 +46,6 @@ This event occurs based upon {{domxref("HTMLMediaElement")}} ({{HTMLElement("aud
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onended")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -39,15 +39,6 @@ The **`loadeddata`** event is fired when the frame at the current playback posit
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onloadeddata")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -41,15 +41,6 @@ The `loadedmetadata` event is fired when the metadata has been loaded.
         {{domxref("GlobalEventHandlers.onloadedmetadata")}}
       </td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/pause_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/pause_event/index.md
@@ -53,15 +53,6 @@ The event is sent once the `pause()` method returns and after the media element'
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onpause")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/play_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play_event/index.md
@@ -39,15 +39,6 @@ The `play` event is fired when the `paused` property is changed from `true` to `
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onplay")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/playing_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/playing_event/index.md
@@ -39,15 +39,6 @@ The `playing` event is fired after playback is first started, and whenever it is
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onplaying")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/ratechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ratechange_event/index.md
@@ -40,15 +40,6 @@ The `ratechange` event is fired when the playback rate has changed.
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onratechange")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/seeked_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seeked_event/index.md
@@ -40,15 +40,6 @@ The `seeked` event is fired when a seek operation completed, the current playbac
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onseeked")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/seeking_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seeking_event/index.md
@@ -40,15 +40,6 @@ The `seeking` event is fired when a seek operation starts, meaning the Boolean `
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onseeking")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/stalled_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/stalled_event/index.md
@@ -40,15 +40,6 @@ The `stalled` event is fired when the user agent is trying to fetch media data, 
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onstalled")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/suspend_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/suspend_event/index.md
@@ -40,15 +40,6 @@ The `suspend` event is fired when media data loading has been suspended.
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onsuspend")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.md
@@ -41,15 +41,6 @@ The event frequency is dependant on the system load, but will be thrown between 
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.ontimeupdate")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
@@ -41,15 +41,6 @@ The `volumechange` event is fired when the volume has changed.
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onvolumechange")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://html.spec.whatwg.org/multipage/media.html#event-media-volumechange"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/api/htmlmediaelement/waiting_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/waiting_event/index.md
@@ -40,15 +40,6 @@ The `waiting` event is fired when playback has stopped because of a temporary la
       <th scope="row">Event handler property</th>
       <td>{{domxref("GlobalEventHandlers.onwaiting")}}</td>
     </tr>
-    <tr>
-      <th scope="row">Specification</th>
-      <td>
-        <a
-          href="https://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#event-media-playing"
-          >HTML5 media</a
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.html
@@ -102,7 +102,7 @@ tags:
 
 <h2 id="Using_the_Media_API">Using the Media API</h2>
 
-<p>HTML5 comes with a JavaScript <a href="/en-US/docs/Web/API/HTMLMediaElement">Media API</a> that allows developers access to and control of HTML5 media. This API will be used to make the custom control set defined above actually do something. In addition, the fullscreen button will use the <a href="/en-US/docs/Web/API/Fullscreen_API">Fullscreen API</a>, another W3C API that controls the ability of web browsers to show apps using your computer's full screen.</p>
+<p>HTML5 comes with a JavaScript <a href="/en-US/docs/Web/API/HTMLMediaElement">Media API</a> that allows developers access to and control of HTML media. This API will be used to make the custom control set defined above actually do something. In addition, the fullscreen button will use the <a href="/en-US/docs/Web/API/Fullscreen_API">Fullscreen API</a>, another W3C API that controls the ability of web browsers to show apps using your computer's full screen.</p>
 
 <h3 id="Setup">Setup</h3>
 

--- a/files/en-us/web/guide/audio_and_video_delivery/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/index.html
@@ -491,7 +491,7 @@ lastsource.addEventListener('error', function(ev) {
  <dt><a href="/en-US/docs/Web/Guide/Audio_and_video_delivery/Live_streaming_web_audio_and_video">Live streaming web audio and video</a></dt>
  <dd>Live streaming technology is often employed to relay live events such as sports, concerts and more generally TV and Radio programmes that are output live. Often shortened to just streaming, live streaming is the process of transmitting media 'live' to computers and devices. This is a fairly complex and nascent subject with a lot of variables, so in this article we'll introduce you to the subject and let you know how you can get started.</dd>
  <dt><a href="/en-US/docs/Web/Guide/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources">Setting up adaptive streaming media sources</a></dt>
- <dd>Let's say you want to set up an adaptive streaming media source on a server, to be consumed inside an HTML5 media element. How would you do that? This article explains how, looking at two of the most common formats: MPEG-DASH and HLS (HTTP Live Streaming.)</dd>
+ <dd>Let's say you want to set up an adaptive streaming media source on a server, to be consumed inside an HTML media element. How would you do that? This article explains how, looking at two of the most common formats: MPEG-DASH and HLS (HTTP Live Streaming.)</dd>
  <dt><a href="/en-US/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video">DASH Adaptive Streaming for HTML 5 Video</a></dt>
  <dd>Details how to set up adaptive streaming using DASH and WebM.</dd>
 </dl>

--- a/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.html
@@ -11,7 +11,7 @@ tags:
   - adaptive streaming
 ---
 <div class="summary">
-<p><span class="seoSummary">Let's say you want to set up an adaptive streaming media source on a server, to be consumed inside an HTML5 media element. How would you do that? This article explains how, looking at two of the most common formats: MPEG-DASH and HLS (HTTP Live Streaming.)</span></p>
+<p><span class="seoSummary">Let's say you want to set up an adaptive streaming media source on a server, to be consumed inside an HTML media element. How would you do that? This article explains how, looking at two of the most common formats: MPEG-DASH and HLS (HTTP Live Streaming.)</span></p>
 </div>
 
 <h2 id="Choosing_formats">Choosing formats</h2>


### PR DESCRIPTION
Remove spec links in event summary tables, which are redundant with the
specification sections in the same pages.

Replace remaining "HTML5 media" with "HTML media".