### PR TITLE
[Markdown] [Web/HTML] Fix up remaining notes

### DIFF
--- a/files/en-us/web/html/attributes/disabled/index.html
+++ b/files/en-us/web/html/attributes/disabled/index.html
@@ -19,7 +19,7 @@ tags:
 <p>This Boolean disabled attribute indicates that the user cannot interact with the control or its descendant controls. If this attribute is not specified, the control inherits its setting from the containing element, for example <code>fieldset</code>; if there is no containing element with the <code>disabled</code> attribute set, and the control itself does not have the attribute, then the control is enabled. If declared on an {{ HTMLElement("optgroup") }}, the select is still interactive (unless otherwise disabled), but none of the items in the option group are selectable.</p>
 
 <div class="notecard note">
-<p>Note: If a {{ HTMLElement("fieldset") }} is disabled, the descendant form controls are all disabled, with the exception of form controls within the {{ HTMLElement("legend") }}.</p>
+<p><strong>Note:</strong> If a {{ HTMLElement("fieldset") }} is disabled, the descendant form controls are all disabled, with the exception of form controls within the {{ HTMLElement("legend") }}.</p>
 </div>
 
 <p>When a supporting element has the <code>disabled</code> attribute applied, the {{cssxref(":disabled")}} pseudo-class also applies to it. Conversely, elements that support the <code>disabled</code> attribute but don't have the attribute set match the {{cssxref(":enabled")}} pseudo-class.</p>

--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -434,7 +434,6 @@ tags:
    <td><code>loading</code> {{experimental_inline}}</td>
    <td>{{ HTMLElement("img") }}, {{ HTMLElement("iframe") }}</td>
    <td>Indicates if the element should be loaded lazily (<code>loading="lazy"</code>) or loaded immediately (<code>loading="eager"</code>).
-    <div class="note"><strong>WIP:</strong> <a href="https://github.com/whatwg/html/pull/3752">WHATWG PR #3752</a></div>
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/html/attributes/required/index.html
+++ b/files/en-us/web/html/attributes/required/index.html
@@ -23,7 +23,7 @@ tags:
 <p>In the case of a same named group of {{HTMLElement("input/checkbox","checkbox")}} input types, only the checkboxes with the <code>required</code> attribute are required.</p>
 
 <div class="notecard note">
-<p>Note: Setting <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute">aria-required</a>="true"</code> tells a screen reader that an element (any element) is required, but has no bearing on the optionality of the element.</p>
+<p><strong>Note:</strong> Setting <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute">aria-required</a>="true"</code> tells a screen reader that an element (any element) is required, but has no bearing on the optionality of the element.</p>
 </div>
 
 <h3 id="Attribute_interactions">Attribute interactions</h3>

--- a/files/en-us/web/html/element/acronym/index.html
+++ b/files/en-us/web/html/element/acronym/index.html
@@ -16,8 +16,8 @@ browser-compat: html.elements.acronym
 
 <p>The <strong><code>&lt;acronym&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element allows authors to clearly indicate a sequence of characters that compose an acronym or abbreviation for a word.</p>
 
-<div class="note">
-<p><strong>Usage note:</strong> This element has been removed in HTML5 and shouldn't be used anymore. Instead web developers should use the {{HTMLElement("abbr")}} element.</p>
+<div class="warning">
+<p><strong>Warning:</strong> Don't use this element. Use the {{HTMLElement("abbr")}} element instead.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>
@@ -27,8 +27,6 @@ browser-compat: html.elements.acronym
 <h2 id="DOM_Interface">DOM Interface</h2>
 
 <p>This element implements the {{domxref('HTMLElement')}} interface.</p>
-
-<div class="note"><strong>Implementation note:</strong> Up to Gecko 1.9.2 inclusive, Firefox implements the {{domxref('HTMLSpanElement')}} interface for this element.</div>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/html/element/bgsound/index.html
+++ b/files/en-us/web/html/element/bgsound/index.html
@@ -17,8 +17,8 @@ browser-compat: html.elements.bgsound
 
 <p>The <strong><code>&lt;bgsound&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is deprecated. It sets up a sound file to play in the background while the page is used; use {{HTMLElement("audio")}} instead.</p>
 
-<div class="note">
-<p><strong>Do not use this! </strong>In order to embed audio in a Web page, you should be using the {{HTMLElement("audio")}} element.</p>
+<div class="warning">
+<p><strong>Warning:</strong> Do not use this! In order to embed audio in a Web page, you should be using the {{HTMLElement("audio")}} element.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>

--- a/files/en-us/web/html/element/big/index.html
+++ b/files/en-us/web/html/element/big/index.html
@@ -13,8 +13,8 @@ browser-compat: html.elements.big
 
 <p>The <strong><code>&lt;big&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> deprecated element renders the enclosed text at a font size one level larger than the surrounding text (<code>medium</code> becomes <code>large</code>, for example). The size is capped at the browser's maximum permitted font size.</p>
 
-<div class="note">
-<p><strong>Usage note:</strong> As it was purely presentational, this element has been removed in {{Glossary("HTML5")}} and shouldn't be used anymore. Instead web developers should use the CSS {{cssxref("font-size")}} property to adjust the font size.</p>
+<div class="warning">
+<p><strong>Warning:</strong> This element has been removed from the specification and shouldn't be used any more. Use the CSS {{cssxref("font-size")}} property to adjust the font size.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>
@@ -64,8 +64,6 @@ browser-compat: html.elements.big
 <h2 id="DOM_interface">DOM interface</h2>
 
 <p>This element implements the {{domxref('HTMLElement')}} interface.</p>
