### PR TITLE
Update Grouping operator ( )

### DIFF
--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -55,16 +55,17 @@ a + (b * c)   // 7
 a * c + b * c // 9
 ```
 
-Notice in these examples that the left-to-right order of evaluation is still
-preserved. In other words, the order in which the *operators* evaluate has changed,
-but the order in which the *operands* evaluate has not.
-For example in this code:
+The grouping operator is also used to clarify a mathematical structure of expressions.
 
 ```js
-a() * (b() + c())
+const z = (x = y); // Or equivalently: const z = x = y;
 ```
 
-The function `a` will be called before the function `b`, which will be called before the function `c`.
+When chaining the expressions, the assignment is evaluated right-to-left.
+
+`w = z = x = y` is equivalent to `w = (z = (x = y))` or `x = y; z = y; w = y`
+
+Essentially, the grouping operator is used to define a dependency graph of expressions along with other operators in a mathematical sense, that is indepedent from an evaluation strategy of a programming langueage. It is possible to derive an evaluation order or the absence of an evaluation order that respects the given dependencies from the dependency graph.
 
 ## Specifications
 


### PR DESCRIPTION
The example in the old version:

------
>Notice in these examples that the left-to-right order of evaluation is still preserved. In other words, the order in which the operators evaluate has changed, but the order in which the operands evaluate has not. For example in this code:

`a() * (b() + c())`

The function `a` will be called before the function `b`, which will be called before the function `c`.

-------

1.
We have another description mentioning the evaluation order becomes **right-to-left** etc. 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators (Return value and chaining)
, so it's extraordinary unnatural to mention as if it's to be "*left-to-right order of evaluation is **still preserved***" in a general principle of JavaScript:

2.
In the old version, the behavior of the example code arises due to eager evaluation of JavaScript, which should be substantially another off-topic here. As the operator illustrated, `+` or `*` is arithmetic operators, so readers naturally consider that the topic is told in the context of algebra.

Here, at least, there are 2 independent concepts:

- Grouping operator ( ) that follows the rule of mathematics in the form of dependency graph (the main target topic here)
- Eager evaluation of JavaScript (off-topic, if really needed, substantial explanations are required to clarify the relation to the main target topic here)

Readers should not be Implicitly misguided into confusion of these independent concepts.

Once an example code that behavior is due to the another substantial off-topic concept is presented, the document should explicitly clarify the concept, or should not provide such a confusing example from the first.

The new version is provided to resolve these problems.
