### PR TITLE
dispatchEvent resides on EventTarget.prototype

### DIFF
--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -1,5 +1,5 @@
 ---
-title: EventTarget.dispatchEvent()
+title: EventTarget.prototype.dispatchEvent()
 slug: Web/API/EventTarget/dispatchEvent
 tags:
   - API
@@ -7,7 +7,7 @@ tags:
   - DOM Element Methods
   - Gecko
   - Method
-browser-compat: api.EventTarget.dispatchEvent
+browser-compat: api.EventTarget.prototype.dispatchEvent
 ---
 {{APIRef("DOM Events")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`dispatchEvent` resides on `EventTarget.prototype`, not on the constructor function itself.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
