### PR TITLE
Unlink BCD from VRLayerInit dictionary

### DIFF
--- a/files/en-us/web/api/vrlayerinit/index.md
+++ b/files/en-us/web/api/vrlayerinit/index.md
@@ -12,7 +12,6 @@ tags:
   - VRLayerInit
   - Virtual Reality
   - WebVR
-browser-compat: api.VRLayerInit
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 
@@ -78,10 +77,6 @@ if(navigator.getVRDisplays) {
 This dictionary was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers [\[1\]](https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/).
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.md
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.md
@@ -12,7 +12,6 @@ tags:
   - Virtual Reality
   - WebVR
   - leftBounds
-browser-compat: api.VRLayerInit.leftBounds
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 
@@ -47,10 +46,6 @@ See [`VRLayerInit`](/en-US/docs/Web/API/VRLayerInit#examples) for example code.
 This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers [\[1\]](https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/).
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.md
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.md
@@ -12,7 +12,6 @@ tags:
   - Virtual Reality
   - WebVR
   - rightBounds
-browser-compat: api.VRLayerInit.rightBounds
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 
@@ -47,10 +46,6 @@ See [`VRLayerInit`](/en-US/docs/Web/API/VRLayerInit#examples) for example code.
 This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers [\[1\]](https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/).
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vrlayerinit/source/index.md
+++ b/files/en-us/web/api/vrlayerinit/source/index.md
@@ -12,7 +12,6 @@ tags:
   - Virtual Reality
   - WebVR
   - source
-browser-compat: api.VRLayerInit.source
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 
@@ -40,10 +39,6 @@ See [`VRLayerInit`](/en-US/docs/Web/API/VRLayerInit#examples) for example code.
 This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers [\[1\]](https://developer.oculus.com/documentation/oculus-browser/browser-vr-xr/).
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
This PR unlinks the BCD tables from the pages for the VRLayerInit dictionary, whilst keeping the page structure intact.  Correlates with its removal in BCD, see https://github.com/mdn/browser-compat-data/pull/12818.
