### PR TITLE
Fixes #9643 - positive -> non-negative seconds

### DIFF
--- a/files/en-us/web/html/element/meta/index.md
+++ b/files/en-us/web/html/element/meta/index.md
@@ -142,8 +142,8 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     - `refresh`This instruction specifies:
 
-      - The number of seconds until the page should be reloaded - only if the {{htmlattrxref("content", "meta")}} attribute contains a positive integer.
-      - The number of seconds until the page should redirect to another - only if the {{htmlattrxref("content", "meta")}} attribute contains a positive integer followed by the string '`;url=`', and a valid URL.
+      - The number of seconds until the page should be reloaded - only if the {{htmlattrxref("content", "meta")}} attribute contains a non-negative integer.
+      - The number of seconds until the page should redirect to another - only if the {{htmlattrxref("content", "meta")}} attribute contains a non-negative integer followed by the string '`;url=`', and a valid URL.
 
       ##### Accessibility concerns
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The `content` attribute allows 0 on Firefox and Chrome. It is also as per the spec.

#### Motivation
Changes to match the behavior on browsers and in spec.

#### Supporting details
The following trigger the desired refresh on Firefox and Chrome on Windows 10 Desktop.

```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<html>
    <head>
        <meta http-equiv="refresh" content="0">
    </head>

    <body>
        <p>Redirecting in 5 seconds...</p>
    </body>
</html>
```

```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<html>
    <head>
        <meta http-equiv="refresh" content="0; url=http://www.google.com/">
    </head>

    <body>
        <p>Redirecting in 5 seconds...</p>
    </body>
</html>

```

#### Related issues
Fixes #9643

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
