### PR TITLE
WebDriver conformance changes for Firefox 93

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -86,7 +86,7 @@ tags:
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
 <ul>
-  <li>Fixed a bug, which caused `WebDriver:Print` to fail for large documents ({{bug 1721982}}).</li>
+  <li>Fixed a bug, which caused `WebDriver:Print` to fail for large documents ({{bug(1721982)}}).</li>
 </ul>
 
 <h4 id="removals_webdriver">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -86,7 +86,7 @@ tags:
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
 <ul>
-  <li>Fixed a bug, which caused `WebDriver:Print` to fail for large documents ({{bug(1721982)}}).</li>
+  <li>Fixed a bug which caused <code>WebDriver:Print</code> to fail for large documents ({{bug(1721982)}}).</li>
 </ul>
 
 <h4 id="removals_webdriver">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -85,6 +85,10 @@ tags:
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
+<ul>
+  <li>Fixed a bug, which caused the `WebDriver:Print` to fail for large documents ({{bug 1721982}}).</li>
+</ul>
+
 <h4 id="removals_webdriver">Removals</h4>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>

--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -86,7 +86,7 @@ tags:
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
 <ul>
-  <li>Fixed a bug, which caused the `WebDriver:Print` to fail for large documents ({{bug 1721982}}).</li>
+  <li>Fixed a bug, which caused `WebDriver:Print` to fail for large documents ({{bug 1721982}}).</li>
 </ul>
 
 <h4 id="removals_webdriver">Removals</h4>


### PR DESCRIPTION
The following PR contains all the user facing changes to Marionette for the Firefox 93 release. 
There was only one bug fixed for this release (see [bug list](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&v1=fixed&component=Marionette&v2=verified&product=Testing&f1=cf_status_firefox93&list_id=15854760)):

- Bug 1719124 - For larger PDF files "WebDriver:Print" can raise "RangeError: too many arguments provided for a function call"

@whimboo could you have a look please?