### PR TITLE
incorrect link in Web/CSS/text-indent

### DIFF
--- a/files/en-us/web/css/text-indent/index.md
+++ b/files/en-us/web/css/text-indent/index.md
@@ -187,7 +187,7 @@ p {
   - [`text-justify`](/en-US/docs/Web/CSS/text-justify)
   - [`text-orientation`](/en-US/docs/Web/CSS/text-orientation)
   - [`text-overflow`](/en-US/docs/Web/CSS/text-overflow)
-  - [`text-rendering`](/en-US/docs/Web/SVG/Attribute/text-rendering)
+  - [`text-rendering`](/en-US/docs/Web/CSS/text-rendering)
   - [`text-transform`](/en-US/docs/Web/CSS/text-transform)
 
 - [CSS Text Decoration](/en-US/docs/Web/CSS/CSS_Text_Decoration) CSS module


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
A link to  `text-rendering` should be CSS's rather than SVG's.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
