### PR TITLE
[Markdown] [Learn] Fix CSS live samples

### DIFF
--- a/files/en-us/learn/css/css_layout/floats/index.html
+++ b/files/en-us/learn/css/css_layout/floats/index.html
@@ -75,7 +75,21 @@ tags:
   padding: 1em;
 }</pre>
 
-<p>If you save and refresh, you'll see something much like what you'd expect: the box is sitting above the text, in normal flow. To float the text around it, add the {{cssxref("float")}} and {{cssxref("margin-right")}} properties to the <code>.box</code> rule:</p>
+<p>If you save and refresh, you'll see something much like what you'd expect: the box is sitting above the text, in normal flow.</p>
+
+<h3>Floating the box</h3>
+
+<p>To float the box, add the {{cssxref("float")}} and {{cssxref("margin-right")}} properties to the <code>.box</code> rule:</p>
+
+<pre class="brush: html hidden">&lt;h1&gt;Simple float example&lt;/h1&gt;
+
+&lt;div class="box"&gt;Float&lt;/div&gt;
+
+&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. &lt;/p&gt;
+
+&lt;p&gt;Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
+
+&lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;</pre>
 
 <pre class="brush: css">.box {
   float: left;
@@ -89,46 +103,13 @@ tags:
 
 <p>Now if you save and refresh you'll see something like the following:</p>
 
-<div id="Float_1">
-<div class="hidden">
-<h6 id="Float_Example_1">Float Example 1</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
-
-&lt;div class="box"&gt;Float&lt;/div&gt;
-
-&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. &lt;/p&gt;
-
-&lt;p&gt;Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
-
-&lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
-</pre>
-
-<pre class="brush: css">body {
-  width: 90%;
-  max-width: 900px;
-  margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
-}
-
-.box {
-  float: left;
-  margin-right: 15px;
-  width: 150px;
-  height: 150px;
-  border-radius: 5px;
-  background-color: rgb(207,232,220);
-  padding: 1em;
-}
-</pre>
-</div>
-</div>
-
-<p>{{ EmbedLiveSample('Float_1', '100%', 500) }}</p>
+<p>{{ EmbedLiveSample('Floating_the_box', '100%', 500) }}</p>
 
 <p>Let's think about how the float works. The element with the float set on it (the {{htmlelement("div")}} element in this case) is taken out of the normal layout flow of the document and stuck to the left-hand side of its parent container ({{htmlelement("body")}}, in this case). Any content that would come below the floated element in the normal layout flow will now wrap around it instead, filling up the space to the right-hand side of it as far up as the top of the floated element. There, it will stop.</p>
 
 <p>Floating the content to the right has exactly the same effect, but in reverse: the floated element will stick to the right, and the content will wrap around it to the left. Try changing the float value to <code>right</code> and replace {{cssxref("margin-right")}} with {{cssxref("margin-left")}} in the last ruleset to see what the result is.</p>
+
+<h3>Visualising the float</h3>
 
 <p>While we can add a margin to the float to push the text away, we can't add a margin to the text to move it away from the float. This is because a floated element is taken out of normal flow and the boxes of the following items actually run behind the float. You can see this by making some changes to your example.</p>
 
@@ -143,11 +124,7 @@ tags:
 
 <p>To make the effect easier to see, change the <code>margin-left</code> on your float to <code>margin</code> so you get space all around the float. You'll be able to see the background on the paragraph running right underneath the floated box, as in the example below.</p>
 
-<div id="Float_2">
-<div class="hidden">
-<h6 id="Float_Example_2">Float Example 2</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Simple float example&lt;/h1&gt;
 
 &lt;div class="box"&gt;Float&lt;/div&gt;
 
@@ -157,7 +134,7 @@ tags:
 
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;    </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
@@ -180,10 +157,8 @@ tags:
   color: #fff;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Float_2', '100%', 500) }}</p>
+<p>{{ EmbedLiveSample('Visualising_the_float', '100%', 500) }}</p>
 
 <p>The <a href="/en-US/docs/Web/CSS/Visual_formatting_model#line_boxes">line boxes</a> of our following element have been shortened so the text runs around the float, but due to the float being removed from normal flow the box around the paragraph still remains full width.</p>
 
@@ -198,11 +173,7 @@ tags:
 }
 </pre>
 
-<div id="Float_3">
-<div class="hidden">
-<h6 id="Float_Example_3">Float Example 3</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Simple float example&lt;/h1&gt;
 
 &lt;div class="box"&gt;Float&lt;/div&gt;
 
@@ -213,7 +184,7 @@ tags:
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
     </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
@@ -240,10 +211,8 @@ tags:
   clear: left;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Float_3', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('Clearing_floats', '100%', 600) }}</p>
 
 <p>You should see that the second paragraph now clears the floated element and no longer comes up alongside it. The <code>clear</code> property accepts the following values:</p>
 
@@ -255,7 +224,11 @@ tags:
 
 <h2 id="Clearing_boxes_wrapped_around_a_float">Clearing boxes wrapped around a float</h2>
 
-<p>You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box wrapped around <em>both</em> elements. Change your document so that the first paragraph and the floated box are jointly wrapped with a {{htmlelement("div")}}, which has a class of <code>wrapper</code>.</p>
+<p>You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box wrapped around <em>both</em> elements.</p>
+
+<h3>The problem</h3>
+
+<p>Change your document so that the first paragraph and the floated box are jointly wrapped with a {{htmlelement("div")}}, which has a class of <code>wrapper</code>.</p>
 
 <pre class="brush: html">&lt;div class="wrapper"&gt;
   &lt;div class="box"&gt;Float&lt;/div&gt;
@@ -274,28 +247,18 @@ tags:
 
 <p>In addition, remove the original <code>.cleared</code> class:</p>
 
-<pre class="brush: css" id="ct-0">.cleared {
+<pre class="brush: css">.cleared {
     clear: left;
 }</pre>
 
 <p>You'll see that, just like in the example where we put a background color on the paragraph, the background color runs behind the float.</p>
 
-<div id="Float_4">
-<div class="hidden">
-<h6 id="Float_Example_4">Float Example 4</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
-&lt;div class="wrapper"&gt;
-  &lt;div class="box"&gt;Float&lt;/div&gt;
-
-  &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. &lt;/p&gt;
-&lt;/div&gt;
-
+<pre class="brush: html hidden">
 &lt;p class="cleared"&gt;Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
 
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;    </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
@@ -318,10 +281,8 @@ tags:
   padding: 1em;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Float_4', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('The_problem', '100%', 600) }}</p>
 
 <p>Once again, this is because the float has been taken out of normal flow. Clearing the following element won't work as it did before. This is a problem if you want the box to wrap jointly around the floated item as well as the text of the first paragraph that wraps around the float, while also having the following content cleared of the box. There are three potential ways to deal with this, two of which work in all browsers — yet are slightly hacky — and a third, newer way that deals with this situation properly.</p>
 
@@ -339,11 +300,7 @@ tags:
 
 <p>Now reload the page and the box should clear. This is essentially the same as if you had added an HTML element such as a <code>&lt;div&gt;</code> below the items and set it to <code>clear: both</code>.</p>
 
-<div id="Float_5">
-<div class="hidden">
-<h6 id="Float_Example_5">Float Example 5</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Simple float example&lt;/h1&gt;
 &lt;div class="wrapper"&gt;
   &lt;div class="box"&gt;Float&lt;/div&gt;
 
@@ -353,7 +310,7 @@ tags:
 
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;      </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
@@ -382,10 +339,8 @@ tags:
   display: block;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Float_5', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('The_clearfix_hack', '100%', 600) }}</p>
 
 <h3 id="Using_overflow">Using overflow</h3>
 
@@ -400,11 +355,7 @@ tags:
   overflow: auto;
 }</pre>
 
-<div id="Float_6">
-<div class="hidden">
-<h6 id="Float_Example_6">Float Example 6</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Simple float example&lt;/h1&gt;
 &lt;div class="wrapper"&gt;
   &lt;div class="box"&gt;Float&lt;/div&gt;
 
@@ -414,7 +365,7 @@ tags:
 
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;    </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
@@ -438,10 +389,8 @@ tags:
   padding: 1em;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Float_6', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('Using_overflow', '100%', 600) }}</p>
 
 <p>This example works by creating what's known as a <strong>block formatting context</strong> (BFC). This is like a mini layout inside your page, inside of which everything is contained. This means our floated element is contained inside the BFC, and the background runs behind both items. This will usually work; however, in certain cases you might find unwanted scrollbars or clipped shadows due to unintended consequences of using overflow.</p>
 
@@ -456,11 +405,7 @@ tags:
   display: flow-root;
 }</pre>
 
-<div id="Float_7">
-<div class="hidden">
-<h6 id="Float_Example_7">Float Example 7</h6>
-
-<pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Simple float example&lt;/h1&gt;
 &lt;div class="wrapper"&gt;
   &lt;div class="box"&gt;Float&lt;/div&gt;
 
