### PR TITLE
RegExp Assertions: fix note about ^ in group

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/assertions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/assertions/index.md
@@ -42,7 +42,7 @@ Assertions include boundaries, which indicate the beginnings and endings of line
             it appears at the start of a
             <a
               href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges"
-              >group</a
+              >range</a
             >.
           </p>
         </div>


### PR DESCRIPTION
#### Summary

Fix the note in the Meaning column for character `^` which says:

> This character has a different meaning when it appears at the start of a group.

to say

> This character has a different meaning when it appears at the start of a range.

#### Motivation

I am unable to find any difference in meaning when ^ is used in a group,
at the start or otherwise.  It does differ when used in a range.

#### Supporting details

I am unable to find anything in [ECMA 262 22.2 RegExp (Regular Expression) Objects](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-regular-expression-objects) (particularly [22.2.2.6 Assertion](https://tc39.es/ecma262/multipage/text-processing.html#sec-assertion)) which indicates that the behavior of `^` differs inside and outside a group.

```js
console.assert(/^H/.test('Hi') === /(^H)/.test('Hi'));
console.assert(/^H/.test('hi') === /(^H)/.test('hi'));
```

I suspect this note is referring to the different behavior when used in a
[CharacterClass], referred to as a range elsewhere in the docs, where it denotes inverting the class/range.  This is also discussed in the "Different meaning of '?!' combination usage in Assertions and Ranges" section of the same file.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

Thanks for considering,
Kevin

[CharacterClass]: https://tc39.es/ecma262/multipage/text-processing.html#sec-characterclass