### PR TITLE
Change Checkbox_radio_button example

### DIFF
--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -44,18 +44,25 @@ This example applies special styles to the labels associated with indeterminate 
 #### HTML
 
 ```html
-<div>
-  <input type="checkbox" id="checkbox">
-  <label for="checkbox">This checkbox label starts out lime.</label>
-</div>
-<div>
-  <input type="radio" id="radio1" name="radioButton">
-  <label for="radio1">This radio label starts out lime.</label>
-</div>
-<div>
-  <input type="radio" id="radio2" name="radioButton">
-  <label for="radio2">This radio label starts out lime.</label>
-</div>
+<fieldset>
+  <legend>Checkbox</legend>
+  <div>
+    <input type="checkbox" id="checkbox">
+    <label for="checkbox">This checkbox label starts out lime.</label>
+  </div>
+</fieldset>
+
+<fieldset>
+  <legend>Radio</legend>
+  <div>
+    <input type="radio" id="radio1" name="radioButton">
+    <label for="radio1">First radio label starts out lime.</label>
+  </div>
+  <div>
+    <input type="radio" id="radio2" name="radioButton">
+    <label for="radio2">Second radio label also starts out lime.</label>
+  </div>
+</fieldset>
 ```
 
 #### CSS
@@ -63,6 +70,20 @@ This example applies special styles to the labels associated with indeterminate 
 ```css
 input:indeterminate + label {
   background: lime;
+}
+```
+
+```css hidden
+fieldset {
+    padding: 1em 0.75em;
+}
+
+fieldset:first-of-type {
+    margin-bottom: 1.5rem;
+}
+
+fieldset:not(:first-of-type) > div:not(:last-child) {
+    margin-bottom: 0.5rem;
 }
 ```
 
@@ -76,7 +97,7 @@ for (let i = 0; i < inputs.length; i++) {
 }
 ```
 
-{{EmbedLiveSample('Checkbox_radio_button', 'auto', 150)}}
+{{EmbedLiveSample('Checkbox_radio_button', 'auto', 230)}}
 
 ### Progress bar
 

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -46,11 +46,15 @@ This example applies special styles to the labels associated with indeterminate 
 ```html
 <div>
   <input type="checkbox" id="checkbox">
-  <label for="checkbox">This label starts out lime.</label>
+  <label for="checkbox">This checkbox label starts out lime.</label>
 </div>
 <div>
-  <input type="radio" id="radio">
-  <label for="radio">This label starts out lime.</label>
+  <input type="radio" id="radio1" name="radioButton">
+  <label for="radio1">This radio label starts out lime.</label>
+</div>
+<div>
+  <input type="radio" id="radio2" name="radioButton">
+  <label for="radio2">This radio label starts out lime.</label>
 </div>
 ```
 
@@ -65,14 +69,14 @@ input:indeterminate + label {
 #### JavaScript
 
 ```js
-var inputs = document.getElementsByTagName("input");
+const inputs = document.getElementsByTagName("input");
 
-for (var i = 0; i < inputs.length; i++) {
+for (let i = 0; i < inputs.length; i++) {
   inputs[i].indeterminate = true;
 }
 ```
 
-{{EmbedLiveSample('Checkbox_radio_button', 'auto', 50)}}
+{{EmbedLiveSample('Checkbox_radio_button', 'auto', 150)}}
 
 ### Progress bar
 


### PR DESCRIPTION
Changes for `Checkbox_radio_button` example to conform to the rule stated at the top of the page (i.e. _<input type="radio"> elements, when all radio buttons with the same name value in the form are unchecked_) that is we need more than one radio button in order to see the effect. Moreover, minor changes have been made.

Note: regarding the `Checkbox_radio_button` example I'm not sure whether changes I've made are enough or should it also be changed in some external example that is used by `{{EmbedLiveSample('Checkbox_radio_button', 'auto', 50)}}`. Any help would be much appreciated.