### PR TITLE
[Markdown] [Learn] Fix dl elements

### DIFF
--- a/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
@@ -57,8 +57,8 @@ tags:
 	<dt>Label (or component)</dt>
 	<dd>
     <p>The labels are what follow the TLD. A label is a case-insensitive character sequence anywhere from one to sixty-three characters in length, containing only the letters A through Z, digits 0 through 9, and the - character (which may not be the first or last character in the label). <code>a</code>, <code>97</code>, and <code>hello-strange-person-16-how-are-you</code> are all examples of valid labels.</p>
-	  <p>The label located right before the TLD is also called a <em>Secondary Level Domain</em> (SLD).</p>
-	  <p>A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. <a href="https://mozilla.org">mozilla.org</a>), you can create "subdomains" with different content located at each, like <a href="https://developer.mozilla.org">developer.mozilla.org</a>, <a href="https://iot.mozilla.org/">iot.mozilla.org</a>, or <a href="https://wiki.developer.mozilla.org">wiki.developer.mozilla.org</a>.</p>
+    <p>The label located right before the TLD is also called a <em>Secondary Level Domain</em> (SLD).</p>
+    <p>A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. <a href="https://mozilla.org">mozilla.org</a>), you can create "subdomains" with different content located at each, like <a href="https://developer.mozilla.org">developer.mozilla.org</a>, <a href="https://iot.mozilla.org/">iot.mozilla.org</a>, or <a href="https://wiki.developer.mozilla.org">wiki.developer.mozilla.org</a>.</p>
   </dd>
 </dl>
 

--- a/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
@@ -55,9 +55,9 @@ tags:
 	<br>
 	The full list of TLDs is <a href="https://www.icann.org/resources/pages/tlds-2012-02-25-en">maintained by ICANN</a>.</dd>
 	<dt>Label (or component)</dt>
-	<dd>The labels are what follow the TLD. A label is a case-insensitive character sequence anywhere from one to sixty-three characters in length, containing only the letters A through Z, digits 0 through 9, and the - character (which may not be the first or last character in the label). <code>a</code>, <code>97</code>, and <code>hello-strange-person-16-how-are-you</code> are all examples of valid labels.</dd>
-	<dd>The label located right before the TLD is also called a <em>Secondary Level Domain</em> (SLD).</dd>
-	<dd>A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. <a href="https://mozilla.org">mozilla.org</a>), you can create "subdomains" with different content located at each, like <a href="https://developer.mozilla.org">developer.mozilla.org</a>, <a href="https://iot.mozilla.org/">iot.mozilla.org</a>, or <a href="https://wiki.developer.mozilla.org">wiki.developer.mozilla.org</a>. </dd>
+	<dd><p>The labels are what follow the TLD. A label is a case-insensitive character sequence anywhere from one to sixty-three characters in length, containing only the letters A through Z, digits 0 through 9, and the - character (which may not be the first or last character in the label). <code>a</code>, <code>97</code>, and <code>hello-strange-person-16-how-are-you</code> are all examples of valid labels.</p>
+	<p>The label located right before the TLD is also called a <em>Secondary Level Domain</em> (SLD).</p>
+	<p>A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. <a href="https://mozilla.org">mozilla.org</a>), you can create "subdomains" with different content located at each, like <a href="https://developer.mozilla.org">developer.mozilla.org</a>, <a href="https://iot.mozilla.org/">iot.mozilla.org</a>, or <a href="https://wiki.developer.mozilla.org">wiki.developer.mozilla.org</a>.</p></dd>
 </dl>
 
 <h3 id="Buying_a_domain_name">Buying a domain name</h3>

--- a/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_domain_name/index.html
@@ -55,9 +55,11 @@ tags:
 	<br>
 	The full list of TLDs is <a href="https://www.icann.org/resources/pages/tlds-2012-02-25-en">maintained by ICANN</a>.</dd>
 	<dt>Label (or component)</dt>
