### PR TITLE
CORS: Align Access-Control-Max-Age documentation with specs

### DIFF
--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -214,7 +214,7 @@ The server responds with `Access-Control-Allow-Origin: https://foo.example`, res
 
 The server also sends `Access-Control-Allow-Headers` with a value of "`X-PINGOTHER, Content-Type`", confirming that these are permitted headers to be used with the actual request. Like `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` is a comma-separated list of acceptable headers.
 
-Finally, {{HTTPHeader("Access-Control-Max-Age")}} gives the value in seconds for how long the response to the preflight request can be cached without sending another preflight request. In the present case, the max age is 86400 seconds (= 24 hours). Note that each browser has a [maximum internal value](/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) that takes precedence when the `Access-Control-Max-Age` exceeds it.
+Finally, {{HTTPHeader("Access-Control-Max-Age")}} gives the value in seconds for how long the response to the preflight request can be cached without sending another preflight request. The default value is 5 seconds. In the present case, the max age is 86400 seconds (= 24 hours). Note that each browser has a [maximum internal value](/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) that takes precedence when the `Access-Control-Max-Age` exceeds it.
 
 Once the preflight request is complete, the real request is sent:
 

--- a/files/en-us/web/http/headers/access-control-max-age/index.md
+++ b/files/en-us/web/http/headers/access-control-max-age/index.md
@@ -34,12 +34,11 @@ Access-Control-Max-Age: <delta-seconds>
 ## Directives
 
 - \<delta-seconds>
-  - : Maximum number of seconds the results can be cached.
+  - : Maximum number of seconds the results can be cached, as an unsigned non-negative integer.
     Firefox [caps this at 24 hours](https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1118) (86400 seconds).
     Chromium (prior to v76) [caps at 10 minutes](https://cs.chromium.org/chromium/src/services/network/public/cpp/cors/preflight_result.cc?l=36&rcl=52002151773d8cd9ffc5f557cd7cc880fddcae3e) (600 seconds).
     Chromium (starting in v76) [caps at 2 hours](https://cs.chromium.org/chromium/src/services/network/public/cpp/cors/preflight_result.cc?l=31&rcl=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa) (7200 seconds).
-    Chromium also specifies a default value of 5 seconds.
-    A value of **-1** will disable caching, requiring a preflight OPTIONS check for all calls.
+    The default value is 5 seconds.
 
 ## Examples
 


### PR DESCRIPTION
Mention the 5-second default value, and remove mention of the invalid **-1** value.

#### Motivation
Accurately represent specifications and browser behavior.

#### Supporting details
* Definition of `Access-Control-Max-Age`: https://fetch.spec.whatwg.org/#http-new-header-syntax
* Definition of the value syntax: https://datatracker.ietf.org/doc/html/rfc7234#section-1.2.1
* Chromium implementation as an unsigned integer: https://source.chromium.org/chromium/chromium/src/+/master:services/network/public/cpp/cors/preflight_result.cc;l=49;drc=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa

#### Related issues
n/a

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error