-
-<div class="note"><strong>Implementation note:</strong> Up to Gecko 1.9.2 inclusive, Firefox implements the {{domxref('HTMLSpanElement')}} interface for this element.</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/caption/index.html
+++ b/files/en-us/web/html/element/caption/index.html
@@ -75,7 +75,7 @@ browser-compat: html.elements.caption
   <dd>The caption is displayed below the table.</dd>
  </dl>
 
- <div class="note"><strong>Usage note:</strong> Do not use this attribute, as it has been deprecated. The {{HTMLElement("caption")}} element should be styled using the <a href="/en-US/docs/Web/CSS">CSS</a> properties {{cssxref("caption-side")}} and {{cssxref("text-align")}}.</div>
+ <div class="warning"><strong>Warning:</strong> Do not use this attribute, as it has been deprecated. The {{HTMLElement("caption")}} element should be styled using the <a href="/en-US/docs/Web/CSS">CSS</a> properties {{cssxref("caption-side")}} and {{cssxref("text-align")}}.</div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/center/index.html
+++ b/files/en-us/web/html/element/center/index.html
@@ -23,10 +23,6 @@ browser-compat: html.elements.center
 
 <p>This element implements the {{domxref("HTMLElement")}} interface.</p>
 
-<div class="note">
-<p><strong>Implementation note:</strong> up to Gecko 1.9.2 inclusive, Firefox implements the {{domxref("HTMLSpanElement")}} interface for this element.</p>
-</div>
-
 <h2 id="Example_1">Example 1</h2>
 
 <pre class="brush: html">&lt;center&gt;This text will be centered.

--- a/files/en-us/web/html/element/col/index.html
+++ b/files/en-us/web/html/element/col/index.html
@@ -76,18 +76,10 @@ browser-compat: html.elements.col
 
  <p>If this attribute is not set, its value is inherited from the {{htmlattrxref("align", "colgroup")}} of the {{HTMLElement("colgroup")}} element this <code>&lt;col&gt;</code> element belongs too. If there are none, the <code>left</code> value is assumed.</p>
 
- <div class="note"><strong>Note: </strong>
+ <div class="note"><p><strong>Note:</strong> To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values, do not try to set the {{cssxref("text-align")}} property on a selector giving a <code>&lt;col&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;col&gt;</code> element, they won't inherit it.</p>
 
- <ul>
-  <li>To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values:
-
-   <ul>
-    <li>Do not try to set the {{cssxref("text-align")}} property on a selector giving a <code>&lt;col&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;col&gt;</code> element, they won't inherit it.</li>
-    <li>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use the <code>td:nth-child(an+b)</code> CSS selector. Set <code>a</code> to zero and <code>b </code>to the position of the column in the table, e.g. <code>td:nth-child(2) { text-align: right; }</code> to right-align the second column.</li>
-    <li>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</li>
-   </ul>
-  </li>
- </ul>
+ <p>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use the <code>td:nth-child(an+b)</code> CSS selector. Set <code>a</code> to zero and <code>b </code>to the position of the column in the table, e.g. <code>td:nth-child(2) { text-align: right; }</code> to right-align the second column.</p>
+    <p>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</p>
  </div>
  </dd>
  <dt>{{htmlattrdef("bgcolor")}} {{Deprecated_inline}}</dt>
@@ -109,13 +101,9 @@ browser-compat: html.elements.col
   <li>and <code>top</code>, which will put the text as close to the top of the cell as it is possible.</li>
  </ul>
 
- <div class="note"><p><strong>Note:</strong></p>
-
- <ul>
-  <li>Do not try to set the {{cssxref("vertical-align")}} property on a selector giving a <code>&lt;col&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;col&gt;</code> element, they won't inherit it.</li>
-  <li>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use the <code>td:nth-child(an+b)</code> CSS selector where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the <code>vertical-align</code> property can be used.</li>
-  <li>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</li>
- </ul>
+ <div class="note"><p><strong>Note:</strong> Do not try to set the {{cssxref("vertical-align")}} property on a selector giving a <code>&lt;col&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;col&gt;</code> element, they won't inherit it.</p>
+ <p>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use the <code>td:nth-child(an+b)</code> CSS selector where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the <code>vertical-align</code> property can be used.</p>
+ <p>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</p>
  </div>
  </dd>
  <dt>{{htmlattrdef("width")}} {{deprecated_inline}}</dt>

--- a/files/en-us/web/html/element/colgroup/index.html
+++ b/files/en-us/web/html/element/colgroup/index.html
@@ -57,12 +57,9 @@ browser-compat: html.elements.colgroup
 
 <dl>
  <dt>{{htmlattrdef("span")}}</dt>
- <dd>This attribute contains a positive integer indicating the number of consecutive columns the <code>&lt;colgroup&gt;</code> element spans. If not present, its default value is <code>1</code>.
- <div class="note"><p><strong>Note:</strong> This attribute is applied on the attributes of the column group, it has no effect on the CSS styling rules associated with it or, even more, to the cells of the column's members of the group.</p>
- <ul>
-  <li>The <code>span</code> attribute is not permitted if there are one or more <code>&lt;col&gt;</code> elements within the <code>&lt;colgroup&gt;</code>.</li>
- </ul>
- </div>
+ <dd><p>This attribute contains a positive integer indicating the number of consecutive columns the <code>&lt;colgroup&gt;</code> element spans. If not present, its default value is <code>1</code>.</p>
+ <p>This attribute is applied on the attributes of the column group, it has no effect on the CSS styling rules associated with it or, even more, to the cells of the column's members of the group.</p>
+ <p>The <code>span</code> attribute is not permitted if there are one or more <code>&lt;col&gt;</code> elements within the <code>&lt;colgroup&gt;</code>.</p>
  </dd>
 </dl>
 
