### PR TITLE
Introduce error to code sample and grammar issue

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -171,7 +171,6 @@ function Child(x, y) {
   }
 }
 
-Child = Object.assign(Child, ParentWithStatic)  // copies over the static members from ParentWithStatic to Child
 Child.prototype = Object.create(ParentWithStatic.prototype)
 Child.prototype.constructor = Child
 
@@ -186,7 +185,7 @@ Child.prototype.getOffsetByInitialPosition = function getOffsetByInitialPosition
 };
 ```
 
-For this example we need either to stay parent constructor to continue to work properly or reassign static properties to child's constructor:
+For this example we need either to keep Parent as the constructor to continue to work properly or reassign static properties to Child's constructor:
 
 ```js
 ...
@@ -195,7 +194,7 @@ Child.prototype = Object.create(ParentWithStatic.prototype)
 ...
 ```
 
-or assign parent constructor identifier to a separate property on the Child constructor function and access it via that property:
+or assign Parent's constructor identifier to a separate property on the Child constructor function and access it via that property:
 
 ```js
 ...

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -185,16 +185,16 @@ Child.prototype.getOffsetByInitialPosition = function getOffsetByInitialPosition
 };
 ```
 
-For this example we need either to keep Parent as the constructor to continue to work properly or reassign static properties to Child's constructor:
+For this example to work properly we need either to keep `Parent` as the constructor or reassign static properties to `Child`'s constructor:
 
 ```js
 ...
-Child = Object.assign(Child, ParentWithStatic) // Notice that we assign it before we create(...) a prototype below
-Child.prototype = Object.create(ParentWithStatic.prototype)
+Child = Object.assign(Child, ParentWithStatic); // Notice that we assign it before we create(...) a prototype below
+Child.prototype = Object.create(ParentWithStatic.prototype);
 ...
 ```
 
-or assign Parent's constructor identifier to a separate property on the Child constructor function and access it via that property:
+or assign `Parent`'s constructor identifier to a separate property on the `Child` constructor function and access it via that property:
 
 ```js
 ...


### PR DESCRIPTION
The code sample is supposed to fail but it currently works fine because it contains the solution described later in the documentation. See the line

```javascript
  let startPosition = this.constructor.getStartPosition() // error undefined is not a function, since the constructor is Child
```

Currently if you take the code sample and run it, it executes perfectly fine and does not throw any errors.
The solution should be either to remove the comment that incorrectly states that there will be an error, or to introduce the error into the code sample that the user should see. I think the original intent of the document was to show the pitfall and then explain the solutions, so I am adding in the error to the code sample.

I'm also cleaning up the grammar a bit.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This commit removes the solution from the sample as it should be introduced later.

#### Motivation
The comment in code sample predicts that the function call will throw an error, but it does not. This is confusing to the reader.

#### Supporting details
None

#### Related issues
NA

#### Metadata
Nope

This PR…
-->
- [ ] Clarifies the code sample in the document
- [ ] Fixes a grammatical issue in the document

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
