### PR TITLE
self.structuredClone() - prep docs for FF94

### DIFF
--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -5,7 +5,14 @@ tags:
   - Transferable
   - Workers
 ---
-Browsers implement a method of passing certain types of objects to or from a {{domxref("Web Workers API", "Web Worker","","true")}} with high performance. **Transferable objects** are transferred from one context to another with a zero-copy operation, which results in a vast performance improvement when sending large data sets. Think of it as pass-by-reference if you're from the C/C++ world. However, unlike pass-by-reference, the 'version' from the calling context is no longer available once transferred. Its ownership is transferred to the new context. For example, when transferring an {{jsxref("ArrayBuffer")}} from your main app to a worker script, the original {{jsxref("ArrayBuffer")}} is cleared and no longer usable. Its content is (quite literally) transferred to the worker context.
+**Transferable objects** are objects for which the underlying resources can be transferred from one context to another using a zero-copy (high performance) operation.
+
+Transfer operations detach specified resources from the original object and move them to the new context.
+Following a transfer, attempts to use transferred objects in the original context will throw an exception.
+
+For example, {{jsxref("ArrayBuffer")}} is a _transferrable object_ that might be moved from a main app to a {{domxref("Web Workers API", "web worker script","","true")}}.
+After transfer the memory from the original `ArrayBuffer` is (quite literally) moved to another version of `ArrayBuffer` in the worker context.
+The `ArrayBuffer` in the original context is cleared/has no access to transferred memory. 
 
 ```js
 // Create a 32MB "file" and fill it.
@@ -14,8 +21,14 @@ for (var i = 0; i < uInt8Array.length; ++i) {
   uInt8Array[i] = i;
 }
 
+// Transfer the underlying buffer to a worker
 worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
 ```
+
+Similarly, the {{domxref("structuredClone()")}} method can be used to make deep copies of a transferrable object, and may additionally transfer specified resources to the cloned object.
+This is useful when you want to safely perform operations on some data and also fail attempts to access the data while performing the operation.
+In this case you clone and transfer the object and peform the operations on the copied data: attempts to access the original object will fail.
+
 
 ## See also
 

--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -20,7 +20,7 @@ Other objects may be transferred by copying the object and then removing it in t
 
 The code below demonstrates the first case: sending a message from a main thread to a {{domxref("Web Workers API", "web worker thread","","true")}}.
 The {{jsxref("Uint8Array")}} is copied (duplicated) in the worker while its buffer is transferred.
-After transfer an attempt to access `uInt8Array` from the worker will throw, but you can check the `byteLength` to confirm it is now zero.
+After transfer any attempt to read or write `uInt8Array` from the main thread will throw, but you can still check the `byteLength` to confirm it is now zero.
 
 ```js
 // Create an 8MB "file" and fill it.

--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -5,20 +5,28 @@ tags:
   - Transferable
   - Workers
 ---
-**Transferable objects** are objects that can be _detached_ from one context and attached to another, rather than simply duplicated in both contexts.
-Following a transfer, the original object is no longer available in the original context, and any attempt to access it will throw an exception.
 
-Transferring is commonly used to share resources between threads that can only be safely exposed to a single JS thread at a time.
-It may also be used when creating deep copies of objects, where the object manages resources for which there must only be one copy.
+**Transferable objects** are objects that own resources that can be _transferred_ from one context to another, ensuring that the resources are only available in one context at a time.
+Following a transfer, the original object is no longer usable; it no longer points to the transferred resource, and any attempt to read or write the object will throw an exception.
 
-Not all objects are transferable, and the mechanism used to transfer an object depends on the object.
-For example, when an {{jsxref("ArrayBuffer")}} is transfered between threads the memory literally moved between threads in a fast and efficient zero-copy operation.
-Other objects may be transferred by copying the object and then removing it in the new context.
+_Transferrable objects_ are commonly use to share resources that can only be safely exposed to a single JavaScript thread at a time.
+For example, an {{jsxref("ArrayBuffer")}} is a transferrable object that owns a block of memory.
+When such a buffer is transferred between threads, the associated memory resource is detached from the original buffer and attached to the buffer object created in the new thread.
+The buffer object in the original thread is no longer usable because it no longer owns a memory resource.
 
+Transferring may also be used when creating deep copies of objects with {{domxref("structuredClone()")}}.
+Following the cloning operation, the transferred resources are moved rather than copied to the cloned object.
+
+The mechanism used to transfer an object's resources depends on the object.
+For example, when an {{jsxref("ArrayBuffer")}} is transferred between threads, the memory resource that it points to is _literally_ moved between contexts in a fast and efficient zero-copy operation.
+Other objects may be transferred by copying the associated resource and then deleting it from the old context.
+
+Not all objects are transferable.
+A list of transferable objects is [provided below](#supported_objects).
 
 ## Transferring objects between threads
 
-The code below demonstrates the first case: sending a message from a main thread to a {{domxref("Web Workers API", "web worker thread","","true")}}.
+The code below demonstrates how transferring works when sending a message from a main thread to a {{domxref("Web Workers API", "web worker thread","","true")}}.
 The {{jsxref("Uint8Array")}} is copied (duplicated) in the worker while its buffer is transferred.
 After transfer any attempt to read or write `uInt8Array` from the main thread will throw, but you can still check the `byteLength` to confirm it is now zero.
 
@@ -37,7 +45,7 @@ console.log(uInt8Array.byteLength);  // 0
 
 > **Note:** [Typed arrays](en-US/docs/Web/JavaScript/Typed_arrays) like {{jsxref("Int32Array")}} and {{jsxref("Uint8Array")}}, are serializable, but not transferable.
 > However their underlying buffer is an {{jsxref("ArrayBuffer")}}, which is a transferable object.
-> We could have sent `uInt8Array.buffer` in the data parameter, but not `uInt8Array` in the transfer sequence.
+> We could have sent `uInt8Array.buffer` in the data parameter, but not `uInt8Array` in the transfer array.
 
 
 ### Transferring during a cloning operation
@@ -48,17 +56,21 @@ The code below shows a {{domxref("structuredClone()")}} operation where the unde
 const original = new Uint8Array(1024);
 const clone = structuredClone(original);
 console.log(original.byteLength);  // 1024
+console.log(clone.byteLength);  // 1024
 
 original[0] = 1;
 console.log(clone[0]);  // 0
 
-// Transfering the Uint8Array would throw an exception:
+// Transfering the Uint8Array would throw an exception as it is not a transferrable object
 // const transferred = structuredClone(original, {transfer: [original]}); 
 
-// We can tranfer its buffer. Afterwards the buffer is removed
+// We can tranfer Uint8Array.buffer.
 const transferred = structuredClone(original, {transfer: [original.buffer]});
-console.log(original.byteLength);  // 0
+console.log(transferred.byteLength);  // 1024
 console.log(transferred[0]);  // 1
+
+// After transferring Uint8Array.buffer cannot be used.
+console.log(original.byteLength);  // 0
 ```
 
 ## Supported objects

--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -27,7 +27,7 @@ worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
 
 Similarly, the {{domxref("structuredClone()")}} method can be used to make deep copies of a transferrable object, and may additionally transfer specified resources to the cloned object.
 This is useful when you want to safely perform operations on some data and also fail attempts to access the data while performing the operation.
-In this case you clone and transfer the object and peform the operations on the copied data: attempts to access the original object will fail.
+In this case you clone and transfer the object and perform the operations on the copied data; attempts to access the original object will fail.
 
 
 ## See also

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -12,23 +12,32 @@ browser-compat: api.DedicatedWorkerGlobalScope.postMessage
 ---
 {{APIRef("Web Workers API")}}
 
-The **`postMessage()`** method of the {{domxref("DedicatedWorkerGlobalScope")}} interface sends a message to the main thread that spawned it. This accepts a single parameter, which is the data to send from the worker to the main thread. The data may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
+The **`postMessage()`** method of the {{domxref("DedicatedWorkerGlobalScope")}} interface sends a message to the main thread that spawned it.
+
+This accepts a data parameter, which contains data to copy from the worker to the main thread.
+The data may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
+
+The method also accepts an optional array of {{Glossary("Transferable objects")}} to _transfer_ to the main thread;
+Unlike the data parameter transferred objects are no longer available in the worker thread.
+(Where possible, objects are transferred using a high performance zero-copy operation).
 
 The main scope that spawned the worker can send back information to the thread that spawned it using the {{domxref("Worker.postMessage")}} method.
 
 ## Syntax
 
 ```js
-postMessage(aMessage, transferList);
+postMessage(aMessage, transferList)
 ```
 
 ### Parameters
 
