### PR TITLE
HTMLScriptElement.supports() method docs

### DIFF
--- a/files/en-us/mozilla/firefox/releases/94/index.html
+++ b/files/en-us/mozilla/firefox/releases/94/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{FirefoxSidebar}}{{draft}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 94 that will affect developers. Firefox 94 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">November 1, 2021</a>.</p>
+<p>This article provides information about the changes in Firefox 94 that will affect developers. Firefox 94 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">November 1, 2021</a>.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 
@@ -39,6 +39,10 @@ tags:
 
 <h4 id="DOM">DOM</h4>
 
+<ul>
+  <li>The {{domxref("HTMLScriptElement.supports()")}} static method is now supported. This provides a simple and unified method for feature checking whether a browser supports particular types of scripts, such as JavaScript modules or classic scripts ({{bug(1729239)}}).</li>
+</ul>
+
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
 
 <h4 id="removals_media">Removals</h4>
@@ -60,4 +64,4 @@ tags:
 
 <h2 id="Older_versions">Older versions</h2>
 
-<p>{{Firefox_for_developers(92)}}</p>
+<p>{{Firefox_for_developers(93)}}</p>

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -56,6 +56,13 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLScriptElement.referrerPolicy")}}
   - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "script")}} HTML attribute indicating which referrer to use when fetching the script, and fetches done by that script.
 
