### PR TITLE
[Markdown] [Learn] Remove (most) inline styles

### DIFF
--- a/files/en-us/learn/common_questions/available_text_editors/index.html
+++ b/files/en-us/learn/common_questions/available_text_editors/index.html
@@ -45,7 +45,7 @@ tags:
 
 <p>Here are some popular editors:</p>
 
-<table class="standard-table" style="height: 522px; width: 917px;">
+<table class="standard-table"">
  <thead>
   <tr>
    <th scope="col">Editor</th>
@@ -61,156 +61,156 @@ tags:
   <tr>
    <td><a href="https://atom.io/">Atom</a></td>
    <td>MIT/BSD</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://discuss.atom.io/categories" rel="external">Forum</a></td>
    <td><a href="https://atom.io/docs/latest/">Online Manual</a></td>
-   <td style="text-align: center;"><a href="https://atom.io/packages">Yes</a></td>
+   <td><a href="https://atom.io/packages">Yes</a></td>
   </tr>
   <tr>
    <td><a href="http://bluefish.openoffice.nl">Bluefish</a></td>
    <td>GPL 3</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://bfwiki.tellefsen.net/index.php/Mailinglists">Mailing list</a>, <a href="https://bfwiki.tellefsen.net/index.php/Main_Page">wiki</a></td>
    <td><a href="http://bluefish.openoffice.nl/manual/">Online Manual</a></td>
-   <td style="text-align: center;">Yes</td>
+   <td>Yes</td>
   </tr>
   <tr>
    <td><a href="http://brackets.io/" rel="external">Brackets</a></td>
    <td>MIT/BSD</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://groups.google.com/forum/#!forum/brackets-dev" rel="external">Forum</a>, <a href="https://webchat.freenode.net/?channels=brackets" rel="external">IRC</a></td>
    <td><a href="https://github.com/adobe/brackets/wiki" rel="external">GitHub Wiki</a></td>
-   <td style="text-align: center;"><a href="https://ingorichter.github.io/BracketsExtensionTweetBot/" rel="external">Yes</a></td>
+   <td><a href="https://ingorichter.github.io/BracketsExtensionTweetBot/" rel="external">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://panic.com/coda/" rel="external">Coda</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">$99</td>
+   <td>$99</td>
    <td>Mac</td>
    <td><a href="https://twitter.com/panic">Twitter</a>, <a href="https://panic.com/qa" rel="external">Forum</a>, <a href="mailto:coda@panic.com">E-mail</a></td>
    <td><a href="https://panic.com/coda/#book">eBook</a></td>
-   <td style="text-align: center;"><a href="https://panic.com/coda/plugins.php">Yes</a></td>
+   <td><a href="https://panic.com/coda/plugins.php">Yes</a></td>
   </tr>
   <tr>
    <td><a href="http://www.codelobster.com">CodeLobster</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="http://www.codelobster.com/forum/index.php" rel="external">Forum</a>, <a href="mailto:support@codelobster.com">E-mail</a></td>
    <td><a href="https://www.codelobsteride.com/help/">Online Manual</a></td>
-   <td style="text-align: center;">Yes</td>
+   <td>Yes</td>
   </tr>
   <tr>
    <td><a href="https://www.gnu.org/software/emacs/" rel="external">Emacs</a></td>
    <td>GPL 3</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://www.gnu.org/software/emacs/manual/efaq.html" rel="external">FAQ</a>, <a href="https://mail.gnu.org/mailman/listinfo/help-gnu-emacs" rel="external">Mailing list</a>, <a href="news://gnu.emacs.help" rel="external">News Group</a></td>
    <td><a href="https://www.gnu.org/software/emacs/manual/html_node/emacs/index.html">Online Manual</a></td>
-   <td style="text-align: center;">Yes</td>
+   <td>Yes</td>
   </tr>
   <tr>
    <td><a href="https://www.macrabbit.com/espresso/">Espresso</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">$75</td>
+   <td>$75</td>
    <td>Mac</td>
    <td><a href="https://www.macrabbit.com/support/" rel="external">FAQ</a>, <a href="mailto:support@macrabbit.com">E-mail</a></td>
    <td>No end user doc,<br>
     but <a href="http://wiki.macrabbit.com/">plug-in doc</a></td>
