### PR TITLE
Fix a link

### DIFF
--- a/files/en-us/glossary/csrf/index.html
+++ b/files/en-us/glossary/csrf/index.html
@@ -20,5 +20,5 @@ tags:
 
 <ul>
  <li>{{Interwiki("wikipedia", "Cross-site request forgery")}} on Wikipedia</li>
- <li><a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet">Prevention measures</a></li>
+ <li><a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html">Prevention measures</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

The existing link is broken - https://owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet


> Anything else that could help us review it
