### PR TITLE
[Markdown] [Learn] Convert notes to callouts

### DIFF
--- a/files/en-us/learn/accessibility/css_and_javascript/test_your_skills_colon__css_and_javascript_accessibility/index.html
+++ b/files/en-us/learn/accessibility/css_and_javascript/test_your_skills_colon__css_and_javascript_accessibility/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/css/css-a11y1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/css/css-a11y1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -50,7 +50,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/css/css-a11y2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/css/css-a11y2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -60,7 +60,7 @@ tags:
 
 <p>But it is not very accessible — in its current state you can only operate it with the mouse. We'd like you to add to the HTML and JavaScript to make it keyboard accessible too.</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/js/js/js1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/accessibility/test_your_skills_colon__html_accessibility/index.html
+++ b/files/en-us/learn/accessibility/test_your_skills_colon__html_accessibility/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/html/html-a11y1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -46,7 +46,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/html/html-a11y2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -64,7 +64,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/html/html-a11y3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -81,7 +81,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y4.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/html/html-a11y4-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/accessibility/wai-aria_basics/test_your_skills_colon__wai-aria/index.html
+++ b/files/en-us/learn/accessibility/wai-aria_basics/test_your_skills_colon__wai-aria/index.html
@@ -27,7 +27,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/aria/aria1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/aria/aria1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -44,7 +44,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/aria/aria2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/html-css/aria/aria2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -54,7 +54,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>The problem we have now is that when the DOM changes to show a new description, screenreaders cannot see what has changed. Can you update it so that description changes are announced by the screenreader?</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/accessibility/tasks/js/aria/aria-js1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/box_model_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/box_model_tasks/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/box-model/box-models.html", '100%', 1100)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/box-model/box-models-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -48,7 +48,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/box-model/mbp.html", '100%', 600)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/box-model/mbp-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -62,7 +62,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/box-model/inline-block.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/box-model/inline-block-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/cascade_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/cascade_tasks/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/cascade/cascade.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/cascade/cascade-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/images_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/images_tasks/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/images/object-fit.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/images/object-fit-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -46,7 +46,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/images/form.html", '100%', 600)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/images/form-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/overflow_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/overflow_tasks/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/overflow/overflow-scroll.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/overflow/overflow-scroll-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -39,7 +39,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/overflow/overflow-hidden.html", '100%', 1100)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/overflow/overflow-hidden-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/selectors/selectors_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/selectors_tasks/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/selectors/type.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/selectors/type-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -52,7 +52,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/selectors/class-id.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/selectors/class-id-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -72,7 +72,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/selectors/pseudo.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/selectors/pseudo-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -91,7 +91,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/selectors/combinators.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/selectors/combinators-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -111,7 +111,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/selectors/attribute-links.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/selectors/attribute-links-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/sizing_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/sizing_tasks/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/sizing/height-min-height.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/sizing/height-min-height-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -42,7 +42,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/sizing/percentages.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/sizing/percentages-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -56,7 +56,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/sizing/max-width.html", '100%', 1200)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/sizing/max-width-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/tables_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/tables_tasks/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/tables/table.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/tables/table-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/test_your_skills_backgrounds_and_borders/index.html
+++ b/files/en-us/learn/css/building_blocks/test_your_skills_backgrounds_and_borders/index.html
@@ -35,7 +35,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/backgrounds/backgrounds1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/backgrounds/backgrounds1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -57,7 +57,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/backgrounds/backgrounds2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/backgrounds/backgrounds2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/values_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/values_tasks/index.html
@@ -34,7 +34,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/values/color.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/values/color-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -55,7 +55,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/values/length.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/values/length-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -69,7 +69,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/values/position.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/values/position-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/building_blocks/writing_modes_tasks/index.html
+++ b/files/en-us/learn/css/building_blocks/writing_modes_tasks/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/writing-modes/writing-mode.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/writing-modes/writing-mode-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -39,7 +39,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/writing-modes/logical-width-height.html", '100%', 1100)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/writing-modes/logical-width-height-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -53,7 +53,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/writing-modes/logical-mbp.html", '100%', 1100)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/writing-modes/logical-mbp-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/css_layout/flexbox_skills/index.html
+++ b/files/en-us/learn/css/css_layout/flexbox_skills/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/flexbox/flexbox1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/flexbox/flexbox1-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -48,7 +48,7 @@ tags:
  <li>Can you now make the first item twice the size of the other items?</li>
 </ul>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/flexbox/flexbox2-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -62,7 +62,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/flexbox/flexbox3.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/flexbox/flexbox3-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -76,7 +76,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/flexbox/flexbox4.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/flexbox/flexbox4-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/css_layout/floats_skills/index.html
