### PR TITLE
[Markdown] [Web/HTML] Suppress conversion of wide tables

### DIFF
--- a/files/en-us/web/html/attributes/capture/index.html
+++ b/files/en-us/web/html/attributes/capture/index.html
@@ -61,7 +61,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/crossorigin/index.html
+++ b/files/en-us/web/html/attributes/crossorigin/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>These attributes are enumerated, and have the following possible values:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<tbody>
 		<tr>
 			<td class="header">Keyword</td>
@@ -61,7 +61,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
 	<thead>
 		<tr>
 			<th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/disabled/index.html
+++ b/files/en-us/web/html/attributes/disabled/index.html
@@ -109,7 +109,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/elementtiming/index.html
+++ b/files/en-us/web/html/attributes/elementtiming/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/for/index.html
+++ b/files/en-us/web/html/attributes/for/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/max/index.html
+++ b/files/en-us/web/html/attributes/max/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h3 id="Syntax">Syntax</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>Syntax for <code>max</code> values by input <code>type</code></caption>
  <thead>
   <tr>
@@ -75,7 +75,7 @@ tags:
 
 <p>For the {{htmlelement('progress')}} element, the <code>max</code> attribute describes how much work the task indicated by the <code>progress</code> element requires. If present, must have a value greater than zero and be a valid floating point number. For the {{htmlelement('meter')}} element, the <code>max</code> attribute defines the upper numeric bound of the measured range. This must be greater than the minimum value (<code><a href="/en-US/docs/Web/HTML/Attributes/min">min</a></code> attribute), if specified. In both cases, if omitted, the value defaults to 1.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>Syntax for <code>max</code> values for other elements</caption>
  <thead>
   <tr>
@@ -104,7 +104,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/maxlength/index.html
+++ b/files/en-us/web/html/attributes/maxlength/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/min/index.html
+++ b/files/en-us/web/html/attributes/min/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h3 id="Syntax">Syntax</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>Syntax for <code>min</code> values by input <code>type</code></caption>
  <thead>
   <tr>
@@ -73,7 +73,7 @@ tags:
 
 <p>For the {{htmlelement('meter')}} element, the <code>min</code> attribute defines the lower numeric bound of the measured range. This must be less than the minimum value (<code><a href="/en-US/docs/Web/HTML/Attributes/max">max</a></code> attribute), if specified. In both cases, if omitted, the value defaults to 1.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>Syntax for <code>min</code> values for other elements</caption>
  <thead>
   <tr>
@@ -117,7 +117,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/minlength/index.html
+++ b/files/en-us/web/html/attributes/minlength/index.html
@@ -39,7 +39,7 @@ input:invalid:focus {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/multiple/index.html
+++ b/files/en-us/web/html/attributes/multiple/index.html
@@ -151,7 +151,7 @@ select[multiple]:active {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/readonly/index.html
+++ b/files/en-us/web/html/attributes/readonly/index.html
@@ -105,7 +105,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/required/index.html
+++ b/files/en-us/web/html/attributes/required/index.html
@@ -65,7 +65,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/attributes/step/index.html
+++ b/files/en-us/web/html/attributes/step/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h3 id="Syntax">Syntax</h3>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>Default values for step</caption>
  <thead>
   <tr>
@@ -99,7 +99,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/html/date_and_time_formats/index.html
+++ b/files/en-us/web/html/date_and_time_formats/index.html
@@ -422,7 +422,7 @@ tags:
 
 <p>While this format allows for time zones between -23:59 and +23:59, the current range of time zone offsets is -12:00 to +14:00, and no time zones are currently offset from the hour by anything other than <code>00</code>, <code>30</code>, or <code>45</code> minutes. This may change at more or less anytime, since countries are free to tamper with their time zones at any time and in any way they wish to do so.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <caption>Examples of valid global date and time strings</caption>
  <thead>
   <tr>

--- a/files/en-us/web/html/element/audio/index.html
+++ b/files/en-us/web/html/element/audio/index.html
@@ -84,7 +84,7 @@ browser-compat: html.elements.audio
 
 <h2 id="Events">Events</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Event name</th>

--- a/files/en-us/web/html/element/index.html
+++ b/files/en-us/web/html/element/index.html
@@ -67,7 +67,7 @@ tags:
 
 <p>You can embed <a href="/en-US/docs/Web/SVG">SVG</a> and <a href="/en-US/docs/Web/MathML">MathML</a> content directly into HTML documents, using the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements.</p>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Element</th>

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -26,7 +26,7 @@ browser-compat: html.elements.input
 
 <p>The available types are as follows:</p>
 
-<table>
+<table class="no-markdown">
  <colgroup>
   <col>
   <col style="width: 50%;">
@@ -233,7 +233,7 @@ browser-compat: html.elements.input
 
 <p>This section provides a table listing all the attributes with a brief description. This table is followed by a list describing each attribute in greater detail, along with which input types they are associated with.Those that are common to most or all input types are defined in greater detail below. Attributes that are unique to particular input types—or attributes which are common to all input types but have special behaviors when used on a given input type—are instead documented on those types' pages. This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>. Those with extra importance as it relates to <code>&lt;input&gt;</code> are highlighted.</p>
 
-<table>
+<table class="no-markdown">
  <caption>Attributes for the <code>&lt;input&gt;</code> element include <a href="/en-US/docs/Web/HTML/Global_attributes">global HTML attributes</a> and:</caption>
  <thead>
   <tr>
@@ -690,7 +690,7 @@ let hatSize = form.elements["hat-size"];
 
 <p>The following non-standard attributes are also available on some browsers. As a general rule, you should avoid using them unless it can't be helped.</p>
 
-<table>
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Attribute</th>
@@ -802,7 +802,7 @@ let hatSize = form.elements["hat-size"];
 
 <h3 id="UI_pseudo-classes">UI pseudo-classes</h3>
 
-<table>
+<table class="no-markdown">
  <caption>Captions super relevant to the <code>&lt;input&gt;</code> element:</caption>
  <thead>
   <tr>
@@ -1020,7 +1020,7 @@ input[min][max] {}
 
 <p>Specific attributes and their values can lead to a specific error {{domxref('ValidityState')}}:</p>
 
-<table>
+<table class="no-markdown">
  <caption>Validity object errors depend on the {{htmlelement('input')}} attributes and their values:</caption>
  <thead>
   <tr>

--- a/files/en-us/web/html/element/video/index.html
+++ b/files/en-us/web/html/element/video/index.html
@@ -107,7 +107,7 @@ browser-compat: html.elements.video
 
 <h2 id="Events">Events</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Event Name</th>

--- a/files/en-us/web/html/global_attributes/enterkeyhint/index.html
+++ b/files/en-us/web/html/global_attributes/enterkeyhint/index.html
@@ -33,7 +33,7 @@ attributes to display a suitable enter key label (or icon).</p>
 
 <p>The <code>enterkeyhint</code> attribute is an enumerated attribute and only accepts the following values:</p>
 
-<table class="standard-table">
+<table class="no-markdown">
   <thead>
    <tr>
     <th>Value</th>

--- a/files/en-us/web/html/viewport_meta_tag/index.html
+++ b/files/en-us/web/html/viewport_meta_tag/index.html
@@ -77,7 +77,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Specification</th>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8961.

This PR tells the converter not to convert any tables which when converted would be >150 characters wide, per https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#gfm_table_maximum_width.

I think this should be the last prep PR: when it is merged we can file the conversion PR :).
