### PR TITLE
fix auto copy for View pug content

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
@@ -111,7 +111,7 @@ block content
       label(for='book') Book:
       select#book.form-control(type='select' placeholder='Select book' name='book' required='true')
         - book_list.sort(function(a, b) {let textA = a.title.toUpperCase(); let textB = b.title.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
-        for book in book_list
+        for book in book_list
           if bookinstance
             option(value=book._id selected=(bookinstance.book.toString()==book._id.toString() ? 'selected' : false)) #{book.title}
           else


### PR DESCRIPTION
Fixed the pug content for the View code block.
Issue is a duplicate of #9778 but for a different page on the express/node tutorial.

I've removed the summary/motivation etc, because they are the same as in #9778
If I shouldn't have done this, please let me know.

edit:
Sorry about that, I completely overlooked the part where it said : ! Do not make changes below this line !
So I tried to manually put back the info which I could find. I'm not sure about the validity of the last commit info in de report details.
<details>
<summary>MDN Content page report details</summary>

* Folder: `en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form`
* MDN URL:https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms/Create_BookInstance_form#view
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
* Last commit: https://github.com/mdn/content/commit/07453ac2b659a397b0fee921fa71db5488e9ca62


</details>