### PR TITLE
Remove summary heading from Touch.target

### DIFF
--- a/files/en-us/web/api/touch/target/index.md
+++ b/files/en-us/web/api/touch/target/index.md
@@ -12,18 +12,18 @@ browser-compat: api.Touch.target
 ---
 {{ APIRef("Touch Events") }}
 
-## Summary
-
-Returns the {{domxref("Element")}} ({{domxref("EventTarget")}}) on which the touch contact started when it was first placed on the surface, even if the touch point has since moved outside the interactive area of that element or even been removed from the document. Note that if the target element is removed from the document, events will still be targeted at it, and hence won't necessarily bubble up to the window or document anymore. If there is any risk of an element being removed while it is being touched, the best practice is to attach the touch listeners directly to the target.
+The read-only **`target`**  property of the `Touch` interface returns the ({{domxref("EventTarget")}}) on which the touch contact started when it was first placed on the surface, even if the touch point has since moved outside the interactive area of that element or even been removed from the document. Note that if the target element is removed from the document, events will still be targeted at it, and hence won't necessarily bubble up to the window or document anymore. If there is any risk of an element being removed while it is being touched, the best practice is to attach the touch listeners directly to the target.
 
 ## Syntax
 
-    var el = touchPoint.target;
+```js
+var el = touchPoint.target;
+
+```
 
 ### Return value
 
-- `el`
-  - : The target element of the {{domxref("Touch")}} object.
+The {{domxref("EventTarget")}} the {{domxref("Touch")}} object applies to.
 
 ## Example
 


### PR DESCRIPTION
There was a very old _Summary_ heading at the top. Removed and minor fixes.