### PR TITLE
Remove Firefox 49 note

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -49,9 +49,6 @@ HTMLMediaElement.seekToNextFrame();
 
 A {{jsxref("Promise")}} which is fulfilled once the seek operation has completed.
 
-> **Note:** Firefox 49 returns {{jsxref("undefined")}} instead of a promise, and performs the
-> seek operation synchronously.
-
 ## Specifications
 
 Not part of any specification.


### PR DESCRIPTION
Removed a Firefox 49 note (the first released version to support this was Fx 56, so this was a limitation in a first implementation in Nightly)