### PR TITLE
MD migration prep: aria-valuenow_attribute

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
@@ -6,7 +6,7 @@ tags:
   - Accessibility
   - NeedsContent
 ---
-<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow" rel="external">aria-valuenow</a> attribute is used to define the current value for a range widget such as a slider, spinbutton or progressbar. If the current value is not known, the author should not set the <code>aria-valuenow</code> attribute. If the <code>aria-valuenow</code> has a known minimum and maximum value, authors should set the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> and <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attributes.</span></p>
+<p>The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow">aria-valuenow</a> attribute is used to define the current value for a range widget such as a slider, spinbutton or progressbar. If the current value is not known, the author should not set the <code>aria-valuenow</code> attribute. If the <code>aria-valuenow</code> has a known minimum and maximum value, authors should set the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> and <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attributes.</p>
 
 <p>When the rendered value cannot be accurately represented as a number, authors <strong>SHOULD</strong> use the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute in conjunction with <code>aria-valuenow</code> to provide a user-friendly representation of the range's current value. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <code>aria-valuenow</code> could range from 1 through 3, which indicate the position of each value in the value space, but the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>.</p>
 
@@ -22,7 +22,9 @@ tags:
 
 <p>For elements with role <a class="role-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role"><code>slider</code></a> and <a class="role-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_spinbutton_role"><code>spinbutton</code></a>, assistive technologies <strong>SHOULD</strong> render the actual value to users.</p>
 
-<div class="note"><p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p></div>
+<div class="note">
+  <p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p>
+</div>
 
 <h3 id="Examples">Examples</h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow" rel="external">aria-valuenow</a> attribute is used to define the current value for a range widget such as a slider, spinbutton or progressbar. If the current value is not known, the author should not set the <code>aria-valuenow</code> attribute. If the <code>aria-valuenow</code> has a known minimum and maximum value, authors should set the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> and <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> attributes.</span></p>
 
-<p>When the rendered value cannot be accurately represented as a number, authors <strong class="rfc2119">SHOULD</strong> use the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute in conjunction with <code>aria-valuenow</code> to provide a user-friendly representation of the range's current value. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <code>aria-valuenow</code> could range from 1 through 3, which indicate the position of each value in the value space, but the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>.</p>
+<p>When the rendered value cannot be accurately represented as a number, authors <strong>SHOULD</strong> use the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> attribute in conjunction with <code>aria-valuenow</code> to provide a user-friendly representation of the range's current value. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <code>aria-valuenow</code> could range from 1 through 3, which indicate the position of each value in the value space, but the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute"><code>aria-valuetext</code></a> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>.</p>
 
 <p><code>aria-valuenow</code> is a <strong>required</strong> attribute of role <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role">slider</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_scrollbar_role">scrollbar</a> and <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_spinbutton_role">spinbutton</a>.</p>
 
@@ -20,9 +20,9 @@ tags:
 
 <p>For elements with role <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_progressbar_role">progressbar</a></code> and <code><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_scrollbar_role">scrollbar</a></code>, assistive technologies <strong>SHOULD</strong> render the actual value as a percentage, calculated as a position on the range from <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute"><code>aria-valuemin</code></a> to <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> if both are defined, otherwise the actual value with a percent indicator.</p>
 
-<p>For elements with role <a class="role-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role"><code>slider</code></a> and <a class="role-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_spinbutton_role"><code>spinbutton</code></a>, assistive technologies <strong class="rfc2119">SHOULD</strong> render the actual value to users.</p>
+<p>For elements with role <a class="role-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role"><code>slider</code></a> and <a class="role-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_spinbutton_role"><code>spinbutton</code></a>, assistive technologies <strong>SHOULD</strong> render the actual value to users.</p>
 
-<div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
+<div class="note"><p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p></div>
 
 <h3 id="Examples">Examples</h3>
 
@@ -83,7 +83,7 @@ tags:
 
 <h3 id="Compatibility">Compatibility</h3>
 
-<p class="comment">TBD: Add support information for common UA and AT product combinations</p>
+<p>TBD: Add support information for common UA and AT product combinations</p>
 
 <h3 id="Additional_resources">Additional resources</h3>
 


### PR DESCRIPTION
#### Summary

Made the following required changes:
- [x] `strong.rfc2119` | Remove `class="rfc2119"` (x 2)
- [x] `div.note` | Must be transformed into: a `<div>` with `class="note"` whose first child is a `<p>` whose first child is `<strong>Note:</strong>`
- [x] `p.comment` | Remove the `class="comment"`

#### Motivation
Updated this page as part of "Writing Day" during the Write the Docs Prague 2021 conference:  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute