### PR TITLE
[Markdown][Add-ons] Fix notes with a misplaced colon

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.downloads.DangerType
 <p>A {{WebExtAPIRef('downloads.DownloadItem')}}'s <code>danger</code> property will contain a string taken from the values defined in this type.</p>
 
 <div class="note">
-<p><strong>Note</strong>: These string constants will never change, however the set of DangerTypes may change.</p>
+<p><strong>Note:</strong> These string constants will never change, however the set of DangerTypes may change.</p>
 </div>
 
 <h2 id="Type">Type</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
@@ -70,7 +70,7 @@ browser-compat: webextensions.api.downloads.download
   <p>If this option is omitted, the browser will show the file chooser or not based on the general user preference for this behavior (in Firefox this preference is labeled "Always ask you where to save files" in about:preferences, or <code>browser.download.useDownloadDir</code> in about:config).</p>
 
   <div class="note">
-  <p><strong>Note</strong>: Firefox for Android raises an error if <code>saveAs</code> is set to <code>true</code>. The parameter is ignored when <code>saveAs</code> is <code>false</code> or not included.</p>
+  <p><strong>Note:</strong> Firefox for Android raises an error if <code>saveAs</code> is set to <code>true</code>. The parameter is ignored when <code>saveAs</code> is <code>false</code> or not included.</p>
   </div>
   </dd>
   <dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
@@ -22,7 +22,7 @@ browser-compat: webextensions.api.downloads.erase
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>
 
 <div class="note">
-<p><strong>Note</strong>: If you want to remove a downloaded file from disk <em>and</em> erase it from history, you have to call {{WebExtAPIRef("downloads.removeFile()")}} before you call <code>erase()</code>. If you try it the other way around you'll get an error when calling {{WebExtAPIRef("downloads.removeFile()")}}, because it no longer exists according to the browser.</p>
+<p><strong>Note:</strong> If you want to remove a downloaded file from disk <em>and</em> erase it from history, you have to call {{WebExtAPIRef("downloads.removeFile()")}} before you call <code>erase()</code>. If you try it the other way around you'll get an error when calling {{WebExtAPIRef("downloads.removeFile()")}}, because it no longer exists according to the browser.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
@@ -24,7 +24,7 @@ browser-compat: webextensions.api.downloads.removeFile
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>
 
 <div class="note">
-<p><strong>Note</strong>: If you want to remove a downloaded file from disk <em>and</em> erase it from history, you have to call <code>removeFile()</code> before you call {{WebExtAPIRef("downloads.erase()")}}. If you try it the other way around you'll get an error when calling <code>removeFile()</code>, because the browser will no longer have a record of the download.</p>
+<p><strong>Note:</strong> If you want to remove a downloaded file from disk <em>and</em> erase it from history, you have to call <code>removeFile()</code> before you call {{WebExtAPIRef("downloads.erase()")}}. If you try it the other way around you'll get an error when calling <code>removeFile()</code>, because the browser will no longer have a record of the download.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.downloads.setShelfEnabled
 <p>If you try to enable the shelf when at least one other extension has already disabled it, the call will fail and {{WebExtAPIRef("runtime.lastError")}} will be set with an appropriate error message.</p>
 
 <div class="note">
-<p><strong>Note</strong>: To use this function in your extension you must ask for the <code>"downloads.shelf"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">manifest permission</a>, as well as the <code>"downloads"</code> permission.</p>
+<p><strong>Note:</strong> To use this function in your extension you must ask for the <code>"downloads.shelf"</code> <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">manifest permission</a>, as well as the <code>"downloads"</code> permission.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.downloads.State
 </dl>
 
 <div class="note">
-<p><strong>Note</strong>: These string constants will never change, but new constants may be added.</p>
+<p><strong>Note:</strong> These string constants will never change, but new constants may be added.</p>
 </div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.extension.getBackgroundPage
 <p>Alias for {{WebExtAPIRef("runtime.getBackgroundPage()")}}.</p>
 
 <div class="note">
