### PR TITLE
Minor edits and rewrites

### DIFF
--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -11,18 +11,17 @@ browser-compat: http.headers.Warning
 ---
 {{HTTPSidebar}}
 
-> **Note:** The `Warning` header is soon to be deprecated; see
+> **Note:** The `Warning` header has been deprecated; see
 > [Warning
 > (https://github.com/httpwg/http-core/issues/139)](https://github.com/httpwg/http-core/issues/139) and [Warning: header &
 > stale-while-revalidate (https://github.com/whatwg/fetch/issues/913)](https://github.com/whatwg/fetch/issues/913) for more
 > details.
 
-The **`Warning`** general HTTP header contains information
+The **`Warning`** HTTP header contains information
 about possible problems with the status of the message. More than one
 `Warning` header may appear in a response.
 
-`Warning` header fields can in general be applied to any message, however
-some warn-codes are specific to caches and can only be applied to response messages.
+`Warning` header fields can, in general, be applied to any message. However, some warn-codes are specific to caches and can only be applied to response messages.
 
 <table class="properties">
   <tbody>
@@ -57,31 +56,31 @@ Warning: <warn-code> <warn-agent> <warn-text> [<warn-date>]
     - `1xx` warn-codes describe the freshness or validation status of the
       response and will be deleted by a cache after deletion.
     - `2xx` warn-codes describe some aspect of the representation that is
-      not rectified by a validation and won't be deleted by a cache after validation
+      not rectified by a validation and will not be deleted by a cache after validation
       unless a full response is sent.
 
 - \<warn-agent>
   - : The name or pseudonym of the server or software adding the `Warning`
     header (might be "-" when the agent is unknown).
 - \<warn-text>
-  - : Advisory text describing the error.
+  - : An advisory text describing the error.
 - \<warn-date>
-  - : Optional. If more than one `Warning` header is sent, include a date that
+  - : A date. This is optional. If more than one `Warning` header is sent, include a date that
     matches the {{HTTPHeader("Date")}} header.
 
 ## Warning codes
 
-The [HTTP Warn Codes registry at iana.org](https://www.iana.org/assignments/http-warn-codes/http-warn-codes.xhtml) defines the namespace for warn codes.
+The [HTTP Warn Codes registry at iana.org](https://www.iana.org/assignments/http-warn-codes/http-warn-codes.xhtml) defines the namespace for warning codes.
 
 | Code | Text                             | Description                                                                                                                           |
 | ---- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| 110  | Response is Stale                | A response provided by a cache is stale (the expiration time set for it has passed).                                                  |
-| 111  | Revalidation Failed              | An attempt to validate the response failed, due to an inability to reach the server.                                                  |
-| 112  | Disconnected Operation           | The cache is disconnected from the rest of the network.                                                                               |
-| 113  | Heuristic Expiration             | Sent If a cache heuristically chose a freshness lifetime greater than 24 hours and the response's age is greater than 24 hours.       |
-| 199  | Miscellaneous Warning            | Arbitrary, non-specific warning                                                                                                       |
+| 110  | Response is Stale                | The response provided by a cache is stale (the expiration time set for the response has passed).                                                  |
+| 111  | Revalidation Failed              | An attempt to validate the stale response failed due to an inability to reach the server.                                                  |
+| 112  | Disconnected Operation           | The cache is intentionally disconnected from the rest of the network.                                                                               |
+| 113  | Heuristic Expiration             | A cache heuristically chose a freshness lifetime greater than 24 hours and the age of the response is greater than 24 hours.       |
+| 199  | Miscellaneous Warning            | Arbitrary information that should be presented to a user or logged.                                                                                                       |
 | 214  | Transformation Applied           | Added by a proxy if it applies any transformation to the representation, such as changing the content-coding, media-type or the like. |
-| 299  | Miscellaneous Persistent Warning | Same as 199, but indicating a persistent warning                                                                                      |
+| 299  | Miscellaneous Persistent Warning | Arbitrary information that should be presented to a user or logged. This warn-code is similar to the warn-code 199 and additionally indicates a persistent warning.                                                                                      |
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
Minor edits and rewrites.

Please note:
1. From [https://github.com/httpwg/http-core/issues/139](https://github.com/httpwg/http-core/issues/139), it seems that the "Warning" header has already been deprecated. I have updated the text to reflect this.
2. I referred to https://www.rfc-editor.org/rfc/rfc7234.html#section-5.5 while updating the text. Although more could be done to improve the clarity, I have not spent more effort seeing that this header is deprecated.

#### Motivation
Edited this page as part of "Writing Day" during the Write the Docs Prague 2021 conference:  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Warning