-	<dd><p>The labels are what follow the TLD. A label is a case-insensitive character sequence anywhere from one to sixty-three characters in length, containing only the letters A through Z, digits 0 through 9, and the - character (which may not be the first or last character in the label). <code>a</code>, <code>97</code>, and <code>hello-strange-person-16-how-are-you</code> are all examples of valid labels.</p>
-	<p>The label located right before the TLD is also called a <em>Secondary Level Domain</em> (SLD).</p>
-	<p>A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. <a href="https://mozilla.org">mozilla.org</a>), you can create "subdomains" with different content located at each, like <a href="https://developer.mozilla.org">developer.mozilla.org</a>, <a href="https://iot.mozilla.org/">iot.mozilla.org</a>, or <a href="https://wiki.developer.mozilla.org">wiki.developer.mozilla.org</a>.</p></dd>
+	<dd>
+    <p>The labels are what follow the TLD. A label is a case-insensitive character sequence anywhere from one to sixty-three characters in length, containing only the letters A through Z, digits 0 through 9, and the - character (which may not be the first or last character in the label). <code>a</code>, <code>97</code>, and <code>hello-strange-person-16-how-are-you</code> are all examples of valid labels.</p>
+	  <p>The label located right before the TLD is also called a <em>Secondary Level Domain</em> (SLD).</p>
+	  <p>A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. <a href="https://mozilla.org">mozilla.org</a>), you can create "subdomains" with different content located at each, like <a href="https://developer.mozilla.org">developer.mozilla.org</a>, <a href="https://iot.mozilla.org/">iot.mozilla.org</a>, or <a href="https://wiki.developer.mozilla.org">wiki.developer.mozilla.org</a>.</p>
+  </dd>
 </dl>
 
 <h3 id="Buying_a_domain_name">Buying a domain name</h3>

--- a/files/en-us/learn/common_questions/what_is_a_url/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_url/index.html
@@ -123,41 +123,47 @@ https://developer.mozilla.org/en-US/search?q=URL</pre>
 
 <h3 id="Examples_of_absolute_URLs">Examples of absolute URLs</h3>
 
-<dl>
- <dt>Full URL (the same as the one we used before)</dt>
- <dd>
- <pre>https://developer.mozilla.org/en-US/docs/Learn</pre>
- </dd>
- <dt>Implicit protocol</dt>
- <dd>
- <pre>//developer.mozilla.org/en-US/docs/Learn</pre>
-
- <p>In this case, the browser will call that URL with the same protocol as the one used to load the document hosting that URL.</p>
- </dd>
- <dt>Implicit domain name</dt>
- <dd>
- <pre>/en-US/docs/Learn</pre>
-
- <p>This is the most common use case for an absolute URL within an HTML document. The browser will use the same protocol and the same domain name as the one used to load the document hosting that URL. <strong>Note:</strong> <em>it isn't possible to omit the domain name without omitting the protocol as well</em>.</p>
- </dd>
-</dl>
+<table>
+  <tr>
+    <td>Full URL (the same as the one we used before)</td>
+    <td><pre>https://developer.mozilla.org/en-US/docs/Learn</pre></td>
+  </tr>
+  <tr>
+    <td>Implicit protocol</td>
+    <td>
+     <pre>//developer.mozilla.org/en-US/docs/Learn</pre>
+     <p>In this case, the browser will call that URL with the same protocol as the one used to load the document hosting that URL.</p>
+   </td>
+  </tr>
+  <tr>
+    <td>Implicit domain name</td>
+    <td>
+     <pre>/en-US/docs/Learn</pre>
+     <p>This is the most common use case for an absolute URL within an HTML document. The browser will use the same protocol and the same domain name as the one used to load the document hosting that URL. <strong>Note:</strong> <em>it isn't possible to omit the domain name without omitting the protocol as well</em>.</p>
+   </td>
+  </tr>
+</table>
 
 <h3 id="Examples_of_relative_URLs">Examples of relative URLs</h3>
 
 <p>To better understand the following examples, let's assume that the URLs are called from within the document located at the following URL: <code>https://developer.mozilla.org/en-US/docs/Learn</code></p>
 