+++ b/files/en-us/learn/css/css_layout/floats_skills/index.html
@@ -29,7 +29,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/float/float1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/float/float1-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -43,7 +43,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/float/float2.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/float/float2-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -57,7 +57,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/float/float3.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/float/float3-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/css_layout/grid_skills/index.html
+++ b/files/en-us/learn/css/css_layout/grid_skills/index.html
@@ -27,7 +27,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/grid/grid1-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -47,7 +47,7 @@ tags:
  <li>Can you now cause the first item to display on top without changing the order of items in the source?</li>
 </ul>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/grid/grid2-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -61,7 +61,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid3.html", '100%', 800)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/grid/grid3-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -75,7 +75,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid4.html", '100%', 1200)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/grid/grid4-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/css_layout/multicol_skills/index.html
+++ b/files/en-us/learn/css/css_layout/multicol_skills/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/multicol/multicol1.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/multicol/multicol1-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -42,7 +42,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/multicol/multicol2.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/multicol/multicol2-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -56,7 +56,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/multicol/multicol3.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/multicol/multicol3-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/css/css_layout/position_skills/index.html
+++ b/files/en-us/learn/css/css_layout/position_skills/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>As an extra challenge, can you change the target to display underneath the text?</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/position/position1-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -42,7 +42,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/learn/tasks/position/position2.html", '100%', 1000)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p>For assessment or further work purposes, <a href="https://github.com/mdn/css-examples/blob/master/learn/tasks/position/position2-download.html">download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__advanced_styling/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__advanced_styling/index.html
@@ -39,7 +39,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/advanced-styling/advanced-styling1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/advanced-styling/advanced-styling1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -60,7 +60,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/advanced-styling/advanced-styling2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/advanced-styling/advanced-styling2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -75,7 +75,7 @@ tags:
  <li>Second, we want you to provide a useful visual indicator of whether the data entered inside each input is valid or not.</li>
 </ol>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/advanced-styling/advanced-styling3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__basic_controls/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__basic_controls/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/basic-controls/basic-controls1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/basic-controls/basic-controls1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -52,7 +52,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/basic-controls/basic-controls2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/basic-controls/basic-controls2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -70,7 +70,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/basic-controls/basic-controls3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/basic-controls/basic-controls3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__form_structure/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__form_structure/index.html
@@ -30,7 +30,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/form-structure/form-structure1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/form-structure/form-structure1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__form_validation/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__form_validation/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>Try submitting your form — it should refuse to submit until the above constraints are followed, and give suitable error messages. To help, you might want to consider adding some simple CSS to show when a form field is valid or invalid.</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/form-validation/form-validation1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -51,7 +51,7 @@ tags:
 
 <p>Again, to help you might want to consider adding some simple CSS to show when a form field is valid or invalid.</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/form-validation/form-validation2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -64,7 +64,7 @@ tags:
  <li>Add an event listener that checks whether the inputted value is an email address, and whether it is long enough. If it doesn't look like an email address or is too short, provide the user with appropriate custom error messages.</li>
 </ol>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/form-validation/form-validation3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__html5_controls/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__html5_controls/index.html
