### PR TITLE
[Markdown] [Learn] Remove summary class from Learn docs

### DIFF
--- a/files/en-us/learn/accessibility/accessibility_troubleshooting/index.html
+++ b/files/en-us/learn/accessibility/accessibility_troubleshooting/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/Accessibility/Mobile", "Learn/Accessibility")}}</div>
 
-<p class="summary">In the assessment for this module, we present to you a simple site with a number of accessibility issues that you need to diagnose and fix.</p>
+<p>In the assessment for this module, we present to you a simple site with a number of accessibility issues that you need to diagnose and fix.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/accessibility/css_and_javascript/index.html
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Accessibility/HTML","Learn/Accessibility/WAI-ARIA_basics", "Learn/Accessibility")}}</div>
 
-<p class="summary">CSS and JavaScript, when used properly, also have the potential to allow for accessible web experiences ... or they can significantly harm accessibility if misused. This article outlines some CSS and JavaScript best practices that should be considered to ensure even complex content is as accessible as possible.</p>
+<p>CSS and JavaScript, when used properly, also have the potential to allow for accessible web experiences ... or they can significantly harm accessibility if misused. This article outlines some CSS and JavaScript best practices that should be considered to ensure even complex content is as accessible as possible.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/accessibility/index.html
+++ b/files/en-us/learn/accessibility/index.html
@@ -16,7 +16,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">Learning some HTML, CSS, and JavaScript is useful if you want to become a web developer. Beyond mechanical use, it's important to learn how to use these technologies <strong>responsibly</strong> so that all readers might use your creations on the web. To help you achieve this, this module will cover general best practices (which are demonstrated throughout the <a href="/en-US/docs/Learn/HTML">HTML</a>, <a href="/en-US/docs/Learn/CSS">CSS</a>, and <a href="/en-US/docs/Learn/JavaScript">JavaScript</a> topics), <a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing">cross browser testing</a>, and some tips on enforcing accessibility from the start. We'll cover accessibility in special detail.</p>
+<p>Learning some HTML, CSS, and JavaScript is useful if you want to become a web developer. Beyond mechanical use, it's important to learn how to use these technologies <strong>responsibly</strong> so that all readers might use your creations on the web. To help you achieve this, this module will cover general best practices (which are demonstrated throughout the <a href="/en-US/docs/Learn/HTML">HTML</a>, <a href="/en-US/docs/Learn/CSS">CSS</a>, and <a href="/en-US/docs/Learn/JavaScript">JavaScript</a> topics), <a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing">cross browser testing</a>, and some tips on enforcing accessibility from the start. We'll cover accessibility in special detail.</p>
 
 <h2 id="Overview">Overview</h2>
 

--- a/files/en-us/learn/accessibility/mobile/index.html
+++ b/files/en-us/learn/accessibility/mobile/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Accessibility/Multimedia","Learn/Accessibility/Accessibility_troubleshooting", "Learn/Accessibility")}}</div>
 
-<p class="summary">With web access on mobile devices being so popular and renowned platforms such as iOS and Android having full-fledged accessibility tools, it is important to consider the accessibility of your web content on these platforms. This article looks at mobile-specific accessibility considerations.</p>
+<p>With web access on mobile devices being so popular and renowned platforms such as iOS and Android having full-fledged accessibility tools, it is important to consider the accessibility of your web content on these platforms. This article looks at mobile-specific accessibility considerations.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/accessibility/multimedia/index.html
+++ b/files/en-us/learn/accessibility/multimedia/index.html
@@ -21,7 +21,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Accessibility/WAI-ARIA_basics","Learn/Accessibility/Mobile", "Learn/Accessibility")}}</div>
 
-<p class="summary">Another category of content that can create accessibility problems is multimedia — video, audio, and image content need to be given proper textual alternatives so they can be understood by assistive technologies and their users. This article shows how.</p>
+<p>Another category of content that can create accessibility problems is multimedia — video, audio, and image content need to be given proper textual alternatives so they can be understood by assistive technologies and their users. This article shows how.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/accessibility/wai-aria_basics/index.html
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Accessibility/CSS_and_JavaScript","Learn/Accessibility/Multimedia", "Learn/Accessibility")}}</div>
 
-<p class="summary">Following on from the previous article, sometimes making complex UI controls that involve unsemantic HTML and dynamic JavaScript-updated content can be difficult. WAI-ARIA is a technology that can help with such problems by adding in further semantics that browsers and assistive technologies can recognize and use to let users know what is going on. Here we'll show how to use it at a basic level to improve accessibility.</p>
+<p>Following on from the previous article, sometimes making complex UI controls that involve unsemantic HTML and dynamic JavaScript-updated content can be difficult. WAI-ARIA is a technology that can help with such problems by adding in further semantics that browsers and assistive technologies can recognize and use to let users know what is going on. Here we'll show how to use it at a basic level to improve accessibility.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/accessibility/what_is_accessibility/index.html
+++ b/files/en-us/learn/accessibility/what_is_accessibility/index.html
@@ -22,7 +22,7 @@ tags:
 
 <div>{{NextMenu("Learn/Accessibility/HTML", "Learn/Accessibility")}}</div>
 
-<p class="summary">This article starts the module off with a good look at what accessibility is — this overview includes what groups of people we need to consider and why, what tools different people use to interact with the web, and how we can make accessibility part of our web development workflow.</p>
+<p>This article starts the module off with a good look at what accessibility is — this overview includes what groups of people we need to consider and why, what tools different people use to interact with the web, and how we can make accessibility part of our web development workflow.</p>
 
 <table>
   <tbody>

--- a/files/en-us/learn/common_questions/how_do_you_host_your_website_on_google_app_engine/index.html
+++ b/files/en-us/learn/common_questions/how_do_you_host_your_website_on_google_app_engine/index.html
@@ -12,7 +12,7 @@ tags:
   - publish
   - website
 ---
-<p class="summary"><a href="https://cloud.google.com/appengine/" title="App Engine - Build Scalable Web &amp; Mobile Backends in Any Language  |  Google Cloud">Google App Engine</a> is a powerful platform that lets you build and run applications on Google’s infrastructure — whether you need to build a multi-tiered web application from scratch or host a static website. Here's a step-by-step guide to hosting your website on Google App Engine.</p>
+<p><a href="https://cloud.google.com/appengine/" title="App Engine - Build Scalable Web &amp; Mobile Backends in Any Language  |  Google Cloud">Google App Engine</a> is a powerful platform that lets you build and run applications on Google’s infrastructure — whether you need to build a multi-tiered web application from scratch or host a static website. Here's a step-by-step guide to hosting your website on Google App Engine.</p>
 
 <h2 id="Creating_a_Google_Cloud_Platform_project">Creating a Google Cloud Platform project</h2>
 

--- a/files/en-us/learn/common_questions/html_features_for_accessibility/index.html
+++ b/files/en-us/learn/common_questions/html_features_for_accessibility/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{draft}}</p>
 
-<p class="summary">The following content describes specific features of HTML that can be used to make a web page more accessible to people with different disabilities.</p>
+<p>The following content describes specific features of HTML that can be used to make a web page more accessible to people with different disabilities.</p>
 
 <h2 id="Tabbing">Tabbing</h2>
 

--- a/files/en-us/learn/common_questions/index.html
+++ b/files/en-us/learn/common_questions/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This section of the Learning Area is designed to provide answers to common questions that may come
+<p>This section of the Learning Area is designed to provide answers to common questions that may come
   up, which are not necessarily part of the structured core learning pathways (e.g. the <a
     href="/en-US/docs/Learn/HTML">HTML</a> or <a href="/en-US/docs/Learn/CSS">CSS</a> learning articles.) These articles
   are designed to work on their own.</p>

--- a/files/en-us/learn/common_questions/thinking_before_coding/index.html
+++ b/files/en-us/learn/common_questions/thinking_before_coding/index.html
@@ -7,7 +7,7 @@ tags:
   - NeedsActiveLearning
   - needsSchema
 ---
-<p class="summary">This article covers the all-important first step of every project: define what you want to accomplish with it.</p>
+<p>This article covers the all-important first step of every project: define what you want to accomplish with it.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/common_questions/using_github_pages/index.html
+++ b/files/en-us/learn/common_questions/using_github_pages/index.html
@@ -10,7 +10,7 @@ tags:
   - git
   - publish
 ---
-<p class="summary"><a href="https://github.com/">GitHub</a> is a "social coding" site. It allows you to upload code repositories for storage in the <a href="https://git-scm.com/">Git</a> <strong>version control system.</strong> You can then collaborate on code projects, and the system is open-source by default, meaning that anyone in the world can find your GitHub code, use it, learn from it, and improve on it. You can do that with other people's code too! This article provides a basic guide to publishing content using Github's gh-pages feature.</p>
+<p><a href="https://github.com/">GitHub</a> is a "social coding" site. It allows you to upload code repositories for storage in the <a href="https://git-scm.com/">Git</a> <strong>version control system.</strong> You can then collaborate on code projects, and the system is open-source by default, meaning that anyone in the world can find your GitHub code, use it, learn from it, and improve on it. You can do that with other people's code too! This article provides a basic guide to publishing content using Github's gh-pages feature.</p>
 
 <h2 id="Publishing_content">Publishing content</h2>
 

--- a/files/en-us/learn/css/building_blocks/a_cool_looking_box/index.html
+++ b/files/en-us/learn/css/building_blocks/a_cool_looking_box/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">In this assessment, you'll get some more practice in creating cool-looking boxes by trying to create an eye-catching box.</p>
+<p>In this assessment, you'll get some more practice in creating cool-looking boxes by trying to create an eye-catching box.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.html
+++ b/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.html
@@ -16,7 +16,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This article acts as a box of tricks, providing an introduction to some interesting advanced styling features such as box shadows, blend modes, and filters.</p>
+<p>This article acts as a box of tricks, providing an introduction to some interesting advanced styling features such as box shadows, blend modes, and filters.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.html
+++ b/files/en-us/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.html
@@ -17,7 +17,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">If you want to make the right impression, writing a letter on nice letterheaded paper can be a really good start. In this assessment we'll challenge you to create an online template to achieve such a look.</p>
+<p>If you want to make the right impression, writing a letter on nice letterheaded paper can be a really good start. In this assessment we'll challenge you to create an online template to achieve such a look.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/building_blocks/fundamental_css_comprehension/index.html
+++ b/files/en-us/learn/css/building_blocks/fundamental_css_comprehension/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">You've covered a lot in this module, so it must feel good to have reached the end! The final step before you move on is to attempt the assessment for the module — this involves a number of related exercises that must be completed in order to create the final design — a business card/gamer card/social media profile.</p>
+<p>You've covered a lot in this module, so it must feel good to have reached the end! The final step before you move on is to attempt the assessment for the module — this involves a number of related exercises that must be completed in order to create the final design — a business card/gamer card/social media profile.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/building_blocks/index.html
+++ b/files/en-us/learn/css/building_blocks/index.html
@@ -9,9 +9,9 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This module carries on where <a href="/en-US/docs/Learn/CSS/First_steps">CSS first steps</a> left off — now that you've gained familiarity with the language and its syntax, and got some basic experience using it, it's time to dive a bit deeper. This module looks at the cascade and inheritance, all the selector types we have available, units, sizing, styling backgrounds and borders, debugging, and lots more.</p>
+<p>This module carries on where <a href="/en-US/docs/Learn/CSS/First_steps">CSS first steps</a> left off — now that you've gained familiarity with the language and its syntax, and got some basic experience using it, it's time to dive a bit deeper. This module looks at the cascade and inheritance, all the selector types we have available, units, sizing, styling backgrounds and borders, debugging, and lots more.</p>
 
-<p class="summary">The aim here is to provide you with a toolkit for writing competent CSS and help you understand all the essential theory, before moving on to more specific disciplines like <a href="/en-US/docs/Learn/CSS/Styling_text">text styling</a> and <a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a>.</p>
+<p>The aim here is to provide you with a toolkit for writing competent CSS and help you understand all the essential theory, before moving on to more specific disciplines like <a href="/en-US/docs/Learn/CSS/Styling_text">text styling</a> and <a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a>.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/css/building_blocks/selectors/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks")}}</div>
 
-<p class="summary">In {{Glossary("CSS")}}, selectors are used to target the {{glossary("HTML")}} elements on our web pages that we want to style. There are a wide variety of CSS selectors available, allowing for fine-grained precision when selecting elements to style. In this article and its sub-articles we'll run through the different types in great detail, seeing how they work.</p>
+<p>In {{Glossary("CSS")}}, selectors are used to target the {{glossary("HTML")}} elements on our web pages that we want to style. There are a wide variety of CSS selectors available, allowing for fine-grained precision when selecting elements to style. In this article and its sub-articles we'll run through the different types in great detail, seeing how they work.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/building_blocks/styling_tables/index.html
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.html
@@ -15,9 +15,9 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}</div>
 
-<p class="summary"></p>
+<p></p>
 
-<p class="summary">Styling an HTML table isn't the most glamorous job in the world, but sometimes we all have to do it. This article provides a guide to making HTML tables look good, with some specific table styling techniques highlighted.</p>
+<p>Styling an HTML table isn't the most glamorous job in the world, but sometimes we all have to do it. This article provides a guide to making HTML tables look good, with some specific table styling techniques highlighted.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/building_blocks/styling_tables/index.html
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.html
@@ -15,8 +15,6 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}</div>
 
-<p></p>
-
 <p>Styling an HTML table isn't the most glamorous job in the world, but sometimes we all have to do it. This article provides a guide to making HTML tables look good, with some specific table styling techniques highlighted.</p>
 
 <table>

--- a/files/en-us/learn/css/css_layout/flexbox/index.html
+++ b/files/en-us/learn/css/css_layout/flexbox/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout")}}</div>
 
-<p class="summary"><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">Flexbox</a> is a one-dimensional layout method for arranging items in rows or columns. Items <em>flex</em> (expand) to fill additional space or shrink to fit into smaller spaces. This article explains all the fundamentals.</p>
+<p><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">Flexbox</a> is a one-dimensional layout method for arranging items in rows or columns. Items <em>flex</em> (expand) to fill additional space or shrink to fit into smaller spaces. This article explains all the fundamentals.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/floats/index.html
+++ b/files/en-us/learn/css/css_layout/floats/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout")}}</div>
 
