### PR TITLE
orientationchange event: Fix link to replacement

### DIFF
--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Window.orientationchange_event
 
 The `orientationchange` event is fired when the orientation of the device has changed.
 
-This event is deprecated. Listen for the {{domxref("ScreenOrientation/change_event", "change")}} event instead.
+This event is deprecated. Listen for the {{domxref("ScreenOrientation/onchange", "ScreenOrientation.onchange")}} event instead.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
#### Summary
Fixed page:
https://developer.mozilla.org/en-US/docs/Web/API/Window/orientationchange_event

The replacement for this deprecated event is linked incorrectly. This PR fixes the link.

The correct replacement event is:
https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/onchange

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error