-   <td style="text-align: center;">Yes</td>
+   <td>Yes</td>
   </tr>
   <tr>
    <td><a href="https://wiki.gnome.org/Apps/Gedit">Gedit</a></td>
    <td>GPL</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://mail.gnome.org/mailman/listinfo/gedit-list" rel="external">Mailing list</a>, <a href="irc://irc.gnome.org/%23gedit">IRC</a></td>
    <td><a href="https://help.gnome.org/users/gedit/stable/">Online Manual</a></td>
-   <td style="text-align: center;"><a href="https://wiki.gnome.org/Apps/Gedit/PluginsLists">Yes</a></td>
+   <td><a href="https://wiki.gnome.org/Apps/Gedit/PluginsLists">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://kate-editor.org/">Kate</a></td>
    <td>LGPL, GPL</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="mailto:kwrite-devel@kde.org">Mailing list</a>, <a href="irc://irc.kde.org/kate">IRC</a></td>
    <td><a href="https://docs.kde.org/stable5/en/applications/kate/index.html">Online Manual</a></td>
-   <td style="text-align: center;">Yes</td>
+   <td>Yes</td>
   </tr>
   <tr>
    <td><a href="https://komodoide.com/komodo-edit/" rel="external">Komodo Edit</a></td>
    <td>MPL</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="http://forum.komodoide.com/" rel="external">Forum</a></td>
    <td><a href="http://docs.activestate.com/komodo/8.5/" rel="external">Online Manual</a></td>
-   <td style="text-align: center;"><a href="https://komodoide.com/resources/addons/">Yes</a></td>
+   <td><a href="https://komodoide.com/resources/addons/">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://www.notepad-plus-plus.org/" rel="external">Notepad++</a></td>
    <td>GPL</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows</td>
    <td><a href="https://sourceforge.net/p/notepad-plus/discussion/">Forum</a></td>
    <td><a href="https://npp-wiki.tuxfamily.org/index.php?title=Main_Page" rel="external">Wiki</a></td>
-   <td style="text-align: center;"><a href="https://npp-wiki.tuxfamily.org/index.php?title=Plugin_Central" rel="external">Yes</a></td>
+   <td><a href="https://npp-wiki.tuxfamily.org/index.php?title=Plugin_Central" rel="external">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://www.pspad.com/">PSPad</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows</td>
    <td><a href="http://gogogadgetscott.info/pspad/dotazy.htm">FAQ</a>, <a href="https://forum.pspad.com/" rel="external">Forum</a></td>
    <td><a href="http://gogogadgetscott.info/pspad/">Online Help</a></td>
-   <td style="text-align: center;"><a href="https://www.pspad.com/en/pspad-extensions.php">Yes</a></td>
+   <td><a href="https://www.pspad.com/en/pspad-extensions.php">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://www.sublimetext.com/" rel="external">Sublime Text</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">$70</td>
+   <td>$70</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://www.sublimetext.com/forum/viewforum.php?f=3" rel="external">Forum</a></td>
    <td><a href="https://www.sublimetext.com/docs/3/">Official</a>,<a href="http://docs.sublimetext.info/en/latest/index.html"> Unofficial</a></td>
-   <td style="text-align: center;"><a href="https://sublime.wbond.net/">Yes</a></td>
+   <td><a href="https://sublime.wbond.net/">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://macromates.com/" rel="external">TextMate</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">$50</td>
+   <td>$50</td>
    <td>Mac</td>
    <td><a href="https://twitter.com/macromates">Twitter</a>, <a href="https://webchat.freenode.net/?channels=textmate">IRC</a>, <a href="https://lists.macromates.com/listinfo/textmate" rel="external">Mailing list</a>, <a href="mailto:tm-support@macromates.com">E-mail</a></td>
    <td><a href="https://manual.macromates.com/en/">Online Manual</a>, <a href="https://wiki.macromates.com/Main/HomePage" rel="external">Wiki</a></td>
-   <td style="text-align: center;"><a href="https://wiki.macromates.com/Main/Plugins" rel="external">Yes</a></td>
+   <td><a href="https://wiki.macromates.com/Main/Plugins" rel="external">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://www.barebones.com/products/textwrangler/" rel="external">TextWrangler</a></td>
    <td>Closed source</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Mac</td>
    <td><a href="https://www.barebones.com/support/textwrangler/faqs.html" rel="external">FAQ</a>, <a href="https://groups.google.com/forum/#!forum/textwrangler">Forum</a></td>
    <td><a href="http://ash.barebones.com/TextWrangler_User_Manual.pdf" rel="external">PDF Manual</a></td>
