### PR TITLE
Simpler `URLSearchParams.getAll` example

### DIFF
--- a/files/en-us/web/api/urlsearchparams/getall/index.md
+++ b/files/en-us/web/api/urlsearchparams/getall/index.md
@@ -34,11 +34,8 @@ An array of {{domxref("USVString")}}s.
 ## Examples
 
 ```js
-let url = new URL('https://example.com?foo=1&bar=2');
-let params = new URLSearchParams(url.search.slice(1));
-
-//Add a second foo parameter.
-params.append('foo', 4);
+let url = new URL('https://example.com?foo=1&bar=2&foo=4');
+let params = new URLSearchParams(url.search);
 
 console.log(params.getAll('foo')) //Prints ["1","4"].
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Simpler code example:
- No need to `slice`
- Params can come directly from the URL. 

#### Motivation
1. (I love the MDN docs and I would like to contribute!)
2. I feel like this example is a much more realistic example, and it explains the same search parameter can appear twice, and that this is what `getAll` is for.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
