### PR TITLE
add `flex-wrap` property in flex-grow css ref

### DIFF
--- a/files/en-us/web/css/flex-grow/index.md
+++ b/files/en-us/web/css/flex-grow/index.md
@@ -81,7 +81,7 @@ The remaining space is the size of the flex container minus the size of all fle
   display: flex;
 
   justify-content: space-around;
-  flex-flow: row wrap;
+  flex-wrap: wrap;
   align-items: stretch;
 }
 


### PR DESCRIPTION
Row is the default value of flex-direction, it does not need to be set.

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
