### PR TITLE
[Markdown][XPath] Prepare XPath for Markdowning

### DIFF
--- a/files/en-us/web/xpath/functions/choose/index.html
+++ b/files/en-us/web/xpath/functions/choose/index.html
@@ -10,7 +10,7 @@ tags:
 <p><br>
  The <code>choose</code> function returns one of the specified objects based on a boolean parameter.</p>
 <div class="note">
- <strong>Note:</strong> This method should be used instead of <code>if()</code>, which has been deprecated.</div>
+ <p><strong>Note:</strong> This method should be used instead of <code>if()</code>, which has been deprecated.</p></div>
 <h3 id="Syntax">Syntax</h3>
 <pre class="eval">choose( boolean , object1, object2 )
 </pre>
@@ -32,7 +32,7 @@ tags:
 <h3 id="Returns">Returns</h3>
 <p>If the boolean parameter is true, the first object is returned; otherwise, the second object is returned.</p>
 <div class="note">
- <strong>Note:</strong> All parameters are evaluated, even the one that's not returned.</div>
+ <p><strong>Note:</strong> All parameters are evaluated, even the one that's not returned.</p></div>
 <h3 id="Defined">Defined</h3>
 <p><a href="https://www.w3.org/TR/xforms11/#fn-choose">XForms 1.1</a></p>
 <h3 id="Gecko_support">Gecko support</h3>

--- a/files/en-us/web/xpath/index.html
+++ b/files/en-us/web/xpath/index.html
@@ -20,8 +20,7 @@ tags:
 <p>XPath uses a path notation (as in URLs) for navigating through the hierarchical structure of an XML document. It uses a non-XML syntax so that it can be used in URIs and XML attribute values.</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Support for XPath varies widely; it's supported reasonably well in Firefox (although there are no plans to improve support further), while other browsers implement it to a lesser extent, if at all. If you need a polyfill, you may consider <a href="https://nchc.dl.sourceforge.net/project/js-xpath/js-xpath/1.0.0/xpath.js">js-xpath</a> or <a href="https://github.com/google/wicked-good-xpath">wicked-good-xpath</a>.</p>
