### PR TITLE
[Markdown] [Learn] Fix heading-style notes

### DIFF
--- a/files/en-us/learn/common_questions/what_is_a_url/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_url/index.html
@@ -51,8 +51,7 @@ https://developer.mozilla.org/en-US/search?q=URL</pre>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>There are <a href="https://en.wikipedia.org/wiki/Uniform_Resource_Locator">some extra parts and some extra rules</a> regarding URLs, but they are not relevant for regular users or Web developers. Don't worry about this, you don't need to know them to build and use fully functional URLs.</p>
+  <p><strong>Note:</strong> There are <a href="https://en.wikipedia.org/wiki/Uniform_Resource_Locator">some extra parts and some extra rules</a> regarding URLs, but they are not relevant for regular users or Web developers. Don't worry about this, you don't need to know them to build and use fully functional URLs.</p>
 </div>
 
 <h2 id="Scheme">Scheme</h2>
@@ -73,8 +72,7 @@ https://developer.mozilla.org/en-US/search?q=URL</pre>
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-<p>The separator between the scheme and authority is <code>://</code>. The colon separates the scheme from the next part of the URL, while <code>//</code> indicates that the next part of the URL is the authority.</p>
+<p><strong>Note:</strong> The separator between the scheme and authority is <code>://</code>. The colon separates the scheme from the next part of the URL, while <code>//</code> indicates that the next part of the URL is the authority.</p>
 <p>One example of a URL that doesn't use an authority is the mail client (<code>mailto:foobar</code>). It contains a scheme but doesn't use an authority component. Therefore, the colon is not followed by two slashes and only acts as a delimiter between the scheme and mail address.</p>
 </div>
 
