### PR TITLE
Point "Garbage collection" link to correct article

### DIFF
--- a/files/en-us/glossary/garbage_collection/index.html
+++ b/files/en-us/glossary/garbage_collection/index.html
@@ -13,7 +13,7 @@ tags:
 
 <ul>
  <li>{{interwiki("wikipedia", "Memory management")}} on Wikipedia</li>
- <li>{{interwiki("wikipedia", "Garbage collection")}} on Wikipedia</li>
+ <li>{{interwiki("wikipedia", "Garbage collection (computer science)")}} on Wikipedia</li>
  <li><a href="/en-US/docs/Web/JavaScript/Memory_Management#garbage_collection">Garbage collection</a> in the MDN JavaScript guide.</li>
  <li><a href="/en-US/docs/Web/JavaScript/Memory_Management">Memory management in JavaScript</a></li>
 </ul>


### PR DESCRIPTION
The "Garbage collection" link points to a Wikipedia article about trash-collecting. I suspect most MDN readers are instead interested in the memory-management concept.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [✔️ ] Fixes a typo, bug, or other error
