### PR TITLE
Delete empty guide list

### DIFF
--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -86006,12 +86006,6 @@
       "teoli"
     ]
   },
-  "Web/API/WebRTC_API/Coding_guide": {
-    "modified": "2019-03-23T22:47:18.640Z",
-    "contributors": [
-      "Sheppy"
-    ]
-  },
   "Web/API/WebRTC_API/Connectivity": {
     "modified": "2019-12-12T10:49:49.555Z",
     "contributors": [

--- a/files/en-us/web/api/webrtc_api/coding_guide/index.md
+++ b/files/en-us/web/api/webrtc_api/coding_guide/index.md
@@ -1,9 +1,0 @@
----
-title: WebRTC coding guide
-slug: Web/API/WebRTC_API/Coding_guide
----
-Once you have an overall understanding of what WebRTC does and how it works, your mind likely turns to implementation. How do you create a Web application that uses two-way video or data streams without having to do all the hard work of compressing frames, building streams, and so forth by yourself? This coding guide will explain in depth how WebRTC works, and will dive into actual code that uses WebRTC to do useful things.
-
-{{LandingPageListSubpages}}
-
-If you need to learn more about the fundamentals of how WebRTC and its protocols work, check out our [High-level guides for WebRTC](/en-US/docs/Web/API/WebRTC_API/High-level_guide).


### PR DESCRIPTION
The list is autogenerated using the subpages. There are none. A `rg` search didn't find any link to this page. Removing.