### PR TITLE
[Markdown][Security] Prepare Security for Markdowning

### DIFF
--- a/files/en-us/web/security/certificate_transparency/index.html
+++ b/files/en-us/web/security/certificate_transparency/index.html
@@ -5,9 +5,9 @@ tags:
   - Security
   - Web
 ---
-<p><span class="seoSummary"><strong>Certificate Transparency</strong> is an open framework designed to protect against and monitor for certificate misissuances. Newly issued certificates are 'logged' to publicly run, often independent CT logs which maintain an append-only, cryptographically assured record of issued TLS certificates.</span></p>
+<p><strong>Certificate Transparency</strong> is an open framework designed to protect against and monitor for certificate misissuances. Newly issued certificates are 'logged' to publicly run, often independent CT logs which maintain an append-only, cryptographically assured record of issued TLS certificates.</p>
 
-<p>In this way, certificate authorities (CAs) can be subject to much greater public scrutiny and oversight. Potentially malicious certificates, such as those that violate the CA/B <span class="st">Forum <em>Baseline Requirements</em></span>, can be detected and revoked much more quickly. Browser vendors and root store maintainers are also empowered to make more informed decisions regarding problematic CAs that they may decide to distrust.</p>
+<p>In this way, certificate authorities (CAs) can be subject to much greater public scrutiny and oversight. Potentially malicious certificates, such as those that violate the CA/B Forum <em>Baseline Requirements</em>, can be detected and revoked much more quickly. Browser vendors and root store maintainers are also empowered to make more informed decisions regarding problematic CAs that they may decide to distrust.</p>
 
 <h2 id="Background">Background</h2>
 
@@ -15,7 +15,7 @@ tags:
 
 <p>In the context of certificate transparency, the data hashed by the leaf nodes are the certificates that have been issued by the various different CAs operating today. Certificate inclusion can be verified via an <em>audit proof</em> which can be generated and verified efficiently, in logarithmic O(log n) time.</p>
 
-<p>Certificate transparency initially came about in 2013 against a backdrop of CA compromises (DigiNotar breach in 2011), questionable decisions (Trustwave subordinate root incident in 2012) and technical issuance issues (<span class="entry-content">weak, 512 bit certificate issuance by Digicert Sdn Bhd of </span>Malaysia).</p>
+<p>Certificate transparency initially came about in 2013 against a backdrop of CA compromises (DigiNotar breach in 2011), questionable decisions (Trustwave subordinate root incident in 2012) and technical issuance issues (weak, 512 bit certificate issuance by Digicert Sdn Bhd of Malaysia).</p>
 
 <h2 id="Implementation">Implementation</h2>
 
@@ -53,8 +53,8 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td><a class="external external-icon" href="https://datatracker.ietf.org/doc/html/rfc6962" hreflang="en" lang="en" rel="noopener">Certificate Transparency</a></td>
-			<td><span class="spec-RFC">IETF RFC</span></td>
+			<td><a href="https://datatracker.ietf.org/doc/html/rfc6962">Certificate Transparency</a></td>
+			<td>IETF RFC</td>
 			<td></td>
 		</tr>
 	</tbody>

--- a/files/en-us/web/security/firefox_security_guidelines/index.html
+++ b/files/en-us/web/security/firefox_security_guidelines/index.html
@@ -10,7 +10,7 @@ tags:
 
 <h2 id="Secure_Coding_Principles">Secure Coding Principles</h2>
 
-<p>Ensure that the application follows the <a class="external-link" href="https://www.owasp.org/index.php/Secure_Coding_Principles" rel="nofollow">OWASP Secure Coding Principles</a>:</p>
+<p>Ensure that the application follows the <a href="https://www.owasp.org/index.php/Secure_Coding_Principles">OWASP Secure Coding Principles</a>:</p>
 
 <ol>
  <li>Minimize attack surface area</li>
@@ -46,40 +46,30 @@ tags:
 
 <p>If so ensure they are safe and that no better alternatives are available.</p>
 
-<div class="table-wrap">
-<table class="confluenceTable tablesorter">
+<table>
  <thead>
-  <tr class="sortableHeader">
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Name</div>
-   </th>
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Risk Level</div>
-   </th>
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Problem</div>
-   </th>
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Solution</div>
-   </th>
+  <tr>
+   <th>Name</th>
+   <th>Risk Level</th>
+   <th>Problem</th>
+   <th>Solution</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td class="confluenceTd">eval</td>
-   <td class="confluenceTd">Very High</td>
-   <td class="confluenceTd">Invokes JavaScript parser - dangerous if used with untrusted input</td>
-   <td class="confluenceTd">Avoid eval if at all possible.</td>
+   <td>eval</td>
+   <td>Very High</td>
+   <td>Invokes JavaScript parser - dangerous if used with untrusted input</td>
+   <td>Avoid eval if at all possible.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">setTimeout(string, time)</td>
-   <td class="confluenceTd">Very High</td>
-   <td class="confluenceTd">Acts like eval</td>
-   <td class="confluenceTd">Use setTimeout(function, time, param1, param2, ...)</td>
+   <td>setTimeout(string, time)</td>
+   <td>Very High</td>
+   <td>Acts like eval</td>
+   <td>Use setTimeout(function, time, param1, param2, ...)</td>
   </tr>
  </tbody>
 </table>
-</div>
 
 <h2 id="C_-_Dangerous_Functions">C++ - Dangerous Functions</h2>
 
@@ -87,66 +77,57 @@ tags:
 
 <p>If so ensure they are safe and that no better alternatives are available.</p>
 
-<div class="table-wrap">
-<table class="confluenceTable tablesorter">
+<table>
  <thead>
-  <tr class="sortableHeader">
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Name</div>
-   </th>
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Risk Level</div>
-   </th>
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Problem</div>
-   </th>
-   <th class="confluenceTh sortableHeader">
-    <div class="tablesorter-header-inner">Solution</div>
-   </th>
+  <tr>
+   <th>Name</th>
+   <th>Risk Level</th>
+   <th>Problem</th>
+   <th>Solution</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td class="confluenceTd">gets</td>
-   <td class="confluenceTd">Very High</td>
-   <td class="confluenceTd">No bounds checking</td>
-   <td class="confluenceTd">Do not use gets. Use fgets instead.</td>
+   <td>gets</td>
+   <td>Very High</td>
+   <td>No bounds checking</td>
+   <td>Do not use gets. Use fgets instead.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">strcpy</td>
-   <td class="confluenceTd">Very High</td>
-   <td class="confluenceTd">No bounds checking</td>
-   <td class="confluenceTd">strcpy is safe only if the source string is a constant and the destination is large enough to hold it. Otherwise, use strncpy.</td>
+   <td>strcpy</td>
+   <td>Very High</td>
+   <td>No bounds checking</td>
+   <td>strcpy is safe only if the source string is a constant and the destination is large enough to hold it. Otherwise, use strncpy.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">sprintf</td>
-   <td class="confluenceTd">Very High</td>
-   <td class="confluenceTd">No bounds checking, format string attacks</td>
-   <td class="confluenceTd">sprintf is very hard to use safely. Use snprintf instead.</td>
+   <td>sprintf</td>
+   <td>Very High</td>
+   <td>No bounds checking, format string attacks</td>
+   <td>sprintf is very hard to use safely. Use snprintf instead.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">scanf, sscanf</td>
-   <td class="confluenceTd">High</td>
-   <td class="confluenceTd">Possibly no bounds checking, format string attacks</td>
-   <td class="confluenceTd">Make sure all %-directives match the corresponding argument types. Do not use '%s' directives with no bounds checking. Use '%xs' where x is the buffer size of the corresponding argument. Do not use untrusted, un-validated data in the format string.</td>
+   <td>scanf, sscanf</td>
+   <td>High</td>
+   <td>Possibly no bounds checking, format string attacks</td>
+   <td>Make sure all %-directives match the corresponding argument types. Do not use '%s' directives with no bounds checking. Use '%xs' where x is the buffer size of the corresponding argument. Do not use untrusted, un-validated data in the format string.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">strcat</td>
-   <td class="confluenceTd">High</td>
-   <td class="confluenceTd">No bounds checking</td>
-   <td class="confluenceTd">If input sizes are not well-known and fixed, use strncat instead.</td>
+   <td>strcat</td>
+   <td>High</td>
+   <td>No bounds checking</td>
+   <td>If input sizes are not well-known and fixed, use strncat instead.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">printf, fprintf, snprintf, vfprintf, vsprintf, syslog</td>
-   <td class="confluenceTd">High</td>
-   <td class="confluenceTd">format string attacks</td>
-   <td class="confluenceTd">Do not use untrusted, un-validated data in the format string. If the format string can be influenced by Web content or user input, validate it for the proper number and type of %-directives before calling these functions. Make sure destination size arguments are correct.</td>
+   <td>printf, fprintf, snprintf, vfprintf, vsprintf, syslog</td>
+   <td>High</td>
+   <td>format string attacks</td>
+   <td>Do not use untrusted, un-validated data in the format string. If the format string can be influenced by Web content or user input, validate it for the proper number and type of %-directives before calling these functions. Make sure destination size arguments are correct.</td>
   </tr>
   <tr>
