### PR TITLE
Remove Date.now() polyfill

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -27,20 +27,6 @@ Date.now()
 
 A {{jsxref("Number")}} representing the milliseconds elapsed since the UNIX epoch.
 
-## Polyfill
-
-This method was standardized in ECMA-262 5th edition. Engines which have not
-been updated to support this method can work around the absence of this method using the
-following shim:
-
-```js
-if (!Date.now) {
-  Date.now = function now() {
-    return new Date().getTime();
-  };
-}
-```
-
 ## Examples
 
 ### Reduced time precision
@@ -81,7 +67,6 @@ is larger.
 
 ## See also
 
-- A polyfill of `Date.now` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{domxref("Performance.now()")}} — provides timestamps with sub-millisecond
   resolution for use in measuring web page performance
 - {{domxref("console.time()")}} / {{domxref("console.timeEnd()")}}

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -67,6 +67,7 @@ is larger.
 
 ## See also
 
+- A polyfill of `Date.now` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{domxref("Performance.now()")}} — provides timestamps with sub-millisecond
   resolution for use in measuring web page performance
 - {{domxref("console.time()")}} / {{domxref("console.timeEnd()")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Remove `Date.now()` polyfill as there is full support for es5 now.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- Fixes #9607 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
