### PR TITLE
Remove trailing commas in JSON

### DIFF
--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -236,8 +236,8 @@ through a preference, turns off chrome errors/warnings in the console, and enabl
         "log": {"level": "trace"},
         "env": {
           "MOZ_LOG": "nsHttp:5",
-          "MOZ_LOG_FILE": "/path/to/my/profile/log",
-        },
+          "MOZ_LOG_FILE": "/path/to/my/profile/log"
+        }
       }
     }
   }


### PR DESCRIPTION
#### Summary
The original JSON standard doesn't allow trailing commas and given that we follow this guideline in all other examples, we should also adhere to it here, as breaking it does not provide any additional value.

#### Supporting details
See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#trailing_commas_in_json

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
