### PR TITLE
For markdown migration prep: aria-required attribute

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.html
@@ -8,9 +8,11 @@ tags:
 ---
 <h3 id="Description">Description</h3>
 
-<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/#aria-required"><code>aria-required</code></a> attribute is used to indicate that user input is required on an element before a form can be submitted. This attribute can be used with any typical HTML form element; it is not limited to elements that have an ARIA <code>role</code> assigned.</span></p>
+<p>The <a href="https://www.w3.org/TR/wai-aria/#aria-required"><code>aria-required</code></a> attribute is used to indicate that user input is required on an element before a form can be submitted. This attribute can be used with any typical HTML form element; it is not limited to elements that have an ARIA <code>role</code> assigned.</p>
 
-<div class="note"><p><strong>Note:</strong> HTML also specifies the <a href="/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a> attribute which is supported well in user agents. Use <code>aria-required</code> for backwards compatibility only.</p></div>
+<div class="note">
+  <p><strong>Note:</strong> HTML also specifies the <a href="/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a> attribute which is supported well in user agents. Use <code>aria-required</code> for backwards compatibility only.</p>
+</div>
 
 <h3 id="Value">Value</h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/#aria-required"><code>aria-required</code></a> attribute is used to indicate that user input is required on an element before a form can be submitted. This attribute can be used with any typical HTML form element; it is not limited to elements that have an ARIA <code>role</code> assigned.</span></p>
 
-<div class="note">Note: HTML also specifies the <a href="/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a> attribute which is supported well in user agents. Use <code>aria-required</code> for backwards compatibility only.</div>
+<div class="note"><p><strong>Note:</strong> HTML also specifies the <a href="/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a> attribute which is supported well in user agents. Use <code>aria-required</code> for backwards compatibility only.</p></div>
 
 <h3 id="Value">Value</h3>
 
@@ -22,7 +22,7 @@ tags:
 
 <p>Note that this attribute will not automatically change the presentation of the field.</p>
 
-<div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
+<div class="note"><p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p></div>
 
 <h3 id="Examples">Examples</h3>
 
@@ -66,7 +66,7 @@ tags:
 
 <h3 id="Compatibility">Compatibility</h3>
 
-<p class="comment">TBD: Add support information for common UA and AT product combinations</p>
+<p>TBD: Add support information for common UA and AT product combinations</p>
 
 <h3 id="Additional_resources">Additional resources</h3>
 


### PR DESCRIPTION
#### Summary

Made the following required changes:
- [x] `div.note` (2x) | Must be transformed into: a `<div>` with `class="note"` whose first child is a `<p>` whose first child is `<strong>Note:</strong>`
- [x] `p.comment` | Remove `class="comment"`

#### Motivation
Updated this page as part of "Writing Day" during the Write the Docs Prague 2021 conference:  
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute