### PR TITLE
Express: Book list page - fix auto copy of pug content

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/book_list_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/book_list_page/index.md
@@ -47,7 +47,7 @@ block content
   h1= title
 
   ul
-    each book in book_list
+    each book in book_list
       li
         a(href=book.url) #{book.title}
         |  (#{book.author.name})


### PR DESCRIPTION
Fixed the code block in the View section. I previously made an issue  with number #9778
Using the copy to clipboard button now doesn't have this issue.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Change the formatted text in the code block to prevent issues with the copy button.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Some beginners (like myself) might just use the copy button to copy/paste the code block into their code editor. This causes an issue with displaying the .pug file. The error message the code editor creates is, I think for beginners not very helpful and confusing, since if you would select all the text and then copy/paste it, the .pug file would display correctly and the code 'looks' exactly the same.(at first sight). I am no markdown expert, but I think the issue is caused by how markdown handles text formatting regarding enter to go to a newline. 
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #9778
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