-<p><strong>Note</strong>: This method cannot be used in Private Browsing mode — it always returns an empty array. Consider using {{WebExtAPIRef("runtime.sendMessage","runtime.sendMessage()")}} or {{WebExtAPIRef("runtime.connect","runtime.connect()")}}. For more info see {{bug(1329304)}}.</p>
+<p><strong>Note:</strong> This method cannot be used in Private Browsing mode — it always returns an empty array. Consider using {{WebExtAPIRef("runtime.sendMessage","runtime.sendMessage()")}} or {{WebExtAPIRef("runtime.connect","runtime.connect()")}}. For more info see {{bug(1329304)}}.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
@@ -19,7 +19,7 @@ browser-compat: webextensions.api.history
 <p>If you are looking for information about the browser session history, see the <a href="/en-US/docs/Web/API/History">History interface</a>.</p>
 
 <div class="note">
-<p><strong>Note</strong>: Downloads are treated as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/HistoryItem" title="A HistoryItem object provides information about a page in the browser history."><code>HistoryItem</code></a> objects. Therefore, events such as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/onVisited" title="Fired each time the user visits a page. A history.HistoryItem object is passed to the listener. This event fires before the page has loaded."><code>history.onVisited</code></a> fire for downloads.</p>
+<p><strong>Note:</strong> Downloads are treated as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/HistoryItem" title="A HistoryItem object provides information about a page in the browser history."><code>HistoryItem</code></a> objects. Therefore, events such as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/onVisited" title="Fired each time the user visits a page. A history.HistoryItem object is passed to the listener. This event fires before the page has loaded."><code>history.onVisited</code></a> fire for downloads.</p>
 </div>
 
 <p>Browser history is a chronological record of pages the user has visited. The history API enables you to:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.html
@@ -17,7 +17,7 @@ tags:
 <p>Each internationalized extension has at least one file named <code>messages.json</code> that provides locale-specific strings. This page describes the format of <code>messages.json</code> files.</p>
 
 <div class="note">
-<p><strong>Note</strong>: For information on how to internationalize your extensions, see our <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization">i18n</a> guide.</p>
+<p><strong>Note:</strong> For information on how to internationalize your extensions, see our <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization">i18n</a> guide.</p>
 </div>
 
 <h2 id="messages.json_example">messages.json example</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
@@ -79,7 +79,7 @@ browser-compat: webextensions.api.menus.create
     }</pre>
 
   <div class="notecard note">
-  <p><strong>Note</strong>: The top-level menu item uses the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">icons</a> specified in the manifest rather than what is specified with this key.</p>
+  <p><strong>Note:</strong> The top-level menu item uses the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">icons</a> specified in the manifest rather than what is specified with this key.</p>
   </div>
   </dd>
   <dt><code>id</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
@@ -58,7 +58,7 @@ browser-compat: webextensions.api.menus.createProperties
     }</pre>
 
  <div class="notecard note">
- <p><strong>Note</strong>: The top-level menu item uses the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">icons</a> specified in the manifest rather than what is specified with this key.</p>
+ <p><strong>Note:</strong> The top-level menu item uses the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">icons</a> specified in the manifest rather than what is specified with this key.</p>
  </div>
  </dd>
  <dt><code>id</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
@@ -80,7 +80,7 @@ browser-compat: webextensions.api.menus.update
     }</pre>
 
   <div class="notecard note">
-  <p><strong>Note</strong>: The top-level menu item uses the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">icons</a> specified in the manifest rather than what is specified with this key.</p>
+  <p><strong>Note:</strong> The top-level menu item uses the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">icons</a> specified in the manifest rather than what is specified with this key.</p>
   </div>
   </dd>
   <dt><code>id</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
@@ -28,7 +28,7 @@ browser-compat: webextensions.api.runtime.getBackgroundPage
 <p>This is an asynchronous function that returns a {{JSxRef("Promise")}}.</p>
 
 <div class="note">
-<p><strong>Note</strong>: In Firefox, this method cannot be used in Private Browsing mode — it always returns <code>null</code>. For more info see {{bug(1329304)}}.</p>
+<p><strong>Note:</strong> In Firefox, this method cannot be used in Private Browsing mode — it always returns <code>null</code>. For more info see {{bug(1329304)}}.</p>
 
 <p>In Chrome, this method is available only with persistent background pages, which are not available in Manifest V3, so consider using Manifest V2. See the <a href="https://developer.chrome.com/extensions/migrating_to_service_workers">this</a> for details.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.runtime.onSuspend
 <p>Sent to the event page just before it is unloaded. This gives the extension an opportunity to do some cleanup. Note that since the page is unloading, any asynchronous operations started while handling this event are not guaranteed to complete.</p>
 
 <div class="note">
-<p><strong>Note</strong>: If something prevents the event page from being unloaded, the {{WebExtAPIRef("runtime.onSuspendCanceled")}} event will be sent and the page won't be unloaded.</p>
+<p><strong>Note:</strong> If something prevents the event page from being unloaded, the {{WebExtAPIRef("runtime.onSuspendCanceled")}} event will be sent and the page won't be unloaded.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.tabs.duplicate
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with a {{WebExtAPIRef('tabs.Tab')}} object containing details about the duplicated tab. The <code>Tab</code> object only contains <code>url</code>, <code>title</code> and <code>favIconUrl</code> if the extension has the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions"><code>"tabs"</code> permission</a> or matching <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permissions</a>. If any error occurs the promise will be rejected with an error message.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: Beginning with Firefox 68, the promise returned by browser.tabs.duplicate() resolves as soon as the tab has been duplicated. Previously, the promise only resolved once the tab had fully been loaded.</p>
+<p><strong>Note:</strong> Beginning with Firefox 68, the promise returned by browser.tabs.duplicate() resolves as soon as the tab has been duplicated. Previously, the promise only resolved once the tab had fully been loaded.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.tabs.highlight
   <p><code>boolean</code>. Defaults to <code>true</code>. If set to <code>false</code>, the {{WebExtAPIRef('windows.Window')}} object won't have a <code>tabs</code> property containing a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs open in the window.</p>
 
   <div class="note">
-  <p><strong>Note</strong>: Populating the window (the default behavior) can be an expensive operation if there are lots of tabs. For better performance it's recommended to manually set <code>populate</code> to <code>false</code> if you don't need tab details.</p>
+  <p><strong>Note:</strong> Populating the window (the default behavior) can be an expensive operation if there are lots of tabs. For better performance it's recommended to manually set <code>populate</code> to <code>false</code> if you don't need tab details.</p>
   </div>
   </dd>
   <dt><code>tabs</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.windows.get
 <p>This example gets the current window and logs the URLs of the tabs it contains. Note that you'll need the "tabs" <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a> or matching <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permissions</a> to access tab URLs.</p>
 
 <div class="note">
-<p><strong>Note</strong>: This example is a bit unrealistic: in this situation you would more probably use {{WebExtAPIRef("windows.getCurrent()")}}.</p>
+<p><strong>Note:</strong> This example is a bit unrealistic: in this situation you would more probably use {{WebExtAPIRef("windows.getCurrent()")}}.</p>
 </div>
 
 <pre class="brush: js">function logTabs(windowInfo) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.windows.onFocusChanged
 <p>Fired when the currently focused window changes. Will be {{WebExtAPIRef('windows.WINDOW_ID_NONE')}} if all browser windows have lost focus.</p>
 
 <div class="note">
-<p><strong>Note</strong>: In Windows and some Linux window managers, WINDOW_ID_NONE will always be sent immediately preceding a switch from one browser window to another.</p>
+<p><strong>Note:</strong> In Windows and some Linux window managers, WINDOW_ID_NONE will always be sent immediately preceding a switch from one browser window to another.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.html
@@ -108,7 +108,7 @@ browser.alarms.onAlarm.addListener(copy);</pre>
 </pre>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The<code>clipboard-write</code> permission name is not currently supported in Firefox — only Chromium browsers.</p>