@@ -470,7 +415,7 @@ tags:
 
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;    </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
@@ -494,10 +439,8 @@ tags:
   padding: 1em;
 }
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Float_7', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('display_flow-root', '100%', 600) }}</p>
 
 <h2 id="Test_your_skills!">Test your skills!</h2>
 

--- a/files/en-us/learn/css/css_layout/grids/index.html
+++ b/files/en-us/learn/css/css_layout/grids/index.html
@@ -72,11 +72,7 @@ tags:
 
 <p>Add the 2nd declaration to your CSS rule, then reload the page. You should see that the items have rearranged themselves such that there's one in each cell of the grid.</p>
 
-<div id="Grid_1">
-<div class="hidden">
-<h6 id="Simple_Grid_Example">Simple Grid Example</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -90,7 +86,7 @@ tags:
   border: 2px solid rgb(79,185,227);
 }          </pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
  &lt;div&gt;One&lt;/div&gt;
  &lt;div&gt;Two&lt;/div&gt;
  &lt;div&gt;Three&lt;/div&gt;
@@ -100,14 +96,7 @@ tags:
  &lt;div&gt;Seven&lt;/div&gt;
 &lt;/div&gt; </pre>
 
-<pre class="brush: css">.container {
-  display: grid;
-  grid-template-columns: 200px 200px 200px;
-} </pre>
-</div>
-</div>
-
-<p>{{ EmbedLiveSample('Grid_1', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Defining_a_grid', '100%', 400) }}</p>
 
 <h3 id="Flexible_grids_with_the_fr_unit">Flexible grids with the <strong>fr</strong> unit</h3>
 
@@ -129,20 +118,11 @@ tags:
 
 <p>The first track now gets <code>2fr</code> of the available space and the other two tracks get <code>1fr</code>, making the first track larger. You can mix <code>fr</code> units with fixed length units — in such a case the space needed for the fixed tracks is used up first; the remaining space is then distributed to the other tracks.</p>
 
-<div id="Grid_2">
-<div class="hidden">
-<h6 id="Simple_Grid_Example_with_fr_units">Simple Grid Example with fr units</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
   font: .9em/1.2 Arial, Helvetica, sans-serif;
-}
-
-.container {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
 }
 
 .container &gt; div {
@@ -151,9 +131,9 @@ tags:
   background-color: rgb(207,232,220);
   border: 2px solid rgb(79,185,227);
 }
-                </pre>
+</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;div&gt;One&lt;/div&gt;
   &lt;div&gt;Two&lt;/div&gt;
   &lt;div&gt;Three&lt;/div&gt;
@@ -161,14 +141,13 @@ tags:
   &lt;div&gt;Five&lt;/div&gt;
   &lt;div&gt;Six&lt;/div&gt;
   &lt;div&gt;Seven&lt;/div&gt;
-&lt;/div&gt;                        </pre>
-</div>
-</div>
+&lt;/div&gt;
+</pre>
 
-<p>{{ EmbedLiveSample('Grid_2', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Flexible_grids_with_the_fr_unit', '100%', 400) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: The <code>fr</code> unit distributes <em>available</em> space, not <em>all</em> space. Therefore, if one of your tracks has something large inside it, there will be less free space to share.</p>
+<p><strong>Note:</strong> The <code>fr</code> unit distributes <em>available</em> space, not <em>all</em> space. Therefore, if one of your tracks has something large inside it, there will be less free space to share.</p>
 </div>
 
 <h3 id="Gaps_between_tracks">Gaps between tracks</h3>
@@ -183,21 +162,11 @@ tags:
 
 <p>These gaps can be any length unit or percentage, but not an <code>fr</code> unit.</p>
 
-<div id="Grid_3">
-<div class="hidden">
-<h6 id="Simple_Grid_Example_with_fr_units_2">Simple Grid Example with fr units</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
   font: .9em/1.2 Arial, Helvetica, sans-serif;
-}
-
-.container {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  gap: 20px;
 }
 
 .container &gt; div {
@@ -208,7 +177,7 @@ tags:
 }
                 </pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;div&gt;One&lt;/div&gt;
   &lt;div&gt;Two&lt;/div&gt;
   &lt;div&gt;Three&lt;/div&gt;
@@ -218,13 +187,11 @@ tags:
   &lt;div&gt;Seven&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Grid_3', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Gaps_between_tracks', '100%', 400) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: The <code>*gap</code> properties used to be prefixed by <code>grid-</code>, but this has been changed in the spec in order to make them usable in multiple layout methods. The prefixed versions will be maintained as an alias, so they'll be safe to use for some time. To be on the safe side, you could double up and add both properties to make your code more bulletproof.</p>
+<p><strong>Note:</strong> The <code>*gap</code> properties used to be prefixed by <code>grid-</code>, but this has been changed in the spec in order to make them usable in multiple layout methods. The prefixed versions will be maintained as an alias, so they'll be safe to use for some time. To be on the safe side, you could double up and add both properties to make your code more bulletproof.</p>
 </div>
 
 <pre class="brush: css">.container {
@@ -252,11 +219,7 @@ tags:
 
 <p>By default, tracks created in the implicit grid are <code>auto</code> sized, which in general means that they're large enough to accomodate their content. If you wish to give implicit grid tracks a size, you can use the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties. If you add <code>grid-auto-rows</code> with a value of <code>100px</code> to your CSS, you'll see that those created rows are now 100 pixels tall.</p>
 
-<div id="Grid_4">
-<div class="hidden">
-<h6 id="Simple_Grid_Example_with_fr_units_3">Simple Grid Example with fr units</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -268,9 +231,10 @@ tags:
   padding: 10px;
   background-color: rgb(207,232,220);
   border: 2px solid rgb(79,185,227);
-}                  </pre>
+}
+</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;div&gt;One&lt;/div&gt;
   &lt;div&gt;Two&lt;/div&gt;
   &lt;div&gt;Three&lt;/div&gt;
@@ -279,8 +243,7 @@ tags:
   &lt;div&gt;Six&lt;/div&gt;
   &lt;div&gt;Seven&lt;/div&gt;
 &lt;/div&gt;
-                        </pre>
-</div>
+</pre>
 
 <pre class="brush: css">.container {
   display: grid;
@@ -288,9 +251,8 @@ tags:
   grid-auto-rows: 100px;
   grid-gap: 20px;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Grid_4', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('The_implicit_and_explicit_grid', '100%', 400) }}</p>
 
 <h3 id="The_minmax_function">The minmax() function</h3>
 
@@ -313,11 +275,7 @@ tags:
 
 <p>Try this in your file now using the CSS below:</p>
 
-<div id="Grid_5">
-<div class="hidden">
-<h6 id="As_many_columns_as_will_fit_2">As many columns as will fit</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -330,9 +288,9 @@ tags:
   background-color: rgb(207,232,220);
   border: 2px solid rgb(79,185,227);
 }
-                </pre>
+</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;div&gt;One&lt;/div&gt;
   &lt;div&gt;Two&lt;/div&gt;
   &lt;div&gt;Three&lt;/div&gt;
@@ -340,8 +298,8 @@ tags:
   &lt;div&gt;Five&lt;/div&gt;
   &lt;div&gt;Six&lt;/div&gt;
   &lt;div&gt;Seven&lt;/div&gt;
-&lt;/div&gt;                      </pre>
-</div>
+&lt;/div&gt;
+</pre>
 
 <pre class="brush: css">.container {
   display: grid;
@@ -351,7 +309,7 @@ tags:
 }</pre>
 </div>
 
-<p>{{ EmbedLiveSample('Grid_5', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('As_many_columns_as_will_fit', '100%', 400) }}</p>
 
 <p>This works because grid is creating as many 200 pixel columns as will fit into the container, then sharing whatever space is leftover among all the columns. The maximum is 1fr which, as we already know, distributes space evenly between tracks.</p>
 
@@ -401,40 +359,18 @@ footer {
   grid-row: 3;
 }</pre>
 
-<div id="Grid_6">
-<div class="hidden">
-<h6 id="Line-based_placement_2">Line-based placement</h6>
-
-<pre class="brush: css">                body {
-                    width: 90%;
-                    max-width: 900px;
-                    margin: 2em auto;
-                    font: .9em/1.2 Arial, Helvetica, sans-serif;
-                }
-
-                .container {
-                    display: grid;
-                    grid-template-columns: 1fr 3fr;
-                    gap: 20px;
-                }
-header {
-    grid-column: 1 / 3;
-    grid-row: 1;
+<pre class="brush: css hidden">
+  body {
+    width: 90%;
+    max-width: 900px;
+    margin: 2em auto;
+    font: .9em/1.2 Arial, Helvetica, sans-serif;
 }
 
-article {
-    grid-column: 2;
-    grid-row: 2;
-}
-
-aside {
-    grid-column: 1;
-    grid-row: 2;
-}
-
-footer {
-    grid-column: 1 / 3;
-    grid-row: 3;
+.container {
+    display: grid;
+    grid-template-columns: 1fr 3fr;
+    gap: 20px;
 }
 
 header,
@@ -450,7 +386,7 @@ aside {
 }
 </pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;header&gt;This is my lovely blog&lt;/header&gt;
   &lt;article&gt;
     &lt;h1&gt;My article&lt;/h1&gt;
@@ -463,14 +399,13 @@ aside {
     &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est.&lt;/p&gt;
   &lt;/aside&gt;
   &lt;footer&gt;Contact me@mysite.com&lt;/footer&gt;
-&lt;/div&gt;               </pre>
-</div>
-</div>
+&lt;/div&gt;
+</pre>
 
-<p>{{ EmbedLiveSample('Grid_6', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Line-based_placement', '100%', 600) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: you can also use the value <code>-1</code> to target the end column or row line, then count inwards from the end using negative values. Note also that lines count always from the edges of the explicit grid, not the <a href="/en-US/docs/Glossary/Grid">implicit grid</a>.</p>
+<p><strong>Note:</strong> you can also use the value <code>-1</code> to target the end column or row line, then count inwards from the end using negative values. Note also that lines count always from the edges of the explicit grid, not the <a href="/en-US/docs/Glossary/Grid">implicit grid</a>.</p>
 </div>
 
 <h2 id="Positioning_with_grid-template-areas">Positioning with grid-template-areas</h2>
@@ -507,11 +442,7 @@ footer {
 
 <p>Reload the page and you will see that your items have been placed just as before without us needing to use any line numbers!</p>
 
-<div id="Grid_7">
-<div class="hidden">
-<h6 id="Line-based_placement_3">Line-based placement</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -529,35 +460,9 @@ footer {
 aside {
   border-right: 1px solid #999;
 }
+</pre>
 
-.container {
-  display: grid;
-  grid-template-areas:
-  "header header"
-  "sidebar content"
-  "footer footer";
-  grid-template-columns: 1fr 3fr;
-  gap: 20px;
-}
-
-header {
-  grid-area: header;
-}
-
-article {
-  grid-area: content;
-}
-
-aside {
-  grid-area: sidebar;
-}
-
-footer {
-  grid-area: footer;
-}
-                </pre>
-
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;header&gt;This is my lovely blog&lt;/header&gt;
   &lt;article&gt;
     &lt;h1&gt;My article&lt;/h1&gt;
@@ -569,11 +474,10 @@ footer {
     &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est.&lt;/p&gt;
   &lt;/aside&gt;
   &lt;footer&gt;Contact me@mysite.com&lt;/footer&gt;
-&lt;/div&gt;                     </pre>
-</div>
-</div>
+&lt;/div&gt;
+</pre>
 
-<p>{{ EmbedLiveSample('Grid_7', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Positioning_with_grid-template-areas', '100%', 600) }}</p>
 
 <p>The rules for <code>grid-template-areas</code> are as follows:</p>
 
@@ -613,11 +517,7 @@ footer {
   grid-row: 3;
 }</pre>
 
-<div id="Grid_8">
-<div class="hidden">
-<h6 id="A_CSS_Grid_Grid_System">A CSS Grid Grid System</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -628,26 +528,6 @@ footer {
   display: grid;
   grid-template-columns: repeat(12, minmax(0,1fr));
   gap: 20px;
-}
-
-header {
-  grid-column: 1 / 13;
-  grid-row: 1;
-}
-
-article {
-  grid-column: 4 / 13;
-  grid-row: 2;
-}
-
-aside {
-  grid-column: 1 / 4;
-  grid-row: 2;
-}
-
-footer {
-  grid-column: 1 / 13;
-  grid-row: 3;
 }
 
 header,
@@ -661,9 +541,9 @@ footer {
 aside {
   border-right: 1px solid #999;
 }
-                </pre>
+</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;header&gt;This is my lovely blog&lt;/header&gt;
   &lt;article&gt;
     &lt;h1&gt;My article&lt;/h1&gt;
@@ -676,11 +556,9 @@ aside {
   &lt;/aside&gt;
   &lt;footer&gt;Contact me@mysite.com&lt;/footer&gt;
 &lt;/div&gt;
-                        </pre>
-</div>
-</div>
+</pre>
 
-<p>{{ EmbedLiveSample('Grid_8', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('A_CSS_Grid_grid_framework', '100%', 600) }}</p>
 
 <p>If you use the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts">Firefox Grid Inspector</a> to overlay the grid lines on your design, you can see how our 12 column grid works.</p>
 

--- a/files/en-us/learn/css/css_layout/introduction/index.html
+++ b/files/en-us/learn/css/css_layout/introduction/index.html
@@ -99,23 +99,19 @@ tags:
 
 <p>Flexbox is the short name for the <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">Flexible Box Layout</a> CSS module, designed to make it easy for us to lay things out in one dimension — either as a row or as a column. To use flexbox, you apply <code>display: flex</code> to the parent element of the elements you want to lay out; all its direct children then become <em>flex items</em>. We can see this in a simple example.</p>
 
+<h3>Setting display: flex</h3>
+
 <p>The HTML markup below gives us a containing element with a class of <code>wrapper</code>, inside of which are three {{htmlelement("div")}} elements. By default these would display as block elements, that is, below one another in our English language document.</p>
 
 <p>However, if we add <code>display: flex</code> to the parent, the three items now arrange themselves into columns. This is due to them becoming <em>flex items</em> and being affected by some initial values that flexbox sets on the flex container. They are displayed in a row because the property {{cssxref("flex-direction")}} of the parent element has an initial value of <code>row</code>. They all appear to stretch in height because the property {{cssxref("align-items")}} of their parent element has an initial value of <code>stretch</code>. This means that the items stretch to the height of the flex container, which in this case is defined by the tallest item. The items all line up at the start of the container, leaving any extra space at the end of the row.</p>
 
-<div id="Flex_1">
-<div class="hidden">
-<h6 id="Flexbox_Example_1">Flexbox Example 1</h6>
-
-<pre class="brush: css">* {box-sizing: border-box;}
-
+<pre class="brush: css hidden">* {box-sizing: border-box;}
 .wrapper &gt; div {
     border-radius: 5px;
     background-color: rgb(207,232,220);
     padding: 1em;
 }
-    </pre>
-</div>
+</pre>
 
 <pre class="brush: css">.wrapper {
   display: flex;
@@ -128,27 +124,25 @@ tags:
   &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Flex_1', '300', '200') }}</p>
+<p>{{ EmbedLiveSample('Setting_display_flex', '300', '200') }}</p>
+
+<h3>Setting the flex property</h3>
 
 <p>In addition to properties that can be applied to a <em>flex container</em>, there are also properties that can be applied to <em>flex items</em>. These properties, among other things, can change the way that items <em>flex</em>, enabling them to expand or contract according to available space.</p>
 
 <p>As a simple example, we can add the {{cssxref("flex")}} property to all of our child items, and give it a value of <code>1</code>. This will cause all of the items to grow and fill the container, rather than leaving space at the end. If there is more space then the items will become wider; if there is less space they will become narrower. In addition, if you add another element to the markup, the other items will all become smaller to make space for it; the items all together continue taking up all the space.</p>
 
-<div id="Flex_2">
-<div class="hidden">
-<h6 id="Flexbox_Example_2">Flexbox Example 2</h6>
-
-<pre class="brush: css">    * {box-sizing: border-box;}
-
-    .wrapper &gt; div {
-        border-radius: 5px;
-        background-color: rgb(207,232,220);
-        padding: 1em;
-    }
-    </pre>
-</div>
+<pre class="brush: css hidden">
+* {
+    box-sizing: border-box;
+}
+.wrapper &gt; div {
+    border-radius: 5px;
+    background-color: rgb(207,232,220);
+    padding: 1em;
+}
+</pre>
 
 <pre class="brush: css">.wrapper {
     display: flex;
@@ -165,33 +159,32 @@ tags:
     &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Flex_2', '300', '200') }}</p>
+<p>{{ EmbedLiveSample('Setting_the_flex_property', '300', '200') }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: This has been a very short introduction to what is possible in Flexbox. To find out more, see our <a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a> article.</p>
+<p><strong>Note:</strong> This has been a very short introduction to what is possible in Flexbox. To find out more, see our <a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a> article.</p>
 </div>
 
 <h2 id="Grid_Layout">Grid Layout</h2>
 
 <p>While flexbox is designed for one-dimensional layout, Grid Layout is designed for two dimensions — lining things up in rows and columns.</p>
 
+<h3>Setting display: grid</h3>
+
 <p>Similar to flexbox, we enable Grid Layout with its specific display value — <code>display: grid</code>. The below example uses similar markup to the flex example, with a container and some child elements. In addition to using <code>display: grid</code>, we also define some row and column <em>tracks</em> for the parent using the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} properties respectively. We've defined three columns, each of <code>1fr</code>, as well as two rows of <code>100px</code>. We don’t need to put any rules on the child elements; they're automatically placed into the cells our grid's created.</p>
 
-<div id="Grid_1">
-<div class="hidden">
-<h6 id="Grid_example_1">Grid example 1</h6>
+<pre class="brush: css hidden">
+* {
+    box-sizing: border-box;
+  }
 
-<pre class="brush: css">    * {box-sizing: border-box;}
-
-    .wrapper &gt; div {
-        border-radius: 5px;
-        background-color: rgb(207,232,220);
-        padding: 1em;
-    }
-    </pre>
-</div>
+.wrapper &gt; div {
+    border-radius: 5px;
+    background-color: rgb(207,232,220);
+    padding: 1em;
+}
+</pre>
 
 <pre class="brush: css">.wrapper {
     display: grid;
@@ -210,25 +203,24 @@ tags:
     &lt;div class="box6"&gt;Six&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Grid_1', '300', '330') }}</p>
+<p>{{ EmbedLiveSample('Setting_display_grid', '300', '330') }}</p>
+
+<h3>Placing items on the grid</h3>
 
 <p>Once you have a grid, you can explicitly place your items on it, rather than relying on the auto-placement behavior seen above. In the next example below, we've defined the same grid, but this time with three child items. We've set the start and end line of each item using the {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. This causes the items to span multiple tracks.</p>
 
-<div id="Grid_2">
-<div class="hidden">
-<h6 id="Grid_example_2">Grid example 2</h6>
+<pre class="brush: css hidden">
+* {
+    box-sizing: border-box;
+}
 
-<pre class="brush: css">    * {box-sizing: border-box;}
-
-    .wrapper &gt; div {
-        border-radius: 5px;
-        background-color: rgb(207,232,220);
-        padding: 1em;
-    }
-    </pre>
-</div>
+.wrapper &gt; div {
+    border-radius: 5px;
+    background-color: rgb(207,232,220);
+    padding: 1em;
+}
+</pre>
 
 <pre class="brush: css">.wrapper {
     display: grid;
@@ -259,12 +251,11 @@ tags:
     &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
 
-<p>{{ EmbedLiveSample('Grid_2', '300', '330') }}</p>
+<p>{{ EmbedLiveSample('Placing_items_on_the_grid', '300', '330') }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: These two examples reveal just a small sample of the power of Grid layout. To learn more, see our <a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid Layout</a> article.</p>
+<p><strong>Note:</strong> These two examples reveal just a small sample of the power of Grid layout. To learn more, see our <a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid Layout</a> article.</p>
 </div>
 
 <p>The rest of this guide covers other layout methods that are less important for the main layout of your page, but still help to achieve specific tasks. By understanding the nature of each layout task you will soon find that when you look at a particular component of your design, the type of layout most suitable for it will often be clear.</p>
@@ -284,11 +275,7 @@ tags:
 
 <p>In the example below, we float a <code>&lt;div&gt;</code> left and give it a {{cssxref("margin")}} on the right to push the surrounding text away it. This gives us the effect of text wrapped around the boxed element, and is most of what you need to know about floats as used in modern web design.</p>
 
-<div id="Float_1">
-<div class="hidden">
-<h6 id="Floats_example">Floats example</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
     width: 90%;
     max-width: 900px;
     margin: 0 auto;
@@ -306,7 +293,6 @@ p {
     border-radius: 5px;
 }
 </pre>
-</div>
 
 <pre class="brush: html">&lt;h1&gt;Simple float example&lt;/h1&gt;
 
@@ -326,10 +312,10 @@ p {
 </pre>
 </div>
 
-<p>{{ EmbedLiveSample('Float_1', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('Floats', '100%', 600) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: Floats are fully explained in our lesson on the <a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">float and clear</a> properties. Prior to techniques such as Flexbox and Grid Layout, floats were used as a method of creating column layouts. You may still come across these methods on the web; we will cover these in the lesson on <a href="/en-US/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods">legacy layout methods</a>.</p>
+<p><strong>Note:</strong> Floats are fully explained in our lesson on the <a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">float and clear</a> properties. Prior to techniques such as Flexbox and Grid Layout, floats were used as a method of creating column layouts. You may still come across these methods on the web; we will cover these in the lesson on <a href="/en-US/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods">legacy layout methods</a>.</p>
 </div>
 
 <h2 id="Positioning_techniques">Positioning techniques</h2>
@@ -392,17 +378,13 @@ p {
 
 <p>Adding this code will give the following result:</p>
 
-<div id="Relative_1">
-<div class="hidden">
-<h6 id="Relative_positioning_example">Relative positioning example</h6>
-
-<pre class="brush: html">&lt;h1&gt;Relative positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Relative positioning&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element.&lt;/p&gt;
 &lt;p class="positioned"&gt;This is my relatively positioned element.&lt;/p&gt;
 &lt;p&gt;I am a basic block level element.&lt;/p&gt;</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
 }
@@ -415,18 +397,16 @@ p {
     border-radius: 5px;
 }
 </pre>
-</div>
 
-<pre class="brush: css">.positioned {
+<pre class="brush: css hidden">.positioned {
   position: relative;
   background: rgba(255,84,104,.3);
   border: 2px solid rgb(255,84,104);
   top: 30px;
   left: 30px;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Relative_1', '100%', 300) }}</p>
+<p>{{ EmbedLiveSample('Relative_positioning', '100%', 300) }}</p>
 
 <h3 id="Absolute_positioning">Absolute positioning</h3>
 
@@ -442,11 +422,7 @@ p {
 
 <p>Here we give our middle paragraph a {{cssxref("position")}} value of <code>absolute</code> and the same {{cssxref("top")}} and {{cssxref("left")}} properties as before. Adding this code will produce the following result:</p>
 
-<div id="Absolute_1">
-<div class="hidden">
-<h6 id="Absolute_positioning_example">Absolute positioning example</h6>
-
-<pre class="brush: html">&lt;h1&gt;Absolute positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Absolute positioning&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element.&lt;/p&gt;
 &lt;p class="positioned"&gt;This is my absolutely positioned element.&lt;/p&gt;
@@ -465,18 +441,13 @@ p {
     border-radius: 5px;
 }
 </pre>
-</div>
 
-<pre class="brush: css">.positioned {
-    position: absolute;
+<pre class="brush: css hidden">.positioned {
     background: rgba(255,84,104,.3);
     border: 2px solid rgb(255,84,104);
-    top: 30px;
-    left: 30px;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Absolute_1', '100%', 300) }}</p>
+<p>{{ EmbedLiveSample('Absolute_positioning', '100%', 300) }}</p>
 
 <p>This is very different! The positioned element has now been completely separated from the rest of the page layout and sits over the top of it. The other two paragraphs now sit together as if their positioned sibling doesn't exist. The {{cssxref("top")}} and {{cssxref("left")}} properties have a different effect on absolutely positioned elements than they do on relatively positioned elements. In this case the offsets have been calculated from the top and left of the page. It is possible to change the parent element that becomes this container and we will take a look at that in the lesson on <a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">positioning</a>.</p></p>
 
@@ -490,28 +461,22 @@ p {
 
 &lt;div class="positioned"&gt;Fixed&lt;/div&gt;
 
-&lt;p&gt;Paragraph 1.&lt;/p&gt;
-&lt;p&gt;Paragraph 2.&lt;/p&gt;
-&lt;p&gt;Paragraph 3.&lt;/p&gt;
+&lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis
+orci, pulvinar id metus ut, rutrum luctus orci.&lt;/p&gt;
+
+&lt;p&gt; Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet.
+Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet
+orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare
+ex malesuada et.&lt;/p&gt;
+
+&lt;p&gt; In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac
+imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis
+ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo
+et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
 </pre>
 
-<div id="Fixed_1">
-<div class="hidden">
-<h6 id="Fixed_positioning_example">Fixed positioning example</h6>
-
-<pre class="brush: html">&lt;h1&gt;Fixed positioning&lt;/h1&gt;
-
-&lt;div class="positioned"&gt;Fixed&lt;/div&gt;
-
-&lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
-
-&lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
-
-&lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
-
-</pre>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
     width: 500px;
     margin: 0 auto;
 }
@@ -523,7 +488,6 @@ p {
     margin: 10px;
     border-radius: 5px;
 }</pre>
-</div>
 
 <pre class="brush: css">.positioned {
     position: fixed;
@@ -532,17 +496,13 @@ p {
 }</pre>
 </div>
 
-<p>{{ EmbedLiveSample('Fixed_1', '100%', 200) }}</p>
+<p>{{ EmbedLiveSample('Fixed_positioning', '100%', 200) }}</p>
 
 <h3 id="Sticky_positioning">Sticky positioning</h3>
 
 <p>Sticky positioning is the final positioning method that we have at our disposal. It mixes static positioning with fixed positioning. When an item has <code>position: sticky</code>, it'll scroll in normal flow until it hits offsets from the viewport that we have defined. At that point it becomes "stuck" as if it had <code>position: fixed</code> applied.</p>
 
-<div id="Sticky_1">
-<div class="hidden">
-<h6 id="Sticky_positioning_example">Sticky positioning example</h6>
-
-<pre class="brush: html">&lt;h1&gt;Sticky positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Sticky positioning&lt;/h1&gt;
 
 &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
 
@@ -550,9 +510,10 @@ p {
 
 &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
 
-&lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;       </pre>
+&lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
+</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
 }
@@ -564,19 +525,17 @@ p {
   margin: 10px;
   border-radius: 5px;
 }</pre>
-</div>
 
 <pre class="brush: css">.positioned {
   position: sticky;
   top: 30px;
   left: 30px;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Sticky_1', '100%', 200) }}</p>
+<p>{{ EmbedLiveSample('Sticky_positioning', '100%', 200) }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: to find more out about positioning, see our <a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">Positioning</a> article.</p>
+<p><strong>Note:</strong> to find more out about positioning, see our <a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">Positioning</a> article.</p>
 </div>
 
 <h2 id="Table_layout">Table layout</h2>
@@ -652,7 +611,7 @@ form p {
 <p>You can also see this example live at <a href="https://mdn.github.io/learning-area/css/styling-boxes/box-model-recap/css-tables-example.html">css-tables-example.html</a> (see the <a href="https://github.com/mdn/learning-area/blob/master/css/styling-boxes/box-model-recap/css-tables-example.html">source code</a> too.)</p>
 
 <div class="note">
-  <p><strong>Note</strong>: Table layout, unlike the other topics of this page, won't be further covered in this module due to its legacy application.</p>
+  <p><strong>Note:</strong> Table layout, unlike the other topics of this page, won't be further covered in this module due to its legacy application.</p>
   </div>
 
 <h2 id="Multi-column_layout">Multi-column layout</h2>
@@ -663,40 +622,42 @@ form p {
 
 <p>In the below example, we start with a block of HTML inside a containing <code>&lt;div&gt;</code> element with a class of <code>container</code>.</p>
 
-<pre class="brush: html">&lt;div class="container"&gt;
-    &lt;h1&gt;Multi-column layout&lt;/h1&gt;
 
-    &lt;p&gt;Paragraph 1.&lt;/p&gt;
-    &lt;p&gt;Paragraph 2.&lt;/p&gt;
+<pre class="brush: html">
+&lt;div class="container"&gt;
+
+ &lt;h1&gt;Multi-column Layout&lt;/h1&gt;
+
+ &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla
+ luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci,
+ pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at
+ ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta.&lt;/p&gt;
+
+ &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget
+ malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut,
+ facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam
+ lorem.&lt;/p&gt;
+
+ &lt;p&gt;Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris
+ ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus
+ viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum
+ sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
+ mus.&lt;/p&gt;
 
 &lt;/div&gt;
 </pre>
 
 <p>We're using a <code>column-width</code> of 200 pixels on that container, causing the browser to create as many 200 pixel columns as will fit. Whatever space is left between the columns will be shared.</p>
 
-<div id="Multicol_1">
-<div class="hidden">
-<h6 id="Multicol_example">Multicol example</h6>
 
-<pre class="brush: html">    &lt;div class="container"&gt;
-        &lt;h1&gt;Multi-column Layout&lt;/h1&gt;
+<pre class="brush: css hidden">body { max-width: 800px; margin: 0 auto; } </pre>
 
-        &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
+<pre class="brush: css">
+.container {
+    column-width: 200px;
+}</pre>
 
-        &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
-
-    &lt;/div&gt;
-        </pre>
-
-<pre class="brush: css">body { max-width: 800px; margin: 0 auto; } </pre>
-</div>
-
-<pre class="brush: css">    .container {
-        column-width: 200px;
-    }</pre>
-</div>
-
-<p>{{ EmbedLiveSample('Multicol_1', '100%', 200) }}</p>
+<p>{{ EmbedLiveSample('Multi-column_layout', '100%', 200) }}</p>
 
 <h2 id="Summary">Summary</h2>
 

--- a/files/en-us/learn/css/css_layout/legacy_layout_methods/index.html
+++ b/files/en-us/learn/css/css_layout/legacy_layout_methods/index.html
@@ -91,48 +91,12 @@ div:nth-of-type(2) {
 
 <p>Putting this all together should give us a result like so:</p>
 
-<div id="Floated_Two_Col">
-<div class="hidden">
-<h6 id="Simple_two-column_layout">Simple two-column layout</h6>
-
-<pre class="brush: html">&lt;h1&gt;2 column layout example&lt;/h1&gt;
-
-&lt;div&gt;
-  &lt;h2&gt;First column&lt;/h2&gt;
-  &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
-&lt;/div&gt;
-
-&lt;div&gt;
-  &lt;h2&gt;Second column&lt;/h2&gt;
-  &lt;p&gt;Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed est. Nam id risus quis ante semper consectetur eget aliquam lorem. Vivamus tristique elit dolor, sed pretium metus suscipit vel. Mauris ultricies lectus sed lobortis finibus. Vivamus eu urna eget velit cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
-&lt;/div&gt;
-</pre>
-
-<pre class="brush: css">body {
-  width: 90%;
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-div:nth-of-type(1) {
-  width: 48%;
-  float: left;
-}
-
-div:nth-of-type(2) {
-  width: 48%;
-  float: right;
-}
-</pre>
-</div>
-</div>
-
-<p>{{ EmbedLiveSample('Floated_Two_Col', '100%', 520) }}</p>
+<p>{{ EmbedLiveSample('A_two_column_layout', '100%', 520) }}</p>
 
 <p>You'll notice here that we are using percentages for all the widths — this is quite a good strategy, as it creates a <strong>liquid layout</strong>, one that adjusts to different screen sizes and keeps the same proportions for the column widths at smaller screen sizes. Try adjusting the width of your browser window to see for yourself. This is a valuable tool for responsive web design.</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can see this example running at <a href="https://mdn.github.io/learning-area/css/css-layout/floats/0_two-column-layout.html">0_two-column-layout.html</a> (see also <a href="https://github.com/mdn/learning-area/blob/master/css/css-layout/floats/0_two-column-layout.html">the source code</a>).</p>
+<p><strong>Note:</strong> You can see this example running at <a href="https://mdn.github.io/learning-area/css/css-layout/floats/0_two-column-layout.html">0_two-column-layout.html</a> (see also <a href="https://github.com/mdn/learning-area/blob/master/css/css-layout/floats/0_two-column-layout.html">the source code</a>).</p>
 </div>
 
 <h2 id="Creating_simple_legacy_grid_frameworks">Creating simple legacy grid frameworks</h2>
@@ -215,7 +179,7 @@ body {
 <p>The top row of single columns will now lay out neatly as a grid.</p>
 
 <div class="note">
-<p><strong>Note</strong>: We've also given each column a light red color so you can see exactly how much space each one takes up.</p>
+<p><strong>Note:</strong> We've also given each column a light red color so you can see exactly how much space each one takes up.</p>
 </div>
 
 <p>Layout containers that we want to span more than one column need to be given special classes to adjust their {{cssxref("width")}} values to the required number of columns (plus gutters in between). We need to create an additional class to allow containers to span 2 to 12 columns. Each width is the result of adding up the column width of that number of columns plus the gutter widths, which will always number one less than the number of columns.</p>

--- a/files/en-us/learn/css/css_layout/multiple-column_layout/index.html
+++ b/files/en-us/learn/css/css_layout/multiple-column_layout/index.html
@@ -34,6 +34,8 @@ tags:
 
 <p>Let's explore how to use multiple-column layout — often referred to as <em>multicol</em>. You can follow along by <a href="https://github.com/mdn/learning-area/blob/master/css/css-layout/multicol/0-starting-point.html">downloading the multicol starting point file</a> and adding the CSS into the appropriate places. At the bottom of the section you can see an example of what the final code should look like.</p>
 
+<h3>A three-column layout</h3>
+
 <p>Our starting point file contains some very simple HTML: a wrapper with a class of <code>container</code>, inside of which is a heading and some paragraphs.</p>
 
 <p>The {{htmlelement("div")}} with a class of container will become our multicol container. We enable multicol by using one of two properties: {{cssxref("column-count")}} or {{cssxref("column-width")}}. The <code>column-count</code> property takes a number as its value and creates that number of columns. If you add the following CSS to your stylesheet and reload the page, you'll get three columns:</p>
@@ -45,11 +47,7 @@ tags:
 
 <p>The columns that you create have flexible widths — the browser works out how much space to assign each column.</p>
 
-<div id="Multicol_1">
-<div class="hidden">
-<h6 id="column-count_example">column-count example</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -58,7 +56,7 @@ tags:
     </pre>
 </div>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;h1&gt;Simple multicol example&lt;/h1&gt;
 
   &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate.
@@ -74,13 +72,9 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<pre class="brush: css">.container {
-  column-count: 3;
-}
-</pre>
-</div>
+<p>{{ EmbedLiveSample('A_three-column_layout', '100%', 400) }}</p>
 
-<p>{{ EmbedLiveSample('Multicol_1', '100%', 400) }}</p>
+<h3>Setting column-width</h3>
 
 <p>Change your CSS to use <code>column-width</code> as follows:</p>
 
@@ -91,18 +85,14 @@ tags:
 
 <p>The browser will now give you as many columns as it can of the size that you specify; any remaining space is then shared between the existing columns. This means that you won't get exactly the width that you specify unless your container is exactly divisible by that width.</p>
 
-<div id="Multicol_2">
-<div class="hidden">
-<h6 id="column-width_example">column-width example</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
   font: .9em/1.2 Arial, Helvetica, sans-serif;
 }</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;h1&gt;Simple multicol example&lt;/h1&gt;
 
   &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate.
@@ -117,15 +107,7 @@ tags:
   dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
 &lt;/div&gt;</pre>
 
-
-<pre class="brush: css">.container {
-  column-width: 200px;
-}
-</pre>
-</div>
-</div>
-
-<p>{{ EmbedLiveSample('Multicol_2', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Setting_column-width', '100%', 400) }}</p>
 
 <h2 id="Styling_the_columns">Styling the columns</h2>
 
@@ -136,14 +118,9 @@ tags:
  <li>Adding a rule between columns with {{cssxref("column-rule")}}.</li>
 </ul>
 
-<p>Using your example above, change the size of the gap by adding a <code>column-gap</code> property:</p>
+<p>Using your example above, change the size of the gap by adding a <code>column-gap</code> property. You can play around with different values — the property accepts any length unit.</p>
 
-<pre class="brush: css">.container {
-  column-width: 200px;
-  column-gap: 20px;
-}</pre>
-
-<p>You can play around with different values — the property accepts any length unit. Now add a rule between the columns with <code>column-rule</code>. In a similar way to the {{cssxref("border")}} property that you encountered in previous lessons, <code>column-rule</code> is a shorthand for {{cssxref("column-rule-color")}}, {{cssxref("column-rule-style")}}, and {{cssxref("column-rule-width")}}, and accepts the same values as <code>border</code>.</p>
+<p>Now add a rule between the columns with <code>column-rule</code>. In a similar way to the {{cssxref("border")}} property that you encountered in previous lessons, <code>column-rule</code> is a shorthand for {{cssxref("column-rule-color")}}, {{cssxref("column-rule-style")}}, and {{cssxref("column-rule-width")}}, and accepts the same values as <code>border</code>.</p>
 
 <pre class="brush: css">.container {
   column-count: 3;
@@ -153,23 +130,15 @@ tags:
 
 <p>Try adding rules of different styles and colors.</p>
 
-<div id="Multicol_3">
-<div class="hidden">
-<h6 id="Styling_the_columns_2">Styling the columns</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
   font: .9em/1.2 Arial, Helvetica, sans-serif;
 }
-.container {
- column-count: 3;
- column-gap: 20px;
- column-rule: 4px dotted rgb(79, 185, 227);
-}</pre>
+</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;h1&gt;Simple multicol example&lt;/h1&gt;
 
   &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate.
@@ -183,10 +152,8 @@ tags:
   cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis
   dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
 &lt;/div&gt;</pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Multicol_3', '100%', 400) }}</p>
+<p>{{ EmbedLiveSample('Styling_the_columns', '100%', 400) }}</p>
 
 <p>Something to take note of is that the rule doesn't take up any width of its own. It lies across the gap you created with <code>column-gap</code>. To make more space on either side of the rule, you'll need to increase the <code>column-gap</code> size.</p>
 
@@ -195,14 +162,10 @@ tags:
 <p>You can cause an element to span across all the columns. In this case, the content breaks where the spanning element's introduced and then continues below the element, creating a new set of columns. To cause an element to span all the columns, specify the value of <code>all</code> for the {{cssxref("column-span")}} property.</p>
 
 <div class="notecard note">
-<p>Note that it isn't possible to cause an element to span just <em>some</em> columns. The property can only have the values of <code>none</code> (which is the default) or <code>all</code>.</p>
+<p><strong>Note:</strong> It isn't possible to cause an element to span just <em>some</em> columns. The property can only have the values of <code>none</code> (which is the default) or <code>all</code>.</p>
 </div>
 
-<div id="Multicol_Span">
-<div class="hidden">
-<h6 id="Spanning_the_columns">Spanning the columns</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
@@ -221,7 +184,7 @@ h2 {
 }
 </pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
   &lt;h1&gt;Simple multicol example&lt;/h1&gt;
 
   &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate.
@@ -237,28 +200,23 @@ h2 {
   cursus viverra quis vestibulum sem. Aliquam tincidunt eget purus in interdum. Cum sociis natoque penatibus et magnis
   dis parturient montes, nascetur ridiculus mus.&lt;/p&gt;
 &lt;/div&gt;</pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Multicol_Span', '100%', 550) }}</p>
+<p>{{ EmbedLiveSample('Spanning_columns', '100%', 550) }}</p>
 
 <h2 id="Columns_and_fragmentation">Columns and fragmentation</h2>
 
 <p>The content of a multi-column layout is fragmented. It essentially behaves the same way as content behaves in paged media, such as when you print a webpage. When you turn your content into a multicol container, it fragments into columns. In order for the content to do this, it must <em>break</em>.</p>
 
+<h3>Fragmented boxes</h3>
+
 <p>Sometimes, this breaking will happen in places that lead to a poor reading experience. In the example below, I have used multicol to lay out a series of boxes, each of which has a heading and some text inside. The heading becomes separated from the text if the columns fragment between the two.</p>
 
-<div id="Multicol_4">
-<div class="hidden">
-<h6 id="Cards_example">Cards example</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
   font: .9em/1.2 Arial, Helvetica, sans-serif;
 }            </pre>
-</div>
 
 <pre class="brush: html">&lt;div class="container"&gt;
     &lt;div class="card"&gt;
@@ -330,16 +288,18 @@ h2 {
   padding: 10px;
   margin: 0 0 1em 0;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Multicol_4', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('Fragmented_boxes', '100%', 1000) }}</p>
+
+<h3>Setting break-inside</h3>
 
 <p>To control this behavior, we can use properties from the <a href="/en-US/docs/Web/CSS/CSS_Fragmentation">CSS Fragmentation</a> specification. This specification gives us properties to control the breaking of content in multicol and in paged media. For example, by adding the property {{cssxref("break-inside")}} with a value of <code>avoid</code> to the rules for <code>.card</code>. This is the container of the heading and text, so we don't want it fragmented.</p>
 
 <pre class="brush: css">.card {
   break-inside: avoid;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  page-break-inside: avoid;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
   padding: 10px;
   margin: 0 0 1em 0;
 }
@@ -347,18 +307,15 @@ h2 {
 
 <p>The addition of this property causes the boxes to stay in one piece—they now do not <em>fragment</em> across the columns.</p>
 
-<div id="Multicol_5">
-<div class="hidden">
-<h6 id="Multicol_Fragmentation">Multicol Fragmentation</h6>
-
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
   font: .9em/1.2 Arial, Helvetica, sans-serif;
-}              </pre>
+}
+</pre>
 
-<pre class="brush: html">&lt;div class="container"&gt;
+<pre class="brush: html hidden">&lt;div class="container"&gt;
     &lt;div class="card"&gt;
       &lt;h2&gt;I am the heading&lt;/h2&gt;
       &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat
@@ -416,24 +373,15 @@ h2 {
 
 &lt;/div&gt;
 </pre>
-</div>
 
-<pre class="brush: css">.container {
+<pre class="brush: css hidden">.container {
   column-width: 250px;
   column-gap: 20px;
 }
+</pre>
 
-.card {
-  break-inside: avoid;
-  page-break-inside: avoid;
-  background-color: rgb(207, 232, 220);
-  border: 2px solid rgb(79, 185, 227);
-  padding: 10px;
-  margin: 0 0 1em 0;
-}</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Multicol_5', '100%', 600) }}</p>
+<p>{{ EmbedLiveSample('Setting_break-inside', '100%', 1100) }}</p>
 
 <h2 id="Test_your_skills!">Test your skills!</h2>
 

--- a/files/en-us/learn/css/css_layout/normal_flow/index.html
+++ b/files/en-us/learn/css/css_layout/normal_flow/index.html
@@ -47,7 +47,6 @@ tags:
 
 <p>Let's look at a simple example that explains all of this:</p>
 
-<div id="Normal_Flow">
 <pre class="brush: html">&lt;h1&gt;Basic document flow&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element. My adjacent block level elements sit on new lines below me.&lt;/p&gt;
@@ -74,9 +73,8 @@ span {
   background: white;
   border: 1px solid black;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Normal_Flow', '100%', 500) }}</p>
+<p>{{ EmbedLiveSample('How_are_elements_laid_out_by_default', '100%', 600) }}</p>
 
 <h2 id="Summary">Summary</h2>
 

--- a/files/en-us/learn/css/css_layout/positioning/index.html
+++ b/files/en-us/learn/css/css_layout/positioning/index.html
@@ -82,8 +82,7 @@ left: 30px;</pre>
 
 <p>If you now save and refresh, you'll get a result something like this:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;h1&gt;Relative positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Relative positioning&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element. My adjacent block level elements sit on new lines below me.&lt;/p&gt;
 
@@ -93,7 +92,7 @@ left: 30px;</pre>
 
 &lt;p&gt;inline elements &lt;span&gt;like this one&lt;/span&gt; and &lt;span&gt;this one&lt;/span&gt; sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements &lt;span&gt;wrap onto a new line if possible — like this one containing text&lt;/span&gt;, or just go on to a new line if not, much like this image will do: &lt;img src="long.jpg"&gt;&lt;/p&gt;</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
 }
@@ -128,15 +127,17 @@ span {
 
 <h2 id="Absolute_positioning">Absolute positioning</h2>
 
-<p>Absolute positioning brings very different results. Let's try changing the position declaration in your code as follows:</p>
+<p>Absolute positioning brings very different results.
+
+<h3>Setting position: absolute</h3>
+
+<p>Let's try changing the position declaration in your code as follows:</p>
 
 <pre class="brush: css">position: absolute;</pre>
 
 <p>If you now save and refresh, you should see something like so:</p>
 
-<div class="hidden">
-<h3 id="hidden_abspos_code">hidden abspos code</h3>
-<pre class="brush: html">&lt;h1&gt;Absolute positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Absolute positioning&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element. My adjacent block level elements sit on new lines below me.&lt;/p&gt;
 
@@ -146,7 +147,7 @@ span {
 
 &lt;p&gt;inline elements &lt;span&gt;like this one&lt;/span&gt; and &lt;span&gt;this one&lt;/span&gt; sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements &lt;span&gt;wrap onto a new line if possible — like this one containing text&lt;/span&gt;, or just go on to a new line if not, much like this image will do: &lt;img src="long.jpg"&gt;&lt;/p&gt;</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
 }
@@ -169,9 +170,8 @@ span {
   top: 30px;
   left: 30px;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('hidden_abspos_code', '100%', 450) }}</p>
+<p>{{ EmbedLiveSample('Setting_position_absolute', '100%', 450) }}</p>
 
 <p>First of all, note that the gap where the positioned element should be in the document flow is no longer there — the first and third elements have closed together like it no longer exists! Well, in a way, this is true. An absolutely positioned element no longer exists in the normal document flow. Instead, it sits on its own layer separate from everything else. This is very useful: it means that we can create isolated UI features that don't interfere with the layout of other elements on the page.  For example, popup information boxes, control menus, rollover panels, UI features that can be dragged and dropped anywhere on the page, and so on.</p>
 
@@ -201,8 +201,7 @@ span {
 
 <p>This should give the following result:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;h1&gt;Positioning context&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Positioning context&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element. My adjacent block level elements sit on new lines below me.&lt;/p&gt;
 
@@ -212,7 +211,7 @@ span {
 
 &lt;p&gt;inline elements &lt;span&gt;like this one&lt;/span&gt; and &lt;span&gt;this one&lt;/span&gt; sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements &lt;span&gt;wrap onto a new line if possible — like this one containing text&lt;/span&gt;, or just go on to a new line if not, much like this image will do: &lt;img src="long.jpg"&gt;&lt;/p&gt;</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
   position: relative;
@@ -236,7 +235,6 @@ span {
   top: 30px;
   left: 30px;
 }</pre>
-</div>
 
 <p>{{ EmbedLiveSample('Positioning_contexts', '100%', 420) }}</p>
 
@@ -271,8 +269,7 @@ span {
 
 <p>You should now see the lime paragraph on top:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;h1&gt;z-index&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;z-index&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element. My adjacent block level elements sit on new lines below me.&lt;/p&gt;
 
@@ -282,7 +279,7 @@ span {
 
 &lt;p&gt;inline elements &lt;span&gt;like this one&lt;/span&gt; and &lt;span&gt;this one&lt;/span&gt; sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements &lt;span&gt;wrap onto a new line if possible — like this one containing text&lt;/span&gt;, or just go on to a new line if not, much like this image will do: &lt;img src="long.jpg"&gt;&lt;/p&gt;</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
   position: relative;
@@ -315,7 +312,6 @@ p:nth-of-type(1) {
   z-index: 1;
 }
 </pre>
-</div>
 
 <p>{{ EmbedLiveSample('Introducing_z-index', '100%', 400) }}</p>
 
@@ -360,8 +356,7 @@ p:nth-of-type(1) {
 
 <p>You should now see the finished example:</p>
 
-<div class="hidden">
-<pre class="brush: html">&lt;h1&gt;Fixed positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Fixed positioning&lt;/h1&gt;
 
 &lt;p&gt;I am a basic block level element. My adjacent block level elements sit on new lines below me.&lt;/p&gt;
 
@@ -371,7 +366,7 @@ p:nth-of-type(1) {
 
 &lt;p&gt;inline elements &lt;span&gt;like this one&lt;/span&gt; and &lt;span&gt;this one&lt;/span&gt; sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements &lt;span&gt;wrap onto a new line if possible — like this one containing text&lt;/span&gt;, or just go on to a new line if not, much like this image will do: &lt;img src="long.jpg"&gt;&lt;/p&gt;</pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   height: 1400px;
   margin: 0 auto;
@@ -400,7 +395,6 @@ h1 {
 p:nth-of-type(1) {
   margin-top: 60px;
 }</pre>
-</div>
 
 <p>{{ EmbedLiveSample('Fixed_positioning', '100%', 400) }}</p>
 
@@ -410,13 +404,13 @@ p:nth-of-type(1) {
 
 <h2 id="position_sticky">Sticky positioning</h2>
 
-<p>There is another position value available called <code>position: sticky</code>, which is somewhat newer than the others. This is basically a hybrid between relative and fixed position. It allows a positioned element to act like it's relatively positioned until it's scrolled to a certain threshold (e.g., 10px from the top of the viewport), after which it becomes fixed. This can be used, for example, to cause a navigation bar to scroll with the page until a certain point and then stick to the top of the page. </p>
+<p>There is another position value available called <code>position: sticky</code>, which is somewhat newer than the others. This is basically a hybrid between relative and fixed position. It allows a positioned element to act like it's relatively positioned until it's scrolled to a certain threshold (e.g., 10px from the top of the viewport), after which it becomes fixed.</p>
 
-<div id="Sticky_1">
-<div class="hidden">
-<h6 id="Sticky_positioning_example">Sticky positioning example</h6>
+<h3>Basic example</h3>
 
-<pre class="brush: html">&lt;h1&gt;Sticky positioning&lt;/h1&gt;
+<p>Sticky positioning can be used, for example, to cause a navigation bar to scroll with the page until a certain point and then stick to the top of the page. </p>
+
+<pre class="brush: html hidden">&lt;h1&gt;Sticky positioning&lt;/h1&gt;
 
 &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;
 
@@ -426,7 +420,7 @@ p:nth-of-type(1) {
 
 &lt;p&gt; Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus aliquam dolor, eu lacinia lorem placerat vulputate. Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat. Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum sapien.&lt;/p&gt;       </pre>
 
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   margin: 0 auto;
 }
@@ -438,16 +432,16 @@ p:nth-of-type(1) {
   margin: 10px;
   border-radius: 5px;
 }</pre>
-</div>
 
 <pre class="brush: css">.positioned {
   position: sticky;
   top: 30px;
   left: 30px;
 }</pre>
-</div>
 
-<p>{{ EmbedLiveSample('Sticky_1', '100%', 200) }}</p>
+<p>{{ EmbedLiveSample('Basic_example', '100%', 200) }}</p>
+
+<h3>Scrolling index</h3>
 
 <p>An interesting and common use of <code>position: sticky</code> is to create a scrolling index page where different headings stick to the top of the page as they reach it. The markup for such an example might look like so:</p>
 
@@ -495,26 +489,14 @@ p:nth-of-type(1) {
 }
 </pre>
 
-<div id="Sticky_2">
-<div class="hidden">
-<pre class="brush: css">body {
+<pre class="brush: css hidden">body {
   width: 500px;
   height: 1400px;
   margin: 0 auto;
 }
-
-dt {
-  background-color: black;
-  color: white;
-  padding: 10px;
-  position: sticky;
-  top: 0;
-  left: 0;
-  margin: 1em 0;
-}
 </pre>
 
-<pre class="brush: html">&lt;h1&gt;Sticky positioning&lt;/h1&gt;
+<pre class="brush: html hidden">&lt;h1&gt;Sticky positioning&lt;/h1&gt;
 
 &lt;dl&gt;
     &lt;dt&gt;A&lt;/dt&gt;
@@ -544,10 +526,8 @@ dt {
     &lt;dd&gt;Egret&lt;/dd&gt;
 &lt;/dl&gt;
 </pre>
-</div>
-</div>
 
-<p>{{ EmbedLiveSample('Sticky_2', '100%', 200) }}</p>
+<p>{{ EmbedLiveSample('Scrolling_index', '100%', 200) }}</p>
 
 <p>Sticky elements are "sticky" relative to the nearest ancestor with a "scrolling mechanism", which is determined by its ancestors' <a href="/en-US/docs/Web/CSS/position">position</a> property.</p>
 

--- a/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
+++ b/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
@@ -60,9 +60,10 @@ tags:
 
 <p>CSS specifications contain information that explains what the browser does when two layout methods are applied to the same item. This means that there is a definition for what happens if a floated item, for example, is also a Grid Item using CSS Grid Layout. Couple this information with the knowledge that browsers ignore CSS that they don’t understand, and you have a way to create simple layouts using the <a href="/en-US/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods">legacy techniques</a> we have already covered, which are then overwritten by your Grid layout in modern browsers that understand it.</p>
 
-<p>In the below example, we have floated three <code>&lt;div&gt;</code>s so they display in a row. Any browser that does not support <a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">CSS Grid Layout</a> will see the row of boxes as a floated layout. A floated item that becomes a grid item loses the float behavior, which means that by turning the wrapper into a Grid Container, the floated items become Grid Items. If the browser supports Grid Layout it will display the grid view, if not it ignores the <code>display: grid</code> and related properties and the floated layout is used.</p>
+<h3>Falling back from grid to float</h3>
 
-<div id="Example1">
+<p>In the example below, we have floated three <code>&lt;div&gt;</code>s so they display in a row. Any browser that does not support <a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">CSS Grid Layout</a> will see the row of boxes as a floated layout. A floated item that becomes a grid item loses the float behavior, which means that by turning the wrapper into a Grid Container, the floated items become Grid Items. If the browser supports Grid Layout it will display the grid view, if not it ignores the <code>display: grid</code> and related properties and the floated layout is used.</p>
+
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .wrapper {
@@ -88,14 +89,13 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('Example1', '100%', '200') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Falling_back_from_grid_to_float', '100%', '200') }}</p>
 
 <div class="note">
 <p><strong>Note</strong>: The {{cssxref("clear")}} property also has no effect once the cleared item becomes a grid item, so you could have a layout with a cleared footer, which is then turned into a Grid Layout.</p>
 </div>
 
-<h3 id="Fallback_Methods">Fallback Methods</h3>
+<h3>Fallback methods</h3>
 
 <p>There are a number of layout methods which can be used in a similar way to this float example. You can choose the one that makes the most sense for the layout pattern you need to create.</p>
 
@@ -116,7 +116,6 @@ tags:
 
 <p>In the floated layout, the percentage is calculated from the container — 33.333% is a third of the container width. In Grid however that 33.333% is calculated from the grid area the item is placed in, so it actually becomes a third of the size we want once the Grid Layout is introduced.</p>
 
-<div id="Example2">
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .wrapper {
@@ -143,8 +142,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('Example2', '100%', '200') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Fallback_methods', '100%', '200') }}</p>
 
 <p>To deal with this issue we need to have a way to detect if Grid is supported and therefore if it will override the width. CSS has a solution for us here.</p>
 
@@ -154,7 +152,6 @@ tags:
 
 <p>If we add a feature query to the above example, we can use it to set the widths of our items back to <code>auto</code>  if we know that we have grid support.</p>
 
-<div id="Example3">
 <pre class="brush: css">* {box-sizing: border-box;}
 
 .wrapper {
@@ -187,10 +184,9 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>{{ EmbedLiveSample('Example3', '100%', '200') }}</p>
-</div>
+<p>{{ EmbedLiveSample('Feature_queries', '100%', '200') }}</p>
 
-<p>Support for feature queries is very good across modern browsers, however, you should note that it is the browsers that do not support CSS Grid, which also doesn’t support feature queries. This means that an approach as detailed above will work for those browsers. What we are doing is writing our old CSS first, outside of any feature query. Browsers that do not support Grid, and do not support the feature query will use that layout information they can understand and completely ignore everything else. The browsers that support the feature query also support CSS Grid and so will run the grid code and the code inside the feature query.</p>
+<p>Support for feature queries is very good across modern browsers. However, you should note that browsers that do not support CSS Grid also tend not to support feature queries. This means that an approach as detailed above will work for those browsers. What we are doing is writing our old CSS first, outside of any feature query. Browsers that do not support Grid, and do not support the feature query will use that layout information they can understand and completely ignore everything else. The browsers that support the feature query also support CSS Grid and so will run the grid code and the code inside the feature query.</p>
 
 <p>The specification for feature queries also contains the ability to test if a browser does not support a feature — this is only helpful if the browser does support feature queries. In the future, an approach of checking for lack of support will work, as the browsers that don’t have feature query support go away. For now, however, use the approach of doing the older CSS, then overwriting it, for the best support.</p>
 

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.html
@@ -270,9 +270,12 @@ p {
 
 <h3 id="Functions">Functions</h3>
 
-<p>While most values are relatively simple keywords or numeric values, there are some values that take the form of a function. An example would be the <code>calc()</code> function, which can do simple math within CSS:</p>
+<p>While most values are relatively simple keywords or numeric values, there are some values that take the form of a function.</p>
 
-<div id="calc_example">
+<h4>The calc() function</h4>
+
+<p>An example would be the <code>calc()</code> function, which can do simple math within CSS:</p>
+
 <pre class="brush: html">&lt;div class="outer"&gt;&lt;div class="box"&gt;The inner box is 90% - 30px.&lt;/div&gt;&lt;/div&gt;</pre>
 
 <pre class="brush: css">.outer {
@@ -285,17 +288,17 @@ p {
   background-color: rebeccapurple;
   color: white;
 }</pre>
-</div>
 
 <p>This renders as:</p>
 
-<p>{{EmbedLiveSample('calc_example', '100%', 200)}}</p>
+<p>{{EmbedLiveSample('The_calc_function', '100%', 200)}}</p>
 
 <p>A function consists of the function name, and parentheses to enclose the values for the function. In the case of the <code>calc()</code> example above, the values define the width of this box to be 90% of the containing block width, minus 30 pixels. The result of the calculation isn't something that can be computed in advance and entered as a static value.</p>
 
+<h4>Transform functions</h4>
+
 <p>Another example would be the various values for {{cssxref("transform")}}, such as <code>rotate()</code>.</p>
 
-<div id="transform_example">
 <pre class="brush: html">&lt;div class="box"&gt;&lt;/div&gt;</pre>
 
 <pre class="brush: css">.box {
@@ -309,7 +312,7 @@ p {
 
 <p>The output from the above code looks like this:</p>
 
-<p>{{EmbedLiveSample('transform_example', '100%', 200)}}</p>
+<p>{{EmbedLiveSample('Transform_functions', '100%', 200)}}</p>
 
 <p><strong>Look up different values of properties listed below. Write CSS rules that apply styling to different HTML elements: </strong></p>
 
@@ -474,7 +477,7 @@ div p + p {
 }
 </pre>
 
-<p id="Very_compact">The next example shows the equivalent CSS in a more compressed format. Although the two examples work the same, the one below is more difficult to read.</p>
+<p>The next example shows the equivalent CSS in a more compressed format. Although the two examples work the same, the one below is more difficult to read.</p>
 
 <pre class="brush: css">body {font: 1em/150% Helvetica, Arial, sans-serif; padding: 1em; margin: 0 auto; max-width: 33em;}
 @media (min-width: 70em) { body {font-size: 130%;} }

--- a/files/en-us/learn/css/first_steps/how_css_works/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.html
@@ -78,9 +78,7 @@ tags:
 
 <p>{{EmbedLiveSample('A_real_DOM_representation', '100%', 55)}}</p>
 
-<div class="hidden">
-<pre class="brush: css">p {margin:0;}</pre>
-</div>
+<pre class="brush: css hidden">p {margin:0;}</pre>
 
 <h2 id="Applying_CSS_to_the_DOM">Applying CSS to the DOM</h2>
 
@@ -120,7 +118,6 @@ tags:
 
 <p>In the example below I have used the British English spelling for color, which makes that property invalid as it is not recognized. So my paragraph has not been colored blue. All of the other CSS have been applied however; only the invalid line is ignored.</p>
 
-<div id="Skipping_example">
 <pre class="brush: html">&lt;p&gt; I want this text to be large, bold and blue.&lt;/p&gt;</pre>
 
 <pre class="brush: css">p {
@@ -128,9 +125,8 @@ tags:
   colour: blue; /* incorrect spelling of the color property */
   font-size: 200%;
 }</pre>
-</div>
 
-<p>{{EmbedLiveSample('Skipping_example', '100%', 200)}}</p>
+<p>{{EmbedLiveSample('What_happens_if_a_browser_encounters_CSS_it_doesnt_understand', '100%', 200)}}</p>
 
 <p>This behavior is very useful. It means that you can use new CSS as an enhancement, knowing that no error will occur if it is not understood — the browser will either get the new feature or not. This enables basic fallback styling.</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This PR fixes up live samples in the CSS part of the Learning area so that they will work in Markdown: this means removing any `<div>` elements and adding the occasional heading so we can have an ID to reference in `EmbedLiveSample`.

Note that I started fixing some notes in here, too, but then decided it would be better to do that in a separate PR.