-   <td class="confluenceTd">strncpy, fgets, strncat</td>
-   <td class="confluenceTd">Low</td>
-   <td class="confluenceTd">May not null-terminate</td>
-   <td class="confluenceTd">Always explicitly null-terminate the destination buffer. Make sure the size argument is correct. Be sure to leave room in the destination buffer to add the null character!</td>
+   <td>strncpy, fgets, strncat</td>
+   <td>Low</td>
+   <td>May not null-terminate</td>
+   <td>Always explicitly null-terminate the destination buffer. Make sure the size argument is correct. Be sure to leave room in the destination buffer to add the null character!</td>
   </tr>
  </tbody>
 </table>
@@ -283,8 +264,8 @@ tags:
 <h2 id="References">References</h2>
 
 <ul>
- <li><a class="external-link" href="https://wiki.mozilla.org/WebAppSec/Web_Security_Verification" rel="nofollow">Web Security Verification</a></li>
- <li><a class="external-link" href="https://www.mozilla.org/projects/security/components/reviewguide.html" rel="nofollow">Mozilla Security Review and Best Practices</a></li>
- <li><a class="external-link" href="https://www.squarefree.com/securitytips/mozilla-developers.html" rel="nofollow">Security tips for Mozilla and extension developers</a></li>
- <li><a class="external-link" href="https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf" rel="nofollow">OWASP Secure Coding Practices - Quick Reference Guide</a></li>
+ <li><a href="https://wiki.mozilla.org/WebAppSec/Web_Security_Verification" >Web Security Verification</a></li>
+ <li><a href="https://www.mozilla.org/projects/security/components/reviewguide.html" >Mozilla Security Review and Best Practices</a></li>
+ <li><a href="https://www.squarefree.com/securitytips/mozilla-developers.html" >Security tips for Mozilla and extension developers</a></li>
+ <li><a href="https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf" >OWASP Secure Coding Practices - Quick Reference Guide</a></li>
 </ul>

--- a/files/en-us/web/security/firefox_security_guidelines/index.html
+++ b/files/en-us/web/security/firefox_security_guidelines/index.html
@@ -131,7 +131,6 @@ tags:
   </tr>
  </tbody>
 </table>
-</div>
 
 <h2 id="URLs">URLs</h2>
 

--- a/files/en-us/web/security/index.html
+++ b/files/en-us/web/security/index.html
@@ -6,8 +6,7 @@ tags:
   - Security
   - Web
 ---
-<div class="summary">
-<p>Ensuring that your website or open web application is secure is critical. Even simple bugs in your code can result in private information being leaked, and bad people are out there trying to find ways to steal data. <span class="seoSummary">The web security-oriented articles listed here provide information that may help you secure your site and its code from attacks and data theft.</span></p>
+<p>Ensuring that your website or open web application is secure is critical. Even simple bugs in your code can result in private information being leaked, and bad people are out there trying to find ways to steal data. The web security-oriented articles listed here provide information that may help you secure your site and its code from attacks and data theft.</p>
 </div>
 
 <h2 id="Content_security">Content security</h2>
@@ -79,7 +78,7 @@ tags:
 
 <h2 id="Clickjacking_protection">Clickjacking protection</h2>
 
-<p id="sect1">In clickjacking, a user is fooled into clicking on a UI element that performs some action other than what the user expects. </p>
+<p>In clickjacking, a user is fooled into clicking on a UI element that performs some action other than what the user expects. </p>
 
 <dl>
  <dt><a href="/en-US/docs/Web/HTTP/Headers/X-Frame-Options">HTTP X-Frame-Options</a></dt>

--- a/files/en-us/web/security/index.html
+++ b/files/en-us/web/security/index.html
@@ -7,7 +7,6 @@ tags:
   - Web
 ---
 <p>Ensuring that your website or open web application is secure is critical. Even simple bugs in your code can result in private information being leaked, and bad people are out there trying to find ways to steal data. The web security-oriented articles listed here provide information that may help you secure your site and its code from attacks and data theft.</p>
-</div>
 
 <h2 id="Content_security">Content security</h2>
 

--- a/files/en-us/web/security/insecure_passwords/index.html
+++ b/files/en-us/web/security/insecure_passwords/index.html
@@ -9,7 +9,7 @@ tags:
   - password
   - passwords
 ---
-<p class="summary">Serving login forms over HTTP is especially dangerous because of the wide variety of attacks that can be used against them to extract a user’s password. Network eavesdroppers could steal a user's password by sniffing the network, or by modifying the served page in transit.</p>
+<p>Serving login forms over HTTP is especially dangerous because of the wide variety of attacks that can be used against them to extract a user’s password. Network eavesdroppers could steal a user's password by sniffing the network, or by modifying the served page in transit.</p>
 
 <p>The <a href="/en-US/docs/Glossary/https">HTTPS</a> protocol is designed to protect user data from eavesdropping (confidentiality) and from modification (integrity) on the network. Websites that handle user data should use HTTPS to protect their users from attackers. If a website uses HTTP instead of HTTPS, it is trivial to steal user information (such as their login credentials). This was famously demonstrated by <a href="https://codebutler.github.io/firesheep/">Firesheep</a>.</p>
 
@@ -24,7 +24,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li class="entry-title"><a href="https://blog.mozilla.org/tanvi/2016/01/28/no-more-passwords-over-http-please/">No More Passwords over HTTP, Please!</a> — detailed blog post with more information, and FAQ.</li>
+ <li><a href="https://blog.mozilla.org/tanvi/2016/01/28/no-more-passwords-over-http-please/">No More Passwords over HTTP, Please!</a> — detailed blog post with more information, and FAQ.</li>
 </ul>
 
-<p class="entry-title">{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}</p>
+<p>{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}</p>

--- a/files/en-us/web/security/mixed_content/index.html
+++ b/files/en-us/web/security/mixed_content/index.html
@@ -8,7 +8,7 @@ tags:
   - Web
   - console
 ---
-<p>When a user visits a page served over {{Glossary("HTTPS")}}, their connection with the web server is encrypted with {{Glossary("TLS")}} and is therefore safeguarded from most sniffers and man-in-the-middle attacks. <span class="seoSummary">An HTTPS page that includes content fetched using cleartext HTTP is called a <strong>mixed content</strong> page. Pages like this are only partially encrypted, leaving the unencrypted content accessible to sniffers and man-in-the-middle attackers.</span> That leaves the pages unsafe.</p>
+<p>When a user visits a page served over {{Glossary("HTTPS")}}, their connection with the web server is encrypted with {{Glossary("TLS")}} and is therefore safeguarded from most sniffers and man-in-the-middle attacks. An HTTPS page that includes content fetched using cleartext HTTP is called a <strong>mixed content</strong> page. Pages like this are only partially encrypted, leaving the unencrypted content accessible to sniffers and man-in-the-middle attackers. That leaves the pages unsafe.</p>
 
 <h2 id="Types_of_mixed_content">Types of mixed content</h2>
 
@@ -73,32 +73,30 @@ tags:
 
 <p>Browsers may support automatic upgrade of requests for display/media content from HTTP to HTTPS on secure pages (this prevents mixed-content conditions in which some content is loaded securely while other content is insecure).</p>
 
-<div class="notecard note">
-<p>Firefox 60 and later support this functionality as an experimental feature. It can be enabled using the preference <code>security.mixed_content.upgrade_display_content</code>).</p>
+<p>Firefox supports this functionality as an experimental feature. It can be enabled using the preference <code>security.mixed_content.upgrade_display_content</code>).</p>
 
 <ul>
  <li>If the upgrade fails (because the media's host doesn't support HTTPS), the media is not loaded.</li>
  <li>Console warnings indicate when content has been successfully upgraded.</li>
  <li>For more information see <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#upgrading_mixed_display_content">Experimental features in Firefox &gt; Upgrading mixed display content</a>.</li>
 </ul>
-</div>
 
 <h2 id="Warnings_in_Firefox_Web_Console">Warnings in Firefox Web Console</h2>
 
 <p>The Firefox Web Console displays a mixed content warning message in the Net pane when a page on your website has this issue. The mixed content resource that was loaded via HTTP will show up in red, along with the text "mixed content", which links to this page.</p>
 
-<p><a class="internal" href="/files/12545/Mixed_content_-_Net_pane.png"><img alt="Screen shot of the web console displaying a mixed content warning." src="mixed_content_-_net_pane.png" style="border-style: solid; border-width: 1px;"></a></p>
+<p><img alt="Screen shot of the web console displaying a mixed content warning." src="mixed_content_-_net_pane.png"></p>
 
-<p>As well as finding these warnings in the Web Console, you could use <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy (CSP)</a> to report issues. You could also use an online crawler like <a href="http://www.jitbit.com/sslcheck/" rel="noopener">SSL-check</a> or <a href="https://www.missingpadlock.com/" rel="noopener">Missing Padlock</a> that will check your website recursively and find links to insecure content.</p>
+<p>As well as finding these warnings in the Web Console, you could use <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy (CSP)</a> to report issues. You could also use an online crawler like <a href="http://www.jitbit.com/sslcheck/">SSL-check</a> or <a href="https://www.missingpadlock.com/">Missing Padlock</a> that will check your website recursively and find links to insecure content.</p>
 
 <p>Starting in Firefox 23, mixed active content is blocked by default (and mixed display content can be blocked by setting a preference). To make it easier for web developers to find mixed content errors, all blocked mixed content requests are logged to the Security pane of the Web Console, as seen below:</p>
 