-- _aMessage_
-  - : The object to deliver to the main thread; this will be in the data field in the event delivered to the {{domxref("Worker.onmessage")}} handler. This may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
-- _transferList_ {{optional_inline}}
+- `aMessage`
+  - : The object to deliver to the main thread; this will be in the data field in the event delivered to the {{domxref("Worker.onmessage")}} handler.
+    This may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
+- `transferList` {{optional_inline}}
 
-  - : An optional [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.
+  - : An optional ordered [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of {{Glossary("transferable objects")}} to transfer ownership of.
+    If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.
 
     Only {{domxref("MessagePort")}} and {{jsxref("ArrayBuffer")}} objects can be transferred.
 
@@ -38,7 +47,8 @@ Void.
 
 ## Example
 
-The following code snippet shows `worker.js`, in which an `onmessage` handler is used to handle messages from the main script. Inside the handler a calculation is done from which a result message is created; this is then sent back to the main thread using `postMessage(workerResult);`
+The following code snippet shows `worker.js`, in which an `onmessage` handler is used to handle messages from the main script.
+Inside the handler a calculation is done from which a result message is created; this is then sent back to the main thread using `postMessage(workerResult);`
 
 ```js
 onmessage = function(e) {
@@ -51,7 +61,7 @@ onmessage = function(e) {
 
 In the main script, `onmessage` would have to be called on a `Worker object`, whereas inside the worker script you just need `onmessage` because the worker is effectively the global scope ({{domxref("DedicatedWorkerGlobalScope")}}).
 
-For a full example, see our[Basic dedicated worker example](https://github.com/mdn/simple-web-worker) ([run dedicated worker](https://mdn.github.io/simple-web-worker/)).
+For a full example, see our [Basic dedicated worker example](https://github.com/mdn/simple-web-worker) ([run dedicated worker](https://mdn.github.io/simple-web-worker/)).
 
 > **Note:** `postMessage()` can only send a single object at once. As seen above, if you want to pass multiple values you can send an array.
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -18,7 +18,7 @@ This accepts a data parameter, which contains data to copy from the worker to th
 The data may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
 
 The method also accepts an optional array of {{Glossary("Transferable objects")}} to _transfer_ to the main thread;
-Unlike the data parameter transferred objects are no longer available in the worker thread.
+Unlike the data parameter transferred objects are no longer usable in the worker thread.
 (Where possible, objects are transferred using a high performance zero-copy operation).
 
 The main scope that spawned the worker can send back information to the thread that spawned it using the {{domxref("Worker.postMessage")}} method.
@@ -39,7 +39,7 @@ postMessage(aMessage, transferList)
   - : An optional ordered [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of {{Glossary("transferable objects")}} to transfer ownership of.
     If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.
 
-    Only {{domxref("MessagePort")}} and {{jsxref("ArrayBuffer")}} objects can be transferred.
+    Only {{Glossary("transferable objects")}} can be transferred.
 
 ### Returns
 

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -51,7 +51,7 @@ const original = { name: "MDN" };
 original.itself = original;
 
 // Clone it
-const clone = self.structuredClone(original);
+const clone = structuredClone(original);
 
 console.assert(clone !== original); // the objects are not the same (not same identity)
 console.assert(clone.name === "MDN"); // they do have the same values

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -63,7 +63,7 @@ Values can be transferred rather than copied to the new object using the optiona
 Transferring makes the specified object unavailable in the original value.
 
 > **Note:** A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
-> To avoid the buffer being modified before the data is saved you can clone the buffer and validate that data.
+> To avoid the buffer being modified before the data is saved, you can clone the buffer and validate that data.
 > If you also _transfer_ the data, any attempts to modify the original buffer will fail, preventing its accidental misuse.
 
 The following code shows how to clone an array and move its underlying resources to the new object.

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -27,7 +27,7 @@ structuredClone(value, { transfer })
   - : The value to be cloned.
     This can be any [structured-clonable type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - `transfer` {{optional_inline}}
-  - : A sequence of objects that are [transferred](/en-US/docs/Web/API/Transferable) with value.
+  - : A sequence of objects that are {{Glossary("Transferable objects","transferred")}} with value.
     The ownership of these objects is transfered from the input value to the cloned value that is returned.
 
 ### Return value

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -32,7 +32,7 @@ structuredClone(value, { transfer })
 
 ### Return value
 
-The returned `clonedValue` is a clone of the original passed `value`, with transfered values for items passed in the `transfer` array.
+The returned value is a clone of the original passed `value`, with transfered values for items passed in the `transfer` array.
 
 ### Exceptions
 

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -44,7 +44,7 @@ The returned value is a clone of the original `value`.
 ## Description
 
 This function can be used to deep copy JavaScript values.
-It also supports circular references as shown below:
+It also supports circular references, as shown below:
 
 ```js
 // Create an object with a value and a circular reference to itself.

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -14,8 +14,8 @@ browser-compat: api.structuredClone
 
 The global **`structuredClone()`** method creates a deep clone of a given value using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 
-The method also allows all or part of the original object to be {{Glossary("transferable objects","transferred")}} (moved) rather than copied to the new object.
-On return, the transferred objects will no longer be accessible in the original object.
+The method also allows {{Glossary("transferable objects")}} in the original value to be _transferred_ rather than cloned to the new object.
+Transferred objects are detached from the original object and attached to the new object; they are no longer accessible in the original object.
 
 ## Syntax
 
@@ -30,11 +30,11 @@ structuredClone(value, { transfer })
   - : The object to be cloned.
     This can be any [structured-clonable type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - `transfer` {{optional_inline}}
-  - : A sequence of {{Glossary("transferable objects")}} in `value` that will be moved rather than copied to the returned object.
+  - : A array of {{Glossary("transferable objects")}} in `value` that will be moved rather than cloned to the returned object.
 
 ### Return value
 
-The returned value is a clone of the original `value`.
+The returned value is a deep copy of the original `value`.
 
 ### Exceptions
 
@@ -59,14 +59,16 @@ console.assert(clone.name === "MDN"); // they do have the same values
 console.assert(clone.itself === clone); // and the circular reference is preserved
 ```
 
-Values can be transferred rather than copied to the new object using the optional parameter's `transfer` value.
+### Transfering values
+
+{{Glossary("Transferable objects")}} (only) can be transferred rather than duplicated in the cloned object, using the optional parameter's `transfer` value.
 Transferring makes the specified object unavailable in the original value.
 
 > **Note:** A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
 > To avoid the buffer being modified before the data is saved, you can clone the buffer and validate that data.
 > If you also _transfer_ the data, any attempts to modify the original buffer will fail, preventing its accidental misuse.
 
-The following code shows how to clone an array and move its underlying resources to the new object.
+The following code shows how to clone an array and transfer its underlying resources to the new object.
 On return, the original `uInt8Array.buffer` will be cleared.
 
 ```js
@@ -75,7 +77,8 @@ for (var i = 0; i < uInt8Array.length; ++i) {
   uInt8Array[i] = i;
 }
 
-const transferred = structuredClone(uInt8Array.buffer, { transfer: [uInt8Array.buffer] }).
+const transferred = structuredClone(uInt8Array, { transfer: [uInt8Array.buffer] }).
+console.log(uInt8Array.byteLength);  // 0
 ```
 
 You can clone any number of objects and transfer any subset of those objects.
@@ -86,6 +89,7 @@ const transferred = structuredClone(
    { x: { y: { z: arrayBuffer1, w: arrayBuffer2 } } },
    { transfer: [arrayBuffer1] });
 ```
+
 
 ## Specifications
 

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -17,29 +17,33 @@ The global **`structuredClone()`** method deep clones a given value using the [s
 ## Syntax
 
 ```js
-const clonedValue = structuredClone(value[, { transfer }]);
+structuredClone(value)
+structuredClone(value, { transfer })
 ```
 
 ### Parameters
 
 - `value`
-  - : The value to be cloned. This can be any [structured-clonable
-    type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+  - : The value to be cloned.
+    This can be any [structured-clonable type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - `transfer` {{optional_inline}}
-  - : A sequence of objects that are [transferred](/en-US/docs/Web/API/Transferable) with value. The
-    ownership of these objects is transfered from the input value to the cloned value
-    that is returned.
+  - : A sequence of objects that are [transferred](/en-US/docs/Web/API/Transferable) with value.
+    The ownership of these objects is transfered from the input value to the cloned value that is returned.
 
 ### Return value
 
-The returned `clonedValue` is a clone of the original passed
-`value`, with transfered values for items passed in the
-`transfer` array.
+The returned `clonedValue` is a clone of the original passed `value`, with transfered values for items passed in the `transfer` array.
+
+### Exceptions
+
+- `DataCloneError` {{domxref("DOMException")}}
+  - : Thrown if any part of the input value is not serializable.
 
 ## Description
 
-This function can be used to deep copy JavaScript values. The structured clone algorithm
-also supports circular references. The below example demonstrates this:
+This function can be used to deep copy JavaScript values.
+The structured clone algorithm also supports circular references.
+The below example demonstrates this:
 
 ```js
 // Create an object with a value and a circular reference to itself.
@@ -49,7 +53,7 @@ original.itself = original;
 // Clone it
 const clone = self.structuredClone(original);
 
-console.assert(clone !== original); // object are not the same (not same identity)
+console.assert(clone !== original); // the objects are not the same (not same identity)
 console.assert(clone.name === "MDN"); // they do have the same values
 console.assert(clone.itself === clone); // and the circular reference is preserved
 ```

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -12,7 +12,10 @@ browser-compat: api.structuredClone
 ---
 {{APIRef("HTML DOM")}}
 
-The global **`structuredClone()`** method deep clones a given value using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+The global **`structuredClone()`** method creates a deep clone of a given value using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+
+The method also allows all or part of the original object to be {{Glossary("transferable objects","transferred")}} (moved) rather than copied to the new object.
+On return, the transferred objects will no longer be accessible in the original object.
 
 ## Syntax
 
@@ -24,15 +27,14 @@ structuredClone(value, { transfer })
 ### Parameters
 
 - `value`
-  - : The value to be cloned.
+  - : The object to be cloned.
     This can be any [structured-clonable type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - `transfer` {{optional_inline}}
-  - : A sequence of objects that are {{Glossary("Transferable objects","transferred")}} with value.
-    The ownership of these objects is transfered from the input value to the cloned value that is returned.
+  - : A sequence of {{Glossary("transferable objects")}} in `value` that will be moved rather than copied to the returned object.
 
 ### Return value
 
-The returned value is a clone of the original passed `value`, with transfered values for items passed in the `transfer` array.
+The returned value is a clone of the original `value`.
 
 ### Exceptions
 
@@ -42,8 +44,7 @@ The returned value is a clone of the original passed `value`, with transfered va
 ## Description
 
 This function can be used to deep copy JavaScript values.
-The structured clone algorithm also supports circular references.
-The below example demonstrates this:
+It also supports circular references as shown below:
 
 ```js
 // Create an object with a value and a circular reference to itself.
@@ -56,6 +57,34 @@ const clone = structuredClone(original);
 console.assert(clone !== original); // the objects are not the same (not same identity)
 console.assert(clone.name === "MDN"); // they do have the same values
 console.assert(clone.itself === clone); // and the circular reference is preserved
+```
+
+Values can be transferred rather than copied to the new object using the optional parameter's `transfer` value.
+Transferring makes the specified object unavailable in the original value.
+
+> **Note:** A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
+> To avoid the buffer being modified before the data is saved you can clone the buffer and validate that data.
+> If you also _transfer_ the data, any attempts to modify the original buffer will fail, preventing its accidental misuse.
+
+The following code shows how to clone an array and move its underlying resources to the new object.
+On return, the original `uInt8Array.buffer` will be cleared.
+
+```js
+var uInt8Array = new Uint8Array(1024 * 1024 * 16); // 16MB
+for (var i = 0; i < uInt8Array.length; ++i) {
+  uInt8Array[i] = i;
+}
+
+const transferred = structuredClone(uInt8Array.buffer, { transfer: [uInt8Array.buffer] }).
+```
+
+You can clone any number of objects and transfer any subset of those objects.
+For example, the code below would transfer `arrayBuffer1` from the passed in value, but not `arrayBuffer2`.
+
+```js
+const transferred = structuredClone(
+   { x: { y: { z: arrayBuffer1, w: arrayBuffer2 } } },
+   { transfer: [arrayBuffer1] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -62,7 +62,7 @@ console.assert(clone.itself === clone); // and the circular reference is preserv
 ### Transfering values
 
 {{Glossary("Transferable objects")}} (only) can be transferred rather than duplicated in the cloned object, using the optional parameter's `transfer` value.
-Transferring makes the specified object unavailable in the original value.
+Transferring makes the original object unusable.
 
 > **Note:** A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
 > To avoid the buffer being modified before the data is saved, you can clone the buffer and validate that data.

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -15,7 +15,7 @@ It clones by recursing through the input object while maintaining a map of previ
 
 ## Things that don't work with structured clone
 
-- {{jsxref("Function")}} objects cannot be duplicated by the structured clone algorithm; attempting to throws a `DATA_CLONE_ERR` exception.
+- {{jsxref("Function")}} objects cannot be duplicated by the structured clone algorithm; attempting to throws a `DataCloneError` exception.
 - Cloning DOM nodes likewise throws a `DataCloneError` exception. 
 - Certain object properties are not preserved:
 
@@ -109,8 +109,9 @@ It clones by recursing through the input object while maintaining a map of previ
 
 ## See also
 
-- {{domxref("structuredClone()")}}
 - [HTML Specification: Safe passing of structured data](https://www.w3.org/TR/html5/infrastructure.html#safe-passing-of-structured-data)
+- {{Glossary("Transferable objects")}}
+- {{domxref("structuredClone()")}}
 - {{domxref("window.history")}}
 - {{domxref("window.postMessage()")}}
 - [Web Workers](/en-US/docs/Web/API/Web_Workers_API)

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -16,7 +16,7 @@ It clones by recursing through the input object while maintaining a map of previ
 ## Things that don't work with structured clone
 
 - {{jsxref("Function")}} objects cannot be duplicated by the structured clone algorithm; attempting to throws a `DATA_CLONE_ERR` exception.
-- Cloning DOM nodes likewise throws a `DATA_CLONE_ERR` exception. 
+- Cloning DOM nodes likewise throws a `DataCloneError` exception. 
 - Certain object properties are not preserved:
 
   - The `lastIndex` property of {{jsxref("RegExp")}} objects is not preserved.

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -8,18 +8,20 @@ tags:
   - JavaScript
   - Reference
 ---
-The **structured clone algorithm** copies complex JavaScript objects. It is used internally when invoking {{domxref("structuredClone()")}}, to transfer data between [Workers](/en-US/docs/Web/API/Worker) via {{domxref("Worker.postMessage()", "postMessage()")}}, storing objects with [IndexedDB](/en-US/docs/Glossary/IndexedDB), or copying objects for [other APIs](#see_also).
+The **structured clone algorithm** copies complex JavaScript objects.
+It is used internally when invoking {{domxref("structuredClone()")}}, to transfer data between [Workers](/en-US/docs/Web/API/Worker) via {{domxref("Worker.postMessage()", "postMessage()")}}, storing objects with [IndexedDB](/en-US/docs/Glossary/IndexedDB), or copying objects for [other APIs](#see_also).
 
 It clones by recursing through the input object while maintaining a map of previously visited references, to avoid infinitely traversing cycles.
 
 ## Things that don't work with structured clone
 
 - {{jsxref("Function")}} objects cannot be duplicated by the structured clone algorithm; attempting to throws a `DATA_CLONE_ERR` exception.
-- Cloning DOM nodes likewise throws a `DATA_CLONE_ERR` exception.
+- Cloning DOM nodes likewise throws a `DATA_CLONE_ERR` exception. 
 - Certain object properties are not preserved:
 
   - The `lastIndex` property of {{jsxref("RegExp")}} objects is not preserved.
-  - Property descriptors, setters, getters, and similar metadata-like features are not duplicated. For example, if an object is marked readonly with a [property descriptor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor), it will be read/write in the duplicate, since that's the default.
+  - Property descriptors, setters, getters, and similar metadata-like features are not duplicated.
+    For example, if an object is marked readonly with a [property descriptor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor), it will be read/write in the duplicate, since that's the default.
   - The prototype chain is not walked or duplicated.
 
 > **Note:** Native {{jsxref("Error")}} types can be cloned in Chrome, and Firefox is [working on it](https://bugzilla.mozilla.org/show_bug.cgi?id=1556604).
@@ -36,9 +38,7 @@ It clones by recursing through the input object while maintaining a map of previ
   <tbody>
     <tr>
       <td>
-        <a href="/en-US/docs/Web/JavaScript/Data_structures#primitive_values"
-          >All primitive types</a
-        >
+        <a href="/en-US/docs/Web/JavaScript/Data_structures#primitive_values">All primitive types</a>
       </td>
       <td>However, not symbols.</td>
     </tr>
@@ -77,8 +77,7 @@ It clones by recursing through the input object while maintaining a map of previ
     <tr>
       <td>{{domxref("ArrayBufferView")}}</td>
       <td>
-        Including other
-        <a href="/en-US/docs/Web/JavaScript/Typed_arrays">typed arrays</a>.
+        Including other <a href="/en-US/docs/Web/JavaScript/Typed_arrays">typed arrays</a>.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -20,8 +20,7 @@ a page and a pop-up that it spawned, or between a page and an iframe embedded wi
 Normally, scripts on different pages are allowed to access each other if and only if
 the pages they originate from share the same protocol, port number, and host (also known
 as the "[same-origin policy](/en-US/docs/Web/Security/Same-origin_policy)").
-`window.postMessage()` provides a controlled mechanism to securely circumvent
-this restriction (if used properly).
+`window.postMessage()` provides a controlled mechanism to securely circumvent this restriction (if used properly).
 
 Broadly, one window may obtain a reference to another (_e.g.,_ via
 `targetWindow = window.opener`), and then dispatch a
@@ -32,7 +31,8 @@ receiving window is then free to [handle this event](/en-US/docs/Web/Events/Even
 ## Syntax
 
 ```js
-targetWindow.postMessage(message, targetOrigin, [transfer]);
+postMessage(message, targetOrigin)
+postMessage(message, targetOrigin, [transfer])
 ```
 
 - `targetWindow`
@@ -42,10 +42,8 @@ targetWindow.postMessage(message, targetOrigin, [transfer]);
 
     - {{domxref("window.open")}} (to spawn a new window and then reference it),
     - {{domxref("window.opener")}} (to reference the window that spawned this one),
-    - {{domxref("HTMLIFrameElement.contentWindow")}} (to reference an embedded
-      {{HTMLElement("iframe")}} from its parent window),
-    - {{domxref("window.parent")}} (to reference the parent window from within an
-      embedded {{HTMLElement("iframe")}}), or
+    - {{domxref("HTMLIFrameElement.contentWindow")}} (to reference an embedded {{HTMLElement("iframe")}} from its parent window),
+    - {{domxref("window.parent")}} (to reference the parent window from within an embedded {{HTMLElement("iframe")}}), or
     - {{domxref("window.frames")}} + an index value (named or numeric).
 
 - `message`
@@ -68,9 +66,8 @@ targetWindow.postMessage(message, targetOrigin, [transfer]);
     window's document should be located. Failing to provide a specific target discloses
     the data you send to any interested malicious site.**
 - `transfer` {{optional_Inline}}
-  - : Is a sequence of {{domxref("Transferable")}} objects that are transferred with the
-    message. The ownership of these objects is given to the destination side and they are
-    no longer usable on the sending side.
+  - : Is a sequence of {{Glossary("transferable objects")}} that are transferred with the message.
+    The ownership of these objects is given to the destination side and they are no longer usable on the sending side.
 
 ## The dispatched event
 


### PR DESCRIPTION
This is minor update to docs around the `self.structuredClone()` in preparation for its addition to FF94. 

Main change is addition of the exception information, and updating to use new syntax.

@sideshowbarker I will add some questions inline which I hope you can help me with. Asking you because you seemed informed on the discussions in the draft spec.

This is part of delivering #9370
