### PR TITLE
Remove oversized "example" of font-synthesis

### DIFF
--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -13,8 +13,6 @@ browser-compat: css.properties.font-synthesis
 
 The **`font-synthesis`** [CSS](/en-US/docs/Web/CSS) property controls which missing typefaces, bold, italic, or small-caps, may be synthesized by the browser.
 
-{{EmbedInteractiveExample("pages/css/font-synthesis.html")}}
-
 ## Syntax
 
 ```css


### PR DESCRIPTION
#### Summary
Remove the example that results in the first block in https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis:
![image](https://user-images.githubusercontent.com/498917/136351753-0c4dbbc6-df73-4ffb-a996-94d104eee901.png)

#### Motivation

This is very similar to the syntax block, but with a lot of whitespace.

It's not actually an example, and is redundant, so just remove it.