+
+## Static methods
+
+- {{domxref("HTMLScriptElement.supports()")}}
+  - : Returns `true` if the browser supports scripts of the specified type and `false` otherwise.
+     This method provides a simple and unified method for script-related feature detection.
+    
 ## Methods
 
 _No specific methods; inherits methods from its parent, {{domxref("HTMLElement")}}._

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -71,7 +71,9 @@ _No specific methods; inherits methods from its parent, {{domxref("HTMLElement")
 
 ### Dynamically importing scripts
 
-Let's create a function that imports new scripts within a document creating a {{HTMLElement("script")}} node _immediately before_ the {{HTMLElement("script")}} that hosts the following code (through {{domxref("document.currentScript")}}). These scripts will be **asynchronously** executed. For more details, see the [`defer`](#defer_property) and [`async`](#async_property) properties.
+Let's create a function that imports new scripts within a document creating a {{HTMLElement("script")}} node _immediately before_ the {{HTMLElement("script")}} that hosts the following code (through {{domxref("document.currentScript")}}).
+These scripts will be **asynchronously** executed.
+For more details, see the [`defer`](#defer_property) and [`async`](#async_property) properties.
 
 ```js
 function loadError(oError) {
@@ -109,6 +111,22 @@ Sample usage:
 affixScriptToHead("myScript1.js");
 affixScriptToHead("myScript2.js", function () { alert("The script \"myScript2.js\" has been correctly loaded."); });
 ```
+
+### Checking if a script type is supported
+
+{{domxref("HTMLScriptElement.supports()")}} provides a unified mechanism for checking whether a browser supports particular types of scripts.
+
+The example below shows how to check for module support, using the existance of the `noModule` attribute as a fallback.
+```js
+function checkModuleSupport() {
+  if ('supports' in HTMLScriptElement) {
+    return HTMLScriptElement.supports('module');
+  }
+  return 'noModule' in document.createElement('script');
+}
+```
+
+Classic scripts are assumed to be supported on all browsers.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -67,27 +67,6 @@ else
 {{ EmbedLiveSample('Examples') }}
 
 
-### Unsupported browsers
-
-Browsers that do not support `HTMLScriptElement.supports()` can simply assume that classic scripts are supported.
-
-Module support can be checked using the `noModule` attribute:
-```js
-function checkModuleSupport() {
-  if ('supports' in HTMLScriptElement) {
-    return HTMLScriptElement.supports('module');
-  }
-  return 'noModule' in document.createElement('script');
-}
-```
-
-You can also use the {{HTMLElement("script")}} element `nomodule` attribute to [fallback to classic scripts when loading modules](/en-US/docs/Web/HTML/Element/script#module_fallback) if needed:
-```html
-<script type="module" src="app.mjs"></script>
-<script nomodule defer src="classic-app-bundle.js"></script>
-```
-
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -1,0 +1,104 @@
+---
+title: HTMLScriptElement.supports()
+slug: Web/API/HTMLScriptElement/supports
+tags:
+  - API
+  - HTMLScriptElement
+  - Method
+  - Reference
+  - supports
+  - Experimental
+  - Feature detection
+browser-compat: api.HTMLScriptElement.supports
+---
+{{APIRef}}{{SeeCompatTable}}
+
+The **`supports()`** static method of the {{domxref("HTMLScriptElement")}} interface provides a simple and consistent method to feature-detect what types of scripts are supported by the user agent.
+
+The method is expected to return `true` for classic and module scripts, which are supported by most modern browsers.
+
+## Syntax
+
+```js
+HTMLScriptElement.supports(type)
+```
+
+### Parameters
+
+- `type`
+  - : A string literal that indicates the type of script for which support is to be checked.
+      Supported values are case sensitive, and include:
+  
+    - `"classic"`: Test if _classic scripts_ are supported.
+      "Classic" scripts are the normal/traditional JavaScript files that predate module scripts.
+    - `"module"`: Test if [module scripts](/en-US/docs/Web/JavaScript/Guide/Modules) are supported.
+
+    Any other value will cause the method to return `false`.
+    
+
+### Return value
+
+Returns `true` if the indicated script type is supported and `false` otherwise.
+
+## Examples
+
+The code below shows how to check if `HTMLScriptElement.supports()` is defined, and if so, to use it to test whether particular types of scripts are supported.
+
+```html hidden
+<textarea id="log" rows="5" cols="110"></textarea>
+```
+
+```js
+if (typeof HTMLScriptElement.supports == 'undefined') {
+  //Check if method is defined
+  log.textContent+="HTMLScriptElement.supports() method is not supported\n";
+}
+else
+{
+  //Returns true for the supported values
+  log.textContent+="HTMLScriptElement.supports('module'): " + HTMLScriptElement.supports('module') +"\n";
+  log.textContent+="HTMLScriptElement.supports('classic'): " + HTMLScriptElement.supports('classic') +"\n";
+
+  //Returns false for any other values
+  log.textContent+="HTMLScriptElement.supports('anything else'): " + HTMLScriptElement.supports('anything else') +"\n";
+}
+```
+
+{{ EmbedLiveSample('Examples') }}
+
+
+### Unsupported browsers
+
+Browsers that do not support `HTMLScriptElement.supports()` can simply assume that classic scripts are supported.
+
+Module support can be checked using the `noModule` attribute:
+```js
+function checkModuleSupport() {
+  if ('supports' in HTMLScriptElement) {
+    return HTMLScriptElement.supports('module');
+  }
+  return 'noModule' in document.createElement('script');
+}
+```
+
+You can also use the {{HTMLElement("script")}} element `nomodule` attribute to [fallback to classic scripts when loading modules](/en-US/docs/Web/HTML/Element/script#module_fallback) if needed:
+```html
+<script type="module" src="app.mjs"></script>
+<script nomodule defer src="classic-app-bundle.js"></script>
+```
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLScriptElement")}}
+- {{HTMLElement("script")}}
+- [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules)
+- {{domxref("Worker/Worker","Worker")}} constructor

--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -139,7 +139,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : This attribute indicates the type of script represented. The value of this attribute will be in one of the following categories:
 
     - **Omitted or a JavaScript MIME type:** This indicates the script is JavaScript. The HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type. In earlier browsers, this identified the scripting language of the embedded or imported (via the `src` attribute) code. JavaScript MIME types are [listed in the specification](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types).
-    - **`module`:** Causes the code to be treated as a JavaScript module. The processing of the script contents is not affected by the `charset` and `defer` attributes. For information on using `module`, see our [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules) guide. Unlike classic scripts, module scripts require the use of the CORS protocol for cross-origin fetching.
+    - **`module`:** Causes the code to be treated as a JavaScript module. The processing of the script contents is not affected by the `charset` and `defer` attributes.
+      For information on using `module`, see our [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules) guide.
+      Unlike classic scripts, module scripts require the use of the CORS protocol for cross-origin fetching.
     - **Any other value:** The embedded content is treated as a data block which won't be processed by the browser. Developers must use a valid MIME type that is not a JavaScript MIME type to denote data blocks. The `src` attribute will be ignored.
 
 ### Deprecated attributes


### PR DESCRIPTION
`HTMLScriptElement.supports()` support is added in FF94 by https://bugzilla.mozilla.org/show_bug.cgi?id=1729239.

This doc adds method docs and release note.

The main purpose of this method is future proofing - the method returns `true` for classic or module scripts, and `false` for everything else (and there are other ways to get this info). However there are other upcoming types that are very hard to work out using other methods - when they come along this will provide a good way to feature test.

I mention this because the method looks a bit pointless and  if you don't know about the upcoming work (and it seems to be policy not to say "in future we will do this..."). Just so you know.

Upshot the doc for the method is very simple. For the parent HTMLScriptElement doc I added an example pointing to this, and also the workaround for modules.

Other docs work  (e.g. BCD) tracked in #9365