-<dl>
- <dt>Sub-resources</dt>
- <dd>
- <pre>Skills/Infrastructure/Understanding_URLs</pre>
- Because that URL does not start with <code>/</code>, the browser will attempt to find the document in a sub-directory of the one containing the current resource. So in this example,  we really want to reach this URL: <code>https://developer.mozilla.org/en-US/docs/Learn/Skills/Infrastructure/Understanding_URLs</code></dd>
- <dt>Going back in the directory tree</dt>
- <dd>
- <pre>../CSS/display</pre>
-
- <p>In this case, we use the <code>../</code> writing convention — inherited from the UNIX file system world — to tell the browser we want to go up from one directory. Here we want to reach this URL: <code>https://developer.mozilla.org/en-US/docs/Learn/../CSS/display</code>, which can be simplified to: <code>https://developer.mozilla.org/en-US/docs/CSS/display</code></p>
- </dd>
-</dl>
+<table>
+  <tr>
+    <td>Sub-resources</td>
+    <td>
+      <pre>Skills/Infrastructure/Understanding_URLs</pre>
+      <p>Because that URL does not start with <code>/</code>, the browser will attempt to find the document in a sub-directory of the one containing the current resource. So in this example,  we really want to reach this URL: https://developer.mozilla.org/en-US/docs/Learn/Skills/Infrastructure/Understanding_URLs.</p>
+   </td>
+  </tr>
+  <tr>
+    <td>Going back in the directory tree</td>
+    <td>
+      <pre>../CSS/display</pre>
+      <p>In this case, we use the <code>../</code> writing convention — inherited from the UNIX file system world — to tell the browser we want to go up from one directory. Here we want to reach this URL: https://developer.mozilla.org/en-US/docs/Learn/../CSS/display, which can be simplified to: https://developer.mozilla.org/en-US/docs/CSS/display.</p>
+   </td>
+  </tr>
+</table>
 
 <h2 id="Semantic_URLs">Semantic URLs</h2>
 

--- a/files/en-us/learn/common_questions/what_is_accessibility/index.html
+++ b/files/en-us/learn/common_questions/what_is_accessibility/index.html
@@ -48,8 +48,8 @@ tags:
 
 <dl>
  <dt>Hearing impairment</dt>
- <dd>How does a hearing-impaired person benefit from a video? You have to provide subtitles —or even better, a full text transcript.</dd>
- <dd>Also, make sure people can adjust the volume to accommodate their unique needs.</dd>
+ <dd><p>How does a hearing-impaired person benefit from a video? You have to provide subtitles —or even better, a full text transcript.</p>
+ <p>Also, make sure people can adjust the volume to accommodate their unique needs.</p></dd>
  <dt>Visual impairment</dt>
  <dd>Again, provide a text transcript that a user can consult without needing to play the video, and an audio-description (an off-screen voice that describes what is happening in the video).</dd>
  <dt>Pausing capacity</dt>

--- a/files/en-us/learn/common_questions/what_is_accessibility/index.html
+++ b/files/en-us/learn/common_questions/what_is_accessibility/index.html
@@ -48,8 +48,10 @@ tags:
 
 <dl>
  <dt>Hearing impairment</dt>
- <dd><p>How does a hearing-impaired person benefit from a video? You have to provide subtitles —or even better, a full text transcript.</p>
- <p>Also, make sure people can adjust the volume to accommodate their unique needs.</p></dd>
+ <dd>
+   <p>How does a hearing-impaired person benefit from a video? You have to provide subtitles —or even better, a full text transcript.</p>
+   <p>Also, make sure people can adjust the volume to accommodate their unique needs.</p>
+ </dd>
  <dt>Visual impairment</dt>
  <dd>Again, provide a text transcript that a user can consult without needing to play the video, and an audio-description (an off-screen voice that describes what is happening in the video).</dd>
  <dt>Pausing capacity</dt>

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.html
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.html
@@ -31,49 +31,37 @@ tags:
 
 <p>In terms of behavior, we are recreating a native HTML element. Therefore it should have the same behaviors and semantics as the native HTML element. We require our control to be usable with a mouse as well as with a keyboard, and comprehensible to a screen reader, just like any native control. Let's start by defining how the control reaches each state:</p>
 