@@ -83,13 +80,9 @@ browser-compat: html.elements.colgroup
 
  <p>If this attribute is not set, the <code>left</code> value is assumed. The descendant {{HTMLElement("col")}} elements may override this value using their own {{htmlattrxref("align", "col")}} attribute.</p>
 
- <div class="note"><p><strong>Note:</strong></p>
-
- <ul>
-  <li>Do not try to set the {{cssxref("text-align")}} property on a selector giving a {{HTMLElement("colgroup")}} element. Because {{HTMLElement("td")}} elements are not descendant of the {{HTMLElement("colgroup")}} element, they won't inherit it.</li>
-  <li>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use one <code>td:nth-child(an+b)</code> CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of this column in the table. Only after this selector the <code>text-align</code> property can be used.</li>
-  <li>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</li>
- </ul>
+ <div class="note"><p><strong>Note:</strong> Do not try to set the {{cssxref("text-align")}} property on a selector giving a {{HTMLElement("colgroup")}} element. Because {{HTMLElement("td")}} elements are not descendant of the {{HTMLElement("colgroup")}} element, they won't inherit it.</p>
+ <p>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use one <code>td:nth-child(an+b)</code> CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of this column in the table. Only after this selector the <code>text-align</code> property can be used.</p>
+ <p>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</p>
  </div>
  </dd>
  <dt>{{htmlattrdef("bgcolor")}} {{Deprecated_inline}}</dt>
@@ -111,13 +104,9 @@ browser-compat: html.elements.colgroup
   <li>and <code>top</code>, which will put the text as close to the top of the cell as it is possible.</li>
  </ul>
 
- <div class="note"><strong>Note: </strong>
-
- <ul>
-  <li>Do not try to set the {{cssxref("vertical-align")}} property on a selector giving a <code>&lt;colgroup&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;colgroup&gt;</code> element, they won't inherit it.</li>
-  <li>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use the <code>td:nth-child(an+b)</code> CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the <code>vertical-align</code> property can be used.</li>
-  <li>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</li>
- </ul>
+ <div class="note"><p><strong>Note:</strong> Do not try to set the {{cssxref("vertical-align")}} property on a selector giving a <code>&lt;colgroup&gt;</code> element. Because {{HTMLElement("td")}} elements are not descendant of the <code>&lt;colgroup&gt;</code> element, they won't inherit it.</p>
+ <p>If the table doesn't use a {{htmlattrxref("colspan", "td")}} attribute, use the <code>td:nth-child(an+b)</code> CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the <code>vertical-align</code> property can be used.</p>
+ <p>If the table does use a {{htmlattrxref("colspan", "td")}} attribute, the effect can be achieved by combining adequate CSS attribute selectors like <code>[colspan=n]</code>, though this is not trivial.</p>
  </div>
  </dd>
 </dl>

--- a/files/en-us/web/html/element/dir/index.html
+++ b/files/en-us/web/html/element/dir/index.html
@@ -17,7 +17,7 @@ browser-compat: html.elements.dir
 
 <p>The <strong><code>&lt;dir&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the {{Glossary("user agent")}}. Do not use this obsolete element; instead, you should use the {{HTMLElement("ul")}} element for lists, including lists of files.</p>
 
-<div class="note"><strong>Usage note:</strong> Do not use this element. Though present in early HTML specifications, it has been deprecated in HTML 4, and has since been removed entirely. <strong>No major browsers support this element.</strong></div>
+<div class="warning"><p><strong>Warning:</strong> Do not use this element. Though present in early HTML specifications, it has been deprecated in HTML 4, and has since been removed entirely. <strong>No major browsers support this element.</strong></p></div>
 
 <h2 id="DOM_interface">DOM interface</h2>
 
@@ -30,7 +30,6 @@ browser-compat: html.elements.dir
 <dl>
  <dt>{{htmlattrdef("compact")}}</dt>
  <dd>This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.
- <div class="note"><strong>Usage note:</strong> Do not use this attribute, as it has been deprecated: the {{HTMLElement("dir")}} element should be styled using <a href="/en-US/docs/Web/CSS">CSS</a>. To give a similar effect as that achieved with the <code>compact</code> attribute, the <a href="/en-US/docs/Web/CSS">CSS</a> property {{cssxref("line-height")}} can be used with a value of <code>80%</code>.</div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/fieldset/index.html
+++ b/files/en-us/web/html/element/fieldset/index.html
@@ -29,7 +29,7 @@ browser-compat: html.elements.fieldset
  <dd>This attribute takes the value of the {{htmlattrxref("id")}} attribute of a {{HTMLElement("form")}} element you want the <code>&lt;fieldset&gt;</code> to be part of, even if it is not inside the form. Please note that usage of this is confusing — if you want the {{HTMLElement("input")}} elements inside the <code>&lt;fieldset&gt;</code> to be associated with the form, you need to use the <code>form</code> attribute directly on those elements. You can check which elements are associated with a form via JavaScript, using {{domxref("HTMLFormElement.elements")}}.</dd>
  <dt>{{htmlattrdef("name")}}</dt>
  <dd>The name associated with the group.
