### PR TITLE
FF supports AV1 but not on android and windows on ARM

### DIFF
--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -486,11 +486,7 @@ In addition, you can [add the `codecs` parameter](/en-US/docs/Web/Media/Formats/
       <td></td>
       <td>
         <p>Yes</p>
-        <p>
-          Firefox support for AV1 is currently disabled by default; it can be
-          enabled by setting the preference <code>media.av1.enabled</code> to
-          <code>true</code>.
-        </p>
+        <p>Firefox support for AV1 is disabled on Android ({{bug(1672276)}}) and on Windows on ARM (enable by setting the preference <code>media.av1.enabled</code> to <code>true</code>).</p>
       </td>
       <td></td>
     </tr>


### PR DESCRIPTION
Fixes #9170

Code inspection shows that AV1 is only disabled on a small subset OS/hardware. This clarifies and links to bug for remaining part. Many thanks to @jwatt