### PR TITLE
[Markdown][Related] Prepare Related for Markdowning

### DIFF
--- a/files/en-us/related/imsc/basics/index.html
+++ b/files/en-us/related/imsc/basics/index.html
@@ -8,12 +8,10 @@ tags:
   - captions
   - subtitles
 ---
-<div class="summary">
-<p class="summary">IMSC allows you to add subtitles or captions to your online video. In this article we'll take you through what you need to get started, including basic document structure, and the basics of how to style, time, and position subtitles.</p>
+<p>IMSC allows you to add subtitles or captions to your online video. In this article we'll take you through what you need to get started, including basic document structure, and the basics of how to style, time, and position subtitles.</p>
 
 <div class="note">
-<p><strong>Note</strong>: IMSC can be used for any kind of timed text you might want to include on a web document, not just for subtitles and captions. But because subtitles and captions represent the most common use cases for IMSC, we will focus on those. For readability we only use the term subtitles. In the technical context we describe, the term "subtitles" is interchangeable with "captions".</p>
-</div>
+<p><strong>Note:</strong> IMSC can be used for any kind of timed text you might want to include on a web document, not just for subtitles and captions. But because subtitles and captions represent the most common use cases for IMSC, we will focus on those. For readability we only use the term subtitles. In the technical context we describe, the term "subtitles" is interchangeable with "captions".</p>
 </div>
 
 <h2 id="So_what_is_IMSC">So what is IMSC?</h2>
@@ -108,7 +106,7 @@ tags:
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: Don’t worry for now about namespaces. We will explain the meaning of <code>xmlns:tts</code> and <code>tts:backgroundColor</code> in a separate guide.</p>
+<p><strong>Note:</strong> Don’t worry for now about namespaces. We will explain the meaning of <code>xmlns:tts</code> and <code>tts:backgroundColor</code> in a separate guide.</p>
 </div>
 
 <p>As explained in the <a href="/en-US/docs/Related/IMSC/Styling">IMSC Styling</a> guide, it is possible to define a collection of styling properties that can be used any number of times. The style <code>s1</code> below is applied three times:</p>

--- a/files/en-us/related/imsc/imsc_and_other_standards/index.html
+++ b/files/en-us/related/imsc/imsc_and_other_standards/index.html
@@ -5,7 +5,7 @@ tags:
   - IMSC
   - Specifications
 ---
-<p class="summary">IMSC is the result of an international effort to bring together popular profiles of <a href="https://www.w3.org/TR/ttml/">TTML</a>, like <a href="https://tech.ebu.ch/publications/tech3380">EBU-TT-D</a> and <a href="https://doi.org/10.5594/SMPTE.ST2052-1.2013">SMPTE-TT</a>. This article provides an overview how IMSC is related to these other subtitle standards, and explains the differences between the versions of IMSC.</p>
+<p>IMSC is the result of an international effort to bring together popular profiles of <a href="https://www.w3.org/TR/ttml/">TTML</a>, like <a href="https://tech.ebu.ch/publications/tech3380">EBU-TT-D</a> and <a href="https://doi.org/10.5594/SMPTE.ST2052-1.2013">SMPTE-TT</a>. This article provides an overview how IMSC is related to these other subtitle standards, and explains the differences between the versions of IMSC.</p>
 
 <h2 id="IMSC_spec_genealogy">IMSC spec genealogy</h2>
 
@@ -39,7 +39,7 @@ tags:
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: IMSC 1.1 also deprecates, but does not prohibit, a limited number features that have no practical use or for which better alternatives exist.</p>
+<p><strong>Note:</strong> IMSC 1.1 also deprecates, but does not prohibit, a limited number features that have no practical use or for which better alternatives exist.</p>
 </div>
 
 <p>In summary, authors are encouraged to create IMSC 1.0.1 documents if possible and for maximal compatibility, and implementers are encouraged to implement support for IMSC 1.1 for worldwide coverage.</p>

--- a/files/en-us/related/imsc/index.html
+++ b/files/en-us/related/imsc/index.html
@@ -6,7 +6,7 @@ tags:
   - captions
   - subtitles
 ---
