### PR TITLE
Adds ImageTrack

### DIFF
--- a/files/en-us/web/api/imagetrack/animated/index.md
+++ b/files/en-us/web/api/imagetrack/animated/index.md
@@ -1,0 +1,37 @@
+---
+title: ImageTrack.animated
+slug: Web/API/ImageTrack/animated
+tags:
+  - API
+  - Property
+  - Reference
+  - animated
+  - ImageTrack
+browser-compat: api.ImageTrack.animated
+---
+{{DefaultAPISidebar("WebCodecs API")}}
+
+The **`animated`**  property of the {{domxref("ImageTrack")}} interface returns `true` if the track is animated and therefore has multiple frames.
+
+### Value
+
+A {{jsxref("boolean")}}, if `true` this is an animated track.
+
+## Examples
+
+The following example prints the value of `animated` to the console.
+
+```js
+let track = imageDecoder.tracks.selectedTrack;
+console.log(track.animated);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+

--- a/files/en-us/web/api/imagetrack/animated/index.md
+++ b/files/en-us/web/api/imagetrack/animated/index.md
@@ -11,7 +11,7 @@ browser-compat: api.ImageTrack.animated
 ---
 {{DefaultAPISidebar("WebCodecs API")}}
 
-The **`animated`**  property of the {{domxref("ImageTrack")}} interface returns `true` if the track is animated and therefore has multiple frames.
+The **`animated`** property of the {{domxref("ImageTrack")}} interface returns `true` if the track is animated and therefore has multiple frames.
 
 ### Value
 

--- a/files/en-us/web/api/imagetrack/framecount/index.md
+++ b/files/en-us/web/api/imagetrack/framecount/index.md
@@ -11,7 +11,7 @@ browser-compat: api.ImageTrack.frameCount
 ---
 {{DefaultAPISidebar("WebCodecs API")}}
 
-The **`frameCount`**  property of the {{domxref("ImageTrack")}} interface returns the number of frames in the track.
+The **`frameCount`** property of the {{domxref("ImageTrack")}} interface returns the number of frames in the track.
 
 ### Value
 

--- a/files/en-us/web/api/imagetrack/framecount/index.md
+++ b/files/en-us/web/api/imagetrack/framecount/index.md
@@ -1,0 +1,37 @@
+---
+title: ImageTrack.frameCount
+slug: Web/API/ImageTrack/frameCount
+tags:
+  - API
+  - Property
+  - Reference
+  - frameCount
+  - ImageTrack
+browser-compat: api.ImageTrack.frameCount
+---
+{{DefaultAPISidebar("WebCodecs API")}}
+
+The **`frameCount`**  property of the {{domxref("ImageTrack")}} interface returns the number of frames in the track.
+
+### Value
+
+An integer.
+
+## Examples
+
+The following example prints the value of `frameCount` to the console.
+
+```js
+let track = imageDecoder.tracks.selectedTrack;
+console.log(track.frameCount);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+

--- a/files/en-us/web/api/imagetrack/index.md
+++ b/files/en-us/web/api/imagetrack/index.md
@@ -1,0 +1,38 @@
+---
+title: ImageTrack
+slug: Web/API/ImageTrack
+tags:
+  - API
+  - Interface
+  - Reference
+  - ImageTrack
+browser-compat: api.ImageTrack
+---
+{{DefaultAPISidebar("WebCodecs API")}}
+
+The **`ImageTrack`** interface of the {{domxref('WebCodecs API','','','true')}} represents an individual image track.
+
+## Properties
+
+- {{domxref("ImageTrack.animated")}}{{ReadOnlyInline}}
+  - : Returns a {{jsxref("boolean")}} indicating whether the track is animated and therefore has multiple frames.
+- {{domxref("ImageTrack.frameCount")}}{{ReadOnlyInline}}
+  - : Returns an integer indicating the number of frames in the track.
+- {{domxref("ImageTrack.repetitionCount")}}{{ReadOnlyInline}}
+  - : Returns an integer indicating the number of times that the animation repeats.
+- {{domxref("ImageTrack.selected")}}{{ReadOnlyInline}}
+  - : Returns a {{jsxref("boolean")}} indicating whether the track is selected for decoding.
+
+### Event handlers
+
+- {{domxref("ImageTrack.onchange")}}
+  - : An event handler fired at the `ImageTrack` when the {{domxref("ImageTrack.frameCount","frameCount")}} is altered.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+