- <div class="note"><strong>Note</strong>: The caption for the fieldset is given by the first {{HTMLElement("legend")}} element nested inside it.</div>
+ <div class="note"><p><strong>Note:</strong> The caption for the fieldset is given by the first {{HTMLElement("legend")}} element nested inside it.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/font/index.html
+++ b/files/en-us/web/html/element/font/index.html
@@ -15,14 +15,8 @@ browser-compat: html.elements.font
 
 <p>The <strong><code>&lt;font&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element defines the font size, color and face for its content.</p>
 
-<div class="note">
-<p><em>Usage note: </em></p>
-
-<p><strong>Do not use this element!</strong> Though once normalized in HTML 3.2, it was deprecated in HTML 4.01, at the same time as all elements related to styling only, then made obsolete in HTML5.</p>
-
-<p>Starting with HTML 4, HTML does not convey styling information anymore (outside the {{HTMLElement("style")}} element or the <strong>style</strong> attribute of each element). For any new web development, styling should be written using <a href="/en-US/docs/Web/CSS">CSS</a> only.</p>
-
-<p>The former behavior of the {{HTMLElement("font")}} element can be achieved, and even better controlled using the <a href="/en-US/docs/Web/CSS/CSS_Fonts">CSS Fonts</a> CSS properties.</p>
+<div class="warning">
+<p><p><strong>Warning:</strong> Do not use this element. Use the CSS <a href="/en-US/docs/Web/CSS/CSS_Fonts">Fonts</a> properties to style text.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>

--- a/files/en-us/web/html/element/iframe/index.html
+++ b/files/en-us/web/html/element/iframe/index.html
@@ -25,7 +25,7 @@ browser-compat: html.elements.iframe
 <p>Each embedded browsing context has its own <a href="/en-US/docs/Web/API/History">session history</a> and <a href="/en-US/docs/Web/API/Document">document</a>. The browsing context that embeds the others is called the <em><dfn>parent</dfn> browsing context</em>. The <em>topmost</em> browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.</p>
 
 <div class="notecard warning">
-<p>Because each browsing context is a complete document environment, every <code>&lt;iframe&gt;</code> in a page requires increased memory and other computing resources. While theoretically you can use as many <code>&lt;iframe&gt;</code>s as you like, check for performance problems.</p>
+<p><strong>Warning:</strong> Because each browsing context is a complete document environment, every <code>&lt;iframe&gt;</code> in a page requires increased memory and other computing resources. While theoretically you can use as many <code>&lt;iframe&gt;</code>s as you like, check for performance problems.</p>
 </div>
 
 <table class="properties">
@@ -71,11 +71,11 @@ browser-compat: html.elements.iframe
  <p>For more information and examples see: <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a> &gt; <a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute">The iframe allow attribute</a>.</p></dd>
  <dt>{{htmlattrdef("allowfullscreen")}}</dt>
  <dd><p>Set to <code>true</code> if the <code>&lt;iframe&gt;</code> can activate fullscreen mode by calling the {{domxref("Element.requestFullscreen", "requestFullscreen()")}} method.</p>
- <div class="note">This attribute is considered a legacy attribute and redefined as <code>allow="fullscreen"</code>.</div>
+ <div class="note"><p><strong>Note:</strong> This attribute is considered a legacy attribute and redefined as <code>allow="fullscreen"</code>.</p></div>
  </dd>
  <dt>{{htmlattrdef("allowpaymentrequest")}}</dt>
  <dd><p>Set to <code>true</code> if a cross-origin <code>&lt;iframe&gt;</code> should be allowed to invoke the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a>.</p>
- <div class="note">This attribute is considered a legacy attribute and redefined as <code>allow="payment"</code>.</div>
+ <div class="note"><p><strong>Note:</strong> This attribute is considered a legacy attribute and redefined as <code>allow="payment"</code>.</p></div>
  </dd>
  <dt>{{htmlattrdef("csp")}} {{experimental_inline}}</dt>
  <dd>A <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> enforced for the embedded resource. See {{domxref("HTMLIFrameElement.csp")}} for details.</dd>
@@ -122,7 +122,7 @@ browser-compat: html.elements.iframe
   <li><code>allow-top-navigation-by-user-activation</code>: Lets the resource navigate the top-level browsing context, but only if initiated by a user gesture.</li>
  </ul>
 
- <div class="note"><strong>Notes about sandboxing:</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <ul>
   <li>When the embedded document has the same origin as the embedding page, it is <strong>strongly discouraged</strong> to use both <code>allow-scripts</code> and <code>allow-same-origin</code>, as that lets the embedded document remove the <code>sandbox</code> attribute — making it no more secure than not using the <code>sandbox</code> attribute at all.</li>
@@ -162,16 +162,6 @@ browser-compat: html.elements.iframe
   <li><code>no</code>: Never show a scrollbar.</li>
  </ul>
  </dd>
-</dl>
-
-<h3 id="Non-standard_attributes">Non-standard attributes</h3>
-
-<dl>
- <dt>{{htmlattrdef("mozbrowser")}} {{non-standard_inline}}</dt>
- <dd>
- <div class="note">See {{bug(1318532)}} for exposing this to WebExtensions in Firefox.</div>
- Makes the <code>&lt;iframe&gt;</code> act like a top-level browser window. See <a href="/en-US/docs/Mozilla/Gecko/Chrome/API/Browser_API">Browser API</a> for details.<br>
- <strong>Available only to <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions">WebExtensions</a>.</strong></dd>
 </dl>
 
 <h2 id="Scripting">Scripting</h2>

