### PR TITLE
[Markdown][XSLT] Prepare XSLT for Markdowning

### DIFF
--- a/files/en-us/web/xslt/element/index.html
+++ b/files/en-us/web/xslt/element/index.html
@@ -25,10 +25,6 @@ tags:
 
 <p>The element annotations that follow include a description, a syntax listing, a list of required and optional attributes, a description of type and position, its source in the W3C Recommendation and an explanation of the degree of present Gecko support.</p>
 
-<div class="hidden">
-<div class="blockIndicator todo">Use the \{{ListSubpages}} macro once <a href="/en-US/docs/MDN/Structures/Compatibility_tables">the BCD</a> for <code><a href="/en-US/docs/Web/XSLT/Element/fallback">&lt;xsl:fallback&gt;</a></code>, <code><a href="/en-US/docs/Web/XSLT/Element/import">&lt;xsl:import&gt;</a></code>, <code><a href="/en-US/docs/Web/XSLT/Element/namespace-alias">&lt;xsl:namespace-alias&gt;</a></code>, <code><a href="/en-US/docs/Web/XSLT/Element/number">&lt;xsl:number&gt;</a></code>, <code><a href="/en-US/docs/Web/XSLT/Element/output">&lt;xsl:output&gt;</a></code>, <code><a href="/en-US/docs/Web/XSLT/Element/stylesheet">&lt;xsl:stylesheet&gt;</a></code>, <code><a href="/en-US/docs/Web/XSLT/Element/text">&lt;xsl:text&gt;</a></code> and <code><a href="/en-US/docs/Web/XSLT/Element/value-of">&lt;xsl:value-of&gt;</a></code> is fully migrated.</div>
-{{ListSubpages("/en-US/docs/Web/XSLT/Element")}}</div>
-
 <ul>
  <li><code><a href="/en-US/docs/Web/XSLT/Element/apply-imports">&lt;xsl:apply-imports&gt;</a></code></li>
  <li><code><a href="/en-US/docs/Web/XSLT/Element/apply-templates">&lt;xsl:apply-templates&gt;</a></code></li>

--- a/files/en-us/web/xslt/element/stylesheet/index.html
+++ b/files/en-us/web/xslt/element/stylesheet/index.html
@@ -29,32 +29,32 @@ tags:
 <h3 id="Required_Attributes">Required Attributes</h3>
 
 <dl>
- <dt><code id="attr-version">version</code></dt>
+ <dt><code>version</code></dt>
  <dd>Specifies the version of XSLT required by this stylesheet.</dd>
 </dl>
 
 <h3 id="Optional_Attributes">Optional Attributes</h3>
 
 <dl>
- <dt><code id="attr-exclude-result-prefixes">exclude-result-prefixes</code></dt>
+ <dt><code>exclude-result-prefixes</code></dt>
  <dd>Specifies any namespace used in this document that should not be sent to the output document. The list is whitespace separated.</dd>
- <dt><code id="attr-extension-element-prefixes">extension-element-prefixes</code></dt>
+ <dt><code>extension-element-prefixes</code></dt>
  <dd>Specifies a space-separated list of any namespace prefixes for extension elements in this document.</dd>
- <dt><code id="attr-default-collation">default-collation</code></dt>
+ <dt><code>default-collation</code></dt>
  <dd>Specifies the default collation used by all {{Glossary("XPath")}} expressions appearing in attributes or text value templates that have the element as an ancestor, unless overridden by another <code>default-collation</code> attribute on an inner element. It also determines the collation used by certain XSLT constructs (such as <code><a href="/en-US/docs/Web/XSLT/Element/key">&lt;xsl:key&gt;</a></code> and <code><a href="/en-US/docs/Web/XSLT/Element/for-each-group">&lt;xsl:for-each-group&gt;</a></code>) within its scope.</dd>
- <dt><code id="attr-default-mode">default-mode</code></dt>
+ <dt><code>default-mode</code></dt>
  <dd>Defines the default value for the <code>mode</code> attribute of all <code><a href="/en-US/docs/Web/XSLT/Element/template">&lt;xsl:template&gt;</a></code> and <code><a href="/en-US/docs/Web/XSLT/Element/apply-templates">&lt;xsl:apply-templates&gt;</a></code> elements within its scope.</dd>
- <dt><code id="attr-default-validation">default-validation</code></dt>
+ <dt><code>default-validation</code></dt>
  <dd>Defines the default value of the <code>validation</code> attribute of all relevant instructions appearing within its scope.</dd>
- <dt><code id="attr-expand-text">expand-text</code></dt>
+ <dt><code>expand-text</code></dt>
  <dd>Determines whether descendant text nodes of the element are treated as text value templates.</dd>