--- a/files/en-us/web/api/imagetrack/repetitioncount/index.md
+++ b/files/en-us/web/api/imagetrack/repetitioncount/index.md
@@ -1,0 +1,38 @@
+---
+title: ImageTrack.repetitionCount
+slug: Web/API/ImageTrack/repetitionCount
+tags:
+  - API
+  - Property
+  - Reference
+  - repetitionCount
+  - ImageTrack
+browser-compat: api.ImageTrack.repetitionCount
+---
+{{DefaultAPISidebar("WebCodecs API")}}
+
+The **`repetitionCount`**  property of the {{domxref("ImageTrack")}} interface returns the number of repetitions of this track.
+
+
+### Value
+
+An integer.
+
+## Examples
+
+The following example prints the value of `repetitionCount` to the console.
+
+```js
+let track = imageDecoder.tracks.selectedTrack;
+console.log(track.repetitionCount);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+

--- a/files/en-us/web/api/imagetrack/repetitioncount/index.md
+++ b/files/en-us/web/api/imagetrack/repetitioncount/index.md
@@ -12,8 +12,6 @@ browser-compat: api.ImageTrack.repetitionCount
 {{DefaultAPISidebar("WebCodecs API")}}
 
 The **`repetitionCount`**  property of the {{domxref("ImageTrack")}} interface returns the number of repetitions of this track.
-
-
 ### Value
 
 An integer.

--- a/files/en-us/web/api/imagetrack/selected/index.md
+++ b/files/en-us/web/api/imagetrack/selected/index.md
@@ -11,7 +11,7 @@ browser-compat: api.ImageTrack.selected
 ---
 {{DefaultAPISidebar("WebCodecs API")}}
 
-The **`selected`**  property of the {{domxref("ImageTrack")}} interface returns `true` if the track is selected for decoding.
+The **`selected`** property of the {{domxref("ImageTrack")}} interface returns `true` if the track is selected for decoding.
 
 ### Value
 

--- a/files/en-us/web/api/imagetrack/selected/index.md
+++ b/files/en-us/web/api/imagetrack/selected/index.md
@@ -1,0 +1,37 @@
+---
+title: ImageTrack.selected
+slug: Web/API/ImageTrack/selected
+tags:
+  - API
+  - Property
+  - Reference
+  - selected
+  - ImageTrack
+browser-compat: api.ImageTrack.selected
+---
+{{DefaultAPISidebar("WebCodecs API")}}
+
+The **`selected`**  property of the {{domxref("ImageTrack")}} interface returns `true` if the track is selected for decoding.
+
+### Value
+
+A {{jsxref("boolean")}}, if `true` the track is selected for decoding.
+
+## Examples
+
+The following example prints the value of `selected` to the console.
+
+```js
+let track = imageDecoder.tracks.selectedTrack;
+console.log(track.selected); // this is the selected track so should return true.
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+

--- a/files/en-us/web/api/webcodecs_api/index.md
+++ b/files/en-us/web/api/webcodecs_api/index.md
@@ -30,14 +30,14 @@ It gives access to raw video frames, chunks of audio data, image decoders, audio
 ##  Interfaces
 
 - {{domxref("AudioDecoder")}}
-  - : Decodes {{domxref("AudioEncoderChunk")}} objects.
+  - : Decodes {{domxref("EncodedAudioChunk")}} objects.
 - {{domxref("VideoDecoder")}}
   - : Decodes {{domxref("EncodedVideoChunk")}} objects.
 - {{domxref("AudioEncoder")}}
   - : Encodes {{domxref("AudioData")}} objects.
 - {{domxref("VideoEncoder")}}
   - : Encodes {{domxref("VideoFrame")}} objects.
-- {{domxref("AudioEncoderChunk")}}
+- {{domxref("EncodedAudioChunk")}}
   - : Represents codec-specific encoded audio bytes.
 - {{domxref("EncodedVideoChunk")}}
   - : Represents codec-specific encoded video bytes.


### PR DESCRIPTION
Reviewer @jpmedley 

Joe, this interface has an event handler which does not appear to be in the IDL. I've left mention of it on the main interface page, however I'm assuming we don't want to document it right now? Let me know, I can:

- leave this as it is, with a mention but no docs.
- document it as per spec.
- remove the mention from the main page.

I also fixed my own typo on the main API page which was causing a broken link.