### PR TITLE
[Markdown][Web/EXSLT] Prepare Web/EXSLT for Markdowning

### DIFF
--- a/files/en-us/web/exslt/exsl/index.html
+++ b/files/en-us/web/exslt/exsl/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}</div>
 
-<p class="summary"><span class="seoSummary">The EXSLT Common package provides basic functions that expand upon the capabilities of XSLT.</span> The namespace for the Common package is <code>http://exslt.org/common</code>.</p>
+<p>The EXSLT Common package provides basic functions that expand upon the capabilities of XSLT. The namespace for the Common package is <code>http://exslt.org/common</code>.</p>
 
 <p>{{SubpagesWithSummaries}}</p>
 

--- a/files/en-us/web/exslt/exsl/object-type/index.html
+++ b/files/en-us/web/exslt/exsl/object-type/index.html
@@ -11,7 +11,7 @@ tags:
 <p><code>exsl:object-type()</code> returns a string that indicates the type of the specified object.</p>
 
 <div class="notecard note">
-  <p>Note: Most <a href="/en-US/docs/Web/XSLTT">XSLT</a> object types can be coerced into each other safely; however, certain coercions to raise error conditions. In particular, treating something that\'s not a node-set as a node-set will do so. This function lets authors of named templates and extension functions easily provide flexibility in parameter values.</p>
+  <p><strong>Note:</strong> Most <a href="/en-US/docs/Web/XSLTT">XSLT</a> object types can be coerced into each other safely; however, certain coercions to raise error conditions. In particular, treating something that\'s not a node-set as a node-set will do so. This function lets authors of named templates and extension functions easily provide flexibility in parameter values.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/exslt/index.html
+++ b/files/en-us/web/exslt/index.html
@@ -6,7 +6,7 @@ tags:
   - Landing
 ---
 
-<p class="summary"><span class="seoSummary">EXSLT is a set of extensions to <a href="/en-US/docs/Web/XSLT">XSLT</a>.</span> There are a number of modules; those that are supported by Firefox are listed below:</p>
+<p>EXSLT is a set of extensions to <a href="/en-US/docs/Web/XSLT">XSLT</a>. There are a number of modules; those that are supported by Firefox are listed below:</p>
 
 <p>{{SubpagesWithSummaries}}</p>
 
@@ -26,8 +26,6 @@ tags:
 &lt;/xsl:stylesheet&gt;
 </pre>
 
-<div class="topicpage-table">
-<div class="section">
 <h3 id="Common">Common</h3>
 
 <p>The EXSLT Common package provides basic functions that expand upon the capabilities of XSLT. The namespace for the Common package is <code>http://exslt.org/common</code>.</p>
@@ -65,9 +63,7 @@ tags:
  <li><code><a href="/en-US/docs/Web/EXSLT/regexp/replace">regexp:replace()</a></code></li>
  <li><code><a href="/en-US/docs/Web/EXSLT/regexp/test">regexp:test()</a></code></li>
 </ul>
-</div>
 
-<div class="section">
 <h3 id="Sets">Sets</h3>
 
 <p>The EXSLT Sets package offers functions that let you perform set manipulation. The namespace for these functions is <code>http://exslt.org/sets</code>.</p>
@@ -94,8 +90,6 @@ tags:
  <li><code><a href="/en-US/docs/Web/EXSLT/str/split">str:split()</a></code></li>
  <li><code><a href="/en-US/docs/Web/EXSLT/str/tokenize">str:tokenize()</a></code></li>
 </ul>
-</div>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/exslt/math/index.html
+++ b/files/en-us/web/exslt/math/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}</div>
 
-<p class="summary"><span class="seoSummary">The EXSLT Math package provides functions for working with numeric values and comparing nodes.</span> The namespace for the Math package is <code>http://exslt.org/math</code>.</p>
+<p>The EXSLT Math package provides functions for working with numeric values and comparing nodes. The namespace for the Math package is <code>http://exslt.org/math</code>.</p>
 
 <p>{{SubpagesWithSummaries}}</p>
 

