### PR TITLE
Document vendor specific search input behavior

### DIFF
--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -197,7 +197,7 @@ This renders like so:
 
 ### Differences between search and text types
 
-The main basic differences come in the way browsers handle them. The first thing to note is that some browsers show a cross icon that can be clicked on to remove the search term instantly if desired. The following screenshot comes from Chrome:
+The main basic differences come in the way browsers handle them. The first thing to note is that some browsers show a cross icon that can be clicked on to remove the search term instantly if desired, in Chrome this action is also triggered when pressing escape. The following screenshot comes from Chrome:
 
 ![](chrome-cross-icon.png)
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This extends the differences between search and text types section of the documentation mentioning that pressing escape while having a search input focused may trigger the clear action. This is chrome specific.

#### Motivation
I spent one hour debugging my custom web component that utilizes a search input with custom keybindings to figure this out.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
