### PR TITLE
Add window.reportError

### DIFF
--- a/files/en-us/web/api/reporterror/index.md
+++ b/files/en-us/web/api/reporterror/index.md
@@ -1,6 +1,6 @@
 ---
-title: self.reportError()
-slug: Web/API/window/reportError
+title: reportError()
+slug: Web/API/reportError
 tags:
   - API
   - Method
@@ -11,7 +11,7 @@ browser-compat: api._globals.reportError
 ---
 {{APIRef}} {{AvailableInWorkers}}
 
-The **`self.reportError()`** method may be used to report errors to the console or global event handlers, emulating an uncaught JavaScript exception.
+The **`reportError()`** global method may be used to report errors to the console or global event handlers, emulating an uncaught JavaScript exception.
 
 This feature is primarily intended for custom event-dispatching or callback-manipulating libraries.
 Libraries can use this feature to catch errors in callback code and re-throw them to the top level handler.
@@ -51,8 +51,8 @@ if (typeof self.reportError == 'function') {
 }
 ```
 
-The following code shows how you might create and report an error, and how it may be caught using either `window.onerror` or by adding a listener for the `error` event.
-Note that `window.onerror` must return `true` to stop the event propagating further.
+The following code shows how you might create and report an error, and how it may be caught using either the global `onerror` handler ({{domxref("GlobalEventHandlers.onerror")}}) or by adding a listener for the `error` event.
+Note that the handler assigned to `onerror` must return `true` to stop the event propagating further.
 
 ```js
 var newError = new Error('Some error message', "someFile.js", 11);
@@ -84,5 +84,7 @@ self.addEventListener('error', (error) => {
 
 ## See also
 
+- [`Window`](/en-US/docs/Web/API/Window#methods_implemented_from_elsewhere)
+- [`WorkerGlobalScope`](/en-US/docs/Web/API/WorkerGlobalScope#methods_implemented_from_elsewhere)
 - {{domxref("GlobalEventHandlers/onerror","GlobalEventHandlers.onerror")}}
 - [error](/en-US/docs/Web/API/Element/error_event) event

--- a/files/en-us/web/api/reporterror/index.md
+++ b/files/en-us/web/api/reporterror/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - Global
   - Errors
-browser-compat: api._globals.reportError
+browser-compat: api.reporterror
 ---
 {{APIRef}} {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -303,7 +303,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : Schedules a function to execute every time a given number of milliseconds elapses.
 - {{domxref("setTimeout()")}}
   - : Schedules a function to execute in a given amount of time.
-- {{domxref("Window.reportError", "self.reportError()")}}
+- {{domxref("reportError()")}}
   - : Reports an error in a script, emulating an unhandled exception.
 
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -303,6 +303,9 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : Schedules a function to execute every time a given number of milliseconds elapses.
 - {{domxref("setTimeout()")}}
   - : Schedules a function to execute in a given amount of time.
+- {{domxref("Window.reportError", "self.reportError()")}}
+  - : Reports an error in a script, emulating an unhandled exception.
+
 
 ### Deprecated methods
 

--- a/files/en-us/web/api/window/reporterror/index.md
+++ b/files/en-us/web/api/window/reporterror/index.md
@@ -1,0 +1,88 @@
+---
+title: self.reportError()
+slug: Web/API/window/reportError
+tags:
+  - API
+  - Method
+  - Reference
+  - Global
+  - Errors
+browser-compat: api._globals.reportError
+---
+{{APIRef}} {{AvailableInWorkers}}
+
+The **`self.reportError()`** method may be used to report errors to the console or global event handlers, emulating an uncaught JavaScript exception.
+
+This feature is primarily intended for custom event-dispatching or callback-manipulating libraries.
+Libraries can use this feature to catch errors in callback code and re-throw them to the top level handler.
+This ensures that an exception in one callback will not prevent others from being handled, while at the same time ensuring that stack trace information is still readily available for debugging at the top level.
+
+{{EmbedInteractiveExample("pages/js/self-reporterror.html")}}
+
+## Syntax
+
+```js
+self.reportError(throwable);
+```
+
+### Parameters
+
+- `throwable`
+  - : An error object such as a {{jsxref("TypeError")}}.
+
+### Return value
+
+Void.
+
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : The method is called without an error argument.
+
+
+## Example
+
+Feature test for the method using:
+
+```js
+if (typeof self.reportError == 'function') {
+  // function is defined
+}
+```
+
+The following code shows how you might create and report an error, and how it may be caught using either `window.onerror` or by adding a listener for the `error` event.
+Note that `window.onerror` must return `true` to stop the event propagating further.
+
+```js
+var newError = new Error('Some error message', "someFile.js", 11);
+self.reportError(newError);
+
+window.onerror = function(message, source, lineno, colno, error) {
+  console.log('message:' + error.message + ', lineno: ' + lineno );
+  return true;
+};
+
+self.addEventListener('error', (error) => {
+    console.log(error.filename);
+});
+
+// Output
+// > "message:Some error message, lineno: 11"
+// > "someFile.js"
+```
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+
+## See also
+
+- {{domxref("GlobalEventHandlers/onerror","GlobalEventHandlers.onerror")}}
+- [error](/en-US/docs/Web/API/Element/error_event) event

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -99,7 +99,9 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : Schedules a function to execute every time a given number of milliseconds elapses.
 - {{domxref("setTimeout()")}}
   - : Schedules a function to execute in a given amount of time.
-
+- {{domxref("reportError()")}}
+  - : Reports an error in a script, emulating an unhandled exception.
+  
 ## Example
 
 You won't access `WorkerGlobalScope` directly in your code; however, its properties and methods are inherited by more specific global scopes such as {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}}. For example, you could import another script into the worker and print out the contents of the worker scope's `navigator` object using the following two lines:


### PR DESCRIPTION
This is first part of `self.reportError()` docs, which is delivered in FF93 as part of #8608.

Edited. It is a global (Api/reportError) linked from top level `Window` and `WorkerGlobalScope`

I am still waiting on information needed for the interactive example: https://github.com/mdn/interactive-examples/issues/1919

Also see, need advice on how the browser key works in this case.