### PR TITLE
Document.clear() exists but does nothing.

### DIFF
--- a/files/en-us/web/api/document/clear/index.md
+++ b/files/en-us/web/api/document/clear/index.md
@@ -7,18 +7,12 @@ tags:
   - Document
   - HTML DOM
   - Method
-  - NeedsExample
-  - NeedsSpecTable
   - Reference
 browser-compat: api.Document.clear
 ---
 {{APIRef("DOM")}}{{Deprecated_Header}}
 
-The **`Document.clear()`** method clears the whole specified
-document in early (pre-1.0) versions of Mozilla.
-
-In recent versions of Mozilla-based applications, as well as in Internet Explorer and
-Netscape 4, this method does nothing.
+The **`Document.clear()`** method does nothing, but doesn't raise any error
 
 ## Syntax
 
@@ -28,7 +22,7 @@ document.clear();
 
 ## Specifications
 
-- [HTML5](https://www.whatwg.org/html/#dom-document-clear)
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/clear/index.md
+++ b/files/en-us/web/api/document/clear/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Document.clear
 ---
 {{APIRef("DOM")}}{{Deprecated_Header}}
 
-The **`Document.clear()`** method does nothing, but doesn't raise any error
+The **`Document.clear()`** method does nothing, but doesn't raise any error.
 
 ## Syntax
 


### PR DESCRIPTION
- Removed pre-Firefox Gecko info
- Made it clear this does nothing
- Removed useless tags
- Use the spec macro (it is defined in HTML, as doing nothing)