-<p><a href="/files/5261/blocked-mixed-content-errors.png"><img alt="A screenshot of blocked mixed content errors in the Security Pane of the Web Console" src="mixed_content_webconsole.png" style="border-style: solid; border-width: 1px;"></a></p>
+<p><img alt="A screenshot of blocked mixed content errors in the Security Pane of the Web Console" src="mixed_content_webconsole.png"></p>
 
 <p>To fix this type of error, all requests to HTTP content should be removed and replaced with content served over HTTPS. Some common examples of mixed content include JavaScript files, stylesheets, images, videos, and other media.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The console will display a message indicating if mixed-display content is being successfully <a href="#upgrading_mixed-display_resources">upgraded from HTTP to HTTPS</a>  (instead of a warning about "Loading mixed (insecure) display content").</p>
+<p><strong>Note:</strong> The console will display a message indicating if mixed-display content is being successfully <a href="#upgrading_mixed-display_resources">upgraded from HTTP to HTTPS</a>  (instead of a warning about "Loading mixed (insecure) display content").</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/security/same-origin_policy/index.html
+++ b/files/en-us/web/security/same-origin_policy/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}</div>
 
-<p><span class="seoSummary">The <strong>same-origin policy</strong> is a critical security mechanism that restricts how a document or script loaded by one {{Glossary("origin")}} can interact with a resource from another origin.</span></p>
+<p>The <strong>same-origin policy</strong> is a critical security mechanism that restricts how a document or script loaded by one {{Glossary("origin")}} can interact with a resource from another origin.</p>
 
 <p>It helps isolate potentially malicious documents, reducing possible attack vectors. For example, it prevents a malicious website on the Internet from running JS in a browser to read data from a third-party webmail service (which the user is signed into) or a company intranet (which is protected from direct access by the attacker by not having a public IP address) and relaying that data to the attacker.</p>
 
@@ -62,13 +62,9 @@ tags:
 
 <p>Scripts executed from pages with an <code>about:blank</code> or <code>javascript:</code> URL inherit the origin of the document containing that URL, since these types of URLs do not contain information about an origin server.</p>
 
-<div class="note">
 <p>For example, <code>about:blank</code> is often used as a URL of new, empty popup windows into which the parent script writes content (e.g. via the {{domxref("Window.open()")}} mechanism). If this popup also contains JavaScript, that script would inherit the same origin as the script that created it.</p>
-</div>
 
-<div class="warning">
 <p><code>data:</code> URLs get a new, empty, security context.</p>
-</div>
 
 <h3 id="Exceptions_in_Internet_Explorer">Exceptions in Internet Explorer</h3>
 
@@ -86,7 +82,7 @@ tags:
 <h2 id="Changing_origin">Changing origin</h2>
 
 <div class="notecard warning">
-<p>The approach described here (using the {{domxref("document.domain")}} setter) is deprecated because it undermines the security protections provided by the same origin policy, and complicates the origin model in browsers, leading to interoperability problems and security bugs.</p>
+<p><strong>Warning:</strong> The approach described here (using the {{domxref("document.domain")}} setter) is deprecated because it undermines the security protections provided by the same origin policy, and complicates the origin model in browsers, leading to interoperability problems and security bugs.</p>
 </div>
 
 <p>A page may change its own origin, with some limitations. A script can set the value of {{domxref("document.domain")}} to its current domain or a superdomain of its current domain. If set to a superdomain of the current domain, the shorter superdomain is used for same-origin checks.</p>
@@ -152,7 +148,7 @@ tags:
 
 <p>The following cross-origin access to these <code>Window</code> properties is allowed:</p>
 
-<table class="fullwidth-table standard-table">
+<table>
  <thead>
   <tr>
    <th scope="col">Methods</th>
@@ -174,7 +170,7 @@ tags:
  </tbody>
 </table>
 
-<table class="fullwidth-table standard-table">
+<table>
  <thead>
   <tr>
    <th scope="col">Attributes</th>
@@ -227,7 +223,7 @@ tags:
 
 <p>The following cross-origin access to <code>Location</code> properties is allowed:</p>
 
-<table class="fullwidth-table standard-table">
+<table>
  <thead>
   <tr>
    <th scope="col">Methods</th>
@@ -240,7 +236,7 @@ tags:
  </tbody>
 </table>
 
-<table class="fullwidth-table standard-table">
+<table>
  <thead>
   <tr>
    <th scope="col">Attributes</th>
