### PR TITLE
Fixes #7831 - Adds note for troubleshooting setup

### DIFF
--- a/files/en-us/webassembly/rust_to_wasm/index.html
+++ b/files/en-us/webassembly/rust_to_wasm/index.html
@@ -43,7 +43,7 @@ tags:
 <pre class="brush: bash no-line-numbers">$ cargo install wasm-pack</pre>
 
 <div class="notecard note">
-<p><strong>Note</strong>: In case you encounter errors in the environment setup, seek help for platform specific troubleshooting steps before proceeding further.</p>
+<p><strong>Note</strong>: In case you encounter errors in the environment setup, please seek help for platform specific troubleshooting steps before proceeding.</p>
 </div>
 
 <h2 id="Building_our_WebAssembly_package">Building our WebAssembly package</h2>

--- a/files/en-us/webassembly/rust_to_wasm/index.html
+++ b/files/en-us/webassembly/rust_to_wasm/index.html
@@ -42,6 +42,10 @@ tags:
 
 <pre class="brush: bash no-line-numbers">$ cargo install wasm-pack</pre>
 
+<div class="notecard note">
+<p><strong>Note</strong>: In case you encounter errors in the environment setup, seek help for platform specific troubleshooting steps before proceeding further.</p>
+</div>
+
 <h2 id="Building_our_WebAssembly_package">Building our WebAssembly package</h2>
 
 <p>Enough setup; let's create a new package in Rust. Navigate to wherever you keep your personal projects, and type this:</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #7831

> What was wrong/why is this fix needed? (quick summary only)

On Windows 10 errors show up in package installation (reported by OP) or in rust installation itself (e.g. link.exe not found due to missing VS deps).

> Anything else that could help us review it

Added a generic note which might not look very useful. We could add detailed instructions for Windows but that does not quite belong in this particular article, I think.