### PR TITLE
[Markdown] [Learn] Suppress conversion for wide tables

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/index.html
@@ -139,7 +139,7 @@ tags:
 
 <p>The below table gives you an overview of the selectors you have available to use, along with links to the pages in this guide which will show you how to use each type of selector. I have also included a link to the MDN page for each selector where you can check browser support information. You can use this as a reference to come back to when you need to look up selectors later in the material, or as you experiment with CSS generally.</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Selector</th>

--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.html
@@ -125,7 +125,7 @@ tags:
 
 <h3 id="Pseudo-classes">Pseudo-classes</h3>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Selector</th>
@@ -338,7 +338,7 @@ tags:
 
 <h3 id="Pseudo-elements">Pseudo-elements</h3>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Selector</th>

--- a/files/en-us/learn/css/building_blocks/values_and_units/index.html
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.html
@@ -60,7 +60,7 @@ tags:
 
 <p>There are various numeric value types that you might find yourself using in CSS. The following are all classed as numeric:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Data type</th>
@@ -148,7 +148,7 @@ tags:
 
 <p>Relative length units are relative to something else, perhaps the size of the parent element's font, or the size of the viewport. The benefit of using relative units is that with some careful planning you can make it so the size of text or other elements scales relative to everything else on the page. Some of the most useful units for web development are listed in the table below.</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Unit</th>

--- a/files/en-us/learn/css/styling_text/fundamentals/index.html
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.html
@@ -113,7 +113,7 @@ occasion such as this that he did.&lt;/p&gt;</pre>
 
 <p>The list of actual web safe fonts will change as operating systems evolve, but it's reasonable to consider the following fonts web safe, at least for now (many of them have been popularized thanks to the Microsoft <em><a href="https://en.wikipedia.org/wiki/Core_fonts_for_the_Web">Core fonts for the Web</a></em> initiative in the late 90s and early 2000s):</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Name</th>
@@ -169,7 +169,7 @@ occasion such as this that he did.&lt;/p&gt;</pre>
 
 <p>The five names are defined as follows:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Term</th>

--- a/files/en-us/learn/forms/basic_native_form_controls/index.html
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.html
@@ -285,7 +285,7 @@ tags:
 
 <p>Many of the elements used to define form controls have some of their own specific attributes. However, there is a set of attributes common to all form elements. You've met some of these already, but below is a list of those common attributes, for your reference:</p>
 
-<table>
+<table class="no-markdown">
  <thead>
   <tr>
    <th scope="col">Attribute name</th>

--- a/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
+++ b/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
@@ -52,7 +52,7 @@ tags:
   &lt;input type="color" id="myColor" name="color"&gt;
 &lt;/label&gt;</pre>
 
-<table>
+<table class="no-markdown">
  <thead>
   <tr>
    <th>Supported</th>

--- a/files/en-us/learn/getting_started_with_the_web/css_basics/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/css_basics/index.html
@@ -87,7 +87,7 @@ tags:
 
 <p>There are many different types of selectors. The examples above use <strong>element selectors</strong>, which select all elements of a given type. But we can make more specific selections as well. Here are some of the more common types of selectors:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Selector name</th>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.html
@@ -293,7 +293,7 @@ textarea.onkeyup = function(){
 
 <p>If you find yourself needing to embed plugin content, this is the kind of information you'll need, at a minimum:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col"></th>

--- a/files/en-us/learn/javascript/first_steps/math/index.html
+++ b/files/en-us/learn/javascript/first_steps/math/index.html
@@ -267,7 +267,7 @@ x = y; // x now contains the same value y contains, 4</pre>
 
 <p>But there are some more complex types, which provide useful shortcuts to keep your code neater and more efficient. The most common are listed below:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Operator</th>

--- a/files/en-us/learn/server-side/django/generic_views/index.html
+++ b/files/en-us/learn/server-side/django/generic_views/index.html
@@ -246,7 +246,7 @@ For example, <strong>&lt;something&gt;</strong> , will capture the marked patt
 
 <p>The main parts of the syntax you will need to know for declaring the pattern matches are:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Symbol</th>
@@ -422,7 +422,7 @@ def book_detail_view(request, primary_key):
   <p><strong>Note:</strong> The author link in the template above has an empty URL because we've not yet created an author detail page to link to.
   Once the detail page exists we can get its URL with either of these two approaches:</p>
   <ul>
-    <li>Use the <code>url</code> template tag to reverse the 'author-detail' URL (defined in the URL mapper), passing it the author instance for the book: 
+    <li>Use the <code>url</code> template tag to reverse the 'author-detail' URL (defined in the URL mapper), passing it the author instance for the book:
       <pre class="brush: python">&lt;a href="{% url 'author-detail' book.author.pk %}"&gt;\{{ book.author }}&lt;/a&gt;</pre>
     </li>
     <li>Call the author model's <code>get_absolute_url()</code> method (this performs the same reversing operation):

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.html
@@ -369,7 +369,7 @@ a:focus, input:focus, button:focus, select:focus {
 
 <p>VO has many keyboard commands, and we won't list them all here. The basic ones you'll need for web page testing are in the following table. In the keyboard shortcuts, "VO" means "the VoiceOver modifier".</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <caption>Most common VoiceOver keyboard shortcuts</caption>
  <thead>
   <tr>
@@ -471,7 +471,7 @@ a:focus, input:focus, button:focus, select:focus {
 
 <p>NVDA has many keyboard commands, and we won't list them all here. The basic ones you'll need for web page testing are in the following table. In the keyboard shortcuts, "NVDA" means "the NVDA modifier".</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <caption>Most common NVDA keyboard shortcuts</caption>
  <thead>
   <tr>

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.html
@@ -322,7 +322,7 @@ https://developer.mozilla.org/en-US/docs/Web/API/fetch</pre>
 
 <p>There's pros and cons each way — and this list of pros and cons for globally installing is far from exhaustive:</p>
 
-<table class="standard-table">
+<table class="standard-table no-markdown">
  <thead>
   <tr>
    <th scope="col">Pros of installing globally</th>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218.

https://github.com/mdn/content/issues/9218#issuecomment-935363690 has an analysis of table conversion in the Learn area.

Of 37 tables that were being converted I suggested we should suppress Markdown conversion for 16 of them, because the GFM representation of those 16 tables would be >150 characters wide, making it hard to read.

This PR does that by adding a class `no-markdown` to those 16 tables, that will stop h2m converting it. I've confirmed that with this change only 21 tables get converted.