### PR TITLE
Remove array escape in HTMLRefTable invocation (parsing breakage in translated-content CI)

### DIFF
--- a/files/en-us/web/html/element/index.md
+++ b/files/en-us/web/html/element/index.md
@@ -60,7 +60,7 @@ HTML supports various multimedia resources such as images, audio, and video.
 
 In addition to regular multimedia content, HTML can include a variety of other content, even if it's not always easy to interact with.
 
-{{HTMLRefTable({"include":\["HTML embedded content"], "exclude":\["multimedia"]})}}
+{{HTMLRefTable({"include":["HTML embedded content"], "exclude":["multimedia"]})}}
 
 ## SVG and MathML
 
@@ -119,7 +119,7 @@ The elements here are used to create and handle tabular data.
 
 HTML provides a number of elements which can be used together to create forms which the user can fill out and submit to the Web site or application. There's a great deal of further information about this available in the [HTML forms guide](/en-US/docs/Learn/Forms).
 
-{{HTMLRefTable({"include": \["HTML forms"], "exclude":\["Deprecated"]})}}
+{{HTMLRefTable({"include": ["HTML forms"], "exclude":["Deprecated"]})}}
 
 ## Interactive elements
 
@@ -131,10 +131,10 @@ HTML offers a selection of elements which help to create interactive user interf
 
 Web Components is an HTML-related technology which makes it possible to, essentially, create and use custom elements as if it were regular HTML. In addition, you can create custom versions of standard HTML elements.
 
-{{HTMLRefTable({"include":\["Web Components"],"exclude":\["Deprecated", "Obsolete"]})}}
+{{HTMLRefTable({"include":["Web Components"],"exclude":["Deprecated", "Obsolete"]})}}
 
 ## Obsolete and deprecated elements
 
 > **Warning:** These are old HTML elements which are deprecated and should not be used. **You should never use them in new projects, and should replace them in old projects as soon as you can.** They are listed here for completeness only.
 
-{{HTMLRefTable({"include":\["Deprecated","Obsolete"]})}}
+{{HTMLRefTable({"include":["Deprecated","Obsolete"]})}}


### PR DESCRIPTION
#### Summary
Long story short but https://github.com/mdn/translated-content/pull/2628 led to https://github.com/mdn/yari/issues/4744 which led here since HTMLRefTable seems to be the only macro using a JSON array in its arguments. Since macros are bad, this triggered an edge case the parser chose to panic on when dealing with "translation differences".

#### Motivation
It would help us unblock the CI situation

#### Supporting details


#### Related issues
https://github.com/mdn/translated-content/pull/2628 
https://github.com/mdn/yari/issues/4744

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