@@ -110,8 +108,7 @@ https://developer.mozilla.org/en-US/search?q=URL</pre>
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>When specifying URLs to load resources as part of a page (such as when using the <code>&lt;script&gt;</code>, <code>&lt;audio&gt;</code>, <code>&lt;img&gt;</code>, <code>&lt;video&gt;</code>, and the like), you should generally only use HTTP and HTTPS URLs, with few exceptions (one notable one being <code>data:</code>; see <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs">Data URLs</a>). Using FTP, for example, is not secure and is no longer supported by modern browsers.</p>
+  <p><strong>Note:</strong> When specifying URLs to load resources as part of a page (such as when using the <code>&lt;script&gt;</code>, <code>&lt;audio&gt;</code>, <code>&lt;img&gt;</code>, <code>&lt;video&gt;</code>, and the like), you should generally only use HTTP and HTTPS URLs, with few exceptions (one notable one being <code>data:</code>; see <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs">Data URLs</a>). Using FTP, for example, is not secure and is no longer supported by modern browsers.</p>
 </div>
 
 <p>Other technologies, such as {{Glossary("CSS")}} or {{Glossary("JavaScript")}}, use URLs extensively, and these are really the heart of the Web.</p>

--- a/files/en-us/learn/css/css_layout/responsive_design/index.html
+++ b/files/en-us/learn/css/css_layout/responsive_design/index.html
@@ -292,8 +292,7 @@ h1 {
 <p>You should avoid using <code>minimum-scale</code>, <code>maximum-scale</code>, and in particular setting <code>user-scalable</code> to <code>no</code>. Users should be allowed to zoom as much or as little as they need to; preventing this causes accessibility problems.</p>
 
 <div class="notecard note">
-<h4>Note</h4>
-<p>There was a CSS @ rule designed to replace the viewport meta tag — <a href="/en-US/docs/Web/CSS/@viewport">@viewport</a> — however, the rule failed to gain traction and has been deprecated. @viewport should not be used.</p></div>
+<p><strong>Note:</strong> There was a CSS @ rule designed to replace the viewport meta tag — <a href="/en-US/docs/Web/CSS/@viewport">@viewport</a> — however, the rule failed to gain traction and has been deprecated. @viewport should not be used.</p></div>
 
 <h2 id="Summary">Summary</h2>
 

--- a/files/en-us/learn/css/first_steps/using_your_new_knowledge/index.html
+++ b/files/en-us/learn/css/first_steps/using_your_new_knowledge/index.html
@@ -29,8 +29,7 @@ tags:
 <p>You can work in the live editor below, or you can <a href="https://github.com/mdn/css-examples/blob/master/learn/getting-started/biog-download.html/">download the starting point file</a> to work with in your own editor. This is a single page containing both the HTML and the starting point CSS (in the head of the document). If you prefer you could move this CSS to a separate file when you create the example on your local computer. Alternatively use an online tool such as <a href="https://codepen.io/" rel="noopener">CodePen</a>, <a href="https://jsfiddle.net/" rel="noopener">jsFiddle</a>, or <a href="https://glitch.com/" rel="noopener">Glitch</a> to work on the tasks.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>If you get stuck, then ask us for help — see the <a href="/en-US/docs/Learn/CSS/First_steps/Using_your_new_knowledge#assessment_or_further_help">Assessment or further help</a> section at the bottom of this page.</p>
+  <p><strong>Note:</strong> If you get stuck, then ask us for help — see the <a href="/en-US/docs/Learn/CSS/First_steps/Using_your_new_knowledge#assessment_or_further_help">Assessment or further help</a> section at the bottom of this page.</p>
 </div>
 
 <h2 id="Working_with_CSS">Working with CSS</h2>

--- a/files/en-us/learn/css/howto/make_box_transparent/index.html
+++ b/files/en-us/learn/css/howto/make_box_transparent/index.html
@@ -28,8 +28,7 @@ tags:
 <p>{{EmbedGHLiveSample("css-examples/howto/opacity.html", '100%', 770)}}</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Take care that your text retains enough contrast with the background in cases where you are overlaying an image; otherwise you may make the content hard to read.</p>
+  <p><strong>Note:</strong> Take care that your text retains enough contrast with the background in cases where you are overlaying an image; otherwise you may make the content hard to read.</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/learn/css/styling_text/styling_links/index.html
+++ b/files/en-us/learn/css/styling_text/styling_links/index.html
@@ -96,8 +96,7 @@ tags:
 </ul>
 
 <div class="notecard note">
-<h4>Note</h4>
-<p>You are not just limited to the above properties to style your links — you are free to use any properties you like.</p>
+<p><strong>Note:</strong> You are not just limited to the above properties to style your links — you are free to use any properties you like.</p>
 </div>
 
 <h3 id="Styling_some_links">Styling some links</h3>

--- a/files/en-us/learn/forms/html5_input_types/index.html
+++ b/files/en-us/learn/forms/html5_input_types/index.html
@@ -174,8 +174,7 @@ price.addEventListener('input', function() {
 <p>Here we store references to the <code>range</code> input and the <code>output</code> in two variables. Then we immediately set the <code>output</code>'s <code><a href="/en-US/docs/Web/API/Node/textContent">textContent</a></code> to the current <code>value</code> of the input. Finally, an event listener is set to ensure that whenever the range slider is moved, the <code>output</code>'s <code>textContent</code> is updated to the new value.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>There is a nice tutorial covering this subject on CSS Tricks: <a href="https://css-tricks.com/the-output-element/">The Output Element</a>.</p>
+  <p><strong>Note:</strong> There is a nice tutorial covering this subject on CSS Tricks: <a href="https://css-tricks.com/the-output-element/">The Output Element</a>.</p>
 </div>
 
 <h2 id="Date_and_time_pickers">Date and time pickers</h2>

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.html
@@ -40,8 +40,7 @@ tags:
 <p>We won't be teaching you how to produce audio and video files — that requires a completely different skillset. We have provided you with <a href="https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/video-and-audio-content">sample audio and video files and example code</a> for your own experimentation, in case you are unable to get hold of your own.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Before you begin here, you should also know that there are quite a few OVPs (online video providers) like <a href="https://www.youtube.com/">YouTube</a>, <a href="https://www.dailymotion.com">Dailymotion</a>, and <a href="https://vimeo.com/">Vimeo</a>, and online audio providers like <a href="https://soundcloud.com/">Soundcloud</a>. Such companies offer a convenient, easy way to host and consume videos, so you don't have to worry about the enormous bandwidth consumption. OVPs even usually offer ready-made code for embedding video/audio in your webpages; if you use that route, you can avoid some of the difficulties we discuss in this article. We'll be discussing this kind of service a bit more in the next article.</p>
+  <p><strong>Note:</strong> Before you begin here, you should also know that there are quite a few OVPs (online video providers) like <a href="https://www.youtube.com/">YouTube</a>, <a href="https://www.dailymotion.com">Dailymotion</a>, and <a href="https://vimeo.com/">Vimeo</a>, and online audio providers like <a href="https://soundcloud.com/">Soundcloud</a>. Such companies offer a convenient, easy way to host and consume videos, so you don't have to worry about the enormous bandwidth consumption. OVPs even usually offer ready-made code for embedding video/audio in your webpages; if you use that route, you can avoid some of the difficulties we discuss in this article. We'll be discussing this kind of service a bit more in the next article.</p>
 </div>
 
 <h3 id="The_&lt;video&gt;_element">The &lt;video&gt; element</h3>
@@ -100,8 +99,7 @@ tags:
 <h4 id="Media_file_support_in_browsers">Media file support in browsers</h4>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Why do we have this problem? It turns out that several popular formats, such as MP3 and MP4/H.264, are excellent but are encumbered by patents; that is, there are patents covering some or all of the technology that they're based upon. In the United States, patents covered MP3 until 2017, and H.264 is encumbered by patents through at least 2027.</p>
+  <p><strong>Note:</strong> Why do we have this problem? It turns out that several popular formats, such as MP3 and MP4/H.264, are excellent but are encumbered by patents; that is, there are patents covering some or all of the technology that they're based upon. In the United States, patents covered MP3 until 2017, and H.264 is encumbered by patents through at least 2027.</p>
   
   <p>Because of those patents, browsers that wish to implement support for those codecs must pay typically enormous license fees. In addition, some people prefer to avoid restricted software and prefer to use only open formats. Due to these legal and preferential reasons, web developers find themselves having to support multiple formats to capture their entire audience.</p>
 </div>
@@ -187,8 +185,7 @@ tags:
 <p><img alt="A simple audio player with a play button, timer, volume control, and progress bar" src="audio-player.png"></p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>You can <a href="https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html">run the audio demo live</a> on Github (also see the <a href="https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html">audio player source code</a>.)</p>
+  <p><strong>Note:</strong> You can <a href="https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html">run the audio demo live</a> on Github (also see the <a href="https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html">audio player source code</a>.)</p>
 </div>
 
 <p>This takes up less space than a video player, as there is no visual component — you just need to display controls to play the audio. Other differences from HTML video are as follows:</p>
@@ -214,8 +211,7 @@ tags:
 <p>Wouldn't it be nice to be able to provide these people with a transcript of the words being spoken in the audio/video? Well, thanks to HTML video, you can. To do so we use the <a href="/en-US/docs/Web/API/WebVTT_API">WebVTT</a> file format and the {{htmlelement("track")}} element.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>"Transcribe" means "to write down spoken words as text." The resulting text is a "transcript."</p>
+  <p><strong>Note:</strong> "Transcribe" means "to write down spoken words as text." The resulting text is a "transcript."</p>
 </div>
 
 <p>WebVTT is a format for writing text files containing multiple strings of text along with metadata such as the time in the video at which each text string should be displayed, and even limited styling/positioning information. These text strings are called <strong>cues</strong>, and there are several kinds of cues which are used for different purposes. The most common cues are:</p>
@@ -266,8 +262,7 @@ This is the second.
 <p>For more details, including on how to add labels please read <a href="/en-US/docs/Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video">Adding captions and subtitles to HTML5 video</a>. You can <a href="https://iandevlin.github.io/mdn/video-player-with-captions/">find the example</a> that goes along with this article on Github, written by Ian Devlin (see the <a href="https://github.com/iandevlin/iandevlin.github.io/tree/master/mdn/video-player-with-captions">source code</a> too.) This example uses some JavaScript to allow users to choose between different subtitles. Note that to turn the subtitles on, you need to press the "CC" button and select an option — English, Deutsch, or Español.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Text tracks also help you with {{glossary("SEO")}}, since search engines especially thrive on text. Text tracks even allow search engines to link directly to a spot partway through the video.</p>
+  <p><strong>Note:</strong> Text tracks also help you with {{glossary("SEO")}}, since search engines especially thrive on text. Text tracks even allow search engines to link directly to a spot partway through the video.</p>
 </div>
 
 <h3 id="Active_learning_Embedding_your_own_audio_and_video">Active learning: Embedding your own audio and video</h3>

--- a/files/en-us/learn/javascript/building_blocks/events/index.html
+++ b/files/en-us/learn/javascript/building_blocks/events/index.html
@@ -54,8 +54,7 @@ tags:
 <p>Each available event has an <strong>event handler</strong>, which is a block of code (usually a JavaScript function that you as a programmer create) that runs when the event fires. When such a block of code is defined to run in response to an event, we say we are <strong>registering an event handler</strong>. Note: Event handlers are sometimes called <strong>event listeners</strong> — they are pretty much interchangeable for our purposes, although strictly speaking, they work together. The listener listens out for the event happening, and the handler is the code that is run in response to it happening.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Web events are not part of the core JavaScript language — they are defined as part of the APIs built into the browser.</p>
+  <p><strong>Note:</strong> Web events are not part of the core JavaScript language — they are defined as part of the APIs built into the browser.</p>
 </div>
 
 <h3 id="A_simple_example">A simple example</h3>
@@ -151,8 +150,7 @@ btn.onclick = bgChange;</pre>
 }</pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>You can find the <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventhandlerattributes.html">full source code</a> for this example on GitHub (also <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventhandlerattributes.html">see it running live</a>).</p>
+  <p><strong>Note:</strong> You can find the <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventhandlerattributes.html">full source code</a> for this example on GitHub (also <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventhandlerattributes.html">see it running live</a>).</p>
 </div>
 
 <p>The earliest method of registering event handlers found on the Web involved <strong>event handler HTML attributes</strong> (or <strong>inline event handlers</strong>) like the one shown above — the attribute value is literally the JavaScript code you want to run when the event occurs. The above example invokes a function defined inside a {{htmlelement("script")}} element on the same page, but you could also insert JavaScript directly inside the attribute, for example:</p>
@@ -178,8 +176,7 @@ for (let i = 0; i &lt; buttons.length; i++) {
 });</pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Separating your programming logic from your content also makes your site more friendly to search engines.</p>
+  <p><strong>Note:</strong> Separating your programming logic from your content also makes your site more friendly to search engines.</p>
 </div>
 
 <h3 id="adding_and_removing_event_handlers">Adding and removing event handlers</h3>
@@ -279,15 +276,13 @@ etc.</pre>
 btn.addEventListener('click', bgChange);</pre>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>You can find the <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventobject.html">full source code</a> for this example on GitHub (also <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html">see it running live</a>).</p>
