### PR TITLE
Glossary entry for transferable objects

### DIFF
--- a/files/en-us/glossary/transferable_objects/index.html
+++ b/files/en-us/glossary/transferable_objects/index.html
@@ -1,0 +1,26 @@
+---
+title: Transferable Objects
+slug: Glossary/Transferable_Objects
+tags:
+  - Transferable
+  - Workers
+---
+
+<p>Browsers implement a method of passing certain types of objects to or from a {{domxref("Web Workers API", "Web Worker","","true")}} with high performance. <strong>Transferable objects</strong> are transferred from one context to another with a zero-copy operation, which results in a vast performance improvement when sending large data sets. Think of it as pass-by-reference if you're from the C/C++ world. However, unlike pass-by-reference, the 'version' from the calling context is no longer available once transferred. Its ownership is transferred to the new context. For example, when transferring an {{jsxref("ArrayBuffer")}} from your main app to a worker script, the original {{jsxref("ArrayBuffer")}} is cleared and no longer usable. Its content is (quite literally) transferred to the worker context.</p>
+
+<pre class="brush: js">
+// Create a 32MB "file" and fill it.
+var uInt8Array = new Uint8Array(1024 * 1024 * 32); // 32MB
+for (var i = 0; i < uInt8Array.length; ++i) {
+  uInt8Array[i] = i;
+}
+
+worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
+</pre>
+
+<h2 id="see_also">See also</h2>
+
+<ul>
+ <li><a href="https://updates.html5rocks.com/2011/12/Transferable-Objects-Lightning-Fast">Transferable Objects: Lightning Fast!</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Using Web Workers</a></li>
+</ul>

--- a/files/en-us/glossary/transferable_objects/index.html
+++ b/files/en-us/glossary/transferable_objects/index.html
@@ -1,6 +1,6 @@
 ---
-title: Transferable Objects
-slug: Glossary/Transferable_Objects
+title: Transferable objects
+slug: Glossary/Transferable_objects
 tags:
   - Transferable
   - Workers
@@ -23,4 +23,5 @@ worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
 <ul>
  <li><a href="https://updates.html5rocks.com/2011/12/Transferable-Objects-Lightning-Fast">Transferable Objects: Lightning Fast!</a></li>
  <li><a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Using Web Workers</a></li>
+<li><a href="https://html.spec.whatwg.org/multipage/structured-data.html#transferable-objects">Transferable objects in the HTML specification</a></li> 
 </ul>

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -558,6 +558,17 @@ It is possible to switch the content of each mainpage -> worker and worker -> ma
 
 Modern browsers contain an additional way to pass certain types of objects to or from a worker with high performance. {{Glossary("Transferable Objects")}} are transferred from one context to another with a zero-copy operation, which results in a vast performance improvement when sending large data sets.
 
+For example, when transferring an {{jsxref("ArrayBuffer")}} from your main app to a worker script, the original {{jsxref("ArrayBuffer")}} is cleared and no longer usable. Its content is (quite literally) transferred to the worker context.
+
+```js
+// Create a 32MB "file" and fill it.
+var uInt8Array = new Uint8Array(1024 * 1024 * 32); // 32MB
+for (var i = 0; i < uInt8Array.length; ++i) {
+  uInt8Array[i] = i;
+}
+worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
+```
+
 ## Embedded workers
 
 There is not an "official" way to embed the code of a worker within a web page, like {{HTMLElement("script")}} elements do for normal scripts. But a {{HTMLElement("script")}} element that does not have a `src` attribute and has a `type` attribute that does not identify an executable MIME type can be considered a data block element that JavaScript could use. "Data blocks" is a more general feature of HTML5 that can carry almost any textual data. So, a worker could be embedded in this way:

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -556,19 +556,7 @@ It is possible to switch the content of each mainpage -> worker and worker -> ma
 
 ### Passing data by transferring ownership (transferable objects)
 
-Google Chrome 17+ and Firefox 18+ contain an additional way to pass certain types of objects (transferable objects, that is objects implementing the {{domxref("Transferable")}} interface) to or from a worker with high performance. Transferable objects are transferred from one context to another with a zero-copy operation, which results in a vast performance improvement when sending large data sets. Think of it as pass-by-reference if you're from the C/C++ world. However, unlike pass-by-reference, the 'version' from the calling context is no longer available once transferred. Its ownership is transferred to the new context. For example, when transferring an {{jsxref("ArrayBuffer")}} from your main app to a worker script, the original {{jsxref("ArrayBuffer")}} is cleared and no longer usable. Its content is (quite literally) transferred to the worker context.
-
-```js
-// Create a 32MB "file" and fill it.
-var uInt8Array = new Uint8Array(1024 * 1024 * 32); // 32MB
-for (var i = 0; i < uInt8Array.length; ++i) {
-  uInt8Array[i] = i;
-}
-
-worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
-```
-
-> **Note:** For more information on transferable objects, performance, and feature-detection for this method, read [Transferable Objects: Lightning Fast!](https://updates.html5rocks.com/2011/12/Transferable-Objects-Lightning-Fast) on HTML5 Rocks.
+Modern browsers contain an additional way to pass certain types of objects to or from a worker with high performance. {{Glossary("Transferable Objects")}} are transferred from one context to another with a zero-copy operation, which results in a vast performance improvement when sending large data sets.
 
 ## Embedded workers
 


### PR DESCRIPTION
As discussed in Slack, adding a Glossary entry for Trsnaferable Objects based on the Web Workers page, then linking to it from that page. 
