### PR TITLE
Fix `Boolean` in Global_Objects/Array/includes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
@@ -52,7 +52,7 @@ includes(searchElement, fromIndex)
 
 ### Return value
 
-A {{jsxref("Boolean")}} which is `true` if the value
+A boolean value which is `true` if the value
 `searchElement` is found within the array (or the part of the array
 indicated by the index `fromIndex`, if specified).
 


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

This function doesn't return a boolean primitive rather than `Boolean` wrapper object.

> Anything else that could help us review it
