### PR TITLE
CSS aspect-ratio: add to FF89 relnotes and remove from exper. features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -265,45 +265,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Property_aspect-ratio">Property: aspect-ratio</h3>
-
-<p>The {{cssxref("aspect-ratio")}} CSS property is part of the <a href="https://drafts.csswg.org/css-sizing-4/">CSS4 Sizing</a> specification and allows you to create boxes which conform to an aspect ratio. (See {{bug(1639963)}} and {{bug(1646096)}} for more details.)</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>81</td>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>81</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference name</th>
-   <th colspan="2"><code>layout.css.aspect-ratio.enabled</code></th>
-  </tr>
- </tbody>
-</table>
 
 <h3 id="Single_numbers_as_aspect_ratio_in_media_queries">Single numbers as aspect ratio in media queries</h3>
 

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -32,6 +32,7 @@ tags:
   <li>The {{cssxref("@media/forced-colors","forced-colors")}} media feature has been implemented ({{bug(1659511)}}).</li>
   <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} <code>@font-face</code> descriptors have been implemented ({{bug(1681691)}} and {{bug(1704494)}}).</li>
   <li>The <code>type()</code> function for {{cssxref("image-set()","image-set()")}} has been implemented ({{bug(1695404)}}).</li>
+  <li>The {{cssxref("aspect-ratio")}} CSS property is now supported ({{bug(1672073)}}).</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>