-<p class="summary">Originally for floating images inside blocks of text, the {{cssxref("float")}} property became one of the most commonly used tools for creating multiple column layouts on webpages. With the advent of flexbox and grid it's now returned to its original purpose, as this article explains.</p>
+<p>Originally for floating images inside blocks of text, the {{cssxref("float")}} property became one of the most commonly used tools for creating multiple column layouts on webpages. With the advent of flexbox and grid it's now returned to its original purpose, as this article explains.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.html
+++ b/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">If you have worked through this module then you will have already covered the basics of what you need to know to do CSS layout today, and to work with older CSS as well. This task will test some of your knowledge by way of developing a simple webpage layout using a variety of techniques.</p>
+<p>If you have worked through this module then you will have already covered the basics of what you need to know to do CSS layout today, and to work with older CSS as well. This task will test some of your knowledge by way of developing a simple webpage layout using a variety of techniques.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> You can try out solutions in the interactive editors below, however it may be helpful to download the code and use an online tool such as <a href="https://codepen.io/">CodePen</a>, <a href="https://jsfiddle.net/">jsFiddle</a>, or <a href="https://glitch.com/">Glitch</a> to work on the tasks.<br>

--- a/files/en-us/learn/css/css_layout/grids/index.html
+++ b/files/en-us/learn/css/css_layout/grids/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}</div>
 
-<p class="summary">CSS Grid Layout is a two-dimensional layout system for the web. It lets you lay content out in rows and columns. It has many features that make building complex layouts straightforward. This article will explain all you need to know to get started with page layout.</p>
+<p>CSS Grid Layout is a two-dimensional layout system for the web. It lets you lay content out in rows and columns. It has many features that make building complex layouts straightforward. This article will explain all you need to know to get started with page layout.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/index.html
+++ b/files/en-us/learn/css/css_layout/index.html
@@ -20,7 +20,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">At this point, we've looked at CSS fundamentals, how to style text, and how to style and manipulate the boxes that your content sits inside. Now it's time to look at how to correctly arrange your boxes in relation to the viewport as well as to one another. We've covered the necessary prerequisites, so let's dive deep into CSS layout, looking at such various features as: different display settings, positioning, modern layout tools like flexbox and CSS grid, and some of the legacy techniques you might still want to know about.</p>
+<p>At this point, we've looked at CSS fundamentals, how to style text, and how to style and manipulate the boxes that your content sits inside. Now it's time to look at how to correctly arrange your boxes in relation to the viewport as well as to one another. We've covered the necessary prerequisites, so let's dive deep into CSS layout, looking at such various features as: different display settings, positioning, modern layout tools like flexbox and CSS grid, and some of the legacy techniques you might still want to know about.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/css/css_layout/introduction/index.html
+++ b/files/en-us/learn/css/css_layout/introduction/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{NextMenu("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout")}}</div>
 
-<p class="summary">This article will recap some of the CSS layout features we've already touched upon in previous modules, such as different {{cssxref("display")}} values, as well as introduce some of the concepts we'll be covering throughout this module.</p>
+<p>This article will recap some of the CSS layout features we've already touched upon in previous modules, such as different {{cssxref("display")}} values, as well as introduce some of the concepts we'll be covering throughout this module.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/legacy_layout_methods/index.html
+++ b/files/en-us/learn/css/css_layout/legacy_layout_methods/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>{{PreviousMenuNext("Learn/CSS/CSS_layout/Media_queries", "Learn/CSS/CSS_layout/Supporting_Older_Browsers", "Learn/CSS/CSS_layout")}}</p>
 
-<p class="summary">Grid systems are a very common feature used in CSS layouts, and before CSS Grid Layout they tended to be implemented using floats or other layout features. You imagine your layout as a set number of columns (e.g. 4, 6, or 12), and then fit your content columns inside these imaginary columns. In this article we'll explore how these older methods work, in order that you understand how they were used if you work on an older project.</p>
+<p>Grid systems are a very common feature used in CSS layouts, and before CSS Grid Layout they tended to be implemented using floats or other layout features. You imagine your layout as a set number of columns (e.g. 4, 6, or 12), and then fit your content columns inside these imaginary columns. In this article we'll explore how these older methods work, in order that you understand how they were used if you work on an older project.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/multiple-column_layout/index.html
+++ b/files/en-us/learn/css/css_layout/multiple-column_layout/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout/Responsive_Design", "Learn/CSS/CSS_layout")}}</div>
 
-<p class="summary">The multiple-column layout specification provides you with a method for laying content out in columns, as you might see in a newspaper. This article explains how to use this feature.</p>
+<p>The multiple-column layout specification provides you with a method for laying content out in columns, as you might see in a newspaper. This article explains how to use this feature.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/normal_flow/index.html
+++ b/files/en-us/learn/css/css_layout/normal_flow/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>{{PreviousMenuNext("Learn/CSS/CSS_layout/Introduction", "Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout")}}</p>
 
-<p class="summary">This article explains normal flow, or the way that webpage elements lay themselves out if you haven't changed their layout.</p>
+<p>This article explains normal flow, or the way that webpage elements lay themselves out if you haven't changed their layout.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/positioning/index.html
+++ b/files/en-us/learn/css/css_layout/positioning/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout")}}</div>
 
-<p class="summary">Positioning allows you to take elements out of normal document flow and make them behave differently, for example, by sitting on top of one another or by always remaining in the same place inside the browser viewport. This article explains the different {{cssxref("position")}} values and how to use them.</p>
+<p>Positioning allows you to take elements out of normal document flow and make them behave differently, for example, by sitting on top of one another or by always remaining in the same place inside the browser viewport. This article explains the different {{cssxref("position")}} values and how to use them.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.html
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This article shows how to build some real world examples to illustrate what kinds of things you can do with positioning.</p>
+<p>This article shows how to build some real world examples to illustrate what kinds of things you can do with positioning.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
+++ b/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>{{PreviousMenuNext("Learn/CSS/CSS_layout/Legacy_Layout_methods", "Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension", "Learn/CSS/CSS_layout")}}</p>
 
-<p class="summary">In this module, we recommend using Flexbox and Grid as the main layout methods for your designs. However, there will be visitors to your site who use older browsers, or browsers which do not support the methods you have used. This will always be the case on the web — as new features are developed, different browsers will prioritise different things. This article explains how to use modern web techniques without locking out users of older technology.</p>
+<p>In this module, we recommend using Flexbox and Grid as the main layout methods for your designs. However, there will be visitors to your site who use older browsers, or browsers which do not support the methods you have used. This will always be the case on the web — as new features are developed, different browsers will prioritise different things. This article explains how to use modern web techniques without locking out users of older technology.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/first_steps/getting_started/index.html
+++ b/files/en-us/learn/css/first_steps/getting_started/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/First_steps/What_is_CSS", "Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps")}}</div>
 
-<p class="summary">In this article we will take a simple HTML document and apply CSS to it, learning some practical things about the language along the way.</p>
+<p>In this article we will take a simple HTML document and apply CSS to it, learning some practical things about the language along the way.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}</div>
 
-<p class="summary">Now that you are beginning to understand the purpose and use of CSS, let's examine the structure of CSS.</p>
+<p>Now that you are beginning to understand the purpose and use of CSS, let's examine the structure of CSS.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/first_steps/how_css_works/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.html
@@ -10,7 +10,7 @@ tags:
 <p>{{LearnSidebar}}<br>
  {{PreviousMenuNext("Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps/Using_your_new_knowledge", "Learn/CSS/First_steps")}}</p>
 
-<p class="summary">We have learned the basics of CSS, what it is for and how to write simple stylesheets. In this lesson we will take a look at how a browser takes CSS and HTML and turns that into a webpage.</p>
+<p>We have learned the basics of CSS, what it is for and how to write simple stylesheets. In this lesson we will take a look at how a browser takes CSS and HTML and turns that into a webpage.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/first_steps/index.html
+++ b/files/en-us/learn/css/first_steps/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">CSS (Cascading Style Sheets) is used to style and lay out web pages — for example, to alter the font, color, size, and spacing of your content, split it into multiple columns, or add animations and other decorative features. This module provides a gentle beginning to your path towards CSS mastery with the basics of how it works, what the syntax looks like, and how you can start using it to add styling to HTML.</p>
+<p>CSS (Cascading Style Sheets) is used to style and lay out web pages — for example, to alter the font, color, size, and spacing of your content, split it into multiple columns, or add animations and other decorative features. This module provides a gentle beginning to your path towards CSS mastery with the basics of how it works, what the syntax looks like, and how you can start using it to add styling to HTML.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/css/first_steps/using_your_new_knowledge/index.html
+++ b/files/en-us/learn/css/first_steps/using_your_new_knowledge/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{LearnSidebar}}{{PreviousMenu("Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}</p>
 
-<p class="summary">With the things you have learned in the last few lessons you should find that you can format simple text documents using CSS to add your own style to them. This assessment gives you a chance to do that.</p>
+<p>With the things you have learned in the last few lessons you should find that you can format simple text documents using CSS to add your own style to them. This assessment gives you a chance to do that.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/first_steps/what_is_css/index.html
+++ b/files/en-us/learn/css/first_steps/what_is_css/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{NextMenu("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps")}}</div>
 
-<p class="summary"><strong>{{Glossary("CSS")}}</strong> (Cascading Style Sheets) allows you to create great-looking web pages, but how does it work under the hood? This article explains what CSS is, with a simple syntax example, and also covers some key terms about the language.</p>
+<p><strong>{{Glossary("CSS")}}</strong> (Cascading Style Sheets) allows you to create great-looking web pages, but how does it work under the hood? This article explains what CSS is, with a simple syntax example, and also covers some key terms about the language.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/howto/add_a_shadow/index.html
+++ b/files/en-us/learn/css/howto/add_a_shadow/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can find out how to add a shadow to any box on your page.</p>
+<p>In this guide you can find out how to add a shadow to any box on your page.</p>
 
 <h2>Adding box shadows</h2>
 

--- a/files/en-us/learn/css/howto/add_a_text_shadow/index.html
+++ b/files/en-us/learn/css/howto/add_a_text_shadow/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can find out how to add a shadow to any text on your page.</p>
+<p>In this guide you can find out how to add a shadow to any text on your page.</p>
 
 <h2>Adding shadows to text</h2>
 

--- a/files/en-us/learn/css/howto/center_an_item/index.html
+++ b/files/en-us/learn/css/howto/center_an_item/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can find out how to center an item inside another element, both horizontally and vertically.</p>
+<p>In this guide you can find out how to center an item inside another element, both horizontally and vertically.</p>
 
 <h2>Center a box</h2>
 

--- a/files/en-us/learn/css/howto/create_fancy_boxes/index.html
+++ b/files/en-us/learn/css/howto/create_fancy_boxes/index.html
@@ -7,7 +7,7 @@ tags:
   - CodingScripting
   - Learn
 ---
-<p class="summary">CSS boxes are the building blocks of any web page styled with CSS. Making them nice looking is both fun and challenging. It's fun because it's all about turning a design idea into working code; it's challenging because of the constraints of CSS. Let's do some fancy boxes.</p>
+<p>CSS boxes are the building blocks of any web page styled with CSS. Making them nice looking is both fun and challenging. It's fun because it's all about turning a design idea into working code; it's challenging because of the constraints of CSS. Let's do some fancy boxes.</p>
 
 <p>Before we start getting into the practical side of it, make sure you are familiar with <a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model">the CSS box model</a>. It's also a good idea, but not a prerequisite, to be familiar with some <a href="/en-US/docs/Learn/CSS/CSS_layout/Introduction">CSS layout basics</a>.</p>
 

--- a/files/en-us/learn/css/howto/fill_a_box_with_an_image/index.html
+++ b/files/en-us/learn/css/howto/fill_a_box_with_an_image/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can learn a technique for causing an HTML image to completely fill a box.</p>
+<p>In this guide you can learn a technique for causing an HTML image to completely fill a box.</p>
 
 <h2>Using object-fit</h2>
 

--- a/files/en-us/learn/css/howto/highlight_first_line/index.html
+++ b/files/en-us/learn/css/howto/highlight_first_line/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you will find out how to highlight the first line of text in a paragraph, even if you don't know how long that line will be.</p>
+<p>In this guide you will find out how to highlight the first line of text in a paragraph, even if you don't know how long that line will be.</p>
 
 <h2>Styling the first line of text</h2>
 

--- a/files/en-us/learn/css/howto/highlight_first_para/index.html
+++ b/files/en-us/learn/css/howto/highlight_first_para/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can find out how to highlight the first paragraph inside a container.</p>
+<p>In this guide you can find out how to highlight the first paragraph inside a container.</p>
 
 <h2>Styling the first paragraph</h2>
 

--- a/files/en-us/learn/css/howto/highlight_para_after_h1/index.html
+++ b/files/en-us/learn/css/howto/highlight_para_after_h1/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can find out how to highlight a paragraph that comes directly after a heading.</p>
+<p>In this guide you can find out how to highlight a paragraph that comes directly after a heading.</p>
 
 <h2>Styling the first paragraph after a heading</h2>
 

--- a/files/en-us/learn/css/howto/index.html
+++ b/files/en-us/learn/css/howto/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This page rounds up questions and answers, and other material on the MDN site that can help you to solve common CSS problems.</p>
+<p>This page rounds up questions and answers, and other material on the MDN site that can help you to solve common CSS problems.</p>
 
 <h2 id="Styling_boxes">Styling boxes</h2>
 

--- a/files/en-us/learn/css/howto/make_box_transparent/index.html
+++ b/files/en-us/learn/css/howto/make_box_transparent/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">This guide will help you to understand the ways to make a box semi-transparent using CSS.</p>
+<p>This guide will help you to understand the ways to make a box semi-transparent using CSS.</p>
 
 <h2>Change the opacity of the box and content</h2>
 

--- a/files/en-us/learn/css/howto/transition_button/index.html
+++ b/files/en-us/learn/css/howto/transition_button/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">In this guide you can find out how to do a gentle fade between two colors when hovering over a button.</p>
+<p>In this guide you can find out how to do a gentle fade between two colors when hovering over a button.</p>
 
 <p>In our button example, we can change the background of our button by defining a different background color for the <code>:hover</code> dynamic pseudo-class. However, hovering over the button will cause the background-color to snap to the new color. To create a more gentle change between the two, we can use CSS Transitions.</p>
 

--- a/files/en-us/learn/css/index.html
+++ b/files/en-us/learn/css/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 {{LearnSidebar}}
 
-<p class="summary">Cascading Stylesheets — or {{glossary("CSS")}} — is the first technology you should start learning after {{glossary("HTML")}}. While HTML is used to define the structure and semantics of your content, CSS is used to style it and lay it out. For example, you can use CSS to alter the font, color, size, and spacing of your content, split it into multiple columns, or add animations and other decorative features.</p>
+<p>Cascading Stylesheets — or {{glossary("CSS")}} — is the first technology you should start learning after {{glossary("HTML")}}. While HTML is used to define the structure and semantics of your content, CSS is used to style it and lay it out. For example, you can use CSS to alter the font, color, size, and spacing of your content, split it into multiple columns, or add animations and other decorative features.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web
@@ -46,9 +46,9 @@ tags:
  <dd>CSS (Cascading Style Sheets) is used to style and lay out web pages — for example, to alter the font, color, size, and spacing of your content, split it into multiple columns, or add animations and other decorative features. This module provides a gentle beginning to your path towards CSS mastery with the basics of how it works, what the syntax looks like, and how you can start using it to add styling to HTML.</dd>
  <dt><a href="/en-US/docs/Learn/CSS/Building_blocks">CSS building blocks</a></dt>
  <dd>
- <p class="summary">This module carries on where <a href="/en-US/docs/Learn/CSS/First_steps">CSS first steps</a> left off — now you've gained familiarity with the language and its syntax, and got some basic experience with using it, its time to dive a bit deeper. This module looks at the cascade and inheritance, all the selector types we have available, units, sizing, styling backgrounds and borders, debugging, and lots more.</p>
+ <p>This module carries on where <a href="/en-US/docs/Learn/CSS/First_steps">CSS first steps</a> left off — now you've gained familiarity with the language and its syntax, and got some basic experience with using it, its time to dive a bit deeper. This module looks at the cascade and inheritance, all the selector types we have available, units, sizing, styling backgrounds and borders, debugging, and lots more.</p>
 
- <p class="summary">The aim here is to provide you with a toolkit for writing competent CSS and help you understand all the essential theory, before moving on to more specific disciplines like <a href="/en-US/docs/Learn/CSS/Styling_text">text styling</a> and <a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a>.</p>
+ <p>The aim here is to provide you with a toolkit for writing competent CSS and help you understand all the essential theory, before moving on to more specific disciplines like <a href="/en-US/docs/Learn/CSS/Styling_text">text styling</a> and <a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a>.</p>
  </dd>
  <dt><a href="/en-US/docs/Learn/CSS/Styling_text">Styling text</a></dt>
  <dd>With the basics of the CSS language covered, the next CSS topic for you to concentrate on is styling text — one of the most common things you'll do with CSS. Here we look at text styling fundamentals, including setting font, boldness, italics, line and letter spacing, drop shadows and other text features. We round off the module by looking at applying custom fonts to your page, and styling lists and links.</dd>

--- a/files/en-us/learn/css/styling_text/fundamentals/index.html
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{NextMenu("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text")}}</div>
 
-<p class="summary"><span class="seoSummary">In this article we'll start you on your journey towards mastering text styling with {{glossary("CSS")}}.</span> Here we'll go through all the basic fundamentals of text/font styling in detail, including setting font weight, family and style, font shorthand, text alignment and other effects, and line and letter spacing.</p>
+<p><span class="seoSummary">In this article we'll start you on your journey towards mastering text styling with {{glossary("CSS")}}.</span> Here we'll go through all the basic fundamentals of text/font styling in detail, including setting font weight, family and style, font shorthand, text alignment and other effects, and line and letter spacing.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/styling_text/index.html
+++ b/files/en-us/learn/css/styling_text/index.html
@@ -19,7 +19,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">With the basics of the CSS language covered, the next CSS topic for you to concentrate on is styling text — one of the most common things you'll do with CSS. Here we look at text styling fundamentals including setting font, boldness, italics, line and letter spacing, drop shadows, and other text features. We round off the module by looking at applying custom fonts to your page, and styling lists and links.</p>
+<p>With the basics of the CSS language covered, the next CSS topic for you to concentrate on is styling text — one of the most common things you'll do with CSS. Here we look at text styling fundamentals including setting font, boldness, italics, line and letter spacing, drop shadows, and other text features. We round off the module by looking at applying custom fonts to your page, and styling lists and links.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/css/styling_text/styling_links/index.html
+++ b/files/en-us/learn/css/styling_text/styling_links/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}</div>
 
