### PR TITLE
[Markdown][Privacy] Prepare Privacy files for  Markdowning

### DIFF
--- a/files/en-us/web/privacy/redirect_tracking_protection/index.html
+++ b/files/en-us/web/privacy/redirect_tracking_protection/index.html
@@ -57,7 +57,7 @@ tags:
  <li>HTTP Authentication Cache</li>
 </ul>
 
-<div class="blockIndicator note">
+<div class="note">
 <p><strong>Note:</strong> Even though we're clearing all of this data, we currently only flag origins for clearing when they use cookies or other site storage.</p>
 </div>
 

--- a/files/en-us/web/privacy/redirect_tracking_protection/index.html
+++ b/files/en-us/web/privacy/redirect_tracking_protection/index.html
@@ -58,7 +58,7 @@ tags:
 </ul>
 
 <div class="blockIndicator note">
-<p><strong>Note</strong>: Even though we're clearing all of this data, we currently only flag origins for clearing when they use cookies or other site storage.</p>
+<p><strong>Note:</strong> Even though we're clearing all of this data, we currently only flag origins for clearing when they use cookies or other site storage.</p>
 </div>
 
 <p>Storage clearing ignores origin attributes. This means that storage will be cleared across <a href="https://wiki.mozilla.org/Security/Contextual_Identity_Project/Containers">containers</a> and isolated storage (i.e. from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation">First-Party Isolation</a>).</p>

--- a/files/en-us/web/privacy/state_partitioning/index.html
+++ b/files/en-us/web/privacy/state_partitioning/index.html
@@ -93,24 +93,15 @@ tags:
 </p>
 
 <h3>Status of partitioning in Firefox</h3>
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="row"><a href="#network_partitioning">Network Partitioning</a></th>
-    <td>Enabled by default for all users since Firefox 85.</td>
-   </tr>
-   <tr>
-    <th scope="row"><a href="#dynamic_state_partitioning">Dynamic State Partitioning</a></th>
-    <td>Enabled by default in <a
-    href="/en-US/docs/Mozilla/Firefox#firefox_nightly">Firefox Nightly</a>. <br>
-      Since Firefox 86: Enabled for users that have
-      <a class="external"
-        href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop#w_strict-enhanced-tracking-protection">
-        "Strict" privacy protections
-      </a> enabled.</td>
-   </tr>
-  </tbody>
- </table>
+
+<ul>
+  <li>
+    <p><a href="#network_partitioning"><strong>Network Partitioning</strong></a>: Enabled by default for all users since Firefox 85.</p>
+  </li>
+  <li><p><a href="#dynamic_state_partitioning"><strong>Dynamic State Partitioning</strong></a>: Since Firefox 86: Enabled for users that have
+  <a href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop#w_strict-enhanced-tracking-protection"> "Strict" privacy protections </a> enabled.</p>
+  </li>
+</ul>
 
 <h3 id="network_partitioning">Network Partitioning</h3>
   <p>Networking-related APIs are not intended to be used for websites to store
@@ -119,7 +110,7 @@ tags:
   for cross-site tracking. As such, the following network APIs and caches are
   <strong>permanently</strong> partitioned by the top-level site.</p>
   <div class="note">
-    <p><strong>Note</strong>: Network Partitioning is permanent. Websites can't
+    <p><strong>Note:</strong> Network Partitioning is permanent. Websites can't
     control or relax these restrictions.</p>
   </div>
   <h4>Partitioned APIs</h4>
@@ -180,7 +171,7 @@ tags:
     third-party integrations that are common on the web to continue to function.
   </p>
   <div class="warning">
-    <p><strong>Warning</strong>: Storage access heuristics are a transitional
+    <p><strong>Warning:</strong> Storage access heuristics are a transitional
     feature meant to prevent website breakage. They should not be relied upon
     for current and future web development.</p>
   </div>
@@ -200,7 +191,7 @@ tags:
     </li>
   </ul>
   <div class="note">
-    <p><strong>Note</strong>: For third-parties which abuse these heuristic for
+    <p><strong>Note:</strong> For third-parties which abuse these heuristic for
     tracking purposes, we may require user interaction with the popup before
     storage access is granted.</p>
   </div>
@@ -240,7 +231,7 @@ tags:
     made in context of the first-party bucket.
   </p>
   <div class="warning">
-    <p><strong>Warning</strong>: When storage access is granted there may still
+    <p><strong>Warning:</strong> When storage access is granted there may still
     be references to the partitioned storage. However, sites shouldn't rely on
     being able to use partitioned and unpartitioned storage at the same
     time.</p>
@@ -271,20 +262,20 @@ tags:
    </thead>
   <tbody>
    <tr>
-    <th scope="row">Storage of a third-party frame is partitioned</th>
+    <td>Storage of a third-party frame is partitioned</td>
     <td>Partitioned cookie or storage access was provided to “b.example” because
     it is loaded in the third-party context and storage partitioning is
     enabled.</td>
    </tr>
    <tr>
-    <th scope="row">Storage access is granted through a <b>heuristic</b></th>
+    <td>Storage access is granted through a <b>heuristic</b></td>
     <td>Storage access automatically granted for First-Party isolation
     “b.example” on “a.example”.</td>
    </tr>
    <tr>
-    <th scope="row">Storage access is granted via the
+    <td>Storage access is granted via the
       <a href="/en-US/docs/Web/API/Document/requestStorageAccess">StorageAccessAPI</a>
-    </th>
+    </td>
     <td>Storage access granted for origin “b.example” on “a.example”.</td>
    </tr>
   </tbody>
@@ -301,7 +292,7 @@ tags:
 
 <h4>Test Preferences</h4>
 <div class="warning">
-  <p><strong>Warning</strong>: Make sure to set these prefs in a separate
+  <p><strong>Warning:</strong> Make sure to set these prefs in a separate
   Firefox profile or reset them after testing.</p>
 </div>
 
@@ -316,14 +307,14 @@ tags:
   <li>
     Enable / disable the <a href="#storage_access_redirect_heuristics">redirect
     heuristics</a>:
-    <code>privacy.restrict3rdpartystorage.heuristic.recently_visited,
-    privacy.restrict3rdpartystorage.heuristic.redirect</code>
+    <code>privacy.restrict3rdpartystorage.heuristic.recently_visited</code>,
+    <code>privacy.restrict3rdpartystorage.heuristic.redirect</code>
   </li>
   <li>
     Enable / disable the <a href="#storage_access_window_open_heuristics">window
     open heuristics</a>:
-    <code>privacy.restrict3rdpartystorage.heuristic.window_open,
-    privacy.restrict3rdpartystorage.heuristic.opened_window_after_interaction</code>
+    <code>privacy.restrict3rdpartystorage.heuristic.window_open</code>,
+    <code>privacy.restrict3rdpartystorage.heuristic.opened_window_after_interaction</code>
   </li>
 </ul>
 
@@ -343,15 +334,15 @@ tags:
    </thead>
   <tbody>
    <tr>
-    <th scope="row">5</th>
+    <td>5</td>
     <td>Reject (known) trackers and partition third-party storage.</td>
    </tr>
    <tr>
-    <th scope="row">4</th>
+    <td>4</td>
     <td>Only reject trackers (Storage partitioning disabled).</td>
    </tr>
    <tr>
-    <th scope="row">0</th>
+    <td>0</td>
     <td>Allow all</td>
    </tr>
   </tbody>

--- a/files/en-us/web/privacy/storage_access_policy/index.html
+++ b/files/en-us/web/privacy/storage_access_policy/index.html
@@ -209,7 +209,7 @@ tags:
 
 <p>The <a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a> in Firefox Developer Tools now includes an indicator for all resource requests that have been classified as tracking resources. This indicator is shown as a shield icon in the domain column. In the sample image below, <code>trackertest.org</code> is classified as a tracking resource, while the request to example.com is not.</p>
 
-<p><img alt="network requests in Firefox devtools indicating which ones are tracking resources with a small shield icon" src="screen_shot_2018-09-21_at_10.34.22_am.png" style="border-style: solid; border-width: 1px; display: block; margin: 0px auto;"></p>
+<p><img alt="network requests in Firefox devtools indicating which ones are tracking resources with a small shield icon" src="screen_shot_2018-09-21_at_10.34.22_am.png"></p>
 
 <h3 id="Adding_custom_domains_to_the_Tracking_Protection_list">Adding custom domains to the Tracking Protection list</h3>
 
@@ -224,7 +224,7 @@ tags:
 </ol>
 
 <div class="warning">
-<p><strong>Warning</strong>: Be sure to remove these entries after you have finished testing.</p>
+<p><strong>Warning:</strong> Be sure to remove these entries after you have finished testing.</p>
 </div>
 
 <h2 id="FAQ">FAQ</h2>

--- a/files/en-us/web/privacy/tracking_protection/index.html
+++ b/files/en-us/web/privacy/tracking_protection/index.html
@@ -20,17 +20,17 @@ tags:
 
 <p>Note that with Firefox for Android, you can access console output using the remote debugger.</p>
 
-<p><img alt="Page information showing possible blocked content." src="blocked_content.png" style="border-style: solid; border-width: 1px; display: block; margin: 0px auto;"></p>
+<p><img alt="Page information showing possible blocked content." src="blocked_content.png"></p>
 
 <p>Click the ⓘ symbol in the address bar to view information about the currently loaded page. The popup that appears will notify you when content has been blocked.  You will also be able to disable tracking protection entirely if you choose by accessing the tracking settings.</p>
 
 <p>If tracking cookies were present, you would be able to view the list by clicking on "Blocking Tracking Cookies" in the above image to view the following popup:</p>
 
-<p><img alt="" src="tracking_cookies.png" style="border-style: solid; border-width: 1px; display: block; margin: 0px auto;"></p>
+<p><img alt="" src="tracking_cookies.png"></p>
 
 <p>You can click "Manage Content Blocking" to change the blocking settings:</p>
 
-<p><img alt="" src="content_blocking.png" style="border-style: solid; border-width: 1px; display: block; margin: 0px auto;"></p>
+<p><img alt="" src="content_blocking.png"></p>
 
 <h2 id="How_does_Firefox_choose_what_to_block">How does Firefox choose what to block?</h2>
 


### PR DESCRIPTION
This PR prepares the https://developer.mozilla.org/en-US/docs/Web/Privacy pages for Markdowning.

After this PR the converter reports zero unconverted elements.
