### PR TITLE
[Markdown] [Learn] Adjust live sample calls to match generated heading ids

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/events/index.html
+++ b/files/en-us/learn/javascript/building_blocks/events/index.html
@@ -505,9 +505,9 @@ video.onclick = function() {
 
 <p>The following example demonstrates the behavior described above. Hover over the numbers and click on them to trigger events, and then observe the output that gets logged.</p>
 
-{{EmbedLiveSample("example_code_event_phases", "85ch", "400")}}
+{{EmbedLiveSample("Example_code_event_phases", "85ch", "400")}}
 
-<h5 id="example_code_event_phases">Example code: event phases</h5>
+<h5>Example code: event phases</h5>
 
 <pre class="brush: html">
 &lt;div&gt;1

--- a/files/en-us/learn/javascript/first_steps/variables/index.html
+++ b/files/en-us/learn/javascript/first_steps/variables/index.html
@@ -62,7 +62,7 @@ buttonA.onclick = function() {
 }
 </pre>
 
-<p>{{ EmbedLiveSample('Variable example', '100%', 120) }}</p>
+<p>{{ EmbedLiveSample('Variable_example', '100%', 120) }}</p>
 
 <p>In this example pressing the button runs some code. The first line pops a box up on the screen that asks the reader to enter their name, and then stores the value in a variable. The second line displays a welcome message that includes their name, taken from the variable value and the third line displays that name on the page.</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9218 (probably the last one!).

This fixes a couple of places where the ID in an`EmbedLiveSample` call didn't match the ID generated from the heading.