### PR TITLE
Add info about AND logical operator in truthy (Glossary)

### DIFF
--- a/files/en-us/glossary/truthy/index.md
+++ b/files/en-us/glossary/truthy/index.md
@@ -28,6 +28,18 @@ if (Infinity)
 if (-Infinity)
 ```
 
+### The logical AND operator, &&
+
+If the first object is truthy, it returns the last one
+
+```js
+true && "dog"
+// ↪ "dog"
+
+[] && "dog"
+// ↪ "dog"
+```
+
 ## See also
 
 - {{Glossary("Falsy")}}

--- a/files/en-us/glossary/truthy/index.md
+++ b/files/en-us/glossary/truthy/index.md
@@ -30,7 +30,7 @@ if (-Infinity)
 
 ### The logical AND operator, &&
 
-If the first object is truthy, it returns the last one
+If the first object is truthy, the logical AND operator returns the second operand:
 
 ```js
 true && "dog"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add info about AND logical operator in truthy, as it is present in the falsy glossary definition

#### Motivation
Not only for consistency, as it is present in falsy, but also because it is a feature that is seen a lot, for example, in React [conditional rendering](https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator)

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
