### PR TITLE
Improve representation header cross linking

### DIFF
--- a/files/en-us/glossary/representation_header/index.html
+++ b/files/en-us/glossary/representation_header/index.html
@@ -8,9 +8,14 @@ tags:
 
 <p>A <strong>representation header</strong> is an {{glossary("HTTP_header", "HTTP header")}} that describes the particular <em>representation</em> of the resource sent in an HTTP message body.</p>
 
-<p>Representations are different versions of a particular resource that might be returned from a request. For example, the same data resource might be formatted as XML or JSON, and that resource might then be encoded in one or more compressed formats for sending. Clients specify the formats that they prefer during content negotiation (using <code>Accept-*</code> headers), and the representation headers tell the client the format of the representation they actually received.</p>
+<p>Representations are different forms of a particular resource.
+  For example, the same data might be formatted as a particular media type such as XML or JSON, localised to a particular written language or geographical region, and/or compressed or otherwise encoded for transmission.
+  The underlying resource is the same in each case, but its representation is different.</p>
 
-<p>Representation headers may be present in both HTTP request and response messages. If sent as a response to a <code>HEAD</code> request, they describe the body content that <em>would</em> be sent if the resource was actually requested.</p>
+<p>Clients specify the formats that they prefer to be sent during <a href="/en-US/docs/Web/HTTP/Content_negotiation">content negotiation</a> (using <code>Accept-*</code> headers), and the representation headers tell the client the format of the <em>selected representation</em> they actually received.</p>
+
+<p>Representation headers may be present in both HTTP request and response messages.
+  If sent as a response to a <code>HEAD</code> request, they describe the body content that <em>would</em> be selected if the resource was actually requested.</p>
 
 <p>Representation headers include: {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Content-Encoding")}}, {{HTTPHeader("Content-Language")}}, and {{HTTPHeader("Content-Location")}}.</p>
 
@@ -21,4 +26,5 @@ tags:
   <li><a href="/en-US/docs/Web/HTTP/Headers">List of all HTTP headers</a></li>
   <li>{{Glossary("Payload header")}}</li>
   <li>{{glossary("Entity header")}}</li>
+  <li>{{HTTPHeader("Digest")}}/ {{HTTPHeader("Want-Digest")}}</li>
 </ul>

--- a/files/en-us/web/http/content_negotiation/index.md
+++ b/files/en-us/web/http/content_negotiation/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{HTTPSidebar}}
 
-In [HTTP](/en-US/docs/Glossary/HTTP), **_content negotiation_** is the mechanism that is used for serving different representations of a resource to the same URI to help the user agent specify which representation is best suited for the user (for example, which document language, which image format, or which content encoding).
+In [HTTP](/en-US/docs/Glossary/HTTP), **_content negotiation_** is the mechanism that is used for serving different {{Glossary("Representation header","representations")}} of a resource to the same URI to help the user agent specify which representation is best suited for the user (for example, which document language, which image format, or which content encoding).
 
 > **Note:** You'll find some disadvantages of HTTP content negotiation in [a wiki page from WHATWG](https://wiki.whatwg.org/wiki/Why_not_conneg). HTML5 provides alternatives to content negotiation via, for example, the [`<source>` element](/en-US/docs/Web/HTML/Element/source).
 

--- a/files/en-us/web/http/headers/digest/index.md
+++ b/files/en-us/web/http/headers/digest/index.md
@@ -12,7 +12,7 @@ browser-compat: http.headers.Digest
 The **`Digest`** response HTTP header provides a {{Glossary("digest")}} of the _selected representation_ of the requested resource.
 
 Representations are different forms of a particular resource that might be returned from a request: for example, the same resource might be formatted in a particular media type such as XML or JSON, localised to a particular written language or geographical region, and/or compressed or otherwise encoded for transmission.
-The representation can be determined from the response's {{Glossary("Representation header","Representation headers")}}.
+The _selected representation_ is the actual format of a resource that is returned following [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation), and can be determined from the response's {{Glossary("Representation header","Representation headers")}}.
 
 The digest applies to the whole representation of a resource, not to a particular message.
 It can be used to verify that the representation data has not been modified during transmission.


### PR DESCRIPTION
This follows on from #9392.

The main aim of this PR is to better clarify the meaning of the term representation (header) and cross link to related concepts and things that refer to it - specifically content negotiation and the HTTP digest header.

FYI @ioggstream