### PR TITLE
For markdown migration prep: aria-valuemin attribute

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
@@ -6,7 +6,9 @@ tags:
   - Accessibility
   - NeedsContent
 ---
-<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin" rel="external">aria-valuemin</a> attribute is used to define the minimum value allowed for a range widget such as a slider, spinbutton or progressbar. If the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> has a known maximum and minimum, the author <strong>SHOULD</strong> provide properties for <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> and <code>aria-valuemin</code>.The value of <code>aria-valuemin</code> <strong>MUST</strong> be less than or equal to the value of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a>.</span></p>
+<p>The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin">aria-valuemin</a> attribute is used to define the minimum value allowed for a range widget such as a slider, spinbutton or progressbar.
+  If the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> has a known maximum and minimum, the author <strong>SHOULD</strong> provide properties for <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> and <code>aria-valuemin</code>.
+  The value of <code>aria-valuemin</code> <strong>MUST</strong> be less than or equal to the value of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a>.</p>
 
 <p><code>aria-valuemin</code> is a <strong>required</strong> attribute of role <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role">slider</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_scrollbar_role">scrollbar</a> and <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_spinbutton_role">spinbutton</a>.</p>
 
@@ -18,7 +20,9 @@ tags:
 
 <p>If <code>aria-valuemin</code> is not less than or equal to the value of <code>aria-valuemax</code>, this creates an error condition that will be handled by the assistive technology.</p>
 
-<div class="note"><p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p></div>
+<div class="note">
+  <p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p>
+</div>
 
 <h3 id="Examples">Examples</h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
@@ -6,7 +6,7 @@ tags:
   - Accessibility
   - NeedsContent
 ---
-<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin" rel="external">aria-valuemin</a> attribute is used to define the minimum value allowed for a range widget such as a slider, spinbutton or progressbar. If the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> has a known maximum and minimum, the author <strong class="rfc2119">SHOULD</strong> provide properties for <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> and <code>aria-valuemin</code>.The value of <code>aria-valuemin</code> <strong class="rfc2119">MUST</strong> be less than or equal to the value of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a>.</span></p>
+<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin" rel="external">aria-valuemin</a> attribute is used to define the minimum value allowed for a range widget such as a slider, spinbutton or progressbar. If the <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> has a known maximum and minimum, the author <strong>SHOULD</strong> provide properties for <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a> and <code>aria-valuemin</code>.The value of <code>aria-valuemin</code> <strong>MUST</strong> be less than or equal to the value of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemax_attribute"><code>aria-valuemax</code></a>.</span></p>
 
 <p><code>aria-valuemin</code> is a <strong>required</strong> attribute of role <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role">slider</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_scrollbar_role">scrollbar</a> and <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_spinbutton_role">spinbutton</a>.</p>
 
@@ -18,7 +18,7 @@ tags:
 
 <p>If <code>aria-valuemin</code> is not less than or equal to the value of <code>aria-valuemax</code>, this creates an error condition that will be handled by the assistive technology.</p>
 
-<div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
+<div class="note"><p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p></div>
 
 <h3 id="Examples">Examples</h3>
 
@@ -79,7 +79,7 @@ tags:
 
 <h3 id="Compatibility">Compatibility</h3>
 
-<p class="comment">TBD: Add support information for common UA and AT product combinations</p>
+<p>TBD: Add support information for common UA and AT product combinations</p>
 
 <h3 id="Additional_resources">Additional resources</h3>
 


### PR DESCRIPTION
#### Summary

Made the following required changes:
- [x] `strong.rfc2119` | Remove `class="rfc2119"` (x 2)
- [x] `div.note` | Must be transformed into: a `<div>` with `class="note"` whose first child is a `<p>` whose first child is `<strong>Note:</strong>`
- [x] `p.comment` | Remove the `class="comment"`

#### Motivation
Updated this page as part of "Writing Day" during the Write the Docs Prague 2021 conference:  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuemin_attribute