### PR TITLE
[Markdown][Webdriver] Prepare WebDriver for Markdowning

### DIFF
--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
@@ -8,7 +8,7 @@ tags:
   - Extension capabilities
   - firefoxOptions
 ---
-<p>The <a id="firefoxOptions"><strong><code>moz:firefoxOptions</code> capability</strong></a> is a namespaced set of
+<p>The <strong><code>moz:firefoxOptions</code> capability</strong> is a namespaced set of
   capabilities specific to <a href="https://www.mozilla.org/en-US/firefox/">Firefox</a>. It is used to control the
   behavior of Firefox and can be used as a member of
   <code><a href="en-US/docs/Web/WebDriver/Capabilities#alwaysMatch">alwaysMatch</a></code> or as a member of one of the
@@ -18,7 +18,7 @@ tags:
 
 <p><code>moz:firefoxOptions</code> is a JSON Object which may contain any of the following fields:</p>
 
-<h5 id="binary_string"><a id="binary"><code>binary</code></a> (string)</h5>
+<h5 id="binary_string"><code>binary</code> (string)</h5>
 
 
 <p>Absolute path to the custom Firefox binary to use.</p>
@@ -64,17 +64,15 @@ tags:
         <p>From the Window system registry:</p>
 
         <ol>
-          <li><code>HKEY_LOCAL_MACHINE\SOFTWARE </code><code
-              id="line-374"><span class="syn_string">WOW6432Node</span></code><code>\Mozilla\Mozilla Firefox\<em>[VERSION]</em>\Main\PathToExe</code>
+          <li><code>HKEY_LOCAL_MACHINE\SOFTWARE WOW6432Node\Mozilla\Mozilla Firefox\[VERSION]\Main\PathToExe</code>
           </li>
-          <li><code>HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\Mozilla Firefox\<em>[VERSION]</em>\Main\PathToExe</code></li>
+          <li><code>HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\Mozilla Firefox\[VERSION]\Main\PathToExe</code></li>
         </ol>
       </td>
     </tr>
   </tbody>
 </table>
 
-<a id="args"></a>
 <h5 id="args_array_of_strings"><code>args</code> (array of strings)</h5>
 
 <p>Command line arguments to pass to the Firefox binary. These must include the leading dash (<code>-</code>) where
@@ -84,7 +82,6 @@ tags:
   <code>["-profile", "/path/to/profile"]</code>. But if a profile has to be transferred to a target machine it is
   recommended to use the <code>profile</code> entry.</p>
 
-<a id="profile"></a>
 <h5 id="profile_string"><code>profile</code> (string)</h5>
 
 <p>Base64-encoded ZIP of a profile directory to use for the Firefox instance. This may be used to e.g. install
@@ -100,47 +97,39 @@ tags:
   <code>{"args": ["-profile", "/path/to/your/profile"]}</code>. Note that if you use a remote client targeting a server
   on a different system, the profile must already exist on the target system.</p>
 
-<a id="log"></a>
 <h5 id="log_Log_object"><code>log</code> (Log object)</h5>
 
 <p>To increase the logging verbosity of geckodriver and Firefox, you may pass a <code><a href="#log">log</a></code>
   object that may look like <code>{"log": {"level": "trace"}}</code> to include all trace-level logs and above</p>
 
-<a id="prefs"></a>
 <h5 id="prefs_Preferences_object"><code>prefs</code> (Preferences object)</h5>
 
 <p>Map of preference name to preference value, which can be a string, a boolean or an integer.</p>
 
-<a id="env"></a>
 <h5 id="env_Env_object"><code>env</code> (Env object)</h5>
 
 <p>Map of environment variable name to environment variable value, both of which must be strings.</p>
 
-<a id="android"></a>
 <h3 id="Android">Android</h3>
 
 <p>Starting with geckodriver 0.26.0 additional capabilities exist if Firefox or an application embedding <a href="https://wiki.mozilla.org/Mobile/GeckoView">GeckoView</a> has to be controlled on Android:</p>
 
-<a id="androidPackage"></a>
 <h5 id="androidPackage_string_required"><code>androidPackage</code> (string, required)</h5>
 
