### PR TITLE
Fix Intl.DateTimeFormat() month option incorrect return value

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -196,8 +196,8 @@ new Intl.DateTimeFormat(locales, options)
 
       - : The representation of the month. Possible values are:
 
-        - "`numeric`" (e.g., `2`)
-        - "`2-digit`" (e.g., `02`)
+        - "`numeric`" (e.g., `3`)
+        - "`2-digit`" (e.g., `03`)
         - "`long`" (e.g., `March`)
         - "`short`" (e.g., `Mar`)
         - "`narrow`" (e.g., `M`). Two months may have


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- The `Intl.DateTimeFormat()` returns months starting from index `1`(for Jan). So the example should be showing `3` , `03` for `March`
---
- Fix example value of `Intl.DateTimeFormat()` with options : `{month: "numeric" || "2-digit"}` to match the flow of document explanation

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Open-Source Contribution
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- Fixes #9636 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
