### PR TITLE
Fix typo in 'rendering'

### DIFF
--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -175,7 +175,7 @@ Each visible node has its CSSOM rules applied to it. The render tree holds all 
 
 ### Layout
 
-The fourth step in the critical rending path is running layout on the render tree to compute the geometry of each node. _Layout_ is the process by which the width, height, and location of all the nodes in the render tree are determined, plus the determination of the size and position of each object on the page. _Reflow_ is any subsequent size and position determination of any part of the page or the entire document.
+The fourth step in the critical rendering path is running layout on the render tree to compute the geometry of each node. _Layout_ is the process by which the width, height, and location of all the nodes in the render tree are determined, plus the determination of the size and position of each object on the page. _Reflow_ is any subsequent size and position determination of any part of the page or the entire document.
 
 Once the render tree is built, layout commences. The render tree identified which nodes are displayed (even if invisible) along with their computed styles, but not the dimensions or location of each node. To determine the exact size and location of each object, the browser starts at the root of the render tree and traverses it.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix typo in rendering word (rending -> rendering).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
While I was reading [Populating the page: how browsers work](https://developer.mozilla.org/en-US/docs/Web/Performance/How_browsers_work) I noticed this typo in [Layout](https://developer.mozilla.org/en-US/docs/Web/Performance/How_browsers_work#layout) section, which I decided to fix.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