-<p class="summary">When styling <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks">links</a>, it's important to understand how to make use of pseudo-classes to style their states effectively. It's also important to know how to style links for use in common interface features whose content varies, such as navigation menus and tabs. We'll look at both these topics in this article.</p>
+<p>When styling <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks">links</a>, it's important to understand how to make use of pseudo-classes to style their states effectively. It's also important to know how to style links for use in common interface features whose content varies, such as navigation menus and tabs. We'll look at both these topics in this article.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/styling_text/styling_lists/index.html
+++ b/files/en-us/learn/css/styling_text/styling_lists/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/Styling_text/Fundamentals", "Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text")}}</div>
 
-<p class="summary"><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#lists">Lists</a> behave like any other text for the most part, but there are some CSS properties specific to lists that you need to know about, as well as some best practices to consider. This article explains all.</p>
+<p><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#lists">Lists</a> behave like any other text for the most part, but there are some CSS properties specific to lists that you need to know about, as well as some best practices to consider. This article explains all.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/styling_text/typesetting_a_homepage/index.html
+++ b/files/en-us/learn/css/styling_text/typesetting_a_homepage/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}</div>
 
-<p class="summary">In this assessment, we'll test your understanding of all the text styling techniques we've covered throughout this module by getting you to style the text for a community school's homepage. You might just have some fun along the way.</p>
+<p>In this assessment, we'll test your understanding of all the text styling techniques we've covered throughout this module by getting you to style the text for a community school's homepage. You might just have some fun along the way.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/css/styling_text/web_fonts/index.html
+++ b/files/en-us/learn/css/styling_text/web_fonts/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text/Typesetting_a_homepage", "Learn/CSS/Styling_text")}}</div>
 
-<p class="summary">In the first article of the module, we explored the basic CSS features available for styling fonts and text. In this article we will go further, exploring web fonts in detail. We'll see how to use custom fonts with your web page to allow for more varied, custom text styling.</p>
+<p>In the first article of the module, we explored the basic CSS features available for styling fonts and text. In this article we will go further, exploring web fonts in detail. We'll see how to use custom fonts with your web page to allow for more varied, custom text styling.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/basic_native_form_controls/index.html
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Forms/How_to_structure_a_web_form", "Learn/Forms/HTML5_input_types", "Learn/Forms")}}</div>
 
-<p class="summary">In the <a href="/en-US/docs/Learn/Forms/How_to_structure_a_web_form">previous article</a>, we marked up a functional web form example, introducing some form controls and common structural elements, and focusing on accessibility best practices. Next we will look at the functionality of the different form controls, or widgets, in detail — studying all the different options available to collect different types of data. In this particular article we will look at the original set of form controls, available in all browsers since the early days of the web.</p>
+<p>In the <a href="/en-US/docs/Learn/Forms/How_to_structure_a_web_form">previous article</a>, we marked up a functional web form example, introducing some form controls and common structural elements, and focusing on accessibility best practices. Next we will look at the functionality of the different form controls, or widgets, in detail — studying all the different options available to collect different types of data. In this particular article we will look at the original set of form controls, available in all browsers since the early days of the web.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.html
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Forms/Your_first_form", "Learn/Forms/Basic_native_form_controls", "Learn/Forms")}}</div>
 
-<p class="summary">With the basics out of the way, we'll now look in more detail at the elements used to provide structure and meaning to the different parts of a form.</p>
+<p>With the basics out of the way, we'll now look in more detail at the elements used to provide structure and meaning to the different parts of a form.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/html5_input_types/index.html
+++ b/files/en-us/learn/forms/html5_input_types/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Forms/Basic_native_form_controls", "Learn/Forms/Other_form_controls", "Learn/Forms")}}</div>
 
-<p class="summary">In the <a href="/en-US/docs/Learn/Forms/Basic_native_form_controls">previous article</a> we looked at the {{htmlelement("input")}} element, covering the original values of the <code>type</code> attribute available since the early days of HTML. Now we'll look at the functionality of newer form controls in detail, including some new input types, which were added in HTML5 to allow collection of specific types of data.</p>
+<p>In the <a href="/en-US/docs/Learn/Forms/Basic_native_form_controls">previous article</a> we looked at the {{htmlelement("input")}} element, covering the original values of the <code>type</code> attribute available since the early days of HTML. Now we'll look at the functionality of newer form controls in detail, including some new input types, which were added in HTML5 to allow collection of specific types of data.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/index.html
+++ b/files/en-us/learn/forms/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This module provides a series of articles that will help you master the essentials of web forms. Web forms are a very powerful tool for interacting with users — most commonly they are used for collecting data from users, or allowing them to control a user interface. However, for historical and technical reasons it's not always obvious how to use them to their full potential. In the articles listed below, we'll cover all the essential aspects of Web forms including marking up their HTML structure, styling form controls, validating form data, and submitting data to the server.</p>
+<p>This module provides a series of articles that will help you master the essentials of web forms. Web forms are a very powerful tool for interacting with users — most commonly they are used for collecting data from users, or allowing them to control a user interface. However, for historical and technical reasons it's not always obvious how to use them to their full potential. In the articles listed below, we'll cover all the essential aspects of Web forms including marking up their HTML structure, styling form controls, validating form data, and submitting data to the server.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.html
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{learnsidebar}}</div>
 
-<p class="summary">The following compatibility tables try to summarize the state of CSS support for HTML forms. Due to the complexity of CSS and HTML forms, these tables can't be considered a perfect reference. However, they will give you good insight into what can and can't be done, which will help you learn how to do things.</p>
+<p>The following compatibility tables try to summarize the state of CSS support for HTML forms. Due to the complexity of CSS and HTML forms, these tables can't be considered a perfect reference. However, they will give you good insight into what can and can't be done, which will help you learn how to do things.</p>
 
 <h2 id="How_to_read_the_tables">How to read the tables</h2>
 

--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.html
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{LearnSidebar}}{{PreviousMenu("Learn/Forms/Form_validation", "Learn/Forms")}}</div>
 
