### PR TITLE
remove repeated padding property

### DIFF
--- a/files/en-us/learn/forms/advanced_form_styling/index.html
+++ b/files/en-us/learn/forms/advanced_form_styling/index.html
@@ -355,7 +355,6 @@ button {
   display: block;
   font-family: inherit;
   font-size: 100%;
-  padding: 0;
   margin: 0;
   box-sizing: border-box;
   width: 100%;


### PR DESCRIPTION
I noticed a reapeted padding property in css. I removed the first one.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)
the second "padiing" property is enough for css to work correctly.


> Anything else that could help us review it
