### PR TITLE
DOMParser: clarify XML error handling

### DIFF
--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -78,17 +78,22 @@ console.log(doc3.body.firstChild.textContent);
 
 ### Error handling
 
-Note that if the XML parser is used and parsing fails, the `DOMParser` throws an error:
+When using the XML parser with a string that doesn't represent well-formed XML, the {{domxref("XMLDocument")}} returned by `parseFromString` will contain a `<parsererror>` node describing the nature of the parsing error.
 
 ```js
 const parser = new DOMParser();
 
 const xmlString = "<warning>Beware of the missing closing tag";
 const doc = parser.parseFromString(xmlString, "application/xml");
-// XML Parsing Error: no root element found
+const errorNode = doc.querySelector('parsererror');
+if (errorNode) {
+  // parsing failed
+} else {
+  // parsing succeeded
+}
 ```
 
-The parsing error may also be reported to the browser's JavaScript console.
+Additionally, the parsing error may be reported to the browser's JavaScript console.
 
 ## Specifications
 

--- a/files/en-us/web/guide/parsing_and_serializing_xml/index.html
+++ b/files/en-us/web/guide/parsing_and_serializing_xml/index.html
@@ -43,9 +43,14 @@ tags:
 <div style="overflow: hidden;">
 <pre class="brush: js">const xmlStr = '&lt;a id="a"&gt;&lt;b id="b"&gt;hey!&lt;/b&gt;&lt;/a&gt;';
 const parser = new DOMParser();
-const dom = parser.parseFromString(xmlStr, "application/xml");
+const doc = parser.parseFromString(xmlStr, "application/xml");
 // print the name of the root element or error message
-console.log(dom.documentElement.nodeName == "parsererror" ? "error while parsing" : dom.documentElement.nodeName);
+const errorNode = doc.querySelector("parsererror");
+if (errorNode) {
+  console.log("error while parsing");
+} else {
+  console.log(dom.documentElement.nodeName);
+}
 </pre>
 </div>
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Updated the `DOMParser.parseFromString` and `Parsing and serializing XML` pages with better error handling.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

According to [the HTML standard](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring-dev), when encountering non-conforming input, the XML parser produces a `<parsererror>` node as the root of the resulting XMLDocument. However, in Safari and Chrome, this node is not always the root.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #9380.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