-<p class="summary">Once the form data has been validated on the client-side, it is okay to submit the form. And, since we covered validation in the previous article, we're ready to submit! This article looks at what happens when a user submits a form — where does the data go, and how do we handle it when it gets there? We also look at some of the security concerns associated with sending form data.</p>
+<p>Once the form data has been validated on the client-side, it is okay to submit the form. And, since we covered validation in the previous article, we're ready to submit! This article looks at what happens when a user submits a form — where does the data go, and how do we handle it when it gets there? We also look at some of the security concerns associated with sending form data.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/styling_web_forms/index.html
+++ b/files/en-us/learn/forms/styling_web_forms/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <p>{{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Other_form_controls","Learn/Forms/Advanced_form_styling","Learn/Forms")}}</p>
 
-<p class="summary">In the previous few articles we looked at all the HTML you'll need to create and structure your web forms. In this article we will move on to looking at how to use <a href="/en-US/docs/Web/CSS">CSS</a> to style your form controls. This has historically been difficult — form controls vary greatly in how easy they are to customize with CSS — but it is getting easier as old browsers are retired and modern browsers give us more features to use.</p>
+<p>In the previous few articles we looked at all the HTML you'll need to create and structure your web forms. In this article we will move on to looking at how to use <a href="/en-US/docs/Web/CSS">CSS</a> to style your form controls. This has historically been difficult — form controls vary greatly in how easy they are to customize with CSS — but it is getting easier as old browsers are retired and modern browsers give us more features to use.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/your_first_form/index.html
+++ b/files/en-us/learn/forms/your_first_form/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{LearnSidebar}}{{NextMenu("Learn/Forms/How_to_structure_a_web_form", "Learn/Forms")}}</div>
 
-<p class="summary">The first article in our series provides you with your very first experience of creating a web form, including designing a simple form, implementing it using the right HTML form controls and other HTML elements, adding some very simple styling via CSS, and describing how data is sent to a server. We'll expand on each of these subtopics in more detail later on in the module.</p>
+<p>The first article in our series provides you with your very first experience of creating a web form, including designing a simple form, implementing it using the right HTML form controls and other HTML elements, adding some very simple styling via CSS, and describing how data is sent to a server. We'll expand on each of these subtopics in more detail later on in the module.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/howto/index.html
+++ b/files/en-us/learn/html/howto/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">The following links point to solutions to common everyday problems you'll need to solve with HTML.</p>
+<p>The following links point to solutions to common everyday problems you'll need to solve with HTML.</p>
 
 <h3 id="Basic_structure">Basic structure</h3>
 

--- a/files/en-us/learn/html/index.html
+++ b/files/en-us/learn/html/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">To build websites, you should know about {{Glossary('HTML')}} — the fundamental technology used to define the structure of a webpage. HTML is used to specify whether your web content should be recognized as a paragraph, list, heading, link, image, multimedia player, form, or one of many other available elements or even a new element that you define.</p>
+<p>To build websites, you should know about {{Glossary('HTML')}} — the fundamental technology used to define the structure of a webpage. HTML is used to specify whether your web content should be recognized as a paragraph, list, heading, link, image, multimedia player, form, or one of many other available elements or even a new element that you define.</p>
 
 <div class="callout">
 	<h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.html
+++ b/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">There are many other elements in HTML for formatting text, which we didn't get to in the <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals">HTML text fundamentals</a> article. The elements described in this article are less known, but still useful to know about (and this is still not a complete list by any means). Here you'll learn about marking up quotations, description lists, computer code and other related text, subscript and superscript, contact information, and more.</p>
+<p>There are many other elements in HTML for formatting text, which we didn't get to in the <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals">HTML text fundamentals</a> article. The elements described in this article are less known, but still useful to know about (and this is still not a complete list by any means). Here you'll learn about marking up quotations, description lists, computer code and other related text, subscript and superscript, contact information, and more.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.html
+++ b/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">Hyperlinks are really important — they are what makes the Web <em>a web</em>. This article shows the syntax required to make a link, and discusses link best practices.</p>
+<p>Hyperlinks are really important — they are what makes the Web <em>a web</em>. This article shows the syntax required to make a link, and discusses link best practices.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/debugging_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/debugging_html/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">Writing HTML is fine, but what if something goes wrong, and you can't work out where the error in the code is? This article will introduce you to some tools that can help you find and fix errors in HTML.</p>
+<p>Writing HTML is fine, but what if something goes wrong, and you can't work out where the error in the code is? This article will introduce you to some tools that can help you find and fix errors in HTML.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.html
+++ b/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">In addition to defining individual parts of your page (such as "a paragraph" or "an image"), {{glossary("HTML")}} also boasts a number of block level elements used to define areas of your website (such as "the header", "the navigation menu", "the main content column"). This article looks into how to plan a basic website structure, and write the HTML to represent this structure.</p>
+<p>In addition to defining individual parts of your page (such as "a paragraph" or "an image"), {{glossary("HTML")}} also boasts a number of block level elements used to define areas of your website (such as "the header", "the navigation menu", "the main content column"). This article looks into how to plan a basic website structure, and write the HTML to represent this structure.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.html
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{NextMenu("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">In this article we cover the absolute basics of HTML. To get you started, this article defines elements, attributes, and all the other important terms you may have heard. It also explains where these fit into HTML. You will learn how HTML elements are structured, how a typical HTML page is structured, and other important basic language features. Along the way, there will be an opportunity to play with HTML too!</p>
+<p>In this article we cover the absolute basics of HTML. To get you started, this article defines elements, attributes, and all the other important terms you may have heard. It also explains where these fit into HTML. You will learn how HTML elements are structured, how a typical HTML page is structured, and other important basic language features. Along the way, there will be an opportunity to play with HTML too!</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.html
+++ b/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">One of HTML's main jobs is to give text structure so that a browser can display an HTML document the way its developer intends. This article explains the way {{glossary("HTML")}} can be used to structure a page of text by adding headings and paragraphs, emphasizing words, creating lists, and more.</p>
+<p>One of HTML's main jobs is to give text structure so that a browser can display an HTML document the way its developer intends. This article explains the way {{glossary("HTML")}} can be used to structure a page of text by adding headings and paragraphs, emphasizing words, creating lists, and more.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/marking_up_a_letter/index.html
+++ b/files/en-us/learn/html/introduction_to_html/marking_up_a_letter/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">We all learn to write a letter sooner or later; it is also a useful example to test our text formatting skills. In this assignment, you'll have a letter to mark up as a test for your HTML text formatting skills, as well as hyperlinks and proper use of the HTML <code>&lt;head&gt;</code> element.</p>
+<p>We all learn to write a letter sooner or later; it is also a useful example to test our text formatting skills. In this assignment, you'll have a letter to mark up as a test for your HTML text formatting skills, as well as hyperlinks and proper use of the HTML <code>&lt;head&gt;</code> element.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/structuring_a_page_of_content/index.html
+++ b/files/en-us/learn/html/introduction_to_html/structuring_a_page_of_content/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">Structuring a page of content ready for laying it out using CSS is a very important skill to master, so in this assessment you'll be tested on your ability to think about how a page might end up looking, and choose appropriate structural semantics to build a layout on top of.</p>
+<p>Structuring a page of content ready for laying it out using CSS is a very important skill to master, so in this assessment you'll be tested on your ability to think about how a page might end up looking, and choose appropriate structural semantics to build a layout on top of.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Getting_started", "Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML")}}</div>
 
-<p class="summary">The {{glossary("Head", "head")}} of an HTML document is the part that is not displayed in the web browser when the page is loaded. It contains information such as the page {{htmlelement("title")}}, links to {{glossary("CSS")}} (if you choose to style your HTML content with CSS), links to custom favicons, and other metadata (data about the HTML, such as the author, and important keywords that describe the document.) In this article we'll cover all of the above and more, in order to give you a good basis for working with markup.</p>
+<p>The {{glossary("Head", "head")}} of an HTML document is the part that is not displayed in the web browser when the page is loaded. It contains information such as the page {{htmlelement("title")}}, links to {{glossary("CSS")}} (if you choose to style your HTML content with CSS), links to custom favicons, and other metadata (data about the HTML, such as the author, and important keywords that describe the document.) In this article we'll cover all of the above and more, in order to give you a good basis for working with markup.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{NextMenu("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<p class="summary">In the beginning, the Web was just text, and it was really quite boring. Fortunately, it wasn't too long before the ability to embed images (and other more interesting types of content) inside web pages was added. There are other types of multimedia to consider, but it is logical to start with the humble {{htmlelement("img")}} element, used to embed a simple image in a webpage. In this article we'll look at how to use it in depth, including the basics, annotating it with captions using {{htmlelement("figure")}}, and detailing how it relates to {{glossary("CSS")}} background images.</p>
+<p>In the beginning, the Web was just text, and it was really quite boring. Fortunately, it wasn't too long before the ability to embed images (and other more interesting types of content) inside web pages was added. There are other types of multimedia to consider, but it is logical to start with the humble {{htmlelement("img")}} element, used to embed a simple image in a webpage. In this article we'll look at how to use it in depth, including the basics, annotating it with captions using {{htmlelement("figure")}}, and detailing how it relates to {{glossary("CSS")}} background images.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/index.html
@@ -25,7 +25,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">We've looked at a lot of text so far in this course, but the web would be really boring only using text. Let's start looking at how to make the web come alive with more interesting content! This module explores how to use HTML to include multimedia in your web pages, including the different ways that images can be included, and how to embed video, audio, and even entire webpages.</p>
+<p>We've looked at a lot of text so far in this course, but the web would be really boring only using text. Let's start looking at how to make the web come alive with more interesting content! This module explores how to use HTML to include multimedia in your web pages, including the different ways that images can be included, and how to embed video, audio, and even entire webpages.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/html/multimedia_and_embedding/mozilla_splash_page/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/mozilla_splash_page/index.html
@@ -24,7 +24,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<p class="summary">In this assessment, we'll test your knowledge of some of the techniques discussed in this module's articles, getting you to add some images and video to a funky splash page all about Mozilla!</p>
+<p>In this assessment, we'll test your knowledge of some of the techniques discussed in this module's articles, getting you to add some images and video to a funky splash page all about Mozilla!</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.html
@@ -26,7 +26,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<p class="summary">In this article, we'll learn about the concept of responsive images — images that work well on devices with widely differing screen sizes, resolutions, and other such features — and look at what tools HTML provides to help implement them. This helps to improve performance across different devices. Responsive images are just one part of <a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">responsive design</a>, a future CSS topic for you to learn.</p>
+<p>In this article, we'll learn about the concept of responsive images — images that work well on devices with widely differing screen sizes, resolutions, and other such features — and look at what tools HTML provides to help implement them. This helps to improve performance across different devices. Responsive images are just one part of <a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">responsive design</a>, a future CSS topic for you to learn.</p>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Images_in_HTML", "Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<p class="summary"><span class="seoSummary">Now that we are comfortable with adding simple images to a webpage, the next step is to start adding video and audio players to your HTML documents! In this article we'll look at doing just that with the {{htmlelement("video")}} and {{htmlelement("audio")}} elements; we'll then finish off by looking at how to add captions/subtitles to your videos.</span></p>
+<p><span class="seoSummary">Now that we are comfortable with adding simple images to a webpage, the next step is to start adding video and audio players to your HTML documents! In this article we'll look at doing just that with the {{htmlelement("video")}} and {{htmlelement("audio")}} elements; we'll then finish off by looking at how to add captions/subtitles to your videos.</span></p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/tables/advanced/index.html
+++ b/files/en-us/learn/html/tables/advanced/index.html
@@ -23,7 +23,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Tables/Basics", "Learn/HTML/Tables/Structuring_planet_data", "Learn/HTML/Tables")}}</div>
 
-<p class="summary">In the second article in this module, we look at some more advanced features of HTML tables — such as captions/summaries and grouping your rows into table head, body and footer sections — as well as looking at the accessibility of tables for visually impaired users.</p>
+<p>In the second article in this module, we look at some more advanced features of HTML tables — such as captions/summaries and grouping your rows into table head, body and footer sections — as well as looking at the accessibility of tables for visually impaired users.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/tables/basics/index.html
+++ b/files/en-us/learn/html/tables/basics/index.html
@@ -21,7 +21,7 @@ tags:
 
 <div>{{NextMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}</div>
 
-<p class="summary">This article gets you started with HTML tables, covering the very basics such as rows and cells, headings, making cells span multiple columns and rows, and how to group together all the cells in a column for styling purposes.</p>
+<p>This article gets you started with HTML tables, covering the very basics such as rows and cells, headings, making cells span multiple columns and rows, and how to group together all the cells in a column for styling purposes.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/tables/index.html
+++ b/files/en-us/learn/html/tables/index.html
@@ -16,7 +16,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">A very common task in HTML is structuring tabular data, and it has a number of elements and attributes for just this purpose. Coupled with a little <a href="/en-US/docs/Learn/CSS">CSS</a> for styling, HTML makes it easy to display tables of information on the web such as your school lesson plan, the timetable at your local swimming pool, or statistics about your favorite dinosaurs or football team. This module takes you through all you need to know about structuring tabular data using HTML.</p>
+<p>A very common task in HTML is structuring tabular data, and it has a number of elements and attributes for just this purpose. Coupled with a little <a href="/en-US/docs/Learn/CSS">CSS</a> for styling, HTML makes it easy to display tables of information on the web such as your school lesson plan, the timetable at your local swimming pool, or statistics about your favorite dinosaurs or football team. This module takes you through all you need to know about structuring tabular data using HTML.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/html/tables/structuring_planet_data/index.html
+++ b/files/en-us/learn/html/tables/structuring_planet_data/index.html
@@ -13,7 +13,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}</div>
 
-<p class="summary">In our table assessment, we provide you with some data on the planets in our solar system, and get you to structure it into an HTML table.</p>
+<p>In our table assessment, we provide you with some data on the planets in our solar system, and get you to structure it into an HTML table.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/index.html
+++ b/files/en-us/learn/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">Welcome to the MDN learning area. This set of articles aims to guide complete beginners to web development with all that they need to start coding websites.</p>
+<p>Welcome to the MDN learning area. This set of articles aims to guide complete beginners to web development with all that they need to start coding websites.</p>
 
 <p>The aim of this area of MDN is not to take you from "beginner" to "expert" but to take you from "beginner" to "comfortable." From there, you should be able to start making your way, learning from <a href="/en-US/">the rest of MDN</a>, and other intermediate to advanced resources that assume a lot of previous knowledge.</p>
 

--- a/files/en-us/learn/javascript/asynchronous/async_await/index.html
+++ b/files/en-us/learn/javascript/asynchronous/async_await/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Promises", "Learn/JavaScript/Asynchronous/Choosing_the_right_approach", "Learn/JavaScript/Asynchronous")}}</div>
 
-<p class="summary">More recent additions to the JavaScript language are <a href="/en-US/docs/Web/JavaScript/Reference/Statements/async_function">async functions</a> and the <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a></code> keyword, added in ECMAScript 2017. These features basically act as syntactic sugar on top of promises, making asynchronous code easier to write and to read afterwards. They make async code look more like old-school synchronous code, so they're well worth learning. This article gives you what you need to know.</p>
+<p>More recent additions to the JavaScript language are <a href="/en-US/docs/Web/JavaScript/Reference/Statements/async_function">async functions</a> and the <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a></code> keyword, added in ECMAScript 2017. These features basically act as syntactic sugar on top of promises, making asynchronous code easier to write and to read afterwards. They make async code look more like old-school synchronous code, so they're well worth learning. This article gives you what you need to know.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/asynchronous/index.html
+++ b/files/en-us/learn/javascript/asynchronous/index.html
@@ -18,7 +18,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary"><span class="seoSummary">In this module we take a look at {{Glossary("asynchronous")}} {{Glossary("JavaScript")}}, why it is important, and how it can be used to effectively handle potential blocking operations such as fetching resources from a server.</span></p>
+<p><span class="seoSummary">In this module we take a look at {{Glossary("asynchronous")}} {{Glossary("JavaScript")}}, why it is important, and how it can be used to effectively handle potential blocking operations such as fetching resources from a server.</span></p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/javascript/asynchronous/introducing/index.html
+++ b/files/en-us/learn/javascript/asynchronous/introducing/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Concepts", "Learn/JavaScript/Asynchronous/Timeouts_and_intervals", "Learn/JavaScript/Asynchronous")}}</div>
 
-<p class="summary">In this article we briefly recap the problems associated with synchronous JavaScript, and take a first look at some of the different asynchronous techniques you'll encounter, showing how they can help us solve such problems.</p>
+<p>In this article we briefly recap the problems associated with synchronous JavaScript, and take a first look at some of the different asynchronous techniques you'll encounter, showing how they can help us solve such problems.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/asynchronous/promises/index.html
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Timeouts_and_intervals", "Learn/JavaScript/Asynchronous/Async_await", "Learn/JavaScript/Asynchronous")}}</div>
 
-<p class="summary"><strong>Promises</strong> are a comparatively new feature of the JavaScript language that allow you to defer further actions until after a previous action has completed, or respond to its failure. This is useful for setting up a sequence of async operations to work correctly. This article shows you how promises work, how you'll see them in use with web APIs, and how to write your own.</p>
+<p><strong>Promises</strong> are a comparatively new feature of the JavaScript language that allow you to defer further actions until after a previous action has completed, or respond to its failure. This is useful for setting up a sequence of async operations to work correctly. This article shows you how promises work, how you'll see them in use with web APIs, and how to write your own.</p>
 
 <table class="learn-box">
  <tbody>

--- a/files/en-us/learn/javascript/asynchronous/timeouts_and_intervals/index.html
+++ b/files/en-us/learn/javascript/asynchronous/timeouts_and_intervals/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Introducing", "Learn/JavaScript/Asynchronous/Promises", "Learn/JavaScript/Asynchronous")}}</div>
 
-<p class="summary">This tutorial looks at the traditional methods JavaScript has available for running code asynchronously after a set time period has elapsed, or at a regular interval (e.g. a set number of times per second), discusses what they are useful for, and considers their inherent issues.</p>
+<p>This tutorial looks at the traditional methods JavaScript has available for running code asynchronously after a set time period has elapsed, or at a regular interval (e.g. a set number of times per second), discusses what they are useful for, and considers their inherent issues.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.html
+++ b/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Functions","Learn/JavaScript/Building_blocks/Return_values", "Learn/JavaScript/Building_blocks")}}</div>
 
-<p class="summary">With most of the essential theory dealt with in the previous article, this article provides practical experience. Here you will get some practice building your own, custom function. Along the way, we'll also explain some useful details of dealing with functions.</p>
+<p>With most of the essential theory dealt with in the previous article, this article provides practical experience. Here you will get some practice building your own, custom function. Along the way, we'll also explain some useful details of dealing with functions.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.html
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{NextMenu("Learn/JavaScript/Building_blocks/Looping_code", "Learn/JavaScript/Building_blocks")}}</div>
 
-<p class="summary">In any programming language, the code needs to make decisions and carry out actions accordingly depending on different inputs. For example, in a game, if the player's number of lives is 0, then it's game over. In a weather app, if it is being looked at in the morning, show a sunrise graphic; show stars and a moon if it is nighttime. In this article, we'll explore how so-called conditional statements work in JavaScript.</p>
+<p>In any programming language, the code needs to make decisions and carry out actions accordingly depending on different inputs. For example, in a game, if the player's number of lives is 0, then it's game over. In a weather app, if it is being looked at in the morning, show a sunrise graphic; show stars and a moon if it is nighttime. In this article, we'll explore how so-called conditional statements work in JavaScript.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/building_blocks/events/index.html
+++ b/files/en-us/learn/javascript/building_blocks/events/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Return_values","Learn/JavaScript/Building_blocks/Image_gallery", "Learn/JavaScript/Building_blocks")}}</div>
 
-<p class="summary">Events are actions or occurrences that happen in the system you are programming, which the system tells you about so you can respond to them in some way if desired. For example, if the user selects a button on a webpage, you might want to respond to that action by displaying an information box. In this article, we discuss some important concepts surrounding events, and look at how they work in browsers. This won't be an exhaustive study; just what you need to know at this stage.</p>
+<p>Events are actions or occurrences that happen in the system you are programming, which the system tells you about so you can respond to them in some way if desired. For example, if the user selects a button on a webpage, you might want to respond to that action by displaying an information box. In this article, we discuss some important concepts surrounding events, and look at how they work in browsers. This won't be an exhaustive study; just what you need to know at this stage.</p>
 
 <table class="learn-box">
  <tbody>

--- a/files/en-us/learn/javascript/building_blocks/functions/index.html
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.html
@@ -22,7 +22,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Looping_code","Learn/JavaScript/Building_blocks/Build_your_own_function", "Learn/JavaScript/Building_blocks")}}</div>
 
-<p class="summary">Another essential concept in coding is <strong>functions</strong>, which allow you to store a piece of code that does a single task inside a defined block, and then call that code whenever you need it using a single short command — rather than having to type out the same code multiple times. In this article we'll explore fundamental concepts behind functions such as basic syntax, how to invoke and define them, scope, and parameters.</p>
+<p>Another essential concept in coding is <strong>functions</strong>, which allow you to store a piece of code that does a single task inside a defined block, and then call that code whenever you need it using a single short command — rather than having to type out the same code multiple times. In this article we'll explore fundamental concepts behind functions such as basic syntax, how to invoke and define them, scope, and parameters.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/building_blocks/index.html
+++ b/files/en-us/learn/javascript/building_blocks/index.html
@@ -19,7 +19,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">In this module, we continue our coverage of all JavaScript's key fundamental features, turning our attention to commonly-encountered types of code blocks such as conditional statements, loops, functions, and events. You've seen this stuff already in the course, but only in passing — here we'll discuss it all explicitly.</p>
+<p>In this module, we continue our coverage of all JavaScript's key fundamental features, turning our attention to commonly-encountered types of code blocks such as conditional statements, loops, functions, and events. You've seen this stuff already in the course, but only in passing — here we'll discuss it all explicitly.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.html
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Building_blocks/conditionals","Learn/JavaScript/Building_blocks/Functions", "Learn/JavaScript/Building_blocks")}}</div>
 
-<p class="summary">Programming languages are very useful for rapidly completing repetitive tasks, from multiple basic calculations to just about any other situation where you've got a lot of similar items of work to complete. Here we'll look at the loop structures available in JavaScript that handle such needs.</p>
+<p>Programming languages are very useful for rapidly completing repetitive tasks, from multiple basic calculations to just about any other situation where you've got a lot of similar items of work to complete. Here we'll look at the loop structures available in JavaScript that handle such needs.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/building_blocks/return_values/index.html
+++ b/files/en-us/learn/javascript/building_blocks/return_values/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Build_your_own_function","Learn/JavaScript/Building_blocks/Events", "Learn/JavaScript/Building_blocks")}}</div>
 
-<p class="summary"><span class="seoSummary">There's one last essential concept about functions for us to discuss — return values. Some functions don't return a significant value, but others do. It's important to understand what their values are, how to use them in your code, and how to make functions return useful values. We'll cover all of these below.</span></p>
+<p><span class="seoSummary">There's one last essential concept about functions for us to discuss — return values. Some functions don't return a significant value, but others do. It's important to understand what their values are, how to use them in your code, and how to make functions return useful values. We'll cover all of these below.</span></p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">Modern web browsers support a number of ways for web sites to store data on the user's computer — with the user's permission — then retrieve it when necessary. This lets you persist data for long-term storage, save sites or documents for offline use, retain user-specific settings for your site, and more. This article explains the very basics of how these work.</p>
+<p>Modern web browsers support a number of ways for web sites to store data on the user's computer — with the user's permission — then retrieve it when necessary. This lets you persist data for long-term storage, save sites or documents for offline use, retain user-specific settings for your site, and more. This article explains the very basics of how these work.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Third_party_APIs", "Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">The browser contains some very powerful graphics programming tools, from the Scalable Vector Graphics (<a href="/en-US/docs/Web/SVG">SVG</a>) language, to APIs for drawing on HTML {{htmlelement("canvas")}} elements, (see <a href="/en-US/docs/Web/API/Canvas_API">The Canvas API</a> and <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a>). This article provides an introduction to canvas, and further resources to allow you to learn more.</p>
+<p>The browser contains some very powerful graphics programming tools, from the Scalable Vector Graphics (<a href="/en-US/docs/Web/SVG">SVG</a>) language, to APIs for drawing on HTML {{htmlelement("canvas")}} elements, (see <a href="/en-US/docs/Web/API/Canvas_API">The Canvas API</a> and <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a>). This article provides an introduction to canvas, and further resources to allow you to learn more.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/fetching_data/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/fetching_data/index.html
@@ -22,7 +22,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Manipulating_documents", "Learn/JavaScript/Client-side_web_APIs/Third_party_APIs", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">Another very common task in modern websites and applications is retrieving individual data items from the server to update sections of a webpage without having to load an entire new page. This seemingly small detail has had a huge impact on the performance and behavior of sites, so in this article, we'll explain the concept and look at technologies that make it possible, such as XMLHttpRequest and the Fetch API.</p>
+<p>Another very common task in modern websites and applications is retrieving individual data items from the server to update sections of a webpage without having to load an entire new page. This seemingly small detail has had a huge impact on the performance and behavior of sites, so in this article, we'll explain the concept and look at technologies that make it possible, such as XMLHttpRequest and the Fetch API.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/index.html
@@ -18,7 +18,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">When writing client-side JavaScript for web sites or applications, you will quickly encounter <strong>Application Programming Interfaces</strong> (<strong>APIs</strong>). APIs are programming features for manipulating different aspects of the browser and operating system the site is running on, or manipulating data from other web sites or services. In this module, we will explore what APIs are, and how to use some of the most common APIs you'll come across often in your development work. </p>
+<p>When writing client-side JavaScript for web sites or applications, you will quickly encounter <strong>Application Programming Interfaces</strong> (<strong>APIs</strong>). APIs are programming features for manipulating different aspects of the browser and operating system the site is running on, or manipulating data from other web sites or services. In this module, we will explore what APIs are, and how to use some of the most common APIs you'll come across often in your development work. </p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{NextMenu("Learn/JavaScript/Client-side_web_APIs/Manipulating_documents", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">First up, we'll start by looking at APIs from a high level — what are they, how do they work, how to use them in your code, and how are they structured? We'll also take a look at what the different main classes of APIs are, and what kind of uses they have.</p>
+<p>First up, we'll start by looking at APIs from a high level — what are they, how do they work, how to use them in your code, and how are they structured? We'll also take a look at what the different main classes of APIs are, and what kind of uses they have.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Introduction", "Learn/JavaScript/Client-side_web_APIs/Fetching_data", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">When writing web pages and apps, one of the most common things you'll want to do is manipulate the document structure in some way. This is usually done by using the Document Object Model (DOM), a set of APIs for controlling HTML and styling information that makes heavy use of the {{domxref("Document")}} object. In this article we'll look at how to use the DOM in detail, along with some other interesting APIs that can alter your environment in interesting ways.</p>
+<p>When writing web pages and apps, one of the most common things you'll want to do is manipulate the document structure in some way. This is usually done by using the Document Object Model (DOM), a set of APIs for controlling HTML and styling information that makes heavy use of the {{domxref("Document")}} object. In this article we'll look at how to use the DOM in detail, along with some other interesting APIs that can alter your environment in interesting ways.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Fetching_data", "Learn/JavaScript/Client-side_web_APIs/Drawing_graphics", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">The APIs we've covered so far are built into the browser, but not all APIs are. Many large websites and services such as Google Maps, Twitter, Facebook, PayPal, etc. provide APIs allowing developers to make use of their data (e.g. displaying your twitter stream on your blog) or services (e.g. using Facebook login to log in your users). This article looks at the difference between browser APIs and 3rd party APIs and shows some typical uses of the latter.</p>
+<p>The APIs we've covered so far are built into the browser, but not all APIs are. Many large websites and services such as Google Maps, Twitter, Facebook, PayPal, etc. provide APIs allowing developers to make use of their data (e.g. displaying your twitter stream on your blog) or services (e.g. using Facebook login to log in your users). This article looks at the difference between browser APIs and 3rd party APIs and shows some typical uses of the latter.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Drawing_graphics", "Learn/JavaScript/Client-side_web_APIs/Client-side_storage", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<p class="summary">HTML5 comes with elements for embedding rich media in documents — {{htmlelement("video")}} and {{htmlelement("audio")}} — which in turn come with their own APIs for controlling playback, seeking, etc. This article shows you how to do common tasks such as creating custom playback controls.</p>
+<p>HTML5 comes with elements for embedding rich media in documents — {{htmlelement("video")}} and {{htmlelement("audio")}} — which in turn come with their own APIs for controlling playback, seeking, etc. This article shows you how to do common tasks such as creating custom playback controls.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.html
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/What_is_JavaScript", "Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">Now you've learned something about the theory of JavaScript and what you can do with it, we are going to give you an idea of what the process of creating a simple JavaScript program is like, by guiding you through a practical tutorial. Here you'll build up a simple "Guess the number" game, step by step.</p>
+<p>Now you've learned something about the theory of JavaScript and what you can do with it, we are going to give you an idea of what the process of creating a simple JavaScript program is like, by guiding you through a practical tutorial. Here you'll build up a simple "Guess the number" game, step by step.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/arrays/index.html
+++ b/files/en-us/learn/javascript/first_steps/arrays/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/Useful_string_methods", "Learn/JavaScript/First_steps/Silly_story_generator", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">In the final article of this module, we'll look at arrays — a neat way of storing a list of data items under a single variable name. Here we look at why this is useful, then explore how to create an array, retrieve, add, and remove items stored in an array, and more besides.</p>
+<p>In the final article of this module, we'll look at arrays — a neat way of storing a list of data items under a single variable name. Here we look at why this is useful, then explore how to create an array, retrieve, add, and remove items stored in an array, and more besides.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/index.html
+++ b/files/en-us/learn/javascript/first_steps/index.html
@@ -20,7 +20,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">In our first JavaScript module, we first answer some fundamental questions such as "what is JavaScript?", "what does it look like?", and "what can it do?", before moving on to taking you through your first practical experience of writing JavaScript. After that, we discuss some key building blocks in detail, such as variables, strings, numbers and arrays.</p>
+<p>In our first JavaScript module, we first answer some fundamental questions such as "what is JavaScript?", "what does it look like?", and "what can it do?", before moving on to taking you through your first practical experience of writing JavaScript. After that, we discuss some key building blocks in detail, such as variables, strings, numbers and arrays.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/javascript/first_steps/math/index.html
+++ b/files/en-us/learn/javascript/first_steps/math/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">At this point in the course we discuss math in JavaScript — how we can use {{Glossary("Operator","operators")}} and other features to successfully manipulate numbers to do our bidding.</p>
+<p>At this point in the course we discuss math in JavaScript — how we can use {{Glossary("Operator","operators")}} and other features to successfully manipulate numbers to do our bidding.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/silly_story_generator/index.html
+++ b/files/en-us/learn/javascript/first_steps/silly_story_generator/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/JavaScript/First_steps/Arrays", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">In this assessment you'll be tasked with taking some of the knowledge you've picked up in this module's articles and applying it to creating a fun app that generates random silly stories. Have fun!</p>
+<p>In this assessment you'll be tasked with taking some of the knowledge you've picked up in this module's articles and applying it to creating a fun app that generates random silly stories. Have fun!</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/strings/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/Math", "Learn/JavaScript/First_steps/Useful_string_methods", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">Next, we'll turn our attention to strings — this is what pieces of text are called in programming. In this article, we'll look at all the common things that you really ought to know about strings when learning JavaScript, such as creating strings, escaping quotes in strings, and joining strings together.</p>
+<p>Next, we'll turn our attention to strings — this is what pieces of text are called in programming. In this article, we'll look at all the common things that you really ought to know about strings when learning JavaScript, such as creating strings, escaping quotes in strings, and joining strings together.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.html
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps/Arrays", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">Now that we've looked at the very basics of strings, let's move up a gear and start thinking about what useful operations we can do on strings with built-in methods, such as finding the length of a text string, joining and splitting strings, substituting one character in a string for another, and more.</p>
+<p>Now that we've looked at the very basics of strings, let's move up a gear and start thinking about what useful operations we can do on strings with built-in methods, such as finding the length of a text string, joining and splitting strings, substituting one character in a string for another, and more.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/variables/index.html
+++ b/files/en-us/learn/javascript/first_steps/variables/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps/Math", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">After reading the last couple of articles you should now know what JavaScript is, what it can do for you, how you use it alongside other web technologies, and what its main features look like from a high level. In this article, we will get down to the real basics, looking at how to work with the most basic building blocks of JavaScript — Variables.</p>
+<p>After reading the last couple of articles you should now know what JavaScript is, what it can do for you, how you use it alongside other web technologies, and what its main features look like from a high level. In this article, we will get down to the real basics, looking at how to work with the most basic building blocks of JavaScript — Variables.</p>
 
 <table class="learn-box">
  <tbody>

--- a/files/en-us/learn/javascript/first_steps/what_went_wrong/index.html
+++ b/files/en-us/learn/javascript/first_steps/what_went_wrong/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps")}}</div>
 
-<p class="summary">When you built up the "Guess the number" game in the previous article, you may have found that it didn't work. Never fear — this article aims to save you from tearing your hair out over such problems by providing you with some tips on how to find and fix errors in JavaScript programs.</p>
+<p>When you built up the "Guess the number" game in the previous article, you may have found that it didn't work. Never fear — this article aims to save you from tearing your hair out over such problems by providing you with some tips on how to find and fix errors in JavaScript programs.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/howto/index.html
+++ b/files/en-us/learn/javascript/howto/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">The following links point to solutions to common problems you may encounter when writing JavaScript.</p>
+<p>The following links point to solutions to common problems you may encounter when writing JavaScript.</p>
 
 <h2 id="Common_beginners_mistakes">Common beginner's mistakes</h2>
 

--- a/files/en-us/learn/javascript/index.html
+++ b/files/en-us/learn/javascript/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">{{Glossary("JavaScript")}} is a programming language that allows you to implement complex things on web pages. Every time a web page does more than just sit there and display static information for you to look at—displaying timely content updates, interactive maps, animated 2D/3D graphics, scrolling video jukeboxes, or more—you can bet that JavaScript is probably involved.</p>
+<p>{{Glossary("JavaScript")}} is a programming language that allows you to implement complex things on web pages. Every time a web page does more than just sit there and display static information for you to look at—displaying timely content updates, interactive maps, animated 2D/3D graphics, scrolling video jukeboxes, or more—you can bet that JavaScript is probably involved.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.html
+++ b/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Objects/Object_building_practice", "", "Learn/JavaScript/Objects")}}</div>
 
-<p class="summary">In this assessment, you are expected to use the bouncing balls demo from the previous article as a starting point, and add some new and interesting features to it.</p>
+<p>In this assessment, you are expected to use the bouncing balls demo from the previous article as a starting point, and add some new and interesting features to it.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/javascript/objects/basics/index.html
+++ b/files/en-us/learn/javascript/objects/basics/index.html
@@ -22,7 +22,7 @@ tags:
 
 <div>{{NextMenu("Learn/JavaScript/Objects/Object-oriented_JS", "Learn/JavaScript/Objects")}}</div>
 
-<p class="summary">In this article, we'll look at fundamental JavaScript object syntax, and revisit some JavaScript features that we've already seen earlier in the course, reiterating the fact that many of the features you've already dealt with are objects.</p>
+<p>In this article, we'll look at fundamental JavaScript object syntax, and revisit some JavaScript features that we've already seen earlier in the course, reiterating the fact that many of the features you've already dealt with are objects.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/objects/index.html
+++ b/files/en-us/learn/javascript/objects/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">In JavaScript, most things are objects, from core JavaScript features like arrays to the browser {{Glossary("API", "APIs")}} built on top of JavaScript. You can even create your own objects to encapsulate related functions and variables into efficient packages and act as handy data containers. The object-based nature of JavaScript is important to understand if you want to go further with your knowledge of the language, therefore we've provided this module to help you. Here we teach object theory and syntax in detail, then look at how to create your own objects.</p>
+<p>In JavaScript, most things are objects, from core JavaScript features like arrays to the browser {{Glossary("API", "APIs")}} built on top of JavaScript. You can even create your own objects to encapsulate related functions and variables into efficient packages and act as handy data containers. The object-based nature of JavaScript is important to understand if you want to go further with your knowledge of the language, therefore we've provided this module to help you. Here we teach object theory and syntax in detail, then look at how to create your own objects.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/javascript/objects/inheritance/index.html
+++ b/files/en-us/learn/javascript/objects/inheritance/index.html
@@ -24,7 +24,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects")}}</div>
 
-<p class="summary">With most of the gory details of OOJS now explained, this article shows how to create "child" object classes (constructors) that inherit features from their "parent" classes. In addition, we present some advice on when and where you might use OOJS, and look at how classes are dealt with in modern ECMAScript syntax.</p>
+<p>With most of the gory details of OOJS now explained, this article shows how to create "child" object classes (constructors) that inherit features from their "parent" classes. In addition, we present some advice on when and where you might use OOJS, and look at how classes are dealt with in modern ECMAScript syntax.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/javascript/objects/json/index.html
+++ b/files/en-us/learn/javascript/objects/json/index.html
@@ -21,7 +21,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Objects/Inheritance", "Learn/JavaScript/Objects/Object_building_practice", "Learn/JavaScript/Objects")}}</div>
 
-<p class="summary">JavaScript Object Notation (JSON) is a standard text-based format for representing structured data based on JavaScript object syntax. It is commonly used for transmitting data in web applications (e.g., sending some data from the server to the client, so it can be displayed on a web page, or vice versa). You'll come across it quite often, so in this article we give you all you need to work with JSON using JavaScript, including parsing JSON so you can access data within it, and creating JSON.</p>
+<p>JavaScript Object Notation (JSON) is a standard text-based format for representing structured data based on JavaScript object syntax. It is commonly used for transmitting data in web applications (e.g., sending some data from the server to the client, so it can be displayed on a web page, or vice versa). You'll come across it quite often, so in this article we give you all you need to work with JSON using JavaScript, including parsing JSON so you can access data within it, and creating JSON.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/objects/object-oriented_js/index.html
+++ b/files/en-us/learn/javascript/objects/object-oriented_js/index.html
@@ -20,7 +20,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Objects/Basics", "Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}</div>
 
-<p class="summary">With the basics out of the way, we'll now focus on object-oriented JavaScript (OOJS) — this article presents a basic view of object-oriented programming (OOP) theory, then explores how JavaScript emulates object classes via constructor functions, and how to create object instances.</p>
+<p>With the basics out of the way, we'll now focus on object-oriented JavaScript (OOJS) — this article presents a basic view of object-oriented programming (OOP) theory, then explores how JavaScript emulates object classes via constructor functions, and how to create object instances.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/javascript/objects/object_building_practice/index.html
+++ b/files/en-us/learn/javascript/objects/object_building_practice/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects/Adding_bouncing_balls_features", "Learn/JavaScript/Objects")}}</div>
 
-<p class="summary">In previous articles we looked at all the essential JavaScript object theory and syntax details, giving you a solid base to start from. In this article we dive into a practical exercise, giving you some more practice in building custom JavaScript objects, with a fun and colorful result.</p>
+<p>In previous articles we looked at all the essential JavaScript object theory and syntax details, giving you a solid base to start from. In this article we dive into a practical exercise, giving you some more practice in building custom JavaScript objects, with a fun and colorful result.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/performance/index.html
+++ b/files/en-us/learn/performance/index.html
@@ -12,9 +12,9 @@ tags:
 ---
 <p>{{LearnSidebar}}</p>
 
-<p class="summary">Building websites requires HTML, CSS, and JavaScript. To build websites and applications people want to use, which attract and retain users, you need to create a good user experience. Part of good user experience is ensuring the content is quick to load and responsive to user interaction. This is known as <strong>web performance</strong>, and in this module you'll focus on the fundamentals of how to create performant websites.</p>
+<p>Building websites requires HTML, CSS, and JavaScript. To build websites and applications people want to use, which attract and retain users, you need to create a good user experience. Part of good user experience is ensuring the content is quick to load and responsive to user interaction. This is known as <strong>web performance</strong>, and in this module you'll focus on the fundamentals of how to create performant websites.</p>
 
-<p class="summary">The rest of our beginner's learning material tried to stick to web best practices such as performance and <a href="/en-US/docs/Learn/Accessibility">accessibility</a> as much as possible, however, it is good to focus specifically on such topics too, and make sure you are familiar with them.</p>
+<p>The rest of our beginner's learning material tried to stick to web best practices such as performance and <a href="/en-US/docs/Learn/Accessibility">accessibility</a> as much as possible, however, it is good to focus specifically on such topics too, and make sure you are familiar with them.</p>
 
 <h2 id="Learning_pathway">Learning pathway</h2>
 

--- a/files/en-us/learn/performance/why_web_performance/index.html
+++ b/files/en-us/learn/performance/why_web_performance/index.html
@@ -33,7 +33,7 @@ tags:
 
 <h2 id="Why_care_about_performance">Why care about performance?</h2>
 
-<p class="summary">Web performance — and its associated best practices—are vital for your website visitors to have a good experience. In a sense, web performance can be considered a subset of <a href="/en-US/docs/Learn/Accessibility">web accessibility</a>. With performance as with accessibility, you consider what device a site visitor is using to access the site and the device connection speed.</p>
+<p>Web performance — and its associated best practices—are vital for your website visitors to have a good experience. In a sense, web performance can be considered a subset of <a href="/en-US/docs/Learn/Accessibility">web accessibility</a>. With performance as with accessibility, you consider what device a site visitor is using to access the site and the device connection speed.</p>
 
 <p>As an example, consider the loading experience of CNN.com, which at the time of this writing had over 400 HTTP requests with a file size of over 22.6MB.</p>
 

--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -14,9 +14,9 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Server-side/First_steps/Introduction", "Learn/Server-side/First_steps/Web_frameworks", "Learn/Server-side/First_steps")}}</div>
 
-<p class="summary">Now that you know the purpose and potential benefits of server-side programming we're going to examine in detail what happens when a server receives a "dynamic request" from a browser. As most website server-side code handles requests and responses in similar ways, this will help you understand what you need to do when writing most of your own code.</p>
+<p>Now that you know the purpose and potential benefits of server-side programming we're going to examine in detail what happens when a server receives a "dynamic request" from a browser. As most website server-side code handles requests and responses in similar ways, this will help you understand what you need to do when writing most of your own code.</p>
 
-<p class="summary"></p>
+<p></p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -16,8 +16,6 @@ tags:
 
 <p>Now that you know the purpose and potential benefits of server-side programming we're going to examine in detail what happens when a server receives a "dynamic request" from a browser. As most website server-side code handles requests and responses in similar ways, this will help you understand what you need to do when writing most of your own code.</p>
 
-<p></p>
-
 <table>
  <tbody>
   <tr>

--- a/files/en-us/learn/server-side/first_steps/introduction/index.html
+++ b/files/en-us/learn/server-side/first_steps/introduction/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{NextMenu("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps")}}</div>
 