-   <td style="text-align: center;">No</td>
+   <td>No</td>
   </tr>
   <tr>
    <td><a href="https://www.vim.org/" rel="external">Vim</a></td>
    <td><a href="http://vimdoc.sourceforge.net/htmldoc/uganda.html#license" rel="external">Specific open license</a></td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://www.vim.org/maillist.php#vim" rel="external">Mailing list</a></td>
    <td><a href="http://vimdoc.sourceforge.net/">Online Manual</a></td>
-   <td style="text-align: center;"><a href="https://www.vim.org/scripts/script_search_results.php?order_by=creation_date&amp;direction=descending" rel="external">Yes</a></td>
+   <td><a href="https://www.vim.org/scripts/script_search_results.php?order_by=creation_date&amp;direction=descending" rel="external">Yes</a></td>
   </tr>
   <tr>
    <td><a href="https://code.visualstudio.com/download">Visual Studio Code</a></td>
    <td><a href="https://github.com/microsoft/vscode">Open Source</a> under MIT licence/ Specific licence for product</td>
-   <td style="text-align: center;">Free</td>
+   <td>Free</td>
    <td>Windows, Mac, Linux</td>
    <td><a href="https://code.visualstudio.com/docs/supporting/faq">FAQ</a>     </td>
    <td><a href="https://code.visualstudio.com/docs">Documentation</a></td>
-   <td style="text-align: center;"><a href="https://marketplace.visualstudio.com/VSCode">Yes</a></td>
+   <td><a href="https://marketplace.visualstudio.com/VSCode">Yes</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/learn/common_questions/how_do_you_host_your_website_on_google_app_engine/index.html
+++ b/files/en-us/learn/common_questions/how_do_you_host_your_website_on_google_app_engine/index.html
@@ -52,13 +52,13 @@ tags:
  <li>Open <a href="https://console.cloud.google.com/cloudshell/editor">Google Cloud Shell</a>.</li>
  <li>Drag and drop the <code>sample-app</code> folder into the left pane of the code editor.</li>
  <li>Run the following in the command line to select your project:
-  <pre class="brush:bash no-line-numbers" style="margin: 1em 0;">gcloud config set project <em>gaesamplesite</em></pre>
+  <pre class="brush: bash">gcloud config set project <em>gaesamplesite</em></pre>
  </li>
  <li>Then run the following command to go to your app's directory:
-  <pre class="brush:bash no-line-numbers" style="margin: 1em 0;">cd <em>sample-app</em></pre>
+  <pre class="brush: bash">cd <em>sample-app</em></pre>
  </li>
  <li>You are now ready to deploy your application, i.e. upload your app to App Engine:
-  <pre class="brush:bash no-line-numbers" style="margin: 1em 0;">gcloud app deploy</pre>
+  <pre class="brush: bash">gcloud app deploy</pre>
  </li>
  <li>Enter a number to choose the region where you want your application located.</li>
  <li>Enter <code>Y</code> to confirm.</li>

--- a/files/en-us/learn/common_questions/pages_sites_servers_and_search_engines/index.html
+++ b/files/en-us/learn/common_questions/pages_sites_servers_and_search_engines/index.html
@@ -82,7 +82,7 @@ tags:
 
 <p>All web pages available on the web are reachable through a unique address. To access a page, just type its address in your browser address bar:</p>
 
-<p style="text-align: center;"><img alt="Example of a web page address in the browser address bar" src="web-page.jpg"></p>
+<img alt="Example of a web page address in the browser address bar" src="web-page.jpg">
 
 <h3 id="Web_site">Web site</h3>
 

--- a/files/en-us/learn/common_questions/thinking_before_coding/index.html
+++ b/files/en-us/learn/common_questions/thinking_before_coding/index.html
@@ -111,7 +111,7 @@ tags:
 	</thead>
 	<tbody>
 		<tr>
-			<td style="vertical-align: top;">Let people hear your music</td>
+			<td>Let people hear your music</td>
 			<td>
 			<ol>
 				<li>Record music</li>
@@ -121,7 +121,7 @@ tags:
 			</td>
 		</tr>
 		<tr>
