### PR TITLE
Remove extra {{cssinfo}}s

### DIFF
--- a/files/en-us/web/css/border-inline-end-width/index.md
+++ b/files/en-us/web/css/border-inline-end-width/index.md
@@ -36,8 +36,6 @@ border-inline-end-width: unset;
 
 Related properties are {{cssxref("border-block-start-width")}}, {{cssxref("border-block-end-width")}}, and {{cssxref("border-inline-start-width")}}, which define the other border widths of the element.
 
-{{cssinfo}}
-
 ### Values
 
 - `<'border-width'>`

--- a/files/en-us/web/css/border-inline-end/index.md
+++ b/files/en-us/web/css/border-inline-end/index.md
@@ -47,8 +47,6 @@ The physical border to which `border-inline-end` maps depends on the element's w
 
 Related properties are {{cssxref("border-block-start")}}, {{cssxref("border-block-end")}}, and {{cssxref("border-inline-start")}}, which define the other borders of the element.
 
-{{cssinfo}}
-
 ### Values
 
 The `border-inline-end` is specified with one or more of the following, in any order:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
There are two {{cssinfo}}s in these articles.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Two {{cssinfo}}s are redundant.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
