### PR TITLE
For markdown migration prep: aria-orientation attribute

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-orientation_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-orientation_attribute/index.html
@@ -28,7 +28,7 @@ tags:
 <h3 id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology </h3>
 
 
-<div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
+<div class="note"><p><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</p></div>
 
 <h3 id="Examples">Examples</h3>
 
@@ -72,7 +72,7 @@ tags:
 
 <h3 id="Compatibility">Compatibility</h3>
 
-<p class="comment">TBD: Add support information for common UA and AT product combinations</p>
+<p>TBD: Add support information for common UA and AT product combinations</p>
 
 <h3 id="Additional_resources">Additional resources</h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-orientation_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-orientation_attribute/index.html
@@ -6,7 +6,7 @@ tags:
   - Accessibility
   - Attribute
 ---
-<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/#aria-orientation" rel="external">aria-orientation</a> attribute is used to indicate whether an element is oriented horizontally or vertically.</span></p>
+<p>The <a href="https://www.w3.org/TR/wai-aria/#aria-orientation">aria-orientation</a> attribute is used to indicate whether an element is oriented horizontally or vertically.</p>
 
 <h3 id="Value">Value</h3>
 


### PR DESCRIPTION
#### Summary

Made the following required changes:
- [x] `div.note` | Must be transformed into: a `<div>` with `class="note"` whose first child is a `<p>` whose first child is `<strong>Note:</strong>`
- [x] `p.comment` | Remove `class="comment"`

#### Motivation
Updated this page as part of "Writing Day" during the Write the Docs Prague 2021 conference:  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-orientation_attribute
