### PR TITLE
Add missing CSS Color Module Level 4 system color: ButtonBorder

### DIFF
--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -922,6 +922,8 @@ The keywords in the following list are defined by the CSS Color Module Level 4 s
   - : Background color of controls
 - ButtonText
   - : Foreground color of controls
+- ButtonBorder
+  - : Base border color of controls
 - Canvas
   - : Background of application content or documents
 - CanvasText

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -918,12 +918,12 @@ The keywords in the following list are defined by the CSS Color Module Level 4 s
 
 - ActiveText
   - : Text of active links
+- ButtonBorder
+  - : Base border color of controls
 - ButtonFace
   - : Background color of controls
 - ButtonText
   - : Foreground color of controls
-- ButtonBorder
-  - : Base border color of controls
 - Canvas
   - : Background of application content or documents
 - CanvasText


### PR DESCRIPTION
#### Summary

Spotted while reviewing [the specification for system colors](https://www.w3.org/TR/css-color-4/#css-system-colors) – all of the other colors are in sync between the spec and MDN, although the order is different. The description I added is inspired by that of ButtonFace and ButtonText.

#### Motivation

Documentation on MDN should match specifications.

#### Supporting details

- [CSS Color Module Level 4 – 6.2. System Colors](https://www.w3.org/TR/css-color-4/#css-system-colors).

---

I couldn’t find any existing issue relating to "ButtonBorder".