### PR TITLE
Edits and rewrites to improve clarity

### DIFF
--- a/files/en-us/web/http/headers/vary/index.md
+++ b/files/en-us/web/http/headers/vary/index.md
@@ -11,14 +11,11 @@ browser-compat: http.headers.Vary
 ---
 {{HTTPSidebar}}
 
-The **`Vary`** HTTP response header determines how to match
-future request headers to decide whether a cached response can be used rather than
-requesting a fresh one from the origin server. It is used by the server to indicate
-which headers it used when selecting a representation of a resource in a [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation) algorithm.
+The **`Vary`** HyperText Transfer Protocol (HTTP) response header determines how to match
+future request headers. This information is required to decide whether or not a cached response can be served instead of requesting a fresh one from the origin server. This response header is used by the server to indicate the headers it used when selecting a representation of a resource in a [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation) algorithm.
 
 The `Vary` header should be set on a {{HTTPStatus("304")}}
-`Not Modified` response exactly like it would have been set on an equivalent
-{{HTTPStatus("200")}} `OK` response.
+`Not Modified` response exactly like it would have been set on an equivalent {{HTTPStatus("200")}} `OK` response.
 
 <table class="properties">
   <tbody>
@@ -43,23 +40,21 @@ Vary: <header-name>, <header-name>, ...
 ## Directives
 
 - \*
-  - : Each request for a URL is supposed to be treated as a unique and uncacheable
+  - : Each request for a URL is treated as a unique and uncacheable
     request. A better way to indicate this is to use {{HTTPHeader("Cache-Control")}}:
-    `no-store`, which is clearer to read and also signals that the object
-    shouldn't be stored ever.
+    `no-store`, which is clearer to read and also signals that the object should never be stored.
 - \<header-name>
-  - : A comma-separated list of header names to take into account when deciding whether or
-    not a cached response can be used.
+  - : A comma-separated list of header names to consider when deciding whether or not a cached response can be used.
 
 ## Examples
 
 ### Dynamic serving
 
 When using the `Vary: User-Agent` header, caching servers should consider
-the user agent when deciding whether to serve the page from cache. For example, if you
-are serving different content to mobile users, it can help you to avoid that a cache may
-mistakenly serve a desktop version of your site to your mobile users. It can help Google
-and other search engines to discover the mobile version of a page, and might also tell
+the user agent when deciding whether or not to serve the page from cache. For example, if you
+are serving different content to mobile users, using this header can help you to avoid a cache
+mistakenly serving a desktop version of your site to your mobile users. This header can help Google
+and other search engines to discover the mobile version of a page and might also tell
 them that no [Cloaking](https://en.wikipedia.org/wiki/Cloaking) is intended.
 
 ```

--- a/files/en-us/web/http/headers/vary/index.md
+++ b/files/en-us/web/http/headers/vary/index.md
@@ -40,7 +40,7 @@ Vary: <header-name>, <header-name>, ...
 ## Directives
 
 - \*
-  - : Each request for a URL is treated as a unique and uncacheable
+  - : Each request for a URL is supposed to be treated as a unique and uncacheable
     request. A better way to indicate this is to use {{HTTPHeader("Cache-Control")}}:
     `no-store`, which is clearer to read and also signals that the object should never be stored.
 - \<header-name>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Rewritten some sentences and replaced pronouns like 'it' to improve the clarity of the content. Hopefully, the technical accuracy of the page is still intact after the changes.

There is scope to improve the content further (like more examples can be added and some sections can be rewritten). I can take that up if I can work with a subject matter expert to resolve the gaps.

#### Motivation
Edited this page as part of "Writing Day" during the Write the Docs Prague 2021 conference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary