### PR TITLE
Correct type coercion link in truthy (Glossary)

### DIFF
--- a/files/en-us/glossary/truthy/index.md
+++ b/files/en-us/glossary/truthy/index.md
@@ -31,5 +31,5 @@ if (-Infinity)
 ## See also
 
 - {{Glossary("Falsy")}}
-- {{Glossary("Type_Conversion", "Coercion")}}
+- {{Glossary("Type_coercion", "Coercion")}}
 - {{Glossary("Boolean")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix the typo where the link of type coercion navigates to type conversion in the glossary

#### Motivation
I was using the documentation as I'm writing an article about falsy and truthy and then I spot the mistake.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