+  <p><strong>Note:</strong> You can find the <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventobject.html">full source code</a> for this example on GitHub (also <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html">see it running live</a>).</p>
 </div>
 
 <p>Here you can see we are including an event object, <strong>e</strong>, in the function, and in the function setting a background color style on <code>e.target</code> — which is the button itself. The <code>target</code> property of the event object is always a reference to the element the event occurred upon. So, in this example, we are setting a random background color on the button, not the page.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>You can use any name you like for the event object — you just need to choose a name that you can then use to reference it inside the event handler function. <code>e</code>/<code>evt</code>/<code>event</code> are most commonly used by developers because they are short and easy to remember. It's always good to be consistent — with yourself, and with others if possible.</p>
+  <p><strong>Note:</strong> You can use any name you like for the event object — you just need to choose a name that you can then use to reference it inside the event handler function. <code>e</code>/<code>evt</code>/<code>event</code> are most commonly used by developers because they are short and easy to remember. It's always good to be consistent — with yourself, and with others if possible.</p>
 </div>
 
 <p><code>e.target</code> is incredibly useful when you want to set the same event handler on multiple elements and do something to all of them when an event occurs on them. You might, for example, have a set of 16 tiles that disappear when selected. It is useful to always be able to just set the thing to disappear as <code>e.target</code>, rather than having to select it in some more difficult way. In the following example (see <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/useful-eventtarget.html">useful-eventtarget.html</a> for the full source code; also see it <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/useful-eventtarget.html">running live</a> here), we create 16 {{htmlelement("div")}} elements using JavaScript. We then select all of them using {{domxref("document.querySelectorAll()")}}, then loop through each one, adding an <code>onclick</code> handler to each that makes it so that a random color is applied to each one when selected:</p>
