### PR TITLE
DOMParser.parseFromString(): clarify usage of XML-based MIME types

### DIFF
--- a/files/en-us/web/api/domparser/domparser/index.md
+++ b/files/en-us/web/api/domparser/domparser/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-A new [`DOMParser`](/en-US/docs/Web/API/DOMParser) object. This object can be used to parse the text of a document using the `parseFromString()` method.
+A new [`DOMParser`](/en-US/docs/Web/API/DOMParser) object. This object can be used to parse the text of a document using the `parseFromString()` method.
 
 ## Specifications
 

--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -46,36 +46,7 @@ from a URL-addressable resource, returning a `Document` in its
 
 ## Examples
 
-### Parsing XML, SVG, and HTML
-
-This example shows how to parse XML, SVG, and HTML. Note that a MIME type of
-`text/html` will invoke the HTML parser, and any of the other MIME types
-that are accepted by this method will invoke the XML parser.
-
-```js
-const parser = new DOMParser();
-
-const xmlString = "<warning>Beware of the tiger</warning>";
-const doc1 = parser.parseFromString(xmlString, "application/xml");
-// XMLDocument
-
-const svgString = "<circle cx=\"50\" cy=\"50\" r=\"50\"/>";
-const doc2 = parser.parseFromString(svgString, "image/svg+xml");
-// XMLDocument
-
-const htmlString = "<strong>Beware of the leopard</strong>";
-const doc3 = parser.parseFromString(htmlString, "text/html");
-// HTMLDocument
-
-console.log(doc1.documentElement.textContent)
-// "Beware of the tiger"
-
-console.log(doc2.firstChild.tagName);
-// "circle"
-
-console.log(doc3.body.firstChild.textContent);
-// "Beware of the leopard"
-```
+The documentation for {{domxref("DOMParser.parseFromString()")}}, this interface's only method, contains examples for parsing XML, SVG, and HTML strings.
 
 ## Specifications
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -33,10 +33,11 @@ const doc = domparser.parseFromString(string, mimeType)
     - `application/xhtml+xml`
     - `image/svg+xml`
 
-    A value of `text/html` will invoke the HTML parser, and the method will return an {{domxref("HTMLDocument")}}.
-    Any other valid value will invoke the XML parser, and the method will return an {{domxref("XMLDocument")}}.
+    A value of `text/html` will invoke the HTML parser, and the method will return an {{domxref("HTMLDocument")}}. 
 
-    Any other value will cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) to be thrown.
+    The other valid values (`text/xml`, `application/xml`, `application/xhtml+xml`, and `image/svg+xml`) are functionally equivalent. They all invoke the XML parser, and the method will return a {{domxref("XMLDocument")}}.
+
+    Any other value is invalid and will cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) to be thrown.
 
 ### Return value
 
@@ -47,9 +48,7 @@ An {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}, depending on th
 
 ### Parsing XML, SVG, and HTML
 
-This example shows how to parse XML, SVG, and HTML. Note that a MIME type of
-`text/html` will invoke the HTML parser, and any other valid MIME type will invoke
-the XML parser.
+> **Note:** That a MIME type of `text/html` will invoke the HTML parser, and any other valid MIME type will invoke the XML parser. The `application/xml` and `image/svg+xml` MIME types in the example below are functionally identical — the latter does not include any SVG-specific parsing rules. Distinguishing between the two serves only to clarify the code's intent.
 
 ```js
 const parser = new DOMParser();

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -48,7 +48,7 @@ An {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}, depending on th
 
 ### Parsing XML, SVG, and HTML
 
-> **Note:** That a MIME type of `text/html` will invoke the HTML parser, and any other valid MIME type will invoke the XML parser. The `application/xml` and `image/svg+xml` MIME types in the example below are functionally identical — the latter does not include any SVG-specific parsing rules. Distinguishing between the two serves only to clarify the code's intent.
+Note that a MIME type of `text/html` will invoke the HTML parser, and any other valid MIME type will invoke the XML parser. The `application/xml` and `image/svg+xml` MIME types in the example below are functionally identical — the latter does not include any SVG-specific parsing rules. Distinguishing between the two serves only to clarify the code's intent.
 
 ```js
 const parser = new DOMParser();


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

A follow-up to #9383, clarify that the different XML-based MIME types are functionally equivalent. 

I've also removed the duplicated code sample from `DOMParser()`, pointed to `parseFromString()` instead — feels confusing to have the same example on two pages. 

#### Motivation

Readers may get the wrong impression that parsing `<circle>` with the `image/svg+xml` MIME type has some advantage over using `application/xml`. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
