### PR TITLE
Fix link to load event in Using_XMLHttpRequest

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -164,7 +164,7 @@ actual events you can monitor to determine the state of an ongoing transfer are:
 
 - {{event("progress")}}
   - : The amount of data that has been retrieved has changed.
-- {{event("load")}}
+- {{domxref("XMLHttpRequest/load_event", "load")}}
   - : The transfer is complete; all data is now in the `response`
 
 ```js


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Link to "load" event was pointing to Web/API/Window/load_event instead of Web/API/XMLHttpRequest/load_event

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This change fixes a link pointing to the wrong documentation page

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I've copied the code from web/api/xmlhttprequest/index.md where it works correctly.

Note that I can't test if the change works, since the preview on GitHub doesn't recognize the syntax used on those pages

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
