### PR TITLE
Adding SubmitEvent and FormDataEvent

### DIFF
--- a/files/en-us/web/api/event/index.md
+++ b/files/en-us/web/api/event/index.md
@@ -51,6 +51,7 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("ErrorEvent")}}
 - {{domxref("FetchEvent")}}
 - {{domxref("FocusEvent")}}
+- {{domxref("FormDataEvent")}}
 - {{domxref("GamepadEvent")}}
 - {{domxref("HashChangeEvent")}}
 - {{domxref("HIDInputReportEvent")}}
@@ -73,6 +74,7 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("RTCPeerConnectionIceEvent")}}
 - {{domxref("SensorEvent")}}
 - {{domxref("StorageEvent")}}
+- {{domxref("SubmitEvent")}}
 - {{domxref("SVGEvent")}}
 - {{domxref("SVGZoomEvent")}}
 - {{domxref("TimeEvent")}}


### PR DESCRIPTION
#### Summary
Adding `SubmitEvent` and `FormDataEvent` to the list of those inheriting from `Event`

#### Motivation
These two are [currently missing from the `Event` list](https://github.com/mdn/content/blob/7b8e35d8531d603d9857d7af02b52d954621b7ec/files/en-us/web/api/event/index.md#L29-L31).  Per [HTML Spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-submitevent-interface), `SubmitEvent` and `FormDataEvent` inherit from the main `Event` and should be listed.



#### Supporting detail
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-submitevent-interface

#### Related issues

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

