### PR TITLE
spelling: Window -> window.showDirectoryPicker

### DIFF
--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -19,7 +19,7 @@ select a directory.
 ## Syntax
 
 ```js
-var FileSystemDirectoryHandle = Window.showDirectoryPicker();
+var FileSystemDirectoryHandle = window.showDirectoryPicker();
 ```
 
 ### Parameters


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The example code uses Window with capital W, which is incorrect. Changed to lowercase w

#### Motivation
To make the example work.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
