### PR TITLE
Adds examples to HIDInputReportEvent

### DIFF
--- a/files/en-us/web/api/hidinputreportevent/data/index.md
+++ b/files/en-us/web/api/hidinputreportevent/data/index.md
@@ -9,19 +9,24 @@ tags:
   - HIDInputReportEvent
 browser-compat: api.HIDInputReportEvent.data
 ---
-{{securecontext_header}}{{DefaultAPISidebar("")}}
+{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
 The **`data`**  property of the {{domxref("HIDInputReportEvent")}} interface returns a {{jsxref("DataView")}} containing the data from the input report, excluding the `reportId` if the HID interface uses report IDs.
 
-## Syntax
-
-```js
-let aDataView = HIDInputReportEvent.data;
-```
-
-### Value
+## Value
 
 A {{jsxref("DataView")}}.
+
+## Examples
+
+In the following example the returned `data` is logged to the console.
+
+```js
+device.addEventListener("inputreport", event => {
+  const { data, device, reportId } = event;
+  console.log(data);
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/hidinputreportevent/device/index.md
+++ b/files/en-us/web/api/hidinputreportevent/device/index.md
@@ -9,19 +9,24 @@ tags:
   - HIDInputReportEvent
 browser-compat: api.HIDInputReportEvent.device
 ---
-{{securecontext_header}}{{DefaultAPISidebar("")}}
+{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
 The **`device`**  property of the {{domxref("HIDInputReportEvent")}} interface returns the {{domxref("HIDDevice")}} instance that represents the HID interface that sent the input report.
 
-## Syntax
-
-```js
-let anHIDDevice = HIDInputReportEvent.device;
-```
-
-### Value
+## Value
 
 An {{domxref("HIDDevice")}}.
+
+## Examples
+
+In the following example `device` is a {{domxref("HIDDevice")}} instance, representing the device sending the report. The `productName` of this device is logged to the console.
+
+```js
+device.addEventListener("inputreport", event => {
+  const { data, device, reportId } = event;
+  console.log(device.productName);
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/hidinputreportevent/index.md
+++ b/files/en-us/web/api/hidinputreportevent/index.md
@@ -8,15 +8,13 @@ tags:
   - HIDInputReportEvent
 browser-compat: api.HIDInputReportEvent
 ---
-{{securecontext_header}}{{DefaultAPISidebar("")}}
+{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
 The **`HIDInputReportEvent`** interface of the {{domxref('WebHID API')}} is passed to {{domxref("HIDDevice.oninputreport")}} when an input report is received from any associated HID device.
 
-## Description
-
-
-
 ## Properties
+
+_This interface also inherits properties from {{domxref("Event")}}._
 
 - {{domxref("HIDInputReportEvent.data")}}{{readonlyinline}}
   - : A {{jsxref("DataView")}} containing the data from the input report, excluding the `reportId` if the HID interface uses report IDs.
@@ -28,6 +26,25 @@ The **`HIDInputReportEvent`** interface of the {{domxref('WebHID API')}} is pass
 ## Methods
 
 _This interface inherits methods from its parent, {{domxref("Event")}}._
+
+## Examples
+
+The following example demonstrates listening for an `inputReport` that will allow the application to detect which button is pressed on a Joy-Con Right device. You can see more examples, and live demos in the article [Connecting to uncommon HID devices](https://web.dev/hid/).
+
+```js
+device.addEventListener("inputreport", event => {
+  const { data, device, reportId } = event;
+
+  // Handle only the Joy-Con Right device and a specific report ID.
+  if (device.productId !== 0x2007 && reportId !== 0x3f) return;
+
+  const value = data.getUint8(0);
+  if (value === 0) return;
+
+  const someButtons = { 1: "A", 2: "X", 4: "B", 8: "Y" };
+  console.log(`User pressed button ${someButtons[value]}.`);
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/hidinputreportevent/reportid/index.md
+++ b/files/en-us/web/api/hidinputreportevent/reportid/index.md
@@ -9,19 +9,24 @@ tags:
   - HIDInputReportEvent
 browser-compat: api.HIDInputReportEvent.reportId
 ---
-{{securecontext_header}} {{DefaultAPISidebar("")}}
+{{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
 The **`reportId`**  property of the {{domxref("HIDInputReportEvent")}} interface returns the one-byte identification prefix for this report, or 0 if the HID interface does not use report IDs.
 
-## Syntax
-
-```js
-let aReportId = HIDInputReportEvent.reportId;
-```
-
-### Value
+## Value
 
 A one-byte identification prefix.
+
+## Examples
+
+In the following example the `reportId` of an incoming input report is logged to the console.
+
+```js
+device.addEventListener("inputreport", event => {
+  const { data, device, reportId } = event;
+  console.log(reportId);
+});
+```
 
 ## Specifications
 


### PR DESCRIPTION
Reviewer @jpmedley 

I wanted to close https://github.com/mdn/content/pull/6103 and I think it was just waiting on a check to see if there was work I'd done that could be merged into your work, so I had a look and brought across my examples.

I also modernized this to the new way to do property pages (removing the syntax section). I'll now close the other PR.