### PR TITLE
Wrapping a variable in code tags

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_events_state/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_events_state/index.html
@@ -285,7 +285,7 @@ export default Form;</pre>
 
 <p>We’ve now got a <code>setTasks</code> hook that we can use in our <code>addTask()</code> function to update our list of tasks. There’s one problem however: we can’t just pass the <code>name</code> argument of <code>addTask()</code> into <code>setTasks</code>, because <code>tasks</code> is an array of objects and <code>name</code> is a string. If we tried to do this, the array would be replaced with the string.</p>
 
-<p>First of all, we need to put name into an object that has the same structure as our existing tasks. Inside of the <code>addTask()</code> function, we will make a <code>newTask</code> object to add to the array.</p>
+<p>First of all, we need to put <code>name</code> into an object that has the same structure as our existing tasks. Inside of the <code>addTask()</code> function, we will make a <code>newTask</code> object to add to the array.</p>
 
 <p>We then need to make a new array with this new task added to it and then update the state of the tasks data to this new state. To do this, we can use spread syntax to <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#copy_an_array">copy the existing array</a>, and add our object at the end. We then pass this array into <code>setTasks()</code> to update the state.</p>
 


### PR DESCRIPTION
`name` is the name of a string.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
In this sentence, the word `name` is the name of a string. It should be wrapped in code tags.

#### Motivation
This is simply a typo fix 🙂, `name` has correct markup elsewhere. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
