### PR TITLE
addEventListener resides on the protototype

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -1,5 +1,5 @@
 ---
-title: EventTarget.addEventListener()
+title: EventTarget.prototype.addEventListener()
 slug: Web/API/EventTarget/addEventListener
 tags:
   - API
@@ -18,7 +18,7 @@ tags:
   - attachEvent
   - events
   - mselementresize
-browser-compat: api.EventTarget.addEventListener
+browser-compat: api.EventTarget.prototype.addEventListener
 ---
 {{APIRef("DOM Events")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`addEventListener` resides on the `protototype` property of `EventTarget`, not on the constructor function itself.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