-<p class="summary"><span class="seoSummary">Welcome to the MDN beginner's server-side programming course! In this first article, we look at server-side programming from a high level, answering questions such as "what is it?", "how does it differ from client-side programming?", and "why it is so useful?". After reading this article you'll understand the additional power available to websites through server-side coding.</span></p>
+<p><span class="seoSummary">Welcome to the MDN beginner's server-side programming course! In this first article, we look at server-side programming from a high level, answering questions such as "what is it?", "how does it differ from client-side programming?", and "why it is so useful?". After reading this article you'll understand the additional power available to websites through server-side coding.</span></p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/server-side/first_steps/web_frameworks/index.html
+++ b/files/en-us/learn/server-side/first_steps/web_frameworks/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps/Website_security", "Learn/Server-side/First_steps")}}</div>
 
-<p class="summary">The previous article showed you what the communication between web clients and servers looks like, the nature of HTTP requests and responses, and what a server-side web application needs to do in order to respond to requests from a web browser. With this knowledge under our belt, it's time to explore how web frameworks can simplify these tasks, and give you an idea of how you'd choose a framework for your first server-side web application.</p>
+<p>The previous article showed you what the communication between web clients and servers looks like, the nature of HTTP requests and responses, and what a server-side web application needs to do in order to respond to requests from a web browser. With this knowledge under our belt, it's time to explore how web frameworks can simplify these tasks, and give you an idea of how you'd choose a framework for your first server-side web application.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/server-side/first_steps/website_security/index.html
+++ b/files/en-us/learn/server-side/first_steps/website_security/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/Server-side/First_steps/Web_frameworks", "Learn/Server-side/First_steps")}}</div>
 