-			<td style="vertical-align: top;">Talk about your music</td>
+			<td>Talk about your music</td>
 			<td>
 			<ol>
 				<li>Write a few articles to start the discussion</li>
@@ -131,7 +131,7 @@ tags:
 			</td>
 		</tr>
 		<tr>
-			<td style="vertical-align: top;">Meet other musicians</td>
+			<td>Meet other musicians</td>
 			<td>
 			<ol>
 				<li>Provide ways for people to contact you (Email? Facebook? Phone? Mail?)</li>
@@ -140,7 +140,7 @@ tags:
 			</td>
 		</tr>
 		<tr>
-			<td style="vertical-align: top;">Sell goodies</td>
+			<td>Sell goodies</td>
 			<td>
 			<ol>
 				<li>Create the goodies</li>
@@ -152,7 +152,7 @@ tags:
 			</td>
 		</tr>
 		<tr>
-			<td style="vertical-align: top;">Teach music through videos</td>
+			<td>Teach music through videos</td>
 			<td>
 			<ol>
 				<li>Record video lessons</li>

--- a/files/en-us/learn/common_questions/what_software_do_i_need/index.html
+++ b/files/en-us/learn/common_questions/what_software_do_i_need/index.html
@@ -147,7 +147,7 @@ tags:
  <thead>
   <tr>
    <th scope="col">Operating system</th>
-   <th colspan="2" scope="col" style="text-align: center;"> FTP software</th>
+   <th colspan="2" scope="col"> FTP software</th>
   </tr>
  </thead>
  <tbody>
@@ -155,7 +155,7 @@ tags:
    <td>Windows</td>
    <td>
     <ul>
-     <li><a href="https://winscp.net" rel="external">WinSCP</a></li>
+     <li><a href="https://winscp.net">WinSCP</a></li>
      <li><a href="https://mobaxterm.mobatek.net/">Moba Xterm</a></li>
     </ul>
    </td>

--- a/files/en-us/learn/css/first_steps/how_css_works/index.html
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.html
@@ -62,7 +62,7 @@ tags:
 &lt;/p&gt;
 </pre>
 
-<p>In the DOM, the node corresponding to our <code>&lt;p&gt;</code> element is a parent. Its children are a text node and the three nodes corresponding to our <code>&lt;span&gt;</code> elements. The <code>SPAN</code> nodes are also <span style="background-color: #f5f6f5;">parents</span>, with text nodes as their children:</p>
+<p>In the DOM, the node corresponding to our <code>&lt;p&gt;</code> element is a parent. Its children are a text node and the three nodes corresponding to our <code>&lt;span&gt;</code> elements. The <code>SPAN</code> nodes are also parents, with text nodes as their children:</p>
 
 <pre>P
 ├─ "Let's use:"

--- a/files/en-us/learn/css/styling_text/fundamentals/index.html
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.html
@@ -117,7 +117,7 @@ occasion such as this that he did.&lt;/p&gt;</pre>
  <thead>
   <tr>
    <th scope="col">Name</th>
-   <th scope="col" style="white-space: nowrap;">Generic type</th>
+   <th scope="col">Generic type</th>
    <th scope="col">Notes</th>
   </tr>
  </thead>
@@ -133,12 +133,12 @@ occasion such as this that he did.&lt;/p&gt;</pre>
    <td>Some OSes have an alternative (possibly older) version of the <em>Courier New</em> font called <em>Courier</em>. It's considered best practice to use both with <em>Courier New</em> as the preferred alternative.</td>
   </tr>
   <tr>
-   <td style="white-space: nowrap;">Georgia</td>
+   <td>Georgia</td>
    <td>serif</td>
    <td></td>
   </tr>
   <tr>
-   <td style="white-space: nowrap;">Times New Roman</td>
+   <td>Times New Roman</td>
    <td>serif</td>
    <td>Some OSes have an alternative (possibly older) version of the <em>Times New Roman</em> font called <em>Times</em>. It's considered best practice to use both with <em>Times New Roman</em> as the preferred alternative.</td>
   </tr>
