### PR TITLE
fix: update broken link to "Memory leak patterns in JavaScript" article

### DIFF
--- a/files/en-us/web/javascript/memory_management/index.md
+++ b/files/en-us/web/javascript/memory_management/index.md
@@ -203,6 +203,6 @@ node --expose-gc --inspect index.js
 
 #### See also
 
-- [IBM article on "Memory leak patterns in JavaScript" (2007)](http://www.ibm.com/developerworks/web/library/wa-memleak/)
+- [IBM article on "Memory leak patterns in JavaScript" (2007)](https://www.ibm.com/developerworks/web/library/wa-memleak/wa-memleak-pdf.pdf)
 - [Kangax article on how to register event handler and avoid memory leaks (2010)](https://msdn.microsoft.com/en-us/magazine/ff728624.aspx)
 - [Performance](/en-US/docs/Mozilla/Performance)


### PR DESCRIPTION
Link to IBM's article on "Memory leak patterns in JavaScript" didn't point to the right address. Updated to link directly to the pdf article.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Updated link to point to the correct article as current link is outdated.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I was going through the docs and tried to open the referenced article. Updating to save others time to find the link.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
