### PR TITLE
Fixes #9149 - Add sufficiently detailed note about escaping certain characters within pre tags

### DIFF
--- a/files/en-us/web/html/element/pre/index.html
+++ b/files/en-us/web/html/element/pre/index.html
@@ -78,6 +78,10 @@ body {
 
 <p>{{EmbedLiveSample("Example")}}</p>
 
+<div class="notecard note"><strong>Note:</strong> Unless they should be parsed as HTML, reserved characters such as &lt; &gt; &apos; &#8217; &quot; &amp; need to be escaped via their
+<a href="https://dev.w3.org/html5/html-author/charref">corresponding HTML entities</a> within the &lt;pre&gt; tag. For example <code>&amp;lt;p&amp;gt;</code> to display <code>&lt;p&gt;</code>.</div>
+
+
 <h2 id="Accessibility_concerns">Accessibility concerns</h2>
 
 <p>It is important to provide an alternate description for any images or diagrams created using preformatted text. The alternate description should clearly and concisely describe the image or diagram's content.</p>

--- a/files/en-us/web/html/element/pre/index.html
+++ b/files/en-us/web/html/element/pre/index.html
@@ -78,8 +78,8 @@ body {
 
 <p>{{EmbedLiveSample("Example")}}</p>
 
-<div class="notecard note"><strong>Note:</strong> Unless they should be parsed as HTML, reserved characters such as &lt; &gt; &apos; &#8217; &quot; &amp; need to be escaped via their
-<a href="https://dev.w3.org/html5/html-author/charref">corresponding HTML entities</a> within the &lt;pre&gt; tag. For example <code>&amp;lt;p&amp;gt;</code> to display <code>&lt;p&gt;</code>.</div>
+<div class="notecard note"><p><strong>Note:</strong> Unless they should be parsed as HTML, reserved characters such as &lt; &gt; &apos; &#8217; &quot; &amp; need to be escaped via their
+<a href="https://dev.w3.org/html5/html-author/charref">corresponding HTML entities</a> within the &lt;pre&gt; tag. For example <code>&amp;lt;p&amp;gt;</code> to display <code>&lt;p&gt;</code>.</p></div>
 
 
 <h2 id="Accessibility_concerns">Accessibility concerns</h2>


### PR DESCRIPTION
Fixes: #9149


> Anything else that could help us review it

There is another fix that tries to address this issue however I felt the note added in that one was not detailed enough. The note I've added here makes reference to **how** and exactly **what** characters need to be escaped (e.g with a character entity reference chart by w3.org) other than  just angle brackets.