### PR TITLE
[Markdown][Plugins] Prepare Plugins for Markdowning

### DIFF
--- a/files/en-us/plugins/blocking_by_domain/index.html
+++ b/files/en-us/plugins/blocking_by_domain/index.html
@@ -5,7 +5,7 @@ slug: Plugins/Blocking_By_Domain
 <p>Plugins such as Flash are a performance and security problem for Firefox users. However, some legacy Flash content hasn't yet been ported to HTML and is valuable to users. Rather than block plugins entirely, Firefox is limiting the impact of plugins by blocking certain domains from using plugins. These blocks improve Firefox security and performance and also make the click-to-activate feature more valuable to users by reducing unnecessary prompts.</p>
 
 <div class="note">
-<p>According to the Firefox plugin <a href="/en-US/docs/Plugins/Roadmap">roadmap</a>, the plugin block list is planned for Firefox 55.</p>
+<p><strong>Note:</strong> According to the Firefox plugin <a href="/en-US/docs/Plugins/Roadmap">roadmap</a>, the plugin block list is planned for Firefox 55.</p>
 </div>
 
 <h2 id="Effects_of_Plugin_Blocking">Effects of Plugin Blocking</h2>

--- a/files/en-us/plugins/flash_to_html5/clipboard/index.html
+++ b/files/en-us/plugins/flash_to_html5/clipboard/index.html
@@ -10,7 +10,7 @@ tags:
   - Selection
   - execCommand
 ---
-<p class="summary">Flash's Clipboard API used to be the only available means for creating advanced clipboard functionality, but this is now available in web standards.</p>
+<p>Flash's Clipboard API used to be the only available means for creating advanced clipboard functionality, but this is now available in web standards.</p>
 
 <p>Operating systems all have standard clipboard (i.e. Copy/Paste/Cut) functionality built in, but what if you want to do something a bit more complex, such as having a button that triggers the copying of a certain text selection?</p>
 

--- a/files/en-us/plugins/flash_to_html5/index.html
+++ b/files/en-us/plugins/flash_to_html5/index.html
@@ -12,7 +12,7 @@ tags:
   - Video
   - conversion
 ---
-<p class="summary">This set of articles provides you with information on how to migrate existing Flash content and functionality to HTML and JavaScript.</p>
+<p>This set of articles provides you with information on how to migrate existing Flash content and functionality to HTML and JavaScript.</p>
 
 <h2 id="Background">Background</h2>
 

