### PR TITLE
[Markdown] [Learn] Remove summary and seoSummary classes

### DIFF
--- a/files/en-us/learn/common_questions/available_text_editors/index.html
+++ b/files/en-us/learn/common_questions/available_text_editors/index.html
@@ -8,9 +8,8 @@ tags:
   - Tools
   - text editor
 ---
-<div class="summary">
+
 <p>In this article we highlight some things to think about when installing a text editor for web development.</p>
-</div>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/common_questions/common_web_layouts/index.html
+++ b/files/en-us/learn/common_questions/common_web_layouts/index.html
@@ -8,9 +8,8 @@ tags:
   - HTML
   - NeedsActiveLearning
 ---
-<div class="summary">
+
 <p>When designing pages for your website, it's good to have an idea of the most common layouts.</p>
-</div>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/common_questions/design_for_all_types_of_users/index.html
+++ b/files/en-us/learn/common_questions/design_for_all_types_of_users/index.html
@@ -10,9 +10,8 @@ tags:
   - Mobile
   - NeedsActiveLearning
 ---
-<div class="summary">
+
 <p>This article provides basic tips to help you design websites for any kind of user.</p>
-</div>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/common_questions/how_does_the_internet_work/index.html
+++ b/files/en-us/learn/common_questions/how_does_the_internet_work/index.html
@@ -8,9 +8,7 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<div class="summary">
 <p>This article discusses what the Internet is and how it works.</p>
-</div>
 
 <table>
  <tbody>
@@ -94,16 +92,16 @@ tags:
 
 <p>Intranets are <em>private</em> networks that are restricted to members of a particular organization.
   They are commonly used to provide a portal for members to securely access shared resources, collaborate and communicate.
-  For example, an organization's intranet might host web pages for sharing department or team information, shared drives for managing key documents and files, 
+  For example, an organization's intranet might host web pages for sharing department or team information, shared drives for managing key documents and files,
   portals for performing business administration tasks, and collaboration tools like wikis, discussion boards, and messaging systems.</p>
-  
+
 <p>Extranets are very similar to Intranets, except they open all or part of a private network to allow sharing and collaboration with other organizations.
   They are typically used to safely and securely share information with clients and stakeholders who work closely with a business.
   Often their functions are similar to those provided by an intranet: information and file sharing, collaboration tools, discussion boards, etc.</p>
 
 <p>Both intranets and extranets run on the same kind of infrastructure as the Internet, and use the same protocols.
 They can therefore be accessed by authorised members from different physical locations.</p>
-  
+
 <p><img src="internet-schema-8.png" alt="Graphical Representation of how Extranet and Intranet work" /></p>
 
 <h2 id="Next_steps">Next steps</h2>

--- a/files/en-us/learn/common_questions/pages_sites_servers_and_search_engines/index.html
+++ b/files/en-us/learn/common_questions/pages_sites_servers_and_search_engines/index.html
@@ -8,9 +8,8 @@ tags:
   - NeedsActiveLearning
   - WebMechanics
 ---
-<div class="summary">
-<p><span class="seoSummary">In this article, we describe various web-related concepts: web pages, websites, web servers, and search engines. These terms are often confused by newcomers to the web or are incorrectly used. Let's learn what they each mean!</span></p>
-</div>
+
+<p>In this article, we describe various web-related concepts: web pages, websites, web servers, and search engines. These terms are often confused by newcomers to the web or are incorrectly used. Let's learn what they each mean!</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/common_questions/upload_files_to_a_web_server/index.html
+++ b/files/en-us/learn/common_questions/upload_files_to_a_web_server/index.html
@@ -11,9 +11,8 @@ tags:
   - rsync
   - SFTP
 ---
-<div class="summary">
+
 <p>This article shows you how to publish your site online using file transfer tools.</p>
-</div>
 
 <table>
  <tbody>

--- a/files/en-us/learn/common_questions/what_are_hyperlinks/index.html
+++ b/files/en-us/learn/common_questions/what_are_hyperlinks/index.html
@@ -7,9 +7,8 @@ tags:
   - Navigation
   - NeedsActiveLearning
 ---
-<div class="summary">
+
 <p>In this article, we'll go over what hyperlinks are and why they matter.</p>
-</div>
 
 <table>
  <tbody>

--- a/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
@@ -9,7 +9,6 @@ tags:
   - NeedsActiveLearning
   - Web
 ---
