### PR TITLE
update html_imports for explanation of html module

### DIFF
--- a/files/en-us/web/web_components/html_imports/index.html
+++ b/files/en-us/web/web_components/html_imports/index.html
@@ -27,3 +27,4 @@ tags:
 
 <p>This feature is not part of any current specification. It is no longer on track to become a standard.</p>
 
+<p>Although this feature has been abandoned, there are still some proposals that try to provide html module solutions, which you can find at <a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/html-modules-explainer.md">WICG/html-modules-explainer</a> and <a href="https://github.com/whatwg/html/pull/4505">Introduce HTML Modules</a>.</p>


### PR DESCRIPTION
Added an explanation of the html module, reference to [WICG/webcomponents](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/html-modules-explainer.md), whatwg/html#4505.