-<p>The package name of Firefox, e.g. <span class="message"><span class="content"><code>org.mozilla.firefox</code>,
-      <code>org.mozilla.firefox_beta,</code> or <code>org.mozilla.fennec</code></span></span> depending on the release
+<p>The package name of Firefox, e.g. <code>org.mozilla.firefox</code>,
+      <code>org.mozilla.firefox_beta,</code> or <code>org.mozilla.fennec</code> depending on the release
   channel, or the package name of the application embedding GeckoView, e.g. <code>org.mozilla.geckoview_example</code>.</p>
 
-<a id="androidActivity"></a>
 <h5 id="androidActivity_string_optional"><code>androidActivity</code> (string, optional)</h5>
 
 <p>The fully qualified class name of the activity to be launched, e.g. <code>.GeckoViewActivity</code>. If not
   specified, the package’s default activity will be used.</p>
 
-<a id="androidDeviceSerial"></a>
 <h5 id="androidDeviceSerial_string_optional"><code>androidDeviceSerial</code> (string, optional)</h5>
 
 <p>The serial number of the device on which to launch the application. If not specified and multiple devices are
   attached, an error will be returned.</p>
 
-<a id="androidIntentArguments"></a>
 <h5 id="androidIntentArguments_array_of_strings_optional"><code>androidIntentArguments</code> (array of strings, optional)</h5>
 
 <p>Arguments to launch the intent with.  Under the hood, geckodriver uses <a
@@ -167,24 +156,21 @@ tags:
 }
 </pre>
 
-<a id="Log"></a>
 <h3 id="Log_object">Log object</h3>
 
 <p>A JSON Object that may have any of these fields:</p>
 
-<a id="level"></a>
 <h5 id="level_string"><code>level</code> (string)</h5>
 
 <p>Set the level of verbosity of geckodriver and Firefox. Available levels are <code>trace</code>, <code>debug</code>,
   <code>config</code>, <code>info</code>, <code>warn</code>, <code>error</code>, and <code>fatal</code>. If left
   undefined the default is <code>info</code>. The value is treated case-insensitively.</p>
 
-<a id="Prefs"></a>
 <h3 id="Preferences_object">Preferences object</h3>
 
 <p>A JSON Object with one entry per preference to set. The preference will be written to the <a
     href="#profile">profile</a> before starting Firefox. A full list of available preferences is available from visiting
-  "<a>about:config</a>" in your Firefox browser. Some of these are documented in <a
+  "about:config" in your Firefox browser. Some of these are documented in <a
     href="https://searchfox.org/mozilla-central/source/modules/libpref/init/all.js">this source</a> file.</p>
 
 <p>An example of a preference object:</p>
@@ -195,7 +181,6 @@ tags:
 }
 </pre>
 
-<a id="Env"></a>
 <h3 id="Env_object">Env object</h3>
 
 <p>A JSON Object with one entry per environment variable to set. On Desktop, the Firefox under test will launch with
@@ -238,15 +223,15 @@ tags:
 }
 </pre>
 
-<p><span class="p">The <code><a href="#firefoxoptions">moz:firefoxOptions</a></code> must be placed—as above—inside
-    <code><a href="/en-US/docs/Web/WebDriver/Capabilities#alwaysmatch">alwaysMatch</a></code>, or in one of the
-  </span><code><a href="/en-US/docs/Web/WebDriver/Capabilities#firstmatch">firstMatch</a></code> <a
+<p>The <a href="#firefoxoptions"><code>moz:firefoxOptions</code></a> must be placed—as above—inside
+    <a href="/en-US/docs/Web/WebDriver/Capabilities#alwaysmatch"><code>alwaysMatch</code></a>, or in one of the
+  <a href="/en-US/docs/Web/WebDriver/Capabilities#firstmatch"><code>firstMatch</code></a> <a
     href="/en-US/docs/Web/WebDriver/Capabilities">capabilities objects</a> as seen here:</p>
 
 <pre class="brush: json">{
   "capabilities": {
     "firstMatch": [
-      {"<a href="#firefoxoptions">moz:firefoxOptions</a>": …}
+      {"moz:firefoxOptions": …}
     ]
   }
 }

--- a/files/en-us/web/webdriver/capabilities/index.html
+++ b/files/en-us/web/webdriver/capabilities/index.html
@@ -10,7 +10,6 @@ tags:
 
 <p>When a WebDriver session is created it returns a set of capabilities describing the negotiated, effective capabilities of the session. Some of the capabilities included in this set are <a href="#list-of-capabilities">standard and shared between all browsers</a>, but the set may also contain <a href="#vendor-specific-capabilities">browser-specific capabilities</a> and these are always prefixed.</p>
 
-<a id="capabilities-negotiation"></a>
 <h2 id="Capabilities_negotiation">Capabilities negotiation</h2>
 
 <p>Capabilities can be used to require a driver that supports a certain subset of features. This can be used to require certain browser features, such as the <a href="/en-US/docs/Web/WebDriver/Capabilities/setWindowRect">ability to resize the window dimensions</a>, but is also used in distributed environments to select a particular browser configuration from a matrix of choices.</p>
@@ -99,31 +98,20 @@ tags:
   }
 }</pre>
 