-<dl>
- <dt>The control is in its normal state when:</dt>
- <dd>
- <ul>
+<p><strong>The control is in its normal state when:</strong></p>
+<ul>
   <li>the page loads.</li>
   <li>the control was active and the user clicks anywhere outside it.</li>
   <li>the control was active and the user moves the focus to another control using the keyboard (e.g. the <kbd>Tab</kbd> key).</li>
- </ul>
- </dd>
- <dt>The control is in its active state when:</dt>
- <dd>
- <ul>
-  <li>the user clicks on it or touches it on a touch screen.</li>
-  <li>the user hits the tab key and it gains focus.</li>
-  <li>the control was in its open state and the user clicks on it.</li>
- </ul>
- </dd>
- <dt>The control is in its open state when:</dt>
- <dd>
- <ul>
-  <li>the control is in any other state than open and the user clicks on it.</li>
- </ul>
- </dd>
-</dl>
+</ul>
+
+<p><strong>The control is in its active state when:</strong></p>
+<ul>
+ <li>the user clicks on it or touches it on a touch screen.</li>
+ <li>the user hits the tab key and it gains focus.</li>
+ <li>the control was in its open state and the user clicks on it.</li>
+</ul>
+<p><strong>The control is in its open state when:</strong></p>
+<ul>
+ <li>the control is in any other state than open and the user clicks on it.</li>
+</ul>
 
 <p>Once we know how to change states, it is important to define how to change the control's value:</p>
 
-<dl>
- <dt>The value changes when:</dt>
- <dd>
- <ul>
-  <li>the user clicks on an option when the control is in the open state.</li>
-  <li>the user hits the up or down arrow keys when the control is in its active state.</li>
- </ul>
- </dd>
- <dt>The value does not change when:</dt>
- <dd>
- <ul>
-  <li>the user hits the up arrow key when the first option is selected.</li>
-  <li>the user hits the down arrow key when the last option is selected.</li>
- </ul>
- </dd>
-</dl>
+<p><strong>The value changes when:</strong></p>
+<ul>
+ <li>the user clicks on an option when the control is in the open state.</li>
+ <li>the user hits the up or down arrow keys when the control is in its active state.</li>
+</ul>
+
+<p><strong>The value does not change when:</strong></p>
+<ul>
+ <li>the user hits the up arrow key when the first option is selected.</li>
+ <li>the user hits the down arrow key when the last option is selected.</li>
+</ul>
 
 <p>Finally, let's define how the control's options will behave:</p>
 

--- a/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.html
+++ b/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.html
@@ -159,29 +159,37 @@ tags:
 
 <h2 id="Example_page_structure">Example page structure</h2>
 
