### PR TITLE
Fix Array JS doc: remove String.replace from RegExp discussion

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -213,7 +213,7 @@ This is explained further on the {{jsxref("Array.length")}} page.
 
 ### Creating an array using the result of a match
 
-The result of a match between a {{jsxref("RegExp")}} and a string can create a JavaScript array. This array has properties and elements which provide information about the match. Such an array is returned by {{jsxref("RegExp.exec()")}}, {{jsxref("String.match()")}}, and {{jsxref("String.replace()")}}.
+The result of a match between a {{jsxref("RegExp")}} and a string can create a JavaScript array. This array has properties and elements which provide information about the match. Such an array is returned by {{jsxref("RegExp.exec()")}} and {{jsxref("String.match()")}}.
 
 To help explain these properties and elements, see this example and then refer to the table below:
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This change removes the mention of `String.replace` in the JS doc for Array


#### Motivation
The discussion of array creation from `RegExp` in the Array doc mentions that arrays might be returned from `String.replace`. But `String.replace` [returns a string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#return_value), instead of an array. Although a string is an array like object, it's technically very different from the array that is being discussed in this particular context:

> This array has properties and elements which provide information about the match.


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
