### PR TITLE
Adds devicePixelContentBoxSize

### DIFF
--- a/files/en-us/web/api/resizeobserverentry/borderboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/borderboxsize/index.md
@@ -3,7 +3,6 @@ title: ResizeObserverEntry.borderBoxSize
 slug: Web/API/ResizeObserverEntry/borderBoxSize
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Resize Observer API
@@ -11,19 +10,13 @@ tags:
   - borderBoxSize
 browser-compat: api.ResizeObserverEntry.borderBoxSize
 ---
-{{APIRef("Resize Observer API")}}{{SeeCompatTable}}
+{{APIRef("Resize Observer API")}}
 
 The **`borderBoxSize`** read-only property of
 the {{domxref("ResizeObserverEntry")}} interface returns an array containing the new
 border box size of the observed element when the callback is run.
 
-## Syntax
-
-```js
-var myBorderBoxSize = ResizeObserverEntry.borderBoxSize;
-```
-
-### Value
+## Value
 
 An array containing objects with the new border box size of the observed element. The
 array is necessary to support elements that have multiple fragments, which occur in

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -3,7 +3,6 @@ title: ResizeObserverEntry.contentBoxSize
 slug: Web/API/ResizeObserverEntry/contentBoxSize
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Resize Observer API
@@ -11,19 +10,13 @@ tags:
   - contentBoxSize
 browser-compat: api.ResizeObserverEntry.contentBoxSize
 ---
-{{APIRef("Resize Observer API")}}{{SeeCompatTable}}
+{{APIRef("Resize Observer API")}}
 
 The **`contentBoxSize`** read-only property of
 the {{domxref("ResizeObserverEntry")}} interface returns an array containing the new
 content box size of the observed element when the callback is run.
 
-## Syntax
-
-```js
-var myContentBoxSize = ResizeObserverEntry.contentBoxSize;
-```
-
-### Value
+## Value
 
 An array containing objects with the new content box size of the observed element.
 The array is necessary to support elements that have multiple fragments, which occur in multi-column scenarios. Each object in the array contains two properties:

--- a/files/en-us/web/api/resizeobserverentry/contentrect/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentrect/index.md
@@ -23,13 +23,7 @@ that this is better supported than {{domxref("ResizeObserverEntry.borderBoxSize"
 implementation of the Resize Observer API, is still included in the spec for web compat
 reasons, and may be deprecated in future versions.
 
-## Syntax
-
-```js
-var contentRect = resizeObserverEntry.contentRect;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMRectReadOnly')}} object containing the new size of the element
 indicated by the {{domxref("ResizeObserverEntry.target", "target")}} property.

--- a/files/en-us/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
@@ -30,15 +30,15 @@ multi-column scenarios. Each object in the array contains two properties:
     with a horizontal {{cssxref("writing-mode")}}, this is the horizontal dimension, or
     width; if the writing-mode is vertical, this is the vertical dimension, or height.
 
-> **Note:** For more explanation of writing modes and block and inline
+> **Note:** For more information about writing modes and block and inline
 > dimensions, read [Handling
 > different text directions](/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions).
 
 ## Examples
 
 The folowing example is taken from the article [Pixel-perfect rendering with devicePixelContentBox](https://web.dev/device-pixel-content-box/). As the callback function of a {{domxref("ResizeObserver")}}
-is called after layout but before paint,
-this provides an opportunity to log the exact size in physical pixels to
+is called after layout but before paint.
+This provides an opportunity to log the exact size in physical pixels to
 ensure a one-to-one mapping of canvas pixels to physical pixels.
 
 ```js

--- a/files/en-us/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
@@ -1,0 +1,61 @@
+---
+title: ResizeObserverEntry.devicePixelContentBoxSize
+slug: Web/API/ResizeObserverEntry/devicePixelContentBoxSize
+tags:
+  - API
+  - Property
+  - Reference
+  - Resize Observer API
+  - ResizeObserverEntry
+  - devicePixelContentBoxSize
+browser-compat: api.ResizeObserverEntry.devicePixelContentBoxSize
+---
+{{APIRef("Resize Observer API")}}
+
+The **`devicePixelContentBoxSize`** read-only property of
+the {{domxref("ResizeObserverEntry")}} interface returns an array containing the size in device pixels of the observed element when the callback is run.
+
+## Value
+
+An array containing objects with the new size of the observed element in device pixels. The
+array is necessary to support elements that have multiple fragments, which occur in
+multi-column scenarios. Each object in the array contains two properties:
+
+- `blockSize`
+  - : The size of the content-box, in device pixels, of the block dimension of the observed element. For boxes
+    with a horizontal {{cssxref("writing-mode")}}, this is the vertical dimension, or
+    height; if the writing-mode is vertical, this is the horizontal dimension, or width.
+- `inlineSize`
+  - : The size of the content box, in device pixels, of the inline direction of the observed element. For boxes
+    with a horizontal {{cssxref("writing-mode")}}, this is the horizontal dimension, or
+    width; if the writing-mode is vertical, this is the vertical dimension, or height.
+
+> **Note:** For more explanation of writing modes and block and inline
+> dimensions, read [Handling
+> different text directions](/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions).
+
+## Examples
+
+The folowing example is taken from the article [Pixel-perfect rendering with devicePixelContentBox](https://web.dev/device-pixel-content-box/). As the callback function of a {{domxref("ResizeObserver")}}
+is called after layout but before paint,
+this provides an opportunity to log the exact size in physical pixels to
+ensure a one-to-one mapping of canvas pixels to physical pixels.
+
+```js
+const observer = new ResizeObserver((entries) => {
+  const entry = entries.find((entry) => entry.target === canvas);
+  canvas.width = entry.devicePixelContentBoxSize[0].inlineSize;
+  canvas.height = entry.devicePixelContentBoxSize[0].blockSize;
+
+  /* … render to canvas … */
+});
+observer.observe(canvas, {box: ['device-pixel-content-box']});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
Adds the missing `devicePixelContentBoxSize` to `ResizeObserverEntry`, also did some tidying up of existing pages while I had it open.

Reviewer @jpmedley 