+<p><strong>Note:</strong> The<code>clipboard-write</code> permission name is not currently supported in Firefox — only Chromium browsers.</p>
 </div>
 
 <h3 id="Browser-specific_considerations">Browser-specific considerations</h3>

--- a/files/en-us/mozilla/add-ons/webextensions/internationalization/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/internationalization/index.html
@@ -116,7 +116,7 @@ tags:
 <p>This file is standard JSON — each one of its members is an object with a name, which contains a <code>message</code> and a <code>description</code>. All of these items are strings; <code>$URL$</code> is a placeholder, which is replaced with a substring at the time the <code>notificationContent</code> member is called by the extension. You'll learn how to do this in the {{anch("Retrieving message strings from JavaScript")}} section.</p>
 
 <div class="note">
-<p><strong>Note</strong>: You can find much more information about the contents of <code>messages.json</code> files in our <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference">Locale-Specific Message reference</a>.</p>
+<p><strong>Note:</strong> You can find much more information about the contents of <code>messages.json</code> files in our <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference">Locale-Specific Message reference</a>.</p>
 </div>
 
 <h2 id="Internationalizing_manifest.json">Internationalizing manifest.json</h2>
@@ -394,7 +394,7 @@ padding-left: 1.5em;</pre>
 </ol>
 
 <div class="note">
-<p><strong>Note</strong>: This works to change the browser's locale, even if you haven't got the <a href="https://addons.mozilla.org/en-US/firefox/language-tools/">language pack</a> installed for that language. You'll just get the browser UI in your default language if this is the case.</p>
+<p><strong>Note:</strong> This works to change the browser's locale, even if you haven't got the <a href="https://addons.mozilla.org/en-US/firefox/language-tools/">language pack</a> installed for that language. You'll just get the browser UI in your default language if this is the case.</p>
 </div>
 
 <div class="note">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -46,11 +46,11 @@ browser-compat: webextensions.manifest.theme
 <p>Use the theme key to define a static theme to apply to Firefox.</p>
 
 <div class="note">
-<p><strong>Note</strong>: If you want to include a theme with an extension, please see the {{WebExtAPIRef("theme")}} API.</p>
+<p><strong>Note:</strong> If you want to include a theme with an extension, please see the {{WebExtAPIRef("theme")}} API.</p>
 </div>
 
 <div class="note">
-<p><strong>Note</strong>: Since May 2019, themes need to be signed to be installed ({{bug(1545109)}}).  See <a href="https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/#distributing-your-addon">Signing and distributing your add-on</a> for more details.</p>
+<p><strong>Note:</strong> Since May 2019, themes need to be signed to be installed ({{bug(1545109)}}).  See <a href="https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/#distributing-your-addon">Signing and distributing your add-on</a> for more details.</p>
 </div>
 
 <div class="note">

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
@@ -89,7 +89,7 @@ browser-compat: webextensions.match_patterns.scheme
 <p>Neither the <a href="https://en.wikipedia.org/wiki/Fragment_identifier">URL fragment identifier</a>, nor the <code>#</code> which precedes it, are considered as part of the <em>path</em>.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The path pattern string should not include a port number. Adding a port, as in: <em>"http://localhost:1234/*"</em> causes the match pattern to be ignored. However, "<em>http://localhost:1234</em>" will match with "<em>http://localhost/*</em>"</p>
+<p><strong>Note:</strong> The path pattern string should not include a port number. Adding a port, as in: <em>"http://localhost:1234/*"</em> causes the match pattern to be ignored. However, "<em>http://localhost:1234</em>" will match with "<em>http://localhost/*</em>"</p>
 </div>
 
 <h3 id="&lt;all_urls&gt;">&lt;all_urls&gt;</h3>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

The Markdown converter expects notes to start like: `<strong>Note:</strong>`. This PR fixes cases in the add-ons docs where the not instead starts like: `<strong>Note</strong>:`.