### PR TITLE
removeEventListener resides on the prototype

### DIFF
--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.md
@@ -1,5 +1,5 @@
 ---
-title: EventTarget.removeEventListener()
+title: EventTarget.prototype.removeEventListener()
 slug: Web/API/EventTarget/removeEventListener
 tags:
   - API
@@ -11,12 +11,12 @@ tags:
   - Reference
   - browser compatibility
   - removeEventListener
-browser-compat: api.EventTarget.removeEventListener
+browser-compat: api.EventTarget.prototype.removeEventListener
 ---
 {{APIRef("DOM Events")}}
 
 The
-**`EventTarget.removeEventListener()`** method removes from
+**`EventTarget..prototype.removeEventListener()`** method removes from
 the {{domxref("EventTarget")}} an event listener previously registered with
 {{domxref("EventTarget.addEventListener()")}}. The event listener to be removed is
 identified using a combination of the event type, the event listener function itself,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`removeEventListener` resides on `EventTarget.prototype`, not on the constructor function itself.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