-<p class="summary">IMSC (TTML Profiles for Internet Media Subtitles and Captions) is a file format for representing subtitles and captions. It uses XML to describe content, timing, layout, and styling. IMSC is very similar to HTML and CSS in concept — in fact, most IMSC styles have a direct equivalent in CSS.</p>
+<p>IMSC (TTML Profiles for Internet Media Subtitles and Captions) is a file format for representing subtitles and captions. It uses XML to describe content, timing, layout, and styling. IMSC is very similar to HTML and CSS in concept — in fact, most IMSC styles have a direct equivalent in CSS.</p>
 
 <h2 id="Concepts_and_usage">Concepts and usage</h2>
 

--- a/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.html
+++ b/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.html
@@ -9,7 +9,7 @@ tags:
   - mapping
   - subtitles
 ---
-<div class="summary">Mapping the time or time code value that is seen within a video track or video editor timeline to an IMSC document can be a little tricky. There are a few different issues that you'll need to be aware of, which we'll cover in this article.</div>
+<p>Mapping the time or time code value that is seen within a video track or video editor timeline to an IMSC document can be a little tricky. There are a few different issues that you'll need to be aware of, which we'll cover in this article.</p>
 
 <h2 id="Considering_time_code_start_times">Considering time code start times</h2>
 

--- a/files/en-us/related/imsc/namespaces/index.html
+++ b/files/en-us/related/imsc/namespaces/index.html
@@ -7,9 +7,7 @@ tags:
   - TTML
   - XML
 ---
-<div class="summary">
 <p>This article covers the subject of XML namespaces, giving you enough information to recognize their usage in IMSC, and be able to use it effectively.</p>
-</div>
 
 <h2 id="What_are_XML_namespaces">What are XML namespaces?</h2>
 

--- a/files/en-us/related/imsc/styling/index.html
+++ b/files/en-us/related/imsc/styling/index.html
@@ -8,9 +8,7 @@ tags:
   - captions
   - subtitles
 ---
-<div class="summary">
 <p>IMSC offers many options for styling documents, and most of the IMSC styling properties have direct CSS equivalents, making them familiar to web developers.  In this guide you'll learn a bit more about IMSC styling including the difference between inline and referential styling, and efficient styling using inheritance and region styling.</p>
-</div>
 
 <h2 id="Inline_styling">Inline styling</h2>
 

--- a/files/en-us/related/imsc/subtitle_placement/index.html
+++ b/files/en-us/related/imsc/subtitle_placement/index.html
@@ -10,7 +10,7 @@ tags:
   - region
   - subtitles
 ---
-<div class="summary">IMSC allows for very explicit positioning of the text over the video content you are displaying it against. There are a few tricks and best practices that can be used in order to simplify the placement of the on-screen text.</div>
+<p>IMSC allows for very explicit positioning of the text over the video content you are displaying it against. There are a few tricks and best practices that can be used in order to simplify the placement of the on-screen text.</p>
 
 <h2 id="Considering_correct_text_placement">Considering correct text placement</h2>
 

--- a/files/en-us/related/imsc/timing_in_imsc/index.html
+++ b/files/en-us/related/imsc/timing_in_imsc/index.html
@@ -8,7 +8,7 @@ tags:
   - captions
   - subtitles
 ---
-<div class="summary">When building an IMSC document, each defined piece of text must include timing information to specify when it should appear. There are multiple ways to describe when a subtitle should start and stop displaying, with pros and cons to each method. This article explains those different methods.</div>
+<p>When building an IMSC document, each defined piece of text must include timing information to specify when it should appear. There are multiple ways to describe when a subtitle should start and stop displaying, with pros and cons to each method. This article explains those different methods.</p>
 
 <p>If you have not already read the <a href="/en-US/docs/Related/IMSC/Basics#timing">IMSC document with timing</a> section in the <a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a> article, you should do so now and then return here — it contains an initial overview of how to describe timing events.</p>
 
@@ -74,7 +74,7 @@ tags:
 <p>The advantage of using this method is that the time expression frame number is the same as the frame number of the media asset. A value of 86400f is frame number 86400 in the video file.</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can find an additional explanation of these values in <a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>.</p>
+<p><strong>Note:</strong> You can find an additional explanation of these values in <a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>.</p>
 </div>
 
 

--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.html
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.html
@@ -8,7 +8,7 @@ tags:
   - rendering
   - subtitles
 ---
-<p class="summary">You currently need a polyfill to render IMSC on the web. imscJS is a good choice as it is actively maintained and has almost complete coverage of the IMSC features. This article shows you how to make use of imscJS and how to integrate it on your own website. </p>
+<p>You currently need a polyfill to render IMSC on the web. imscJS is a good choice as it is actively maintained and has almost complete coverage of the IMSC features. This article shows you how to make use of imscJS and how to integrate it on your own website. </p>
 
 <h2 id="Introducing_imscJS">Introducing imscJS</h2>
 

--- a/files/en-us/related/index.html
+++ b/files/en-us/related/index.html
@@ -4,10 +4,10 @@ slug: Related
 tags:
   - Related
 ---
-<p class="summary">This section of the site is a home for documentation on web-related technologies that aren't central to the MDN's remit (i.e. they aren't web standards technologies), but are nonetheless related to the web and of interest to web developers.</p>
+<p>This section of the site is a home for documentation on web-related technologies that aren't central to the MDN's remit (i.e. they aren't web standards technologies), but are nonetheless related to the web and of interest to web developers.</p>
 
 <div class="note">
-<p><strong>Note</strong>: These documentation resources generally aren't maintained by the MDN writer's team — if you have suggestions or queries related to these resources, check out the landing pages for those technologies for contact details of the relevant maintenance team.</p>
+<p><strong>Note:</strong> These documentation resources generally aren't maintained by the MDN writer's team — if you have suggestions or queries related to these resources, check out the landing pages for those technologies for contact details of the relevant maintenance team.</p>
 </div>
 
 <h2 id="Technology_list">Technology list</h2>
@@ -24,10 +24,6 @@ tags:
 <p>To determine if it does, Carefully read the <a href="/en-US/docs/Related/Criteria_for_inclusion">Criteria for inclusion</a>. This outlines the criteria a technology should match to be considered for inclusion on this area of the site.</p>
 
 <p>If the technology does fit the criteria for inclusion, you should next follow the <a href="/en-US/docs/Related/Process_for_selection">process for selection</a>. The short version is that you assemble some supporting resources and then send them to the MDN team so we can make a decision on whether to include the technology. We want to consider each technology on a case-by-case basis, so we can carefully control what is published here and maintain quality.</p>
-
-<div class="warning">
-<p><strong>Warning</strong>: If you publish new documentation here without talking to the MDN team, it will be deleted.</p>
-</div>
 
 <h2 id="Creating_a_documentation_project">Creating a documentation project</h2>
 

--- a/files/en-us/related/project_guidelines/index.html
+++ b/files/en-us/related/project_guidelines/index.html
@@ -5,7 +5,7 @@ tags:
   - Related
   - project guidelines
 ---
-<p class="summary">If you've had your chosen technology accepted for documentation on MDN Web Docs, the next step is to get started. This article provides you with all you need to know to get started on documenting your project.</p>
+<p>If you've had your chosen technology accepted for documentation on MDN Web Docs, the next step is to get started. This article provides you with all you need to know to get started on documenting your project.</p>
 
 <h2 id="What_does_a_successful_project_need">What does a successful project need?</h2>
 
@@ -48,7 +48,7 @@ tags:
 <p>In terms of standards, you are expected to main a reasonable level of quality for your documentation to stay on MDN. Your MDN rep will work with you on this to make you clear on what is expected. It is a good idea to produce a prototype showing what each type of page in your documentation should look like (e.g. an element or method reference page, a code example...) so that people have a template to follow.</p>
 
 <div class="note">
-<p><strong>Note</strong>: MDN is primarily an English site (en-US). The primary language for your resource should be in US English. If this really doesn't make sense for your project (e.g. it might be for a tool usable in a specific non-English locale), then talk to us about it, and we'll see how we can accommodate this.</p>
+<p><strong>Note:</strong> MDN is primarily an English site (en-US). The primary language for your resource should be in US English. If this really doesn't make sense for your project (e.g. it might be for a tool usable in a specific non-English locale), then talk to us about it, and we'll see how we can accommodate this.</p>
 </div>
 
 <h2 id="Intuitive_structure">Intuitive structure</h2>


### PR DESCRIPTION
This PR prepares https://developer.mozilla.org/en-US/docs/Related for Markdowning.

After this the only unconverted elements are the `<section id="Quick_links">` elements that are used to make sidebars.
