### PR TITLE
URLSearchParams treats "foo" and "foo=" the same

### DIFF
--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -119,8 +119,12 @@ searchParams2.has('query'); // true
 const url = new URL('http://example.com/search?query=%40');
 const searchParams3 = new URLSearchParams(url.search);
 searchParams3.has('query') // true
+```
 
-const base64 = btoa(String.fromCharCode(19,224,23,64,31,128)); // base64 is "E+AXQB+A"
+It interprets `+` in the value as a space
+
+```js
+const base64 = btoa(String.fromCharCode(19, 224, 23, 64, 31, 128)); // base64 is "E+AXQB+A"
 const searchParams = new URLSearchParams('q=foo&bin=' + base64); // q=foo&bin=E+AXQB+A
 const getBin = searchParams.get('bin'); // "E AXQB A" + char is replaced by spaces
 btoa(atob(getBin)); // "EAXQBA==" no error thrown
@@ -130,6 +134,17 @@ getBin.replace(/ /g, '+'); // "E+AXQB+A" is one solution
 // or use set to add the parameter, but this increases the query string length
 searchParams.set('bin2', base64) // "q=foo&bin=E+AXQB+A&bin2=E%2BAXQB%2BA" encodes + as %2B
 searchParams.get('bin2'); // "E+AXQB+A"
+```
+
+It doesn't distinguish between a parameter with nothing after the `=` and a parameter
+that doesn't have a `=` altogether.
+
+```js
+const emptyVal = new URLSearchParams('foo=&bar=baz')
+emptyVal.get('foo') // returns ''
+const noEquals = new URLSearchParams('foo&bar=baz')
+noEquals.get('foo') // also returns ''
+noEquals.toString() // 'foo=&bar=baz'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -121,7 +121,7 @@ const searchParams3 = new URLSearchParams(url.search);
 searchParams3.has('query') // true
 ```
 
-It interprets `+` in the value as a space
+It interprets `+` as a space
 
 ```js
 const base64 = btoa(String.fromCharCode(19, 224, 23, 64, 31, 128)); // base64 is "E+AXQB+A"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

I added another gotcha to URLSearchParams' documentation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

This gotcha (and the `+` being replaced with ` `  gotcha) is important because it means URLSearchParams doesn't round-trip arbitrary strings.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Works on #2104

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
