### PR TITLE
Remove some self-links in Learn area

### DIFF
--- a/files/en-us/learn/css/css_layout/floats/index.html
+++ b/files/en-us/learn/css/css_layout/floats/index.html
@@ -459,7 +459,7 @@ tags:
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow">Normal flow</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid</a></li>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">Floats</a></li>
+ <li>Floats</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">Positioning</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Multiple-column_Layout">Multiple-column layout</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">Responsive design</a></li>

--- a/files/en-us/learn/css/css_layout/grids/index.html
+++ b/files/en-us/learn/css/css_layout/grids/index.html
@@ -587,7 +587,7 @@ aside {
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Introduction">Introduction to CSS layout</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow">Normal flow</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a></li>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid</a></li>
+ <li>Grid</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">Floats</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">Positioning</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Multiple-column_Layout">Multiple-column layout</a></li>

--- a/files/en-us/learn/css/css_layout/legacy_layout_methods/index.html
+++ b/files/en-us/learn/css/css_layout/legacy_layout_methods/index.html
@@ -544,7 +544,7 @@ body {
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Multiple-column_Layout">Multiple-column layout</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">Responsive design</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Media_queries">Beginner's guide to media queries</a></li>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods">Legacy layout methods</a></li>
+ <li>Legacy layout methods</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers">Supporting older browsers</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension">Fundamental layout comprehension assessment</a></li>
 </ul>

--- a/files/en-us/learn/css/css_layout/normal_flow/index.html
+++ b/files/en-us/learn/css/css_layout/normal_flow/index.html
@@ -86,7 +86,7 @@ span {
 
 <ul>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Introduction">Introduction to CSS layout</a></li>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow">Normal flow</a></li>
+ <li>Normal flow</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">Floats</a></li>

--- a/files/en-us/learn/css/css_layout/positioning/index.html
+++ b/files/en-us/learn/css/css_layout/positioning/index.html
@@ -560,7 +560,7 @@ p:nth-of-type(1) {
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Floats">Floats</a></li>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">Positioning</a></li>
+ <li>Positioning</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Multiple-column_Layout">Multiple-column layout</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">Responsive design</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Media_queries">Beginner's guide to media queries</a></li>

--- a/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
+++ b/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
@@ -238,6 +238,6 @@ tags:
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">Responsive design</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Media_queries">Beginner's guide to media queries</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods">Legacy layout methods</a></li>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers">Supporting older browsers</a></li>
+ <li>Supporting older browsers</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension">Fundamental layout comprehension assessment</a></li>
 </ul>

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.html
@@ -522,7 +522,7 @@ padding- left: 10px;</pre>
 <ol>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/What_is_CSS">What is CSS?</a></li>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/Getting_started">Getting started with CSS</a></li>
- <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured">How CSS is structured</a></li>
+ <li>How CSS is structured</li>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">How CSS works</a></li>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/Using_your_new_knowledge">Using your new knowledge</a></li>
 </ol>

--- a/files/en-us/learn/css/first_steps/how_css_works/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.html
@@ -151,6 +151,6 @@ tags:
  <li><a href="/en-US/docs/Learn/CSS/First_steps/What_is_CSS">What is CSS?</a></li>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/Getting_started">Getting started with CSS</a></li>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured">How CSS is structured</a></li>
- <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">How CSS works</a></li>
+ <li>How CSS works</li>
  <li><a href="/en-US/docs/Learn/CSS/First_steps/Using_your_new_knowledge">Using your new knowledge</a></li>
 </ol>


### PR DESCRIPTION
This fixes the broken link flaw "Link points to the page it's already on"