### PR TITLE
Unlink BCD from FileSystemFlags dictionary

### DIFF
--- a/files/en-us/web/api/filesystemflags/create/index.md
+++ b/files/en-us/web/api/filesystemflags/create/index.md
@@ -33,11 +33,9 @@ fileSystemFlags.create = booleanValue
 
 ## Specifications
 
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
+| Specification                        | Status                           | Comment         |
+| ------------------------------------ | -------------------------------- | --------------- |
+| {{SpecName('File System API', '#dom-filesystemflags-create')}} | {{Spec2('File System API')}} | |
 
 ## See also
 

--- a/files/en-us/web/api/filesystemflags/exclusive/index.md
+++ b/files/en-us/web/api/filesystemflags/exclusive/index.md
@@ -33,11 +33,9 @@ fileSystemFlags.exclusive = booleanValue
 
 ## Specifications
 
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
+| Specification                        | Status                           | Comment         |
+| ------------------------------------ | -------------------------------- | --------------- |
+| {{SpecName('File System API', '#dom-filesystemflags-exclusive')}} | {{Spec2('File System API')}} | |
 
 ## See also
 

--- a/files/en-us/web/api/filesystemflags/index.md
+++ b/files/en-us/web/api/filesystemflags/index.md
@@ -125,11 +125,9 @@ Note that, when `create` is `false`, the value of `exclusive` is irrelevant and 
 
 ## Specifications
 
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
+| Specification                        | Status                           | Comment         |
+| ------------------------------------ | -------------------------------- | --------------- |
+| {{SpecName('File System API', '#dictdef-filesystemflags')}} | {{Spec2('File System API')}} | |
 
 ## See also
 


### PR DESCRIPTION
This PR unlinks the BCD from the FileSystemFlags dictionary to follow along with its removal in BCD, see https://github.com/mdn/browser-compat-data/pull/12766.
