### PR TITLE
[Markdown][Web/Manifest] Prepare Web/Manifest for Markdowning

### DIFF
--- a/files/en-us/web/manifest/background_color/index.html
+++ b/files/en-us/web/manifest/background_color/index.html
@@ -27,7 +27,7 @@ browser-compat: html.manifest.background_color
 <p>Therefore <code>background_color</code> should match the {{cssxref("background-color")}} CSS property in the site’s stylesheet for a smooth transition between launching the web application and loading the site's content.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The <code>background_color</code> member is only meant to improve the user experience while the main stylesheet is loading from the network or the storage media; it is not used by the user agent as the {{cssxref("background-color")}} CSS property when the progressive web app stylesheet is available.</p>
+<p><strong>Note:</strong> The <code>background_color</code> member is only meant to improve the user experience while the main stylesheet is loading from the network or the storage media; it is not used by the user agent as the {{cssxref("background-color")}} CSS property when the progressive web app stylesheet is available.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/manifest/dir/index.html
+++ b/files/en-us/web/manifest/dir/index.html
@@ -41,7 +41,7 @@ browser-compat: html.manifest.dir
 </ul>
 
 <div class="notecard note">
-<p><strong>Note</strong>: If the value is omitted or set to <code>auto</code>, the browser will use the <a href="/en-US/docs/Web/Guide/Unicode_Bidrectional_Text_Algorithm">Unicode bidirectional algorithm</a> to make a best guess about the text's direction.</p>
+<p><strong>Note:</strong> If the value is omitted or set to <code>auto</code>, the browser will use the <a href="/en-US/docs/Web/Guide/Unicode_Bidrectional_Text_Algorithm">Unicode bidirectional algorithm</a> to make a best guess about the text's direction.</p>
 </div>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/manifest/iarc_rating_id/index.html
+++ b/files/en-us/web/manifest/iarc_rating_id/index.html
@@ -25,7 +25,7 @@ browser-compat: html.manifest.iarc_rating_id
 <p>The <dfn><code>iarc_rating_id</code></dfn> member is a string that represents the <a href="https://www.globalratings.com/">International Age Rating Coalition (IARC)</a> certification code of the web application. It is intended to be used to determine which ages the web application is appropriate for.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The same code can be shared across multiple participating storefronts, as long as the distributed product remains the same (i.e., doesn’t serve totally different code paths on different storefronts).</p>
+<p><strong>Note:</strong> The same code can be shared across multiple participating storefronts, as long as the distributed product remains the same (i.e., doesn’t serve totally different code paths on different storefronts).</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/manifest/index.html
+++ b/files/en-us/web/manifest/index.html
@@ -18,10 +18,7 @@ browser-compat: html.manifest
 
 <p>The web app manifest provides information about a web application in a {{Glossary("JSON")}} text file, necessary for the web app to be downloaded and be presented to the user similarly to a native app (e.g., be installed on the homescreen of a device, providing users with quicker access and a richer experience). PWA manifests include its name, author, icon(s), version, description, and list of all the necessary resources (among other things).</p>
 
-<div class="hidden">
-<p>Can PWA manifest contain comments?<br>
-It is a {{Glossary("JSON")}}-formatted file, with one exception: it is allowed to contain "<code>//</code>"-style comments.</p>
-</div>
+<p>A manifest is a {{Glossary("JSON")}}-formatted file, with one exception: it is allowed to contain "<code>//</code>"-style comments.</p>
 
 <h2 id="Members">Members</h2>
 
@@ -69,11 +66,11 @@ It is a {{Glossary("JSON")}}-formatted file, with one exception: it is allowed t
   }]
 }</pre>
 
-<h2 id="Deploying_a_manifest_with_the_link_tag">Deploying a manifest</h2>
+<h2>Deploying a manifest</h2>
 
 <p>Web app manifests are deployed in your HTML pages using a {{HTMLElement("link")}} element in the {{HTMLElement("head")}} of a document:</p>
 
-<pre id="output_head" class="brush: html">&lt;link rel="manifest" href="manifest.json"&gt;</pre>
+<pre class="brush: html">&lt;link rel="manifest" href="manifest.json"&gt;</pre>
 
 <p>The <code>.webmanifest</code> extension is specified in the <a href="https://w3c.github.io/manifest/#media-type-registration">Media type registration</a> section of the specification (the response of the manifest file should return <code>Content-Type: application/manifest+json</code>). Browsers generally support manifests with other appropriate extensions like <code>.json</code> (<code>Content-Type: application/json</code>).</p>
 

--- a/files/en-us/web/manifest/related_applications/index.html
+++ b/files/en-us/web/manifest/related_applications/index.html
@@ -45,7 +45,7 @@ browser-compat: html.manifest.related_applications
 
 <p>Application objects may contain the following values:</p>
 
-<table class="fullwidth-table standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Member</th>


### PR DESCRIPTION
This PR prepares the Web/Manifest docs (https://developer.mozilla.org/en-US/docs/Web/Manifest) for Markdowning.

After this PR there will be 23 unconverted elements, all tables:

* 19 `.properties` tables which appear at the tops of pages like https://developer.mozilla.org/en-US/docs/Web/Manifest/name
* 4 normal tables which are too wide to be usable in GFM.
