### PR TITLE
[Markdown][Add-ons] Make acknowledgements convertible as Markdown notes

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.alarms.Alarm
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.html
@@ -52,7 +52,7 @@ clearAlarm.then(onCleared);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.html
@@ -47,7 +47,7 @@ clearAlarms.then(onClearedAll);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
@@ -86,7 +86,7 @@ browser.alarms.create("my-periodic-alarm", {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.html
@@ -54,7 +54,7 @@ getAlarm.then(gotAlarm);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.html
@@ -49,7 +49,7 @@ getAlarms.then(gotAll);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
@@ -54,7 +54,7 @@ browser-compat: webextensions.api.alarms
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
@@ -67,7 +67,7 @@ browser.alarms.onAlarm.addListener(handleAlarm);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/alarms"><code>chrome.alarms</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
@@ -50,7 +50,7 @@ browser-compat: webextensions.api.bookmarks.BookmarkTreeNode
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#type-BookmarkTreeNode"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#type-BookmarkTreeNodeUnmodifiable"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
@@ -62,7 +62,7 @@ createBookmark.then(onCreated);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-create"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.bookmarks.CreateDetails
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#type-CreateDetails"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.html
@@ -58,7 +58,7 @@ gettingBookmarks.then(onFulfilled, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-get"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
@@ -62,7 +62,7 @@ gettingChildren.then(onFulfilled, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-getChildren"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
@@ -60,7 +60,7 @@ gettingRecent.then(onFulfilled, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-getRecent"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.html
@@ -82,7 +82,7 @@ gettingSubTree.then(logSubTree, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-getSubTree"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.html
@@ -75,7 +75,7 @@ gettingTree.then(logTree, onRejected);
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-getTree"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.html
@@ -91,7 +91,7 @@ browser-compat: webextensions.api.bookmarks
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
@@ -77,7 +77,7 @@ movingBookmark.then(onMoved, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-move"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
@@ -86,7 +86,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onChanged"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
@@ -85,7 +85,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onChildrenReordered"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
@@ -71,7 +71,7 @@ browser.bookmarks.onCreated.addListener(handleCreated);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onCreated"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.html
@@ -72,7 +72,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onImportBegan"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.html
@@ -72,7 +72,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onImportEnded"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
@@ -94,7 +94,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onMoved"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
@@ -89,7 +89,7 @@ browser.browserAction.onClicked.addListener(handleClick);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#event-onRemoved"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
@@ -64,7 +64,7 @@ removingBookmark.then(onRemoved, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-remove"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
@@ -71,7 +71,7 @@ searchingBookmarks.then(removeMDN, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-removeTree"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
@@ -108,7 +108,7 @@ browser.browserAction.onClicked.addListener(checkActiveTab);
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <code><a href="https://developer.chrome.com/extensions/bookmarks#method-search">chrome.bookmarks</a></code> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
@@ -85,7 +85,7 @@ searching.then(updateFolders, onRejected);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/bookmarks#method-update"><code>chrome.bookmarks</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json"><code>bookmarks.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.browserAction.ColorArray
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#type-ColorArray"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
@@ -56,7 +56,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-disable"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.html
@@ -50,7 +50,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-enable"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
@@ -69,7 +69,7 @@ browser.browserAction.getBadgeBackgroundColor({}).then(onGot, onFailure);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-getBadgeBackgroundColor"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
@@ -67,7 +67,7 @@ gettingBadgeText.then(gotBadgeText);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-getBadgeText"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
@@ -72,7 +72,7 @@ browser.browserAction.getBadgeTextColor({}).then(onGot, onFailure);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-getBadgeBackgroundColor"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
@@ -67,7 +67,7 @@ gettingPopup.then(gotPopup); </pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-getPopup"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-getTitle"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.browserAction.ImageDataType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#type-ImageDataType"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.html
@@ -94,7 +94,7 @@ browser-compat: webextensions.api.browserAction
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
@@ -78,7 +78,7 @@ browser.browserAction.onClicked.hasListener(listener)
 
  <p>{{WebExtExamples}}</p>
 
- <div class="note"><strong>Acknowledgements</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#event-onClicked"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
@@ -87,7 +87,7 @@ browser.browserAction.onClicked.addListener((tab)=&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-setBadgeBackgroundColor"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener(increment);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-setBadgeText"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
@@ -80,7 +80,7 @@ browser.browserAction.onClicked.addListener((tab)=&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-setBadgeBackgroundColor"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
@@ -153,7 +153,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-setIcon"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
@@ -105,7 +105,7 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-setPopup"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.html
@@ -84,7 +84,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browserAction#method-setTitle"><code>chrome.browserAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json"><code>browser_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
@@ -60,7 +60,7 @@ browser-compat: webextensions.api.browsingData.DataTypeSet
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.html
@@ -87,7 +87,7 @@ browser-compat: webextensions.api.browsingData
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.browsingData.RemovalOptions
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
@@ -87,7 +87,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
@@ -59,7 +59,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
@@ -91,7 +91,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
@@ -84,7 +84,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
@@ -84,7 +84,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
@@ -84,7 +84,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
@@ -64,7 +64,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.html
@@ -82,7 +82,7 @@ browser.browsingData.removePasswords({}).then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.html
@@ -83,7 +83,7 @@ then(onRemoved, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
@@ -68,7 +68,7 @@ browser.browsingData.settings().then(onGotSettings, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.captivePortal.canonicalURL
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#property-TAB_ID_NONE"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>{{Compat("webextensions.api.clipboard")}} {{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/apps/clipboard"><code>chrome.clipboard</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
@@ -73,7 +73,7 @@ fetch(browser.runtime.getURL('image.png'))
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/apps/clipboard"><code>chrome.clipboard</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.commands.Command
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/commands"><code>chrome.commands</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.html
@@ -51,7 +51,7 @@ getCommands.then(logCommands);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/commands"><code>chrome.commands</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.html
@@ -51,7 +51,7 @@ tags:
 
 <p>{{Compat("webextensions.api.commands")}} {{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/commands"><code>chrome.commands</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
@@ -84,7 +84,7 @@ browser.commands.onCommand.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/commands"><code>chrome.commands</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
@@ -72,7 +72,7 @@ gettingAll.then(logCookies);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#type-Cookie"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
@@ -58,7 +58,7 @@ getting.then(logStores);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#type-CookieStore"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
@@ -81,7 +81,7 @@ getActive.then(getCookie);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#method-get"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
@@ -79,7 +79,7 @@ gettingAll.then(logCookies);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#method-getAll"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.html
@@ -53,7 +53,7 @@ getting.then(logStores);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#method-getAllCookieStores"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.html
@@ -127,7 +127,7 @@ browser-compat: webextensions.api.cookies
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
@@ -87,7 +87,7 @@ browser.cookies.onChanged.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#event-onChanged"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.cookies.OnChangedCause
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#type-OnChangedCause"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
@@ -80,7 +80,7 @@ getActive.then(removeCookie);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#method-remove"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
@@ -87,7 +87,7 @@ function setCookie(tabs) {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/cookies#method-set"><code>chrome.cookies</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json"><code>cookies.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.devtools
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/docs/extensions/mv2/devtools/"><code>chrome.devtools</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
@@ -179,7 +179,7 @@ inspectButton.addEventListener("click", () =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.devtools.inspectedWindow
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_inspectedWindow"><code>chrome.devtools.inspectedWindow</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
@@ -60,7 +60,7 @@ reloadButton.addEventListener("click", () =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
@@ -45,7 +45,7 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.html
@@ -50,7 +50,7 @@ logRequestsButton.addEventListener("click", logRequests);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_network"><code>chrome.devtools.network</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.devtools.network
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_network"><code>chrome.devtools.network</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
@@ -63,7 +63,7 @@ browser.devtools.network.onNavigated.addListener(handleNavigated);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
@@ -74,7 +74,7 @@ browser.devtools.network.onRequestFinished.addListener(handleRequestFinished);</
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.html
@@ -70,7 +70,7 @@ browser.devtools.panels.create(
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.html
@@ -22,7 +22,7 @@ browser-compat: webextensions.api.devtools.panels.elements
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
@@ -68,7 +68,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.devtools.panels.ElementsPanel
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.html
@@ -66,7 +66,7 @@ browser.devtools.panels.elements.onSelectionChanged.addListener(handleSelectedEl
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools"><code>chrome.devtools</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.html
@@ -53,7 +53,7 @@ browser.devtools.panels.create(
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.html
@@ -53,7 +53,7 @@ browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.html
@@ -72,7 +72,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.html
@@ -71,7 +71,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.html
@@ -67,7 +67,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
@@ -65,7 +65,7 @@ browser.devtools.panels.elements.createSidebarPane(&quot;My pane&quot;).then(onC
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
@@ -52,7 +52,7 @@ browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setPage
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.html
@@ -70,7 +70,7 @@ browser-compat: webextensions.api.devtools.panels
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
@@ -63,7 +63,7 @@ browser.devtools.panels.onThemeChanged.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.html
@@ -30,7 +30,7 @@ browser-compat: webextensions.api.devtools.panels.themeName
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.html
@@ -45,7 +45,7 @@ browser-compat: webextensions.api.downloads.acceptDanger
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-acceptDanger"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.downloads.BooleanDelta
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-BooleanDelta"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.html
@@ -58,7 +58,7 @@ canceling.then(onCanceled, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-cancel"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
@@ -52,7 +52,7 @@ browser-compat: webextensions.api.downloads.DangerType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-DangerType"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.downloads.DoubleDelta
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-DoubleDelta"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
@@ -113,7 +113,7 @@ downloading.then(onStartedDownload, onFailed);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-download"><code>chrome.downloads</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
@@ -72,7 +72,7 @@ browser-compat: webextensions.api.downloads.DownloadItem
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-DownloadItem"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
@@ -84,7 +84,7 @@ browser-compat: webextensions.api.downloads.DownloadQuery
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-DownloadQuery"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.downloads.DownloadTime
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-DownloadTime"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.downloads.drag
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-drag"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
@@ -81,7 +81,7 @@ erasing.then(onErased, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-erase"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.downloads.FilenameConflictAction
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-FilenameConflictAction"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
@@ -83,7 +83,7 @@ searching.then(getIcon, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-getFileIcon"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.html
@@ -93,7 +93,7 @@ browser-compat: webextensions.api.downloads
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.html
@@ -78,7 +78,7 @@ browser-compat: webextensions.api.downloads.InterruptReason
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-InterruptReason"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
@@ -108,7 +108,7 @@ browser.downloads.onChanged.addListener(handleChanged);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#event-onChanged"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
@@ -69,7 +69,7 @@ browser.downloads.onCreated.addListener(handleCreated);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#event-onCreated"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
@@ -74,7 +74,7 @@ var erasing = browser.downloads.erase({
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#event-onErased"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.html
@@ -71,7 +71,7 @@ searching.then(openDownload, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-open"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.html
@@ -56,7 +56,7 @@ pausing.then(onPaused, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-pause"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
@@ -77,7 +77,7 @@ searching.then(remove, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-removeFile"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.html
@@ -58,7 +58,7 @@ resuming.then(onResumed, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-resume"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.html
@@ -126,7 +126,7 @@ searching.then(logDownloads, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-search"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
@@ -43,7 +43,7 @@ browser-compat: webextensions.api.downloads.setShelfEnabled
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-setShelfEnabled"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.html
@@ -70,7 +70,7 @@ searching.then(openDownload, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-show"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.html
@@ -42,7 +42,7 @@ showBtn.onclick = function() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#method-showDefaultFolder"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.downloads.State
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-State"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.downloads.StringDelta
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/downloads#type-StringDelta"><code>chrome.downloads</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.html
@@ -46,7 +46,7 @@ browser-compat: webextensions.api.events.Event
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/events#type-Event"><code>chrome.events</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json"><code>events.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.events
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/events"><code>chrome.events</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json"><code>events.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.events.Rule
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/events#type-Rule"><code>chrome.events</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json"><code>events.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
@@ -57,7 +57,7 @@ page.foo(); // -&gt; "I'm defined in background.js"</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-getBackgroundPage"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
@@ -47,7 +47,7 @@ browser-compat: webextensions.api.extension.getExtensionTabs
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-getExtensionTabs"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.html
@@ -56,7 +56,7 @@ browser-compat: webextensions.api.extension.getURL
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-getURL"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
@@ -76,7 +76,7 @@ for (var extensionWindow of windows) {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-getViews"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.html
@@ -71,7 +71,7 @@ browser-compat: webextensions.api.extension
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.extension.inIncognitoContext
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#property-inIncognitoContext"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.html
@@ -52,7 +52,7 @@ isAllowed.then(logIsAllowed);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-isAllowedFileSchemeAccess"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.html
@@ -47,7 +47,7 @@ isAllowed.then(logIsAllowed);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-isAllowedIncognitoAccess"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.extension.lastError
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#property-lastError"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
@@ -75,7 +75,7 @@ chrome.extension.onRequest.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#event-onRequest"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
@@ -75,7 +75,7 @@ chrome.extension.onRequestExternal.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#event-onRequestExternal"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
@@ -57,7 +57,7 @@ browser-compat: webextensions.api.extension.sendRequest
 
 <p>{{WebExtExamples}}</p>
 
-<div class="notecard note"><strong>Acknowledgements</strong>
+<div class="notecard note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-sendRequest"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.extension.setUpdateUrlData
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#method-setUpdateUrlData"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.extension.ViewType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extension#type-ViewType"><code>chrome.extension</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json"><code>extension.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
@@ -48,7 +48,7 @@ browser-compat: webextensions.api.extensionTypes.ImageDetails
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extensionTypes#type-ImageDetails"><code>chrome.extensionTypes</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json"><code>extension_types.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.extensionTypes.ImageFormat
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extensionTypes#type-ImageFormat"><code>chrome.extensionTypes</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json"><code>extension_types.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.extensionTypes
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extensionTypes"><code>chrome.extensionTypes</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json"><code>extension_types.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
@@ -35,7 +35,7 @@ browser-compat: webextensions.api.extensionTypes.RunAt
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/extensionTypes#type-RunAt"><code>chrome.extensionTypes</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json"><code>extension_types.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
@@ -109,7 +109,7 @@ addingUrl.then(onAdded);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#method-addUrl"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.html
@@ -55,7 +55,7 @@ deleteAllHistory();</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#method-deleteAll"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
@@ -66,7 +66,7 @@ browser.history.deleteRange({
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#method-deleteRange"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
@@ -101,7 +101,7 @@ searching.then(onGot);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#method-deleteUrl"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
@@ -78,7 +78,7 @@ searching.then(listVisits);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#method-getVisits"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.history.HistoryItem
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#type-HistoryItem"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
@@ -93,7 +93,7 @@ browser-compat: webextensions.api.history
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
@@ -74,7 +74,7 @@ browser.history.onTitleChanged.addListener(handleTitleChanged);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#event-onVisited"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
@@ -72,7 +72,7 @@ browser.history.onVisited.addListener(onVisited);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#event-onVisited"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
@@ -81,7 +81,7 @@ browser.history.onVisitRemoved.addListener(onRemoved);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#event-onVisitRemoved"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
@@ -114,7 +114,7 @@ searching.then(onGot);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#method-search"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.html
@@ -52,7 +52,7 @@ browser-compat: webextensions.api.history.TransitionType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#type-TransitionType"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.history.VisitItem
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/history#type-VisitItem"><code>chrome.history</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json"><code>history.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
@@ -74,7 +74,7 @@ detecting.then(onLanguageDetected);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/i18n#method-detectLanguage"><code>chrome.i18n</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json"><code>i18n.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
@@ -50,7 +50,7 @@ gettingAcceptLanguages.then(onGot);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/i18n#method-getAcceptLanguages"><code>chrome.i18n</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json"><code>i18n.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
@@ -78,7 +78,7 @@ console.log(message);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/i18n#method-getMessage"><code>chrome.i18n</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json"><code>i18n.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
@@ -43,7 +43,7 @@ console.log(uiLanguage);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/i18n#method-getUILanguage"><code>chrome.i18n</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json"><code>i18n.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.i18n
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/i18n"><code>chrome.i18n</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json"><code>i18n.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.i18n.LanguageCode
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/i18n#type-LanguageCode"><code>chrome.i18n</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json"><code>i18n.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
@@ -45,7 +45,7 @@ browser-compat: webextensions.api.identity.getRedirectURL
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/identity"><code>identity</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.html
@@ -74,7 +74,7 @@ browser-compat: webextensions.api.identity
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/identity"><code>chrome.identity</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
@@ -112,7 +112,7 @@ function getAccessToken() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/identity"><code>identity</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.idle.IdleState
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/idle#type-IdleState"><code>chrome.idle</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json"><code>idle.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/index.html
@@ -49,7 +49,7 @@ browser-compat: webextensions.api.idle
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/idle"><code>chrome.idle</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json"><code>idle.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
@@ -71,7 +71,7 @@ browser.idle.onStateChanged.addListener(newState);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/idle#event-onStateChanged"><code>chrome.idle</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json"><code>idle.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.html
@@ -58,7 +58,7 @@ querying.then(onGot);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/idle#method-queryState"><code>chrome.idle</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json"><code>idle.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.html
@@ -43,7 +43,7 @@ browser-compat: webextensions.api.idle.setDetectionInterval
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/idle#method-setDetectionInterval"><code>chrome.idle</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json"><code>idle.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
@@ -87,7 +87,7 @@ browser-compat: webextensions.api.management.ExtensionInfo
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#type-ExtensionInfo"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.html
@@ -57,7 +57,7 @@ getting.then(got);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-get"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.html
@@ -55,7 +55,7 @@ gettingAll.then(gotAll);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-getAll"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.html
@@ -61,7 +61,7 @@ gettingWarnings.then(gotWarnings);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-getPermissionWarningsById"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.html
@@ -70,7 +70,7 @@ gettingWarnings.then(gotWarnings, gotError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-getPermissionWarningsByManifest"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.html
@@ -49,7 +49,7 @@ gettingSelf.then(gotSelf);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-getSelf"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/index.html
@@ -75,7 +75,7 @@ browser-compat: webextensions.api.management
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
@@ -65,7 +65,7 @@ browser.management.onDisabled.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a class="external external-icon" href="https://developer.chrome.com/extensions/management#event-onDisabled"><code>chrome.management</code></a> API. This documentation is derived from <a class="external external-icon" href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
@@ -65,7 +65,7 @@ browser.management.onEnabled.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a class="external external-icon" href="https://developer.chrome.com/extensions/management#event-onEnabled"><code>chrome.management</code></a> API. This documentation is derived from <a class="external external-icon" href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
@@ -65,7 +65,7 @@ browser.management.onInstalled.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a class="external external-icon" href="https://developer.chrome.com/extensions/management#event-onInstalled"><code>chrome.management</code></a> API. This documentation is derived from <a class="external external-icon" href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
@@ -65,7 +65,7 @@ browser.management.onUninstalled.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a class="external-icon external" href="https://developer.chrome.com/extensions/management#event-onUninstalled"><code>chrome.management</code></a> API. This documentation is derived from <a class="external-icon external" href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.html
@@ -66,7 +66,7 @@ toggleEnabled(id);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-setEnabled"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.html
@@ -66,7 +66,7 @@ uninstalling.then(null, onCanceled);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-uninstall"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
@@ -78,7 +78,7 @@ uninstalling.then(null, onCanceled);</pre>
 
  <p>{{WebExtExamples}}</p>
 
- <div class="note"><strong>Acknowledgements</strong>
+ <div class="note"><p><strong>Note:</strong></p>
 
  <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/management#method-uninstallSelf"><code>chrome.management</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json"><code>management.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#property-ACTION_MENU_TOP_LEVEL_LIMIT"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
@@ -67,7 +67,7 @@ browser-compat: webextensions.api.menus.ContextType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-ContextType"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
@@ -187,7 +187,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#method-create"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
@@ -99,7 +99,7 @@ browser-compat: webextensions.api.menus.createProperties
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-OnClickData" style="outline: 1px dotted currentcolor; outline-offset: 0px;"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.html
@@ -165,7 +165,7 @@ browser.menus.create({
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.menus.ItemType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-ItemType"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
@@ -66,7 +66,7 @@ browser-compat: webextensions.api.menus.OnClickData
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-OnClickData" style="outline: 1px dotted currentcolor; outline-offset: 0px;"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
@@ -79,7 +79,7 @@ browser.menus.onClicked.addListener((info, tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#event-onClicked"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.html
@@ -72,7 +72,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 <p>{{Compat}}</p>
 
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#method-remove"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.html
@@ -68,7 +68,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#method-removeAll"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
@@ -154,7 +154,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#method-update"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.html
@@ -70,7 +70,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
@@ -139,7 +139,7 @@ browser.notifications.onButtonClicked.addListener((id, index) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications#method-create"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.html
@@ -78,7 +78,7 @@ browser.notifications.getAll().then(logNotifications);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.html
@@ -60,7 +60,7 @@ browser-compat: webextensions.api.notifications
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
@@ -82,7 +82,7 @@ browser-compat: webextensions.api.notifications.NotificationOptions
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
@@ -59,7 +59,7 @@ browser.notifications.onButtonClicked.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
@@ -65,7 +65,7 @@ browser.notifications.onClicked.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
@@ -67,7 +67,7 @@ browser.notifications.onClosed.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
@@ -70,7 +70,7 @@ browser.notifications.onShown.addListener(logShown);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
@@ -59,7 +59,7 @@ browser-compat: webextensions.api.notifications.TemplateType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.html
@@ -100,7 +100,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/notifications"><code>chrome.notifications</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.html
@@ -62,7 +62,7 @@ browser-compat: webextensions.api.omnibox
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.html
@@ -50,7 +50,7 @@ browser.omnibox.onInputCancelled.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.html
@@ -143,7 +143,7 @@ browser.omnibox.onInputEntered.addListener((url, disposition) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.html
@@ -143,7 +143,7 @@ browser.omnibox.onInputEntered.addListener((url, disposition) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
@@ -35,7 +35,7 @@ browser-compat: webextensions.api.omnibox.OnInputEnteredDisposition
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.html
@@ -60,7 +60,7 @@ browser.omnibox.onInputStarted.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.html
@@ -48,7 +48,7 @@ browser-compat: webextensions.api.omnibox.setDefaultSuggestion
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox">chrome.omnibox</a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.omnibox.SuggestResult
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/omnibox"><code>chrome.omnibox</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
@@ -69,7 +69,7 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-getPopup"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
@@ -64,7 +64,7 @@ browser.pageAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-getTitle"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.html
@@ -47,7 +47,7 @@ browser-compat: webextensions.api.pageAction.hide
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-hide"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.pageAction.ImageDataType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#type-ImageDataType"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.html
@@ -69,7 +69,7 @@ browser-compat: webextensions.api.pageAction
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
@@ -80,7 +80,7 @@ browser.pageAction.onClicked.addListener(function () {
 
 	<p>{{WebExtExamples}}</p>
 
-	<div class="note"><strong>Acknowledgements</strong>
+	<div class="note"><p><strong>Note:</strong></p>
 
 	<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#event-onClicked"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
@@ -96,7 +96,7 @@ browser-compat: webextensions.api.pageAction.setIcon
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-setIcon"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
@@ -68,7 +68,7 @@ browser-compat: webextensions.api.pageAction.setPopup
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-setPopup"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
@@ -59,7 +59,7 @@ browser-compat: webextensions.api.pageAction.setTitle
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-setTitle"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.html
@@ -65,7 +65,7 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/pageAction#method-show"><code>chrome.pageAction</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json"><code>page_action.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.html
@@ -85,7 +85,7 @@ browser.permissions.contains(testPermissions4).then((result) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.html
@@ -46,7 +46,7 @@ browser.permissions.getAll().then((result) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.html
@@ -81,7 +81,7 @@ browser-compat: webextensions.api.permissions
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
@@ -65,7 +65,7 @@ browser.permissions.onAdded.addListener(handleAdded);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
@@ -65,7 +65,7 @@ browser.permissions.onRemoved.addListener(handleRemoved);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.permissions.Permissions
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.html
@@ -60,7 +60,7 @@ document.querySelector("#remove").addEventListener("click", remove);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/permissions"><code>chrome.permissions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
@@ -80,7 +80,7 @@ document.querySelector("#request").addEventListener("click", requestPermissions)
 <p>{{WebExtExamples}}</p>
 
 <div class="note">
-<p><strong>Acknowledgements</strong></p>
+<p><p><strong>Note:</strong></p></p>
 
 <p>Currently has a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1411873">bug with requesting origins</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1382953">requesting permissions on the about:addons page</a>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
@@ -80,7 +80,7 @@ document.querySelector("#request").addEventListener("click", requestPermissions)
 <p>{{WebExtExamples}}</p>
 
 <div class="note">
-<p><p><strong>Note:</strong></p></p>
+<p><strong>Note:</strong></p>
 
 <p>Currently has a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1411873">bug with requesting origins</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1382953">requesting permissions on the about:addons page</a>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.privacy
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/privacy"><code>chrome.privacy</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
@@ -92,7 +92,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/privacy"><code>chrome.privacy</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json"><code>privacy.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.html
@@ -53,7 +53,7 @@ browser-compat: webextensions.api.privacy.services
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/privacy"><code>chrome.privacy</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.html
@@ -121,7 +121,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/privacy"><code>chrome.privacy</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json"><code>privacy.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
@@ -119,7 +119,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-connect"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.html
@@ -77,7 +77,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-connectNative"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
@@ -79,7 +79,7 @@ getting.then(onGot, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-getBackgroundPage"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.html
@@ -55,7 +55,7 @@ gettingInfo.then(gotBrowserInfo);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.html
@@ -43,7 +43,7 @@ console.log(manifest.name);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-getManifest"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.html
@@ -47,7 +47,7 @@ gettingEntry.then(gotDirectoryEntry);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-getPackageDirectoryEntry"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.html
@@ -49,7 +49,7 @@ gettingInfo.then(gotPlatformInfo);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-getPlatformInfo"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.html
@@ -52,7 +52,7 @@ console.log(fullURL);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-getURL"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.runtime.id
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#property-id"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.html
@@ -125,7 +125,7 @@ browser-compat: webextensions.api.runtime
 
 <div>{{WebExtExamples("h2")}}</div>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.html
@@ -77,7 +77,7 @@ setCookie.then(logCookie, logError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#property-lastError"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
@@ -45,7 +45,7 @@ browser-compat: webextensions.api.runtime.MessageSender
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-MessageSender"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.html
@@ -63,7 +63,7 @@ browser.runtime.onBrowserUpdateAvailable.addListener(handleBrowserUpdateAvailabl
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onBrowserUpdateAvailable"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
@@ -114,7 +114,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onConnect"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
@@ -99,7 +99,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onConnectExternal"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
@@ -84,7 +84,7 @@ browser.runtime.onInstalled.addListener(handleInstalled);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onInstalled"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.runtime.OnInstalledReason
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-OnInstalledReason"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -283,7 +283,7 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onMessage"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
@@ -112,7 +112,7 @@ browser.runtime.onMessageExternal.addListener(handleMessage);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onMessageExternal"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
@@ -59,7 +59,7 @@ browser.runtime.onRestartRequired.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onRestartRequired"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.runtime.OnRestartRequiredReason
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-OnRestartRequiredReason"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.html
@@ -66,7 +66,7 @@ browser.runtime.onStartup.addListener(handleStartup);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onStartup"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
@@ -67,7 +67,7 @@ browser.runtime.onSuspend.addListener(handleSuspend);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onSuspend"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.html
@@ -62,7 +62,7 @@ browser.runtime.onSuspendCanceled.addListener(handleSuspendCanceled);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onSuspendCanceled"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
@@ -77,7 +77,7 @@ browser.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#event-onUpdateAvailable"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
@@ -54,7 +54,7 @@ opening.then(onOpened, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-openOptionsPage"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.runtime.PlatformArch
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-PlatformArch"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.runtime.PlatformInfo
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-PlatformInfo"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.runtime.PlatformNaclArch
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-PlatformNaclArch"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.runtime.PlatformOs
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-PlatformOs"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -204,7 +204,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-Port"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.runtime.reload
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-reload"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
@@ -69,7 +69,7 @@ requestingCheck.then(onRequested, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-requestUpdateCheck"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.runtime.RequestUpdateCheckStatus
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#type-RequestUpdateCheckStatus"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -122,7 +122,7 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-sendMessage"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-sendNativeMessage"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.html
@@ -56,7 +56,7 @@ settingUrl.then(onSetURL, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/runtime#method-setUninstallURL"><code>chrome.runtime</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json"><code>runtime.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.sessions.Filter
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.html
@@ -74,7 +74,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.html
@@ -95,7 +95,7 @@ browser-compat: webextensions.api.sessions
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.sessions.MAX_SESSION_RESULTS
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.html
@@ -82,7 +82,7 @@ browser.sessions.onChanged.addListener(restoreMostRecent);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.html
@@ -71,7 +71,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
@@ -47,7 +47,7 @@ browser-compat: webextensions.api.sessions.Session
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/sessions"><code>chrome.sessions</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
@@ -68,7 +68,7 @@ gettingPanel.then(onGot); </pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a class="external external-icon" href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a class="external external-icon" href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.html
@@ -26,7 +26,7 @@ browser-compat: webextensions.api.sidebarAction.ImageDataType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a class="external external-icon" href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.sidebarAction
  <li><a class="external external-icon" href="https://github.com/mdn/webextensions-examples/tree/master/annotate-page">annotate-page</a></li>
 </ul>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
@@ -129,7 +129,7 @@ browser.browserAction.onClicked.addListener(toggle);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a class="external external-icon" href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
@@ -91,7 +91,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a class="external external-icon" href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
@@ -82,7 +82,7 @@ browser.browserAction.onClicked.addListener(setTitleForTab);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Opera's <a class="external external-icon" href="https://dev.opera.com/extensions/sidebar-action-api/"><code>chrome.sidebarAction</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/index.html
@@ -70,7 +70,7 @@ browser-compat: webextensions.api.storage
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.html
@@ -53,7 +53,7 @@ browser-compat: webextensions.api.storage.local
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage#property-local"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.html
@@ -48,7 +48,7 @@ storageItem.then((res) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage#property-managed"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.html
@@ -83,7 +83,7 @@ browser.storage.onChanged.addListener(logStorageChange);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage#event-onChanged"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.html
@@ -54,7 +54,7 @@ clearStorage.then(onCleared, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
@@ -141,7 +141,7 @@ gettingItem.then(onGot, onError);
 <pre class="brush: js">let gettingItem = new Promise(resolve =&gt; chrome.storage.local.get("kitten", resolve));
 gettingItem.then(onGot); // -&gt; Object { kitten: Object }</pre>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.html
@@ -50,7 +50,7 @@ browser-compat: webextensions.api.storage.StorageArea.getBytesInUse
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.storage.StorageArea
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage#type-StorageArea"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.html
@@ -62,7 +62,7 @@ removeKitten.then(onRemoved, onError);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
@@ -97,7 +97,7 @@ browser.storage.local.get("monster")
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.storage.StorageChange
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage#type-StorageChange"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.html
@@ -81,7 +81,7 @@ browser-compat: webextensions.api.storage.sync
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/storage#property-sync"><code>chrome.storage</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json"><code>storage.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.html
@@ -63,7 +63,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-captureVisibleTab"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.html
@@ -64,7 +64,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-captureVisibleTab"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.html
@@ -81,7 +81,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-connect"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -106,7 +106,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-create"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.html
@@ -86,7 +86,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-detectLanguage"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.html
@@ -77,7 +77,7 @@ discarding.then(onDiscarded, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-discard"><code>chrome.tabs</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
@@ -85,7 +85,7 @@ querying.then(duplicateFirstTab, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-duplicate"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.html
@@ -58,7 +58,7 @@ browser.tabs.onActivated.addListener(logListener);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-get"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.html
@@ -49,7 +49,7 @@ browser-compat: webextensions.api.tabs.getAllInWindow
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-getAllInWindow"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.html
@@ -59,7 +59,7 @@ gettingCurrent.then(onGot, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-getCurrent"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.html
@@ -48,7 +48,7 @@ browser-compat: webextensions.api.tabs.getSelected
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-getSelected"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.html
@@ -71,7 +71,7 @@ gettingZoom.then(onGot, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-getZoom"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.html
@@ -58,7 +58,7 @@ gettingZoomSettings.then(onGot, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-getZoomSettings"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.tabs.highlight
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-highlight"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
@@ -182,7 +182,7 @@ browser-compat: webextensions.api.tabs
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.html
@@ -126,7 +126,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-move"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.getZoom</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.tabs.MutedInfo
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#type-MutedInfo"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.tabs.MutedInfoReason
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#type-MutedInfoReason"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.html
@@ -81,7 +81,7 @@ browser.tabs.onActivated.addListener(handleActivated);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onActivated"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
@@ -74,7 +74,7 @@ browser.tabs.onActiveChanged.hasListener(listener)
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onActiveChanged"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.html
@@ -85,7 +85,7 @@ browser.tabs.onAttached.addListener(handleAttached);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onAttached"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.html
@@ -69,7 +69,7 @@ browser.tabs.onCreated.addListener(handleCreated);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onCreated"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.html
@@ -85,7 +85,7 @@ browser.tabs.onDetached.addListener(handleDetached);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onDetached"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
@@ -69,7 +69,7 @@ browser.tabs.onHighlightChanged.hasListener(listener)
 
 <p>{{Compat}}</p>
 
-<p><strong>Acknowledgements</strong></p>
+<p><p><strong>Note:</strong></p></p>
 
 <div class="note">
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onHighlightChanged"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
@@ -69,7 +69,7 @@ browser.tabs.onHighlightChanged.hasListener(listener)
 
 <p>{{Compat}}</p>
 
-<p><p><strong>Note:</strong></p></p>
+<p><strong>Note:</strong></p>
 
 <div class="note">
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onHighlightChanged"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.html
@@ -80,7 +80,7 @@ browser.tabs.onHighlighted.addListener(handleHighlighted);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onHighlighted"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.html
@@ -89,7 +89,7 @@ browser.tabs.onMoved.addListener(handleMoved);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onMoved"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.html
@@ -85,7 +85,7 @@ browser.tabs.onRemoved.addListener(handleRemoved);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onRemoved"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.html
@@ -76,7 +76,7 @@ browser.tabs.onReplaced.addListener(handleReplaced);
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onReplaced"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
@@ -74,7 +74,7 @@ browser.tabs.onSelectionChanged.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onSelectionChanged"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
@@ -242,7 +242,7 @@ browser.tabs.onUpdated.addListener(
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onUpdated"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.html
@@ -84,7 +84,7 @@ browser.tabs.onZoomChange.addListener(handleZoomed);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#event-onZoomChange"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.html
@@ -148,7 +148,7 @@ querying.then(logTabs, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-query"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.html
@@ -74,7 +74,7 @@ reloading.then(onReloaded, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-reload"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.html
@@ -71,7 +71,7 @@ removing.then(onRemoved, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-remove"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.html
@@ -79,7 +79,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-insertCSS"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
@@ -106,7 +106,7 @@ browser.runtime.onMessage.addListener(request =&gt; {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-sendMessage"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.html
@@ -49,7 +49,7 @@ browser-compat: webextensions.api.tabs.sendRequest
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-sendRequest"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.html
@@ -66,7 +66,7 @@ setting.then(null, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-setZoom"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.html
@@ -61,7 +61,7 @@ setting.then(onSet, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-setZoomSettings"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.tabs.TAB_ID_NONE
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#property-TAB_ID_NONE"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.html
@@ -27,7 +27,7 @@ browser-compat: webextensions.api.tabs.TabStatus
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#type-TabStatus"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
@@ -128,7 +128,7 @@ querying.then(updateFirstTab, onError);</pre>
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-update"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.tabs.WindowType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#type-WindowType"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.tabs.ZoomSettings
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#type-ZoomSettings"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.tabs.ZoomSettingsMode
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#type-ZoomSettingsMode"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
@@ -110,7 +110,7 @@ gettingTopSites.then(logTopSites, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/topSites"><code>chrome.topSites</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.topSites
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/topSites"><code>chrome.topSites</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.topSites.MostVisitedURL
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/topSites"><code>chrome.topSites</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.html
@@ -58,7 +58,7 @@ clearing.then(onCleared);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/types"><code>chrome.types</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.html
@@ -81,7 +81,7 @@ getting.then((got) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/types"><code>chrome.types</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.html
@@ -44,7 +44,7 @@ browser-compat: webextensions.api.types.BrowserSetting
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/types"><code>chrome.types</code></a> API.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
@@ -89,7 +89,7 @@ BrowserSetting.onChange.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/types"><code>chrome.types</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.html
@@ -87,7 +87,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/types"><code>chrome.types</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/types"><code>chrome.types</code></a> API.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.html
@@ -94,7 +94,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#method-getAllFrames"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.html
@@ -85,7 +85,7 @@ gettingFrame.then(onGot, onError);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#method-getFrame"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.html
@@ -104,7 +104,7 @@ browser-compat: webextensions.api.webNavigation
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.html
@@ -101,7 +101,7 @@ browser.webNavigation.onBeforeNavigate.addListener(logOnBefore, filter);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.html
@@ -107,7 +107,7 @@ browser.webNavigation.onCommitted.addListener(logOnCommitted, filter);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.html
@@ -100,7 +100,7 @@ browser.webNavigation.onCompleted.addListener(logOnCompleted, filter);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.html
@@ -115,7 +115,7 @@ browser.webNavigation.onCreatedNavigationTarget.addListener(logOnCreatedNavigati
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.html
@@ -101,7 +101,7 @@ browser.webNavigation.onDOMContentLoaded.addListener(logOnDOMContentLoaded, filt
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.html
@@ -114,7 +114,7 @@ browser.webNavigation.onErrorOccurred.addListener(logOnErrorOccurred, filter);
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.html
@@ -106,7 +106,7 @@ browser.webNavigation.onHistoryStateUpdated.addListener(logOnHistoryStateUpdated
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.html
@@ -106,7 +106,7 @@ browser.webNavigation.onReferenceFragmentUpdated.addListener(logOnReferenceFragm
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onBeforeNavigate"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.html
@@ -81,7 +81,7 @@ browser.webNavigation.onTabReplaced.addListener(logOnTabReplaced);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#event-onTabReplaced"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.webNavigation.TransitionQualifier
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#type-TransitionQualifier"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.html
@@ -54,7 +54,7 @@ browser-compat: webextensions.api.webNavigation.TransitionType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webNavigation#type-TransitionType"><code>chrome.webNavigation</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json"><code>web_navigation.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.html
@@ -58,7 +58,7 @@ browser-compat: webextensions.api.webRequest.BlockingResponse
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#type-BlockingResponse"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.html
@@ -73,7 +73,7 @@ flushingCache.then(onFlushed, onError);</pre>
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#method-handlerBehaviorChanged"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.webRequest.HttpHeaders
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#type-HttpHeaders"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.html
@@ -26,7 +26,7 @@ browser-compat: webextensions.api.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#property-MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
@@ -194,7 +194,7 @@ browser.webRequest.onCompleted.addListener(
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#event-onCompleted"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
@@ -185,7 +185,7 @@ browser.webRequest.onSendHeaders.addListener(
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#event-onSendHeaders"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.webRequest.RequestFilter
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#type-RequestFilter"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.html
@@ -76,7 +76,7 @@ browser-compat: webextensions.api.webRequest.ResourceType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#type-ResourceType"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.webRequest.UploadData
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/webRequest#type-UploadData"><code>chrome.webRequest</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json"><code>web_request.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
@@ -151,7 +151,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{Compat}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-create"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.windows.CreateType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#type-CreateType"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
@@ -82,7 +82,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-get"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.html
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-getAll"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
@@ -78,7 +78,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-getCurrent"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
@@ -76,7 +76,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-getLastFocused"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/index.html
@@ -76,7 +76,7 @@ browser-compat: webextensions.api.windows
 
 <p>{{WebExtExamples("h2")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.html
@@ -65,7 +65,7 @@ browser.windows.onCreated.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#event-onCreated"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
@@ -69,7 +69,7 @@ browser.windows.onFocusChanged.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#event-onFocusChanged"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.html
@@ -66,7 +66,7 @@ browser.windows.onRemoved.hasListener(listener)
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#event-onRemoved"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.html
@@ -76,7 +76,7 @@ document.querySelector('#close').addEventListener(async ({ button, }) =&gt; { tr
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-remove"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.html
@@ -89,7 +89,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#method-update"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.html
@@ -59,7 +59,7 @@ browser-compat: webextensions.api.windows.Window
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#type-Window"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.windows.WINDOW_ID_CURRENT
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#property-WINDOW_ID_CURRENT"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.windows.WINDOW_ID_NONE
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#property-WINDOW_ID_NONE"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.windows.WindowState
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#type-WindowState"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.windows.WindowType
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/windows#type-WindowType"><code>chrome.windows</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json"><code>windows.json</code></a> in the Chromium code.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>{{Compat("webextensions.manifest",2)}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
+<div class="note"><p><strong>Note:</strong></p>
 
 <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.manifest.storage
 <p>{{Compat}}</p>
 
 <div class="notecard note">
-<p><strong>Acknowledgements</strong></p>
+<p><p><strong>Note:</strong></p></p>
 
 <p>This page includes details from the Chrome developer website page <a href="https://developer.chrome.com/apps/manifest/storage">Manifest for storage areas</a> included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.manifest.storage
 <p>{{Compat}}</p>
 
 <div class="notecard note">
-<p><p><strong>Note:</strong></p></p>
+<p><strong>Note:</strong></p>
 
 <p>This page includes details from the Chrome developer website page <a href="https://developer.chrome.com/apps/manifest/storage">Manifest for storage areas</a> included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

In Markdown notes have to start with **Note:**. Many of the notes in the add-ons docs are to acknowledge that the APIs are derived from Chrome APIs, and use **Acknowledgement** instead. This PR changes those cases to use **Note:** instead.
