### PR TITLE
Fix links /docs/CSS as /docs/Web/CSS

### DIFF
--- a/files/en-us/web/api/window/transitionrun_event/index.md
+++ b/files/en-us/web/api/window/transitionrun_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Window.transitionrun_event
 ---
 {{APIRef}} {{SeeCompatTable}}
 
-The **`transitionrun`** event is fired when a [CSS transition](/en-US/docs/CSS/Using_CSS_transitions) is first created, i.e. before any {{cssxref("transition-delay")}} has begun.
+The **`transitionrun`** event is fired when a [CSS transition](/en-US/docs/Web/CSS/Using_CSS_transitions) is first created, i.e. before any {{cssxref("transition-delay")}} has begun.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/api/window/transitionstart_event/index.md
+++ b/files/en-us/web/api/window/transitionstart_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Window.transitionstart_event
 ---
 {{APIRef}} {{SeeCompatTable}}
 
-The **`transitionstart`** event is fired when a [CSS transition](/en-US/docs/CSS/Using_CSS_transitions) has actually started, i.e., after any {{cssxref("transition-delay")}} has ended.
+The **`transitionstart`** event is fired when a [CSS transition](/en-US/docs/Web/CSS/Using_CSS_transitions) has actually started, i.e., after any {{cssxref("transition-delay")}} has ended.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/css/@media/grid/index.md
+++ b/files/en-us/web/css/@media/grid/index.md
@@ -11,7 +11,7 @@ browser-compat: css.at-rules.media.grid
 ---
 {{CSSRef}}
 
-The **`grid`** [CSS](/en-US/docs/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features) can be used to test whether the output device uses a grid-based screen.
+The **`grid`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features) can be used to test whether the output device uses a grid-based screen.
 
 Most modern computers and smartphones have bitmap-based screens. Examples of grid-based devices include text-only terminals and basic phones with only one fixed font.
 

--- a/files/en-us/web/css/aspect-ratio/index.md
+++ b/files/en-us/web/css/aspect-ratio/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.aspect-ratio
 ---
 {{CSSRef}}
 
-The **`aspect-ratio`**  [CSS](/en-US/docs/CSS) property sets a **preferred aspect ratio** for the box, which will be used in the calculation of auto sizes and some other layout functions.
+The **`aspect-ratio`**  [CSS](/en-US/docs/Web/CSS) property sets a **preferred aspect ratio** for the box, which will be used in the calculation of auto sizes and some other layout functions.
 
 ```css
 aspect-ratio: 1 / 1;

--- a/files/en-us/web/css/background-size/index.md
+++ b/files/en-us/web/css/background-size/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.background-size
 ---
 {{CSSRef}}
 
-The **`background-size`** [CSS](/en-US/docs/CSS) property sets the size of the element's background image. The image can be left to its natural size, stretched, or constrained to fit the available space.
+The **`background-size`** [CSS](/en-US/docs/Web/CSS) property sets the size of the element's background image. The image can be left to its natural size, stretched, or constrained to fit the available space.
 
 {{EmbedInteractiveExample("pages/css/background-size.html")}}
 
@@ -177,6 +177,6 @@ See [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/
 
 ## See also
 
-- [Scaling background images](/en-US/docs/CSS/Scaling_background_images)
+- [Scaling background images](/en-US/docs/Web/CSS/Scaling_background_images)
 - [Scaling of SVG backgrounds](/en-US/docs/Web/CSS/Scaling_of_SVG_backgrounds)
 - {{cssxref("object-fit")}}

--- a/files/en-us/web/css/border-style/index.md
+++ b/files/en-us/web/css/border-style/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.border-style
 ---
 {{CSSRef}}
 
-The **`border-style`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/CSS) property sets the line style for all four sides of an element's border.
+The **`border-style`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property sets the line style for all four sides of an element's border.
 
 {{EmbedInteractiveExample("pages/css/border-style.html")}}
 

--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -10,7 +10,7 @@ browser-compat: css.selectors.class
 ---
 {{CSSRef}}
 
-The [CSS](/en-US/docs/CSS) **class selector** matches elements based on the contents of their {{htmlattrxref("class")}} attribute.
+The [CSS](/en-US/docs/Web/CSS) **class selector** matches elements based on the contents of their {{htmlattrxref("class")}} attribute.
 
 ```css
 /* All elements with class="spacious" */

