### PR TITLE
Remove Image in Example of <filter> svg ref

### DIFF
--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -59,7 +59,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 
 #### Result
 
-{{EmbedLiveSample("Example",235,140)}}
+{{EmbedLiveSample("Example",235,145)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -45,7 +45,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 #### SVG
 
 ```html
-<svg height="120" width="230" xmlns="http://www.w3.org/2000/svg">
+<svg width="230" height="120" xmlns="http://www.w3.org/2000/svg">
   
   <filter id="blurMe">
     <feGaussianBlur stdDeviation="5"/>

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -45,7 +45,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 #### SVG
 
 ```html
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 120">
+<svg height="120" width="230" xmlns="http://www.w3.org/2000/svg">
   
   <filter id="blurMe">
     <feGaussianBlur stdDeviation="5"/>
@@ -59,7 +59,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 
 #### Result
 
-{{EmbedLiveSample("Example",232,135)}}
+{{EmbedLiveSample("Example",235,135)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -45,21 +45,21 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 #### SVG
 
 ```html
-<svg width="230" height="120" xmlns="http://www.w3.org/2000/svg">
- <filter id="blurMe">
-   <feGaussianBlur stdDeviation="5"/>
- </filter>
-
- <circle cx="60" cy="60" r="50" fill="green" />
-
- <circle cx="170" cy="60" r="50" fill="green"
-          filter="url(#blurMe)" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 120">
+  
+  <filter id="blurMe">
+    <feGaussianBlur stdDeviation="5"/>
+  </filter>
+  
+  <circle cx="60" cy="60" r="50" fill="green"/>
+  
+  <circle cx="170" cy="60" r="50" fill="green" filter="url(#blurMe)"/>
 </svg>
 ```
 
 #### Result
 
-{{EmbedLiveSample("Example",232,124,"/files/4227/feGaussianBlur.png")}}
+{{EmbedLiveSample("Example",232,135)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -59,7 +59,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 
 #### Result
 
-{{EmbedLiveSample("Example",235,135)}}
+{{EmbedLiveSample("Example",235,140)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -59,7 +59,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 
 #### Result
 
-{{EmbedLiveSample("Example",235,145)}}
+{{EmbedLiveSample("Example",235,150)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -46,7 +46,6 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 
 ```html
 <svg width="230" height="120" xmlns="http://www.w3.org/2000/svg">
-  
   <filter id="blurMe">
     <feGaussianBlur stdDeviation="5"/>
   </filter>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)

1. Remove screenshot image of live example
2. increase height to remove vertical scrolling

> Anything else that could help us review it
[99.3% global support of svg filter](https://caniuse.com/svg-filters)