--- a/files/en-us/web/html/element/input/image/index.html
+++ b/files/en-us/web/html/element/input/image/index.html
@@ -62,7 +62,7 @@ browser-compat: html.elements.input.input-image
 <p>For example, if you have a graphical button that shows an image with an icon and/or image text "Login Now", you should also set the <code>alt</code> attribute to something like <code>Login Now</code>.</p>
 
 <div class="note">
-<p><strong>Important:</strong> While the <code>alt</code> attribute is technically optional, you should always include one to maximize the usability of your content.</p>
+<p><strong>Note:</strong> While the <code>alt</code> attribute is technically optional, you should always include one to maximize the usability of your content.</p>
 </div>
 
 <p>Functionally, the <code>&lt;input type="image"&gt;</code> <code>alt</code> attribute works just like the {{htmlattrxref("alt", "img")}} attribute on {{HTMLElement("img")}} elements.</p>

--- a/files/en-us/web/html/element/input/radio/index.html
+++ b/files/en-us/web/html/element/input/radio/index.html
@@ -305,7 +305,7 @@ button:active {
 <p>Most notable here is the use of the {{cssxref("appearance")}} property (with prefixes needed to support some browsers). By default, radio buttons (and <a href="/en-US/docs/Web/HTML/Element/input/checkbox">checkboxes</a>) are styled with the operating system's native styles for those controls. By specifying <code>appearance: none</code>, you can remove the native styling altogether, and create your own styles for them. Here we've used a {{cssxref("border")}} along with {{cssxref("border-radius")}} and a {{cssxref("transition")}} to create a nice animating radio selection. Notice also how the {{cssxref(":checked")}} pseudo-class is used to specify the styles for the radio button's appearance when selected.</p>
 
 <div class="note">
-<p><strong>Compatibility note</strong>: If you wish to use the {{cssxref("appearance")}} property, you should test it very carefully. Although it is supported in most modern browsers, its implementation varies widely. In older browsers, even the keyword <code>none</code> does not have the same effect across different browsers, and some do not support it at all. The differences are smaller in the newest browsers.</p>
+<p><strong>Note:</strong> If you wish to use the {{cssxref("appearance")}} property, you should test it very carefully. Although it is supported in most modern browsers, its implementation varies widely. In older browsers, even the keyword <code>none</code> does not have the same effect across different browsers, and some do not support it at all. The differences are smaller in the newest browsers.</p>
 </div>
 
 <p>{{EmbedLiveSample('Styling_radio_inputs', 600, 120)}}</p>

--- a/files/en-us/web/html/element/label/index.html
+++ b/files/en-us/web/html/element/label/index.html
@@ -53,7 +53,7 @@ browser-compat: html.elements.label
 
  <p>Multiple <code>label</code> elements can be given the same value for their <code>for</code> attribute; doing so causes the associated form control (the form control that <code>for</code> value references) to have multiple labels.</p>
 
- <div class="note"><strong>Note</strong>: A <code>&lt;label&gt;</code> element can have both a <code>for</code> attribute and a contained control element, as long as the <code>for</code> attribute points to the contained control element.</div>
+ <div class="note"><p><strong>Note:</strong> A <code>&lt;label&gt;</code> element can have both a <code>for</code> attribute and a contained control element, as long as the <code>for</code> attribute points to the contained control element.</p></div>
  </dd>
 </dl>
 

--- a/files/en-us/web/html/element/li/index.html
+++ b/files/en-us/web/html/element/li/index.html
@@ -54,7 +54,6 @@ browser-compat: html.elements.li
 <dl>
  <dt>{{htmlattrdef("value")}}</dt>
  <dd>This integer attribute indicates the current ordinal value of the list item as defined by the {{HTMLElement("ol")}} element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The <strong>value</strong> attribute has no meaning for unordered lists ({{HTMLElement("ul")}}) or for menus ({{HTMLElement("menu")}}).
- <div class="note"><strong>Note</strong>: This attribute was deprecated in HTML4, but reintroduced in HTML5.</div>
  </dd>
  <dt>{{htmlattrdef("type")}} {{Deprecated_inline}}</dt>
  <dd>This character attribute indicates the numbering type:

--- a/files/en-us/web/html/element/link/index.html
+++ b/files/en-us/web/html/element/link/index.html
@@ -90,7 +90,7 @@ browser-compat: html.elements.link
      <p>fetch, XHR</p>
 
      <div class="notecard note">
-     <p>This value also requires <code>&lt;link&gt;</code> to contain the crossorigin attribute.</p>
+     <p><strong>Note:</strong> This value also requires <code>&lt;link&gt;</code> to contain the crossorigin attribute.</p>
      </div>
     </td>
    </tr>
@@ -157,7 +157,7 @@ browser-compat: html.elements.link
  <dt>{{HTMLAttrDef("media")}}</dt>
  <dd>This attribute specifies the media that the linked resource applies to. Its value must be a media type / <a href="/en-US/docs/Web/CSS/Media_Queries">media query</a>. This attribute is mainly useful when linking to external stylesheets — it allows the user agent to pick the best adapted one for the device it runs on.
  <div class="notecard note">
- <p><strong>Notes:</strong></p>
+ <p><strong>Note:</strong></p>
 
  <ul>
   <li>In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., <a href="/en-US/docs/Web/CSS/@media">media types and groups</a>, where defined and allowed as values for this attribute, such as <code>print</code>, <code>screen</code>, <code>aural</code>, <code>braille</code>. HTML5 extended this to any kind of <a href="/en-US/docs/Web/CSS/Media_Queries">media queries</a>, which are a superset of the allowed values of HTML 4.</li>
@@ -210,7 +210,7 @@ browser-compat: html.elements.link
 <dl>
  <dt>{{HTMLAttrDef("charset")}} {{deprecated_inline}}</dt>
  <dd>This attribute defines the character encoding of the linked resource. The value is a space- and/or comma-delimited list of character sets as defined in {{rfc(2045)}}. The default value is <code>iso-8859-1</code>.
- <div class="note"><strong>Usage note:</strong> To produce the same effect as this obsolete attribute, use the {{HTTPHeader("Content-Type")}} HTTP header on the linked resource.</div>
+ <div class="note"><p><strong>Note:</strong> To produce the same effect as this obsolete attribute, use the {{HTTPHeader("Content-Type")}} HTTP header on the linked resource.</p></div>
  </dd>
  <dt>{{HTMLAttrDef("rev")}} {{deprecated_inline}}</dt>
  <dd><p>The value of this attribute shows the relationship of the current document to the linked document, as defined by the {{HTMLAttrxRef("href", "link")}} attribute. The attribute thus defines the reverse relationship compared to the value of the <code>rel</code> attribute. <a href="/en-US/docs/Web/HTML/Link_types">Link type values</a> for the attribute are similar to the possible values for {{HTMLAttrxRef("rel", "link")}}.</p>

--- a/files/en-us/web/html/element/menu/index.html
+++ b/files/en-us/web/html/element/menu/index.html
@@ -23,8 +23,7 @@ browser-compat: html.elements.menu
 <p>The <strong><code>&lt;menu&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element is a semantic alternative to {{HTMLElement("ul")}}. It represents an unordered list of items (represented by {{HTMLElement("li")}} elements), each of these represent a link or other command that the user can activate.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>In previous version of the HTML specification, the <code>&lt;menu&gt;</code> element had an additional use case as a context menu. This functionality is now considered obsolete, and has been removed from the specification. Firefox was the only browser to implement this functionality which included the {{HTMLAttrDef("label")}} {{Deprecated_inline}} and <code>context</code> {{Deprecated_inline}} attributes. </p>
+  <p><strong>Note:</strong> In previous version of the HTML specification, the <code>&lt;menu&gt;</code> element had an additional use case as a context menu. This functionality is now considered obsolete, and has been removed from the specification. Firefox was the only browser to implement this functionality which included the {{HTMLAttrDef("label")}} {{Deprecated_inline}} and <code>context</code> {{Deprecated_inline}} attributes. </p>
 </div>
 
 <table class="properties">
@@ -79,7 +78,7 @@ browser-compat: html.elements.menu
 <p>In this example, a <code>&lt;menu&gt;</code> is used to create a toolbar in an editing application.</p>
 
 <div class="notecard warning">
-<p>Toolbar menus haven't been implemented in any known browsers yet.</p>
+<p><strong>Warning:</strong> Toolbar menus haven't been implemented in any known browsers yet.</p>
 </div>
 
 <h4 id="HTML_3">HTML</h4>

--- a/files/en-us/web/html/element/meta/name/index.html
+++ b/files/en-us/web/html/element/meta/name/index.html
@@ -72,7 +72,7 @@ browser-compat: html.elements.meta.name
    </tbody>
   </table>
 
-  <div class="note"><strong>Notes:</strong>
+  <div class="note"><p><strong>Note:</strong></p>
 
   <ul>
    <li>Dynamically inserting <code>&lt;meta name="referrer"&gt;</code> (with {{domxref("Document.write", "document.write()")}} or {{domxref("Node.appendChild", "appendChild()")}}) makes the referrer behavior unpredictable.</li>
@@ -167,7 +167,7 @@ browser-compat: html.elements.meta.name
    </tbody>
   </table>
 
-  <div class="note"><strong>Notes:</strong>
+  <div class="note"><p><strong>Note:</strong></p>
 
   <ul>
    <li>Though unstandardized, this declaration is respected by most mobile browsers due to de-facto dominance.</li>
@@ -263,7 +263,7 @@ browser-compat: html.elements.meta.name
    </tbody>
   </table>
 
-  <div class="note"><strong>Notes:</strong>
+  <div class="note"><p><strong>Note:</strong></p>
 
   <ul>
    <li>Only cooperative robots follow these rules. Do not expect to prevent e-mail harvesters with them.</li>

--- a/files/en-us/web/html/element/plaintext/index.html
+++ b/files/en-us/web/html/element/plaintext/index.html
@@ -15,7 +15,7 @@ browser-compat: html.elements.plaintext
 
 <p>The <strong><code>&lt;plaintext&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element renders everything following the start tag as raw text, ignoring any following HTML. There is no closing tag, since everything after it is considered raw text.</p>
 
-<div class="note"><p><strong>Note:</strong> Do not use this element.</p>
+<div class="warning"><p><strong>Warning:</strong> Do not use this element.</p>
 
 <ul>
  <li><code>&lt;plaintext&gt;</code> is deprecated since HTML 2, and not all browsers implemented it. Browsers that did implement it didn't do so consistently.</li>
@@ -33,10 +33,6 @@ browser-compat: html.elements.plaintext
 <h2 id="DOM_interface">DOM interface</h2>
 
 <p>This element implements the {{domxref('HTMLElement')}} interface.</p>
-
-<div class="note">
-<p><strong>Implementation note:</strong> In Gecko 1.9.2 and before, Firefox implements the interface {{domxref('HTMLSpanElement')}} for this element.</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/q/index.html
+++ b/files/en-us/web/html/element/q/index.html
@@ -55,7 +55,7 @@ browser-compat: html.elements.q
 </table>
 
 <div class="note">
-<p><strong>Usage note:</strong> Most modern browsers will automatically add quotation marks around text inside a <code>&lt;q&gt;</code> element. A style rule may be needed to add quotation marks in older browsers.</p>
+<p><strong>Note:</strong> Most modern browsers will automatically add quotation marks around text inside a <code>&lt;q&gt;</code> element. A style rule may be needed to add quotation marks in older browsers.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>

--- a/files/en-us/web/html/element/s/index.html
+++ b/files/en-us/web/html/element/s/index.html
@@ -53,8 +53,6 @@ browser-compat: html.elements.s
 
 <p>This element only includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
-<div class="note"><strong>Implementation note:</strong> Up to Gecko 1.9.2 inclusive, Firefox implements the {{domxref("HTMLSpanElement")}} interface for this element.</div>
-
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: html">&lt;s&gt;Today's Special: Salmon&lt;/s&gt; SOLD OUT&lt;br&gt;

--- a/files/en-us/web/html/element/strike/index.html
+++ b/files/en-us/web/html/element/strike/index.html
@@ -13,8 +13,8 @@ browser-compat: html.elements.strike
 
 <p>The <strong><code>&lt;strike&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element places a strikethrough (horizontal line) over text.</p>
 
-<div class="notecard note">
-<p><strong>Usage note:</strong> This element is deprecated in HTML 4 and XHTML 1, and obsoleted in HTML5. If semantically appropriate, i.e., if it represents <em>deleted</em> content, use {{HTMLElement("del")}} instead. In all other cases use {{HTMLElement("s")}}.</p>
+<div class="notecard warning">
+<p><strong>Warning:</strong> This element is deprecated in HTML 4 and XHTML 1, and obsoleted in HTML5. If semantically appropriate, i.e., if it represents <em>deleted</em> content, use {{HTMLElement("del")}} instead. In all other cases use {{HTMLElement("s")}}.</p>
 </div>
 
 <table class="properties">

--- a/files/en-us/web/html/element/thead/index.html
+++ b/files/en-us/web/html/element/thead/index.html
@@ -68,7 +68,7 @@ browser-compat: html.elements.thead
 
  <p>If this attribute is not set, the <code>left</code> value is assumed.</p>
 
- <div class="note"><p><strong>Note:</strong> Do not use this attribute as it is obsolete (not supported) in the latest standard.</p>
+ <div class="warning"><p><strong>Warning:</strong> Do not use this attribute as it is obsolete (not supported) in the latest standard.</p>
 
  <ul>
   <li>To achieve the same effect as the <code>left</code>, <code>center</code>, <code>right</code> or <code>justify</code> values, use the CSS {{cssxref("text-align")}} property on it.</li>
@@ -97,7 +97,7 @@ browser-compat: html.elements.thead
   <li><code>aqua</code> = "#00FFFF"</li>
  /ul>
 
- <div class="note"><strong>Usage note:</strong> Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: the {{HTMLElement("thead")}} element should be styled using <a href="/en-US/docs/Web/CSS">CSS</a>. To give a similar effect to the <strong>bgcolor</strong> attribute, use the <a href="/en-US/docs/Web/CSS">CSS</a> property {{cssxref("background-color")}}, on the relevant {{HTMLElement("td")}} or {{HTMLElement("th")}} elements.</div>
+ <div class="note"><p><strong>Note:</strong> Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: the {{HTMLElement("thead")}} element should be styled using <a href="/en-US/docs/Web/CSS">CSS</a>. To give a similar effect to the <strong>bgcolor</strong> attribute, use the <a href="/en-US/docs/Web/CSS">CSS</a> property {{cssxref("background-color")}}, on the relevant {{HTMLElement("td")}} or {{HTMLElement("th")}} elements.</p></div>
  </dd>
  <dt>{{htmlattrdef("char")}} {{deprecated_inline}}</dt>
  <dd>This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If {{htmlattrxref("align", "thead")}} is not set to <code>char</code>, this attribute is ignored.

--- a/files/en-us/web/html/element/tt/index.html
+++ b/files/en-us/web/html/element/tt/index.html
@@ -24,7 +24,7 @@ browser-compat: html.elements.tt
 
 <p>This element is obsolete, however. You should use the more semantically helpful {{HTMLElement("code")}}, {{HTMLElement("kbd")}}, {{HTMLElement("samp")}}, or {{HTMLElement("var")}} elements for inline text that needs to be presented in monospace type, or the {{HTMLElement("pre")}} tag for content that should be presented as a separate block.</p>
 
-<div class="note">If none of the semantic elements are appropriate for your use case (for example, if you need to show some content in a non-proportional font), you should consider using the {{ HTMLElement("span") }} element, styling it as desired using CSS. The {{cssxref("font-family")}} property is a good place to start.</div>
+<div class="note"><p><strong>Note:</strong> If none of the semantic elements are appropriate for your use case (for example, if you need to show some content in a non-proportional font), you should consider using the {{ HTMLElement("span") }} element, styling it as desired using CSS. The {{cssxref("font-family")}} property is a good place to start.</p></div>
 
 <table class="properties">
  <tbody>
@@ -100,7 +100,7 @@ The telnet client should display: &lt;tt&gt;Local Echo is on&lt;/tt&gt;&lt;/p&gt
 <p>The <code>&lt;tt&gt;</code> element is, by default, rendered using the browser's default non-proportional font. You can override this using CSS by creating a rule using the <code>tt</code> selector, as seen in the example {{anch("Overriding the default font")}} above.</p>
 
 <div class="note">
-<p>User-configured changes to the default monospace font setting may take precedence over your CSS.</p>
+<p><strong>Note:</strong> User-configured changes to the default monospace font setting may take precedence over your CSS.</p>
 </div>
 
 <p>Although this element wasn't officially deprecated in HTML 4.01, its use was discouraged in favor of the semantic elements and/or CSS. The <code>&lt;tt&gt;</code> element is obsolete in HTML 5.</p>

--- a/files/en-us/web/html/global_attributes/autofocus/index.html
+++ b/files/en-us/web/html/global_attributes/autofocus/index.html
@@ -17,8 +17,7 @@ browser-compat: html.global_attributes.autofocus
 <p>No more than one element in the document or dialog may have the autofocus attribute. If applied to multiple elements the first one will receive focus.</p>
 
 <div class="notecard note">
-  <h4>Note:</h4>
-  <p>The <code>autofocus</code> attribute applies to all elements, not just form controls. For example, it might be used on a <a href="/en-US/docs/Web/HTML/Global_attributes/contenteditable">contenteditable</a> area.</p>
+  <p><strong>Note:</strong> The <code>autofocus</code> attribute applies to all elements, not just form controls. For example, it might be used on a <a href="/en-US/docs/Web/HTML/Global_attributes/contenteditable">contenteditable</a> area.</p>
 </div>
 
 <h2 id="Accessibility_considerations">Accessibility considerations</h2>

--- a/files/en-us/web/html/global_attributes/itemprop/index.html
+++ b/files/en-us/web/html/global_attributes/itemprop/index.html
@@ -187,7 +187,7 @@ browser-compat: html.global_attributes.itemprop
 &lt;/div&gt;</pre>
 
 <div class="note">
-<p>Note: There is no relationship between the microdata and the content of the document where the microdata is marked up.</p>
+<p><strong>Note:</strong> There is no relationship between the microdata and the content of the document where the microdata is marked up.</p>
 </div>
 
 <h3 id="Same_structured_data_marked_up_in_two_different_ways">Same structured data marked up in two different ways</h3>
@@ -281,7 +281,7 @@ browser-compat: html.global_attributes.itemprop
  </li>
 </ol>
 
-<p class="note"><strong>Note:</strong> the rules above disallow ":" characters in non-URL values because otherwise they could not be distinguished from URLs. Values with "." characters are reserved for future extensions. Space characters are disallowed because otherwise the values would be parsed as multiple tokens.</p>
+<div class="note"><p><strong>Note:</strong> The rules above disallow ":" characters in non-URL values because otherwise they could not be distinguished from URLs. Values with "." characters are reserved for future extensions. Space characters are disallowed because otherwise the values would be parsed as multiple tokens.</p></div>
 
 <h2 id="Values">Values</h2>
 

--- a/files/en-us/web/html/global_attributes/nonce/index.html
+++ b/files/en-us/web/html/global_attributes/nonce/index.html
@@ -19,10 +19,10 @@ be allowed to proceed for a given element.</p>
 <p>The <code>nonce</code> attribute is useful to allow-list specific elements, such as a particular inline script or style elements.
 It can help you to avoid using the <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> <code>unsafe-inline</code> directive, which would allow-list <em>all</em> inline scripts or styles.</p>
 
-<div class="note">Note: Only use <code>nonce</code> for cases where you have no way around using unsafe inline script
+<div class="note"><p><strong>Note:</strong> Only use <code>nonce</code> for cases where you have no way around using unsafe inline script
 or style contents. If you don't need <code>nonce</code>, don't use it. If your script is static, you could also use a CSP hash instead.
 (See usage notes on <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a>.)
-Always try to take full advantage of <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> protections and avoid nonces or unsafe inline scripts whenever possible.</div>
+Always try to take full advantage of <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> protections and avoid nonces or unsafe inline scripts whenever possible.</p></div>
 
 <h3>Using nonce to allow-list a &lt;script&gt; element</h3>
 

--- a/files/en-us/web/html/global_attributes/style/index.html
+++ b/files/en-us/web/html/global_attributes/style/index.html
@@ -14,7 +14,7 @@ browser-compat: html.global_attributes.style
 <div>{{EmbedInteractiveExample("pages/tabbed/attribute-style.html","tabbed-shorter")}}</div>
 
 <div class="note">
-<p><strong>Usage note:</strong> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the <a href="/en-US/docs/Web/HTML/Global_attributes/hidden"><code>hidden</code></a> attribute.</p>
+<p><strong>Note:</strong> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the <a href="/en-US/docs/Web/HTML/Global_attributes/hidden"><code>hidden</code></a> attribute.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This fixes up the remaining notes in the HTML docs. There might be a small follow-up: it'll be easier to see once the other note fixes are all merged.

Many notes here are about not using obsolete elements/attributes and I've often changed them to warnings. I think we ought to remove all documentation of obsolete HTML (and possibly keep it in a separate HTML/Obsolete, or just delete it).