-<a id="list-of-capabilities"></a>
 <h2 id="List_of_capabilities">List of capabilities</h2>
 
-<dl>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/browserName" id="browserName">browserName</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/browserVersion" id="browserVersion">browserVersion</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/platformName" id="platformName">platformName</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/acceptInsecureCerts" id="acceptInsecureCerts">acceptInsecureCerts</a></code></dt>
- <dd>The <code>acceptInsecureCerts</code> capability communicates whether expired or invalid <a href="/en-US/docs/Glossary/TLS">TLS certificates</a> are checked when <a href="/en-US/docs/Web/WebDriver/Commands/NavigateTo">navigating</a>. If the capability is false, an <a href="/en-US/docs/Web/WebDriver/Errors/InsecureCertificate">insecure certificate</a> error will be returned as navigation encounters domains with certificate problems. Otherwise, self-signed or otherwise invalid certificates will be implicitly trusted by the browser on navigation. The capability has effect for the lifetime of the session.</dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/pageLoadStrategy" id="pageLoadStrategy">pageLoadStrategy</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/proxy" id="proxy">proxy</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/setWindowRect" id="setWindowRect">setWindowRect</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/timeouts" id="timeouts">timeouts</a></code></dt>
- <dd></dd>
- <dt><code><a href="/en-US/docs/Web/WebDriver/Capabilities/unhandledPromptBehavior" id="unhandledPromptBehavior">unhandledPromptBehavior</a></code></dt>
- <dd></dd>
-</dl>
+<ul>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/browserName" id="browserName">browserName</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/browserVersion" id="browserVersion">browserVersion</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/platformName" id="platformName">platformName</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/acceptInsecureCerts">acceptInsecureCerts</a></code>: This capability communicates whether expired or invalid <a href="/en-US/docs/Glossary/TLS">TLS certificates</a> are checked when <a href="/en-US/docs/Web/WebDriver/Commands/NavigateTo">navigating</a>. If the capability is false, an <a href="/en-US/docs/Web/WebDriver/Errors/InsecureCertificate">insecure certificate</a> error will be returned as navigation encounters domains with certificate problems. Otherwise, self-signed or otherwise invalid certificates will be implicitly trusted by the browser on navigation. The capability has effect for the lifetime of the session.</li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/pageLoadStrategy" id="pageLoadStrategy">pageLoadStrategy</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/proxy" id="proxy">proxy</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/setWindowRect" id="setWindowRect">setWindowRect</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/timeouts" id="timeouts">timeouts</a></code></li>
+ <li><code><a href="/en-US/docs/Web/WebDriver/Capabilities/unhandledPromptBehavior" id="unhandledPromptBehavior">unhandledPromptBehavior</a></code></li>
+</ul>
 
-<a id="vendor-specific-capabilities"></a>
 <h2 id="Vendor-specific_capabilities">Vendor-specific capabilities</h2>
 
 <p>In addition to the <a href="#list-of-capabilities">standard capabilities</a> WebDriver allows third-parties to <em>extend</em> the set of capabilities to match their needs. Browser vendors and suppliers of drivers typically use extension capabilities to provide configuration to the browser, but they can also be used by intermediaries for arbitrary blobs of information.</p>
@@ -133,7 +121,6 @@ tags:
  <li><a href="/en-US/docs/Web/WebDriver/Capabilities/goog/chromeOptions">Chrome capabilities</a> (<code>goog:chromeOptions</code>)</li>
 </ul>
 
-<a id="Legacy"></a>
 <h2 id="Legacy_capabilities">Legacy capabilities</h2>
 
 <p>The majority of Selenium clients use <code>desiredCapabilities</code> and <code>requiredCapabilities</code> to configure the new session. These are very similar to <code>firstMatch</code> and <code>alwaysMatch</code> described above. Some drivers support these legacy capabilities, but they are deprecated and should be avoided.</p>

--- a/files/en-us/web/webdriver/commands/setwindowrect/index.html
+++ b/files/en-us/web/webdriver/commands/setwindowrect/index.html
@@ -16,7 +16,7 @@ browser-compat: webdriver.commands.SetWindowRect
 
 <p>When setting the width or height, it is not guaranteed that the resulting window size will exactly match that which was requested. The driver is expected to clamp values that are larger than the physical screen dimensions, or smaller than the minimum window size. Some drivers may also have other limitations such as not being able to resize in single-pixel increments. For this reason, the returned <code>width</code> and <code>height</code> might not exactly match <code><a href="/en-US/docs/Web/API/Window/outerWidth">Window.outerWidth</a></code> and <code><a href="/en-US/docs/Web/API/Window/outerHeight">Window.outerHeight</a></code>.</p>
 
-<p>Setting the window’s position is similar in nature to calling <code><a href="/en-US/docs/Web/API/Window/moveTo">Window.moveTo(<em>x</em>, <em>y</em>)</a></code>, but differences itself by bypassing security restrictions related to window manipulation.</p>
+<p>Setting the window’s position is similar in nature to calling <a href="/en-US/docs/Web/API/Window/moveTo"><code>Window.moveTo(x, y)</code></a>, but differences itself by bypassing security restrictions related to window manipulation.</p>
 
 <p>The Set Window Rect command is blocking.</p>
 
@@ -32,7 +32,7 @@ browser-compat: webdriver.commands.SetWindowRect
  <tbody>
   <tr>
    <td><a href="/en-US/docs/Web/HTTP/Methods/POST">POST</a></td>
-   <td><code>/session/{<em>session id</em>}/window/rect</code></td>
+   <td><code>/session/{session id}/window/rect</code></td>
   </tr>
  </tbody>
 </table>
@@ -50,13 +50,13 @@ browser-compat: webdriver.commands.SetWindowRect
 
 <dl>
  <dt><code>x</code></dt>
- <dd>Horizontal position of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which equivalent to <code><a href="/en-US/docs/Web/API/Window/screenX">Window.screenX</a></code>. Must be a number in the −(2<sup>31</sup>) to 2<sup>31</sup> − 1 range, null, or undefined.</dd>
+ <dd>Horizontal position of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which equivalent to <code><a href="/en-US/docs/Web/API/Window/screenX">Window.screenX</a></code>. Must be a number in the −(2^31</) to 2^31 − 1 range, null, or undefined.</dd>
  <dt><code>y</code></dt>
- <dd>Vertical position of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which is equivalent to <code><a href="/en-US/docs/Web/API/Window/screenY">Window.screenY</a></code>. Must be a number in the −(2<sup>31</sup>) to 2<sup>31</sup> − 1 range, null, or undefined.</dd>
+ <dd>Vertical position of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which is equivalent to <code><a href="/en-US/docs/Web/API/Window/screenY">Window.screenY</a></code>. Must be a number in the −(2^31) to 2^31 − 1 range, null, or undefined.</dd>
  <dt><code>width</code></dt>
- <dd>Outer width of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which is equivalent to <code><a href="/en-US/docs/Web/API/Window/outerWidth">Window.outerWidth</a></code>. Must be a number in the 0 to 2<sup>31</sup> − 1 range, null, or undefined.</dd>
+ <dd>Outer width of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which is equivalent to <code><a href="/en-US/docs/Web/API/Window/outerWidth">Window.outerWidth</a></code>. Must be a number in the 0 to 2^31 − 1 range, null, or undefined.</dd>
  <dt><code>height</code></dt>
- <dd>Outer width of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which is equivalent to <code><a href="/en-US/docs/Web/API/Window/outerHeight">Window.outerHeight</a></code>. Must be a number in the 0 to 2<sup>31</sup> − 1 range, null, or undefined.</dd>
+ <dd>Outer width of the <code><a href="/en-US/docs/Web/API/Window">window</a></code>, which is equivalent to <code><a href="/en-US/docs/Web/API/Window/outerHeight">Window.outerHeight</a></code>. Must be a number in the 0 to 2^31 − 1 range, null, or undefined.</dd>
 </dl>
 
 <h3 id="Response">Response</h3>

