### PR TITLE
Fixing Intl.DisplayNames optional constructor args

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.md
@@ -24,14 +24,12 @@ translation of language, region and script display names.
 ## Syntax
 
 ```js
-new Intl.DisplayNames()
-new Intl.DisplayNames(locales)
 new Intl.DisplayNames(locales, options)
 ```
 
 ### Parameters
 
-- `locales` {{optional_inline}}
+- `locales`
 
   - : A string with a BCP 47 language tag, or an array of such strings. For the
     general form and interpretation of the `locales`
@@ -50,7 +48,7 @@ new Intl.DisplayNames(locales, options)
         "`tamldec`", "`telu`", "`thai`",
         "`tibt`".
 
-- `options` {{optional_inline}}
+- `options`
 
   - : An object with some or all of the following properties:
 


### PR DESCRIPTION
The two arguments of constructor of `Intl.DisplayNames` are non optional.
checked via spec and browser behaviour: https://tc39.es/ecma402/#sec-intl-displaynames-constructor
