### PR TITLE
[Markdown][Web/Media] Prepare Web/Media for Markdowning

### DIFF
--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -208,7 +208,7 @@ When the browser starts to load a page, it starts to download (preload) any ima
 
 ### Use modern image formats boldly
 
-New image formats like [WebP](/en-US/docs/Web/Media/Formats/Image_types#webp) and [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif) can maintain a low file size and high quality at the same time. These formats now have relatively broad browser support but little "historical depth".
+New image formats like [WebP](/en-US/docs/Web/Media/Formats/Image_types#WebP_image) and [AVIF](/en-US/docs/Web/Media/Formats/Image_types#AVIF_image) can maintain a low file size and high quality at the same time. These formats now have relatively broad browser support but little "historical depth".
 
 `<picture>` lets us continue catering to older browsers. You can supply MIME types inside `type` attributes so the browser can immediately reject unsupported file types:
 

--- a/files/en-us/learn/performance/multimedia/index.md
+++ b/files/en-us/learn/performance/multimedia/index.md
@@ -67,7 +67,7 @@ The optimal file format typically depends on the character of the image.
 
 > **Note:** For general information on image types see the [Image file type and format guide](/en-US/docs/Web/Media/Formats/Image_types)
 
-The [SVG](/en-US/docs/Web/Media/Formats/Image_types#svg) format is more appropriate for images that have few colors and that are not photo-realistic. This requires the source to be available as in a vector graphic format. Should such an image only exist as a bitmap, then [PNG](/en-US/docs/Web/Media/Formats/Image_types#png) would be the fallback format to chose. Examples for these types of motifs are logos, illustrations, charts or icons (note: SVGs are far better than icon fonts!). Both formats support transparency.
+The [SVG](/en-US/docs/Web/Media/Formats/Image_types#SVG_Scalable_Vector_Graphics) format is more appropriate for images that have few colors and that are not photo-realistic. This requires the source to be available as in a vector graphic format. Should such an image only exist as a bitmap, then [PNG](/en-US/docs/Web/Media/Formats/Image_types#PNG_Portable_Network_Graphics) would be the fallback format to chose. Examples for these types of motifs are logos, illustrations, charts or icons (note: SVGs are far better than icon fonts!). Both formats support transparency.
 
 PNGs can be saved with three different output combinations:
 
@@ -81,11 +81,11 @@ With photographic motifs that do not feature transparency there is a lot wider r
 
 Other formats improve on JPEG's capabilities in regards to compression, but are not available on every browser:
 
-- [WebP](/en-US/docs/Web/Media/Formats/Image_types#webp) — Excellent choice for both images and animated images. WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. (but not progressive display.). Supported by all major browsers except Safari 14 on macOS desktop.
+- [WebP](/en-US/docs/Web/Media/Formats/Image_types#WebP_image) — Excellent choice for both images and animated images. WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. (but not progressive display.). Supported by all major browsers except Safari 14 on macOS desktop.
 
   > **Note:** Despite having [announced support](https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174) for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.
 
-- [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif) — Good choice for both images and animated images due to high performance and royalty free image format (even more efficient that WebP, but not as widely supported). It is now supported on Chrome, Opera and Firefox. See also [an online tool to convert previous image formats to AVIF](https://avif-converter.online).
+- [AVIF](/en-US/docs/Web/Media/Formats/Image_types#AVIF_image) — Good choice for both images and animated images due to high performance and royalty free image format (even more efficient that WebP, but not as widely supported). It is now supported on Chrome, Opera and Firefox. See also [an online tool to convert previous image formats to AVIF](https://avif-converter.online).
 - **JPEG-XR** — created by Microsoft and only available in Internet Explorer and EdgeHTML based Edge. Doesn't support progressive display and the image decoding is not hardware accelerated and therefore resource-intensive on the browser's main thread. Progressive JPEG above-the-fold is that they render progressively (hence the name), meaning the user sees a low-resolution version that gains clarity as the image downloads, rather than the image loading at full resolution top-to-bottom or even only rendering once completely downloaded.
 - **JPEG2000** — once to be successor to JPEG but only supported in Safari. Doesn't support progressive display either.
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1220,7 +1220,7 @@ tags:
 
 <h4 id="AVIF_compliance_strictness">AVIF compliance strictness</h4>
 
-<p>The <code>image.avif.compliance_strictness</code> preference can be used to control the <em>strictness</em> appliied when processing <a href="/en-US/docs/Web/Media/Formats/Image_types#AVIF_image">AVIF</a> images.
+<p>The <code>image.avif.compliance_strictness</code> preference can be used to control the <em>strictness</em> applied when processing <a href="/en-US/docs/Web/Media/Formats/Image_types#AVIF_image">AVIF</a> images.
   This allows Firefox users to display images that render on some other browsers, even if they are not strictly compliant.</p>
 
 <p>Permitted values are:</p>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1220,7 +1220,7 @@ tags:
 
 <h4 id="AVIF_compliance_strictness">AVIF compliance strictness</h4>
 
-<p>The <code>image.avif.compliance_strictness</code> preference can be used to control the <em>strictness</em> appliied when processing <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> images.
+<p>The <code>image.avif.compliance_strictness</code> preference can be used to control the <em>strictness</em> appliied when processing <a href="/en-US/docs/Web/Media/Formats/Image_types#AVIF_image">AVIF</a> images.
   This allows Firefox users to display images that render on some other browsers, even if they are not strictly compliant.</p>
 
 <p>Permitted values are:</p>

--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{FirefoxSidebar}}{{draft}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 93 that will affect developers. Firefox 93 was released on October 5, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 93 that will affect developers. Firefox 93 was released on October 5, 2021.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 
@@ -38,7 +38,7 @@ tags:
 
 <ul>
   <li>The SHA-256 algorithm is now supported for <a href="/en-US/docs/Web/HTTP/Authentication">HTTP Authentication</a> using digests. This allows much more secure authentication than previously available using the MD5 algorithm ({{bug(1682995)}}).</li>
-  <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> image format). ({{bug(1682995)}}).</li>
+  <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#AVIF_image">AVIF</a> image format). ({{bug(1682995)}}).</li>
 </ul>
 
 <h3 id="APIs">APIs</h3>
@@ -83,7 +83,7 @@ tags:
 <h2 id="Other">Other</h2>
 
 <ul>
-  <li>Support for <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> images is now enabled by default ({{bug(1682995)}}).
+  <li>Support for <a href="/en-US/docs/Web/Media/Formats/Image_types#AVIF_image">AVIF</a> images is now enabled by default ({{bug(1682995)}}).
     This format has excellent compression and no patent restrictions (it was developed by the <a href="http://aomedia.org/">Alliance for Open Media</a>).
     Firefox can display still images, with colorspace support for both full and limited range colors, and image transforms for mirroring and rotation.
     The preference <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_compliance_strictness">image.avif.compliance_strictness</a> can be used to adjust the compliance strictness with the specification. Animated images are not supported.</li>

--- a/files/en-us/web/api/htmlimageelement/alt/index.md
+++ b/files/en-us/web/api/htmlimageelement/alt/index.md
@@ -180,8 +180,8 @@ instead of the icon when the icons cannot be or are intentionally not used.
 
 When an image contains information presented as a diagram, chart, graph, or map,
 the `alt` text should provide the same information, at least in summary form.
-This is true whether the /me image is in a bitmapped format such as [PNG](/en-US/docs/Web/Media/Formats/Image_types#png) or [JPEG](/en-US/docs/Web/Media/Formats/Image_types#jpeg) or in a vector format
-like [SVG](/en-US/docs/Web/Media/Formats/Image_types#svg).
+This is true whether the /me image is in a bitmapped format such as [PNG](/en-US/docs/Web/Media/Formats/Image_types#PNG_Portable_Network_Graphics) or [JPEG](/en-US/docs/Web/Media/Formats/Image_types#JPEG_Joint_Photographic_Experts_Group_image) or in a vector format
+like [SVG](/en-US/docs/Web/Media/Formats/Image_types#SVG_Scalable_Vector_Graphics).
 
 - For a map, the `alt` text could be directions to the place indicated by
   the map, similarly to how you would explain it verbally.

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.md
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.md
@@ -36,7 +36,7 @@ A {{domxref("DOMString")}} which may be either an empty string (indicating that 
 description is available) or the URL of a file containing a long form description of the
 image's contents.
 
-For example, if the image is a [PNG](/en-US/docs/Web/Media/Formats/Image_types#png) of a flowchart.
+For example, if the image is a [PNG](/en-US/docs/Web/Media/Formats/Image_types#PNG_Portable_Network_Graphics) of a flowchart.
 The `longDesc` property could be used to provide an explanation of the flow
 of control represented by the chart, using only text. This can be used by readers both
 as an explanation, but also as a substitute for visually-impaired users.

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -48,15 +48,15 @@ The HTML standard doesn't list what image formats to support, so {{glossary("use
 
 The image file formats that are most commonly used on the web are:
 
-- [APNG (Animated Portable Network Graphics)](/en-US/docs/Web/Media/Formats/Image_types#apng) — Good choice for lossless animation sequences (GIF is less performant)
-- [AVIF (AV1 Image File Format)](/en-US/docs/Web/Media/Formats/Image_types#avif) — Good choice for both images and animated images due to high performance.
-- [GIF (Graphics Interchange Format)](/en-US/docs/Web/Media/Formats/Image_types#gif) — Good choice for _simple_ images and animations.
-- [JPEG (Joint Photographic Expert Group image)](/en-US/docs/Web/Media/Formats/Image_types#jpeg) — Good choice for lossy compression of still images (currently the most popular).
-- [PNG (Portable Network Graphics)](/en-US/docs/Web/Media/Formats/Image_types#png) — Good choice for lossy compression of still images (slightly better quality than JPEG).
-- [SVG (Scalable Vector Graphics)](/en-US/docs/Web/Media/Formats/Image_types#svg) — Vector image format. Use for images that must be drawn accurately at different sizes.
-- [WebP (Web Picture format)](/en-US/docs/Web/Media/Formats/Image_types#webp) — Excellent choice for both images and animated images
+- [APNG (Animated Portable Network Graphics)](/en-US/docs/Web/Media/Formats/Image_types#APNG_Animated_Portable_Network_Graphics) — Good choice for lossless animation sequences (GIF is less performant)
+- [AVIF (AV1 Image File Format)](/en-US/docs/Web/Media/Formats/Image_types#AVIF_image) — Good choice for both images and animated images due to high performance.
+- [GIF (Graphics Interchange Format)](/en-US/docs/Web/Media/Formats/Image_types#GIF_Graphics_Interchange_Format) — Good choice for _simple_ images and animations.
+- [JPEG (Joint Photographic Expert Group image)](/en-US/docs/Web/Media/Formats/Image_types#JPEG_Joint_Photographic_Experts_Group_image) — Good choice for lossy compression of still images (currently the most popular).
+- [PNG (Portable Network Graphics)](/en-US/docs/Web/Media/Formats/Image_types#PNG_Portable_Network_Graphics) — Good choice for lossy compression of still images (slightly better quality than JPEG).
+- [SVG (Scalable Vector Graphics)](/en-US/docs/Web/Media/Formats/Image_types#SVG_Scalable_Vector_Graphics) — Vector image format. Use for images that must be drawn accurately at different sizes.
+- [WebP (Web Picture format)](/en-US/docs/Web/Media/Formats/Image_types#WebP_image) — Excellent choice for both images and animated images
 
-Formats like [WebP](/en-US/docs/Web/Media/Formats/Image_types#webp) and [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif) are highly recommended as they are now broadly (and somewhat deeply) supported by web browsers, and perform much better than PNG, JPEG, GIF for both still and animated images. SVG remains the recommended format for images that must be drawn accurately at different sizes.
+Formats like [WebP](/en-US/docs/Web/Media/Formats/Image_types#WebP_image) and [AVIF](/en-US/docs/Web/Media/Formats/Image_types#AVIF_image) are highly recommended as they are now broadly (and somewhat deeply) supported by web browsers, and perform much better than PNG, JPEG, GIF for both still and animated images. SVG remains the recommended format for images that must be drawn accurately at different sizes.
 
 ## Image loading errors
 

--- a/files/en-us/web/html/element/picture/index.md
+++ b/files/en-us/web/html/element/picture/index.md
@@ -34,7 +34,7 @@ Common use cases for `<picture>`:
 - **Art direction.** Cropping or modifying images for different `media` conditions (for example, loading a simpler version of an image which has too many details, on smaller displays).
 - **Offering alternative image formats**, for cases where certain formats are not supported.
 
-  > **Note:** For example, newer formats like [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif) or [WEBP](/en-US/docs/Web/Media/Formats/Image_types#webp) have many advantages, but  might not be supported by the browser. A list of supported image formats can be found in: [Image file type and format guide](/en-US/docs/Web/Media/Formats/Image_types).
+  > **Note:** For example, newer formats like [AVIF](/en-US/docs/Web/Media/Formats/Image_types#AVIF_image) or [WEBP](/en-US/docs/Web/Media/Formats/Image_types#WebP_image) have many advantages, but  might not be supported by the browser. A list of supported image formats can be found in: [Image file type and format guide](/en-US/docs/Web/Media/Formats/Image_types).
 
 - **Saving bandwidth and speeding page load times** by loading the most appropriate image for the viewer's display.
 

--- a/files/en-us/web/media/formats/audio_codecs/index.html
+++ b/files/en-us/web/media/formats/audio_codecs/index.html
@@ -77,7 +77,8 @@ tags:
   <tr>
    <th scope="row"><a href="#mp3_mpeg-1_audio_layer_iii">MP3</a></th>
    <td>MPEG-1 Audio Layer III</td>
-   <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg">MPEG</a><sup><a href="#in-brief-footnote1">1</a></sup>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
+   <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg">MPEG</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a>
+   <p>When MPEG-1 Audio Layer III codec data is stored in an MPEG file, and there is no video track on the file, the file is typically referred to as an MP3 file, even though it's still an MPEG format file.</p></td>
   </tr>
   <tr>
    <th scope="row"><a href="#opus">Opus</a></th>
@@ -91,8 +92,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="in-brief-footnote1">[1]</a> When MPEG-1 Audio Layer III codec data is stored in an MPEG file, and there is no video track on the file, the file is typically referred to as an MP3 file, even though it's still an MPEG format file.</p>
 
 <h2 id="Factors_affecting_the_encoded_audio">Factors affecting the encoded audio</h2>
 
@@ -115,7 +114,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_concepts#channel_count">Channel count</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_concepts#Audio_data_format_and_structure">Channel count</a></th>
    <td>The number of channels affects only the perception of directionality, not the quality.</td>
    <td>Each channel may substantially increase the encoded audio size, depending on contents and encoder settings.</td>
   </tr>
@@ -125,12 +124,12 @@ tags:
    <td>Hiss, static, or background noise increases the audio complexity, which generally reduces the amount of compression which is possible.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_concepts#sample_rate">Sample rate</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_concepts#Sampling_audio">Sample rate</a></th>
    <td>The more samples available per second, the higher the resulting encoded audio fidelity is likely to be.</td>
    <td>Increasing the sample rate increases the encoded audio file's size.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_concepts#sample_size">Sample size</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_concepts#Audio_data_format_and_structure">Sample size</a></th>
    <td>The larger the samples, the more detail each sample can contain, resulting in more accurate representation of each sample.</td>
    <td>Depends on the codec; codecs typically have an internal sample format that may or may not be the same as the original sample size. But more source detail may make the encoded file larger; it will never make it smaller.</td>
   </tr>
@@ -224,7 +223,6 @@ tags:
 
 <p>Below we take a brief look at each of these codecs, looking at their basic capabilities and their primary use cases.</p>
 
-<a id="AAC"></a>
 <h3 id="aac_advanced_audio_coding">AAC (Advanced Audio Coding)</h3>
 
 <p>The <strong>Advanced Audio Coding</strong> (<strong>AAC</strong>) codec is defined as part of the MPEG-4 (H.264) standard; specifically, as part of <a href="https://www.iso.org/standard/53943.html">MPEG-4 Part 3</a> and <a href="https://www.iso.org/standard/43345.html">MPEG-2 Part 7</a>. Designed to be able to provide more compression with higher audio fidelity than MP3, AAC has become a popular choice, and is the standard format for audio in many types of media, including Blu-Ray discs and HDTV, as well as being the format used for songs purchased from online vendors including iTunes.</p>
@@ -288,15 +286,17 @@ tags:
       </tr>
       <tr>
        <th scope="row">AAC support</th>
-       <td>Yes<sup><a href="#aac-foot-2">[2]</a></sup></td>
        <td>Yes</td>
-       <td>Yes<sup><a href="#aac-foot-1">[1]</a></sup></td>
+       <td>Yes</td>
+       <td>Yes</td>
        <td>9</td>
        <td>Yes</td>
        <td>3.1</td>
       </tr>
      </tbody>
     </table>
+    <p>Due to patent issues, Firefox does not directly support AAC. Instead, Firefox relies upon a platform's native support for AAC. This capability was introduced on each platform in different Firefox releases:</p>
+    <p>Chrome supports AAC only in MP4 containers, and only supports AAC's Main Profile. In addition, AAC is not available in Chromium builds.</p>
    </td>
   </tr>
   <tr>
@@ -313,8 +313,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a name="aac-foot-1">[1]</a> Due to patent issues, Firefox does not directly support AAC. Instead, Firefox relies upon a platform's native support for AAC. This capability was introduced on each platform in different Firefox releases:</p>
 
 <table class="standard-table" style="margin-left: 4em; max-width: 30em;">
  <caption>AAC support in Firefox using external library, by platform</caption>
@@ -345,9 +343,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="aac-foot-2">[2]</a> Chrome supports AAC only in MP4 containers, and only supports AAC's Main Profile. In addition, AAC is not available in Chromium builds.</p>
-
-<a id="alac"></a>
 <h3 id="alac_apple_lossless_audio_codec">ALAC (Apple Lossless Audio Codec)</h3>
 
 <p>The <strong>Apple Lossless Audio Codec</strong> (<strong>ALAC</strong> or <strong>Apple Lossless</strong>) is a lossless codec developed by Apple. After initially being a closed format, Apple opened it up under an Apache license.</p>
@@ -436,7 +431,6 @@ tags:
  </tbody>
 </table>
 
-<a id="AMR"></a>
 <h3 id="AMR_Adaptive_Multi-Rate">AMR (Adaptive Multi-Rate)</h3>
 
 <p>The <strong><a href="http://www.voiceage.com/AMR-NB.AMR.html">Adaptive Multi-Rate audio codec</a></strong> is optimized for encoding human speech efficiently. It was standardized in 1999 as part of the 3GPP audio standard used for both {{interwiki("wikipedia", "GSM")}} and {{interwiki("wikipedia", "UMTS")}} cellular telephony, and uses a multi-rate narrowband algorithm to encode audio frequencies at a telephony-grade quality level at around 7.4 kbps. In addition to being used for real-time telephony, AMR audio may be used for voicemail and other short audio recordings.</p>
@@ -502,15 +496,16 @@ tags:
       </tr>
       <tr>
        <th scope="row">AMR support</th>
-       <td>No<sup><a href="#amr-foot-1">[1]</a></sup></td>
+       <td>No</td>
        <td>?</td>
-       <td>No<sup><a href="#amr-foot-2">[2]</a></sup></td>
+       <td>No</td>
        <td>?</td>
        <td>No</td>
        <td>?</td>
       </tr>
      </tbody>
     </table>
+    <p>While the Chrome browser does not support AMR, Chrome OS supports AMR-NB (narrowband) and AMR-WB (wideband).</p>
    </td>
   </tr>
   <tr>
@@ -528,11 +523,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="amr-foot-1">[1]</a> While the Chrome browser does not support AMR, Chrome OS supports AMR-NB (narrowband) and AMR-WB (wideband).</p>
-
-<p><a id="amr-foot-2">[2]</a> The Firefox browser doesn't support AMR; however, the Boot to Gecko platform does support both narrow and wideband AMR in 3GP containers.</p>
-
-<a id="flac"></a>
 <h3 id="flac_free_lossless_audio_codec">FLAC (Free Lossless Audio Codec)</h3>
 
 <p><strong>FLAC </strong>(<strong>Free Lossless Audio Codec</strong>) is a lossless audio codec published by the <a href="https://xiph.org/">Xiph.org Foundation</a>. It provides good compression rates with no loss of audio fidelity; that is, the decompressed audio is identical to the original. Because the compression algorithm is specifically designed for audio, it gives better results than would be achieved using a general-purpose compression algorithm.</p>
@@ -620,7 +610,6 @@ tags:
  </tbody>
 </table>
 
-<a id="g.711"></a>
 <h3 id="g.711_pulse_code_modulation_of_voice_frequencies">G.711 (Pulse Code Modulation of Voice Frequencies)</h3>
 <p>The <strong>G.711</strong> specification, published by the International Telecommunications Union (ITU), was issued in 1972 to define standard audio encoding for telephone applications. It supports voice-grade audio covering frequencies from 300 to 3400 Hz. It is used extensively for telephone traffic and voicemail, and it is the highest quality audio encoding which can be transmitted through the public telephone network.</p>
 
@@ -683,15 +672,16 @@ tags:
       </tr>
       <tr>
        <th scope="row">G.711 support</th>
-       <td>23<sup><a href="#g711-foot-1">[1]</a></sup></td>
-       <td>15<sup><a href="#g711-foot-1">[1]</a></sup></td>
-       <td>22<sup><a href="#g711-foot-1">[1]</a></sup></td>
+       <td>23</td>
+       <td>15</td>
+       <td>22</td>
        <td>No</td>
-       <td>43<sup><a href="#g711-foot-1">[1]</a></sup></td>
-       <td>11<sup><a href="#g711-foot-1">[1]</a></sup></td>
+       <td>43</td>
+       <td>11</td>
       </tr>
      </tbody>
     </table>
+    <p>G.711 is supported only for WebRTC connections.</p>
    </td>
   </tr>
   <tr>
@@ -709,9 +699,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="g711-foot-1">[1]</a> G.711 is supported only for WebRTC connections.</p>
-
-<a id="G.722"></a>
 <h3 id="g.722_64_kbps_7_khz_audio_coding">G.722 (64 kbps (7 kHz) audio coding)</h3>
 
 <p>Published by the International Telecommunications Union (ITU), the <strong>G.722</strong> codec is designed specifically for voice compression. Its audio coding bandwidth is limited to the 50 Hz to 7,000 Hz range, which covers most of the frequency range of typical human vocalization. This makes it ill-suited for handling any audio that might range outside the human speech range, such as music.</p>
@@ -777,15 +764,16 @@ tags:
       </tr>
       <tr>
        <th scope="row">G.722 support</th>
-       <td>Yes<sup><a href="#g722-foot-1">[1]</a></sup></td>
-       <td>Yes<sup><a href="#g722-foot-1">[1]</a></sup></td>
-       <td>Yes<sup><a href="#g722-foot-1">[1]</a></sup></td>
+       <td>Yes</td>
+       <td>Yes</td>
+       <td>Yes</td>
        <td>No</td>
-       <td>Yes<sup><a href="#g722-foot-1">[1]</a></sup></td>
-       <td>Yes<sup><a href="#g722-foot-1">[1]</a></sup></td>
+       <td>Yes</td>
+       <td>Yes</td>
       </tr>
      </tbody>
     </table>
+    <p>WebRTC only.</p>
    </td>
   </tr>
   <tr>
@@ -803,9 +791,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="g722-foot-1">[1]</a> WebRTC only.</p>
-
-<a id="MP3"></a>
 <h3 id="mp3_mpeg-1_audio_layer_iii">MP3 (MPEG-1 Audio Layer III)</h3>
 
 <p>Of the audio formats specified by the MPEG/MPEG-2 standards, <strong>MPEG-1 Audio Layer III</strong>—otherwise known as <strong>{{interwiki("wikipedia", "MP3")}}</strong>—is by far the most widely used and best-known. The MP3 codec is defined by <a href="https://www.iso.org/standard/22412.html">MPEG-1 Part 3</a> and <a href="https://www.iso.org/standard/26797.html">MPEG-2 Part 3</a>, and was introduced in 1991 (and finalized in 1992).</p>
@@ -881,7 +866,7 @@ tags:
        <th scope="row">MP3 support</th>
        <td>Yes</td>
        <td>Yes</td>
-       <td>Yes<sup><a href="#mp3-foot-1">[1]</a></sup></td>
+       <td>Yes</td>
        <td>9</td>
        <td>Yes</td>
        <td>3.1</td>
@@ -905,7 +890,7 @@ tags:
  </tbody>
 </table>
 
-<p><a id="mp3-foot-1">[1]</a> For patent reasons, Firefox did not directly support MP3 prior to version 71; instead, platform-native libraries were used to support MP3. This capability was introduced on each platform in different Firefox releases:</p>
+<p>For patent reasons, Firefox did not directly support MP3 prior to version 71; instead, platform-native libraries were used to support MP3. This capability was introduced on each platform in different Firefox releases:</p>
 
 <table class="standard-table" style="margin-left: 4em; max-width: 30em;">
  <caption>MP3 support with external library, by platform, in Firefox</caption>
@@ -985,10 +970,11 @@ tags:
       </tr>
       <tr>
        <th scope="row">Fullband (FB)</th>
-       <td>48 kHz<sup><a href="#opus-footnote1">[1]</a></sup></td>
+       <td>48 kHz</td>
       </tr>
      </tbody>
     </table>
+    <p>The specified sample rates are <em>effective sample rates</em>. Opus uses an algorithm based on audio bandwidths rather than sample rates. See {{RFC(6716, "", 2)}} for details. In addition, there is an <em>optional</em> part of the Opus specification (Opus Custom) that does allow for non-standard sample rates, but the use of this feature is discouraged.</p>
    </td>
   </tr>
   <tr>
@@ -1032,10 +1018,11 @@ tags:
       </tr>
       <tr>
        <th scope="row">Fullband (FB)</th>
-       <td>20 kHz<sup><a href="#opus-foot-3">[3]</a></sup></td>
+       <td>20 kHz</td>
       </tr>
      </tbody>
     </table>
+    <p>Although the {{interwiki("wikipedia", "Nyquist–Shannon sampling theorem")}} shows that audio bandwidth can be as much as one half of the sampling rate, Opus doesn't allow encoding outside a maximum 20 kHz audio frequency band, since the human ear can't percieve anything above the 20 kHz point anyway. This saves some space in the encoded audio.</p>
    </td>
   </tr>
   <tr>
@@ -1063,12 +1050,13 @@ tags:
        <td>15</td>
        <td>No</td>
        <td>20</td>
-       <td>11<sup><a href="#opus-foot-2">[2]</a></sup></td>
+       <td>11</td>
       </tr>
      </tbody>
     </table>
-
     <p>This information refers to support for Opus in HTML {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements, and not to WebRTC.</p>
+
+    <p>Safari supports Opus in the {{HTMLElement("audio")}} element only when packaged in a CAF file, and only on macOS High Sierra (10.13) or iOS 11.</p>
    </td>
   </tr>
   <tr>
@@ -1085,12 +1073,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="opus-footnote1">[1]</a> The specified sample rates are <em>effective sample rates</em>. Opus uses an algorithm based on audio bandwidths rather than sample rates. See {{RFC(6716, "", 2)}} for details. In addition, there is an <em>optional</em> part of the Opus specification (Opus Custom) that does allow for non-standard sample rates, but the use of this feature is discouraged.</p>
-
-<p><a id="opus-foot-2">[2]</a> Safari supports Opus in the {{HTMLElement("audio")}} element only when packaged in a CAF file, and only on macOS High Sierra (10.13) or iOS 11.</p>
-
-<p><a id="opus-foot-3">[3]</a> Although the {{interwiki("wikipedia", "Nyquist–Shannon sampling theorem")}} shows that audio bandwidth can be as much as one half of the sampling rate, Opus doesn't allow encoding outside a maximum 20 kHz audio frequency band, since the human ear can't percieve anything above the 20 kHz point anyway. This saves some space in the encoded audio.</p>
 
 <h3 id="vorbis">Vorbis</h3>
 
@@ -1220,8 +1202,7 @@ tags:
 <p>If you need to minimize latency during music playback, you should strongly consider Opus, which has the lowest range of latencies of the general-purpose codecs (5 ms to 66.5 ms, compared to at least 100 ms for the others).</p>
 
 <div class="notecard note">
-  <h4>Note</h4>
-  <p>Compatibility information described here is generally correct as of the time this article was written; however, there may be caveats and exceptions. Be sure to refer to the compatibility tables before committing to a given media format.</p>
+  <p><strong>Note:</strong> Compatibility information described here is generally correct as of the time this article was written; however, there may be caveats and exceptions. Be sure to refer to the compatibility tables before committing to a given media format.</p>
 </div>
 
 <p>Based on this, AAC is likely your best choice if you can only support one audio format. Of course, if you can provide multiple formats (for example, by using the {{HTMLElement("source")}} element within your {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements), you can avoid many or all of those exceptions.</p>

--- a/files/en-us/web/media/formats/audio_concepts/index.html
+++ b/files/en-us/web/media/formats/audio_concepts/index.html
@@ -45,15 +45,15 @@ tags:
 
 <p>When it comes time to play back that sound later, these amplitudes are used to generate an approximation of the original waveform; instead of playing back an exact duplicate of the original, smooth wave, the rougher, blue wave is played.</p>
 
-<p>The more often you take samples of the original audio, the closer to the original you can get. The number of samples taken per second is called the <a id="Sample_rate"><strong>sample rate</strong></a>. Consider the wave above, and how much different the blue, digital wave would look if you took samples twice as often. Or ten times as often. The more samples you take, the smoother the wave becomes.</p>
+<p>The more often you take samples of the original audio, the closer to the original you can get. The number of samples taken per second is called the <strong>sample rate</strong>. Consider the wave above, and how much different the blue, digital wave would look if you took samples twice as often. Or ten times as often. The more samples you take, the smoother the wave becomes.</p>
 
 <h2 id="Audio_data_format_and_structure">Audio data format and structure</h2>
 
-<p>At the most basic level, audio is represented by a stream of samples, each specifying the amplitude of the audio waveform as measured for a given slice of the overall waveform of the audio signal. There are several formats used for the individual samples within an audio file. Most audio files use 16-bit signed integers for each sample, but others use 32-bit floating-point values or 24-bit or 32-bit integers. Some older audio file formats—which you won't find in use on the web—used 8-bit integer samples. In addition, samples may use signed or unsigned values, as well. The size of an individual sample is called the <a id="Sample_size"><strong>sample size</strong></a>.</p>
+<p>At the most basic level, audio is represented by a stream of samples, each specifying the amplitude of the audio waveform as measured for a given slice of the overall waveform of the audio signal. There are several formats used for the individual samples within an audio file. Most audio files use 16-bit signed integers for each sample, but others use 32-bit floating-point values or 24-bit or 32-bit integers. Some older audio file formats—which you won't find in use on the web—used 8-bit integer samples. In addition, samples may use signed or unsigned values, as well. The size of an individual sample is called the <strong>sample size</strong>.</p>
 
-<p>The position of each audio source within the audio signal is called a <a id="Channels"><strong>channel</strong></a>. Each channel contains a sample indicating the amplitude of the audio being produced by that source at a given moment in time. For instance, in stereo sound, there are two audio sources: one speaker on the left, and one on the right. Each of these is represented by one channel, and the number of channels contained in the audio signal is called the <a id="Channel_count"><strong>channel count</strong></a>.</p>
+<p>The position of each audio source within the audio signal is called a <strong>channel</strong>. Each channel contains a sample indicating the amplitude of the audio being produced by that source at a given moment in time. For instance, in stereo sound, there are two audio sources: one speaker on the left, and one on the right. Each of these is represented by one channel, and the number of channels contained in the audio signal is called the <strong>channel count</strong>.</p>
 
-<p>While recording or generating multi-channel audio files, the channels are assembled into a series of <a id="Audio_frames"><strong>audio frames</strong></a>, each consisting of one sample for each of the audio's channels. An individual sample is a numeric value representing the amplitude of the sound {{interwiki("wikipedia", "waveform")}} at a single moment in time, and may be represented in various formats.</p>
+<p>While recording or generating multi-channel audio files, the channels are assembled into a series of <strong>audio frames</strong>, each consisting of one sample for each of the audio's channels. An individual sample is a numeric value representing the amplitude of the sound {{interwiki("wikipedia", "waveform")}} at a single moment in time, and may be represented in various formats.</p>
 
 <p>Stereo audio is probably the most commonly used channel arrangement in web audio, and 16-bit samples are used for the majority of day-to-day audio in use today. For 16-bit stereo audio, each sample taken from the analog signal is recorded as two 16-bit integers, one for the left channel and one for the right. That means each sample requires 32 bits of memory. At the common sample rate of 48 kHz (48,000 samples per second), this means each second of audio occupies 192 kB of memory. Therefore, a typical three-minute song requires about 34.5 MB of memory. That's a lot of storage, but worse, it's an insane amount of network bandwidth to use for a relatively short piece of audio. That's why most digital audio is compressed.</p>
 
@@ -61,13 +61,12 @@ tags:
 
 <h3 id="Audio_channels_and_frames">Audio channels and frames</h3>
 
-<p>There are two types of audio channel. Standard audio channels are used to present the majority of the audible sound. The sound for the left and right main channels, as well as all of your surround sound speakers (center, left and right rear, left and right sides, ceiling channels, and so forth) are all standard audio channels. Special <a id="Low_Frequency_Enhancement_channel"><strong>Low Frequency Enhancement</strong></a> (<strong>LFE</strong>) channels provide the signal for special speakers designed to produce the low frequency sounds and vibration to create a visceral sensation when listening to the audio. The LFE channels typically drive subwoofers and similar devices.</p>
+<p>There are two types of audio channel. Standard audio channels are used to present the majority of the audible sound. The sound for the left and right main channels, as well as all of your surround sound speakers (center, left and right rear, left and right sides, ceiling channels, and so forth) are all standard audio channels. Special <strong>Low Frequency Enhancement</strong> (<strong>LFE</strong>) channels provide the signal for special speakers designed to produce the low frequency sounds and vibration to create a visceral sensation when listening to the audio. The LFE channels typically drive subwoofers and similar devices.</p>
 
 <p>Monophonic audio has one channel, stereo sound has two channels, 5.1 surround sound has 6 channels (five standard and one LFE), and so forth. Each audio frame is a data record that contains the samples for all of the channels available in an audio signal. The size of an audio frame is calculated by multiplying the sample size in bytes by the number of channels, so a single frame of stereo 16-bit audio is 4 bytes long and a single frame of 5.1 floating-point audio is 24 (4 bytes per sample multiplied by 6 channels).</p>
 
 <div class="notecard note">
-	<h4>Note</h4>
-<p>It's worth noting that some codecs will actually separate the left and right channels, storing them in separate blocks within their data structure. However, an audio frame is always comprised of all of the data for all available channels.</p>
+<p><strong>Note:</strong> Some codecs will actually separate the left and right channels, storing them in separate blocks within their data structure. However, an audio frame is always comprised of all of the data for all available channels.</p>
 </div>
 
 <p>The number of frames that comprise a single second of audio varies depending on the sample rate used when recording the sound. Since the sample rate corresponds to the number of "slices" a sound wave is divided into for each second of time, it's sometimes thought of as a frequency (in the sense that it's a description of something that repeats periodically, not in terms of actual audio frequency), and the samples per second measurement therefore uses the {{interwiki("wikipedia", "Hertz")}} as its unit.</p>
@@ -106,8 +105,7 @@ tags:
 <p>To solve this problem, the audio must be made smaller using compression.</p>
 
 <div class="notecard note">
-<h4>Note</h4>
-<p>Network bandwidth is obviously not the same thing as audio bandwidth, which is discussed in {{anch("Sampling audio")}}, above.</p>
+<p><strong>Note:</strong> Network bandwidth is obviously not the same thing as audio bandwidth, which is discussed in {{anch("Sampling audio")}}, above.</p>
 </div>
 
 <h2 id="Audio_compression_basics">Audio compression basics</h2>
@@ -135,8 +133,7 @@ tags:
 <p>If loss of detail and potentially fidelity is unacceptable or undesirable, a <strong>lossless</strong> codec is preferred. On the other hand, if some degree of reduction of audio fidelity is okay, a <strong>lossy</strong> codec can be used. Generally, lossy compression results in significantly smaller output than lossless compression methods; also, many lossy codecs are excellent, with the loss in quality and detail being difficult or even impossible for the average listener to discern.</p>
 
 <div class="notecard note">
-<h4>Note</h4>
-<p>While a high-quality lossy compression algorithm's effect on sound quality may be difficult for the average person to detect, certain people have exceptionally good hearing, or are particularly adept at noticing the kinds of changes introduced to music by lossy compression techniques.</p>
+<p><strong>Note:</strong> While a high-quality lossy compression algorithm's effect on sound quality may be difficult for the average person to detect, certain people have exceptionally good hearing, or are particularly adept at noticing the kinds of changes introduced to music by lossy compression techniques.</p>
 </div>
 
 <p>The majority of audio codecs use some form of lossy compression, because of the better compression ratio those algorithms offer. Whereas lossless compression algorithms usually manage no better than a 40-50% of the size of the original, uncompressed sound data, modern lossy compression algorithms can reduce the size of the audio to between 5-20% of the original size, depending on the complexity of the audio. The vastly superior compression ratios possible with lossy compression usually make it a compelling choice, and adequate or excellent audio quality is possible with well-chosen codec configurations.</p>
@@ -168,8 +165,7 @@ tags:
 <p>The type of content being encoded can affect the choice of codec. In particular, the waveform for music is almost always more complex than that of an audio sample that contains only human voices. In addition, the human voice uses a small portion of the range of audio frequencies the human ear can detect.</p>
 
 <div class="notecard note">
-	<h3>Note</h3>
-	<p>Telephone networks, which were originally designed specifically to transmit human voices, can only carry audio (or any other kind of signal) in the frequency band from 300 Hz to 3,000 Hz. This doesn't quite cover the entire range of human speech at the low end, but enough of the waveform is available that the human ear and brain compensate easily. This also means that humans are generally acclimated to hearing speech constrainted to so narrow an audio bandwidth.</p>
+	<p><strong>Note:</strong> Telephone networks, which were originally designed specifically to transmit human voices, can only carry audio (or any other kind of signal) in the frequency band from 300 Hz to 3,000 Hz. This doesn't quite cover the entire range of human speech at the low end, but enough of the waveform is available that the human ear and brain compensate easily. This also means that humans are generally acclimated to hearing speech constrainted to so narrow an audio bandwidth.</p>
 </div>
 
 <p>Human speech uses a relatively narrow frequency band (around 300 Hz to 18,000 Hz, though the exact range varies from person to person due to factors including gender). In addition, the vast majority of human speech sounds tend to lie between 500 Hz and 3,000 Hz or so, making it possible to drop substantial portions of the overall waveform without compromising the listener's ability to understand the words being said. You can even adjust the audio bandwidth to factor in the pitch of the individual speaker's voice.</p>
@@ -191,8 +187,7 @@ tags:
 <p>Importantly, codecs do all the hard work for you. It's why so much engineering and scientific study goes into the creation of new algorithms and codecs. All you need to do is consider the options and your use case, then choose the appropriate codec for your needs.</p>
 
 <div class="notecard note">
-<h3>Note</h3>
-<p>For a more detailed guide to choosing audio codecs, see {{SectionOnPage("/en-US/docs/Web/Media/Formats/Audio_codecs", "Choosing a codec")}}.</p>
+<p><strong>Note:</strong> For a more detailed guide to choosing audio codecs, see {{SectionOnPage("/en-US/docs/Web/Media/Formats/Audio_codecs", "Choosing a codec")}}.</p>
 </div>
 
 <h2 id="Lossless_encoder_parameters">Lossless encoder parameters</h2>
@@ -249,21 +244,17 @@ tags:
 
 <p>In other words, given a left channel, L, and a right channel, R, you perform the following calculations when encoding a sample:</p>
 
-<div class="twocolumns" style="max-width: 42em;">
-<div><math display="block"><semantics><mrow><mi mathvariant="italic">mid</mi><mo>=</mo><mfrac><mrow><mi>L</mi><mo>+</mo><mi>R</mi></mrow><mn>2</mn></mfrac></mrow><annotation encoding="TeX">mid = \frac { L + R }{ 2 } </annotation></semantics></math></div>
+<math display="block"><semantics><mrow><mi mathvariant="italic">mid</mi><mo>=</mo><mfrac><mrow><mi>L</mi><mo>+</mo><mi>R</mi></mrow><mn>2</mn></mfrac></mrow><annotation encoding="TeX">mid = \frac { L + R }{ 2 } </annotation></semantics></math>
 
-<div><math display="block"><semantics><mrow><mi mathvariant="italic">side</mi><mo>=</mo><mfrac><mrow><mi>L</mi><mo>-</mo><mi>R</mi></mrow><mn>2</mn></mfrac></mrow><annotation encoding="TeX">side = \frac { L - R }{ 2 } </annotation></semantics></math></div>
-</div>
+<math display="block"><semantics><mrow><mi mathvariant="italic">side</mi><mo>=</mo><mfrac><mrow><mi>L</mi><mo>-</mo><mi>R</mi></mrow><mn>2</mn></mfrac></mrow><annotation encoding="TeX">side = \frac { L - R }{ 2 } </annotation></semantics></math>
 
 <p>Then you store the values of <code>mid</code> and <code>side</code>. While <code>mid</code> is still the same size as your sample size (such as 16 bits), the value of <code>side</code> can probably be stored in a smaller number of bits, since the amplitude of the two channels is probably relatively similar. The encoder can then take this smaller number of total bits per frame and perform additional computations to further reduce the size.</p>
 
 <p>While decoding the audio, the absolute left and right channel values are calculated like this:</p>
 
-<div class="twocolumns" style="max-width: 42em;">
-<div><math display="block"><semantics><mrow><mi>L</mi><mo>=</mo><mi mathvariant="italic">mid</mi> <mo>+</mo> <mi mathvariant="italic">side</mi></mrow><annotation encoding="TeX">L\quad =\quad mid\quad +\quad side</annotation></semantics></math></div>
+<math display="block"><semantics><mrow><mi>L</mi><mo>=</mo><mi mathvariant="italic">mid</mi> <mo>+</mo> <mi mathvariant="italic">side</mi></mrow><annotation encoding="TeX">L\quad =\quad mid\quad +\quad side</annotation></semantics></math>
 
-<div><math display="block"><semantics><mrow><mi>R</mi><mo>=</mo><mi mathvariant="italic">mid</mi> <mo>-</mo> <mi mathvariant="italic">side</mi></mrow><annotation encoding="TeX">L\quad =\quad mid\quad -\quad side</annotation></semantics></math></div>
-</div>
+<math display="block"><semantics><mrow><mi>R</mi><mo>=</mo><mi mathvariant="italic">mid</mi> <mo>-</mo> <mi mathvariant="italic">side</mi></mrow><annotation encoding="TeX">L\quad =\quad mid\quad -\quad side</annotation></semantics></math>
 
 <p>On its own, mid-side stereo coding is lossless, and is commonly used by both lossless and lossy audio codecs. Any loss of detail comes from other steps of the encoding process.</p>
 

--- a/files/en-us/web/media/formats/codecs_parameter/index.html
+++ b/files/en-us/web/media/formats/codecs_parameter/index.html
@@ -54,14 +54,13 @@ tags:
 <p>As is the case with any MIME type parameter, <code>codecs</code> must be changed to <code>codecs*</code> (note the asterisk character, <code>*</code>) if any of the properties of the codec use special characters which must be percent-encoded per {{RFC(2231, "MIME Parameter Value and Encoded Word Extensions", 4)}}. You can use the JavaScript {{jsxref("Global_Objects/encodeURI", "encodeURI()")}} function to encode the parameter list; similarly, you can use {{jsxref("Global_Objects/decodeURI", "decodeURI()")}} to decode a previously encoded parameter list.</p>
 
 <div class="notecard note">
-<p>When the <code>codecs</code> parameter is used, the specified list of codecs must include every codec used for the contents of the file. The list may also contain codecs not present in the file.</p>
+<p><strong>Note:</strong> When the <code>codecs</code> parameter is used, the specified list of codecs must include every codec used for the contents of the file. The list may also contain codecs not present in the file.</p>
 </div>
 
 <h2 id="Codec_options_by_container">Codec options by container</h2>
 
 <p>The containers below support extended codec options in their <code>codecs</code> parameters:</p>
 
-<div class="index">
 <ul>
  <li>{{anch("iso_base_media_file_format_mp4_quicktime_and_3gp", "3GP")}}</li>
  <li>{{anch("AV1")}}</li>
@@ -70,7 +69,6 @@ tags:
  <li>{{anch("iso_base_media_file_format_mp4_quicktime_and_3gp", "QuickTime")}}</li>
  <li>{{anch("WebM")}}</li>
 </ul>
-</div>
 
 <p>Several of the links above go to the same section; that's because those media types are all based on ISO Base Media File Format (ISO BMFF), so they share the same syntax.</p>
 
@@ -669,12 +667,17 @@ tags:
   </tr>
   <tr>
    <td><code>43</code></td>
-   <td>SAOC (Spatial Audio Object Coding)<sup><a href="#audio-object-types-foot-1">[1]</a></sup></td>
+   <td>
+     <p>SAOC (Spatial Audio Object Coding)</p>
+     <p>Defined in <a href="https://www.iso.org/standard/54838.html">ISO/IEC 14496-3:2009/Amd.2:2010(E)</a>.</p></td>
    <td></td>
   </tr>
   <tr>
    <td><code>44</code></td>
-   <td>LD MPEG Surround (Low Delay MPEG Surround)<sup><a href="#audio-object-types-foot-1">[1]</a></sup></td>
+   <td>
+     <p>LD MPEG Surround (Low Delay MPEG Surround)</p>
+     <p>Defined in <a href="https://www.iso.org/standard/54838.html">ISO/IEC 14496-3:2009/Amd.2:2010(E)</a>.</p>
+   </td>
    <td></td>
   </tr>
   <tr>
@@ -684,8 +687,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a name="audio-object-types-foot-1">[1]</a> SAOC and LD MPEG Surround are defined in <a href="https://www.iso.org/standard/54838.html">ISO/IEC 14496-3:2009/Amd.2:2010(E)</a>.</p>
 
 <h3 id="WebM">WebM</h3>
 

--- a/files/en-us/web/media/formats/containers/index.html
+++ b/files/en-us/web/media/formats/containers/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <th scope="row">Codec name (short)</th>
    <th scope="col">Full codec name</th>
-   <th scope="col">Browser compatibility<sup><a href="#index-foot-1">1</a></sup></th>
+   <th scope="col">Browser compatibility</th>
   </tr>
  </thead>
  <tbody>
@@ -46,7 +46,9 @@ tags:
   <tr>
    <th scope="row">{{anch("ADTS")}}</th>
    <td>Audio Data Transport Stream</td>
-   <td>Firefox<sup><a href="#index-foot-2">2</a></sup></td>
+   <td>
+     <p>Firefox</p>
+     <p>Available only if available on the underlying operating system's media framework.</p></td>
   </tr>
   <tr>
    <th scope="row">{{anch("FLAC")}}</th>
@@ -66,7 +68,10 @@ tags:
   <tr>
    <th scope="row">{{anch("Ogg")}}</th>
    <td>Ogg</td>
-   <td>Chrome 3, Firefox 3.5, Edge 17<sup><a href="#index-foot-3">3</a></sup> (desktop only), Internet Explorer 9, Opera 10.50</td>
+   <td>
+     <p>Chrome 3, Firefox 3.5, Edge 17 (desktop only), Internet Explorer 9, Opera 10.50</p>
+     <p>Edge requires <a href="https://www.microsoft.com/store/productId/9N5TDP8VCMHS">Web Media Extensions</a> to be installed.</p>
+   </td>
   </tr>
   <tr>
    <th scope="row">{{anch("QuickTime", "QuickTime (MOV)")}}</th>
@@ -76,16 +81,15 @@ tags:
   <tr>
    <th scope="row">{{anch("WebM")}}</th>
    <td>Web Media</td>
-   <td>Chrome 6, Edge 17<sup><a href="#index-foot-3">3</a></sup> (desktop only), Firefox 4, Opera 10.6, Safari (WebRTC only)</td>
+   <td>
+     <p>Chrome 6, Edge 17 (desktop only), Firefox 4, Opera 10.6, Safari (WebRTC only)</p>
+     <p>Edge requires <a href="https://www.microsoft.com/store/productId/9N5TDP8VCMHS">Web Media Extensions</a> to be installed.</p>
+   </td>
   </tr>
  </tbody>
 </table>
 
-<p><a id="index-foot-1">[1]</a> Unless otherwise specified, both mobile and desktop browser compatibility is implied if a browser is listed here. Support is also implied only for the container itself, not for any specific codecs.</p>
-
-<p><a id="index-foot-2">[2]</a> Available only if available on the underlying operating system's media framework.</p>
-
-<p><a name="index-foot-3">[3]</a> Requires <a href="https://www.microsoft.com/store/productId/9N5TDP8VCMHS">Web Media Extensions</a> to be installed.</p>
+<p>Unless otherwise specified, both mobile and desktop browser compatibility is implied if a browser is listed here. Support is also implied only for the container itself, not for any specific codecs.</p>
 
 <h3 id="3GP">3GP</h3>
 
@@ -138,36 +142,32 @@ tags:
    <th scope="row">AVC (H.264)</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-vid-footnote-1">1</a>,<a href="#3gp-vid-footnote-1">2</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">H.263</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-vid-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">MPEG-4 Part 2 (MP4v-es)</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-vid-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">VP8</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-vid-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
  </tbody>
 </table>
-
-<p><a id="3gp-vid-footnote-1">[1]</a> Firefox only supports 3GP on <a href="https://www.khronos.org/openmax/">OpenMAX</a>-based devices, which currently means the Boot to Gecko (B2G) platform.</p>
-
-<p><a id="3gp-vid-footnote-2">[2]</a> Firefox support for H.264 relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
 
 <table class="standard-table">
  <caption>Audio codecs supported by 3GP</caption>
@@ -188,57 +188,53 @@ tags:
    <th scope="row">AMR-NB</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">AMR-WB</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">AMR-WB+</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">AAC-LC</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a>,<a href="#av1-vid-footnote-2">2</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">HE-AAC v1</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a>,<a href="#av1-vid-footnote-2">2</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">HE-AAC v2</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a>,<a href="#av1-vid-footnote-2">2</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">MP3</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#3gp-aud-footnote-1">1</a></sup></td>
+   <td></td>
    <td></td>
   </tr>
  </tbody>
 </table>
-
-<p><a id="3gp-aud-footnote-1">[1]</a> Firefox only supports 3GP on <a href="https://www.khronos.org/openmax/">OpenMAX</a>-based devices, which currently means the Boot to Gecko (B2G) platform.</p>
-
-<p><a id="3gp-aud-footnote-2">[2]</a> Firefox support for AAC relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
 
 <h3 id="ADTS">ADTS</h3>
 
@@ -253,15 +249,15 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code>audio/aac</code><sup><a href="#adts-foot-1">[1]</a></sup></td>
+   <td><code>audio/aac</code></td>
   </tr>
   <tr>
-   <td><code>audio/mpeg</code><sup><a href="#adts-foot-1">[1]</a></sup></td>
+   <td><code>audio/mpeg</code></td>
   </tr>
  </tbody>
 </table>
 
-<p><a id="adts-foot-1">[1]</a> The MIME type used for ADTS depends on what kind of audio frames are contained within. If ADTS frames are used, the <code>audio/aac</code> MIME type should be used. If the audio frames are in MPEG-1/MPEG-2 Audio Layer I, II, or III format, the MIME type should be <code>audio/mpeg</code>.</p>
+<p>The MIME type used for ADTS depends on what kind of audio frames are contained within. If ADTS frames are used, the <code>audio/aac</code> MIME type should be used. If the audio frames are in MPEG-1/MPEG-2 Audio Layer I, II, or III format, the MIME type should be <code>audio/mpeg</code>.</p>
 
 <table class="standard-table">
  <caption>Audio codecs supported by ADTS</caption>
@@ -282,7 +278,7 @@ tags:
    <th scope="row">AAC</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#adts-aud-footnote-1">1</a></sup></td>
+   <td>Yes</td>
    <td></td>
   </tr>
   <tr>
@@ -295,7 +291,7 @@ tags:
  </tbody>
 </table>
 
-<p><a id="adts-aud-footnote-1">[1]</a> Firefox support for AAC relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
+<p>Firefox support for AAC relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
 
 <h3 id="FLAC">FLAC</h3>
 
@@ -483,14 +479,20 @@ tags:
    <th scope="row">AVC (H.264)</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#mp4-vid-footnote-1">1</a></sup></td>
+   <td>
+     <p>Yes</p>
+     <p>Firefox support for H.264 relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
+   </td>
    <td></td>
   </tr>
   <tr>
    <th scope="row">AV1</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#mp4-vid-footnote-1">1</a></sup></td>
+   <td>
+     <p>Yes</p>
+     <p>Firefox support for AV1 is currently disabled by default; it can be enabled by setting the preference <code>media.av1.enabled</code> to <code>true</code>.</p>
+   </td>
    <td></td>
   </tr>
   <tr>
@@ -517,10 +519,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="mp4-vid-footnote-1">[1]</a> Firefox support for H.264 relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
-
-<p><a id="mp4-vid-footnote-2">[2]</a> Firefox support for AV1 is currently disabled by default; it can be enabled by setting the preference <code>media.av1.enabled</code> to <code>true</code>.</p>
-
 <table class="standard-table">
  <caption>Audio codecs supported by MPEG-4</caption>
  <thead>
@@ -540,7 +538,10 @@ tags:
    <th scope="row">AAC</th>
    <td></td>
    <td></td>
-   <td>Yes<sup><a href="#mp4-aud-footnote-1">1</a></sup></td>
+   <td>
+     <p>Yes</p>
+     <p>Firefox support for H.264 relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
+   </td>
    <td></td>
   </tr>
   <tr>
@@ -566,8 +567,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="mp4-aud-footnote-1">[1]</a> Firefox support for H.264 relies upon the operating system's media infrastructure, so it is available as long as the OS supports it.</p>
 
 <h3 id="Ogg">Ogg</h3>
 
@@ -884,7 +883,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code>audio/wave</code><sup><a href="#wave-foot-1">1</a></sup></td>
+   <td><code>audio/wave</code></td>
   </tr>
   <tr>
    <td><code>audio/wav</code></td>
@@ -898,7 +897,7 @@ tags:
  </tbody>
 </table>
 
-<p><a id="wave-foot-1">[1]</a> The <code>audio/wave</code> MIME type is the standard type, and is preferred; however, the others have been used by various products over the years and may be used as well in some environments. </p>
+<p>The <code>audio/wave</code> MIME type is the standard type, and is preferred; however, the others have been used by various products over the years and may be used as well in some environments. </p>
 
 <table class="standard-table">
  <caption>Audio codecs supported by WAVE</caption>
@@ -994,7 +993,10 @@ tags:
    <th scope="row">AV1</th>
    <td>Yes</td>
    <td>Yes</td>
-   <td>Yes<sup><a href="#av1-vid-footnote-1">1</a></sup></td>
+   <td>
+     <p>Yes</p>
+     <p>Firefox support for AV1 was added to macOS in Firefox 66; for Windows in Firefox 67; and Firefox 68 on Linux. Firefox for Android does not yet support AV1; the implementation in Firefox is designed to use a secure process, which is not supported yet in Android.</p>
+   </td>
    <td>Yes</td>
   </tr>
   <tr>
@@ -1013,8 +1015,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="av1-vid-footnote-1">[1]</a> Firefox support for AV1 was added to macOS in Firefox 66; for Windows in Firefox 67; and Firefox 68 on Linux. Firefox for Android does not yet support AV1; the implementation in Firefox is designed to use a secure process, which is not supported yet in Android.</p>
 
 <table class="standard-table">
  <caption>Audio codecs supported by WebM</caption>
@@ -1135,8 +1135,6 @@ tags:
 <p>In the example shown here, a video is offered to the browser in two formats: WebM and MP4.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/source.html", "tabbed-standard")}}</div>
-
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</p>
 
 <p>The video is offered first in WebM format (with the {{htmlattrxref("type", "video")}} attribute set to <code>video/webm</code>). If the {{Glossary("user agent")}} can't play that, it moves on to the next option, whose <code>type</code> is specified as <code>video/mp4</code>. If neither of those can be played, the text "This browser does not support the HTML5 video element." is presented.</p>
 

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -34,7 +34,6 @@ tags:
 
 <p>The image file formats that are most commonly used on the web are listed below.</p>
 
-<div id="table-of-image-file-types">
 <table class="standard-table">
  <thead>
   <tr>
@@ -47,7 +46,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="#apng">APNG</a></th>
+   <th scope="row"><a href="#APNG_Animated_Portable_Network_Graphics">APNG</a></th>
    <th scope="row">Animated Portable Network Graphics</th>
    <td><code>image/apng</code></td>
    <td><code>.apng</code></td>
@@ -55,7 +54,7 @@ tags:
     <strong>Supported</strong>: Chrome, Edge, Firefox, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="#avif">AVIF</a></th>
+   <th scope="row"><a href="#AVIF_image">AVIF</a></th>
    <th scope="row">AV1 Image File Format</th>
    <td><code>image/avif</code></td>
    <td><code>.avif</code></td>
@@ -65,7 +64,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <th scope="row"><a href="#gif">GIF</a></th>
+   <th scope="row"><a href="#GIF_Graphics_Interchange_Format">GIF</a></th>
    <th scope="row">Graphics Interchange Format</th>
    <td><code>image/gif</code></td>
    <td><code>.gif</code></td>
@@ -73,7 +72,7 @@ tags:
     <strong>Supported:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="#jpeg">JPEG</a></th>
+   <th scope="row"><a href="#JPEG_Joint_Photographic_Experts_Group_image">JPEG</a></th>
    <th scope="row">Joint Photographic Expert Group image</th>
    <td><code>image/jpeg</code></td>
    <td><code>.jpg</code>, <code>.jpeg</code>, <code>.jfif</code>, <code>.pjpeg</code>, <code>.pjp</code></td>
@@ -83,7 +82,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <th scope="row"><a href="#png">PNG</a></th>
+   <th scope="row"><a href="#PNG_Portable_Network_Graphics">PNG</a></th>
    <th scope="row">Portable Network Graphics</th>
    <td><code>image/png</code></td>
    <td><code>.png</code></td>
@@ -93,7 +92,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <th scope="row"><a href="#svg">SVG</a></th>
+   <th scope="row"><a href="#SVG_Scalable_Vector_Graphics">SVG</a></th>
    <th scope="row">Scalable Vector Graphics</th>
    <td><code>image/svg+xml</code></td>
    <td><code>.svg</code></td>
@@ -101,7 +100,7 @@ tags:
     <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row"><a href="#webp">WebP</a></th>
+   <th scope="row"><a href="#WebP_image">WebP</a></th>
    <th scope="row">Web Picture format</th>
    <td><code>image/webp</code></td>
    <td><code>.webp</code></td>
@@ -110,7 +109,6 @@ tags:
   </tr>
  </tbody>
 </table>
-</div>
 
 <div class="notecard note">
   <p><strong>Note:</strong> The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).</p>
@@ -118,7 +116,6 @@ tags:
 
 <p>The following list includes image formats that appear on the web, but which should be avoided for web content (generally this is because either they do not have wide browser support, or because there are better alternatives).</p>
 
-<div id="table-of-less-used-image-file-types">
 <table class="standard-table">
  <thead>
   <tr>
@@ -131,21 +128,21 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="#bmp">BMP</a></th>
+   <th scope="row"><a href="#BMP_Bitmap_file">BMP</a></th>
    <th scope="row">Bitmap file</th>
    <td><code>image/bmp</code></td>
    <td><code>.bmp</code></td>
    <td>Chrome, Edge, Firefox, IE, Opera, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="#ico">ICO</a></th>
+   <th scope="row"><a href="#ICO_Microsoft_Windows_icon">ICO</a></th>
    <th scope="row">Microsoft Icon</th>
    <td><code>image/x-icon</code></td>
    <td><code>.ico</code>, <code>.cur</code></td>
    <td>Chrome, Edge, Firefox, IE, Opera, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="#tiff">TIFF</a></th>
+   <th scope="row"><a href="#TIFF_Tagged_Image_File_Format">TIFF</a></th>
    <th scope="row">Tagged Image File Format</th>
    <td><code>image/tiff</code></td>
    <td><code>.tif</code>, <code>.tiff</code></td>
@@ -153,14 +150,13 @@ tags:
   </tr>
  </tbody>
 </table>
-</div>
 
 <div class="notecard note">
   <p><strong>Note:</strong> The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).</p>
 </div>
 
 <div class="notecard note">
-	<p><strong>Tip:</strong> Safari 11.1 added the ability to use a video format, as an animated gif replacement. No other browser supports this. See the <a href="https://crbug.com/791658">Chromium bug</a>, and <a href="https://bugzil.la/895131">Firefox bug</a> for more information.</p>
+	<p><strong>Note:</strong> Safari 11.1 added the ability to use a video format, as an animated gif replacement. No other browser supports this. See the <a href="https://crbug.com/791658">Chromium bug</a>, and <a href="https://bugzil.la/895131">Firefox bug</a> for more information.</p>
 </div>
 
 <h2 id="Image_file_type_details">Image file type details</h2>
@@ -169,7 +165,6 @@ tags:
 
 <p>In the tables below, the term <strong>bits per component</strong> refers to the number of bits used to represent each color component. For example, an RGB color depth of 8 indicates that each of the red, green, and blue components are represented by an 8-bit value. <strong>Bit depth</strong>, on the other hand, is the total number of bits used to represent each pixel in memory.</p>
 
-<a id="apng"></a>
 <h3 id="APNG_Animated_Portable_Network_Graphics">APNG (Animated Portable Network Graphics)</h3>
 
 <p>APNG is a file format first introduced by Mozilla which extends the {{anch("PNG")}} standard to add support for animated images. Conceptually similar to the animated GIF format which has been in use for decades, APNG is more capable in that it supports a variety of {{interwiki("wikipedia", "color depth", "color depths")}}, whereas animated GIF supports only 8-bit {{interwiki("wikipedia", "indexed color")}}.</p>
@@ -250,7 +245,6 @@ tags:
  </tbody>
 </table>
 
-<a id="avif"></a>
 <h3 id="AVIF_image">AVIF image</h3>
 
 <p>AV1 Image File Format (AVIF) is a powerful, open source, royalty-free file format that encodes <dfn>AV1 bitstreams in the High Efficiency Image File Format (HEIF) container.</dfn></p>
@@ -340,14 +334,12 @@ tags:
  </tbody>
 </table>
 
-<a id="bmp"></a>
 <h3 id="BMP_Bitmap_file">BMP (Bitmap file)</h3>
 
 <p>The <strong>BMP</strong> (<strong>Bitmap image</strong>) file type is most prevalent on Windows computers, and is generally used only for special cases in web apps and content.</p>
 
 <div class="notecard warning">
-  <h4>Warning</h4>
-  <p>You should typically avoid using BMP files for web site content. The most common form of BMP file represents the data as an uncompressed raster image, resulting in large file sizes compared to png or jpg image tpes.  More efficient BMP formats exist but are not widely used, and rarely supported in web browsers.</p>
+  <p><strong>Warning:</strong> You should typically avoid using BMP files for web site content. The most common form of BMP file represents the data as an uncompressed raster image, resulting in large file sizes compared to png or jpg image tpes.  More efficient BMP formats exist but are not widely used, and rarely supported in web browsers.</p>
 </div>
 
 <p>BMP theoretically supports a variety of internal data representations. The simplest, and most commonly used, form of BMP file is an uncompressed raster image, with each pixel occupying 3 bytes representing its red, green, and blue components, and each row padded with <code>0x00</code> bytes to a multiple of 4 bytes wide.</p>
@@ -430,7 +422,6 @@ tags:
  </tbody>
 </table>
 
-<a id="gif"></a>
 <h3 id="GIF_Graphics_Interchange_Format">GIF (Graphics Interchange Format)</h3>
 
 <p>In 1987, the CompuServe online service provider introduced the <strong>{{interwiki("wikipedia", "GIF")}}</strong> (<strong>Graphics Interchange Format</strong>) image file format to provide a compressed graphics format that all members of their service would be able to use. GIF uses the {{interwiki("wikipedia", "Lempel-Ziv-Welch")}} (LZW) algorithm to losslessly compress 8-bit indexed color graphics. GIF was one of the first two graphics formats supported by {{Glossary("HTML")}}, along with {{anch("XBM")}}.</p>
@@ -522,7 +513,6 @@ tags:
  </tbody>
 </table>
 
-<a id="ico"></a>
 <h3 id="ICO_Microsoft_Windows_icon">ICO (Microsoft Windows icon)</h3>
 
 <p>The ICO (Microsoft Windows icon) file format was designed by Microsoft for desktop icons of Windows systems. However, early versions of Internet Explorer introduced the ability for a web site to provide a ICO file named <code>favicon.ico</code> in a web site's root directory to specify a <strong><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_custom_icons_to_your_site">favicon</a></strong> — an icon to be displayed in the Favorites menu, and other places where an iconic representation of the site would be useful.</p>
@@ -530,8 +520,7 @@ tags:
 <p>An ICO file can contain multiple icons, and begins with a directory listing details about each. Following the directory comes the data for the icons. Each icon's data can be either a {{anch("BMP")}} image without the file header, or a complete {{anch("PNG")}} image (including the file header). If you use ICO files, you should use the BMP format, as support for PNG inside ICO files wasn't added until Windows Vista and may not be well supported.</p>
 
 <div class="notecard warning">
-  <h4>Warning</h4>
-  <p>ICO files <em>should not</em> be used in web content. Additionally, their use for favicons has subsided in favor of using a PNG file and the {{HTMLElement("link")}} element, as described in {{SectionOnPage("/en-US/docs/Web/HTML/Element/link", "Providing icons for different usage contexts")}}.</p>
+  <p><strong>Warning:</strong> ICO files <em>should not</em> be used in web content. Additionally, their use for favicons has subsided in favor of using a PNG file and the {{HTMLElement("link")}} element, as described in {{SectionOnPage("/en-US/docs/Web/HTML/Element/link", "Providing icons for different usage contexts")}}.</p>
 </div>
 
 <table class="standard-table">
@@ -643,7 +632,6 @@ tags:
  </tbody>
 </table>
 
-<a id="jpeg"></a>
 <h3 id="JPEG_Joint_Photographic_Experts_Group_image">JPEG (Joint Photographic Experts Group image)</h3>
 
 <p>The {{Glossary("JPEG")}} (typically pronounced "<strong>jay-peg</strong>") image format is currently the most widely used lossy compression format for still images. It's particulary useful for photographs; applying lossy compression to content requiring sharpness, like diagrams or charts, can produce unsatisfactory results.</p>
@@ -724,7 +712,6 @@ tags:
  </tbody>
 </table>
 
-<a id="png"></a>
 <h3 id="PNG_Portable_Network_Graphics">PNG (Portable Network Graphics)</h3>
 
 <p>The {{Glossary("PNG")}} (pronounced "<strong>ping</strong>") image format uses lossless or lossy compression to provide more efficient compression, and supports higher color depths than {{anch("GIF")}}, as well as full alpha transparency support.</p>
@@ -863,12 +850,11 @@ tags:
   </tr>
   <tr>
    <th scope="row">Licensing</th>
-   <td>©2003 <a href="https://www.w3.org/">W3C</a><sup>®</sup> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
+   <td>©2003 <a href="https://www.w3.org/">W3C</a> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
   </tr>
  </tbody>
 </table>
 
-<a id="svg"></a>
 <h3 id="SVG_Scalable_Vector_Graphics">SVG (Scalable Vector Graphics)</h3>
 
 <p>SVG is an <a href="/en-US/docs/Glossary/XML">XML</a>-based {{interwiki("wikipedia", "vector graphics")}} format that specifies the contents of an image as a set of drawing commands that create shapes, lines, apply colors, filters, and so forth. SVG files are ideal for diagrams, icons, and other images which can be accurately drawn at any size. As such, SVG is popular for user interface elements in modern Web design.</p>
@@ -956,12 +942,11 @@ tags:
   </tr>
   <tr>
    <th scope="row">Licensing</th>
-   <td>©2018 <a href="https://www.w3.org/">W3C</a><sup>®</sup> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
+   <td>©2018 <a href="https://www.w3.org/">W3C</a> (<a href="http://www.lcs.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">software licensing</a> rules apply. No known royalty-bearing patents.</td>
   </tr>
  </tbody>
 </table>
 
-<a id="tiff"></a>
 <h3 id="TIFF_Tagged_Image_File_Format">TIFF (Tagged Image File Format)</h3>
 
 <p>{{interwiki("wikipedia", "TIFF")}} is a raster graphics file format which was created to store scanned photos, although it can be any kind of image. It is a somewhat "heavy" format, in that TIFF files have a tendency to be larger than images in other formats. This is because of the metadata often included, as well as the fact that most TIFF images are either uncompressed or use compression algorithms that still leave fairly large files after compression.</p>
@@ -1099,7 +1084,6 @@ tags:
  </tbody>
 </table>
 
-<a id="webp"></a>
 <h3 id="WebP_image">WebP image</h3>
 
 <p>WebP supports lossy compression via predictive coding based on the VP8 video codec, and lossless compression that uses substitutions for repeating data. Lossy WebP images average 25–35% smaller than JPEG images of visually similar compression levels. Lossless WebP images are typically 26% smaller than the same images in PNG format.</p>
@@ -1197,7 +1181,6 @@ tags:
   <p><strong>Note:</strong> Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
 </div>
 
-<a id="xbm"></a>
 <h3 id="XBM_X_Window_System_Bitmap_file">XBM (X Window System Bitmap file)</h3>
 
 <p>XBM (X Bitmap) files were the first to be supported on the Web, but are no longer used and should be avoided, as their format has potential security concerns. Modern browsers have not supported XBM files in many years, but when dealing with older content, you may find some still around.</p>

--- a/files/en-us/web/media/formats/index.html
+++ b/files/en-us/web/media/formats/index.html
@@ -48,7 +48,7 @@ tags:
 </dl>
 
 
-<h2 class="Documentation" id="Guides">Guides</h2>
+<h2 id="Guides">Guides</h2>
 
 <h3 id="Concepts">Concepts</h3>
 

--- a/files/en-us/web/media/formats/video_codecs/index.html
+++ b/files/en-us/web/media/formats/video_codecs/index.html
@@ -24,6 +24,8 @@ tags:
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}</div>
 
+<p>This guide introduces the video codecs you're most likely to encounter or consider using on the web, summaries of their capabilities and any compatibility and utility concerns, and advice to help you choose the right codec for your project's video.</p>
+
 <p>Due to the sheer size of uncompressed video data, it's necessary to compress it significantly in order to store it, let alone transmit it over a network. Imagine the amount of data needed to store uncompressed video:</p>
 
 <ul>
@@ -36,8 +38,6 @@ tags:
 <p>Not only is the required storage space enormous, but the network bandwidth needed to transmit an uncompressed video like that would be enormous, at 249 MB/sec—not including audio and overhead. This is where video codecs come in. Just as audio codecs do for the sound data, video codecs compress the video data and encode it into a format that can later be decoded and played back or edited.</p>
 
 <p>Most video codecs are <strong>lossy</strong>, in that the decoded video does not precisely match the source. Some details may be lost; the amount of loss depends on the codec and how it's configured, but as a general rule, the more compression you achieve, the more loss of detail and fidelity will occur. Some lossless codecs do exist, but they are typically used for archival and storage for local playback rather than for use on a network.</p>
-
-<p><span class="seoSummary">This guide introduces the video codecs you're most likely to encounter or consider using on the web, summaries of their capabilities and any compatibility and utility concerns, and advice to help you choose the right codec for your project's video.</span></p>
 
 <h2 id="Common_codecs">Common codecs</h2>
 
@@ -83,7 +83,7 @@ tags:
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#mpeg-2_part_2_video">MPEG-2</a></th> 
+   <th scope="row"><a href="#mpeg-2_part_2_video">MPEG-2</a></th>
    <td>MPEG-2 Part 2 Visual</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a></td>
   </tr>
@@ -348,7 +348,10 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Supported bit rates</th>
-   <td>Varies depending on the video's level; theoretical maximum reaches 800 Mbps at level 6.3<sup><a href="#av1-foot-2">[2]</a></sup></td>
+   <td>
+     <p>Varies depending on the video's level; theoretical maximum reaches 800 Mbps at level 6.3</p>
+     <p>See the AV1 specification's <a href="https://aomediacodec.github.io/av1-spec/#levels">tables of levels</a>, which describe the maximum resolutions and rates at each level.</p>
+   </td>
   </tr>
   <tr>
    <th scope="row">Supported frame rates</th>
@@ -430,7 +433,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Container support</th>
-   <td>ISOBMFF<sup><a href="#av1-foot-1">[1]</a></sup>, MPEG-TS, <a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
+   <td><a href="https://en.wikipedia.org/wiki/ISO/IEC_base_media_file_format">ISOBMFF</a>, MPEG-TS, <a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> compatible</th>
@@ -451,11 +454,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="av1-foot-1">[1]</a> {{interwiki("wikipedia", "ISO Base Media File Format")}}</p>
-
-<p><a name="av1-foot-2">[2]</a> See the AV1 specification's <a href="https://aomediacodec.github.io/av1-spec/#levels">tables of levels</a>, which describe the maximum resolutions and rates at each level.</p>
-
-<a name="AVC"></a>
 <h3 id="avc_h.264">AVC (H.264)</h3>
 
 <p>The MPEG-4 specification suite's <strong>Advanced Video Coding</strong> (<strong>AVC</strong>) standard is specified by the identical ITU H.264 specification and the MPEG-4 Part 10 specification. It's a motion compensation based codec that is widely used today for all sorts of media, including broadcast television, {{Glossary("RTP")}} videoconferencing, and as the video codec for Blu-Ray discs.</p>
@@ -575,13 +573,14 @@ tags:
        <th scope="row">AVC/H.264 support</th>
        <td>4</td>
        <td>12</td>
-       <td>35<sup><a href="#avc-foot-1">[1]</a></sup></td>
+       <td>35</td>
        <td>9</td>
        <td>25</td>
        <td>3.2</td>
       </tr>
      </tbody>
     </table>
+    <p>Firefox support for AVC is dependent upon the operating system's built-in or preinstalled codecs for AVC and its container in order to avoid patent concerns.</p>
    </td>
   </tr>
   <tr>
@@ -607,8 +606,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="avc-foot-1">[1]</a> Firefox support for AVC is dependent upon the operating system's built-in or preinstalled codecs for AVC and its container in order to avoid patent concerns.</p>
 
 <h3 id="H.263">H.263</h3>
 
@@ -638,7 +635,9 @@ tags:
   </tr>
   <tr>
    <th scope="row">Supported frame sizes</th>
-   <td>Up to 1408 x 1152 pixels<sup><a href="#h263-foot-2">[2]</a></sup></td>
+   <td>
+     <p>Up to 1408 x 1152 pixels.</p>
+     <p>Version 1 of H.263 specifies a set of picture sizes which are supported. Later versions may support additional resolutions.</p></td>
   </tr>
   <tr>
    <th scope="row">Supported color modes</th>
@@ -670,7 +669,7 @@ tags:
        <th scope="row">H.263 support</th>
        <td>No</td>
        <td>No</td>
-       <td>No<sup><a href="#h263-foot-1">[1]</a></sup></td>
+       <td>No</td>
        <td>No</td>
        <td>No</td>
        <td>No</td>
@@ -702,11 +701,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="h263-foot-1">[1]</a> While Firefox does not generally support H.263, the OpenMax platform implementation (used for the Boot to Gecko project upon which Firefox OS was based) did support H.263 in 3GP files.</p>
-
-<p><a id="h263-foot-2">[2]</a> Version 1 of H.263 specifies a set of picture sizes which are supported. Later versions may support additional resolutions.</p>
-
-<a id="hevc"></a>
 <h3 id="hevc_h.265">HEVC (H.265)</h3>
 
 <p>The <strong><a href="http://hevc.info/">High Efficiency Video Coding</a></strong> (<strong>HVEC</strong>) codec is defined by ITU's <strong>H.265</strong> as well as by MPEG-H Part 2 (the still in-development follow-up to MPEG-4). HEVC was designed to support efficient encoding and decoding of video in sizes including very high resolutions (including 8K video), with a structure specifically designed to let software take advantage of modern processors. Theoretically, HEVC can achieve compressed file sizes half that of <a href="#avc_h.264">AVC</a> but with comparable image quality.</p>
@@ -823,14 +817,17 @@ tags:
       <tr>
        <th scope="row">HEVC / H.265 support</th>
        <td>No</td>
-       <td>18<sup><a href="#hevc-foot--1">[1]</a></sup></td>
-       <td>No<sup><a href="#hevc-foot-2">[2]</a></sup></td>
-       <td>11<sup><a href="#hevc-foot--1">[1]</a></sup></td>
+       <td>18</td>
+       <td>No</td>
+       <td>11</td>
        <td>No</td>
        <td>11</td>
       </tr>
      </tbody>
     </table>
+    <p>Internet Explorer and Edge only supports HEVC on devices with a hardware codec.</p>
+
+    <p>Mozilla will not support HEVC while it is encumbered by patents.</p>
    </td>
   </tr>
   <tr>
@@ -856,10 +853,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="hevc-foot--1">[1]</a> Internet Explorer and Edge only supports HEVC on devices with a hardware codec.</p>
-
-<p><a id="hevc-foot-2">[2]</a> Mozilla will not support HEVC while it is encumbered by patents.</p>
 
 <h3 id="MP4V-ES">MP4V-ES</h3>
 
@@ -915,15 +908,18 @@ tags:
       </tr>
       <tr>
        <th scope="row">MP4V-ES support</th>
-       <td>No<sup><a href="#mp4ves-foot-2">[2]</a></sup></td>
        <td>No</td>
-       <td>Yes<sup><a href="#mp4ves-foot-1">[1]</a></sup></td>
+       <td>No</td>
+       <td>Yes</td>
        <td>No</td>
        <td>No</td>
        <td>No</td>
       </tr>
      </tbody>
     </table>
+    <p>Firefox supports MP4V-ES in <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a> containers only.</p>
+
+    <p>Chrome does not support MP4V-ES; however, Chrome OS does.</p>
    </td>
   </tr>
   <tr>
@@ -949,11 +945,6 @@ tags:
  </tbody>
 </table>
 
-<p><a id="mp4ves-foot-1">[1]</a> Firefox supports MP4V-ES in <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a> containers only.</p>
-
-<p><a name="mp4ves-foot-2">[2]</a> Chrome does not support MP4V-ES; however, Chrome OS does.</p>
-
-<a id="MPEG-1"></a>
 <h3 id="mpeg-1_part_2_video">MPEG-1 Part 2 Video</h3>
 
 <p><strong>MPEG-1 Part 2 Video</strong> was unveiled at the beginning of the 1990s. Unlike the later MPEG video standards, MPEG-1 was created solely by MPEG, without the {{Glossary("ITU", "ITU's")}} involvement.</p>
@@ -1040,10 +1031,9 @@ tags:
  </tbody>
 </table>
 
-<a id="MPEG-2"></a>
 <h3 id="mpeg-2_part_2_video">MPEG-2 Part 2 Video</h3>
 
-<p><span class="seoSummary"><strong><a href="https://en.wikipedia.org/wiki/H.262/MPEG-2_Part_2">MPEG-2 Part 2</a></strong> is the video format defined by the MPEG-2 specification, and is also occasionally referred to by its {{Glossary("ITU")}} designation, H.262.</span> It is very similar to MPEG-1 video—in fact, any MPEG-2 player can automatically handle MPEG-1 without any special work—except it has been expanded to support higher bit rates and enhanced encoding techniques.</p>
+<p><strong><a href="https://en.wikipedia.org/wiki/H.262/MPEG-2_Part_2">MPEG-2 Part 2</a></strong> is the video format defined by the MPEG-2 specification, and is also occasionally referred to by its {{Glossary("ITU")}} designation, H.262. It is very similar to MPEG-1 video—in fact, any MPEG-2 player can automatically handle MPEG-1 without any special work—except it has been expanded to support higher bit rates and enhanced encoding techniques.</p>
 
 <p>The goal was to allow MPEG-2 to compress standard definition television, so interlaced video is also supported. The standard definition compression rate and the quality of the resulting video met needs well enough that MPEG-2 is the primary video codec used for DVD video media.</p>
 
@@ -1232,7 +1222,9 @@ tags:
   </tr>
   <tr>
    <th scope="row">Variable Frame Rate (VFR) support</th>
-   <td>Yes<sup><a href="#theora-foot-1">[1]</a></sup></td>
+   <td>
+     <p>Yes</p>
+     <p>While Theora doesn't support Variable Frame Rate (VFR) within a single stream, multiple streams can be chained together within a single file, and each of those can have its own frame rate, thus allowing what is essentially VFR. However, this is impractical if the frame rate needs to change frequently.</p></td>
   </tr>
   <tr>
    <th scope="row">Browser compatibility</th>
@@ -1251,7 +1243,7 @@ tags:
       <tr>
        <th scope="row">Theora support</th>
        <td>3</td>
-       <td>Yes<sup><a href="#theora-foot-2">[2]</a></sup></td>
+       <td>Yes</td>
        <td>3.5</td>
        <td>No</td>
        <td>10.5</td>
@@ -1259,6 +1251,7 @@ tags:
       </tr>
      </tbody>
     </table>
+    <p>Edge supports Theora with the optional <a href="https://www.microsoft.com/en-us/p/web-media-extensions/9n5tdp8vcmhs?activetab=pivot:overviewtab">Web Media Extensions</a> add-on.</p>
    </td>
   </tr>
   <tr>
@@ -1283,10 +1276,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="theora-foot-1">[1]</a> While Theora doesn't support Variable Frame Rate (VFR) within a single stream, multiple streams can be chained together within a single file, and each of those can have its own frame rate, thus allowing what is essentially VFR. However, this is impractical if the frame rate needs to change frequently.</p>
-
-<p><a name="theora-foot-2">[2]</a> Edge supports Theora with the optional <a href="https://www.microsoft.com/en-us/p/web-media-extensions/9n5tdp8vcmhs?activetab=pivot:overviewtab">Web Media Extensions</a> add-on.</p>
 
 <h3 id="VP8">VP8</h3>
 
@@ -1343,23 +1332,30 @@ tags:
       <tr>
        <th scope="row">VP8 support</th>
        <td>25</td>
-       <td>14<sup><a href="#vp8-foot-1">[1]</a></sup></td>
+       <td>14</td>
        <td>4</td>
        <td>9</td>
        <td>16</td>
-       <td>12.1<sup><a href="#vp8-foot-2">[2]</a></sup></td>
+       <td>12.1</td>
       </tr>
       <tr>
        <th scope="row">MSE compatibility</th>
        <td></td>
        <td></td>
-       <td>Yes<sup><a href="#vp8-foot-3">3</a></sup></td>
+       <td>Yes</td>
        <td></td>
        <td></td>
        <td></td>
       </tr>
      </tbody>
     </table>
+
+    <p>Edge support for VP8 requires the use of <a href="/en-US/docs/Web/API/Media_Source_Extensions_API">Media Source Extensions</a>.</p>
+
+    <p>Safari only supports VP8 in WebRTC connections.</p>
+
+    <p>Firefox only supports VP8 in MSE when no H.264 hardware decoder is available. Use {{domxref("MediaSource.isTypeSupported()")}} to check for availability.</p>
+
    </td>
   </tr>
   <tr>
@@ -1384,12 +1380,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a name="vp8-foot-1">[1]</a> Edge support for VP8 requires the use of <a href="/en-US/docs/Web/API/Media_Source_Extensions_API">Media Source Extensions</a>.</p>
-
-<p><a id="vp8-foot-2">[2]</a> Safari only supports VP8 in WebRTC connections.</p>
-
-<p><a id="vp8-foot-3">[3]</a> Firefox only supports VP8 in MSE when no H.264 hardware decoder is available. Use {{domxref("MediaSource.isTypeSupported()")}} to check for availability.</p>
 
 <h3 id="VP9">VP9</h3>
 
@@ -1492,13 +1482,14 @@ tags:
        <th scope="row">MSE compatibility</th>
        <td></td>
        <td></td>
-       <td>Yes<sup><a href="#vp9-foot-1">1</a></sup></td>
+       <td>Yes</td>
        <td></td>
        <td></td>
        <td></td>
       </tr>
      </tbody>
     </table>
+    <p>Firefox only supports VP8 in MSE when no H.264 hardware decoder is available. Use {{domxref("MediaSource.isTypeSupported()")}} to check for availability.</p>
    </td>
   </tr>
   <tr>
@@ -1523,8 +1514,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><a id="vp9-foot-1">[1]</a> Firefox only supports VP8 in MSE when no H.264 hardware decoder is available. Use {{domxref("MediaSource.isTypeSupported()")}} to check for availability.</p>
 
 <h2 id="Choosing_a_video_codec">Choosing a video codec</h2>
 
@@ -1566,7 +1555,7 @@ tags:
 </ol>
 
 <div class="notecard note">
-<p>Keep in mind that the {{HTMLElement("video")}} element requires a closing <code>&lt;/video&gt;</code> tag, whether or not you have any {{HTMLElement("source")}} elements inside it.</p>
+<p><strong>Note:</strong> The {{HTMLElement("video")}} element requires a closing <code>&lt;/video&gt;</code> tag, whether or not you have any {{HTMLElement("source")}} elements inside it.</p>
 </div>
 
 <h3 id="Recommendations_for_high-quality_video_presentation">Recommendations for high-quality video presentation</h3>

--- a/files/en-us/web/media/formats/webrtc_codecs/index.html
+++ b/files/en-us/web/media/formats/webrtc_codecs/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Containerless_media">Containerless media</h2>
 
-<p>WebRTC uses bare {{domxref("MediaStreamTrack")}} objects for each track being shared from one peer to another, without a container or even a {{domxref("MediaStream")}} associated with the tracks. Which codecs can be within those tracks is not mandated by the WebRTC specification. However, {{RFC(7742)}} specifies that all WebRTC-compatible browsers must support <a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a> and <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">H.264</a>'s Constrained Baseline profile for video, and {{RFC(7874)}} specifies that browsers must support at least the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a> codec as well as <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711</a>'s PCMA and PCMU formats.</p>
+<p>WebRTC uses bare {{domxref("MediaStreamTrack")}} objects for each track being shared from one peer to another, without a container or even a {{domxref("MediaStream")}} associated with the tracks. Which codecs can be within those tracks is not mandated by the WebRTC specification. However, {{RFC(7742)}} specifies that all WebRTC-compatible browsers must support <a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a> and <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">H.264</a>'s Constrained Baseline profile for video, and {{RFC(7874)}} specifies that browsers must support at least the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a> codec as well as <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711_pulse_code_modulation_of_voice_frequencies">G.711</a>'s PCMA and PCMU formats.</p>
 
 <p>These two RFCs also lay out options that must be supported for each codec, as well as specific user comfort features such as echo cancelation. This guide reviews the codecs that browsers are required to implement as well as other codecs that some or all browsers support for WebRTC.</p>
 
@@ -55,12 +55,13 @@ tags:
   <tr>
    <th scope="row">{{anch("AVC", "AVC / H.264")}}</th>
    <td>Constrained Baseline (CB)</td>
-   <td>Chrome (52+), Edge, Firefox<sup><a href="#supported-foot-1">[1]</a></sup>, Safari</td>
+   <td>
+     <p>Chrome (52+), Edge, Firefox, Safari</p>
+     <p>Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See <a href="https://support.mozilla.org/en-US/kb/firefox-android-openh264">this article on SUMO</a> for details.</p>
+   </td>
   </tr>
  </tbody>
 </table>
-
-<p><a name="supported-foot-1">[1]</a> Firefox for Android 68 and later do not support AVC (H.264) anymore. This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections. See <a href="https://support.mozilla.org/en-US/kb/firefox-android-openh264">this article on SUMO</a> for details.</p>
 
 <p>For details on WebRTC-related considerations for each codec, see the sub-sections below by following the links on each codec's name.</p>
 
@@ -177,11 +178,11 @@ tags:
    <td>Chrome, Edge, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711 PCM (A-law)</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711_pulse_code_modulation_of_voice_frequencies">G.711 PCM (A-law)</a></th>
    <td>Chrome, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711 PCM (µ-law)</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711_pulse_code_modulation_of_voice_frequencies">G.711 PCM (µ-law)</a></th>
    <td>Chrome, Firefox, Safari</td>
   </tr>
  </tbody>
@@ -211,19 +212,19 @@ tags:
    <td>Chrome, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row">iLBC<sup><a href="#other-audio-foot-1">[1]</a></sup></th>
+   <th scope="row">iLBC</th>
    <td>Chrome, Safari</td>
   </tr>
   <tr>
-   <th scope="row">iSAC<sup><a href="#other-audio-foot-2">[2]</a></sup></th>
+   <th scope="row">iSAC</th>
    <td>Chrome, Safari</td>
   </tr>
  </tbody>
 </table>
 
-<p><a id="other-audio-foot-1">[1]</a> <strong>{{interwiki("wikipedia", "Internet Low Bitrate Codec")}}</strong> (<strong>iLBC</strong>) is an open-source narrow-band codec developed by Global IP Solutions and now Google, designed specifically for streaming voice audio. Google and some other browser developers have adopted it for WebRTC, but it is not available in all browsers and is not one of the mandatory codecs.</p>
+<p><strong>{{interwiki("wikipedia", "Internet Low Bitrate Codec")}}</strong> (<strong>iLBC</strong>) is an open-source narrow-band codec developed by Global IP Solutions and now Google, designed specifically for streaming voice audio. Google and some other browser developers have adopted it for WebRTC.</p>
 
-<p><a id="other-audio-foot-2">[2]</a> The <strong>{{interwiki("wikipedia", "Internet Speech Audio Codec")}}</strong> (<strong>iSAC</strong>) is another codec developed by Global IP Solutions and now owned by Google, which has open-sourced it. It's used by Google Talk, QQ, and other instant messaging clients and is specifically designed for voice transmissions which are encapsulated within an RTP stream. While it's not a mandatory codec, Safari and Chrome support it. Firefox and Edge do not.</p>
+<p>The <strong>{{interwiki("wikipedia", "Internet Speech Audio Codec")}}</strong> (<strong>iSAC</strong>) is another codec developed by Global IP Solutions and now owned by Google, which has open-sourced it. It's used by Google Talk, QQ, and other instant messaging clients and is specifically designed for voice transmissions which are encapsulated within an RTP stream.</p>
 
 <p><strong>{{interwiki("wikipedia", "Comfort noise")}}</strong> (<strong>CN</strong>) is a form of artificial background noise which is used to fill gaps in a transmission instead of using pure silence. This helps to avoid a jarring effect that can occur when voice activation and similar features cause a stream to stop sending data temporarily—a capability known as Discontinuous Transmission (DTX). In {{RFC(3389)}}, a method for providing an appropriate filler to use during silences.</p>
 

--- a/files/en-us/web/media/images/aspect_ratio_mapping/index.html
+++ b/files/en-us/web/media/images/aspect_ratio_mapping/index.html
@@ -46,10 +46,10 @@ tags:
   aspect-ratio: attr(width) / attr(height);
 }</pre>
 
-<p>This actually affects any element that acts as a container for complex or mixed visual media — {{htmlelement("embed")}}, {{htmlelement("iframe")}}, {{htmlelement("marquee")}}, {{htmlelement("object")}}, {{htmlelement("table")}}, and {{htmlelement("video")}}, in addition to actual images ({{htmlelement("img")}} and <strong id="docs-internal-guid-1a994dc9-7fff-a700-71f0-25b6cfe48215"> </strong><code>&lt;input type="image"&gt;</code>). When such an element has <code>width</code> and <code>height</code> attributes set on it, its aspect ratio will be calculated before load time, and be available to the browser.</p>
+<p>This actually affects any element that acts as a container for complex or mixed visual media — {{htmlelement("embed")}}, {{htmlelement("iframe")}}, {{htmlelement("marquee")}}, {{htmlelement("object")}}, {{htmlelement("table")}}, and {{htmlelement("video")}}, in addition to actual images ({{htmlelement("img")}} and <code>&lt;input type="image"&gt;</code>). When such an element has <code>width</code> and <code>height</code> attributes set on it, its aspect ratio will be calculated before load time, and be available to the browser.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Currently on Firefox this effect is being limited to actual <code>&lt;img&gt;</code> elements, as applying to other such elements may have undesirable results. See ({{bug(1583980)}}).</p>
+<p><strong>Note:</strong> Currently on Firefox this effect is being limited to actual <code>&lt;img&gt;</code> elements, as applying to other such elements may have undesirable results. See ({{bug(1583980)}}).</p>
 </div>
 
 <p>When the <code>width</code>/<code>height</code> of an <code>&lt;img&gt;</code> element — as set using HTML attributes — is overridden using CSS using something like this:</p>

--- a/files/en-us/web/media/images/index.html
+++ b/files/en-us/web/media/images/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>The {{Glossary("HTML")}} {{HTMLElement("img")}} element lets you embed images into an HTML document, while the {{HTMLElement("picture")}} element enables <a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images">responsive images</a>. In this guide you'll find links to resources that deal with adding images to websites.</p>
 
-<h2 class="Documentation" id="References">References</h2>
+<h2 id="References">References</h2>
 
 <p>These articles cover some of the HTML elements and CSS properties that are used to control how images are displayed on the web.</p>
 
@@ -33,7 +33,7 @@ tags:
  <dd>The <strong><code>background-image</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets one or more background images for an element.</dd>
 </dl>
 
-<h2 class="Documentation" id="Guides">Guides</h2>
+<h2 id="Guides">Guides</h2>
 
 <p>These articles provide guidance on selecting and configuring image types.</p>
 

--- a/files/en-us/web/media/index.html
+++ b/files/en-us/web/media/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p><span class="seoSummary">Over the years, the Web's ability to present, create, and manage audio, video, and other media has grown at an increasing pace. Today, there are a large number of APIs available, as well as HTML elements, DOM interfaces, and other features that make it possible to not only perform these tasks, but use media in tandem with other technologies to do truly remarkable things. This article lists the various APIs with links to documentation you may find helpful in mastering them.</span></p>
 
-<h2 class="Documentation" id="References">References</h2>
+<h2 id="References">References</h2>
 
 <h3 id="HTML">HTML</h3>
 
@@ -46,7 +46,7 @@ tags:
  <dd>WebRTC (Web Real-Time Communication) makes it possible to stream live audio and video, as well as transfer arbitrary data, between two peers over the Internet, without requiring an intermediary.</dd>
 </dl>
 
-<h2 class="Documentation" id="Guides">Guides</h2>
+<h2 id="Guides">Guides</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Media/HTML_media">Using audio and video in HTML</a></dt>


### PR DESCRIPTION
This PR prepares https://developer.mozilla.org/en-US/docs/Web/Media for Markdowning.

Apart from the usual randomness, the main changes here are:
* removing elements like `<a id="AAC"></a>`, that are used to provide link targets, and updating any links that use those targets to use heading IDs instead.
* removing elements like `<a name="aac-foot-1">[1]</a>`, that are used to provide targets for footnotes linked from the tables, and doing something else with the footnote (usually just copying it into the table).

After this PR there will be lots of unconverted tables, but nothing else.

There is good content in this bit of the docs, but I think it would be much more approachable if it were split up into more pages.