### PR TITLE
Update Firefox Dev Tools - Minor Text Change

### DIFF
--- a/files/en-us/tools/index.html
+++ b/files/en-us/tools/index.html
@@ -55,77 +55,70 @@ tags:
  </tbody>
 </table>
 
+
 <div class="column-container">
 <div class="column-half">
 <h3 id="Page_Inspector">Page Inspector</h3>
-
-<p><a href="/en-US/docs/Tools/Page_Inspector"><img alt="The all-new Inspector panel in Firefox 57." src="landingpage_pageinspector.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>View and edit page content and layout. Visualize many aspects of the page including the box model, animations, and grid layouts.</p>
+<p><a href="/en-US/docs/Tools/Page_Inspector"><img alt="The all-new Inspector panel in Firefox 57." src="landingpage_pageinspector.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 
+  
 <div class="column-half">
 <h3 id="Web_Console">Web Console</h3>
-
-<p><a href="/en-US/docs/Tools/Web_Console"><img alt="The all-new Console in Firefox 57." src="landingpage_console.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>See messages logged by a web page and interact with the page using JavaScript.</p>
+<p><a href="/en-US/docs/Tools/Web_Console"><img alt="The all-new Console in Firefox 57." src="landingpage_console.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 </div>
+
 
 <div class="column-container">
 <div class="column-half">
 <h3 id="JavaScript_Debugger">JavaScript Debugger</h3>
-
-<p><a href="/en-US/docs/Tools/Debugger"><img alt="The all-new Firefox 57 Debugger.html" src="landingpage_debugger.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>Stop, step through, and examine the JavaScript running on a page.</p>
+<p><a href="/en-US/docs/Tools/Debugger"><img alt="The all-new Firefox 57 Debugger.html" src="landingpage_debugger.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 
+  
 <div class="column-half">
 <h3 id="Network_Monitor">Network Monitor</h3>
-
-<p><a href="/en-US/docs/Tools/Network_Monitor"><img alt="The Network panel in Firefox 57 DevTools." src="landingpage_network.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>See the network requests made when a page is loaded.</p>
+<p><a href="/en-US/docs/Tools/Network_Monitor"><img alt="The Network panel in Firefox 57 DevTools." src="landingpage_network.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 </div>
+
 
 <div class="column-container">
 <div class="column-half">
 <h3 id="Performance_Tools">Performance Tools</h3>
-
-<p><a href="/en-US/docs/Tools/Performance"><img alt="Performance Tools in Firefox 57 Developer Tools" src="landingpage_performance.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>Analyze your site's general responsiveness, JavaScript, and layout performance.</p>
+<p><a href="/en-US/docs/Tools/Performance"><img alt="Performance Tools in Firefox 57 Developer Tools" src="landingpage_performance.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 
+  
 <div class="column-half">
 <h3 id="Responsive_Design_Mode">Responsive Design Mode</h3>
-
-<p><a href="/en-US/docs/Tools/Responsive_Design_Mode"><img alt="Responsive Design mode in Firefox 57." src="landingpage_responsivedesign.png" style="border-style: solid; border-width: 1px; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>See how your website or app will look and behave on different devices and network types.</p>
+<p><a href="/en-US/docs/Tools/Responsive_Design_Mode"><img alt="Responsive Design mode in Firefox 57." src="landingpage_responsivedesign.png" style="border-style: solid; border-width: 1px; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 </div>
+
 
 <div class="column-container">
 <div class="column-half">
 <h3 id="Accessibility_inspector">Accessibility inspector</h3>
-
-<p><a href="/en-US/docs/Tools/Accessibility_inspector"><img alt="Performance Tools in Firefox 57 Developer Tools" src="landingpage_accessibility.png" style="border-style: solid; border-width: 1px; border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>Provides a means to access the page's accessibility tree, allowing you to check what's missing or otherwise needs attention.</p>
+<p><a href="/en-US/docs/Tools/Accessibility_inspector"><img alt="Performance Tools in Firefox 57 Developer Tools" src="landingpage_accessibility.png" style="border-style: solid; border-width: 1px; border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 
+  
 <div class="column-half">
 <h3 id="Application_panel">Application panel</h3>
-
-<p><a href="/en-US/docs/Tools/Application"><img alt="Performance Tools in Firefox 57 Developer Tools" src="just-application-panel.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
-
 <p>Provides tools for inspecting and debugging modern web apps (also known as <a href="/en-US/docs/Web/Progressive_web_apps">Progressive Web Apps</a>). This includes inspection of <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a> and <a href="/en-US/docs/Web/Manifest">web app manifests</a>.</p>
+<p><a href="/en-US/docs/Tools/Application"><img alt="Performance Tools in Firefox 57 Developer Tools" src="just-application-panel.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></a></p>
 </div>
 </div>
+
 
 <div class="note">
 <p><strong>Note</strong>: The collective term for the UI inside which the DevTools all live is the <a href="/en-US/docs/Tools/Tools_Toolbox">Toolbox</a>.</p>


### PR DESCRIPTION
A minor change. When the article covers the main tools (that have the screenshots such as Web Console and JavaScript Debugger) I noticed that the description for that tool is after the screenshot. The usability issues with this are:
(1) When a newish user see's the screenshot they won't really know what they are looking at until they look at the text after the screenshot.
(2) It is unclear, at first, if the descriptive text belongs to the screenshot below or after the text.

I just copied and pasted the descriptive text (in the <p> tag) from the bottom of the image to the top of the image right under the title. You should find that more users will understand immediately what they are look at when they can read the descriptive text right before starring at the image. If anything the descriptive text can remind some users what the panel is for so they remember what they are looking at.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
