### PR TITLE
Update typo in JS slice docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -69,7 +69,7 @@ A new array containing the extracted elements.
 elements from the original array. Elements of the original array are copied into the
 returned array as follows:
 
-- For object `slice` copies object references into the new array. Both the
+- For objects, `slice` copies object references into the new array. Both the
   original and new array refer to the same object. If an object changes, the changes are
   visible to both the new and original arrays.
 - For strings, numbers and booleans (not {{jsxref("String")}}, {{jsxref("Number")}}


### PR DESCRIPTION
#### Summary
Update a sentence in the JS docs for the `slice` method.

#### Motivation
The sentence structure did not match the style of the following sentence.

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
