### PR TITLE
Fixes #9776 - immediate return from Promise.any

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Promise.any
 ---
 {{JSRef}}
 
-`Promise.any()` takes an iterable of {{JSxRef("Promise")}} objects and, as soon as one of the promises in the iterable fulfills, returns a single promise that resolves with the value from that promise. If no promises in the iterable fulfill (if all of the given promises are rejected), then the returned promise is rejected with an {{JSxRef("AggregateError")}}, a new subclass of {{JSxRef("Error")}} that groups together individual errors.
+`Promise.any()` takes an iterable of {{JSxRef("Promise")}} objects and returns a single promise that resolves with the value of the earliest fulfilled promise from the iterable. If no promises in the iterable fulfill (if all of the given promises are rejected), then the returned promise is rejected with an {{JSxRef("AggregateError")}}, a new subclass of {{JSxRef("Error")}} that groups together individual errors.
 
 {{EmbedInteractiveExample("pages/js/promise-any.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Promise.any
 ---
 {{JSRef}}
 
-`Promise.any()` takes an iterable of {{JSxRef("Promise")}} objects and returns a single promise that resolves with the value of the earliest fulfilled promise from the iterable. If no promises in the iterable fulfill (if all of the given promises are rejected), then the returned promise is rejected with an {{JSxRef("AggregateError")}}, a new subclass of {{JSxRef("Error")}} that groups together individual errors.
+`Promise.any()` takes an iterable of {{JSxRef("Promise")}} objects. It returns a single promise that resolves as soon as any of the promises in the iterable fulfills, with the value of the fulfilled promise. If no promises in the iterable fulfill (if all of the given promises are rejected), then the returned promise is rejected with an {{JSxRef("AggregateError")}}, a new subclass of {{JSxRef("Error")}} that groups together individual errors.
 
 {{EmbedInteractiveExample("pages/js/promise-any.html")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`Promise.any()`'s opening description seems to suggest that the function does not `return` until any one promise resolves. The `return`  however is immediate.

#### Motivation
Original is misleading

#### Supporting details
https://2ality.com/2019/12/promise-any.html

#### Related issues
Fixes #9776

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