--- a/files/en-us/plugins/flash_to_html5/video/advertising/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/advertising/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{PreviousMenuNext("Plugins/Flash_to_HTML5/Video/DRM_and_authentication", "Plugins/Flash_to_HTML5/Video/Distribution", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">You may also want to incorporate advertising into your video delivery system, via an ad network.</p>
+<p>You may also want to incorporate advertising into your video delivery system, via an ad network.</p>
 
 <h2 id="In_a_nutshell">In a nutshell</h2>
 

--- a/files/en-us/plugins/flash_to_html5/video/distribution/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/distribution/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>{{PreviousMenuNext("Plugins/Flash_to_HTML5/Video/Advertising", "Plugins/Flash_to_HTML5/Video/Players", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">A CDN is a popular choice for effective delivery of media content.</p>
+<p>A CDN is a popular choice for effective delivery of media content.</p>
 
 <h2 id="CDN_requirements">CDN requirements</h2>
 

--- a/files/en-us/plugins/flash_to_html5/video/drm_and_authentication/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/drm_and_authentication/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{PreviousMenuNext("Plugins/Flash_to_HTML5/Video/File_format_conversion", "Plugins/Flash_to_HTML5/Video/Advertising", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">If your media requires authentication/rights to access, you'll need to work out how to hook up the necessary digital rights management and authentication mechanisms.</p>
+<p>If your media requires authentication/rights to access, you'll need to work out how to hook up the necessary digital rights management and authentication mechanisms.</p>
 
 <p>You can either work directly with the listed tools and technologies for DRM, or through a third-party vendor such as <a href="https://www.brightcove.com/en/online-video-platform/content-protection-encryption-drm">Brightcove</a>, <a href="https://www.widevine.com/">Google</a> or <a href="https://www.adobe.com/uk/marketing-cloud/primetime/digital-rights-management.html">Adobe</a>. The advantage of using a third-party vendor's system is that generally they will provide or assist with code for checking which platform the user is on, coordinating with the relevant key system for that platform to handle the DRM, etc.</p>
 

--- a/files/en-us/plugins/flash_to_html5/video/file_format_conversion/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/file_format_conversion/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{PreviousMenuNext("Plugins/Flash_to_HTML5/Video/Planning", "Plugins/Flash_to_HTML5/Video/DRM_and_authentication", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">Once you've planned out what you want to do, the first step is to convert your video (or audio) files into formats compatible with HTML embedding.</p>
+<p>Once you've planned out what you want to do, the first step is to convert your video (or audio) files into formats compatible with HTML embedding.</p>
 
 <h2 id="What_files_have_you_got">What files have you got?</h2>
 

--- a/files/en-us/plugins/flash_to_html5/video/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/index.html
@@ -7,14 +7,14 @@ tags:
   - Plugins
   - Video
 ---
-<p class="summary">This resource provides an outline of all the topics you need to know about to convert Flash video to native HTML, plus resources covering all the finer details.</p>
+<p>This resource provides an outline of all the topics you need to know about to convert Flash video to native HTML, plus resources covering all the finer details.</p>
 
 <h2 id="In_a_nutshell">In a nutshell</h2>
 
 <p>HTML5 video is enabled through browser support for video and audio playback, Javascript extensions to control that playback, and ecosystem support for critical functions such as content protection and advertising. </p>
 
 <div class="note">
-<p><strong>Note</strong>: Most of the processes described in the below articles talk about video, but audio content works in such a similar way that they are generally applicable to audio too.</p>
+<p><strong>Note:</strong> Most of the processes described in the below articles talk about video, but audio content works in such a similar way that they are generally applicable to audio too.</p>
 </div>
 
 <h2 id="Planning">Planning</h2>
@@ -60,7 +60,7 @@ tags:
 
 <h3 id="Desktop">Desktop</h3>
 
-<table class="style1">
+<table>
  <thead>
   <tr>
    <th>Browser</th>
@@ -125,7 +125,7 @@ tags:
 
 <h3 id="Mobile">Mobile</h3>
 
-<table class="style1">
+<table>
  <thead>
   <tr>
    <th>Browser</th>

--- a/files/en-us/plugins/flash_to_html5/video/planning/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/planning/index.html
@@ -17,7 +17,7 @@ tags:
 ---
 <p>{{NextMenu("Plugins/Flash_to_HTML5/Video/File_format_conversion", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">Transitioning from Flash to HTML5 can take several months and may require new skills and software. This guide shows you how to plan for that transition.</p>
+<p>Transitioning from Flash to HTML5 can take several months and may require new skills and software. This guide shows you how to plan for that transition.</p>
 
 <h2 id="Auditing_what_you_have">Auditing what you have</h2>
 

--- a/files/en-us/plugins/flash_to_html5/video/players/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/players/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <p>{{PreviousMenuNext("Plugins/Flash_to_HTML5/Video/Distribution", "Plugins/Flash_to_HTML5/Video/Subtitles_captions", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">There are a number of ways to play back web media depending on the scale of your needs and whether you need ad integration and digital rights management.</p>
+<p>There are a number of ways to play back web media depending on the scale of your needs and whether you need ad integration and digital rights management.</p>
 
 <p>For media playback on the web, a spectrum of options is available including:</p>
 

--- a/files/en-us/plugins/flash_to_html5/video/subtitles_captions/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/subtitles_captions/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{PreviousMenu("Plugins/Flash_to_HTML5/Video/Players", "Plugins/Flash_to_HTML5/Video")}}</p>
 
-<p class="summary">Just as audio and video may need transcoding for the web, subtitles and closed captions may also need to be converted and made available.</p>
+<p>Just as audio and video may need transcoding for the web, subtitles and closed captions may also need to be converted and made available.</p>
 
 <h2 id="Getting_subtitles_and_closed_captions">Getting subtitles and closed captions</h2>
 

--- a/files/en-us/plugins/guide/browser_side_plug-in_api/index.html
+++ b/files/en-us/plugins/guide/browser_side_plug-in_api/index.html
@@ -9,25 +9,12 @@ tags:
   - Plugins
   - Reference
 ---
-<div class="noinclude">
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Side_Plug-in_API" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins">Next  »</a></p>
-</div>
-</div>
 
 <p>This chapter describes methods in the plug-in API that are available from the browser. The names of all of these methods begin with <code>NPN_</code> to indicate that they are implemented by the browser and called by the plug-in. For an overview of how these two sides of the plug-in API interact, see the <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Plug-ins_Work">How Plug-ins Work</a> and <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Overview_of_Plug-in_Structure">Overview of Plug-in Structure</a> sections in the introduction.</p>
 
-<div class="warning"><strong>Warning:</strong> You must only call these from the main thread; calling them from other threads is not supported and may have unpredictable results.</div>
+<div class="warning"><p><strong>Warning:</strong> You must only call these from the main thread; calling them from other threads is not supported and may have unpredictable results.</p></div>
 
-<div class="noinclude">
 <h3 id="Netscape_Plug-in_Method_Summary">Netscape Plug-in Method Summary</h3>
-</div>
-
-<div class="noinclude">
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Side_Plug-in_API" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins">Next  »</a></p>
-</div>
-</div>
 
 <dl>
  <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_DestroyStream">NPN_DestroyStream</a></code></dt>

--- a/files/en-us/plugins/guide/constants/index.html
+++ b/files/en-us/plugins/guide/constants/index.html
@@ -6,21 +6,20 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference/Structures" style="float: left;">« Previous</a><br></p>
-</div>
 
 <p>This section is a reference to the program definitions used by the Plug-in API. All program definitions are found in <a href="https://dxr.mozilla.org/mozilla-central/source/modules/plugin/base/public/npapi.h" rel="custom">npapi.h</a>.</p>
 
 <h2 id="Error_Codes">Error Codes</h2>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
-   <td class="header">Code</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
+   <th>Code</th>
+   <th>Value</th>
+   <th>Description</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>NPERR_NO_ERROR</code></td>
    <td>0</td>
@@ -97,12 +96,14 @@ tags:
 <h2 id="Result_Codes">Result Codes</h2>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+    <th>Constant</th>
+    <th>Value</th>
+    <th>Description</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td class="header">Constant</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
-  </tr>
   <tr>
    <td><code>NPRES_DONE</code></td>
    <td>0</td>
@@ -124,12 +125,14 @@ tags:
 <h2 id="Plug-in_Version_Constants">Plug-in Version Constants</h2>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
-   <td class="header">Constant</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
+   <th>Constant</th>
+   <th>Value</th>
+   <th>Description</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>NP_VERSION_MAJOR</code></td>
    <td>0</td>
@@ -146,12 +149,14 @@ tags:
 <h2 id="Version_Feature_Constants">Version Feature Constants</h2>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
-   <td class="header">NPVERS Constant: Version Feature Information</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
+   <th>NPVERS Constant: Version Feature Information</th>
+   <th>Value</th>
+   <th>Description</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>NPVERS_HAS_STREAMOUTPUT</code></td>
    <td>8</td>
@@ -214,7 +219,3 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference/Structures" style="float: left;">« Previous</a><br></p>
-</div>

--- a/files/en-us/plugins/guide/drawing_and_event_handling/index.html
+++ b/files/en-us/plugins/guide/drawing_and_event_handling/index.html
@@ -7,9 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Initialization_and_Destruction" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Streams">Next »</a></p>
-</div>
 
 <p>This chapter tells how to determine whether a plug-in instance is windowed or windowless, how to draw and redraw plug-ins, and how to handle plug-in events.</p>
 
@@ -23,7 +20,7 @@ tags:
 <p>For information about the way HTML determines plug-in display mode, see <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Using_HTML_to_Display_Plug-ins">Using HTML to Display Plug-ins</a>.</p>
 
 <div class="note">
-<p><strong>NOTE:</strong> Windowless plug-ins were not supported on the X Window System platform prior to Gecko 1.9 Alpha 7 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=137189" title="FIXED: Windowless plug-in support for X (WMODE)">bug 137189</a>).</p>
+<p><strong>Note:</strong> Windowless plug-ins were not supported on the X Window System platform prior to Gecko 1.9 Alpha 7 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=137189" title="FIXED: Windowless plug-in support for X (WMODE)">bug 137189</a>).</p>
 </div>
 
 <h3 id="The_NPWindow_Structure">The NPWindow Structure</h3>
@@ -31,7 +28,7 @@ tags:
 <p>When a plug-in is loaded, it is drawn into a target area. This target is either the windowed plug-in's native window, or the drawable of a windowless plug-in. The <a href="/en-US/NPWindow">NPWindow</a> structure represents either the native window or a drawable. This structure contains information about coordinate position, size, the state of the plug-in (windowed or windowless), and some platform-specific information.</p>
 
 <div class="note">
-<p><strong>NOTE:</strong> When a plug-in is drawn to a window, the plug-in is responsible for preserving state information and ensuring that the original state is restored.</p>
+<p><strong>Note:</strong> When a plug-in is drawn to a window, the plug-in is responsible for preserving state information and ensuring that the original state is restored.</p>
 </div>
 
 <p>For windowless plug-ins, the browser calls the <a href="/en-US/NPP_SetWindow">NPP_SetWindow</a> method with an <a href="/en-US/NPWindow">NPWindow</a> structure that represents a drawable. For windowed plug-ins, the browser calls the <code>NPP_SetWindow</code> method with an <code>NPWindow</code> structure that represents a window.</p>
@@ -317,7 +314,9 @@ void NPN_InvalidateRegion(NPP instance, NPRegion invalidRegion);
 
 <p>This method results in a synchronous update event or paint message for the plug-in.</p>
 
-<div class="note"><strong>Note:</strong> Some browsers, including Firefox 4, may ignore calls to <code>NPN_ForceRedraw()</code>.</div>
+<div class="note">
+  <p><strong>Note:</strong> Some browsers, including Firefox 4, may ignore calls to <code>NPN_ForceRedraw()</code>.</p>
+</div>
 
 <h4 id="Receiving_a_Paint_Message">Receiving a Paint Message</h4>
 
@@ -416,7 +415,3 @@ int16 NPP_HandleEvent(NPP instance, NPEvent* event);
 
 <p><br>
  On Mac OS, when <code>NPP_HandleEvent</code> is called, the current port is set up correctly so that its origin matches the upper-left corner of the plug-in. A plug-in does not need to set up the current port for mouse coordinate translation.</p>
-
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Initialization_and_Destruction" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Streams">Next »</a></p>
-</div>

--- a/files/en-us/plugins/guide/memory/index.html
+++ b/files/en-us/plugins/guide/memory/index.html
@@ -7,9 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:URLs" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Version,_UI,_and_Status_Information">Next  »</a></p>
-</div>
 
 <p>This chapter describes the Plug-in API functions that allocate and free memory as needed by the plug-in.</p>
 
@@ -70,7 +67,3 @@ tags:
 </pre>
 
 <p>The size parameter is an unsigned long integer that represents the amount of memory, in bytes, to free in the browser's memory space. This function returns the amount of freed memory, in bytes, or 0 if no memory could be freed.</p>
-
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:URLs" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Version,_UI,_and_Status_Information">Next  »</a></p>
-</div>

--- a/files/en-us/plugins/guide/plug-in_basics/index.html
+++ b/files/en-us/plugins/guide/plug-in_basics/index.html
@@ -7,10 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Plug-in_Development_Overview">Next »</a></p>
-</div>
-
 
 <h3 id="How_Plug-ins_Are_Used">How Plug-ins are used</h3>
 
@@ -37,7 +33,7 @@ tags:
  <li>communicate with <a href="/en-US/docs/Web/JavaScript">JavaScript</a>/<a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> from native code</li>
 </ul>
 
-<p>You can see which plug-ins are installed on your system and have been properly associated with the browser by consulting the Installed Plug-ins page. <span class="comment">Go to the Help menu, and click Help and then About Plug-ins.</span> Type "about:plugins" in the Location bar. The Installed Plug-ins page lists each installed plug-in along with its MIME type or types, description, file extensions, and the current state (enabled or disabled) of the plug-in for each MIME type assigned to it. Notice in view-source that this information is gathered from the JavaScript.</p>
+<p>You can see which plug-ins are installed on your system and have been properly associated with the browser by consulting the Installed Plug-ins page. Go to the Help menu, and click Help and then About Plug-ins. Type "about:plugins" in the Location bar. The Installed Plug-ins page lists each installed plug-in along with its MIME type or types, description, file extensions, and the current state (enabled or disabled) of the plug-in for each MIME type assigned to it. Notice in view-source that this information is gathered from the JavaScript.</p>
 
 <p>Because plug-ins are platform-specific, you must port them to every operating system and processor platform upon which you want to deploy your plug-in.</p>
 
@@ -47,7 +43,7 @@ tags:
 
 <p>When the browser encounters a MIME type, it always searches for a registered plug-in first. If there are no matches for the MIME type, it looks for a helper application.</p>
 
-<p>Plug-ins and helper applications fill different application needs. <span class="comment">For more information about helper applications, refer to the Netscape online help.</span></p>
+<p>Plug-ins and helper applications fill different application needs. For more information about helper applications, refer to the Netscape online help.</p>
 
 <h3 id="How_Plug-ins_Work">How plug-ins work</h3>
 
@@ -79,7 +75,7 @@ tags:
 <p>Gecko calls the plug-in API function <a href="/en-US/NP_Initialize">NP_Initialize</a> when the plug-in code is first loaded. By convention, all of the plug-in specific functions have the prefix "NPP", and all of the browser-specific functions have the prefix "NPN".</p>
 
 <div class="note">
-<p><strong>Note</strong>: <code>NP_Initialize</code> and <code>NP_Shutdown</code> are not technically a part of the function table that the plug-in hands to the browser. The browser calls them when the plug-in software is loaded and unloaded. These functions are exported from the plug-in DLL and accessed with a system table lookup, which means that they are not related to any particular plug-in instance. Again, see <a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction">Initialization and Destruction</a> for more information about initializing and destructing.</p>
+<p><strong>Note:</strong> <code>NP_Initialize</code> and <code>NP_Shutdown</code> are not technically a part of the function table that the plug-in hands to the browser. The browser calls them when the plug-in software is loaded and unloaded. These functions are exported from the plug-in DLL and accessed with a system table lookup, which means that they are not related to any particular plug-in instance. Again, see <a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction">Initialization and Destruction</a> for more information about initializing and destructing.</p>
 </div>
 
 <ul>
@@ -89,7 +85,7 @@ tags:
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: Plug-in API calls and callbacks use the main Navigator thread. In general, if you want a plug-in to generate additional threads to handle processing at any stage in its lifespan, you should be careful to isolate these from Plug-in API calls.</p>
+<p><strong>Note:</strong> Plug-in API calls and callbacks use the main Navigator thread. In general, if you want a plug-in to generate additional threads to handle processing at any stage in its lifespan, you should be careful to isolate these from Plug-in API calls.</p>
 </div>
 
 <p>See <a href="/en-US/docs/Gecko_Plugin_API_Reference/Initialization_and_Destruction">Initialization and Destruction</a> for more information about using these methods.</p>
@@ -129,7 +125,7 @@ tags:
  <li>Directory pointed to by <code>MOZ_PLUGIN_PATH</code> environment variable. For example:</li>
 </ul>
 
-<pre class="brush: bash" dir="ltr">#!/bin/bash
+<pre class="brush: bash">#!/bin/bash
 
 export MOZ_PLUGIN_PATH=/usr/lib64/mozilla/plugins
 exec /usr/lib64/firefox/firefox</pre>
@@ -141,7 +137,7 @@ exec /usr/lib64/firefox/firefox</pre>
  <li><code>/usr/lib64/firefox/plugins</code> (for 64-bit Firefox)</li>
 </ul>
 
-<p><em>Note:</em> Firefox Nightly checks a subset of these locations. Also some Linux distributions provide a system browser configured differently.<span class="short_text" id="result_box" lang="en"><span class="alt-edited hps"> </span></span></p>
+<p><strong>Note:</strong> Firefox Nightly checks a subset of these locations. Also some Linux distributions provide a system browser configured differently.</p>
 
 <blockquote>
 <p><em>Advanced:</em> You can determine which directories a Gecko program checks with the Linux <code>strace</code> command, for example:</p>
@@ -304,7 +300,7 @@ if (mimetype) {
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: Whether a plug-in is windowed or windowless is not meaningful if the plug-in is invoked with the <code>hidden</code> attribute.</p>
+<p><strong>Note:</strong> Whether a plug-in is windowed or windowless is not meaningful if the plug-in is invoked with the <code>hidden</code> attribute.</p>
 </div>
 
 <p>You can also create hidden plug-ins using the <code>object</code> element. Though the <code>object</code> element has no <code>hidden</code> attribute, you can create <a href="/en-US/docs/Web/CSS">CSS</a> rules to override the sizing attributes of the <code>object</code> element</p>
@@ -334,7 +330,7 @@ object.hiddenObject {
 <p>A <strong>full-page plug-in</strong> is a visible plug-in that is not part of an HTML page. The server looks for the media (MIME) type registered by a plug-in, based on the file extension, and starts sending the file to the browser. Gecko looks up the MIME type and loads the appropriate plug-in if it finds a plug-in registered to that type. This type of plug-in completely fills the web page. Full-page plug-ins are commonly used for document viewers, such as Adobe Acrobat.</p>
 
 <div class="note">
-<p><strong>Note</strong>: The browser does not display scroll bars automatically for a full-page plug-in. The plug-in must draw its own scroll bars if it requires them.</p>
+<p><strong>Note:</strong> The browser does not display scroll bars automatically for a full-page plug-in. The plug-in must draw its own scroll bars if it requires them.</p>
 </div>
 
 <p>The browser user interface remains relatively constant regardless of which type of plug-in is displayed. The part of the application window that does not display plug-in data does not change. The basic operations of the browser, such as navigation, history, and opening files, apply to all pages, regardless of the plug-ins in use.</p>
@@ -574,8 +570,3 @@ argv = {"movie.avi", "100", "125", "true", "true"}
 <ul>
  <li><a class="external" href="https://www.mozilla.org/projects/plugins/">The Mozilla Plug-ins project page</a></li>
 </ul>
-
-
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Preface" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Plug-in_Development_Overview">Next »</a></p>
-</div>

--- a/files/en-us/plugins/guide/plug-in_development_overview/index.html
+++ b/files/en-us/plugins/guide/plug-in_development_overview/index.html
@@ -7,9 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Plug-in_Basics" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Initialization_and_Destruction">Next  »</a></p>
-</div>
 
 <h3 id="Writing_Plug-ins">Writing Plug-ins</h3>
 
@@ -87,17 +84,17 @@ tags:
 <p><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_GetValue">NPP_GetValue</a></code> is called after the plug-in is initialized to get the scripting interface while <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_GetValue">NP_GetValue</a></code> is called during initialization to retrieve the plug-in's name and description, which will appear in the <code><a href="/en-US/docs/Web/API/NavigatorPlugins/plugins">navigator.plugins</a></code> DOM object which is used to populate <em>about:plugins</em>.</p>
 
 <div class="warning">
-<p><strong>Caution:</strong> Gecko caches the values returned by these functions and will only call it if the plug-in's timestamp has changed. See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=125469" title="[pluggerrc changes not read] Plugin caching preventing dynamic mime types through NP_GetMIMEDescritpion">bug 125469</a>.</p>
+<p><strong>Warning:</strong> Gecko caches the values returned by these functions and will only call it if the plug-in's timestamp has changed. See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=125469" title="[pluggerrc changes not read] Plugin caching preventing dynamic mime types through NP_GetMIMEDescritpion">bug 125469</a>.</p>
 </div>
 
 <h4 id="Mac_OS_X">Mac OS X</h4>
 
-<p>Mac OS X plug-ins are found according to the section <a href="/en-US/Gecko_Plugin_API_Reference/Plug-in_Basics#how_gecko_finds_plug-ins" style="text-decoration: none; color: rgb(4, 137, 183) !important; cursor: default;">How Gecko Finds Plug-ins</a>. Plug-ins are identified by file type NSPL.</p>
+<p>Mac OS X plug-ins are found according to the section <a href="/en-US/Gecko_Plugin_API_Reference/Plug-in_Basics#how_gecko_finds_plug-ins">How Gecko Finds Plug-ins</a>. Plug-ins are identified by file type NSPL.</p>
 
-<p>To determine the supported MIME types, Gecko first checks for <a class="external" href="https://developer.apple.com/mac/library/documentation/InternetWeb/Conceptual/WebKit_PluginProgTopic/Concepts/AboutPlugins.html#//apple_ref/doc/uid/30001248-198944">registry information in the plugins Info.plist</a>. If nothing is found there, Gecko checks for an <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_GetMIMEDescription">NP_GetMIMEDescription</a></code> entry point, and will use the information returned by this function.</p>
+<p>To determine the supported MIME types, Gecko first checks for <a href="https://developer.apple.com/mac/library/documentation/InternetWeb/Conceptual/WebKit_PluginProgTopic/Concepts/AboutPlugins.html#//apple_ref/doc/uid/30001248-198944">registry information in the plugins Info.plist</a>. If nothing is found there, Gecko checks for an <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_GetMIMEDescription">NP_GetMIMEDescription</a></code> entry point, and will use the information returned by this function.</p>
 
 <div class="warning">
-<p><strong>Note:</strong> The resource method described below is deprecated. Plugins should use the Info.plist approach, and only use the following method as a supplement to support older browsers.</p>
+<p><strong>Warning:</strong> The resource method described below is deprecated. Plugins should use the Info.plist approach, and only use the following method as a supplement to support older browsers.</p>
 </div>
 
 <p>If neither is present, Gecko will check the plugins resources. 'STR#' 128 should contain a list of MIME types and file extensions in alternating strings. For example:</p>

--- a/files/en-us/plugins/guide/plug-in_side_plug-in_api/index.html
+++ b/files/en-us/plugins/guide/plug-in_side_plug-in_api/index.html
@@ -8,9 +8,6 @@ tags:
   - Plugins
   - Reference
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Version,_UI,_and_Status_Information" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Browser_Side_Plug-in_API">Next  »</a></p>
-</div>
 
 <p>This chapter describes methods in the plug-in API that are available for the plug-in object. The names of all of these methods begin with <code>NPP_</code> to indicate that they are implemented by the plug-in and called by the browser. For an overview of how these two sides of the plug-in API interact, see the <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#How_Plug-ins_Work">How Plug-ins Work</a> and <a href="/en-US/docs/Gecko_Plugin_API_Reference/Plug-in_Basics#Overview_of_Plug-in_Structure">Overview of Plug-in Structure</a> sections in the introduction.</p>
 
@@ -54,7 +51,3 @@ tags:
  <dt><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_WriteReady">NPP_WriteReady</a></code></dt>
  <dd>Determines maximum number of bytes that the plug-in can consume.</dd>
 </dl>
-
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Version,_UI,_and_Status_Information" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Browser_Side_Plug-in_API">Next  »</a></p>
-</div>

--- a/files/en-us/plugins/guide/scripting_plugins/index.html
+++ b/files/en-us/plugins/guide/scripting_plugins/index.html
@@ -7,19 +7,13 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Browser_Side_Plug-in_API" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Structures">Next  »</a></p>
-</div>
-
-<p><span class="comment">XXX: Dummy p element</span></p>
-
 
 <p>This document describes the new cross-browser NPAPI extensions, commonly called <em>npruntime</em>, that have been developed by a group of browser and plugin vendors, including the <a class="external" href="https://www.mozilla.org">Mozilla Foundation</a>, <a class="external" href="https://www.adobe.com">Adobe</a>, <a class="external" href="https://www.apple.com">Apple</a>, <a class="external" href="https://www.opera.com">Opera</a>, and <a class="external" href="http://www.sun.com">Sun Microsystems</a> (see <a class="external" href="https://www.mozilla.org/press/mozilla-2004-06-30.html">press release</a>). This document also explains how to make a plugin use these new extensions to be scriptable as well as how to access objects in a browser.</p>
 
 <p>(A bit of history: <a href="/en-US/docs/Plugins">NPAPI plugins</a> that used to take advantage of being scriptable via LiveConnect in 4.x Netscape browsers lost this possibility in Mozilla (due to the <a class="external" href="https://java.sun.com/j2se/1.3/docs/guide/jni/spec/jniTOC.doc.html">JNI</a> making the Netscape 4.x JRI obsolete). As an answer to this large gap in the Netscape Plugin API, an extension to the API has been developed that lets plugins be scriptable again, independent of Java. This extension will also let plugins access the script objects in the browser, and is thus a much stronger and more flexible API.)</p>
 
 <div class="note">
-<p>The information in this section applies to Firefox 1.0 and Mozilla 1.7.5 and newer versions.</p>
+<p><strong>Note:</strong> The information in this section applies to Firefox 1.0 and Mozilla 1.7.5 and newer versions.</p>
 </div>
 
 <h2 id="How_the_DOM_handles_scripting">How the DOM handles scripting</h2>
@@ -110,7 +104,3 @@ NPNVPluginElementNPObject = 16
  </li>
  <li><code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPClass">NPClass</a></code></li>
 </ul>
-
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Browser_Side_Plug-in_API" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Structures">Next  »</a></p>
-</div>

--- a/files/en-us/plugins/guide/streams/index.html
+++ b/files/en-us/plugins/guide/streams/index.html
@@ -7,9 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Drawing_and_Event_Handling" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:URLs">Next  »</a></p>
-</div>
 
 <p>This chapter describes using plug-in API functions to receive and send streams.</p>
 
@@ -80,7 +77,7 @@ NPStream *stream, NPBool seekable, uint16* stype);
 <p>Once all data in the stream has been written to the plug-in, the stream is destroyed. To do this, either the browser can call <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_DestroyStream">NPP_DestroyStream</a></code> or the plug-in can call <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_DestroyStream">NPN_DestroyStream</a></code>. This applies to all plug-in modes except <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NP_SEEK">NP_SEEK</a></code>.</p>
 
 <div class="note">
-<p>NOTE: A plug-in can also use the <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetURL">NPN_GetURL</a></code> method to request a stream for an arbitrary URL.</p>
+<p><strong>Note:</strong> A plug-in can also use the <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_GetURL">NPN_GetURL</a></code> method to request a stream for an arbitrary URL.</p>
 </div>
 
 <h3 id="Telling_the_Plug-in_When_a_Stream_Is_Deleted">Telling the Plug-in When a Stream Is Deleted</h3>
@@ -171,7 +168,7 @@ int32 offset, int32 len, void *buf);
 <p>File mode is determined in <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_NewStream">NPP_NewStream</a></code> by setting the mode NP_ASFILEONLY. This mode gives the plug-in full random access to the data with platform-specific file operations. The browser saves stream data to a local file, and, when the stream is complete, delivers the path of the file through a call to <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_StreamAsFile">NPP_StreamAsFile</a></code>.</p>
 
 <div class="note">
-<p>NOTE: Most plug-ins that need the stream saved to a file should use NP_ASFILEONLY mode rather than the older NP_ASFILE; this mode is less efficient because it uses successive calls to <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_Write">NPP_Write</a></code>. <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_StreamAsFile">NPP_StreamAsFile</a></code> provides the plug-in with a full path to a local file for the stream. It is a good idea to check that the file exists in the directory at the start of this method. If an error occurs during data retrieval or writing to the file, the browser passes null for the filename. If the file is created from a stream from the network, the file is locked in the browser disk cache until the stream or its instance is destroyed.</p>
+<p><strong>Note:</strong> Most plug-ins that need the stream saved to a file should use NP_ASFILEONLY mode rather than the older NP_ASFILE; this mode is less efficient because it uses successive calls to <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_Write">NPP_Write</a></code>. <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPP_StreamAsFile">NPP_StreamAsFile</a></code> provides the plug-in with a full path to a local file for the stream. It is a good idea to check that the file exists in the directory at the start of this method. If an error occurs during data retrieval or writing to the file, the browser passes null for the filename. If the file is created from a stream from the network, the file is locked in the browser disk cache until the stream or its instance is destroyed.</p>
 </div>
 
 <pre>void NPP_StreamAsFile(NPP instance, NPStream *stream,
@@ -269,7 +266,3 @@ err = NPN_DestroyStream(instance, stream, NPRES_DONE);
 </pre>
 
 <p>Your plug-in can create another instance of itself by specifying its own MIME type and a new target name in a call to <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_NewStream">NPN_NewStream</a></code>.</p>
-
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Drawing_and_Event_Handling" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:URLs">Next  »</a></p>
-</div>

--- a/files/en-us/plugins/guide/structures/index.html
+++ b/files/en-us/plugins/guide/structures/index.html
@@ -7,9 +7,6 @@ tags:
   - Plugins
   - Reference
 ---
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference/Constants">Next  »</a></p>
-</div>
 
 <p>This chapter describes the data structures that are used to represent the various objects in the plug-in API.</p>
 
@@ -79,7 +76,3 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<div class="prevnext" style="text-align: right;">
-    <p><a href="/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference/Constants">Next  »</a></p>
-</div>

--- a/files/en-us/plugins/guide/urls/index.html
+++ b/files/en-us/plugins/guide/urls/index.html
@@ -7,9 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Streams" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Memory">Next »</a></p>
-</div>
 
 <p>This chapter describes retrieving URLs and displaying them on specified target pages, posting data to an HTTP server, uploading files to an FTP server, and sending mail.</p>
 
@@ -18,11 +15,13 @@ tags:
 <p>The table below summarizes URLs supported by Gecko. In addition, Gecko may support URLs not listed on this table.</p>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
-   <td class="header">URL Scheme</td>
-   <td class="header">Description</td>
-  </tr>
+   <th>URL Scheme</th>
+   <th>Description</th>
+   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td><code>about</code></td>
    <td>Locates browser information or "fun" pages.</td>
@@ -34,10 +33,6 @@ tags:
   <tr>
    <td><code>ftp</code></td>
    <td>(File Transfer Protocol) Locates files and directories on Internet hosts for file download.</td>
-  </tr>
-  <tr>
-   <td><code>gopher</code></td>
-   <td>(Gopher protocol) Locates specified items on a Gopher server. <span class="inlineIndicator obsolete obsoleteInline" title="(Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1)">Obsolete since Gecko 2.0</span></td>
   </tr>
   <tr>
    <td><code>http</code></td>
@@ -131,7 +126,9 @@ tags:
 
 <p>The instance and url parameters have the same definitions as those of <code>NPN_GetURL</code>. The notifyData parameter contains the private plug-in data passed to the corresponding call to <code>NPN_GetURLNotify</code> and <code>NPN_PostURLNotify</code>.</p>
 
-<div class="warning"><strong>Warning</strong>: In Gecko 2.0 (Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1), <code>NPN_GetURLNotify()</code> does not notify the plug-in if <code>notifyData</code> is <code>NULL</code>. See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=638367" title="[Firefox 4] [NPAPI plugins] NPN_GetURLNotify does not call NPP_URLNotify if notifyData is null">bug 638367</a> for details.</div>
+<div class="warning">
+  <p><strong>Warning:</strong> In Gecko 2.0 (Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1), <code>NPN_GetURLNotify()</code> does not notify the plug-in if <code>notifyData</code> is <code>NULL</code>. See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=638367" title="[Firefox 4] [NPAPI plugins] NPN_GetURLNotify does not call NPP_URLNotify if notifyData is null">bug 638367</a> for details.</p>
+</div>
 
 <h4 id="Getting_the_URL_and_Displaying_the_Page">Getting the URL and Displaying the Page</h4>
 
@@ -193,7 +190,8 @@ const char *buf, NPBool file);</pre>
 
 <p>Possible URL types include http (similar to an HTML form submission), mailto (sending mail), news (posting a news article), and ftp (uploading a file). For protocols in which the headers must be distinguished from the body, such as http, the buffer or file should contain the headers, followed by a blank line, then the body. If no custom headers are required, add a blank line ('\n') to the beginning of the file or buffer.</p>
 
-<div class="note"><strong>NOTE</strong>: You cannot use <code>NPN_PostURL</code> to specify headers (even a blank line) in a memory buffer. To do this, use <code>NPN_PostURLNotify</code> for this purpose. § The <code>NPN_PostURLNotify</code> function has all the same capabilities and works like <code>NPN_PostURL</code> in most ways except that (1) it supports specifying headers when posting a memory buffer, and (2) it calls <code>NPP_URLNotify</code> upon successful or unsuccessful completion of the request. <code>NPN_PostURLNotify</code> is typically asynchronous: it returns immediately and only later handles the request and calls <code>NPP_URLNotify</code>.</div>
+<div class="note">
+  <p><strong>Note:</strong> You cannot use <code>NPN_PostURL</code> to specify headers (even a blank line) in a memory buffer. To do this, use <code>NPN_PostURLNotify</code> for this purpose. § The <code>NPN_PostURLNotify</code> function has all the same capabilities and works like <code>NPN_PostURL</code> in most ways except that (1) it supports specifying headers when posting a memory buffer, and (2) it calls <code>NPP_URLNotify</code> upon successful or unsuccessful completion of the request. <code>NPN_PostURLNotify</code> is typically asynchronous: it returns immediately and only later handles the request and calls <code>NPP_URLNotify</code>.</p></div>
 
 <pre>NPError NPN_PostURLNotify(
 
@@ -211,11 +209,11 @@ const char *buf, NPBool file);</pre>
 
 <p>The following code posts two name-value pairs to a CGI script through HTTP. The response from the server is displayed in a new window.</p>
 
-<p class="p0" style="margin-bottom: 0pt; margin-top: 0pt;"><em>char* pPostData = "Content-Type:\tapplication/x-www-form-urlencoded\nContent-Length:\t17\n\nname=aaashun@gmail.com\n";</em></p>
+<p><em>char* pPostData = "Content-Type:\tapplication/x-www-form-urlencoded\nContent-Length:\t17\n\nname=aaashun@gmail.com\n";</em></p>
 
-<p class="p0" style="margin-bottom: 0pt; margin-top: 0pt;"><em>uint32 nPostDataLen = (uint32)strlen(pPostData);</em></p>
+<p><em>uint32 nPostDataLen = (uint32)strlen(pPostData);</em></p>
 
-<p class="p0" style="margin-bottom: 0pt; margin-top: 0pt;"><em>NPN_PostURL(npInstance, "http://www.baidu.com","_blank", nPostDataLen, pPostData, FALSE);</em></p>
+<p><em>NPN_PostURL(npInstance, "http://www.baidu.com","_blank", nPostDataLen, pPostData, FALSE);</em></p>
 
 <h4 id="Uploading_Files_to_an_FTP_Server">Uploading Files to an FTP Server</h4>
 
@@ -244,7 +242,3 @@ NULL, myLength, myData, FALSE);</pre>
 <p>The example starts by defining the mail message, <code>myData</code>, and its length, <code>myLength</code>. It sends <code>myData</code> and <code>myLength</code> to the mailto URL <code>mailto:fred@example.com</code>. The target window for displaying the message is null in the example. Normally, using a null target window causes the response to be delivered from the server to the plug-in instance in a new stream, but no response is expected for a mailto URL.</p>
 
 <p>You cannot use either of these functions to set the body or attachments of an email message.</p>
-
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Streams" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Memory">Next »</a></p>
-</div>

--- a/files/en-us/plugins/guide/version_ui_and_status_information/index.html
+++ b/files/en-us/plugins/guide/version_ui_and_status_information/index.html
@@ -7,11 +7,6 @@ tags:
   - NPAPI
   - Plugins
 ---
-<div>
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Memory" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Plug-in_Side_Plug-in_API">Next »</a></p>
-</div>
-</div>
 
 <p>This chapter describes the functions that allow a plug-in to display a message on the status line, get agent information, and check on the current version of the Plug-in API and the browser.</p>
 
@@ -119,13 +114,7 @@ void NPN_Version(
 
 <p>When the browser starts up, it loads all the plug-ins it finds in the Plugins directory for the platform. If you call <code><a href="/en-US/docs/Mozilla/Add-ons/Plugins/Reference/NPN_ReloadPlugins">NPN_ReloadPlugins</a></code>, the browser reloads all plug-ins in the Plugins directory without restarting. This causes the browser to install a new plug-in and load it, or remove a plug-in, without having to restart. Consider using this function as part of the plug-in's SmartUpdate process.</p>
 
-<pre class="eval">void NPN_ReloadPlugins(NPBool reloadPages);
+<pre class="brush: plain">void NPN_ReloadPlugins(NPBool reloadPages);
 </pre>
 
 <p>The <code>reloadPages</code> parameter is a boolean that indicates whether to reload the page (<code>true</code>) or not (<code>false</code>).</p>
-
-<div>
-<div class="prevnext" style="text-align: right;">
-<p><a href="/en-US/docs/Gecko_Plugin_API_Reference:Memory" style="float: left;">« Previous</a><a href="/en-US/docs/Gecko_Plugin_API_Reference:Plug-in_Side_Plug-in_API">Next »</a></p>
-</div>
-</div>

--- a/files/en-us/plugins/index.html
+++ b/files/en-us/plugins/index.html
@@ -5,10 +5,10 @@ tags:
   - Flash
   - Plugins
 ---
-<p class="summary">Plugins are shared libraries that users can install to display content that the browser can't display natively.</p>
+<p>Plugins are shared libraries that users can install to display content that the browser can't display natively.</p>
 
 <div class="warning">
-<p><strong>Important</strong>: plugins are a legacy technology that are a security and performance problem for Firefox (and other browser) users. They may not be supported in the future. New content should not be written using Flash or any other plugin technology.</p>
+<p><strong>Warning:</strong> plugins are a legacy technology that are a security and performance problem for Firefox (and other browser) users. They may not be supported in the future. New content should not be written using Flash or any other plugin technology.</p>
 </div>
 
 <h2 id="Roadmap">Roadmap</h2>


### PR DESCRIPTION
This PR prepares the Plugins docs (https://developer.mozilla.org/en-US/docs/Plugins) for Markdowning.

After this PR there will be a few unconvertible tables, all of which should stay in HTML.

