### PR TITLE
Fixes #9652 - MutationObserver not GC'ed

### DIFF
--- a/files/en-us/web/api/mutationobserver/disconnect/index.md
+++ b/files/en-us/web/api/mutationobserver/disconnect/index.md
@@ -49,8 +49,9 @@ None.
 ## Usage notes
 
 If the element being observed is removed from the DOM, and then subsequently released
-by the browser's garbage collection mechanism, the `MutationObserver` is
-likewise deleted.
+by the browser's garbage collection mechanism, the `MutationObserver` will stop observing 
+the removed element. However, the `MutationObserver` itself can continue to exist to observe 
+other existing elements.
 
 ## Example
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The `MutationObserver` is not garbage collected. Haven't tested this but more evidence [here](https://stackoverflow.com/questions/35290789/reconnect-and-disconnect-a-mutationobserver)

#### Motivation
Fixes #9652

#### Supporting details
https://stackoverflow.com/questions/35290789/reconnect-and-disconnect-a-mutationobserver

#### Related issues
Fixes #9652

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
