### PR TITLE
Fix parenthesis in codeblock

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.md
@@ -27,7 +27,7 @@ processing {{event("animationend")}} events.
 
 The `animationend` event fires when a [CSS animation](/en-US/docs/Web/CSS/CSS_Animations)
 reaches the end of its active period (which is calculated as
-`{{cssxref("animation-duration")}} * {{cssxref("animation-iteration-count")}}) + {{cssxref("animation-delay")}}`).
+`({{cssxref("animation-duration")}} * {{cssxref("animation-iteration-count")}}) + {{cssxref("animation-delay")}}`).
 
 ## Syntax
 


### PR DESCRIPTION

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A (I felt like creating an issue was unnecessary for a simple typo)

> What was wrong/why is this fix needed? (quick summary only)

Fixes...
"_The animationend event fires when a CSS animation reaches the end of its active period (which is calculated as `animation-duration * animation-iteration-count) + animation-delay`)_"
...by adding an open parenthesis before `animation-duration`, correctly enclosing the multiplication operation to preserve the intended evaluation order.

> Anything else that could help us review it