@@ -398,8 +393,7 @@ form.onsubmit = function(e) {
 <p>{{ EmbedLiveSample('Preventing_default_behavior', '100%', 140, "", "", "hide-codepen-jsfiddle") }}</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>for the full source code, see <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/preventdefault-validation.html">preventdefault-validation.html</a> (also see it <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html">running live</a> here.)</p>
+  <p><strong>Note:</strong> for the full source code, see <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/preventdefault-validation.html">preventdefault-validation.html</a> (also see it <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html">running live</a> here.)</p>
 </div>
 
 <h3 id="Event_bubbling_and_capture">Event bubbling and capture</h3>
@@ -546,13 +540,11 @@ video.onclick = function() {
 </ul>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>All JavaScript events go through the capturing and target phases. Whether an event enters the bubbling phase can be checked by the read-only {{domxref("Event.bubbles", "bubbles")}} property.</p>
+  <p><strong>Note:</strong> All JavaScript events go through the capturing and target phases. Whether an event enters the bubbling phase can be checked by the read-only {{domxref("Event.bubbles", "bubbles")}} property.</p>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Event listeners registered for the <code>&lt;html&gt;</code> element aren’t at the top of hierarchy. For example, event listeners registered for the {{domxref("Window", "window")}} and {{domxref("Document", "document")}} objects are higher in the hierarchy.</p>
+  <p><strong>Note:</strong> Event listeners registered for the <code>&lt;html&gt;</code> element aren’t at the top of hierarchy. For example, event listeners registered for the {{domxref("Window", "window")}} and {{domxref("Document", "document")}} objects are higher in the hierarchy.</p>
 </div>
 
 <p>The following example demonstrates the behavior described above. Hover over the numbers and click on them to trigger events, and then observe the output that gets logged.</p>
@@ -646,13 +638,11 @@ clearButton.addEventListener('click', clearOutput);
 <p>You can try making a local copy of the <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/show-video-box.html">show-video-box.html source code</a> and fixing it yourself, or looking at the fixed result in <a href="https://mdn.github.io/learning-area/javascript/building-blocks/events/show-video-box-fixed.html">show-video-box-fixed.html</a> (also see the <a href="https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/show-video-box-fixed.html">source code</a> here).</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Why bother with both capturing and bubbling? Well, in the bad old days when browsers were much less cross-compatible than they are now, Netscape only used event capturing, and Internet Explorer used only event bubbling. When the W3C decided to try to standardize the behavior and reach a consensus, they ended up with this system that included both, which is the one modern browsers implemented.</p>
+  <p><strong>Note:</strong> Why bother with both capturing and bubbling? Well, in the bad old days when browsers were much less cross-compatible than they are now, Netscape only used event capturing, and Internet Explorer used only event bubbling. When the W3C decided to try to standardize the behavior and reach a consensus, they ended up with this system that included both, which is the one modern browsers implemented.</p>
 </div>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>As mentioned above, by default all event handlers are registered in the bubbling phase, and this makes more sense most of the time. If you really want to register an event in the capturing phase instead, you can do so by registering your handler using <code><a href="/en-US/docs/Web/API/EventTarget/addEventListener">addEventListener()</a></code>, and setting the optional third property to <code>true</code>.</p>
+  <p><strong>Note:</strong> As mentioned above, by default all event handlers are registered in the bubbling phase, and this makes more sense most of the time. If you really want to register an event in the capturing phase instead, you can do so by registering your handler using <code><a href="/en-US/docs/Web/API/EventTarget/addEventListener">addEventListener()</a></code>, and setting the optional third property to <code>true</code>.</p>
 </div>
 
 <h4 id="Event_delegation">Event delegation</h4>

--- a/files/en-us/learn/performance/multimedia/index.html
+++ b/files/en-us/learn/performance/multimedia/index.html
@@ -28,8 +28,7 @@ tags:
 </table>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>This is a high-level introduction to optimizing multimedia delivery on the web, covering general principles and techniques. For a more in-depth guide, see  <a href="https://images.guide">https://images.guide</a>.</p>
+  <p><strong>Note:</strong> This is a high-level introduction to optimizing multimedia delivery on the web, covering general principles and techniques. For a more in-depth guide, see  <a href="https://images.guide">https://images.guide</a>.</p>
 </div>
 
 <h2 id="Why_optimize_your_multimedia">Why optimize your multimedia?</h2>
@@ -61,8 +60,7 @@ tags:
 <p>The optimal file format typically depends on the character of the image.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>For general information on image types see the <a href="/en-US/docs/Web/Media/Formats/Image_types">Image file type and format guide</a></p>
+  <p><strong>Note:</strong> For general information on image types see the <a href="/en-US/docs/Web/Media/Formats/Image_types">Image file type and format guide</a></p>
 </div>
 
 <p>The <a href="/en-US/docs/Web/Media/Formats/Image_types#svg">SVG</a> format is more appropriate for images that have few colors and that are not photo-realistic. This requires the source to be available as in a vector graphic format. Should such an image only exist as a bitmap, then <a href="/en-US/docs/Web/Media/Formats/Image_types#png">PNG</a> would be the fallback format to chose. Examples for these types of motifs are logos, illustrations, charts or icons (note: SVGs are far better than icon fonts!). Both formats support transparency.</p>

--- a/files/en-us/learn/performance/perceived_performance/index.html
+++ b/files/en-us/learn/performance/perceived_performance/index.html
@@ -33,8 +33,7 @@ tags:
 <p>A good general rule for improving perceived performance is that it is usually better to provide a quick response and regular status updates than make the user wait until an operation fully completes (before providing any information). For example, when loading a page it is better to display the text when it arrives rather than wait for all the images and other resources. Even though the content has not fully downloaded the user can see something is happening and they can start interacting with the content.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Time appears to pass more quickly for users who are actively engaged, distracted, or entertained, than for those who are waiting passively for something to happen. Where possible, actively engage and inform users who are waiting for a task to complete.</p>
+  <p><strong>Note:</strong> Time appears to pass more quickly for users who are actively engaged, distracted, or entertained, than for those who are waiting passively for something to happen. Where possible, actively engage and inform users who are waiting for a task to complete.</p>
 </div>
 
 <p>Similarly, it is better to display a "loading animation" as soon as a user clicks a link to perform a long running operation. While this doesn't change the time taken to complete the operation, the site feels more responsive, and the user knows that it is working on something useful.</p>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This PR fixes notes that use the "heading style":

```
<div class="note">
<h4>Note:</h4>
<p>...
```

...so they use the style that the converter likes:

```
<div class="note">
<p><strong>Note:</strong>...
```