@@ -34,7 +34,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/html5-controls/html5-controls1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/html5-controls/html5-controls1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -52,7 +52,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/html5-controls/html5-controls2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/html5-controls/html5-controls2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__other_controls/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__other_controls/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/other-controls/other-controls1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/other-controls/other-controls1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -54,7 +54,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/other-controls/other-controls2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/other-controls/other-controls2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -72,7 +72,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/forms/tasks/other-controls/other-controls3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/other-controls/other-controls3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/forms/test_your_skills_colon__styling_basics/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__styling_basics/index.html
@@ -30,7 +30,7 @@ tags:
  <li>Use some kind of layout technique to make the inputs and labels line up neatly.</li>
 </ol>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/forms/tasks/styling-basics/styling-basics1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__advanced_html_text/index.html
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__advanced_html_text/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/advanced-text/advanced-text1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/advanced-text/advanced-text1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -45,7 +45,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/advanced-text/advanced-text2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/advanced-text/advanced-text2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.html
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/basic-text/basic-text1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -36,7 +36,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/basic-text/basic-text2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -48,7 +48,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/basic-text/basic-text3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.html
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/links/links1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/links/links1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -60,7 +60,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/links/links2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/links/links2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -81,7 +81,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/links/links3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/tasks/links/links3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/test_your_skills_colon__html_images/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/test_your_skills_colon__html_images/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/images/images1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -45,7 +45,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/images/images2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -57,7 +57,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/images/images3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/test_your_skills_colon__multimedia_and_embedding/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/test_your_skills_colon__multimedia_and_embedding/index.html
@@ -34,7 +34,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/media-embed/mediaembed1.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/media-embed/mediaembed1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -57,7 +57,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/media-embed/mediaembed2.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/media-embed/mediaembed2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -74,7 +74,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/media-embed/mediaembed3.html", '100%', 700)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/media-embed/mediaembed3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.html
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/conditionals/conditionals1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/conditionals/conditionals1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -69,7 +69,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/conditionals/conditionals2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/conditionals/conditionals2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -81,7 +81,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/conditionals/conditionals3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/conditionals/conditionals3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -104,7 +104,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/conditionals/conditionals4.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/conditionals/conditionals4-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.html
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/events/events1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -56,7 +56,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/events/events2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -70,7 +70,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/events/events3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.html
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/functions/functions1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/functions/functions1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -58,7 +58,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/functions/functions2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/functions/functions2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -76,7 +76,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/functions/functions3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/functions/functions3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__loops/index.html
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__loops/index.html
@@ -27,7 +27,7 @@ tags:
 
 <p>In our first looping task we want you start by creating a simple loop that goes through all the items in the provided <code>myArray</code> and prints them out on the screen inside list items (i.e., <code><a href="/en-US/docs/Web/HTML/Element/li">&lt;li&gt;</a></code> elements), which are appended to the provided <code>list</code>.</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/loops/loops1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -47,7 +47,7 @@ tags:
 
 <p>You should use a type of loop that you've not used in the previous task.</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/loops/loops2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -65,7 +65,7 @@ tags:
 
 <p>You should use a type of loop that you've not used in the previous two tasks.</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/loops/loops3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__arrays/index.html
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__arrays/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/arrays/arrays1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/arrays/arrays1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -50,7 +50,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/arrays/arrays2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/arrays/arrays2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -69,7 +69,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/arrays/arrays3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/arrays/arrays3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__math/index.html
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__math/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/math/math1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/math/math1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -59,7 +59,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/math/math2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/math/math2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -69,7 +69,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/math/math3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/math/math3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__strings/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/strings/strings1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/strings/strings1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -55,7 +55,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/strings/strings2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/strings/strings2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -73,7 +73,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/strings/strings3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/strings/strings3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -96,7 +96,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/strings/strings4.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/strings/strings4-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__variables/index.html
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__variables/index.html
@@ -36,7 +36,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/variables/variables1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/variables/variables1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -48,7 +48,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/variables/variables2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/variables/variables2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -60,7 +60,7 @@ If you get stuck, then ask us for help — see the {{anch("Assessment or further
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/variables/variables3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/tasks/variables/variables3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/objects/test_your_skills_colon__object-oriented_javascript/index.html
+++ b/files/en-us/learn/javascript/objects/test_your_skills_colon__object-oriented_javascript/index.html
@@ -39,7 +39,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/oojs/oojs1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/oojs/oojs1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -53,7 +53,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/oojs/oojs2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/oojs/oojs2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -69,7 +69,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/oojs/oojs3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/oojs/oojs3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 

--- a/files/en-us/learn/javascript/objects/test_your_skills_colon__object_basics/index.html
+++ b/files/en-us/learn/javascript/objects/test_your_skills_colon__object_basics/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/object-basics/object-basics1.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/object-basics/object-basics1-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -67,7 +67,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/object-basics/object-basics2.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/object-basics/object-basics2-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 
@@ -85,7 +85,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/object-basics/object-basics3.html", '100%', 400)}}</p>
 
-<div class="notecard note">
+<div class="callout">
 <p><a href="https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/object-basics/object-basics3-download.html">Download the starting point for this task</a> to work in your own editor or in an online editor.</p>
 </div>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This fixes notes in the Learn area that really want to be callouts instead: they are there to highlight a link.