### PR TITLE
fix[minor]: unnecessary assignment in code example

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/async_await/index.md
+++ b/files/en-us/learn/javascript/asynchronous/async_await/index.md
@@ -101,7 +101,7 @@ Here is a trivial example:
 
 ```js
 async function hello() {
-  return greeting = await Promise.resolve("Hello");
+  return await Promise.resolve("Hello");
 };
 
 hello().then(alert);


### PR DESCRIPTION



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`return greeting = await Promise.resolve("Hello");` leads to a linter error ('greeting' is not defined) and seems to serve no purpose. 

#### Supporting details
Further related [example ](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await#asyncawait_class_methods) returns a promise without assigning it to a variable.


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
