### PR TITLE
[Markdown][MathML] Prepare MathML for Markdowning

### DIFF
--- a/files/en-us/web/mathml/attribute/index.html
+++ b/files/en-us/web/mathml/attribute/index.html
@@ -27,29 +27,29 @@ tags:
   </tr>
  </thead>
  <tbody>
-  <tr id="accent">
+  <tr>
    <td><code>accent</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mover") }}, {{ MathMLElement("munderover") }}</td>
    <td>A Boolean value specifying whether the operator should be treated as an accent.</td>
   </tr>
-  <tr id="accentunder">
+  <tr>
    <td><code>accentunder</code></td>
    <td>{{ MathMLElement("munder") }}, {{ MathMLElement("munderover") }}</td>
    <td>A Boolean value specifying whether the operator should be treated as an accent.</td>
   </tr>
-  <tr id="actiontype">
+  <tr>
    <td><code>actiontype</code></td>
    <td>{{ MathMLElement("maction") }}</td>
    <td>A string value specifying the action happening for this element.</td>
   </tr>
-  <tr id="align">
+  <tr>
    <td><code>align</code> {{deprecated_inline}}</td>
    <td>{{ MathMLElement("mtable") }}<br>
     {{ MathMLElement("munder") }}, {{ MathMLElement("mover") }}, {{ MathMLElement("munderover") }}<br>
     {{ MathMLElement("mstack") }}</td>
    <td>Specifies different alignments of several elements (see element pages for details).</td>
   </tr>
-  <tr id="alt-*">
+  <tr>
    <td>{{ unimplemented_inline() }}<br>
     <code>altimg</code><br>
     <code>altimg-width</code><br>
@@ -59,67 +59,67 @@ tags:
    <td>{{ MathMLElement("math") }}</td>
    <td>Visual and textual fall-back options.</td>
   </tr>
-  <tr id="bevelled">
+  <tr>
    <td><code>bevelled</code> {{deprecated_inline}}</td>
    <td>{{ MathMLElement("mfrac") }}</td>
    <td>Specifies the style how the fraction should be displayed. Deprecated. Use U+2044 (fraction slash) instead.</td>
   </tr>
-  <tr id="charalign">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>charalign</code></td>
    <td>{{ MathMLElement("mstack") }}</td>
    <td>Specifies the horizontal alignment of digits.</td>
   </tr>
-  <tr id="close">
+  <tr>
    <td><code>close</code></td>
    <td>{{ MathMLElement("mfenced") }}</td>
    <td>A string for the closing delimiter.</td>
   </tr>
-  <tr id="columnalign">
+  <tr>
    <td><code>columnalign</code></td>
    <td>{{ MathMLElement("mtable") }}, {{ MathMLElement("mtd") }}, {{ MathMLElement("mtr") }}</td>
    <td>Specifies the horizontal alignment of table cells.</td>
   </tr>
-  <tr id="columnlines">
+  <tr>
    <td><code>columnlines</code></td>
    <td>{{ MathMLElement("mtable") }}</td>
    <td>Specifies table column borders.</td>
   </tr>
-  <tr id="columnspacing">
+  <tr>
    <td><code>columnspacing</code></td>
    <td>{{ MathMLElement("mtable") }}</td>
    <td>Specifies the space between table columns.</td>
   </tr>
-  <tr id="columnspan">
+  <tr>
    <td><code>columnspan</code></td>
    <td>{{ MathMLElement("mtd") }}</td>
    <td>A non-negative integer value that indicates over how many table columns the cell extends.</td>
   </tr>
-  <tr id="crossout">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>crossout</code></td>
    <td>{{ MathMLElement("mscarry") }}</td>
    <td>Specifies what kind of line is drawn to cross out carries.</td>
   </tr>
-  <tr id="denomalign">
+  <tr>
    <td><code>denomalign</code> {{deprecated_inline}}</td>
    <td>{{ MathMLElement("mfrac") }}</td>
    <td>The alignment of the denominator under the fraction.</td>
   </tr>
-  <tr id="depth">
+  <tr>
    <td><code>depth</code></td>
    <td>{{ MathMLElement("mpadded") }}</td>
    <td>Sets or increments the depth. See <a href="/en-US/docs/Web/MathML/Attribute/Values">length</a>.</td>
   </tr>
-  <tr id="dir">
+  <tr>
    <td><code>dir</code></td>
    <td>{{ MathMLElement("math") }}, {{ MathMLElement("mi") }}, {{ MathMLElement("mo") }}, {{ MathMLElement("mrow") }}, {{ MathMLElement("ms") }}, {{ MathMLElement("mtext") }}</td>
    <td>The text direction. Possible values are either ltr (left to right) or rtl (right to left).</td>
   </tr>
-  <tr id="display">
+  <tr>
    <td><code>display</code></td>
    <td>{{ MathMLElement("math") }}</td>
    <td>Specifies the rendering mode. The values <code>block</code> and <code>inline</code> are allowed.</td>
   </tr>
-  <tr id="displaystyle">
+  <tr>
    <td><code>displaystyle</code></td>
    <td><em>All</em></td>
    <td>
@@ -128,297 +128,297 @@ tags:
     <p><em>In MathML 3 this attribute was only valid on {{ MathMLElement("mstyle") }}, {{ MathMLElement("mtable") }}, and  {{ MathMLElement("math") }}.</em></p>
    </td>
   </tr>
-  <tr id="edge">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>edge</code></td>
    <td>{{ MathMLElement("malignmark") }}</td>
    <td></td>
   </tr>
-  <tr id="fence">
+  <tr>
    <td><code>fence</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>A Boolean value specifying whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.</td>
   </tr>
-  <tr id="frame">
+  <tr>
    <td><code>frame</code></td>
    <td>{{ MathMLElement("mtable") }}</td>
    <td>Specifies borders of an entire {{ MathMLElement("mtable") }}. Possible values are: <code>none</code> (default), <code>solid</code> and <code>dashed</code>.</td>
   </tr>
-  <tr id="framespacing">
+  <tr>
    <td><code>framespacing</code></td>
    <td>{{ MathMLElement("mtable") }}</td>
    <td>Specifies additional space added between the table and <code>frame</code>.</td>
   </tr>
-  <tr id="groupalign">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>groupalign</code></td>
    <td>{{ MathMLElement("maligngroup") }}</td>
    <td></td>
   </tr>
-  <tr id="height">
+  <tr>
    <td><code>height</code></td>
    <td>{{ MathMLElement("mpadded") }}, {{ MathMLElement("mspace") }}</td>
    <td>Specifies the desired height. See <a href="/en-US/docs/Web/MathML/Attribute/Values#lengths">lengths</a> for possible values.</td>
   </tr>
-  <tr id="href">
+  <tr>
    <td><code>href</code></td>
    <td><em>All</em></td>
    <td>Used to set a hyperlink to a specified URI.</td>
   </tr>
-  <tr id="id">
+  <tr>
    <td><code>id</code></td>
    <td><em>All</em></td>
    <td>Sets up a unique identifier associated with the element.</td>
   </tr>
-  <tr id="indentalign">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indentalign</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="indentalignfirst">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indentalignfirst</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="indentalignlast">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indentalignlast</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="indentshift">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indentshift</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="indentshiftfirst">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indentshiftfirst</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="indentshiftlast">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indentshiftlast</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="indenttarget">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>indenttarget</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="infixlinebreakstyle">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>infixlinebreakstyle</code></td>
    <td>{{ MathMLElement("mstyle") }}</td>
    <td>Specifies the default <code>linebreakstyle</code> to use for infix operators.</td>
   </tr>
-  <tr id="length">
+  <tr>
    <td><code>length</code></td>
    <td>{{ MathMLElement("msline") }}</td>
    <td></td>
   </tr>
-  <tr id="linebreak">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>linebreak</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td></td>
   </tr>
-  <tr id="linebreakmultchar">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>linebreakmultchar</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="linebreakstyle">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>linebreakstyle</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="lineleading">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>lineleading</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mspace") }}</td>
    <td></td>
   </tr>
-  <tr id="linethickness">
+  <tr>
    <td><code>linethickness</code></td>
    <td>{{ MathMLElement("mfrac") }}</td>
    <td>The thickness of the horizontal fraction line.</td>
   </tr>
-  <tr id="location">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>location</code></td>
    <td>{{ MathMLElement("mscarries") }}</td>
    <td></td>
   </tr>
-  <tr id="longdivstyle">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>longdivstyle</code></td>
    <td>{{ MathMLElement("mlongdiv") }}</td>
    <td>Controls the style of the long division layout.</td>
   </tr>
-  <tr id="lspace">
+  <tr>
    <td><code>lspace</code></td>
    <td>{{ MathMLElement("mo") }}, {{ MathMLElement("mpadded") }}</td>
    <td>The amount of space before the operator (see <a href="/en-US/docs/Web/MathML/Attribute/Values#lengths">length</a> for values and units).</td>
   </tr>
-  <tr id="lquote">
+  <tr>
    <td><code>lquote</code></td>
    <td>{{ MathMLElement("ms") }}</td>
    <td>The opening quote character (depends on <code>dir</code>) to enclose the content. The default value is "<code>&amp;quot;</code>".</td>
   </tr>
-  <tr id="mathbackground">
+  <tr>
    <td><code>mathbackground</code></td>
    <td><em>All</em></td>
    <td>The background color. You can use <code>#rgb</code>, <code>#rrggbb</code> and <a href="/en-US/docs/Web/CSS/color_value#html.2fsvg.2fx11.c2.a0_color_keywords">HTML color names</a>.</td>
   </tr>
-  <tr id="mathcolor">
+  <tr>
    <td><code>mathcolor</code></td>
    <td><em>All</em></td>
    <td>The text color. You can use <code>#rgb</code>, <code>#rrggbb</code> and <a href="/en-US/docs/Web/CSS/color_value#html.2fsvg.2fx11.c2.a0_color_keywords">HTML color names</a>.</td>
   </tr>
-  <tr id="mathsize">
+  <tr>
    <td><code>mathsize</code></td>
    <td>{{ MathMLElement("mi") }}, {{ MathMLElement("mn") }}, {{ MathMLElement("mo") }}, {{ MathMLElement("ms") }}, {{ MathMLElement("mtext") }}</td>
    <td>The size of the content.</td>
   </tr>
-  <tr id="mathvariant">
+  <tr>
    <td><code>mathvariant</code></td>
    <td>{{ MathMLElement("mi") }}, {{ MathMLElement("mn") }}, {{ MathMLElement("mo") }}, {{ MathMLElement("ms") }}, {{ MathMLElement("mtext") }}</td>
    <td>The logical class of the identifier, which varies in typography.</td>
   </tr>
-  <tr id="maxsize">
+  <tr>
    <td><code>maxsize</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>The maximum size of the operator.</td>
   </tr>
-  <tr id="minsize">
+  <tr>
    <td><code>minsize</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>The minimum size of the operator.</td>
   </tr>
-  <tr id="movablelimits">
+  <tr>
    <td><code>movablelimits</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>Specifies whether attached under- and overscripts move to sub- and superscript positions.</td>
   </tr>
-  <tr id="notation">
+  <tr>
    <td><code>notation</code></td>
    <td>{{ MathMLElement("menclose") }}</td>
    <td>A list of notations, separated by white space, to apply to the child elements.</td>
   </tr>
-  <tr id="numalign">
+  <tr>
    <td><code>numalign</code> {{deprecated_inline}}</td>
    <td>{{ MathMLElement("mfrac") }}</td>
    <td>The alignment of the numerator over the fraction.</td>
   </tr>
-  <tr id="open">
+  <tr>
    <td><code>open</code></td>
    <td>{{ MathMLElement("mfenced") }}</td>
    <td>A string for the opening delimiter.</td>
   </tr>
-  <tr id="position">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>position</code></td>
    <td>{{ MathMLElement("msgroup") }}, {{ MathMLElement("msrow") }}, {{ MathMLElement("mscarries") }}, {{ MathMLElement("msline") }}</td>
    <td></td>
   </tr>
-  <tr id="rowalign">
+  <tr>
    <td><code>rowalign</code></td>
    <td>{{ MathMLElement("mtable") }}, {{ MathMLElement("mtd") }}, {{ MathMLElement("mtr") }}</td>
    <td>Specifies the vertical alignment of table cells.</td>
   </tr>
-  <tr id="rowlines">
+  <tr>
    <td><code>rowlines</code></td>
    <td>{{ MathMLElement("mtable") }}</td>
    <td>Specifies table row borders.</td>
   </tr>
-  <tr id="rowspacing">
+  <tr>
    <td><code>rowspacing</code></td>
    <td>{{ MathMLElement("mtable") }}</td>
    <td>Specifies the space between table rows.</td>
   </tr>
-  <tr id="rowspan">
+  <tr>
    <td><code>rowspan</code></td>
    <td>{{ MathMLElement("mtd") }}</td>
    <td>A non-negative integer value that indicates on how many rows does the cell extend.</td>
   </tr>
-  <tr id="rspace">
+  <tr>
    <td><code>rspace</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>The amount of space after the operator.</td>
   </tr>
-  <tr id="rquote">
+  <tr>
    <td><code>rquote</code></td>
    <td>{{ MathMLElement("ms") }}</td>
    <td>The closing quote mark (depends on <code>dir</code>) to enclose the content. The default value is "<code>&amp;quot;</code>".</td>
   </tr>
-  <tr id="scriptlevel">
+  <tr>
    <td><code>scriptlevel</code></td>
    <td>{{ MathMLElement("mstyle") }}</td>
    <td>Controls mostly the font-size. The higher the <code>scriptlevel</code>, the smaller the font size.</td>
   </tr>
-  <tr id="scriptminsize">
+  <tr>
    <td><code>scriptminsize</code></td>
    <td>{{ MathMLElement("mstyle") }}</td>
    <td>Specifies a minimum font size allowed due to changes in <code>scriptlevel</code>.</td>
   </tr>
-  <tr id="scriptsizemultiplier">
+  <tr>
    <td><code>scriptsizemultiplier</code></td>
    <td>{{ MathMLElement("mstyle") }}</td>
    <td>Specifies the multiplier to be used to adjust font size due to changes in <code>scriptlevel</code>.</td>
   </tr>
-  <tr id="selection">
+  <tr>
    <td><code>selection</code></td>
    <td>{{ MathMLElement("maction") }}</td>
    <td>The child element which is addressed by the action.</td>
   </tr>
-  <tr id="separator">
+  <tr>
    <td><code>separator</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>There is no visual effect for this attribute, but it specifies whether the operator is a separator (such as commas).</td>
   </tr>
-  <tr id="separators">
+  <tr>
    <td><code>separators</code></td>
    <td>{{ MathMLElement("mfenced") }}</td>
    <td>A sequence of zero or more characters to be used for different separators.</td>
   </tr>
-  <tr id="shift">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>shift</code></td>
    <td>{{ MathMLElement("msgroup") }}</td>
    <td></td>
   </tr>
-  <tr id="stackalign">
+  <tr>
    <td>{{ unimplemented_inline() }} <code>stackalign</code></td>
    <td>{{ MathMLElement("mstack") }}</td>
    <td></td>
   </tr>
-  <tr id="stretchy">
+  <tr>
    <td><code>stretchy</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>Specifies whether the operator stretches to the size of the adjacent element.</td>
   </tr>
-  <tr id="subscriptshift">
+  <tr>
    <td><code>subscriptshift</code> {{deprecated_inline}}</td>
    <td>{{ MathMLElement("mmultiscripts") }}, {{ MathMLElement("msub") }}, {{ MathMLElement("msubsup") }}</td>
    <td>The minimum space by which to shift the subscript below the baseline of the expression.</td>
   </tr>
-  <tr id="supscriptshift">
+  <tr>
    <td><code>supscriptshift</code> {{deprecated_inline}}</td>
    <td>{{ MathMLElement("mmultiscripts") }}, {{ MathMLElement("msup") }}, {{ MathMLElement("msubsup") }}</td>
    <td>The minimum space by which to shift the superscript above the baseline of the expression.</td>
   </tr>
-  <tr id="symmetric">
+  <tr>
    <td><code>symmetric</code></td>
    <td>{{ MathMLElement("mo") }}</td>
    <td>If <code>stretchy</code> is <code>true</code>, this attribute specifies whether the operator should be vertically symmetric around the imaginary math axis (centered fraction line).</td>
   </tr>
-  <tr id="voffset">
+  <tr>
    <td><code>voffset</code></td>
    <td>{{ MathMLElement("mpadded") }}</td>
    <td>Sets the vertical position of the child content.</td>
   </tr>
-  <tr id="width">
+  <tr>
    <td><code>width</code></td>
    <td>{{ MathMLElement("mpadded") }}, {{ MathMLElement("mspace") }}, {{ MathMLElement("mtable") }}</td>
    <td>Specifies the desired width. See <a href="/en-US/docs/Web/MathML/Attribute/Values#lengths">lengths</a> for possible values.</td>
   </tr>
-  <tr id="xlink-href">
+  <tr>
    <td><code>xlink:href</code> {{deprecated_inline}}</td>
    <td><em>All</em></td>
    <td>Can be used to set a hyperlink to a specfied URI. However, authors are encouraged to use the <code>href</code> attribute instead.</td>
   </tr>
-  <tr id="xmlns">
+  <tr>
    <td><code>xmlns</code></td>
    <td>{{ MathMLElement("math") }}</td>
    <td>Specifies the URI for the MathML namespace (<code><a href="https://www.w3.org/1998/Math/MathML">http://www.w3.org/1998/Math/MathML</a></code>)</td>

--- a/files/en-us/web/mathml/attribute/values/index.html
+++ b/files/en-us/web/mathml/attribute/values/index.html
@@ -112,9 +112,6 @@ veryverythickmathspace =&gt; 0.3888888888888889em</code></pre>
    <td>7/18<code>em</code></td>
   </tr>
   <tr>
-   <th colspan="2">Negative <em>contstants</em> are introduced in Gecko 7.0 {{ geckoRelease("7.0") }} ({{ bug(650530) }})</th>
-  </tr>
-  <tr>
    <td><code>negativeveryverythinmathspace</code></td>
    <td>-1/18<code>em</code></td>
   </tr>

--- a/files/en-us/web/mathml/authoring/index.html
+++ b/files/en-us/web/mathml/authoring/index.html
@@ -277,7 +277,7 @@ sudo make install
 
 <p>Note that <a href="https://github.com/michal-h21/tex4ebook">tex4ebook</a> relies on TeX4ht to generate EPUB documents.</p>
 
-<p><a href="https://dlmf.nist.gov/LaTeXML/" name="LaTeXML">LaTeXML</a> is another tool that can generate HTML5 and EPUB documents. Windows users can watch this <a href="https://www.youtube.com/watch?v=Dg881w2e-lI">video tutorial</a>. Given a foo.tex LaTeX file, you can use these simple commands:</p>
+<p><a href="https://dlmf.nist.gov/LaTeXML/">LaTeXML</a> is another tool that can generate HTML5 and EPUB documents. Windows users can watch this <a href="https://www.youtube.com/watch?v=Dg881w2e-lI">video tutorial</a>. Given a foo.tex LaTeX file, you can use these simple commands:</p>
 
 <pre>  latexmlc --dest foo.html foo.tex # Generate a HTML5 document foo.html
   latexmlc --dest foo.epub foo.tex # Generate an EPUB document foo.epub</pre>
@@ -316,7 +316,7 @@ sudo make install
 
 <p><a href="https://github.com/fred-wang/TeXZilla">TeXZilla</a> has several interfaces, including a <a href="https://ckeditor.com/addon/texzilla">CKEditor plugin</a> used on MDN, an <a href="https://fred-wang.github.io/TeXZilla/">online demo</a>, a <a href="https://addons.mozilla.org/en-US/firefox/addon/texzilla/">Firefox add-on</a> or a <a href="https://marketplace.firefox.com/app/texzilla-1/">FirefoxOS Webapp</a>. It has also been integrated into <a href="https://www.seamonkey-project.org/">SeaMonkey</a> since version 2.28 and into <a href="https://www.mozilla.org/thunderbird/">Thunderbird</a> since version 31.<a href="http://abisource.org/"> Abiword</a> contains a small equation editor, based on itex2MML. Finally, <a href="http://www.bluegriffon.com/"> Bluegriffon</a> has an add-on to insert MathML formulas in your document, using ASCII/LaTeX-like syntax.</p>
 
-<p style="text-align: center;"><img alt="BlueGriffon" src="mathml-shot1.png"></p>
+<p><img alt="BlueGriffon" src="mathml-shot1.png"></p>
 
 <h3 id="WYSIYWG_Editors">WYSIYWG Editors</h3>
 
@@ -326,11 +326,11 @@ sudo make install
 
 <p><a href="https://www.texmacs.org/">TeXmacs</a> is a free structured editor with special facilities for mathematics, graphics and interactive sessions. TeXmacs documents can be exported in XHTML+MathML.</p>
 
-<p style="text-align: center;"><img alt="TeXmacs MathML example" src="tm-mathml-collage.png"></p>
+<p><img alt="TeXmacs MathML example" src="tm-mathml-collage.png"></p>
 
 <p><a href="https://www.openoffice.org/">OpenOffice</a> and <a href="https://libreoffice.org/">LibreOffice</a> have an equation editor (File → New → Formula). It is semi-WYSIWYG: you enter the source of the formula using the equation panel/keyboard and a preview of the formula is regularly refreshed. The editor uses its own syntax "StarMath" for the source but MathML is also generated when the document is saved. To get the MathML code, save the document as mml and open it with any text editor. Alternatively, you can extract the odf file (which is actually a zip archive) and open an xml file called <code>content.xml</code>.</p>
 
-<p style="text-align: center;"><img alt="Open Office Math" src="openoffice.png"></p>
+<p><img alt="Open Office Math" src="openoffice.png"></p>
 
 <p><a href="https://www.w3.org/Amaya/">Amaya</a> is the W3C's web editor, which is able to handle MathML inside XHTML documents. Use the Elements and the Special Chars panels to create various advanced mathematical constructs. Simple text such as <code>a+2</code> is automatically parsed and the appropriate MathML markup is generated. Once you are done, you can directly save your XHTML page and open it in Mozilla.</p>
 
@@ -338,7 +338,6 @@ sudo make install
 
 <p><a href="https://www.inftyreader.org/">Inftyreader</a> is able to perform some Optical Character Recognition, including translation of mathematical equations into MathML. Other tools can do handwriting recognition such as the <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd371698(v=vs.85).aspx">Windows Math Input Panel</a> or the online converter <a href="https://webdemo.myscript.com/views/math.html">Web Equation</a>.</p>
 
-<div class="originaldocinfo">
 <h3 id="Original_Document_Information">Original Document Information</h3>
 
 <ul>
@@ -346,4 +345,3 @@ sudo make install
  <li>Other Contributors: Florian Scholz</li>
  <li>Copyright Information: Portions of this content are © 2010 by individual mozilla.org contributors; content available under a Creative Commons license | <a href="https://www.mozilla.org/foundation/licensing/website-content.html">Details</a>.</li>
 </ul>
-</div>

--- a/files/en-us/web/mathml/element/index.html
+++ b/files/en-us/web/mathml/element/index.html
@@ -15,7 +15,6 @@ tags:
 
 <h2 id="MathML_presentation_elements_A_to_Z">MathML presentation elements A  to Z</h2>
 
-<div class="multiColumnList">
 <h3 id="math">math</h3>
 
 <ul>
@@ -130,7 +129,6 @@ tags:
  <li><a href="/en-US/docs/Web/MathML/Element/semantics#annotation"><code>&lt;annotation&gt;</code></a> (Data annotations)</li>
  <li><a href="/en-US/docs/Web/MathML/Element/semantics#annotation-xml"><code>&lt;annotation-xml&gt;</code></a> (XML annotations)</li>
 </ul>
-</div>
 
 <h2 id="MathML_presentation_elements_by_category">MathML presentation elements by category</h2>
 

--- a/files/en-us/web/mathml/element/mfrac/index.html
+++ b/files/en-us/web/mathml/element/mfrac/index.html
@@ -45,7 +45,7 @@ browser-compat: mathml.elements.mfrac
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="(a/b)/(c/d)" src="mfrac.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="(a/b)/(c/d)" src="mfrac.png"></p>
 
 <p>Your browser rendering: <math> <mfrac bevelled="true"> <mfrac> <mi> a </mi> <mi> b </mi> </mfrac> <mfrac> <mi> c </mi> <mi> d </mi> </mfrac> </mfrac> </math></p>
 

--- a/files/en-us/web/mathml/element/mmultiscripts/index.html
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.html
@@ -48,7 +48,7 @@ browser-compat: mathml.elements.mmultiscripts
 
 <h3 id="Using_&lt;mprescripts&gt;">Using <code>&lt;mprescripts/&gt;</code></h3>
 
-<p>Sample rendering: <img alt="" src="mmultiscripts_prescripts.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="" src="mmultiscripts_prescripts.png"></p>
 
 <p>Rendering in your browser: <math> <mmultiscripts> <mi>X</mi> <mi>d</mi> <mi>c</mi> <mprescripts></mprescripts> <mi>b</mi> <mi>a</mi> </mmultiscripts> </math></p>
 
@@ -72,7 +72,7 @@ browser-compat: mathml.elements.mmultiscripts
 
 <h3 id="Using_&lt;none&gt;">Using <code>&lt;none/&gt;</code></h3>
 
-<p>Sample rendering: <img alt="" src="mmultiscripts_none.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="" src="mmultiscripts_none.png"></p>
 
 <p>Rendering in your browser:
     <math>

--- a/files/en-us/web/mathml/element/mover/index.html
+++ b/files/en-us/web/mathml/element/mover/index.html
@@ -35,7 +35,7 @@ browser-compat: mathml.elements.mover
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="x+y+z" src="mover.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="x+y+z" src="mover.png"></p>
 
 <p>Rendering in your browser: <math> <mover accent="true"> <mrow> <mi> x </mi> <mo> + </mo> <mi> y </mi> <mo> + </mo> <mi> z </mi> </mrow> <mo> ⏞ </mo> </mover> </math></p>
 

--- a/files/en-us/web/mathml/element/mphantom/index.html
+++ b/files/en-us/web/mathml/element/mphantom/index.html
@@ -25,7 +25,7 @@ browser-compat: mathml.elements.mphantom
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="x+  z" src="mphantom.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="x+  z" src="mphantom.png"></p>
 
 <p>Rendering in your browser: <math> <mrow> <mi> x </mi> <mo> + </mo> <mphantom> <mi> y </mi> <mo> + </mo> </mphantom> <mi> z </mi> </mrow> </math></p>
 

--- a/files/en-us/web/mathml/element/mroot/index.html
+++ b/files/en-us/web/mathml/element/mroot/index.html
@@ -29,7 +29,7 @@ browser-compat: mathml.elements.mroot
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample Rendering: <img alt="x" src="mroot.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample Rendering: <img alt="x" src="mroot.png"></p>
 
 <p>Rendering in your browser: <math> <mroot> <mi>x</mi> <mn>3</mn> </mroot> </math></p>
 

--- a/files/en-us/web/mathml/element/msqrt/index.html
+++ b/files/en-us/web/mathml/element/msqrt/index.html
@@ -29,7 +29,7 @@ browser-compat: mathml.elements.msqrt
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="root-x" src="msqrt.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="root-x" src="msqrt.png"></p>
 
 <p>Rendering in your browser: <math> <msqrt> <mi>x</mi> </msqrt> </math></p>
 

--- a/files/en-us/web/mathml/element/msub/index.html
+++ b/files/en-us/web/mathml/element/msub/index.html
@@ -34,7 +34,7 @@ browser-compat: mathml.elements.msub
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="x1" src="msub.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="x1" src="msub.png"></p>
 
 <p>Rendering in your browser: <math> <msub> <mi>X</mi> <mn>1</mn> </msub> </math></p>
 

--- a/files/en-us/web/mathml/element/msubsup/index.html
+++ b/files/en-us/web/mathml/element/msubsup/index.html
@@ -39,7 +39,7 @@ browser-compat: mathml.elements.msubsup
 
 <p>Sample rendering: <img alt="x1" src="msubsup.png"></p>
 
-<p>Rendering in your browser: <math displaystyle="true"> <msubsup> <mo> ∫</mo> <mn> 0 </mn> <mn> 1 </mn> </msubsup> </math></p>
+<p>Rendering in your browser: <math> <msubsup> <mo> ∫</mo> <mn> 0 </mn> <mn> 1 </mn> </msubsup> </math></p>
 
 <pre class="brush: html">&lt;math displaystyle="true"&gt;
 

--- a/files/en-us/web/mathml/element/msubsup/index.html
+++ b/files/en-us/web/mathml/element/msubsup/index.html
@@ -37,7 +37,7 @@ browser-compat: mathml.elements.msubsup
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="x1" src="msubsup.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="x1" src="msubsup.png"></p>
 
 <p>Rendering in your browser: <math displaystyle="true"> <msubsup> <mo> ∫</mo> <mn> 0 </mn> <mn> 1 </mn> </msubsup> </math></p>
 

--- a/files/en-us/web/mathml/element/msup/index.html
+++ b/files/en-us/web/mathml/element/msup/index.html
@@ -34,7 +34,7 @@ browser-compat: mathml.elements.msup
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="x1" src="msup.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="x1" src="msup.png"></p>
 
 <p>Rendering in your browser: <math> <msup> <mi>X</mi> <mn>2</mn> </msup> </math></p>
 

--- a/files/en-us/web/mathml/element/mtable/index.html
+++ b/files/en-us/web/mathml/element/mtable/index.html
@@ -64,7 +64,7 @@ browser-compat: mathml.elements.mtable
 
 <h3 id="Alignment_with_row_number">Alignment with row number</h3>
 
-<p>Rendering: <img alt="" src="mtable-1.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Rendering: <img alt="" src="mtable-1.png"></p>
 
 <pre class="brush: html">&lt;math&gt;
 

--- a/files/en-us/web/mathml/element/munder/index.html
+++ b/files/en-us/web/mathml/element/munder/index.html
@@ -35,7 +35,7 @@ browser-compat: mathml.elements.munder
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="x+y+z" src="munder.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="x+y+z" src="munder.png"></p>
 
 <p>Rendering in your browser: <math> <munder accentunder="true"> <mrow> <mi> x </mi> <mo> + </mo> <mi> y </mi> <mo> + </mo> <mi> z </mi> </mrow> <mo> ⏟ </mo> </munder> </math></p>
 

--- a/files/en-us/web/mathml/element/munderover/index.html
+++ b/files/en-us/web/mathml/element/munderover/index.html
@@ -40,7 +40,7 @@ browser-compat: mathml.elements.munderover
 
 <h2 id="Examples">Examples</h2>
 
-<p>Sample rendering: <img alt="integral-0-infinity" src="munderover.png" style="margin-left: 10px; vertical-align: middle;"></p>
+<p>Sample rendering: <img alt="integral-0-infinity" src="munderover.png"></p>
 
 <p>Rendering in your browser: <math displaystyle="true"> <munderover> <mo> ∫ </mo> <mn> 0 </mn> <mi> ∞ </mi> </munderover> </math></p>
 

--- a/files/en-us/web/mathml/element/munderover/index.html
+++ b/files/en-us/web/mathml/element/munderover/index.html
@@ -42,7 +42,7 @@ browser-compat: mathml.elements.munderover
 
 <p>Sample rendering: <img alt="integral-0-infinity" src="munderover.png"></p>
 
-<p>Rendering in your browser: <math displaystyle="true"> <munderover> <mo> ∫ </mo> <mn> 0 </mn> <mi> ∞ </mi> </munderover> </math></p>
+<p>Rendering in your browser: <math> <munderover> <mo> ∫ </mo> <mn> 0 </mn> <mi> ∞ </mi> </munderover> </math></p>
 
 <pre class="brush: html">&lt;math displaystyle="true"&gt;
 

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.html
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.html
@@ -35,95 +35,95 @@ tags:
   </math>.</p>
 
 <p><strong>Proof:</strong>  We can prove the theorem algebraically by showing that the area of the big square
-  equals the area of the inner square (hypotenuse squared) plus the area of the four triangles: <math
-    style="display: block;">
-    <mtable columnalign="right center left">
-      <mtr>
-        <mtd>
-          <msup>
-            <mrow>
-              <mo> ( </mo>
-              <mi> a </mi>
-              <mo> + </mo>
-              <mi> b </mi>
-              <mo> ) </mo>
-            </mrow>
-            <mn> 2 </mn>
-          </msup>
-        </mtd>
-        <mtd>
-          <mo> = </mo>
-        </mtd>
-        <mtd>
-          <msup>
-            <mi> c </mi>
-            <mn>2</mn>
-          </msup>
-          <mo> + </mo>
-          <mn> 4 </mn>
-          <mo> ⋅ </mo>
-          <mo>(</mo>
-          <mfrac>
-            <mn> 1 </mn>
-            <mn> 2 </mn>
-          </mfrac>
-          <mi> a </mi>
-          <mi> b </mi>
-          <mo>)</mo>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msup>
+  equals the area of the inner square (hypotenuse squared) plus the area of the four triangles:</p>
+
+<math>
+  <mtable columnalign="right center left">
+    <mtr>
+      <mtd>
+        <msup>
+          <mrow>
+            <mo> ( </mo>
             <mi> a </mi>
-            <mn>2</mn>
-          </msup>
-          <mo> + </mo>
+            <mo> + </mo>
+            <mi> b </mi>
+            <mo> ) </mo>
+          </mrow>
           <mn> 2 </mn>
+        </msup>
+      </mtd>
+      <mtd>
+        <mo> = </mo>
+      </mtd>
+      <mtd>
+        <msup>
+          <mi> c </mi>
+          <mn>2</mn>
+        </msup>
+        <mo> + </mo>
+        <mn> 4 </mn>
+        <mo> ⋅ </mo>
+        <mo>(</mo>
+        <mfrac>
+          <mn> 1 </mn>
+          <mn> 2 </mn>
+        </mfrac>
+        <mi> a </mi>
+        <mi> b </mi>
+        <mo>)</mo>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <msup>
           <mi> a </mi>
+          <mn>2</mn>
+        </msup>
+        <mo> + </mo>
+        <mn> 2 </mn>
+        <mi> a </mi>
+        <mi> b </mi>
+        <mo> + </mo>
+        <msup>
           <mi> b </mi>
-          <mo> + </mo>
-          <msup>
-            <mi> b </mi>
-            <mn>2</mn>
-          </msup>
-        </mtd>
-        <mtd>
-          <mo> = </mo>
-        </mtd>
-        <mtd>
-          <msup>
-            <mi> c </mi>
-            <mn>2</mn>
-          </msup>
-          <mo> + </mo>
-          <mn> 2 </mn>
-          <mi> a </mi>
-          <mi> b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msup>
-            <mi>a </mi>
-            <mn>2</mn>
-          </msup>
-          <mo> + </mo>
-          <msup>
-            <mi> b </mi>
-            <mn>2</mn>
-          </msup>
-        </mtd>
-        <mtd>
-          <mo> = </mo>
-        </mtd>
-        <mtd>
-          <msup>
-            <mi> c </mi>
-            <mn>2</mn>
-          </msup>
-        </mtd>
-      </mtr>
-    </mtable>
-  </math>
-</p>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+      <mtd>
+        <mo> = </mo>
+      </mtd>
+      <mtd>
+        <msup>
+          <mi> c </mi>
+          <mn>2</mn>
+        </msup>
+        <mo> + </mo>
+        <mn> 2 </mn>
+        <mi> a </mi>
+        <mi> b</mi>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <msup>
+          <mi>a </mi>
+          <mn>2</mn>
+        </msup>
+        <mo> + </mo>
+        <msup>
+          <mi> b </mi>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+      <mtd>
+        <mo> = </mo>
+      </mtd>
+      <mtd>
+        <msup>
+          <mi> c </mi>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.html
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.html
@@ -34,7 +34,7 @@ tags:
     </mrow>
   </math>.</p>
 
-<p><strong><u>Proof:</u></strong>  We can prove the theorem algebraically by showing that the area of the big square
+<p><strong>Proof:</strong>  We can prove the theorem algebraically by showing that the area of the big square
   equals the area of the inner square (hypotenuse squared) plus the area of the four triangles: <math
     style="display: block;">
     <mtable columnalign="right center left">

--- a/files/en-us/web/mathml/fonts/index.html
+++ b/files/en-us/web/mathml/fonts/index.html
@@ -43,7 +43,7 @@ tags:
 </ol>
 
 <div class="note notecard">
-<p><strong>Note:</strong> A deprecated version of STIX is preinstalled starting with OS X Lion and should ensure relatively good MathML rendering. Enhancement requests have been submitted to Apple to ship OpenType MATH fonts <span class="probNo" id="displayFullDetailsProblemID">in the default installation. If you have a developer account, these are problems </span><span class="probNo" id="displayFullDetailsProblemID">16841023</span> and <span class="probNo" id="displayFullDetailsProblemID">17021145.</span></p>
+<p><strong>Note:</strong> A deprecated version of STIX is preinstalled starting with OS X Lion and should ensure relatively good MathML rendering. Enhancement requests have been submitted to Apple to ship OpenType MATH fonts in the default installation. If you have a developer account, these are problems 16841023 and 17021145.</p>
 </div>
 
 <h3 id="Linux">Linux</h3>
@@ -70,7 +70,7 @@ sudo urpmi texlive-dist texlive-fontsextra # Mageia
 
 <p>However, you might need to ensure that the fonts are known by your system. Typically,  use a fontconfig configuration <code>/etc/fonts/conf.avail/09-texlive-fonts.conf</code> that points to the <code>opentype</code> directory of TeXLive, such as:</p>
 
-<pre class="brush: tex">&lt;?xml version=&quot;1.0&quot;?&gt;
+<pre class="brush: plain">&lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!DOCTYPE fontconfig SYSTEM &quot;fonts.dtd&quot;&gt;
 &lt;fontconfig&gt;
   &lt;dir&gt;/your/path/to/texmf-dist/fonts/opentype&lt;/dir&gt;
@@ -95,12 +95,12 @@ fc-cache -sf
 <p>You must use the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>.</p>
 
 <div class="note notecard">
-<p><strong>Note:</strong> We <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=775060">plan to bundle</a> a <a href="#math_fonts">MATH font</a> in the default installation.</p>
+<p><strong>Note:</strong> We <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=775060">plan to bundle</a> a <a href="#Fonts_with_a_MATH_table">MATH font</a> in the default installation.</p>
 </div>
 
 <h3 id="Other_systems">Other systems</h3>
 
-<p>On other systems, consider installing a <a href="#math_fonts">MATH font</a> using your package manager. Note that these fonts are generally delivered with TeX distributions such as <a href="https://www.tug.org/texlive/">TeX Live</a>, but you might need to follow specific instructions so that your system is aware of the fonts. As a last resort, install the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML fonts add-on</a>.</p>
+<p>On other systems, consider installing a <a href="#Fonts_with_a_MATH_table">MATH font</a> using your package manager. Note that these fonts are generally delivered with TeX distributions such as <a href="https://www.tug.org/texlive/">TeX Live</a>, but you might need to follow specific instructions so that your system is aware of the fonts. As a last resort, install the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML fonts add-on</a>.</p>
 
 <h2 id="Advanced_setup">Advanced setup</h2>
 
@@ -112,7 +112,6 @@ fc-cache -sf
 
 <p>If you need to install fonts on a system without adminstrator privilege, the easiest option is to use math font the <a href="https://addons.mozilla.org/firefox/addon/mathml-fonts/">MathML-fonts add-on</a>. Note that using the add-on is not optimal since it forces your Gecko browser to load a CSS stylesheet on each page you visit as well as Web math fonts on all pages with MathML content. A better alternative on UNIX systems is to install the OTF files for <a href="http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip">Latin Modern Math</a> and <a href="https://github.com/stipub/stixfonts">STIX</a> into some local font folder and (if necessary) to run <code>fc-cache</code> on it. On OS X and Linux, the standard paths are <code>~/Library/Fonts/</code> and <code>~/.fonts</code>.</p>
 
-<a id="MATH_fonts"></a>
 <h3 id="Fonts_with_a_MATH_table">Fonts with a MATH table</h3>
 
 <p>You can actually render MathML using any font with a MATH table and related Open Font Format features. A list of such math fonts is provided below. You can use the <em>advanced font preference menu</em> to configure the default font for mathematics. Alternatively, you can try the <a href="https://addons.mozilla.org/en-US/firefox/addon/mathml-font-settings/">MathML-fontsettings add-on</a>.</p>

--- a/files/en-us/web/mathml/fonts/test/index.html
+++ b/files/en-us/web/mathml/fonts/test/index.html
@@ -2,7 +2,7 @@
 title: Test
 slug: Web/MathML/Fonts/Test
 ---
-<p style="width: 500px; background: white;">You should see a grid with perfectly straight black lines. If not, please consider installing some <a href="/en-US/docs/Web/MathML/Fonts">MathML fonts</a>.</p>
+<p>You should see a grid with perfectly straight black lines. If not, please consider installing some <a href="/en-US/docs/Web/MathML/Fonts">MathML fonts</a>.</p>
 <div style="width: 540px; height: 540px; background: #eef;">
   <div style="position: absolute;">
     <div style="position: absolute; left: 20px; top: 20px;">

--- a/files/en-us/web/mathml/fonts/test/index.html
+++ b/files/en-us/web/mathml/fonts/test/index.html
@@ -3,90 +3,97 @@ title: Test
 slug: Web/MathML/Fonts/Test
 ---
 <p>You should see a grid with perfectly straight black lines. If not, please consider installing some <a href="/en-US/docs/Web/MathML/Fonts">MathML fonts</a>.</p>
-<div style="width: 540px; height: 540px; background: #eef;">
-  <div style="position: absolute;">
-    <div style="position: absolute; left: 20px; top: 20px;">
-      <div style="position: absolute;">
-        <div style="position: absolute; top: 0; left: 0;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 30px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 60px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 90px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 120px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 150px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 180px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 210px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 240px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 270px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 300px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 330px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 360px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 390px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 420px;">
-          <math><mo minsize="500px">√</mo></math></div>
-        <div style="position: absolute; top: 0; left: 450px;">
-          <math><mo minsize="500px">√</mo></math></div>
-      </div>
-      <div style="position: absolute;">
-        <div style="position: absolute; top: 0; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 30px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 60px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 90px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 120px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 150px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 180px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 210px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 240px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 270px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 300px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 330px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 360px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 390px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 420px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-        <div style="position: absolute; top: 450px; left: 0;">
-          <math> <mover><mo>⏜</mo><mspace width="500px"></mspace></mover> </math></div>
-      </div>
-      <div style="position: absolute;">
-        <div style="position: absolute; background: #eef; top: -20px; height: 40px; width: 500px;">
-           </div>
-        <div style="position: absolute; background: #eef; top: 480px; height: 40px; width: 500px;">
-           </div>
-      </div>
-      <div style="position: absolute;">
-        <div style="position: absolute; background: #eef; left: -20px; width: 40px; height: 500px;">
-           </div>
-        <div style="position: absolute; background: #eef; left: 480px; width: 40px; height: 500px;">
-           </div>
-      </div>
-    </div>
-  </div>
-</div>
-<p> </p>
+
+<h2>Test grid</h2>
+
+<pre class="brush: html">
+
+&lt;div style="width: 540px; height: 540px; background: #eef;"&gt;
+  &lt;div style="position: absolute;"&gt;
+    &lt;div style="position: absolute; left: 20px; top: 20px;"&gt;
+      &lt;div style="position: absolute;"&gt;
+        &lt;div style="position: absolute; top: 0; left: 0;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 30px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 60px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 90px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 120px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 150px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 180px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 210px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 240px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 270px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 300px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 330px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 360px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 390px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 420px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 0; left: 450px;"&gt;
+          &lt;math&gt;&lt;mo minsize="500px"&gt;√&lt;/mo&gt;&lt;/math&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div style="position: absolute;"&gt;
+        &lt;div style="position: absolute; top: 0; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 30px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 60px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 90px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 120px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 150px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 180px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 210px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 240px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 270px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 300px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 330px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 360px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 390px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 420px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+        &lt;div style="position: absolute; top: 450px; left: 0;"&gt;
+          &lt;math&gt; &lt;mover&gt;&lt;mo&gt;⏜&lt;/mo&gt;&lt;mspace width="500px"&gt;&lt;/mspace&gt;&lt;/mover&gt; &lt;/math&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div style="position: absolute;"&gt;
+        &lt;div style="position: absolute; background: #eef; top: -20px; height: 40px; width: 500px;"&gt;
+           &lt;/div&gt;
+        &lt;div style="position: absolute; background: #eef; top: 480px; height: 40px; width: 500px;"&gt;
+           &lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div style="position: absolute;"&gt;
+        &lt;div style="position: absolute; background: #eef; left: -20px; width: 40px; height: 500px;"&gt;
+           &lt;/div&gt;
+        &lt;div style="position: absolute; background: #eef; left: 480px; width: 40px; height: 500px;"&gt;
+           &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+</pre>
+
+{{EmbedLiveSample("Test_grid", 100, 570)}}

--- a/files/en-us/web/mathml/index.html
+++ b/files/en-us/web/mathml/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{MathMLRef}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>Mathematical Markup Language (MathML)</strong> is a dialect of <a href="/en-US/docs/Web/XML">XML</a> for describing mathematical notation and capturing both its structure and content.</span></p>
+<p><strong>Mathematical Markup Language (MathML)</strong> is a dialect of <a href="/en-US/docs/Web/XML">XML</a> for describing mathematical notation and capturing both its structure and content.</p>
 
 <p>Here you'll find links to documentation, examples, and tools to help you work with this powerful technology. For a quick overview, see the <a href="https://fred-wang.github.io/MozSummitMathML/index.html">slides for the innovation fairs at Mozilla Summit 2013</a>.</p>
 


### PR DESCRIPTION
This PR prepares the MathML docs (https://developer.mozilla.org/en-US/docs/Web/MathML) for Markdowning.

After this PR the only unconverted element is the table in https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute which should stay in HTML because it will be too wide in GFM.

Technically I ought to convert all the examples, like this one:
https://github.com/mdn/content/blob/ca43b812115fe06655700f5d0abb715da75ac808/files/en-us/web/mathml/element/mfrac/index.html#L50

...to be live samples, but it doesn't really  seem worth it.