### PR TITLE
Remove duplicate article from Matching Features

### DIFF
--- a/files/en-us/mdn/contribute/processes/matching_features_to_browser_version/index.html
+++ b/files/en-us/mdn/contribute/processes/matching_features_to_browser_version/index.html
@@ -184,7 +184,7 @@ tags:
  </li>
 </ul>
 
-<h3 id="From_a_the_name_of_a_Web_API_interface_or_member">From a the name of a Web API interface or member</h3>
+<h3 id="From_the_name_of_a_Web_API_interface_or_member">From the name of a Web API interface or member</h3>
 
 <p>If you're updating compatibility data for a given API interface, or for a property, method, or other feature within that interface, you may not necessarily have a bug number or changeset number to start from. This means doing a little detective work is in order. There are two approaches to take: you can try searching Bugzilla, looking for a bug that covers the change you want to identify, or you can isolate the information directly from the source tree.</p>
 


### PR DESCRIPTION
I guess the only way this could be kind of correct would be if it should be an enumeration (a, b, c) but I guess it's just a typo :D
I think we could also write `a` instead of `the` but for me, this variant sounds better. However, I'd also be open to change it to `From a name of a Web API interface or member` if you want me to.
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
