### PR TITLE
minor corrections in JavaScript/Reference/Operators

### DIFF
--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
@@ -64,6 +64,6 @@ foo += 'bar' // "foobar"
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Addition
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)

--- a/files/en-us/web/javascript/reference/operators/assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/assignment/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.operators.assignment
 
 The simple assignment operator (`=`) is used to assign a value to a
 variable. The assignment operation evaluates to the assigned value. Chaining the
-assignment operator is possible in order to assign a single value to multiple variables
+assignment operator is possible in order to assign a single value to multiple variables.
 
 {{EmbedInteractiveExample("pages/js/expressions-assignment.html")}}
 
@@ -48,4 +48,4 @@ x = y = z // x, y and z are all 25
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)

--- a/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -45,6 +45,6 @@ a &= 2; // 0
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Bitwise AND
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND)

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -47,7 +47,7 @@ a |= 2; // 7
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Bitwise OR
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR)
 - [Logical

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
@@ -52,6 +52,6 @@ console.log(b); // 00000000000000000000000000000101
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Bitwise XOR
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR)

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.md
@@ -47,6 +47,6 @@ bar /= 'foo' // NaN
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Division
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -45,6 +45,6 @@ bar **= 'foo' // NaN
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Exponentiation
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)

--- a/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
@@ -43,5 +43,5 @@ a <<= 2; // 20
 
 ## See also
 
-- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Left shift operator](/en-US/docs/Web/JavaScript/Reference/Operators/Left_shift)

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
@@ -80,6 +80,5 @@ y &&= 0; // 0
   nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
 - [Bitwise
   AND assignment (`&=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment)
-- {{jsxref("Boolean")}}
 - {{Glossary("Truthy")}}
 - {{Glossary("Falsy")}}

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -89,6 +89,5 @@ otherwise you want to use the `??=` operator (for {{jsxref("null")}} or
   nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
 - [Bitwise
   OR assignment (`|=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment)
-- {{jsxref("Boolean")}}
 - {{Glossary("Truthy")}}
 - {{Glossary("Falsy")}}

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -45,6 +45,6 @@ bar *= 'foo' // NaN
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Multiplication
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)

--- a/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
@@ -46,6 +46,6 @@ bar %= 0     // NaN
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Remainder
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)

--- a/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
@@ -45,6 +45,6 @@ b >>= 2;  // -2 (-00000000000000000000000000000010)
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Right shift
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift)

--- a/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -45,6 +45,6 @@ bar -= 'foo' // NaN
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Subtraction
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
@@ -45,6 +45,6 @@ b >>>= 2;   // 1073741822 (00111111111111111111111111111110)
 ## See also
 
 - [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment)
+  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
 - [Unsigned
   right shift operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift)


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

none

> What was wrong/why is this fix needed? (quick summary only)

- fix a link (fragment)
- Remove `Boolean` link which is a wrapper object. These operators don't return it.

> Anything else that could help us review it
