### PR TITLE
API Routing would be a useful definition here.

### DIFF
--- a/files/en-us/glossary/routers/index.html
+++ b/files/en-us/glossary/routers/index.html
@@ -9,7 +9,7 @@ tags:
 <ol>
  <li>For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions. They are distributed by retailers allowing user interaction to the internet.</li>
  <li>For a {{Glossary('SPA', 'Single-page application' )}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.</li>
- <li>In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
+ <li>In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program.  The router code usually accepts a response from the handler and facilitates its return to the requester.</li>
 </ol>
 
 <h2 id="see_also">See also</h2>

--- a/files/en-us/glossary/routers/index.html
+++ b/files/en-us/glossary/routers/index.html
@@ -9,7 +9,7 @@ tags:
 <ol>
  <li>For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions. They are distributed by retailers allowing user interaction to the internet.</li>
  <li>For {{Glossary('SPA')}} in application layer, router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.</li>
- <li>For {{Glossary('API')}} in a service layer, router is code that parses a request and directs or routes the request to various handlers within a program.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
+ <li>In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
 </ol>
 
 <h2 id="see_also">See also</h2>

--- a/files/en-us/glossary/routers/index.html
+++ b/files/en-us/glossary/routers/index.html
@@ -9,7 +9,7 @@ tags:
 <ol>
  <li>For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions. They are distributed by retailers allowing user interaction to the internet.</li>
  <li>For {{Glossary('SPA')}} in application layer, router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.</li>
- <li>For {{Glossary('API')}} in a service layer, router is code that parses a request and directs or routes the request to various handlers within a progam.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
+ <li>For {{Glossary('API')}} in a service layer, router is code that parses a request and directs or routes the request to various handlers within a program.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
 </ol>
 
 <h2 id="see_also">See also</h2>

--- a/files/en-us/glossary/routers/index.html
+++ b/files/en-us/glossary/routers/index.html
@@ -8,7 +8,7 @@ tags:
 
 <ol>
  <li>For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions. They are distributed by retailers allowing user interaction to the internet.</li>
- <li>For {{Glossary('SPA')}} in application layer, router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.</li>
+ <li>For a {{Glossary('SPA', 'Single-page application' )}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.</li>
  <li>In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
 </ol>
 

--- a/files/en-us/glossary/routers/index.html
+++ b/files/en-us/glossary/routers/index.html
@@ -4,11 +4,12 @@ slug: Glossary/routers
 tags:
   - Intro
 ---
-<p>There are two definitions for <strong>routers</strong> on the web:</p>
+<p>There are three definitions for <strong>routers</strong> on the web:</p>
 
 <ol>
  <li>For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions. They are distributed by retailers allowing user interaction to the internet.</li>
  <li>For {{Glossary('SPA')}} in application layer, router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.</li>
+ <li>For {{Glossary('API')}} in a service layer, router is code that parses a request and directs or routes the request to various handlers within a progam.  The code usually accepts a response from the handler and facilitates its return to the requester.</li>
 </ol>
 
 <h2 id="see_also">See also</h2>


### PR DESCRIPTION
Similar to application layer routing.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Adding API routing as it is used all over the place in API Development, (Express, Fastify, League/Route, etc.) Service layer or API routing is similar but different from client appliation routing.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'm building a list of (Restful API) vocabulary words for my team at NOAA NEFSC and am using MDN Web Docs as one of my primary resources.  It would be nice to have a good definition of routing on the server.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Not sure.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