-<div class="summary"></div>
 
 <table>
 	<tbody>
@@ -26,7 +25,7 @@ tags:
 
 <h2 id="Summary">Summary</h2>
 
-<p><span class="seoSummary">Domain names are a key part of the Internet infrastructure. They provide a human-readable address for any web server available on the Internet.</span></p>
+<p>Domain names are a key part of the Internet infrastructure. They provide a human-readable address for any web server available on the Internet.</p>
 
 <p>Any Internet-connected computer can be reached through a public {{Glossary("IP")}} address, either an IPv4 address (e.g. <code>173.194.121.32</code>) or an IPv6 address (e.g., <code>2027:0da8:8b73:0000:0000:8a2e:0370:1337</code>).</p>
 

--- a/files/en-us/learn/common_questions/what_is_a_url/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_url/index.html
@@ -8,9 +8,8 @@ tags:
   - resources
   - urls
 ---
-<div class="summary">
+
 <p>This article discusses Uniform Resource Locators (URLs), explaining what they are and how they're structured.</p>
-</div>
 
 <table>
  <tbody>

--- a/files/en-us/learn/common_questions/what_is_a_web_server/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_web_server/index.html
@@ -6,9 +6,8 @@ tags:
   - Infrastructure
   - needsSchema
 ---
-<div class="summary">
-<p><span class="seoSummary">In this article, we explain what web servers are, how web servers work, and why they are important.</span></p>
-</div>
+
+<p>In this article, we explain what web servers are, how web servers work, and why they are important.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/common_questions/what_is_accessibility/index.html
+++ b/files/en-us/learn/common_questions/what_is_accessibility/index.html
@@ -8,9 +8,8 @@ tags:
   - NeedsActiveLearning
   - Web
 ---
-<div class="summary">
+
 <p>This article introduces the basic concepts behind web accessibility.</p>
-</div>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/common_questions/what_software_do_i_need/index.html
+++ b/files/en-us/learn/common_questions/what_software_do_i_need/index.html
@@ -6,9 +6,8 @@ tags:
   - NeedsActiveLearning
   - WebMechanics
 ---
-<div class="summary">
+
 <p>In this article, we lay out which software components you need when you're editing, uploading, or viewing a website.</p>
-</div>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/css/styling_text/fundamentals/index.html
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.html
@@ -19,7 +19,7 @@ tags:
 
 <div>{{NextMenu("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text")}}</div>
 
-<p><span class="seoSummary">In this article we'll start you on your journey towards mastering text styling with {{glossary("CSS")}}.</span> Here we'll go through all the basic fundamentals of text/font styling in detail, including setting font weight, family and style, font shorthand, text alignment and other effects, and line and letter spacing.</p>
+<p>In this article we'll start you on your journey towards mastering text styling with {{glossary("CSS")}}. Here we'll go through all the basic fundamentals of text/font styling in detail, including setting font weight, family and style, font shorthand, text alignment and other effects, and line and letter spacing.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/advanced_form_styling/index.html
+++ b/files/en-us/learn/forms/advanced_form_styling/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Forms/Styling_web_forms", "Learn/Forms/UI_pseudo-classes", "Learn/Forms")}}</div>
 
