### PR TITLE
Description confusing concepts clarified

### DIFF
--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -55,16 +55,17 @@ a + (b * c)   // 7
 a * c + b * c // 9
 ```
 
-Notice in these examples that the left-to-right order of evaluation is still
-preserved. In other words, the order in which the *operators* evaluate has changed,
-but the order in which the *operands* evaluate has not.
-For example in this code:
+The grouping operator is also used to clarify a mathematical structure of expressions.
 
 ```js
-a() * (b() + c())
+const z = (x = y); // Or equivalently: const z = x = y;
 ```
 
-The function `a` will be called before the function `b`, which will be called before the function `c`.
+When chaining the expressions, the assignment is evaluated right-to-left.
+
+`w = z = x = y` is equivalent to `w = (z = (x = y))` or `x = y; z = y; w = y`
+
+Essentially, the grouping operator is used to define a dependency graph of expressions along with other operators in a mathematical sense, that is independent from an evaluation strategy of a programming language. It is possible to derive an evaluation order or the absence of an evaluation order that respects the given dependencies from the dependency graph.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The example in the old version:

------

Notice in these examples that the left-to-right order of evaluation is still
preserved. In other words, the order in which the *operators* evaluate has changed,
but the order in which the *operands* evaluate has not.
For example in this code:

```js
a() * (b() + c())
```

The function `a` will be called before the function `b`, which will be called before the function `c`.

-------

This description in the old version holds confusion of concepts and misleads readers.


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

This description in the old version holds confusion of concepts and misleads readers.

1.
In MDN, we already have another description mentioning the evaluation order becomes **right-to-left** etc. 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators (Return value and chaining)
, so it's extraordinary unnatural to mention "*left-to-right order of evaluation is **still preserved***" as if in a general principle of JavaScript or in the principle of Grouping operator itself.

2.
In the old version, 

> but the order in which the *operands* evaluate has not.

the order of  *operands* evaluation in this example code arises due to **eager evaluation** of JavaScript, which should be substantially another off-topic here. As the operator illustrated, `+` or `*` is arithmetic operators, so readers naturally consider that the topic is told in the context of algebra.

Here, at least, there are 2 independent concepts:

- Grouping operator ( ) that follows the rule of mathematics in the form of dependency graph (the main target topic here)
- Eager evaluation of JavaScript (off-topic, if really needed, substantial explanations are required to clarify the relation to the main target topic here)

Readers should not be Implicitly misguided into confusion of these independent concepts.

Once an example code that behavior is due to the another substantial off-topic concept is presented, the document should explicitly clarify the concept, or should not provide such a confusing example from the first.

The new version is provided to resolve these problems.

---
The point of view here has been shared in [stack overflow question](https://stackoverflow.com/questions/69384610/does-the-functionality-of-grouping-operator-in-javascript-differ-from-haske/69386130) , and [a third person confirmed the fact as the answer](https://stackoverflow.com/a/69386130/11316608
):

>Grouping parentheses mean the same thing in Haskell as they do in high school mathematics. They group a sub-expression into a single term. This is also what they mean in Javascript and most other programming language,

>A language needs other rules beyond just the grouping of sub-expressions to pin down evaluation order (if it wants to specify the order), whether it's strict or lazy. So since you need other rules to determine it anyway, **it is best (in my opinion) to think of evaluation order as a totally separate concept than grouping.** **Mixing them up seems like a shortcut when you're learning high school mathematics, but it's just a handicap in more general settings.**

Therefore, for the explanation of Grouping operator (parentheses) itself, the priority of the article should be to focus the functionality given as the meaning of  "high school mathematics".

The wording of old version "operands" of "preserved" actively misleads readers to confuse the  "high school mathematics" principle of the Grouping operator and the evaluation strategy of JavaScript runtime. 
 
If anyone think such an example is required and to be included in this page, they need to explain thoroughly for readers to avoid the confusion of concepts between the mathematical aspect and evaluation strategy that the latter is essentially off-topic here.

---

#### Reference material

[Does the functionality of Grouping operator () in JavaScript differ from Haskell or other programming languages?](https://dev.to/stken2050/does-the-functionality-of-grouping-operator-in-javascript-differ-from-haskell-or-other-programming-languages-1f20)

https://stackoverflow.com/a/69386130/11316608

This PR…

- Adds a new document
- Rewrites (or significantly expands) a document



