### PR TITLE
Make chrome_settings_overrides docs consistent with other WebExtension docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
@@ -11,6 +11,19 @@ browser-compat: webextensions.manifest.chrome_settings_overrides
 ---
 <div>{{AddonSidebar}}</div>
 
+<table class="fullwidth-table standard-table">
+	<tbody>
+		<tr>
+			<th scope="row" style="width: 30%;">Type</th>
+			<td><code>Object</code></td>
+		</tr>
+		<tr>
+			<th scope="row">Mandatory</th>
+			<td>No</td>
+		</tr>
+	</tbody>
+</table>
+
 <p>Use the <code>chrome_settings_overrides</code> key to override certain browser settings. Two settings are available:</p>
 
 <ul>
@@ -30,22 +43,6 @@ browser-compat: webextensions.manifest.chrome_settings_overrides
     "favicon_url": "https://www.discogs.com/favicon.ico"
   }
 }</pre>
-
-<table class="properties">
- <tbody>
-  <tr>
-   <th colspan="2" scope="row">Manifest key: <code>chrome_settings_overrides</code></th>
-  </tr>
-  <tr>
-   <th scope="row">Type</th>
-   <td><code>Object</code></td>
-  </tr>
-  <tr>
-   <th scope="row">Mandatory</th>
-   <td>No</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Have table at top like other manifest key docs

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

This page: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides didn't follow the same structure as these pages listed here: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json


> Anything else that could help us review it