-<p class="summary">Website security requires vigilance in all aspects of website design and usage. This introductory article won't make you a website security guru, but it will help you understand where threats come from, and what you can do to harden your web application against the most common attacks.</p>
+<p>Website security requires vigilance in all aspects of website design and usage. This introductory article won't make you a website security guru, but it will help you understand where threats come from, and what you can do to harden your web application against the most common attacks.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/server-side/index.html
+++ b/files/en-us/learn/server-side/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">The <strong><em>Dynamic Websites </em></strong>–<em><strong> Server-side programming</strong></em> topic is a series of modules that show how to create dynamic websites; websites that deliver customised information in response to HTTP requests. The modules provide a general introduction to server-side programming, along with specific beginner-level guides on how to use the Django (Python) and Express (Node.js/JavaScript) web frameworks to create basic applications.</p>
+<p>The <strong><em>Dynamic Websites </em></strong>–<em><strong> Server-side programming</strong></em> topic is a series of modules that show how to create dynamic websites; websites that deliver customised information in response to HTTP requests. The modules provide a general introduction to server-side programming, along with specific beginner-level guides on how to use the Django (Python) and Express (Node.js/JavaScript) web frameworks to create basic applications.</p>
 
 <p>Most major websites use some kind of server-side technology to dynamically display data as required. For example, imagine how many products are available on Amazon, and imagine how many posts have been written on Facebook. Displaying all of these using different static pages would be extremely inefficient, so instead such sites display static templates (built using <a href="/en-US/docs/Learn/HTML">HTML</a>, <a href="/en-US/docs/Learn/CSS">CSS</a>, and <a href="/en-US/docs/Learn/JavaScript">JavaScript</a>), and then dynamically update the data displayed inside those templates when needed, such as when you want to view a different product on Amazon.</p>
 