--- a/files/en-us/web/webdriver/errors/index.html
+++ b/files/en-us/web/webdriver/errors/index.html
@@ -70,12 +70,12 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/ElementClickIntercepted">element click intercepted</a></td>
    <td>{{HTTPStatus(400, "400 Bad Request")}}</td>
-   <td>The <a class="internalDFN" href="/en-US/docs/Web/WebDriver/ElementClick">Element Click</a> <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> could not be completed because the <a class="internalDFN" href="/en-US/docs/Web/WebDriver/WebElement">element</a> receiving the events is obscuring the element that was requested clicked.</td>
+   <td>The <a href="/en-US/docs/Web/WebDriver/ElementClick">Element Click</a> <a href="/en-US/docs/Web/WebDriver/Command">command</a> could not be completed because the <a href="/en-US/docs/Web/WebDriver/WebElement">element</a> receiving the events is obscuring the element that was requested clicked.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/ElementNotInteractable">element not interactable</a></td>
    <td>{{HTTPStatus(400, "400 Bad Request")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> could not be completed because the element is not pointer- or keyboard interactable.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> could not be completed because the element is not pointer- or keyboard interactable.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/InsecureCertificate">insecure certificate</a></td>
@@ -85,7 +85,7 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/InvalidArgument">invalid argument</a></td>
    <td>{{HTTPStatus(400, "400 Bad Request")}}</td>
-   <td>The arguments passed to a <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> are either invalid or malformed.</td>
+   <td>The arguments passed to a <a href="/en-US/docs/Web/WebDriver/Command">command</a> are either invalid or malformed.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/InvalidCookieDomain">invalid cookie domain</a></td>
@@ -95,7 +95,7 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/InvalidElementState">invalid element state</a></td>
    <td>{{HTTPStatus(400, "400 Bad Request")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> could not be completed because the element is in an invalid state, e.g. attempting to <a class="internalDFN" href="/en-US/docs/Web/WebDriver/ElementClear">clear</a> an element that isn't both editable and resettable.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> could not be completed because the element is in an invalid state, e.g. attempting to <a href="/en-US/docs/Web/WebDriver/ElementClear">clear</a> an element that isn't both editable and resettable.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/InvalidSelector">invalid selector</a></td>
@@ -125,7 +125,7 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/NoSuchCookie">no such cookie</a></td>
    <td>{{HTTPStatus(404, "404 Not Found")}}</td>
-   <td>No cookie matching the given path name was found amongst the <a class="internalDFN" href="/en-US/docs/Glossary/Cookie">cookies</a> of the current <a href="/en-US/docs/Web/API/Document">document</a>.</td>
+   <td>No cookie matching the given path name was found amongst the <a href="/en-US/docs/Glossary/Cookie">cookies</a> of the current <a href="/en-US/docs/Web/API/Document">document</a>.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/NoSuchElement">no such element</a></td>
@@ -135,12 +135,12 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/NoSuchFrame">no such frame</a></td>
    <td>{{HTTPStatus(404, "404 Not Found")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> to switch to a frame could not be satisfied because the frame could not be found.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> to switch to a frame could not be satisfied because the frame could not be found.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/NoSuchWindow">no such window</a></td>
    <td>{{HTTPStatus(404, "404 Not Found")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> to switch to a window could not be satisfied because the window could not be found.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> to switch to a window could not be satisfied because the window could not be found.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/ScriptTimeout">script timeout</a></td>
@@ -155,7 +155,7 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/StaleElementReference">stale element reference</a></td>
    <td>{{HTTPStatus(404, "404 Not Found")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> failed because the referenced <a class="internalDFN" href="/en-US/docs/Web/WebDriver/WebElement">element</a> is no longer attached to the DOM.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> failed because the referenced <a href="/en-US/docs/Web/WebDriver/WebElement">element</a> is no longer attached to the DOM.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/Timeout">timeout</a></td>
@@ -165,7 +165,7 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/UnableToSetCookie">unable to set cookie</a></td>
    <td>{{HTTPStatus(500, "500 Internal Server Error")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> to set a cookie’s value could not be satisfied.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> to set a cookie’s value could not be satisfied.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/UnableToCaptureScreen">unable to capture screen</a></td>
@@ -180,22 +180,22 @@ tags:
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/UnknownCommand">unknown command</a></td>
    <td>{{HTTPStatus(404, "404 Not Found")}}</td>
-   <td>A <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> could not be executed because the driver was unaware of it.</td>
+   <td>A <a href="/en-US/docs/Web/WebDriver/Command">command</a> could not be executed because the driver was unaware of it.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/UnknownError">unknown error</a></td>
    <td>{{HTTPStatus(500, "500 Internal Server Error")}}</td>
-   <td>An unknown error occurred in the driver whilst processing the <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a>.</td>
+   <td>An unknown error occurred in the driver whilst processing the <a href="/en-US/docs/Web/WebDriver/Command">command</a>.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/UnknownMethod">unknown method</a></td>
    <td>{{HTTPStatus(405, "405 Method Not Allowed")}}</td>
-   <td>The requested <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> matched a known URL but did not match a method for that URL.</td>
+   <td>The requested <a href="/en-US/docs/Web/WebDriver/Command">command</a> matched a known URL but did not match a method for that URL.</td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/WebDriver/Errors/UnsupportedOperation">unsupported operation</a></td>
    <td>{{HTTPStatus(500, "500 Internal Server Error")}}</td>
-   <td>Indicates that a <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Command">command</a> that should have executed properly cannot be supported for some reason.</td>
+   <td>Indicates that a <a href="/en-US/docs/Web/WebDriver/Command">command</a> that should have executed properly cannot be supported for some reason.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/webdriver/errors/invalidargument/index.html
+++ b/files/en-us/web/webdriver/errors/invalidargument/index.html
@@ -7,7 +7,7 @@ tags:
   - WebDriver
   - invalid argument
 ---
-<p>The <strong>invalid argument</strong> error is a <a href="/en-US/docs/Web/WebDriver/Errors">WebDriver error</a> that occurs when the arguments passed to a <a class="internalDFN" href="/en-US/docs/Web/WebDriver/Commands">command</a> are either invalid or malformed.</p>
+<p>The <strong>invalid argument</strong> error is a <a href="/en-US/docs/Web/WebDriver/Errors">WebDriver error</a> that occurs when the arguments passed to a <a href="/en-US/docs/Web/WebDriver/Commands">command</a> are either invalid or malformed.</p>
 
 <p>Invalid argument errors can be likened to <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError">TypeError</a></code>s in <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, in that they can occur for a great many APIs when the input value is not of the expected type or malformed in some way. See the type- and bounds constraints for each <a href="/en-US/docs/Web/WebDriver/Commands">WebDriver command</a>.</p>
 

--- a/files/en-us/web/webdriver/index.html
+++ b/files/en-us/web/webdriver/index.html
@@ -51,8 +51,6 @@ with webdriver.Firefox() as driver:
 
 <h2 id="Reference">Reference</h2>
 
-<div class="column-container">
-<div class="column-half">
 <h3 id="Commands">Commands</h3>
 
 <p><a href="/en-US/docs/Web/WebDriver/Commands">Commands</a></p>
@@ -67,9 +65,7 @@ with webdriver.Firefox() as driver:
  <li><a href="/en-US/docs/Web/WebDriver/WebElement">WebElement</a></li>
  <li><a href="/en-US/docs/Web/WebDriver/WebWindow">WebWindow</a></li>
 </ul>
-</div>
 
-<div class="column-half">
 <h3 id="Capabilities">Capabilities</h3>
 <p><a href="/en-US/docs/Web/WebDriver/Capabilities">Capabilities</a></p>
 <p>{{ListSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}</p>
@@ -77,8 +73,6 @@ with webdriver.Firefox() as driver:
 <h3 id="Errors">Errors</h3>
 <p><a href="/en-US/docs/Web/WebDriver/Errors">Errors</a></p>
 <p>{{ListSubpages("/en-US/docs/Web/WebDriver/Errors")}}</p>
-</div>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This PR prepares the WebDriver docs (https://developer.mozilla.org/en-US/docs/Web/WebDriver) for Markdowning.

After this PR the only unconverted element is the table in https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions, which will stay in HTML because it has cells containing block elements.
