### PR TITLE
add example for readAsText

### DIFF
--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -49,7 +49,7 @@ function previewFile() {
   const reader = new FileReader();
 
   reader.addEventListener("load", () => {
-    // this will then display a .txt file
+    // this will then display a text file
     content.innerText = reader.result;
   }, false);
 

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -11,20 +11,17 @@ browser-compat: api.FileReader.readAsText
 ---
 {{APIRef("File API")}}
 
-The **`readAsText()`** method is used to read the contents of
-the specified {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is
-complete, the {{domxref("FileReader.readyState","readyState")}} is changed to
-`DONE`, the {{domxref("FileReader/loadend_event", "loadend")}} event is triggered, and the
-{{domxref("FileReader.result","result")}} property contains the contents of the file as
-a text string.
+The **`readAsText()`** method is used to read the contents of the specified {{domxref("Blob")}} or {{domxref("File")}}.
+When the read operation is complete, the {{domxref("FileReader.readyState","readyState")}} is changed to `DONE`,
+the {{domxref("FileReader/loadend_event", "loadend")}} event is triggered, and the {{domxref("FileReader.result","result")}} property contains the contents of the file as a text string.
 
-> **Note:** The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as
-> text.
+> **Note:** The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as text.
 
 ## Syntax
 
 ```js
-instanceOfFileReader.readAsText(blob[, encoding]);
+readAsText(blob)
+readAsText(blob, encoding)
 ```
 
 ### Parameters
@@ -32,8 +29,7 @@ instanceOfFileReader.readAsText(blob[, encoding]);
 - `blob`
   - : The {{domxref("Blob")}} or {{domxref("File")}} from which to read.
 - `encoding` {{optional_inline}}
-  - : A string specifying the encoding to use for the returned data. By default, UTF-8 is
-    assumed if this parameter is not specified.
+  - : A string specifying the encoding to use for the returned data. By default, UTF-8 is assumed if this parameter is not specified.
 
 ## Example
 

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -59,6 +59,10 @@ function previewFile() {
 }
 ```
 
+### Result
+
+{{EmbedLiveSample("Example", "100%", 240)}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -35,6 +35,34 @@ instanceOfFileReader.readAsText(blob[, encoding]);
   - : A string specifying the encoding to use for the returned data. By default, UTF-8 is
     assumed if this parameter is not specified.
 
+## Example
+
+### HTML
+
+```html
+<input type="file" onchange="previewFile()"><br>
+<p class="content"></p>
+```
+
+### JavaScript
+
+```js
+function previewFile() {
+  const content = document.querySelector('.content');
+  const [file] = document.querySelector('input[type=file]').files;
+  const reader = new FileReader();
+
+  reader.addEventListener("load", function () {
+    // convert image file to base64 string
+    content.innerText = reader.result;
+  }, false);
+
+  if (file) {
+    reader.readAsText(file);
+  }
+}
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -48,8 +48,8 @@ function previewFile() {
   const [file] = document.querySelector('input[type=file]').files;
   const reader = new FileReader();
 
-  reader.addEventListener("load", function () {
-    // convert image file to base64 string
+  reader.addEventListener("load", () => {
+    // this will then display a .txt file
     content.innerText = reader.result;
   }, false);
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

No issue number, it was my personal issue when reading the file.

> What was wrong/why is this fix needed? (quick summary only)

It was unlear to me how to use it. When I saw the example used in [`readAsDataUrl()`](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL), which is a bit similar to `readAsText`. So I added an example to this file as well. Example works with a `.txt` file in mind, for other text files more code would need to be written, this is a basic usage.

> Anything else that could help us review it

Working example: https://jsfiddle.net/u9q6en4g/