- <dt><code id="attr-id">id</code></dt>
+ <dt><code>id</code></dt>
  <dd>Specifies an <code>id</code> for this stylesheet. This is most often used when the stylesheet is embedded in another XML document.</dd>
- <dt><code id="attr-input-type-annotations">input-type-annotations</code></dt>
+ <dt><code>input-type-annotations</code></dt>
  <dd>Specifies whether type annotations are stripped from the element so the same results are produced whether the source documents have been validated against a schema or not.</dd>
- <dt><code id="attr-use-when">use-when</code></dt>
+ <dt><code>use-when</code></dt>
  <dd>Determines whether the element and all the nodes that have it as ancestor are excluded from the stylesheet.</dd>
- <dt><code id="attr-xpath-default-namespace">xpath-default-namespace</code></dt>
+ <dt><code>xpath-default-namespace</code></dt>
  <dd>Specifies the namespace that will be used if the element name is unprefixed or an unprefixed type name within an XPath expression.</dd>
 </dl>
 

--- a/files/en-us/web/xslt/index.html
+++ b/files/en-us/web/xslt/index.html
@@ -28,9 +28,8 @@ tags:
  </li>
 </ol>
 </div>
-{{QuickLinksWithSubpages("/en-US/docs/Web/XSLT")}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>Extensible Stylesheet Language Transformations (XSLT)</strong> is an <a href="/en-US/docs/Web/XML/XML_introduction">XML</a>-based language used, in conjunction with specialized processing software, for the transformation of XML documents.</span></p>
+<p><strong>Extensible Stylesheet Language Transformations (XSLT)</strong> is an <a href="/en-US/docs/Web/XML/XML_introduction">XML</a>-based language used, in conjunction with specialized processing software, for the transformation of XML documents.</p>
 
 <p>Although the process is referred to as "transformation," the original document is not changed; rather, a new XML document is created based on the content of an existing document. Then, the new document may be serialized (output) by the processor in standard XML syntax or in another format, such as <a href="/en-US/docs/Web/HTML">HTML</a> or plain text.</p>
 
@@ -46,7 +45,7 @@ tags:
  <dt><a href="/en-US/docs/Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations">Using the Mozilla JavaScript interface to XSL Transformations</a></dt>
  <dd>This document describes the JavaScript interface to the XSLT processing engine in Mozilla 1.2 and up.</dd>
  <dt><a href="/en-US/docs/Web/XSLT/PI_Parameters">Specifying parameters using processing instructions</a></dt>
- <dd>Firefox allows stylesheet parameters to be specified when using the <code style="white-space: nowrap;">&lt;?xml-stylesheet?&gt;</code> processing instruction. This is done using the <code style="white-space: nowrap;">&lt;?xslt-param?&gt;</code> PI described in this document.</dd>
+ <dd>Firefox allows stylesheet parameters to be specified when using the <code>&lt;?xml-stylesheet?&gt;</code> processing instruction. This is done using the <code>&lt;?xslt-param?&gt;</code> PI described in this document.</dd>
  <dt><a href="https://www.w3schools.com/xml/xsl_intro.asp">XSLT Tutorial</a></dt>
  <dd>This <a href="https://www.w3schools.com">W3Schools</a> tutorial teaches the reader how to use XSLT to transform XML documents into other formats, like XHTML.</dd>
  <dt><a href="https://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></dt>

--- a/files/en-us/web/xslt/pi_parameters/index.html
+++ b/files/en-us/web/xslt/pi_parameters/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>The following document passes the two parameters "color" and "size" to the stylesheet "style.xsl".</p>
 
-<pre class="eval">&lt;?xslt-param name="color" value="blue"?&gt;
+<pre class="plain">&lt;?xslt-param name="color" value="blue"?&gt;
 &lt;?xslt-param name="size" select="2"?&gt;
 &lt;?xml-stylesheet type="text/xsl" href="style.xsl"?&gt;
 </pre>
@@ -26,7 +26,7 @@ tags:
 
 <p>Both the <code>xslt-param</code> and the <code>xslt-param-namespace</code> PIs must appear in the prolog of the document, i.e. before the first element tag. All PIs in the prolog must be honored, both ones occurring before and onces occurring after any <code>xml-stylesheet</code> PIs.</p>
 
-<p>If there are multiple <code>xml-stylesheet</code> PIs the parameters apply to all stylesheets as a consequence of that all stylesheets are imported into a single stylesheet per the XSLT spec.<span class="comment">reference?</span> Note that multiple <code>xml-stylesheet</code> XSLT PIs are not supported in Firefox currently.</p>
+<p>If there are multiple <code>xml-stylesheet</code> PIs the parameters apply to all stylesheets as a consequence of that all stylesheets are imported into a single stylesheet per the XSLT spec.reference? Note that multiple <code>xml-stylesheet</code> XSLT PIs are not supported in Firefox currently.</p>
 
 <h4 id="xslt-param">xslt-param</h4>
 

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/for_further_reading/index.html
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/for_further_reading/index.html
@@ -30,7 +30,7 @@ tags:
  </li>
 </ul>
 
-<p><span class="comment"><a href="https://www.amazon.com/XSLT-Programmers-Reference-Programmer/dp/0764543814">https://www.amazon.com/XSLT-Programmers-Reference-Programmer/dp/0764543814</a></span></p>
+<p><a href="https://www.amazon.com/XSLT-Programmers-Reference-Programmer/dp/0764543814">https://www.amazon.com/XSLT-Programmers-Reference-Programmer/dp/0764543814</a></p>
 
 <ul>
  <li><strong>XSLT</strong>
@@ -48,7 +48,7 @@ tags:
  </li>
 </ul>
 
-<p><span class="comment"><a href="https://www.amazon.com/Xslt-Doug-Tidwell/dp/0596000537">https://www.amazon.com/Xslt-Doug-Tidwell/dp/0596000537</a></span></p>
+<p><a href="https://www.amazon.com/Xslt-Doug-Tidwell/dp/0596000537">https://www.amazon.com/Xslt-Doug-Tidwell/dp/0596000537</a></p>
 
 <ul>
  <li><strong>Learning XML, Second Edition</strong>
@@ -66,7 +66,7 @@ tags:
  </li>
 </ul>
 
-<p><span class="comment"><a href="https://www.amazon.com/gp/product/0596004206">https://www.amazon.com/gp/product/0596004206</a></span></p>
+<p><a href="https://www.amazon.com/gp/product/0596004206">https://www.amazon.com/gp/product/0596004206</a></p>
 
 <h2 id="Digital">Digital</h2>
 

--- a/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.html
+++ b/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.html
@@ -18,8 +18,7 @@ tags:
 <p>Before you can use it, you must import a stylesheet with the {{domxref("XSLTProcessor.importStylesheet()")}} method. It has a single parameter, which is the DOM Node of the XSLT stylesheet to import.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>The import is live, meaning that if you alter the stylesheet DOM after importing it, this will be reflected in the processing. Rather than modifying the DOM it is recommended to use stylesheet parameters which are usually easier and can give better performance.</p>
+  <p><strong>Note:</strong> The import is live, meaning that if you alter the stylesheet DOM after importing it, this will be reflected in the processing. Rather than modifying the DOM it is recommended to use stylesheet parameters which are usually easier and can give better performance.</p>
 </div>
 
 <pre class="brush: js">var testTransform = document.implementation.createDocument("", "test", null);
@@ -114,7 +113,7 @@ var newFragment = processor.transformToFragment(domToBeTransformed, ownerDocumen
 <h3 id="Original_Document_Information">Original Document Information</h3>
 
 <ul>
- <li>Author(s): <a class="link-mailto" href="mailto:mike@theoretic.com">Mike Hearn</a></li>
+ <li>Author(s): Mike Hearn</li>
  <li>Last Updated Date: December 21, 2005</li>
  <li>Copyright Information: Copyright (C) Mike Hearn</li>
 </ul>

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/advanced_example/index.html
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/advanced_example/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>Once the transformation is complete, the result is appended to the document, as shown in this example.</p>
 
-<p><small><strong>Figure 7: Sorting based on div content<span class="comment">view example</span></strong></small></p>
+<p><strong>Figure 7: Sorting based on div content: view example</strong></p>
 
 <pre class="brush: js">// XHTML Fragment:
 

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/basic_example/index.html
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/basic_example/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p><small><strong>Figure 4 : XML file</strong></small></p>
 
-<pre class="brush:xml auto-links:false">&lt;?xml version="1.0"?&gt;
+<pre class="brush:xml">&lt;?xml version="1.0"?&gt;
 &lt;myNS:Article xmlns:myNS="http://devedge.netscape.com/2002/de"&gt;
   &lt;myNS:Title&gt;My Article&lt;/myNS:Title&gt;
   &lt;myNS:Authors&gt;
@@ -24,7 +24,7 @@ tags:
 
 <p><small><strong>Figure 5 : XSLT Stylesheet</strong></small></p>
 
-<pre class="brush:xml auto-links:false">&lt;?xml version="1.0"?&gt;
+<pre class="brush:xml">&lt;?xml version="1.0"?&gt;
 &lt;xsl:stylesheet version="1.0"
                    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                    xmlns:myNS="http://devedge.netscape.com/2002/de"&gt;


### PR DESCRIPTION
This PR prepares the docs under https://developer.mozilla.org/en-US/docs/Web/XSLT.

After this PR we will have only one unconvertible element, which is the `<div id="Quick_links">` used in https://developer.mozilla.org/en-US/docs/Web/XSLT to make a sidebar.