--- a/files/en-us/web/exslt/regexp/index.html
+++ b/files/en-us/web/exslt/regexp/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}</div>
 
-<p class="summary"><span class="seoSummary">The EXSLT Regular Expressions package provides functions that allow testing, matching, and replacing text using JavaScript style regular expressions.</span> The namespace for the Regular Expressions package is <code>http://exslt.org/regular-expressions</code>.</p>
+<p>The EXSLT Regular Expressions package provides functions that allow testing, matching, and replacing text using JavaScript style regular expressions. The namespace for the Regular Expressions package is <code>http://exslt.org/regular-expressions</code>.</p>
 
 <p>{{SubpagesWithSummaries}}</p>
 

--- a/files/en-us/web/exslt/regexp/match/index.html
+++ b/files/en-us/web/exslt/regexp/match/index.html
@@ -29,11 +29,9 @@ tags:
 
 <dl>
  <dt><code>g</code></dt>
- <dd>Global match</dd>
- <dd>The submatches from every match in the string are returned. If this flag isn't specified, only the submatches from the first match are returned.</dd>
+ <dd>Global match. The submatches from every match in the string are returned. If this flag isn't specified, only the submatches from the first match are returned.</dd>
  <dt><code>i</code></dt>
- <dd>Case insensitive match</dd>
- <dd>If this flag is specified, the match is performed in a case insensitive fashion.</dd>
+ <dd>Case insensitive match. If this flag is specified, the match is performed in a case insensitive fashion.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>

--- a/files/en-us/web/exslt/regexp/test/index.html
+++ b/files/en-us/web/exslt/regexp/test/index.html
@@ -29,11 +29,9 @@ tags:
 
 <dl>
  <dt><code>g</code></dt>
- <dd>Global match</dd>
- <dd>Has no effect for this function; it's allowed for consistency with other regexp functions.</dd>
+ <dd>Global match. Has no effect for this function; it's allowed for consistency with other regexp functions.</dd>
  <dt><code>i</code></dt>
- <dd>Case insensitive match</dd>
- <dd>If this flag is specified, the match is performed in a case insensitive fashion.</dd>
+ <dd>Case insensitive match<. If this flag is specified, the match is performed in a case insensitive fashion.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>

--- a/files/en-us/web/exslt/set/has-same-node/index.html
+++ b/files/en-us/web/exslt/set/has-same-node/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}</p>
 
-<p><code>set:<span style="white-space: nowrap;">has-same-node</span>()</code> determines whether two node<span style="white-space: nowrap;">-</span>sets have any nodes in common.</p>
+<p><code>set:has-same-node()</code> determines whether two node-sets have any nodes in common.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/exslt/set/index.html
+++ b/files/en-us/web/exslt/set/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}</p>
 
-<p class="summary"><span class="seoSummary">The EXSLT Sets package offers functions that let you perform set manipulation.</span> The namespace for these functions is <code>http://exslt.org/sets</code>.</p>
+<p>The EXSLT Sets package offers functions that let you perform set manipulation. The namespace for these functions is <code>http://exslt.org/sets</code>.</p>
 
 <p>{{SubpagesWithSummaries}}</p>
 

--- a/files/en-us/web/exslt/str/index.html
+++ b/files/en-us/web/exslt/str/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}</p>
 
-<p class="summary"><span class="seoSummary">The EXSLT Strings package provides functions that allow the manipulation of strings.</span> The namespace for the Strings package is <code>http://exslt.org/strings</code>.</p>
+<p>The EXSLT Strings package provides functions that allow the manipulation of strings. The namespace for the Strings package is <code>http://exslt.org/strings</code>.</p>
 
 <p>{{SubpagesWithSummaries}}</p>
 


### PR DESCRIPTION
This PR prepares the Web/EXSLT docs (https://developer.mozilla.org/en-US/docs/Web/EXSLT) for Markdowning.

After this PR the only unconverted element is the `<section id="Quick_links">`, used to make a sidebar in the main page: https://developer.mozilla.org/en-US/docs/Web/EXSLT.