### PR TITLE
Updates to CSS perspective property and perspective() function.

### DIFF
--- a/files/en-us/web/css/perspective/index.md
+++ b/files/en-us/web/css/perspective/index.md
@@ -42,17 +42,19 @@ perspective: unset;
 - `none`
   - : Indicates that no perspective transform is to be applied.
 - `<length>`
-  - : A {{cssxref("&lt;length&gt;")}} giving the distance from the user to the z=0 plane. It is used to apply a perspective transform to the element and its content. If the value is `0` or a negative number, no perspective transform is applied.
+  - : A {{cssxref("&lt;length&gt;")}} giving the distance from the user to the z=0 plane. It is used to apply a perspective transform to the children of the element.  Negative values are syntax errors.  If the value is smaller than `1px`, it is clamped to `1px`.
 
 ## Description
 
 Each 3D element with z>0 becomes larger; each 3D-element with z<0 becomes smaller. The strength of the effect is determined by the value of this property.
+Large values of `perspective` cause a small transformation;
+small values of `perspective` cause a large transformation.
 
 The parts of the 3D elements that are behind the user — i.e. their z-axis coordinates are greater than the value of the `perspective` CSS property — are not drawn.
 
 The _vanishing point_ is by default placed at the center of the element, but its position can be changed using the {{cssxref("perspective-origin")}} property.
 
-Using this property with a value different than `0` and `none` creates a new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context). Also, in that case, the object will act as a containing block for `position: fixed` elements that it contains.
+Using this property with a value other than `none` creates a new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context). Also, in that case, the object will act as a containing block for `position: fixed` elements that it contains.
 
 ## Formal definition
 

--- a/files/en-us/web/css/transform-function/perspective()/index.md
+++ b/files/en-us/web/css/transform-function/perspective()/index.md
@@ -24,9 +24,21 @@ properties which are attached to the parent of a child transformed in 3-dimensio
 ## Syntax
 
 The perspective distance used by `perspective()` is specified by a {{cssxref("&lt;length&gt;")}} value,
-which represents the distance between the user and the z=0 plane. The z=0 plane is the plane where everything appears
-in a 2-dimensional view, or the screen. A positive value makes the element appear closer to the user than the rest of
-the interface, a negative value farther. The greater the value, the further away the perspective of the user is.
+which represents the distance between the user and the z=0 plane,
+or by `none`.
+The z=0 plane is the plane where everything appears
+in a 2-dimensional view, or the screen.
+Negative values are syntax errors.
+Values smaller than `1px` (including zero) are clamped to `1px`.
+Values other than `none` cause
+elements with positive z positions to appear larger,
+and elements with negative z positions to appear smaller.
+Elements with z positions equal to or larger than the perspective value
+disappear as though they are behind the user.
+Large values of perspective represent a small transformation;
+small values of `perspective()` represent a large transformation;
+`perspective(none)` represents perspective from infinite distance
+and no transformation.
 
 ```css
 perspective(d)


### PR DESCRIPTION
This updates the `perspective` property and `perspective()` function to
reflect some existing errors (regarding negative values) and some new
CSS working group resolutions that have at this point all shipped in at
least one of Firefox or Chrome (and which I think are all likely to ship
in the other soon, and hopefully in Safari as well):

* https://github.com/w3c/csswg-drafts/issues/413 resolved that 0 is
  allowed in both the property and the function, but values of both that
  are less than 1px are clamped to 1px.

* https://github.com/w3c/csswg-drafts/issues/6488 added the `none` value
  to the perspective() function; it was already a value of the
  perspective property.

It also adds some clarification about what large/small/none values mean.

#### Supporting details
* implementing `perspective(none)`: [Mozilla bug 1725207](https://bugzilla.mozilla.org/show_bug.cgi?id=1725207), [Chromium bug 1253596](https://bugs.chromium.org/p/chromium/issues/detail?id=1253596), [WebKit bug 231361](https://bugs.webkit.org/show_bug.cgi?id=231361)
* clamping of perspective less than `1px`: [Chromium code change](https://chromium.googlesource.com/chromium/src/+/50b1cc46560ac75003b6c64db76fc14d23508735), [Chromium announcement](https://groups.google.com/a/chromium.org/g/blink-dev/c/Up0ruPbddro/m/7J-f9pqiAQAJ), [Mozilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1713961)

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error