### PR TITLE
Use lowercase anchor

### DIFF
--- a/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.html
+++ b/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.html
@@ -18,7 +18,7 @@ tags:
 <p>This section lists all the APIs available only in secure contexts, along with browser versions the limitation was introduced in, as appropriate.</p>
 
 <div class="note">
-<p><strong>Note</strong>: Only the browsers that actually support secure contexts are listed in this document. <a href="/en-US/docs/Web/Security/Secure_Contexts#Browser_compatibility">See here</a> for information on secure contexts support.</p>
+<p><strong>Note</strong>: Only the browsers that actually support secure contexts are listed in this document. <a href="/en-US/docs/Web/Security/Secure_Contexts#browser_compatibility">See here</a> for information on secure contexts support.</p>
 </div>
 
 <table class="standard-table">


### PR DESCRIPTION
This fixes the broken link flaw "Anchor not lowercase" reported by yari.