--- a/files/en-us/web/css/aspect-ratio/index.md
+++ b/files/en-us/web/css/aspect-ratio/index.md
@@ -76,3 +76,4 @@ You can read more about this feature in [Setting Height And Width On Images Is I
 
 - [Mapping the width and height attributes of media container elements to their aspect-ratio](/en-US/docs/Web/Media/images/aspect_ratio_mapping)
 - [Designing an aspect ratio unit for CSS](https://www.smashingmagazine.com/2019/03/aspect-ratio-unit-css/)
+- [Setting Height And Width On Images Is Important Again](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/)

--- a/files/en-us/web/css/aspect-ratio/index.md
+++ b/files/en-us/web/css/aspect-ratio/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.aspect-ratio
 ---
 {{CSSRef}}
 
-The **`aspect-ratio`**  [CSS](/en-US/docs/CSS) property sets a **preferred aspect ratio** for the box, which will be used in the calculation of auto sizes and some other layout functions.
+The **`aspect-ratio`**  [CSS](/en-US/docs/Web/CSS) property sets a **preferred aspect ratio** for the box, which will be used in the calculation of auto sizes and some other layout functions.
 
 ```css
 aspect-ratio: 1 / 1;

--- a/files/en-us/web/media/images/aspect_ratio_mapping/index.html
+++ b/files/en-us/web/media/images/aspect_ratio_mapping/index.html
@@ -1,7 +1,6 @@
 ---
 title: >-
-  Mapping the width and height attributes of media container elements to their
-  aspect-ratio
+  Mapping the width and height attributes of media container elements to their aspect-ratio
 slug: Web/Media/images/aspect_ratio_mapping
 tags:
   - CSS
@@ -39,7 +38,9 @@ tags:
 
 <p>Mozilla then <a href="https://github.com/WICG/intrinsicsize-attribute/issues/16">brought the idea up in the WICG community group</a> and discussed it further until representatives from Chrome were onboard with the idea.</p>
 
-<p>Due to this work, browsers are working on adding a new mechanism for sizing images before the actual image is loaded. Firefox has added an internal <code>aspect-ratio</code> property (in version 69 onwards) that applies to replaced elements, and other related elements that accept <code>width</code> and <code>height</code> attributes. This appears in the browser's internal UA stylesheet, similar to the following:</p>
+<p>Due to this work, browsers are working on adding a new mechanism for sizing images before the actual image is loaded.
+  The {{cssxref("aspect-ratio")}} property that applies to replaced elements, and other related elements that accept <code>width</code> and <code>height</code> attributes.
+  This appears in the browser's internal UA stylesheet, similar to the following:</p>
 
 <pre class="brush: css">img, input[type="image"], video, embed, iframe, marquee, object, table {
   aspect-ratio: attr(width) / attr(height);
@@ -48,7 +49,7 @@ tags:
 <p>This actually affects any element that acts as a container for complex or mixed visual media — {{htmlelement("embed")}}, {{htmlelement("iframe")}}, {{htmlelement("marquee")}}, {{htmlelement("object")}}, {{htmlelement("table")}}, and {{htmlelement("video")}}, in addition to actual images ({{htmlelement("img")}} and <strong id="docs-internal-guid-1a994dc9-7fff-a700-71f0-25b6cfe48215"> </strong><code>&lt;input type="image"&gt;</code>). When such an element has <code>width</code> and <code>height</code> attributes set on it, its aspect ratio will be calculated before load time, and be available to the browser.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Currently this effect is being limited to actual <code>&lt;img&gt;</code> elements, as applying to other such elements may have undesirable results. See ({{bug(1583980)}}).</p>
+<p><strong>Note</strong>: Currently on Firefox this effect is being limited to actual <code>&lt;img&gt;</code> elements, as applying to other such elements may have undesirable results. See ({{bug(1583980)}}).</p>
 </div>
 
 <p>When the <code>width</code>/<code>height</code> of an <code>&lt;img&gt;</code> element — as set using HTML attributes — is overridden using CSS using something like this:</p>
@@ -70,8 +71,12 @@ tags:
 
 <h2 id="Summary">Summary</h2>
 
-<p>So there you have it — eliminating another piece of jank from web layout! There is no need for a web developer to do anything special to their code to take advantage of this, besides returning to the habit of using <code>width</code> and <code>height</code> attributes in their HTML. They'll just get it for free.</p>
+<p>So there you have it — eliminating another piece of jank from web layout!
+  There is no need for a web developer to do anything special to their code to take advantage of this, besides returning to the habit of using <code>width</code> and <code>height</code> attributes in their HTML. They'll just get it for free.</p>
 
-<div class="notecard note">
-<p><strong>Note</strong>: This new mechanism is enabled in Firefox 69 in beta and Nightly as the spec is worked out (controlled by the <code>layout.css.width-and-height-map-to-aspect-ratio.enabled</code> pref), and it is <a href="https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/hbhKRuBzZ4o">currently being implemented in Chrome</a>. It will ship with <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1585637">Firefox 71</a>.</p>
-</div>
+<h2 id="see_also">See also</h2>
+
+<ul>
+  <li><a href="https://www.smashingmagazine.com/2019/03/aspect-ratio-unit-css/">Designing an aspect ratio unit for CSS</a></li>
+  <li><a href="https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/">Setting Height And Width On Images Is Important Again</a></li>
+</ul>

--- a/files/en-us/web/media/images/aspect_ratio_mapping/index.html
+++ b/files/en-us/web/media/images/aspect_ratio_mapping/index.html
@@ -38,7 +38,7 @@ tags:
 
 <p>Mozilla then <a href="https://github.com/WICG/intrinsicsize-attribute/issues/16">brought the idea up in the WICG community group</a> and discussed it further until representatives from Chrome were onboard with the idea.</p>
 
-<p>Due to this work, browsers are working on adding a new mechanism for sizing images before the actual image is loaded.
+<p>Due to this work, browsers have implemented a mechanism for sizing images before the actual image is loaded.
   The {{cssxref("aspect-ratio")}} property that applies to replaced elements, and other related elements that accept <code>width</code> and <code>height</code> attributes.
   This appears in the browser's internal UA stylesheet, similar to the following:</p>
 


### PR DESCRIPTION
This CSS property was added in FF89 but is not mentioned in the release notes:
- Added release note
- Removed from Experimental features
- Verified BCD is correct
- Removed dev-doc-needed - perhaps prematurely

Fixes #9349

What is missing from a normal docs release is the checkbox item "Docs are adequate".
IMO they are not adequate - I have done minimal "fixes" but I am hoping perhaps someone else proper job or suggest how this might be done. 

How this works docs are old and out of date. All the essential ideas are there but it firefox specific and it is not clear what ended up happening from those docs. It all needs to be updated with the current  state of play.

@rachelandrew is the expert, and already wrote a blog on this that is linked.

Specifically:
- [aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) 
  - is documented and cross links to useful additional documentation
  - the [example](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#examples_of_values_for_aspect-ratio) is simplistic. It would be useful to pull in a brief explanation of what you need to do for this to be useful - ie when would you set it or not set it. There is an implication that you need to set the box width and height attributes in HTML in other docs but that is not clear.
  - The section [mapping_width_and_height_to_aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#mapping_width_and_height_to_aspect-ratio) seems to imply that you don't have to set this aspect-ratio on most browsers but it is worth spelling that out. It may be that someone more expert would infer that.
  - In summary, it would be worth some of the info from the linked doc coming into this doc.
 - [Mapping the width and height attributes of media container elements to their aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/Media/images/aspect_ratio_mapping) - this is supposed to provide the answers to why `aspect-ratio` is important. 
  - It was written early in the spec
  - It refers to properties like `intrinsicsize` which do not appear to have got into spec - but may have made it in as [contain-intrinsic-size](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size)
  - There is a statement that this only applies to img in FF - https://bugzilla.mozilla.org/show_bug.cgi?id=1583980 - . FF states full support so it is probably not true anymore. 
  - All I have done for this is removed a little FF versioning and linked to `aspect-ratio`.