+  <p><strong>Note:</strong> Support for XPath varies widely; it's supported reasonably well in Firefox (although there are no plans to improve support further), while other browsers implement it to a lesser extent, if at all. If you need a polyfill, you may consider <a href="https://nchc.dl.sourceforge.net/project/js-xpath/js-xpath/1.0.0/xpath.js">js-xpath</a> or <a href="https://github.com/google/wicked-good-xpath">wicked-good-xpath</a>.</p>
 </div>
 
 <h2 id="Documentation">Documentation</h2>

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
@@ -52,7 +52,7 @@ tags:
 <pre class="brush: js">var nsResolver = document.createNSResolver( contextNode.ownerDocument == null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
 </pre>
 
-<p><span class="comment">Or alternatively by using the <code>createNSResolver</code> method of a <code>XPathEvaluator</code> object.</span></p>
+<p>Or alternatively by using the <code>createNSResolver</code> method of a <code>XPathEvaluator</code> object.</p>
 <pre class="brush: js">var xpEvaluator = new XPathEvaluator();
 var nsResolver = xpEvaluator.createNSResolver( contextNode.ownerDocument == null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
 </pre>
@@ -130,8 +130,6 @@ alert( 'This document contains ' + paragraphCount.stringValue + ' paragraph elem
 
 <p>Note however, that if the document is mutated (the document tree is modified) between iterations that will invalidate the iteration and the <code>invalidIteratorState</code> property of <code>XPathResult</code> is set to <code>true</code>, and a <code>NS_ERROR_DOM_INVALID_STATE_ERR</code> exception is thrown.</p>
 
-<h6 id="Iterator_Example">Iterator Example</h6>
-
 <pre class="brush: js">var iterator = document.evaluate('//phoneNumber', documentNode, null, XPathResult.UNORDERED_NODE_ITERATOR_TYPE, null );
 
 try {
@@ -160,8 +158,6 @@ catch (e) {
 
 <p>Snapshots do not change with document mutations, so unlike the iterators, the snapshot does not become invalid, but it may not correspond to the current document, for example, the nodes may have been moved, it might contain nodes that no longer exist, or new nodes could have been added.</p>
 
-<h6 id="Snapshot_Example">Snapshot Example</h6>
-
 <pre class="brush: js">var nodesSnapshot = document.evaluate('//phoneNumber', documentNode, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
 
 for ( var i=0 ; i &lt; nodesSnapshot.snapshotLength; i++ )
@@ -183,8 +179,6 @@ for ( var i=0 ; i &lt; nodesSnapshot.snapshotLength; i++ )
 
 <p>Note that, for the unordered subtype the single node returned might not be the first in document order, but for the ordered subtype you are guaranteed to get the first matched node in the document order.</p>
 
-<h6 id="First_Node_Example">First Node Example</h6>
-
 <pre class="brush: js">var firstPhoneNumber = document.evaluate('//phoneNumber', documentNode, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null );
 
 alert( 'The first phone number found is ' + firstPhoneNumber.singleNodeValue.textContent );
@@ -196,7 +190,7 @@ alert( 'The first phone number found is ' + firstPhoneNumber.singleNodeValue.tex
 
 <p>It could be any of the simple types (<code>NUMBER_TYPE, STRING_TYPE, BOOLEAN_TYPE</code>), <strong>but</strong>, if the returned result type is a node-set then it will <strong>only</strong> be an <code>UNORDERED_NODE_ITERATOR_TYPE</code>.</p>
 
-<p>To determine that type after evaluation, we use the <code>resultType</code> property of the <code>XPathResult</code> object. The <a href="#xpathresult_defined_constants">constant</a> values of this property are defined in the appendix. <span class="comment">None Yet =====Any_Type Example===== &lt;pre&gt; &lt;/pre&gt;</span></p>
+<p>To determine that type after evaluation, we use the <code>resultType</code> property of the <code>XPathResult</code> object. The <a href="#xpathresult_defined_constants">constant</a> values of this property are defined in the appendix. None Yet =====Any_Type Example===== &lt;pre&gt; &lt;/pre&gt;</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -204,7 +198,7 @@ alert( 'The first phone number found is ' + firstPhoneNumber.singleNodeValue.tex
 
 <p>The following code is intended to be placed in any JavaScript fragment within or linked to the HTML document against which the XPath expression is to be evaluated.</p>
 
-<p>To extract all the <code>&lt;h2&gt;</code> heading elements in an HTML document using XPath, the <code>xpathExpression</code> is '<code>//h2</code>'. Where, <code>//</code> is the Recursive Descent Operator that matches elements with the nodeName <code>h2</code> anywhere in the document tree. The full code for this is: <span class="comment">link to introductory xpath doc</span></p>
+<p>To extract all the <code>&lt;h2&gt;</code> heading elements in an HTML document using XPath, the <code>xpathExpression</code> is '<code>//h2</code>'. Where, <code>//</code> is the Recursive Descent Operator that matches elements with the nodeName <code>h2</code> anywhere in the document tree. The full code for this is: link to introductory xpath doc</p>
 
 <pre class="brush: js">var headings = document.evaluate('//h2', document, null, XPathResult.ANY_TYPE, null );
 </pre>
@@ -347,9 +341,9 @@ var thisitemEl = thislevel.iterateNext();
 <table class="standard-table">
  <thead>
   <tr>
-   <td class="header">Result Type Defined Constant</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
+   <th>Result Type Defined Constant</th>
+   <th>Value</th>
+   <th>Description</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/web/xpath/snippets/index.html
+++ b/files/en-us/web/xpath/snippets/index.html
@@ -8,7 +8,7 @@ tags:
   - XPath
   - XSLT
 ---
-<p><span class="seoSummary">This article provides some XPath code snippets</span>—simple examples of how to a few simple <strong>utility functions</strong> based on standard interfaces from the <a href="https://www.w3.org/TR/DOM-Level-3-XPath/">DOM Level 3 XPath specification</a> that expose XPath functionality to JavaScript code<span class="seoSummary">. The snippets are functions you can use in the real world in your own code.</span></p>
+<p>This article provides some XPath code snippets — simple examples of how to a few simple <strong>utility functions</strong> based on standard interfaces from the <a href="https://www.w3.org/TR/DOM-Level-3-XPath/">DOM Level 3 XPath specification</a> that expose XPath functionality to JavaScript code<span class="seoSummary">. The snippets are functions you can use in the real world in your own code.</span></p>
 
 <h3 id="Node-specific_evaluator_function">Node-specific <em>evaluator</em> function</h3>
 


### PR DESCRIPTION
This PR prepares the docs under https://developer.mozilla.org/en-US/docs/Web/XPath.

After this PR the only unconvertible elements are two occurrences of `<div id="Quick_links">`, used to make sidebars in:
https://developer.mozilla.org/en-US/docs/Web/XPath/Comparison_with_CSS_selectors
https://developer.mozilla.org/en-US/docs/Web/XPath

The `<h6>` elements look awful on MDN: https://developer.mozilla.org/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript#iterator_example - I thought about replacing them with `<strong>`, but think the page is just as sensible here without anything before the examples.