-<p>· <code>{{htmlelement('html')}}</code></p>
-
-<dl>
- <dt>· <code>{{htmlelement('head')}}</code></dt>
- <dd>
- <dl>
-  <dt>· <code>{{htmlelement('link')}}</code> ...</dt>
-  <dd>CSS files required for page appearance. Minimize the number of files for performance while keeping unrelated CSS in separate files for maintenance.</dd>
-  <dt>· <code>{{htmlelement('script')}}</code> ...</dt>
-  <dd>JavaScript files for functions <strong>required</strong> during the loading of the page, but not any interaction related JavaScript that can only run after page loads.
-  Minimize the number of files for performance while keeping unrelated JavaScript in separate files for maintenance.</dd>
- </dl>
- </dd>
- <dt>· <code>{{htmlelement('body')}}</code></dt>
- <dd>· User visible page content in small chunks ( <code>{{htmlelement('header')}}</code>/ <code>{{htmlelement('main')}}/</code> <code>{{htmlelement('table')}}</code>) that can be displayed without waiting for the full page to download.
- <dl>
-  <dt>· <code>{{htmlelement('script')}}</code> ...</dt>
-  <dd>Any scripts which will be used to perform interactivity. Interaction scripts typically can only run after the page has completely loaded and all necessary objects have been initialized. There is no need to load these scripts before the page content. That only slows down the initial appearance of the page load.<br>
-  Minimize the number of files for performance while keeping unrelated JavaScript in separate files for maintenance.<br>
-  If any images are used for rollover effects, you should preload them here after the page content has downloaded.</dd>
- </dl>
- </dd>
-</dl>
+<ul>
+  <li>
+    <code>{{htmlelement('html')}}</code>
+    <ul>
+      <li>
+        <code>{{htmlelement('head')}}</code>
+        <ul>
+          <li>
+            <code>{{htmlelement('link')}}</code> ...
+            <p>CSS files required for page appearance. Minimize the number of files for performance while keeping unrelated CSS in separate files for maintenance.</p>
+          </li>
+          <li>
+            <code>{{htmlelement('script')}}</code> ...
+            <p>JavaScript files for functions <strong>required</strong> during the loading of the page, but not any interaction related JavaScript that can only run after page loads.</p>
+            <p>Minimize the number of files for performance while keeping unrelated JavaScript in separate files for maintenance.</p>
+        </ul>
+      </li>
+      <li>
+        <code>{{htmlelement('body')}}</code>
+        <p>User visible page content in small chunks ( <code>{{htmlelement('header')}}</code>/ <code>{{htmlelement('main')}}/</code> <code>{{htmlelement('table')}}</code>) that can be displayed without waiting for the full page to download.</p>
+        <ul>
+          <li>
+            <code>{{htmlelement('script')}}</code>
+            <p>Any scripts which will be used to perform interactivity. Interaction scripts typically can only run after the page has completely loaded and all necessary objects have been initialized. There is no need to load these scripts before the page content. That only slows down the initial appearance of the page load.</p>
+            <p>Minimize the number of files for performance while keeping unrelated JavaScript in separate files for maintenance.</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/learn/html/howto/define_terms_with_html/index.html
+++ b/files/en-us/learn/html/howto/define_terms_with_html/index.html
@@ -31,8 +31,6 @@ tags:
  <dt>Blue (<em>Adjective</em>)</dt>
  <dd>Of a color like the sky in a sunny day.<br>
  <em><q>The clear blue sky</q></em></dd>
- <dd>Of a subtle sadness, melancholy.<br>
- <em><q>I'm feeling blue</q></em></dd>
 </dl>
 </blockquote>
 

--- a/files/en-us/learn/performance/javascript_performance/index.html
+++ b/files/en-us/learn/performance/javascript_performance/index.html
@@ -35,17 +35,18 @@ tags:
 
 <p>Performance optimizations should include:</p>
 
