### PR TITLE
Missing preposition `in` on Visual Viewport API

### DIFF
--- a/files/en-us/web/api/visual_viewport_api/index.md
+++ b/files/en-us/web/api/visual_viewport_api/index.md
@@ -36,7 +36,7 @@ To access a window's visual viewport, you can obtain a {{domxref("VisualViewport
 
 ## Example
 
-The code below is based on the sample in the specification, though it adds a few things that make it function better. It shows a function called `viewportHandler()`. When called it queries the `offsetLeft` and `height` properties for values it uses in a CSS `translate()` method. You invoke this function by passing it to *both* event calls.
+The code below is based on [the sample in the specification](https://github.com/WICG/visual-viewport/blob/gh-pages/examples/fixed-to-viewport.html), though it adds a few things that make it function better. It shows a function called `viewportHandler()`. When called it queries the `offsetLeft` and `height` properties for values it uses in a CSS `translate()` method. You invoke this function by passing it to *both* event calls.
 
 One thing that may not be clear in this example is the use of the `pendingUpdate` flag and the call to `requestAnimationFrame()`. The `pendingUpdate` flag serves to prevent multiple invocations of the transfrom that can occur when `onresize` and `onscroll` fire at the same time. Using `requestAnimationFrame()` ensures that the transform occurs before the next render.
 

--- a/files/en-us/web/api/visual_viewport_api/index.md
+++ b/files/en-us/web/api/visual_viewport_api/index.md
@@ -36,7 +36,7 @@ To access a window's visual viewport, you can obtain a {{domxref("VisualViewport
 
 ## Example
 
-The code below is based on the sample the specification, though it adds a few things that make it function better. It shows a function called `viewportHandler()`. When called it queries the `offsetLeft` and `height` properties for values it uses in a CSS `translate()` method. You invoke this function by passing it to *both* event calls.
+The code below is based on the sample in the specification, though it adds a few things that make it function better. It shows a function called `viewportHandler()`. When called it queries the `offsetLeft` and `height` properties for values it uses in a CSS `translate()` method. You invoke this function by passing it to *both* event calls.
 
 One thing that may not be clear in this example is the use of the `pendingUpdate` flag and the call to `requestAnimationFrame()`. The `pendingUpdate` flag serves to prevent multiple invocations of the transfrom that can occur when `onresize` and `onscroll` fire at the same time. Using `requestAnimationFrame()` ensures that the transform occurs before the next render.
 


### PR DESCRIPTION
#### Summary
Inserts the preposition ~~`of`~~ `in` between `the sample` and `the specification`
Current: `the sample the specification`
My suggestion: `the sample in the specification`

It also links to the actual code of the sample in the specification repository.

#### Motivation
I believe that there is a missing ~~`of`~~ `in` preposition that links the part `sample` to the whole `specification`, at least it sounds better in my head with it.

**Question**: should we take advantage of this and also link to the actual example code of the specification repository?
I can't find the example code linked in the spec page, so perhaps it's useful to provide a direct link to it as it also has more examples.
Code example: https://github.com/WICG/visual-viewport/blob/gh-pages/examples/fixed-to-viewport.html
Spec page: https://wicg.github.io/visual-viewport/

It would end up like this:
```md
The code below is based on [the sample in the specification](https://github.com/WICG/visual-viewport/blob/gh-pages/examples/fixed-to-viewport.html), though it adds
```


#### Supporting details
https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API#example

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