--- a/files/en-us/learn/server-side/node_server_without_framework/index.html
+++ b/files/en-us/learn/server-side/node_server_without_framework/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This article provides a simple static file server built with pure Node.js without the use of a framework.</p>
+<p>This article provides a simple static file server built with pure Node.js without the use of a framework.</p>
 
 <p><a href="https://nodejs.org/en/">Node.js</a> has many frameworks to help you get your server up and running.</p>
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_deployment_next","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">It is now time to look at Google's Angular framework, another popular option that you'll come across often. In this article we look at what Angular has to offer, install the prerequisites and set up a sample app, and look at Angular's basic architecture.</p>
+<p>It is now time to look at Google's Angular framework, another popular option that you'll come across often. In this article we look at what Angular has to offer, install the prerequisites and set up a sample app, and look at Angular's basic architecture.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_conditional_footer/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_conditional_footer/index.html
@@ -14,7 +14,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_interactivity_events_state","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_routing", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Now it's time to start tackling the footer functionality in our app. Here we'll get the todo counter to update to show the correct number of todos still to complete, and correctly apply styling to completed todos (i.e. where the checkbox has been checked). We'll also wire up our "Clear completed" button. Along the way, we'll learn about using conditional rendering in our templates.</p>
+<p>Now it's time to start tackling the footer functionality in our app. Here we'll get the todo counter to update to show the correct number of todos still to complete, and correctly apply styling to completed todos (i.e. where the checkbox has been checked). We'll also wire up our "Clear completed" button. Along the way, we'll learn about using conditional rendering in our templates.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_getting_started/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_resources","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_structure_componentization", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In our first Ember article we will look at how Ember works and what it's useful for, install the Ember toolchain locally, create a sample app, and then do some initial setup to get it ready for development.</p>
+<p>In our first Ember article we will look at how Ember works and what it's useful for, install the Ember toolchain locally, create a sample app, and then do some initial setup to get it ready for development.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.html
@@ -17,7 +17,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_structure_componentization","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_conditional_footer", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">At this point we'll start adding some interactivity to our app, providing the ability to add and display new todo items. Along the way, we'll look at using events in Ember, creating component classes to contain JavaScript code to control interactive features, and setting up a service to keep track of the data state of our app.</p>
+<p>At this point we'll start adding some interactivity to our app, providing the ability to add and display new todo items. Along the way, we'll look at using events in Ember, creating component classes to contain JavaScript code to control interactive features, and setting up a service to keep track of the data state of our app.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_resources/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_resources/index.html
@@ -13,7 +13,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_routing","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Our final Ember article provides you with a list of resources that you can use to go further in your learning, plus some useful troubleshooting and other information.</p>
+<p>Our final Ember article provides you with a list of resources that you can use to go further in your learning, plus some useful troubleshooting and other information.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_routing/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_routing/index.html
@@ -13,7 +13,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_conditional_footer","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_resources", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In this article we learn about <strong>routing</strong>, or URL-based filtering as it is sometimes referred to. We'll use it to provide a unique URL for each of the three todo views — "All", "Active", and "Completed".</p>
+<p>In this article we learn about <strong>routing</strong>, or URL-based filtering as it is sometimes referred to. We'll use it to provide a unique URL for each of the three todo views — "All", "Active", and "Completed".</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_structure_componentization/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_structure_componentization/index.html
@@ -14,7 +14,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_getting_started","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_interactivity_events_state", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In this article we'll get right on with planning out the structure of our TodoMVC Ember app, adding in the HTML for it, and then breaking that HTML structure into components.</p>
+<p>In this article we'll get right on with planning out the structure of our TodoMVC Ember app, adding in the HTML for it, and then breaking that HTML structure into components.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.html
@@ -12,7 +12,7 @@ tags:
 
 <div>{{NextMenu("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Main_features", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">We begin our look at frameworks with a general overview of the area, looking at a brief history of JavaScript and frameworks, why frameworks exist and what they give us, how to start thinking about choosing a framework to learn, and what alternatives there are to client-side frameworks.</p>
+<p>We begin our look at frameworks with a general overview of the area, looking at a brief history of JavaScript and frameworks, why frameworks exist and what they give us, how to start thinking about choosing a framework to learn, and what alternatives there are to client-side frameworks.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/main_features/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/main_features/index.html
@@ -13,7 +13,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Each major JavaScript framework has a different approach to updating the DOM, handling browser events, and providing an enjoyable developer experience. This article will explore the main features of “the big 4” frameworks, looking at how frameworks tend to work from a high level, and the differences between them.</p>
+<p>Each major JavaScript framework has a different approach to updating the DOM, handling browser events, and providing an enjoyable developer experience. This article will explore the main features of “the big 4” frameworks, looking at how frameworks tend to work from a high level, and the differences between them.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_accessibility/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_accessibility/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_interactivity_filtering_conditional_rendering","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_resources", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In our final tutorial article, we'll focus on (pun intended) accessibility, including focus management in React, which can improve usability and reduce confusion for both keyboard-only and screenreader users.</p>
+<p>In our final tutorial article, we'll focus on (pun intended) accessibility, including focus management in React, which can improve usability and reduce confusion for both keyboard-only and screenreader users.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_interactivity_events_state", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">At this point, our app is a monolith. Before we can make it do things, we need to break it apart into manageable, descriptive components. React doesn’t have any hard rules for what is and isn’t a component – that’s up to you! In this article we will show you a sensible way to break our app up into components.</p>
+<p>At this point, our app is a monolith. Before we can make it do things, we need to break it apart into manageable, descriptive components. React doesn’t have any hard rules for what is and isn’t a component – that’s up to you! In this article we will show you a sensible way to break our app up into components.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Main_features","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In this article we will say hello to React. We'll discover a little bit of detail about its background and use cases, set up a basic React toolchain on our local computer, and create and play with a simple starter app — learning a bit about how React works in the process.</p>
+<p>In this article we will say hello to React. We'll discover a little bit of detail about its background and use cases, set up a basic React toolchain on our local computer, and create and play with a simple starter app — learning a bit about how React works in the process.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_events_state/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_events_state/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_components","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_interactivity_filtering_conditional_rendering", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">With our component plan worked out, it's now time to start updating our app from a completely static UI to one that actually allows us to interact and change things. In this article we'll do this, digging into events and state along the way, and ending up with an app in which we can successfully add and delete tasks, and toggle tasks as completed.</p>
+<p>With our component plan worked out, it's now time to start updating our app from a completely static UI to one that actually allows us to interact and change things. In this article we'll do this, digging into events and state along the way, and ending up with an app in which we can successfully add and delete tasks, and toggle tasks as completed.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_filtering_conditional_rendering/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_filtering_conditional_rendering/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_interactivity_events_state","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_accessibility", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">As we near the end of our React journey (for now at least), we'll add the finishing touches to the main areas of functionality in our Todo list app. This includes allowing you to edit existing tasks, and filtering the list of tasks between all, completed, and incomplete tasks. We'll look at conditional UI rendering along the way.</p>
+<p>As we near the end of our React journey (for now at least), we'll add the finishing touches to the main areas of functionality in our Todo list app. This includes allowing you to edit existing tasks, and filtering the list of tasks between all, completed, and incomplete tasks. We'll look at conditional UI rendering along the way.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_resources/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_resources/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_accessibility","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Our final article provides you with a list of React resources that you can use to go further in your learning.</p>
+<p>Our final article provides you with a list of React resources that you can use to go further in your learning.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_components/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_components/index.html
@@ -15,7 +15,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_variables_props","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_reactivity_lifecycle_accessibility", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In the last article we started developing our Todo list app. The central objective of this article is to look at how to break our app into manageable components and share information between them. We'll componentize our app, then add more functionality to allow users to update existing components.</p>
+<p>In the last article we started developing our Todo list app. The central objective of this article is to look at how to break our app into manageable components and share information between them. We'll componentize our app, then add more functionality to allow users to update existing components.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.html
@@ -13,7 +13,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_resources","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In this article we'll provide a quick introduction to the <a href="https://svelte.dev/">Svelte framework</a>. We will see how Svelte works and what sets it apart from the rest of the frameworks and tools we've seen so far. Then we will learn how to setup our development environment, create a sample app, understand the structure of the project, and see how to run it locally and build it for production.</p>
+<p>In this article we'll provide a quick introduction to the <a href="https://svelte.dev/">Svelte framework</a>. We will see how Svelte works and what sets it apart from the rest of the frameworks and tools we've seen so far. Then we will learn how to setup our development environment, create a sample app, understand the structure of the project, and see how to run it locally and build it for production.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.html
@@ -17,7 +17,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_components","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_stores", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In the last article we added more features to our To-Do list and started to organize our app into components. In this article we will add the app's final features and further componentize our app. We will learn how to deal with reactivity issues related to updating objects and arrays. To avoid common pitfalls, we'll have to dig a little deeper into Svelte's reactivity system. We'll also look at solving some accessibility focus issues, and more besides.</p>
+<p>In the last article we added more features to our To-Do list and started to organize our app into components. In this article we will add the app's final features and further componentize our app. We will learn how to deal with reactivity issues related to updating objects and arrays. To avoid common pitfalls, we'll have to dig a little deeper into Svelte's reactivity system. We'll also look at solving some accessibility focus issues, and more besides.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.html
@@ -15,9 +15,9 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_variables_props", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Now that we have a basic understanding of how things work in Svelte, we can start building our example app: a todo list. In this article we will first have a look at the desired functionality of our app, then we'll create a <code>Todos.svelte</code> component and put static markup and styles in place, leaving everything ready to start developing our To-Do list app features, which we'll go on to in subsequent articles.</p>
+<p>Now that we have a basic understanding of how things work in Svelte, we can start building our example app: a todo list. In this article we will first have a look at the desired functionality of our app, then we'll create a <code>Todos.svelte</code> component and put static markup and styles in place, leaving everything ready to start developing our To-Do list app features, which we'll go on to in subsequent articles.</p>
 
-<p class="summary">We want our users to be able to browse, add and delete tasks, and also to mark them as complete. This will be the basic functionality that we'll be developing in this tutorial series, plus we'll look at some more advanced concepts along the way too.</p>
+<p>We want our users to be able to browse, add and delete tasks, and also to mark them as complete. This will be the basic functionality that we'll be developing in this tutorial series, plus we'll look at some more advanced concepts along the way too.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
@@ -13,9 +13,9 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_stores","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_deployment_next", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In the last article we learned about Svelte stores and even implemented our own custom store to persist the app's information to Web Storage. We also had a look at using the transition directive to implement animations on DOM elements in Svelte.</p>
+<p>In the last article we learned about Svelte stores and even implemented our own custom store to persist the app's information to Web Storage. We also had a look at using the transition directive to implement animations on DOM elements in Svelte.</p>
 
-<p class="summary">We will now learn how to use TypeScript in Svelte applications. First we'll learn what TypeScript is and what benefits it can bring us. Then we'll see how to configure our project to work with TypeScript files. Finally we will go over our app and see what modifications we have to make to fully take advantage of TypeScript features.</p>
+<p>We will now learn how to use TypeScript in Svelte applications. First we'll learn what TypeScript is and what benefits it can bring us. Then we'll see how to configure our project to work with TypeScript files. Finally we will go over our app and see what modifications we have to make to fully take advantage of TypeScript features.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.html
@@ -15,7 +15,7 @@ tags:
 <div>{{LearnSidebar}}<br>
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_Todo_list_beginning","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_components", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Now that we have our markup and styles ready we can start developing the required features for our Svelte To-Do list app. In this article we'll be using variables and props to make our app dynamic, allowing us to add and delete todos, mark them as complete, and filter them by status.</p>
+<p>Now that we have our markup and styles ready we can start developing the required features for our Svelte To-Do list app. In this article we'll be using variables and props to make our app dynamic, allowing us to add and delete todos, mark them as complete, and filter them by status.</p>
 
 <table>
 	<tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_styling","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">In this article we'll add a counter that displays the number of completed todo items, using a feature of Vue called computed properties. These work similarly to methods, but only re-run when one of their dependencies changes.</p>
+<p>In this article we'll add a counter that displays the number of completed todo items, using a feature of Vue called computed properties. These work similarly to methods, but only re-run when one of their dependencies changes.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_conditional_rendering/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_conditional_rendering/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_properties","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_refs_focus_management", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Now it is time to add one of the major parts of functionality that we're still missing — the ability to edit existing todo items. To do this, we will take advantage of Vue's conditional rendering capabilities — namely <code>v-if</code> and <code>v-else</code> — to allow us to toggle between the existing todo item view, and an edit view where you can update todo item labels. We'll also look at adding functionality to delete todo items.</p>
+<p>Now it is time to add one of the major parts of functionality that we're still missing — the ability to edit existing todo items. To do this, we will take advantage of Vue's conditional rendering capabilities — namely <code>v-if</code> and <code>v-else</code> — to allow us to toggle between the existing todo item view, and an edit view where you can update todo item labels. We'll also look at adding functionality to delete todo items.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_methods_events_models/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_methods_events_models/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_rendering_lists","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_styling", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">We now have sample data in place, and a loop that takes each bit of data and renders it inside a <code>ToDoItem</code> in our app. What we really need next is the ability to allow our users to enter their own todo items into the app, and for that we'll need a text <code>&lt;input&gt;</code>, an event to fire when the data is submitted, a method to fire upon submission to add the data and rerender the list, and a model to control the data. This is what we'll cover in this article.</p>
+<p>We now have sample data in place, and a loop that takes each bit of data and renders it inside a <code>ToDoItem</code> in our app. What we really need next is the ability to allow our users to enter their own todo items into the app, and for that we'll need a text <code>&lt;input&gt;</code>, an event to fire when the data is submitted, a method to fire upon submission to add the data and rerender the list, and a model to control the data. This is what we'll cover in this article.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_refs_focus_management/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_refs_focus_management/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_resources", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">We are nearly done with Vue. The last bit of functionality to look at is focus management, or put another way, how we can improve our app's keyboard accessibility. We'll look at using <strong>Vue refs</strong> to handle this — an advanced feature that allows you to have direct access to the underlying DOM nodes below the virtual DOM, or direct access from one component to the internal DOM structure of a child component.</p>
+<p>We are nearly done with Vue. The last bit of functionality to look at is focus management, or put another way, how we can improve our app's keyboard accessibility. We'll look at using <strong>Vue refs</strong> to handle this — an advanced feature that allows you to have direct access to the underlying DOM nodes below the virtual DOM, or direct access from one component to the internal DOM structure of a child component.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_rendering_lists/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_rendering_lists/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_first_component","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_methods_events_models", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">At this point we've got a fully working component; we're now ready to add multiple <code>ToDoItem</code> components to our App. In this article we'll look at adding a set of todo item data to our <code>App.vue</code> component, which we'll then loop through and display inside <code>ToDoItem</code> components using the <code>v-for</code> directive.</p>
+<p>At this point we've got a fully working component; we're now ready to add multiple <code>ToDoItem</code> components to our App. In this article we'll look at adding a set of todo item data to our <code>App.vue</code> component, which we'll then loop through and display inside <code>ToDoItem</code> components using the <code>v-for</code> directive.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_resources/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_resources/index.html
@@ -10,7 +10,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">Now we'll round off our study of Vue by giving you a list of resources that you can use to go further in your learning, plus some other useful tips.</p>
+<p>Now we'll round off our study of Vue by giving you a list of resources that you can use to go further in your learning, plus some other useful tips.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_methods_events_models","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_properties", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</div>
 
-<p class="summary">The time has finally come to make our app look a bit nicer. In this article we'll explore the different ways of styling Vue components with CSS.</p>
+<p>The time has finally come to make our app look a bit nicer. In this article we'll explore the different ways of styling Vue components with CSS.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Feature_detection", "Learn/Tools_and_testing/Cross_browser_testing/Your_own_automation_environment", "Learn/Tools_and_testing/Cross_browser_testing")}}</div>
 
-<p class="summary">Manually running tests on several browsers and devices, several times per day, can get tedious, and time-consuming. To handle this efficiently, you should become familiar with automation tools. In this article, we look at what is available, how to use task runners, and how to use the basics of commercial browser test automation apps such as LambdaTest, Sauce Labs, BrowserStack, and TestingBot.</p>
+<p>Manually running tests on several browsers and devices, several times per day, can get tedious, and time-consuming. To handle this efficiently, you should become familiar with automation tools. In this article, we look at what is available, how to use task runners, and how to use the basics of commercial browser test automation apps such as LambdaTest, Sauce Labs, BrowserStack, and TestingBot.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Accessibility","Learn/Tools_and_testing/Cross_browser_testing/Automated_testing", "Learn/Tools_and_testing/Cross_browser_testing")}}</div>
 
-<p class="summary">Feature detection involves working out whether a browser supports a certain block of code, and running different code depending on whether it does (or doesn't), so that the browser can always provide a working experience rather than crashing/erroring in some browsers. This article details how to write your own simple feature detection, how to use a library to speed up implementation, and native features for feature detection such as <code>@supports</code>.</p>
+<p>Feature detection involves working out whether a browser supports a certain block of code, and running different code depending on whether it does (or doesn't), so that the browser can always provide a working experience rather than crashing/erroring in some browsers. This article details how to write your own simple feature detection, how to use a library to speed up implementation, and native features for feature detection such as <code>@supports</code>.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/index.html
@@ -18,7 +18,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">This module focuses on testing web projects across different browsers. We look at identifying your target audience (e.g. what users, browsers, and devices do you most need to worry about?), how to go about doing testing, the main issues that you'll face with different types of code and how to mitigate them, what tools are most useful in helping you test and fix problems, and how to use automation to speed up testing.</p>
+<p>This module focuses on testing web projects across different browsers. We look at identifying your target audience (e.g. what users, browsers, and devices do you most need to worry about?), how to go about doing testing, the main issues that you'll face with different types of code and how to mitigate them, what tools are most useful in helping you test and fix problems, and how to use automation to speed up testing.</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">Looking to become a front-end web

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/introduction/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/introduction/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{NextMenu("Learn/Tools_and_testing/Cross_browser_testing/Testing_strategies", "Learn/Tools_and_testing/Cross_browser_testing")}}</div>
 
-<p class="summary">This article starts the module off by providing an overview of the topic of (cross) browser testing, answering questions such as "what is cross browser testing?", "what are the most common types of problems you'll encounter?", and "what are the main approaches for testing, identifying, and fixing problems?"</p>
+<p>This article starts the module off by providing an overview of the topic of (cross) browser testing, answering questions such as "what is cross browser testing?", "what are the most common types of problems you'll encounter?", and "what are the main approaches for testing, identifying, and fixing problems?"</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/testing_strategies/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/testing_strategies/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Introduction","Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS", "Learn/Tools_and_testing/Cross_browser_testing")}}</div>
 
-<p class="summary">In this article we drill down into carrying out testing, looking at identifying a target audience (e.g. what browsers, devices, and other segments should you make sure are tested), lo-fi testing strategies (get yourself a range of devices and some virtual machines and do ad-hoc tests when needed), higher tech strategies (automation, using dedicated testing apps), and testing with user groups.</p>
+<p>In this article we drill down into carrying out testing, looking at identifying a target audience (e.g. what browsers, devices, and other segments should you make sure are tested), lo-fi testing strategies (get yourself a range of devices and some virtual machines and do ad-hoc tests when needed), higher tech strategies (automation, using dedicated testing apps), and testing with user groups.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.html
@@ -18,7 +18,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/Tools_and_testing/Cross_browser_testing/Automated_testing", "Learn/Tools_and_testing/Cross_browser_testing")}}</div>
 
-<p class="summary">In this article, we will teach you how to install your own automation environment and run your own tests using Selenium/WebDriver and a testing library such as selenium-webdriver for Node. We will also look at how to integrate your local testing environment with commercial tools like the ones discussed in the previous article.</p>
+<p>In this article, we will teach you how to install your own automation environment and run your own tests using Selenium/WebDriver and a testing library such as selenium-webdriver for Node. We will also look at how to integrate your local testing environment with commercial tools like the ones discussed in the previous article.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/github/index.html
+++ b/files/en-us/learn/tools_and_testing/github/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">All developers will use some kind of <strong>version control system</strong> (<strong>VCS</strong>), a tool to allow them to collaborate with other developers on a project without the danger of them overwriting each other's work, and roll back to previous versions of the code base if a problem is discovered later on. The most popular VCS (at least among web developers) is <strong>Git</strong>, along with <strong>GitHub</strong>, a site that provides hosting for your repositories and several tools for working with them. This module aims to teach you what you need to know about both of them.</p>
+<p>All developers will use some kind of <strong>version control system</strong> (<strong>VCS</strong>), a tool to allow them to collaborate with other developers on a project without the danger of them overwriting each other's work, and roll back to previous versions of the code base if a problem is discovered later on. The most popular VCS (at least among web developers) is <strong>Git</strong>, along with <strong>GitHub</strong>, a site that provides hosting for your repositories and several tools for working with them. This module aims to teach you what you need to know about both of them.</p>
 
 <h2 id="Overview">Overview</h2>
 

--- a/files/en-us/learn/tools_and_testing/index.html
+++ b/files/en-us/learn/tools_and_testing/index.html
@@ -19,7 +19,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">Once you've started to become comfortable programming with core web technologies (like HTML, CSS, and JavaScript), and you start to get more experience, read more resources, and learn more tips and tricks, you'll start to come across all kind of tools, from JavaScript frameworks, to testing and automation tools, and more besides. As your web projects become larger and more complex, you'll want to start taking advantage of some of these tools, working out a reliable toolchain to give your development process superpowers.</p>
+<p>Once you've started to become comfortable programming with core web technologies (like HTML, CSS, and JavaScript), and you start to get more experience, read more resources, and learn more tips and tricks, you'll start to come across all kind of tools, from JavaScript frameworks, to testing and automation tools, and more besides. As your web projects become larger and more complex, you'll want to start taking advantage of some of these tools, working out a reliable toolchain to give your development process superpowers.</p>
 
 <p>On top of that, we still need to keep cross-browser support in the forefront of our minds, and make sure that our code follows best practices that allow our projects to work across different browsers and devices that our users are using to browse the Web, and be usable by people with disabilities.</p>
 

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Understanding_client-side_tools/Overview","Learn/Tools_and_testing/Understanding_client-side_tools/Package_management", "Learn/Tools_and_testing/Understanding_client-side_tools")}}</div>
 
-<p class="summary">In your development process you'll undoubtedly be required to run some command in the terminal (or on the "command line" — these are effectively the same thing). This article provides an introduction to the terminal, the essential commands you'll need to enter into it, how to chain commands together, and how to add your own command line interface (CLI) tools.</p>
+<p>In your development process you'll undoubtedly be required to run some command in the terminal (or on the "command line" — these are effectively the same thing). This article provides an introduction to the terminal, the essential commands you'll need to enter into it, how to chain commands together, and how to add your own command line interface (CLI) tools.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/deployment/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/deployment/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenu("Learn/Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain", "Learn/Tools_and_testing/Understanding_client-side_tools")}}</div>
 
-<p class="summary">In the final article in our series, we take the example toolchain we built up in the previous article and add to it so that we can deploy our sample app. We push the code to GitHub, deploy it using Netlify, and even show you how to add a simple test into the process.</p>
+<p>In the final article in our series, we take the example toolchain we built up in the previous article and add to it so that we can deploy our sample app. We push the code to GitHub, deploy it using Netlify, and even show you how to add a simple test into the process.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.html
@@ -15,9 +15,9 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">Client-side tooling can be intimidating, but this series of articles aims to illustrate the purpose of some of the most common client-side tool types, explain the tools you can chain together, how to install them using package managers, and control them using the command line. We finish up by providing a complete toolchain example showing you how to get productive.</p>
+<p>Client-side tooling can be intimidating, but this series of articles aims to illustrate the purpose of some of the most common client-side tool types, explain the tools you can chain together, how to install them using package managers, and control them using the command line. We finish up by providing a complete toolchain example showing you how to get productive.</p>
 
-<p class="summary"><strong><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">Get started now, with our "Client-side tooling overview"</a></strong></p>
+<p><strong><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">Get started now, with our "Client-side tooling overview"</a></strong></p>
 
 <h2 id="Prerequisites">Prerequisites</h2>
 

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Understanding_client-side_tools/Package_management","Learn/Tools_and_testing/Understanding_client-side_tools/Deployment", "Learn/Tools_and_testing/Understanding_client-side_tools")}}</div>
 
-<p class="summary">In the final couple of articles in the series we will solidify your tooling knowledge by walking you through the process of building up a sample case study toolchain. We'll go all the way from setting up a sensible development environment and putting transformation tools in place to actually deploying your app on Netlify. In this article we'll introduce the case study, set up our development environment, and set up our code transformation tools.</p>
+<p>In the final couple of articles in the series we will solidify your tooling knowledge by walking you through the process of building up a sample case study toolchain. We'll go all the way from setting up a sensible development environment and putting transformation tools in place to actually deploying your app on Netlify. In this article we'll introduce the case study, set up our development environment, and set up our code transformation tools.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/overview/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/overview/index.html
@@ -12,7 +12,7 @@ tags:
 
 <div>{{NextMenu("Learn/Tools_and_testing/Understanding_client-side_tools/Command_line", "Learn/Tools_and_testing/Understanding_client-side_tools")}}</div>
 
-<p class="summary">In this article we provide an overview of modern web tooling, what kinds of tools are available and where you’ll meet them in the lifecycle of web app development, and how to find help with individual tools.</p>
+<p>In this article we provide an overview of modern web tooling, what kinds of tools are available and where you’ll meet them in the lifecycle of web app development, and how to find help with individual tools.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/package_management/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/package_management/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Tools_and_testing/Understanding_client-side_tools/Command_line","Learn/Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain", "Learn/Tools_and_testing/Understanding_client-side_tools")}}</div>
 
-<p class="summary">In this article we'll look at package managers in some detail to understand how we can use them in our own projects — to install project tool dependencies, keep them up-to-date, and more.</p>
+<p>In this article we'll look at package managers in some detail to understand how we can use them in our own projects — to install project tool dependencies, keep them up-to-date, and more.</p>
 
 <table>
  <tbody>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This PR removes the `summary` class from the Learn documentation.
