### PR TITLE
Update the CSS code of the quantitative query

### DIFF
--- a/files/en-us/web/css/_colon_nth-last-child/index.md
+++ b/files/en-us/web/css/_colon_nth-last-child/index.md
@@ -147,7 +147,7 @@ A _quantity query_ styles elements depending on how many of them there are. In t
 /* If there are at least three list items,
    style them all */
 li:nth-last-child(n+3),
-li:nth-last-child(n+3) ~ li {
+li:nth-last-child(3) ~ li {
   color: red;
 }
 ```


### PR DESCRIPTION
#### Summary
Update the CSS code of the quantitative query

#### Motivation
n+3 is not needed in the second part of the selector, since this option selects each n element and selects all subsequent li elements for each, but if you just specify 3, then all subsequent li elements will be selected only for the 3rd element

#### Supporting details
Example: https://jsfiddle.net/michydev/61p27y4u/
