### PR TITLE
Rename DOMQuad ctor in interface page

### DIFF
--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -16,7 +16,7 @@ A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbit
 
 ## Constructor
 
-- {{domxref("DOMQuad.DOMQuad()")}}
+- {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}}
   - : Creates a new `DOMQuad` object.
 
 ## Properties


### PR DESCRIPTION
Make it coherent with what we do all over the place.