--- a/files/en-us/web/css/counter-set/index.md
+++ b/files/en-us/web/css/counter-set/index.md
@@ -81,7 +81,7 @@ h1 {
 
 ## See also
 
-- [Using CSS Counters](/en-US/docs/CSS/Counters)
+- [Using CSS Counters](/en-US/docs/Web/CSS/Counters)
 - {{cssxref("counter-increment")}}
 - {{cssxref("counter-reset")}}
 - {{cssxref("@counter-style")}}

--- a/files/en-us/web/css/cross-fade()/index.md
+++ b/files/en-us/web/css/cross-fade()/index.md
@@ -141,5 +141,5 @@ Browsers do not provide any special information on background images to assistiv
 - {{cssxref("_image", "image()")}}
 - {{cssxref("image-set")}}
 - {{cssxref("element")}}
-- [Using CSS gradients](/en-US/docs/CSS/Using_CSS_gradients "Using gradients")
+- [Using CSS gradients](/en-US/docs/Web/CSS/Using_CSS_gradients "Using gradients")
 - Gradient functions: {{cssxref("linear-gradient", "linear-gradient()")}}, {{cssxref("radial-gradient", "radial-gradient()")}}, {{cssxref("repeating-linear-gradient", "repeating-linear-gradient()")}}, {{cssxref("repeating-radial-gradient", "repeating-radial-gradient()")}}, {{cssxref("conic-gradient", "conic-gradient()")}},

--- a/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -60,4 +60,4 @@ As you can see here, the Firefox logo (listed first within {{ cssxref("backgroun
 
 ## See also
 
-- [Using CSS gradients](/en-US/docs/CSS/Using_CSS_gradients)
+- [Using CSS gradients](/en-US/docs/Web/CSS/Using_CSS_gradients)

--- a/files/en-us/web/css/list_of_proprietary_css_features/index.md
+++ b/files/en-us/web/css/list_of_proprietary_css_features/index.md
@@ -14,7 +14,7 @@ tags:
 > - [Mozilla CSS Extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)
 > - [WebKit CSS Extensions](/en-US/docs/Web/CSS/Webkit_Extensions)
 
-This list includes proprietary extensions to CSS in different browser engines which are not experimental implementations of features being standardized (see [Draft Implementations of CSS Features](/en-US/docs/CSS/Draft_Implementations_of_CSS_Features) for a list of these).
+This list includes proprietary extensions to CSS in different browser engines which are not experimental implementations of features being standardized (see [Draft Implementations of CSS Features](/en-US/docs/Web/CSS/Draft_Implementations_of_CSS_Features) for a list of these).
 
 ## Gecko
 

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -15,7 +15,7 @@ The **`margin-left`** [CSS](/en-US/docs/Web/CSS) property sets the [margin area]
 
 {{EmbedInteractiveExample("pages/css/margin-left.html")}}
 
-The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/CSS/margin_collapsing).
+The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/Web/CSS/margin_collapsing).
 
 In the rare cases where width is overconstrained (i.e., when all of `width`, `margin-left`, `border`, `padding`, the content area, and `margin-right` are defined), `margin-left` is ignored, and will have the same calculated value as if the `auto` value was specified.
 

--- a/files/en-us/web/css/margin-right/index.md
+++ b/files/en-us/web/css/margin-right/index.md
@@ -14,7 +14,7 @@ The **`margin-right`** [CSS](/en-US/docs/Web/CSS) property sets the [margin area
 
 {{EmbedInteractiveExample("pages/css/margin-right.html")}}
 
-The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/CSS/margin_collapsing).
+The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/Web/CSS/margin_collapsing).
 
 ## Syntax
 

--- a/files/en-us/web/css/orphans/index.md
+++ b/files/en-us/web/css/orphans/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.orphans
 ---
 {{CSSRef}}
 
-The **`orphans`** [CSS](/en-US/docs/CSS) property sets the minimum number of lines in a block container that must be shown at the _bottom_ of a [page](/en-US/docs/Web/CSS/Paged_Media), region, or [column](/en-US/docs/Web/CSS/CSS_Columns).
+The **`orphans`** [CSS](/en-US/docs/Web/CSS) property sets the minimum number of lines in a block container that must be shown at the _bottom_ of a [page](/en-US/docs/Web/CSS/Paged_Media), region, or [column](/en-US/docs/Web/CSS/CSS_Columns).
 
 ```css
 /* <integer> values */

--- a/files/en-us/web/css/perspective-origin/index.md
+++ b/files/en-us/web/css/perspective-origin/index.md
@@ -17,7 +17,7 @@ browser-compat: css.properties.perspective-origin
 ---
 {{CSSRef}}
 
-The **`perspective-origin`** [CSS](/en-US/docs/CSS) property determines the position at which the viewer is looking. It is used as the _vanishing point_ by the {{cssxref("perspective")}} property.
+The **`perspective-origin`** [CSS](/en-US/docs/Web/CSS) property determines the position at which the viewer is looking. It is used as the _vanishing point_ by the {{cssxref("perspective")}} property.
 
 {{EmbedInteractiveExample("pages/css/perspective-origin.html")}}
 

--- a/files/en-us/web/css/text-decoration-line/index.md
+++ b/files/en-us/web/css/text-decoration-line/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.text-decoration-line
 ---
 {{CSSRef}}
 
-The **`text-decoration-line`** [CSS](/en-US/docs/CSS) property sets the kind of decoration that is used on text in an element, such as an underline or overline.
+The **`text-decoration-line`** [CSS](/en-US/docs/Web/CSS) property sets the kind of decoration that is used on text in an element, such as an underline or overline.
 
 {{EmbedInteractiveExample("pages/css/text-decoration-line.html")}}
 

--- a/files/en-us/web/css/text-decoration-style/index.md
+++ b/files/en-us/web/css/text-decoration-style/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.text-decoration-style
 ---
 {{CSSRef}}
 
-The **`text-decoration-style`** [CSS](/en-US/docs/CSS) property sets the style of the lines specified by {{ cssxref("text-decoration-line") }}. The style applies to all lines that are set with `text-decoration-line`.
+The **`text-decoration-style`** [CSS](/en-US/docs/Web/CSS) property sets the style of the lines specified by {{ cssxref("text-decoration-line") }}. The style applies to all lines that are set with `text-decoration-line`.
 
 {{EmbedInteractiveExample("pages/css/text-decoration-style.html")}}
 

--- a/files/en-us/web/css/text-underline-offset/index.md
+++ b/files/en-us/web/css/text-underline-offset/index.md
@@ -13,7 +13,7 @@ browser-compat: css.properties.text-underline-offset
 ---
 {{CSSRef}}
 
-The **`text-underline-offset`** [CSS](/en-US/docs/CSS) property sets the offset distance of an underline text decoration line (applied using {{cssxref("text-decoration")}}) from its original position.
+The **`text-underline-offset`** [CSS](/en-US/docs/Web/CSS) property sets the offset distance of an underline text decoration line (applied using {{cssxref("text-decoration")}}) from its original position.
 
 `text-underline-offset` is not part of the {{cssxref('text-decoration')}} shorthand. While an element can have multiple `text-decoration` lines, `text-underline-offset` only impacts underlining, and **not** other possible line decoration options such as `overline` or `line-through`.
 

--- a/files/en-us/web/css/text-underline-position/index.md
+++ b/files/en-us/web/css/text-underline-position/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.text-underline-position
 ---
 {{CSSRef}}
 
-The **`text-underline-position`** [CSS ](/en-US/docs/CSS)property specifies the position of the underline which is set using the {{cssxref("text-decoration")}} property's `underline` value.
+The **`text-underline-position`** [CSS ](/en-US/docs/Web/CSS)property specifies the position of the underline which is set using the {{cssxref("text-decoration")}} property's `underline` value.
 
 {{EmbedInteractiveExample("pages/css/text-underline-position.html")}}
 

--- a/files/en-us/web/css/transform-style/index.md
+++ b/files/en-us/web/css/transform-style/index.md
@@ -158,4 +158,4 @@ checkbox.addEventListener('change', () => {
 
 ## See also
 
-- [Using CSS transforms](/en-US/docs/CSS/Using_CSS_transforms)
+- [Using CSS transforms](/en-US/docs/Web/CSS/Using_CSS_transforms)

--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -128,6 +128,6 @@ Please see [Using CSS transforms](/en-US/docs/Web/Guide/CSS/Using_CSS_transforms
 
 ## See also
 
-- [Using CSS transforms](/en-US/docs/CSS/Using_CSS_transforms)
+- [Using CSS transforms](/en-US/docs/Web/CSS/Using_CSS_transforms)
 - {{cssxref("&lt;transform-function&gt;")}} data type with all the transform functions explained.
 - Online tool to visualize CSS Transform functions: [CSS Transform Playground](https://css-transform.moro.es/)

--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -13,37 +13,37 @@ This page lists them all, with a short description. They are grouped by complexi
 
 ## Beginner-level CSS tutorials
 
-- [Getting started](/en-US/docs/CSS/Getting_Started)
+- [Getting started](/en-US/docs/Web/CSS/Getting_Started)
   - : This guide is aimed at complete beginners: You haven't written one single line of CSS? — this is for you. It explains the fundamental concepts of the language and guides you in writing basic stylesheets.
-- [Using multiple backgrounds](/en-US/docs/CSS/Using_CSS_multiple_backgrounds)
+- [Using multiple backgrounds](/en-US/docs/Web/CSS/Using_CSS_multiple_backgrounds)
   - : Backgrounds are fundamental for nice styling: CSS allows you to set several of them on each box. This tutorial explains how they interact and how to achieve nice effects.
-- [Scaling background images](/en-US/docs/CSS/Scaling_background_images)
+- [Scaling background images](/en-US/docs/Web/CSS/Scaling_background_images)
   - : CSS allows you to resize images used as an element's background. This tutorial describes how to achieve this in a simple way.
-- [Media queries](/en-US/docs/CSS/Media_queries)
+- [Media queries](/en-US/docs/Web/CSS/Media_queries)
   - : The size of the screens, or the kind of devices like touchscreens or printed sheets vary greatly nowadays. Media queries are the fundamental building blocks in achieving Web sites that render everywhere in their best quality.
-- [Understanding z-index](/en-US/docs/CSS/Understanding_z-index)
+- [Understanding z-index](/en-US/docs/Web/CSS/Understanding_z-index)
   - : Controlling superposition of boxes is a basic feature that is very quickly needed by Web developers. Though not that difficult, it requires a basic knowledge of CSS.
 
 ## Intermediate-level CSS tutorials
 
 After the release of CSS 2 (Level 1), new features have been added to CSS. Some of them are _fancy_ and are pretty self contained. They are easy to use for anybody with a fair knowledge of basic concepts.
 
-- [CSS Counters](/en-US/docs/CSS/Counters)
+- [CSS Counters](/en-US/docs/Web/CSS/Counters)
   - : Counting items and pages is an easy task in CSS. Learn to use {{cssxref("counter-reset")}}, {{cssxref("counter-increment")}}, {{cssxref("counters", "counters()")}}, and {{cssxref("counter", "counter()")}}.
-- [CSS Animations](/en-US/docs/CSS/Tutorials/Using_CSS_animations)
-  - : CSS3 Animations allow you to define configurations of style, as [keyframes](/en-US/docs/CSS/@keyframes), and to transition between them defining an animation.
-- [CSS Transitions](/en-US/docs/CSS/Tutorials/Using_CSS_transitions)
+- [CSS Animations](/en-US/docs/Web/CSS/Tutorials/Using_CSS_animations)
+  - : CSS3 Animations allow you to define configurations of style, as [keyframes](/en-US/docs/Web/CSS/@keyframes), and to transition between them defining an animation.
+- [CSS Transitions](/en-US/docs/Web/CSS/Tutorials/Using_CSS_transitions)
   - : CSS3 Transitions allow you to define an animation between several styles and to control the way this transition happens.
-- [CSS Transforms](/en-US/docs/CSS/Tutorials/Using_CSS_transforms)
+- [CSS Transforms](/en-US/docs/Web/CSS/Tutorials/Using_CSS_transforms)
   - : Transforms allow you to change the position of elements by modifying their coordinate space: it allows for translating, rotating, and deforming them in the 2D or 3D spaces.
-- [CSS Gradients](/en-US/docs/CSS/Using_CSS_gradients)
+- [CSS Gradients](/en-US/docs/Web/CSS/Using_CSS_gradients)
   - : Gradients are images that transition smoothly from one color to another. There are several types of gradients allowed in CSS: linear or radial, repeating or not. This tutorial describes how to use them.
 
 ## Advanced-level CSS tutorials
 
 CSS also got new features allowing you to create complex layouts. Though the simplest way to achieve such layout, they are more complex to use for people without too much experience.
 
-- [CSS multi-column layouts](/en-US/docs/CSS/Using_CSS_multi-column_layouts)
+- [CSS multi-column layouts](/en-US/docs/Web/CSS/Using_CSS_multi-column_layouts)
   - : CSS3 introduces a new layout allowing you to easily define multiple columns in an element. Though multi-column text is not that common on devices like screens, this is particularly useful on printed pages, or for indexes.
-- [CSS flexible boxes layouts](/en-US/docs/CSS/Using_CSS_flexible_boxes)
+- [CSS flexible boxes layouts](/en-US/docs/Web/CSS/Using_CSS_flexible_boxes)
   - : This new layout allow you to give boxes flexibility, allowing them to be resized smoothly. It is a powerful way to describe complex interfaces.

--- a/files/en-us/web/css/widows/index.md
+++ b/files/en-us/web/css/widows/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.widows
 ---
 {{CSSRef}}
 
-The **`widows`** [CSS](/en-US/docs/CSS) property sets the minimum number of lines in a block container that must be shown at the _top_ of a [page](/en-US/docs/Web/CSS/Paged_Media), region, or [column](/en-US/docs/Web/CSS/CSS_Columns).
+The **`widows`** [CSS](/en-US/docs/Web/CSS) property sets the minimum number of lines in a block container that must be shown at the _top_ of a [page](/en-US/docs/Web/CSS/Paged_Media), region, or [column](/en-US/docs/Web/CSS/CSS_Columns).
 
 ```css
 /* <integer> values */


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
There are some links to /docs/CSS which should be /docs/Web/CSS.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To reduce redirects.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
