### PR TITLE
Fix typo: cancelation->cancellation

### DIFF
--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -51,7 +51,7 @@ function step(timestamp) {
   }
 }
 myReq = requestAnimationFrame(step);
-// the cancelation uses the last requestId
+// the cancellation uses the last requestId
 cancelAnimationFrame(myReq);
 ```
 


### PR DESCRIPTION
Typo fix

Fixed wrong spelling of "cancellation" in comments.