-<p><span class="seoSummary">In this article, we will see what can be done with CSS to style the types of form control that are more difficult to style — the "bad" and "ugly" categories.</span> As we saw <a href="/en-US/docs/Learn/Forms/Styling_web_forms"> in the previous article</a>, text fields and buttons are perfectly easy to style; now we will dig into styling the bits that are more problematic.</p>
+<p>In this article, we will see what can be done with CSS to style the types of form control that are more difficult to style — the "bad" and "ugly" categories. As we saw <a href="/en-US/docs/Learn/Forms/Styling_web_forms"> in the previous article</a>, text fields and buttons are perfectly easy to style; now we will dig into styling the bits that are more problematic.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.html
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <p>{{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Advanced_form_styling", "Learn/Forms/Form_validation", "Learn/Forms")}}</p>
 
-<p>In the previous articles, we covered the styling of various form controls, in a general manner. This included some usage of pseudo-classes, for example using <code>:checked</code> to target a checkbox only when it is selected. <span class="seoSummary">In this article, we will explore in detail the different UI pseudo-classes available to us in modern browsers for styling forms in different states.</span></p>
+<p>In the previous articles, we covered the styling of various form controls, in a general manner. This included some usage of pseudo-classes, for example using <code>:checked</code> to target a checkbox only when it is selected. In this article, we will explore in detail the different UI pseudo-classes available to us in modern browsers for styling forms in different states.</p>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.html
@@ -18,9 +18,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<div class="summary">
 <p>Vector graphics are very useful in many circumstances — they have small file sizes and are highly scalable, so they don't pixelate when zoomed in or blown up to a large size. In this article we'll show you how to include one in your webpage.</p>
-</div>
 
 <table>
  <tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Images_in_HTML", "Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<p><span class="seoSummary">Now that we are comfortable with adding simple images to a webpage, the next step is to start adding video and audio players to your HTML documents! In this article we'll look at doing just that with the {{htmlelement("video")}} and {{htmlelement("audio")}} elements; we'll then finish off by looking at how to add captions/subtitles to your videos.</span></p>
+<p>Now that we are comfortable with adding simple images to a webpage, the next step is to start adding video and audio players to your HTML documents! In this article we'll look at doing just that with the {{htmlelement("video")}} and {{htmlelement("audio")}} elements; we'll then finish off by looking at how to add captions/subtitles to your videos.</p>
 
 <table>
  <tbody>
@@ -100,7 +100,7 @@ tags:
 
 <div class="notecard note">
   <p><strong>Note:</strong> Why do we have this problem? It turns out that several popular formats, such as MP3 and MP4/H.264, are excellent but are encumbered by patents; that is, there are patents covering some or all of the technology that they're based upon. In the United States, patents covered MP3 until 2017, and H.264 is encumbered by patents through at least 2027.</p>
-  
+
   <p>Because of those patents, browsers that wish to implement support for those codecs must pay typically enormous license fees. In addition, some people prefer to avoid restricted software and prefer to use only open formats. Due to these legal and preferential reasons, web developers find themselves having to support multiple formats to capture their entire audience.</p>
 </div>
 

--- a/files/en-us/learn/performance/css/index.html
+++ b/files/en-us/learn/performance/css/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{LearnSidebar}}{{PreviousMenuNext("Learn/Performance/html", "Learn/Performance/fonts", "Learn/Performance")}} {{draft}}</p>
 
-<p>Painting an unstyled page, and then repainting it once styles are parsed would be bad user experience. For this reason, <span class="seoSummary">CSS is render blocking</span>, unless the browser knows the CSS is not currently needed. The browser can paint the page once it has downloaded the CSS and built the CSS object model. Browsers follow a specific rendering path: paint only occurs after layout, which occurs after the render tree is created, which in turn requires both the DOM and the CSSOM trees. <span class="seoSummary">To optimize the CSSOM construction, remove unnecessary styles, minify, compress and cache it, and split CSS not required at page load into additional files to reduce CSS render blocking.</span></p>
+<p>Painting an unstyled page, and then repainting it once styles are parsed would be bad user experience. For this reason, CSS is render blocking, unless the browser knows the CSS is not currently needed. The browser can paint the page once it has downloaded the CSS and built the CSS object model. Browsers follow a specific rendering path: paint only occurs after layout, which occurs after the render tree is created, which in turn requires both the DOM and the CSSOM trees. To optimize the CSSOM construction, remove unnecessary styles, minify, compress and cache it, and split CSS not required at page load into additional files to reduce CSS render blocking.</p>
 
 <h3 id="Optimizing_for_render_blocking">Optimizing for render blocking</h3>
 

--- a/files/en-us/learn/server-side/first_steps/introduction/index.html
+++ b/files/en-us/learn/server-side/first_steps/introduction/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{NextMenu("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps")}}</div>
 
-<p><span class="seoSummary">Welcome to the MDN beginner's server-side programming course! In this first article, we look at server-side programming from a high level, answering questions such as "what is it?", "how does it differ from client-side programming?", and "why it is so useful?". After reading this article you'll understand the additional power available to websites through server-side coding.</span></p>
+<p>Welcome to the MDN beginner's server-side programming course! In this first article, we look at server-side programming from a high level, answering questions such as "what is it?", "how does it differ from client-side programming?", and "why it is so useful?". After reading this article you'll understand the additional power available to websites through server-side coding.</p>
 
 <table>
  <tbody>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This PR removes `summary` and `seoSummary` classes from the Learn docs.
