### PR TITLE
XRWebGLBinding.createProjectionLayer: options not optional

### DIFF
--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -17,42 +17,38 @@ The **`createProjectionLayer()`** method of the {{domxref("XRWebGLBinding")}} in
 ## Syntax
 
 ```js
-createProjectionLayer()
 createProjectionLayer(options)
 ```
 
 ### Parameters
 
-- `options` {{optional_inline}}
-  - : An optional object to configure the {{domxref("XRProjectionLayer")}}. If none is provided, a default configuration will be used.
-
-The `options` object can have the following optional properties:
-
-- `textureType` {{optional_inline}}: An string defining the type of texture the layer will have. Possible values:
-    - `texture`: The textures of {{domxref("XRWebGLSubImage")}} will be of type `gl.TEXTURE_2D`.
-    - `texture-array`: the textures of {{domxref("XRWebGLSubImage")}} will be of type `gl.TEXTURE_2D_ARRAY` (WebGL 2 contexts only).
-    The default value is `texture`.
-- `colorFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the color texture data. Possible values:
-    - `gl.RGB`
-    - `gl.RGBA`
-    Additionally, for contexts with the {{domxref("EXT_sRGB")}} extension enabled:
-    - `ext.SRGB_EXT`
-    - `ext.SRGB_ALPHA_EXT`
-    Additionally, for {{domxref("WebGL2RenderingContext")}} contexts:
-    - `gl.RGBA8`
-    - `gl.RGB8`
-    - `gl.SRGB8`
-    - `gl.RGB8_ALPHA8`
-   The default value is `gl.RGBA`.
-- `depthFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture. (In that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`.)
-  Possible values within {{domxref("WebGLRenderingContext")}} contexts with the {{domxref("WEBGL_depth_texture")}} extension enabled, or within {{domxref("WebGL2RenderingContext")}} contexts (no extension required):
-    - `gl.DEPTH_COMPONENT`
-    - `gl.DEPTH_STENCIL`
-    Additionally, for {{domxref("WebGL2RenderingContext")}} contexts:
-    - `gl.DEPTH_COMPONENT24`
-    - `gl.DEPTH24_STENCIL24`
-   The default value is `gl.DEPTH_COMPONENT`.
-- `scaleFactor` {{optional_inline}}: A floating-point value which is used to scale the layer during compositing. A value of `1.0` represents the default pixel size for the frame buffer. (See also {{domxref("XRWebGLLayer.getNativeFramebufferScaleFactor()")}}.) Unlike other layers, the `XRProjectionLayer` can't be created with an explicit pixel width and height, because the size is inferred by the hardware. (Projection layers fill the observer's entire view.)
+- `options`
+  - : An object to configure the {{domxref("XRProjectionLayer")}}.
+    - `textureType` {{optional_inline}}: An string defining the type of texture the layer will have. Possible values:
+      - `texture`: The textures of {{domxref("XRWebGLSubImage")}} will be of type `gl.TEXTURE_2D`.
+      - `texture-array`: the textures of {{domxref("XRWebGLSubImage")}} will be of type `gl.TEXTURE_2D_ARRAY` (WebGL 2 contexts only).
+      The default value is `texture`.
+    - `colorFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the color texture data. Possible values:
+      - `gl.RGB`
+      - `gl.RGBA`
+      Additionally, for contexts with the {{domxref("EXT_sRGB")}} extension enabled:
+      - `ext.SRGB_EXT`
+      - `ext.SRGB_ALPHA_EXT`
+      Additionally, for {{domxref("WebGL2RenderingContext")}} contexts:
+      - `gl.RGBA8`
+      - `gl.RGB8`
+      - `gl.SRGB8`
+      - `gl.RGB8_ALPHA8`
+      The default value is `gl.RGBA`.
+    - `depthFormat` {{optional_inline}}: A {{domxref("GLenum")}} defining the data type of the depth texture data or `0` indicating that the layer should not provide a depth texture. (In that case {{domxref("XRProjectionLayer.ignoreDepthValues")}} will be `true`.)
+      Possible values within {{domxref("WebGLRenderingContext")}} contexts with the {{domxref("WEBGL_depth_texture")}} extension enabled, or within {{domxref("WebGL2RenderingContext")}} contexts (no extension required):
+        - `gl.DEPTH_COMPONENT`
+        - `gl.DEPTH_STENCIL`
+        Additionally, for {{domxref("WebGL2RenderingContext")}} contexts:
+        - `gl.DEPTH_COMPONENT24`
+        - `gl.DEPTH24_STENCIL24`
+      The default value is `gl.DEPTH_COMPONENT`.
+      - `scaleFactor` {{optional_inline}}: A floating-point value which is used to scale the layer during compositing. A value of `1.0` represents the default pixel size for the frame buffer. (See also {{domxref("XRWebGLLayer.getNativeFramebufferScaleFactor()")}}.) Unlike other layers, the `XRProjectionLayer` can't be created with an explicit pixel width and height, because the size is inferred by the hardware. (Projection layers fill the observer's entire view.)
 
 ### Return value
 


### PR DESCRIPTION
The IDL says `XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});` however, this is an issue with bikeshed. It is not actually optional.

(first time WebIDL isn't reliable to me!)

See https://immersive-web.github.io/layers/#XRWebGLBindingtype where it says: "the init dictionaries shouldn’t be optional. This is bikeshed issue 1566."