### PR TITLE
FF93 Release Note: self.reportError()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -60,6 +60,7 @@ tags:
 <ul>
   <li>{{domxref("ElementInternals.shadowRoot")}} and {{domxref("HTMLElement.attachInternals")}} are now supported ({{bug(1723521)}}).</li>
   <li>The value <code>device-pixel-content-box</code> is now supported for {{domxref("ResizeObserver.Observe()")}} ({{bug(1587973)}}).</li>
+  <li>The {{domxref("reportError()")}} global function is now supported, allowing scripts to report errors to the console or global event handlers, emulating an uncaught JavaScript exception ({{bug(1722448)}}).</li>
 </ul>
 
 <h4 id="DOM">DOM</h4>

--- a/files/en-us/web/api/reporterror/index.md
+++ b/files/en-us/web/api/reporterror/index.md
@@ -17,7 +17,7 @@ This feature is primarily intended for custom event-dispatching or callback-mani
 Libraries can use this feature to catch errors in callback code and re-throw them to the top level handler.
 This ensures that an exception in one callback will not prevent others from being handled, while at the same time ensuring that stack trace information is still readily available for debugging at the top level.
 
-{{EmbedInteractiveExample("pages/js/self-reporterror.html")}}
+<!-- {{EmbedInteractiveExample("pages/js/self-reporterror.html")}} -->
 
 ## Syntax
 


### PR DESCRIPTION
Adds release note for feature in: https://bugzilla.mozilla.org/show_bug.cgi?id=1722448

Also hides the non-existent interactive example (which I may create [if this is answered](https://github.com/mdn/interactive-examples/issues/1919))

Part of #8608