@@ -270,10 +266,4 @@ tags:
  <li><a href="https://web.dev/secure/same-origin-policy">Same-origin policy at web.dev</a></li>
  <li>{{httpheader("Cross-Origin-Resource-Policy")}}</li>
  <li>{{httpheader("Cross-Origin-Embedder-Policy")}}</li>
-</ul>
-
-<h2 id="Original_Document_Information">Original Document Information</h2>
-
-<ul>
- <li>Author(s): Jesse Ruderman</li>
 </ul>

--- a/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.html
+++ b/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.html
@@ -18,7 +18,7 @@ tags:
 <p>This section lists all the APIs available only in secure contexts, along with browser versions the limitation was introduced in, as appropriate.</p>
 
 <div class="note">
-<p><strong>Note</strong>: Only the browsers that actually support secure contexts are listed in this document. <a href="/en-US/docs/Web/Security/Secure_Contexts#browser_compatibility">See here</a> for information on secure contexts support.</p>
+<p><strong>Note:</strong> Only the browsers that actually support secure contexts are listed in this document. <a href="/en-US/docs/Web/Security/Secure_Contexts#browser_compatibility">See here</a> for information on secure contexts support.</p>
 </div>
 
 <table class="standard-table">

--- a/files/en-us/web/security/secure_contexts/index.html
+++ b/files/en-us/web/security/secure_contexts/index.html
@@ -52,12 +52,14 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
+ <thead>
+   <tr>
+    <th>Specification</th>
+    <th>Status</th>
+    <th>Comment</th>
+   </tr>
+ </thead>
  <tbody>
-  <tr>
-   <td>Specification</td>
-   <td>Status</td>
-   <td>Comment</td>
-  </tr>
   <tr>
    <td>{{SpecName('Secure Contexts')}}</td>
    <td>{{Spec2('Secure Contexts')}}</td>

--- a/files/en-us/web/security/securing_your_site/index.html
+++ b/files/en-us/web/security/securing_your_site/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>There are a number of things you can do to help secure your site. This article offers an assortment of suggestions, as well as links to other articles providing more useful information.</p>
 
-<div class="note"><strong>Note:</strong> This article is a work in progress, and is neither complete nor does following its suggestions guarantee your site will be fully secure.</div>
+<div class="note"><p><strong>Note:</strong> This article is a work in progress, and is neither complete nor does following its suggestions guarantee your site will be fully secure.</p></div>
 
 <h2 id="User_information_security">User information security</h2>
 
@@ -34,7 +34,7 @@ tags:
  <dt><a href="/en-US/docs/Web/HTTP/CORS">HTTP access control</a></dt>
  <dd>The Cross-Origin Resource Sharing standard provides a way to specify what content may be loaded from other domains. You can use this to prevent your site from being used improperly; in addition, you can use it to establish resources that other sites are expressly permitted to use.</dd>
  <dt><a href="/en/Security/CSP">Content Security Policy</a></dt>
- <dd>An added layer of security that helps to detect and mitigate certain types of attacks, including {{Glossary("Cross-site_scripting", "Cross Site Scripting (XSS)")}} and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. Code is executed by the victims and lets the attackers bypass access controls and impersonate users. According to the Open Web Application Security Project, XSS was the <a class="external external-icon" href="https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf" rel="noopener">seventh most common Web app vulnerability</a> in 2017.</dd>
+ <dd>An added layer of security that helps to detect and mitigate certain types of attacks, including {{Glossary("Cross-site_scripting", "Cross Site Scripting (XSS)")}} and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. Code is executed by the victims and lets the attackers bypass access controls and impersonate users. According to the Open Web Application Security Project, XSS was the <a href="https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf">seventh most common Web app vulnerability</a> in 2017.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/X-Frame-Options">The X-Frame-Options response header</a></dt>
  <dd>
  <p>The <code>X-Frame-Options:</code> <a href="/en/HTTP">HTTP</a> response header can be used to indicate whether or not a browser should be allowed to render a page in a {{ HTMLElement("frame") }}. Sites can use this to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites.</p>

--- a/files/en-us/web/security/subresource_integrity/index.html
+++ b/files/en-us/web/security/subresource_integrity/index.html
@@ -8,10 +8,10 @@ tags:
   - Networking
   - Security
 ---
-<p><span class="seoSummary"><strong>Subresource Integrity</strong> (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a <a href="/en-US/docs/Glossary/CDN">CDN</a>) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.</span></p>
+<p><strong>Subresource Integrity</strong> (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a <a href="/en-US/docs/Glossary/CDN">CDN</a>) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.</p>
 
 <div class="note">