-<dl>
- <dt>Reducing the amount of JavaScript that is needed.</dt>
- <dd>Some features requiring complex JavaScript can be done with a few lines of JavaScript. Requiring a library for other features may improve developer experience, but is all that JavaScript required? Is there a lighter weight or home spun solutions? Some features may not be necessary, and though they may add some bling, is the cost of the feature in terms of performance worth it?</dd>
- <dt>Remove unused code</dt>
- <dd></dd>
- <dt>Split the JavaScript into smaller files</dt>
- <dd>Code-split JavaScript into critical and non-critical parts. Module bundlers like webpack support code-splitting.</dd>
- <dt>Optimize these smaller files</dt>
- <dd><a href="/en-US/docs/Glossary/minification">Minification</a> reduces the number of characters in your file, thereby reducing the number of bytes or weight of your JavaScript. <a href="/en-US/docs/Glossary/GZip_compression">Gzipping</a> compresses the file further, and should be used even if you don't minify. <a href="/en-US/docs/Glossary/brotli_compression">Brotli</a> is similar to Gzip, generally outperforming Gzip's compression.</dd>
- <dd></dd>
-</dl>
+<ul>
+ <li>
+   <p><strong>Reducing the amount of JavaScript that is needed.</strong> Some features requiring complex JavaScript can be done with a few lines of JavaScript. Requiring a library for other features may improve developer experience, but is all that JavaScript required? Is there a lighter weight or home spun solutions? Some features may not be necessary, and though they may add some bling, is the cost of the feature in terms of performance worth it?</p>
+ </li>
+ <li><strong>Remove unused code.</strong></li>
+ <li>
+   <p><strong>Split the JavaScript into smaller files.</strong> Code-split JavaScript into critical and non-critical parts. Module bundlers like webpack support code-splitting.</p>
+ </li>
+ <li>
+   <p><strong>Optimize these smaller files.</strong> <a href="/en-US/docs/Glossary/minification">Minification</a> reduces the number of characters in your file, thereby reducing the number of bytes or weight of your JavaScript. <a href="/en-US/docs/Glossary/GZip_compression">Gzipping</a> compresses the file further, and should be used even if you don't minify. <a href="/en-US/docs/Glossary/brotli_compression">Brotli</a> is similar to Gzip, generally outperforming Gzip's compression.</p>
+ </li>
+</ul>
 
 <h2 id="Render_impact">Render impact</h2>
 

--- a/files/en-us/learn/server-side/configuring_server_mime_types/index.html
+++ b/files/en-us/learn/server-side/configuring_server_mime_types/index.html
@@ -37,11 +37,15 @@ tags:
 
 <dl>
  <dt>Loss of control</dt>
- <dd>If the browser ignores the reported MIME type, web administrators and authors no longer have control over how their content is to be processed.</dd>
- <dd>For example, a web site oriented for web developers might wish to send certain example HTML documents as either <code>text/html</code> or <code>text/plain</code> in order to have the documents either processed and displayed as HTML or as source code. If the browser guesses the MIME type, this option is no longer available to the author.</dd>
+ <dd>
+   <p>If the browser ignores the reported MIME type, web administrators and authors no longer have control over how their content is to be processed.</p>
+   <p>For example, a web site oriented for web developers might wish to send certain example HTML documents as either <code>text/html</code> or <code>text/plain</code> in order to have the documents either processed and displayed as HTML or as source code. If the browser guesses the MIME type, this option is no longer available to the author.</p>
+ </dd>
  <dt>Security</dt>
- <dd>Some content types, such as executable programs, are inherently unsafe. For this reason, these MIME types are usually restricted in terms of what actions a web browser will take when given that type of content. An executable program should not be executed on the user's computer and should at least cause a dialog to appear <strong>asking the user</strong> if they wish to download the file.</dd>
- <dd>MIME type guessing has led to security exploits in Internet Explorer that were based upon a malicious author incorrectly reporting a MIME type of a dangerous file as a safe type. This bypassed the normal download dialog, resulting in Internet Explorer guessing that the content was an executable program and then running it on the user's computer.</dd>
+ <dd>
+   <p>Some content types, such as executable programs, are inherently unsafe. For this reason, these MIME types are usually restricted in terms of what actions a web browser will take when given that type of content. An executable program should not be executed on the user's computer and should at least cause a dialog to appear <strong>asking the user</strong> if they wish to download the file.</p>
+   <p>MIME type guessing has led to security exploits in Internet Explorer that were based upon a malicious author incorrectly reporting a MIME type of a dangerous file as a safe type. This bypassed the normal download dialog, resulting in Internet Explorer guessing that the content was an executable program and then running it on the user's computer.</p>
+ </dd>
 </dl>
 
 <h2 id="JavaScript_legacy_MIME_types">JavaScript legacy MIME types</h2>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This PR fixes up `<dl>` elements in the Learn area so they will be converted properly. In a few places I thought it would be better to use alternatives.
