### PR TITLE
Replace `Boolean` (object) with boolean (primitive)

### DIFF
--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -35,7 +35,7 @@ document.execCommand(aCommandName, aShowDefaultUI, aValueArgument)
 
 ### Return value
 
-A {{jsxref('Boolean')}} that is `false` if the command is unsupported or
+A boolean value that is `false` if the command is unsupported or
 disabled.
 
 > **Note:** `document.execCommand()` only returns

--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -115,7 +115,7 @@ Arithmetic operators take numerical values (either literals or variables) as the
 
 ### Relational operators
 
-A comparison operator compares its operands and returns a `Boolean` value based on whether the comparison is true.
+A comparison operator compares its operands and returns a boolean value based on whether the comparison is true.
 
 - {{JSxRef("Operators/in", "in")}}
   - : The `in` operator determines whether an object has a given property.
@@ -134,7 +134,7 @@ A comparison operator compares its operands and returns a `Boolean` value based 
 
 ### Equality operators
 
-The result of evaluating an equality operator is always of type `Boolean` based on whether the comparison is true.
+The result of evaluating an equality operator is always of type boolean based on whether the comparison is true.
 
 - {{JSxRef("Operators/Equality", "==")}}
   - : Equality operator.


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

There are some `Boolean` objects which should be boolean primitive in some documents.

> Anything else that could help us review it
