### PR TITLE
docs(modules): remove outdated .mjs notes

### DIFF
--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -85,7 +85,7 @@ If you really value the clarity of using `.mjs` for modules versus using `.js` f
 
 It is also worth noting that:
 
-- Some tools may never support `.mjs`, such as [TypeScript](https://www.typescriptlang.org/).
+- Some tools may never support `.mjs`.
 - The `<script type="module">` attribute is used to denote when a module is being pointed to, as you'll see below.
 
 ## Exporting module features


### PR DESCRIPTION
typescripts now supports .mjs
https://github.com/microsoft/TypeScript/issues/27957

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

no

> What was wrong/why is this fix needed? (quick summary only)

typescripts now supports .mjs. 
checkout this [PR](https://github.com/microsoft/TypeScript/pull/45884)

> Anything else that could help us review it
