### PR TITLE
Change background color in example of Child combinator page

### DIFF
--- a/files/en-us/web/css/child_combinator/index.md
+++ b/files/en-us/web/css/child_combinator/index.md
@@ -33,7 +33,7 @@ selector1 > selector2 { style properties }
 
 ```css
 span {
-  background-color: white;
+  background-color: red;
 }
 
 div > span {

--- a/files/en-us/web/css/child_combinator/index.md
+++ b/files/en-us/web/css/child_combinator/index.md
@@ -33,7 +33,7 @@ selector1 > selector2 { style properties }
 
 ```css
 span {
-  background-color: red;
+  background-color: aqua;
 }
 
 div > span {


### PR DESCRIPTION
```css
 span {
  background-color: white;
}
```
changing with
```css
/* Instead of using the default value, a different value should be used in the background color to demonstrate the example. */
 span {
  background-color: aqua;
}
```

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'



> What was wrong/why is this fix needed? (quick summary only)



> Anything else that could help us review it
