### PR TITLE
removing outdated browser support information

### DIFF
--- a/files/en-us/web/css/css_logical_properties/basic_concepts/index.md
+++ b/files/en-us/web/css/css_logical_properties/basic_concepts/index.md
@@ -50,20 +50,6 @@ This diagram shows block and inline in a vertical writing mode:
 
 ![Diagram showing the block axis running horizontally the inline axis vertically.](mdn-vertical.png)
 
-## Browser support
-
-Logical Properties and Values can be thought of as a couple of groups in terms of current browser support. Some of the properties are essentially mappings from the physical versions, for example {{CSSxRef("inline-size")}} for {{CSSxRef("width")}} or {{CSSxRef("margin-inline-start")}} rather than {{CSSxRef("margin-left")}}. These mapped properties are starting to see good browser support, and if you look at the individual pages for the properties in the [reference here on MDN](/en-US/docs/Web/CSS/CSS_Logical_Properties#reference) you will see that Edge is the only modern browser currently missing these.
-
-There are then a group of properties which do not have a direct mapping in terms of existing physical properties. These are shorthands made possible by the fact that we can refer to both edges of the block or inline dimension at once. An example would be {{CSSxRef("margin-block")}}, which is a shorthand setting for {{CSSxRef("margin-block-start")}} and {{CSSxRef("margin-block-end")}}.
-
-> **Note:** The CSS Working Group are currently trying to decide what to do about the four-value shorthands for logical properties, for example the equivalents to setting four physical properties at once, like margins with the {{CSSxRef("margin")}} property. We would need some kind of modifier if we were to reuse `margin` for flow-relative properties. If you would like to read the suggestions or comment on them the relevant GitHub issue is [#1282](https://github.com/w3c/csswg-drafts/issues/1282).
-
-### Testing for browser support
-
-You can test for support of logical properties and values using feature queries. For example you could set a {{CSSxRef("width")}}, test for {{CSSxRef("inline-size")}} and, if it is supported, set the `width` to `auto` and the `inline-size` to the original `width` value.
-
-{{EmbedGHLiveSample("css-examples/logical/intro-feature-queries.html", "100%", 700)}}
-
 ## See also
 
 - [Box Alignment in Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)

--- a/files/en-us/web/css/css_logical_properties/floating_and_positioning/index.md
+++ b/files/en-us/web/css/css_logical_properties/floating_and_positioning/index.md
@@ -65,8 +65,6 @@ As with other properties in the specification we have some new shorthand propert
 - {{cssxref("inset-inline")}} — sets both logical inline insets.
 - {{cssxref("inset-block")}} — sets both logical block insets.
 
-> **Note:** The browsers that have implemented the Logical Properties specification have so far implemented the direct mappings and not the new shorthands. Look to the browser compatibility data section on each property page reference for more details.
-
 ## Example: Logical values for text-align
 
 The {{cssxref("text-align")}} property has logical values that relate to text direction — rather than using `left` and `right` we can use `start` and `end`. In the below example I have set `text-align: right` in the first block and `text-align: end` in the second.

--- a/files/en-us/web/css/css_logical_properties/index.md
+++ b/files/en-us/web/css/css_logical_properties/index.md
@@ -49,7 +49,7 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 - {{CSSxRef("border-block-start-width")}}
 - {{CSSxRef("border-block-style")}}
 - {{CSSxRef("border-block-width")}}
-- {{CSSxRef("border-color")}} (`logical` {{Experimental_Inline}} keyword)
+- {{CSSxRef("border-color")}}
 - {{CSSxRef("border-inline")}}
 - {{CSSxRef("border-inline-color")}}
 - {{CSSxRef("border-inline-end")}}
@@ -66,8 +66,8 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 - {{CSSxRef("border-start-end-radius")}}
 - {{CSSxRef("border-end-start-radius")}}
 - {{CSSxRef("border-end-end-radius")}}
-- {{CSSxRef("border-style")}} (`logical` {{Experimental_Inline}} keyword)
-- {{CSSxRef("border-width")}} (`logical` {{Experimental_Inline}} keyword)
+- {{CSSxRef("border-style")}}
+- {{CSSxRef("border-width")}}
 - {{CSSxRef("margin")}} (`logical` {{Experimental_Inline}} keyword)
 - {{CSSxRef("margin-block")}}
 - {{CSSxRef("margin-block-end")}}
@@ -107,10 +107,10 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 
 ### Deprecated properties
 
-- {{CSSxRef("offset-block-end")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-end")}} {{Experimental_Inline}})
-- {{CSSxRef("offset-block-start")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-start")}} {{Experimental_Inline}})
-- {{CSSxRef("offset-inline-end")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-end")}} {{Experimental_Inline}})
-- {{CSSxRef("offset-inline-start")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-start")}} {{Experimental_Inline}})
+- {{CSSxRef("offset-block-end")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-end")}})
+- {{CSSxRef("offset-block-start")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-start")}})
+- {{CSSxRef("offset-inline-end")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-end")}})
+- {{CSSxRef("offset-inline-start")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-start")}})
 
 ## Guides
 
@@ -126,13 +126,5 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 | {{SpecName("CSS Logical Properties")}} | {{Spec2("CSS Logical Properties")}} | Initial definition. |
 
 ## Browser compatibility
-
-In general:
-
-- Firefox has support for the mapped properties — where there is a direct mapping from the physical to the logical version.
-- Chrome, from version 69, has support for the mapped properties.
-- Edge, from version 79, has the same support as Chrome.
-- Firefox 66 introduces support for two value shorthands, also behind a flag in Chrome.
-- Internet Explorer has no support.
 
 See the individual property pages for full compatibility information.

--- a/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -92,8 +92,6 @@ In a horizontal writing mode this CSS would apply a 5px margin to the top of the
 }
 ```
 
-> **Note:** The shorthand properties `margin-inline` and `margin-block` shipped in Firefox 66. As these are new properties check browser support before using.
-
 ## Padding examples
 
 The mapped padding properties of {{cssxref("padding-inline-start")}}, {{cssxref("padding-inline-end")}}, {{cssxref("padding-block-start")}}, and {{cssxref("padding-inline-end")}} can be used instead of their physical counterparts.
@@ -118,8 +116,6 @@ In a horizontal `writing-mode` this CSS would apply `5px` of padding to the top 
 }
 ```
 
-> **Note:** The shorthand properties `padding-inline` and `padding-block` shipped in Firefox 66. As these are new properties check browser support before using.
-
 ## Border examples
 
 The border properties are the main reason that Logical Properties and Values seems to have so many properties, as we have the longhands for the color, width, and style of the border on each side of a box, along with the shorthand to set all three at once for each side. As with margin and padding we have a mapped version of each physical property.
@@ -140,8 +136,6 @@ There are two-value shorthands to set the width, style and, color of the block o
   border-inline-color: rebeccapurple;
 }
 ```
-
-> **Note:** These two value shorthands shipped in Firefox 66, check browser support before using as other browsers may not have implemented them yet.
 
 ### Flow relative border-radius properties
 

--- a/files/en-us/web/css/css_logical_properties/sizing/index.md
+++ b/files/en-us/web/css/css_logical_properties/sizing/index.md
@@ -59,4 +59,3 @@ The keyword value of `both` for the resize property works whether you are think
 
 {{EmbedGHLiveSample("css-examples/logical/size-resize.html", "100%", 700)}}
 
-> **Warning:** Note that currently the logical values for resize are only supported by Firefox.


### PR DESCRIPTION
The logical properties guides were full of outdated browser support info. I've removed it and also removed experimental flags from things that are now are well supported.
