### PR TITLE
fix: fix typo in sample code under WebXR doc Target ray space.

### DIFF
--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -86,7 +86,7 @@ The {{domxref("XRSpace")}} used to describe the position and orientation of the 
 You can easily obtain the target ray corresponding to the `targetRaySpace` from within the drawing handler for a given frame using {{domxref("XRFrame")}}'s {{domxref("XRFrame.getPose", "getPose()")}} method. The returned {{domxref("XRPose")}}'s {{domxref("XRPose.transform", "transform")}} is the transform corresponding to the target ray. Thus, for an input controller `primaryInput`:
 
 ```js
-let targetRayPose = frame.session.getPose(primaryInput.targetRaySpace,
+let targetRayPose = frame.getPose(primaryInput.targetRaySpace,
                        viewerRefSpace);
 let targetRayOrigin = targetRayPose.transform.position;
 let targetRayVector = targetRayPose.transform.orientation;


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Fixes #9311 

> What was wrong/why is this fix needed? (quick summary only)

> You can easily obtain the target ray corresponding to the targetRaySpace from within the drawing handler for a given frame using XRFrame's getPose() method

Above description clearly says `getPose()` method belongs to `XRFrame`, but the code sample

`let targetRayPose = frame.session.getPose(primaryInput.targetRaySpace, viewerRefSpace);`

Calls `getPose()` from `frame.session` which seems to refer to `XRSession`.

> Anything else that could help us review it

- @JakeJustLearning Please kindly review whether the changes I made are enough.