### PR TITLE
FF94 Release Note: structuredClone() supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/94/index.html
+++ b/files/en-us/mozilla/firefox/releases/94/index.html
@@ -37,6 +37,10 @@ tags:
 
 <h3 id="APIs">APIs</h3>
 
+<ul>
+  <li>The {{domxref("structuredClone()")}} global function is now supported for copying complex JavaScript objects ({{bug(1722576)}}).</li>
+</ul>
+
 <h4 id="DOM">DOM</h4>
 
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>


### PR DESCRIPTION
`self.structuredClone()` supported in FF94. Other work for this can be tracked in #9370