@@ -309,13 +309,13 @@ p {
  <li>{{cssxref("font-style")}}: Used to turn italic text on or off. Possible values are as follows (you'll rarely use this, unless you want to turn some italic styling off for some reason):
   <ul>
    <li><code>normal</code>: Sets the text to the normal font (turns existing italics off.)</li>
-   <li><code>italic</code>: Sets the text to use the <em>italic version of the font</em>, if available; if not, it will simulate italics with oblique instead.</li>
-   <li><code>oblique</code>: Sets the text to use a simulated version of an italic font, created by <span style="font-style: oblique;">slanting the normal version</span>.</li>
+   <li><code>italic</code>: Sets the text to use the italic version of the font, if available; if not, it will simulate italics with oblique instead.</li>
+   <li><code>oblique</code>: Sets the text to use a simulated version of an italic font, created by slanting the normal version.</li>
   </ul>
  </li>
  <li>{{cssxref("font-weight")}}: Sets how bold the text is. This has many values available in case you have many font variants available (such as <em>-light</em>, <em>-normal</em>, <em>-bold</em>, <em>-extrabold</em>, <em>-black</em>, etc.), but realistically you'll rarely use any of them except for <code>normal</code> and <code>bold</code>:
   <ul>
-   <li><code>normal</code>, <code>bold</code>: Normal and <strong style="font-weight: bold;">bold</strong> font weight</li>
+   <li><code>normal</code>, <code>bold</code>: Normal and bold font weight</li>
    <li><code>lighter</code>, <code>bolder</code>: Sets the current element's boldness to be one step lighter or heavier than its parent element's boldness.</li>
    <li><code>100</code>–<code>900</code>: Numeric boldness values that provide finer grained control than the above keywords, if needed. </li>
   </ul>
@@ -323,20 +323,20 @@ p {
  <li>{{cssxref("text-transform")}}: Allows you to set your font to be transformed. Values include:
   <ul>
    <li><code>none</code>: Prevents any transformation.</li>
-   <li><code>uppercase</code>: Transforms <span style="text-transform: uppercase;">all text to capitals</span>.</li>
+   <li><code>uppercase</code>: Transforms all text to capitals.</li>
    <li><code>lowercase</code>: Transforms all text to lower case.</li>
-   <li><code>capitalize</code>: Transforms all words to <span style="text-transform: capitalize;">have the first letter capitalized</span>.</li>
-   <li><code>full-width</code>: Transforms all glyphs to be <span style="text-transform: full-width;">written inside a fixed-width square</span>, similar to a monospace font, allowing aligning of, e.g., Latin characters along with Asian language glyphs (like Chinese, Japanese, Korean).</li>
+   <li><code>capitalize</code>: Transforms all words to have the first letter capitalized.</li>
+   <li><code>full-width</code>: Transforms all glyphs to be written inside a fixed-width square, similar to a monospace font, allowing aligning of, e.g., Latin characters along with Asian language glyphs (like Chinese, Japanese, Korean).</li>
   </ul>
  </li>
  <li>{{cssxref("text-decoration")}}: Sets/unsets text decorations on fonts (you'll mainly use this to unset the default underline on links when styling them.) Available values are:
   <ul>
    <li><code>none</code>: Unsets any text decorations already present.</li>
-   <li><code>underline</code>: <u>Underlines the text</u>.</li>
-   <li><code>overline</code>: <span style="text-decoration: overline;">Gives the text an overline</span>.</li>
-   <li><code>line-through</code>: Puts a <s style="text-decoration: line-through;">strikethrough over the text</s>.</li>
+   <li><code>underline</code>: Underlines the text.</li>
+   <li><code>overline</code>: Gives the text an overline.</li>
+   <li><code>line-through</code>: Puts a strikethrough over the text.</li>
   </ul>
-  You should note that {{cssxref("text-decoration")}} can accept multiple values at once if you want to add multiple decorations simultaneously, for example, <span style="text-decoration: underline overline;"><code>text-decoration: underline overline</code></span>. Also note that {{cssxref("text-decoration")}} is a shorthand property for {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-style")}}, and {{cssxref("text-decoration-color")}}. You can use combinations of these property values to create interesting effects, for example <span style="text-decoration: line-through red wavy;"><code>text-decoration: line-through red wavy</code>.</span></li>
+  You should note that {{cssxref("text-decoration")}} can accept multiple values at once if you want to add multiple decorations simultaneously, for example, <code>text-decoration: underline overline</code>. Also note that {{cssxref("text-decoration")}} is a shorthand property for {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-style")}}, and {{cssxref("text-decoration-color")}}. You can use combinations of these property values to create interesting effects, for example: <code>text-decoration: line-through red wavy</code>.</li>
 </ul>
 
 <p>Let's look at adding a couple of these properties to our example:</p>

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.html
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.html
@@ -295,9 +295,9 @@ tags:
 <table>
  <thead>
   <tr>
-   <th scope="col" style="text-align: center;">Basic state</th>
-   <th scope="col" style="text-align: center;">Active state</th>
-   <th scope="col" style="text-align: center;">Open state</th>
+   <th scope="col">Basic state</th>
+   <th scope="col">Active state</th>
+   <th scope="col">Open state</th>
   </tr>
  </thead>
  <tbody>
@@ -307,7 +307,7 @@ tags:
    <td>{{EmbedLiveSample("Open_state",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_1")}}</td>
   </tr>
   <tr>
-   <td colspan="3" style="text-align: center;"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_1">Check out the source code</a></td>
+   <td colspan="3"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_1">Check out the source code</a></td>
   </tr>
  </tbody>
 </table>
@@ -392,8 +392,8 @@ tags:
 <table>
  <thead>
   <tr>
-   <th scope="col" style="text-align: center;">Without JS</th>
-   <th scope="col" style="text-align: center;">With JS</th>
+   <th scope="col">Without JS</th>
+   <th scope="col">With JS</th>
   </tr>
  </thead>
  <tbody>
@@ -402,7 +402,7 @@ tags:
    <td>{{EmbedLiveSample("JS",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_2")}}</td>
   </tr>
   <tr>
-   <td colspan="2" style="text-align: center;"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_2">Check out the source code</a></td>
+   <td colspan="2"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_2">Check out the source code</a></td>
   </tr>
  </tbody>
 </table>
@@ -570,7 +570,7 @@ window.addEventListener('load', function () {
 <table>
  <thead>
   <tr>
-   <th scope="col" style="text-align: center;">Live example</th>
+   <th scope="col">Live example</th>
   </tr>
  </thead>
  <tbody>
@@ -578,7 +578,7 @@ window.addEventListener('load', function () {
    <td>{{EmbedLiveSample("Change_states",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_3")}}</td>
   </tr>
   <tr>
-   <td style="text-align: center;"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_3">Check out the source code</a></td>
+   <td><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_3">Check out the source code</a></td>
   </tr>
  </tbody>
 </table>
@@ -677,7 +677,7 @@ window.addEventListener('load', function () {
 <table>
  <thead>
   <tr>
-   <th scope="col" style="text-align: center;">Live example</th>
+   <th scope="col">Live example</th>
   </tr>
  </thead>
  <tbody>
@@ -685,7 +685,7 @@ window.addEventListener('load', function () {
    <td>{{EmbedLiveSample("Change_states",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_4")}}</td>
   </tr>
   <tr>
-   <td style="text-align: center;"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_4">Check out the source code</a></td>
+   <td><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_4">Check out the source code</a></td>
   </tr>
  </tbody>
 </table>
@@ -755,7 +755,7 @@ window.addEventListener('load', function () {
 <table>
  <thead>
   <tr>
-   <th scope="col" style="text-align: center;">Live example</th>
+   <th scope="col">Live example</th>
   </tr>
  </thead>
  <tbody>
@@ -763,7 +763,7 @@ window.addEventListener('load', function () {
    <td>{{EmbedLiveSample("Change_states",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_5")}}</td>
   </tr>
   <tr>
-   <td style="text-align: center;"><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_5">Check out the final source code</a></td>
+   <td><a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls/Example_5">Check out the final source code</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
+++ b/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
@@ -55,14 +55,14 @@ tags:
 <table>
  <thead>
   <tr>
-   <th scope="col" style="text-align: center;">Supported</th>
-   <th scope="col" style="text-align: center;">Not supported</th>
+   <th>Supported</th>
+   <th>Not supported</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <th style="text-align: center;"><img alt="Screen shot of the color input on Chrome for Mac OSX" src="color-fallback-chrome.png"></th>
-   <th style="text-align: center;"><img alt="Screen shot of the color input on Firefox for Mac OSX" src="color-fallback-firefox.png"></th>
+   <td><img alt="Screen shot of the color input on Chrome for Mac OSX" src="color-fallback-chrome.png"></td>
+   <td><img alt="Screen shot of the color input on Firefox for Mac OSX" src="color-fallback-firefox.png"></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.html
@@ -176,7 +176,7 @@ Everything in between is a comment.
 
 <p>If your comment contains no line breaks, it's an option to put it behind two slashes like this:</p>
 
-<pre class="brush: js" style="font-size: 14px;">// This is a comment
+<pre class="brush: js">// This is a comment
 </pre>
 
 <h3 id="Operators">Operators</h3>

--- a/files/en-us/learn/javascript/first_steps/math/index.html
+++ b/files/en-us/learn/javascript/first_steps/math/index.html
@@ -282,29 +282,29 @@ x = y; // x now contains the same value y contains, 4</pre>
    <td><code>+=</code></td>
    <td>Addition assignment</td>
    <td>Adds the value on the right to the variable value on the left, then returns the new variable value</td>
-   <td style="white-space: nowrap;"><code>x += 4;</code></td>
-   <td style="white-space: nowrap;"><code>x = x + 4;</code></td>
+   <td><code>x += 4;</code></td>
+   <td><code>x = x + 4;</code></td>
   </tr>
   <tr>
    <td><code>-=</code></td>
    <td>Subtraction assignment</td>
    <td>Subtracts the value on the right from the variable value on the left, and returns the new variable value</td>
-   <td style="white-space: nowrap;"><code>x -= 3;</code></td>
-   <td style="white-space: nowrap;"><code>x = x - 3;</code></td>
+   <td><code>x -= 3;</code></td>
+   <td><code>x = x - 3;</code></td>
   </tr>
   <tr>
    <td><code>*=</code></td>
    <td>Multiplication assignment</td>
    <td>Multiplies the variable value on the left by the value on the right, and returns the new variable value</td>
-   <td style="white-space: nowrap;"><code>x *= 3;</code></td>
-   <td style="white-space: nowrap;"><code>x = x * 3;</code></td>
+   <td><code>x *= 3;</code></td>
+   <td><code>x = x * 3;</code></td>
   </tr>
   <tr>
    <td><code>/=</code></td>
    <td>Division assignment</td>
    <td>Divides the variable value on the left by the value on the right, and returns the new variable value</td>
-   <td style="white-space: nowrap;"><code>x /= 5;</code></td>
-   <td style="white-space: nowrap;"><code>x = x / 5;</code></td>
+   <td><code>x /= 5;</code></td>
+   <td><code>x = x / 5;</code></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/learn/server-side/first_steps/website_security/index.html
+++ b/files/en-us/learn/server-side/first_steps/website_security/index.html
@@ -117,7 +117,7 @@ tags:
 
 <p>If a user clicks the submit button, an HTTP <code>POST</code> request will be sent to the server containing the transaction details and any client-side cookies that the browser associated with the site (adding associated site cookies to requests is normal browser behavior). The server will check the cookies, and use them to determine whether or not the user is logged in and has permission to make the transaction.</p>
 
-<p>The result is that a<span style="line-height: 1.5;">ny user who clicks the <em>Submit</em> button while they are logged in to the trading site will make the transaction. John gets rich.</span></p>
+<p>The result is that any user who clicks the <em>Submit</em> button while they are logged in to the trading site will make the transaction. John gets rich.</p>
 
 <div class="note">
 <p><strong>Note:</strong> The trick here is that John doesn't need to have access to the user's cookies (or access credentials). The browser of the user stores this information and automatically includes it in all requests to the associated server.</p>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.html
@@ -227,7 +227,7 @@ export default class TodoListComponent extends Component {
 
 <p>With a dynamic <code>#each</code> block (which is basically syntactic sugar over the top of JavaScript's <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach">forEach()</a></code>) that creates a <code>&lt;Todo /&gt;</code> component for each todo available in the list of todos returned by the service’s <code>all()</code> getter:</p>
 
-<pre class="brush: js" dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;">\{{#each this.todos.all as |todo|}}
+<pre class="brush: js">\{{#each this.todos.all as |todo|}}
   &lt;Todo @todo=\{{todo}} /&gt;
 \{{/each}}</pre>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

This PR removes most inline styles from the Learn docs.

It leaves them alone in:
* the table at https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#default_fonts
* the tables at https://developer.mozilla.org/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls#compatibility_tables
* the table at https://developer.mozilla.org/en-US/docs/Learn/HTML/Cheatsheet#inline_elements

I don't love the use of inline styles in these tables, but they will not be converted to Markdown anyway, so removing them is a fair bit of work and doesn't get the conversion any further.
