### PR TITLE
Add coercion link in falsy (Glossary)

### DIFF
--- a/files/en-us/glossary/falsy/index.md
+++ b/files/en-us/glossary/falsy/index.md
@@ -54,4 +54,5 @@ false && "dog"
 ## See also
 
 - {{Glossary("Truthy")}}
+- {{Glossary("Type_coercion", "Coercion")}}
 - {{Glossary("Boolean")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add the coercion link in falsy, as it is present in the truthy definition of the Glossary

#### Motivation
I was reading both definitions, it is missing in falsy. Saw the need for more information about type coercion as it is a direct influence on the topic.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