-<p><strong>Note</strong>: For subresource-integrity verification of a resource served from an origin other than the document in which it’s embedded, browsers additionally check the resource using <a href="/en-US/docs/Web/HTTP/CORS">Cross-Origin Resource Sharing (CORS)</a>, to ensure the origin serving the resource allows it to be shared with the requesting origin.</p>
+<p><strong>Note:</strong> For subresource-integrity verification of a resource served from an origin other than the document in which it’s embedded, browsers additionally check the resource using <a href="/en-US/docs/Web/HTTP/CORS">Cross-Origin Resource Sharing (CORS)</a>, to ensure the origin serving the resource allows it to be shared with the requesting origin.</p>
 </div>
 
 <h2 id="How_Subresource_Integrity_helps">How Subresource Integrity helps</h2>
@@ -27,7 +27,7 @@ tags:
 <p>An <code>integrity</code> value begins with at least one string, with each string including a prefix indicating a particular hash algorithm (currently the allowed prefixes are <code>sha256</code>, <code>sha384</code>, and <code>sha512</code>), followed by a dash, and ending with the actual base64-encoded hash.</p>
 
 <div class="note">
-<p><strong>Note</strong>: An <strong>integrity</strong> value may contain multiple hashes separated by whitespace. A resource will be loaded if it matches one of those hashes.</p>
+<p><strong>Note:</strong> An <strong>integrity</strong> value may contain multiple hashes separated by whitespace. A resource will be loaded if it matches one of those hashes.</p>
 </div>
 
 <p>Example <code>integrity</code> string with base64-encoded sha384 hash:</p>
@@ -38,7 +38,7 @@ tags:
 <p>So <code>oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC</code> is the "hash" part, and the prefix <code>sha384</code> indicates that it's a sha384 hash.</p>
 
 <div class="note">
-<p><strong>Note</strong>: An <code>integrity</code> value's "hash" part is, strictly speaking, a <strong><em>cryptographic</em> <em>digest</em></strong> formed by applying a particular hash function to some input (for example, a script or stylesheet file). But it’s common to use the shorthand "hash" to mean <em>cryptographic</em> <em>digest</em>, so that's what's used in this article.</p>
+<p><strong>Note:</strong> An <code>integrity</code> value's "hash" part is, strictly speaking, a <strong><em>cryptographic</em> <em>digest</em></strong> formed by applying a particular hash function to some input (for example, a script or stylesheet file). But it’s common to use the shorthand "hash" to mean <em>cryptographic</em> <em>digest</em>, so that's what's used in this article.</p>
 </div>
 
 <h3 id="Tools_for_generating_SRI_hashes">Tools for generating SRI hashes</h3>
@@ -55,7 +55,7 @@ tags:
 </pre>
 
 <div class="note">
-<p><strong>Notes</strong>:</p>
+<p><strong>Note:</strong></p>
 
 <ul>
 	<li>The pipe-through-<code>xxd</code> step takes the hexadecimal output from <code>shasum</code> and converts it to binary.</li>
@@ -90,7 +90,7 @@ pause
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following examples, assume that <code id="sriSnippet">oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC</code> is already known to be the expected SHA-384 hash (digest) of a particular script <code>example-framework.js</code>, and there’s a copy of the script hosted at <code>https://example.com/example-framework.js</code>.</p>
+<p>In the following examples, assume that <code>oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC</code> is already known to be the expected SHA-384 hash (digest) of a particular script <code>example-framework.js</code>, and there’s a copy of the script hosted at <code>https://example.com/example-framework.js</code>.</p>
 
 <h3 id="Subresource_Integrity_with_the_&lt;script&gt;_element">Subresource Integrity with the &lt;script&gt; element</h3>
 
@@ -101,7 +101,7 @@ pause
         crossorigin="anonymous"&gt;&lt;/script&gt;</pre>
 
 <div class="note">
-<p><strong>Note</strong>: For more details on the purpose of the <code>crossorigin</code> attribute, see <a href="/en-US/docs/Web/HTML/Attributes/crossorigin">CORS settings attributes</a>.</p>
+<p><strong>Note:</strong> For more details on the purpose of the <code>crossorigin</code> attribute, see <a href="/en-US/docs/Web/HTML/Attributes/crossorigin">CORS settings attributes</a>.</p>
 </div>
 
 <h2 id="How_browsers_handle_Subresource_Integrity">How browsers handle Subresource Integrity</h2>
@@ -112,7 +112,7 @@ pause
 	<li>
 	<p>When a browser encounters a {{HTMLElement("script")}} or {{HTMLElement("link")}} element with an <code>integrity</code> attribute, before executing the script or before applying any stylesheet specified by the {{HTMLElement("link")}} element, the browser must first compare the script or stylesheet to the expected hash given in the <code>integrity</code> value.</p>
 
