### PR TITLE
Add an example using the second parameter

### DIFF
--- a/files/en-us/web/api/domtokenlist/toggle/index.md
+++ b/files/en-us/web/api/domtokenlist/toggle/index.md
@@ -40,6 +40,8 @@ list after the call.
 
 ## Examples
 
+### Toggling a class on click
+
 In the following example we retrieve the list of classes set on a
 {{htmlelement("span")}} element as a `DOMTokenList` using
 {{domxref("Element.classList")}}. We then replace a token in the list, and write the
@@ -70,9 +72,11 @@ span.addEventListener('click', function() {
 
 The output looks like this:
 
-{{ EmbedLiveSample('Examples', '100%', 60) }}
+{{ EmbedLiveSample('Toggling_a_class_on_click', '100%', 60) }}
 
-The second parameter can be used to determine whether the class is included or not. This next example would include the 'c' class only if the browser window is over 1000 pixels wide:
+### Setting the force parameter
+
+The second parameter can be used to determine whether the class is included or not. This example would include the 'c' class only if the browser window is over 1000 pixels wide:
 
 ```js
 span.classList.toggle("c", window.innerWidth > 1000);

--- a/files/en-us/web/api/domtokenlist/toggle/index.md
+++ b/files/en-us/web/api/domtokenlist/toggle/index.md
@@ -72,6 +72,12 @@ The output looks like this:
 
 {{ EmbedLiveSample('Examples', '100%', 60) }}
 
+The second parameter can be used to determine whether the class is included or not. This next example would include the 'c' class only if the browser window is over 1000 pixels wide:
+
+```js
+span.classList.toggle("c", window.innerWidth > 1000);
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
#### Summary
Adding an example line of code to the DOMTokenList.toggle() page using the second parameter.

#### Motivation
The second parameter of DOMTokenList.toggle() can be very useful for web developers.

#### Supporting details
There is a similar example on this page: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList

#### Related issues
none that I could find

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
(None of the above; just adds one line of example code with explanation.)

