### PR TITLE
Update description of possible window.fetch() exceptions

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -137,8 +137,7 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
   - : The request was aborted due to a call to the {{domxref("AbortController")}}
     {{domxref("AbortController.abort", "abort()")}} method.
 - `TypeError`
-  - : The specified URL string includes user credentials. This information should instead
-    be provided using an {{HTTPHeader("Authorization")}} header.
+  - : The specified URL string includes user credentials that should instead be passed with an {{HTTPHeader("Authorization")}} header, or a `NetworkError` has happened (this can include [CORS errors](/en-US/docs/Web/HTTP/CORS/Errors)).
 
 ## Examples
 


### PR DESCRIPTION
Update the description of the `window.fetch()` page to detail that a `TypeError` throwed by fetch can be a `NetworkError`, and possibly a CORS-linked issue.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Update the description to detail that a `TypeError` throwed by window.fetch() can be a `NetworkError`, and possibly a CORS-linked issue.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Reading the MDN page I was under the impression that Fetch would never throw as long as the arguments were right. It would have helped me to know that network issues, and CORS specifically, could result in a throwed error.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Sample test code:

```js
const uri = "https://xxxxxxxxx.com/test.pdf";
try {
  const response = await window.fetch(uri, {
    method: "GET",
    mode: "cors",
    credentials: "omit",
    cache: "reload",
  });

  if (!response.ok) {
    throw new Error("Fetch fail");
  }
} catch(e) {
  console.error(e);
}
```

Resulting error log in Firefox devtools console:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/24496417/135731880-5ae59831-ab30-4247-9344-706271922b25.png">


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