-	<p class="note"><strong>Note</strong>: For subresource-integrity verification of a resource served from an origin other than the document in which it’s embedded, browsers additionally check the resource using <a href="/en-US/docs/Web/HTTP/CORS">Cross-Origin Resource Sharing (CORS)</a>, to ensure the origin serving the resource allows it to be shared with the requesting origin.</p>
+	<p> For subresource-integrity verification of a resource served from an origin other than the document in which it’s embedded, browsers additionally check the resource using <a href="/en-US/docs/Web/HTTP/CORS">Cross-Origin Resource Sharing (CORS)</a>, to ensure the origin serving the resource allows it to be shared with the requesting origin.</p>
 	</li>
 	<li>If the script or stylesheet doesn’t match its associated <code>integrity</code> value, the browser must refuse to execute the script or apply the stylesheet, and must instead return a network error indicating that fetching of that script or stylesheet failed.</li>
 </ol>
@@ -152,8 +152,8 @@ pause
 <ul>
 	<li>Content Security Policy</li>
 	<li>{{httpheader("Content-Security-Policy")}}</li>
-	<li><a href="https://frederik-braun.com/using-subresource-integrity.html" id="page-title">A CDN that can not XSS you: Using Subresource Integrity</a></li>
-	<li><a href="https://w3c-test.org/subresource-integrity/subresource-integrity.html" id="w3c-test">Subresource Integrity test from W3C</a></li>
+	<li><a href="https://frederik-braun.com/using-subresource-integrity.html">A CDN that can not XSS you: Using Subresource Integrity</a></li>
+	<li><a href="https://w3c-test.org/subresource-integrity/subresource-integrity.html">Subresource Integrity test from W3C</a></li>
 	<li><a href="https://www.srihash.org/">SRI Hash Generator</a></li>
 </ul>
 

--- a/files/en-us/web/security/transport_layer_security/index.html
+++ b/files/en-us/web/security/transport_layer_security/index.html
@@ -11,17 +11,15 @@ tags:
   - Security
   - TLS
 ---
-<p><span class="seoSummary">The security of any connection using Transport Layer Security (TLS) is heavily dependent upon the cipher suites and security parameters selected. This article's goal is to help you make these decisions to ensure the confidentiality and integrity communication between client and server.</span> The Mozilla Operations Security (OpSec) team <a href="https://wiki.mozilla.org/Security/Server_Side_TLS">maintains a wiki entry</a> with reference configurations for servers.</p>
+<p>The security of any connection using Transport Layer Security (TLS) is heavily dependent upon the cipher suites and security parameters selected. This article's goal is to help you make these decisions to ensure the confidentiality and integrity communication between client and server. The Mozilla Operations Security (OpSec) team <a href="https://wiki.mozilla.org/Security/Server_Side_TLS">maintains a wiki entry</a> with reference configurations for servers.</p>
 
-<p class="summary">The Transport Layer Security (TLS) protocol is the standard for enabling two networked applications or devices to exchange information privately and robustly. Applications that use TLS can choose their security parameters, which can have a substantial impact on the security and reliability of data. This article provides an overview of TLS and the kinds of decisions you need to make when securing your content.</p>
+<p>The Transport Layer Security (TLS) protocol is the standard for enabling two networked applications or devices to exchange information privately and robustly. Applications that use TLS can choose their security parameters, which can have a substantial impact on the security and reliability of data. This article provides an overview of TLS and the kinds of decisions you need to make when securing your content.</p>
 
 <h2 id="History">History</h2>
 
 <p>When HTTPS was introduced, it was based on Secure Sockets Layer (SSL) 2.0, a technology introduced by Netscape. It was updated to SSL 3.0 not long after, and as its usage expanded, it became clear that a common, standard encryption technology needed to be specified to ensure interoperability among all web browsers and servers. The <a href="https://www.ietf.org/">Internet Engineering Task Force</a> (IETF) specified TLS 1.0 in {{RFC(2246)}} in January, 1999. The current version of TLS is 1.3 ({{RFC(8446)}}).</p>
 
-<div class="note">
 <p>Despite the fact that the web now uses TLS for encryption, many people still refer to it as "SSL" out of habit.</p>
-</div>
 
 <p>Although TLS can be used on top of any low-level transport protocol, the original goal of the protocol was to encrypt HTTP traffic. HTTP encrypted using TLS is commonly referred to as {{Glossary("HTTPS")}}. TLS-encrypted web traffic is by convention exchanged on port 443 by default, while unencrypted HTTP uses port 80 by default. HTTPS remains an important use case for TLS.</p>
 


### PR DESCRIPTION
This prepares the https://developer.mozilla.org/en-US/docs/Web/Security docs for Markdowning.

After this there will be zero unconverted elements.