### PR TITLE
[Markdown][Add-ons] Fix hidden elements

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.html
@@ -83,12 +83,6 @@ browser-compat: webextensions.api.bookmarks
 
 <p>{{Compat}}</p>
 
-<div class="hidden note">
-<p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>
-
-<p>If you need to update this content, edit <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities</a>, then shift-refresh this page to see your changes.</p>
-</div>
-
 <p>{{WebExtExamples("h2")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.html
@@ -86,12 +86,6 @@ browser-compat: webextensions.api.browserAction
 
 <p>{{Compat}}</p>
 
-<div class="hidden note">
-<p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>
-
-<p>If you need to update this content, edit <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a>, then shift-refresh this page to see your changes.</p>
-</div>
-
 <p>{{WebExtExamples("h2")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
@@ -86,7 +86,7 @@ browser.browserAction.onClicked.hasListener(listener)
  </div>
 
  <div class="hidden">
- <pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+<pre>// Copyright 2015 The Chromium Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.html
@@ -79,12 +79,6 @@ browser-compat: webextensions.api.browsingData
 
 <p>{{Compat}}</p>
 
-<div class="note hidden">
-<p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>
-
-<p>If you need to update this content, edit <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a>, then shift-refresh this page to see your changes.</p>
-</div>
-
 <p>{{WebExtExamples("h2")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.html
@@ -24,10 +24,6 @@ browser-compat: webextensions.api.captivePortal.getLastChecked
 
 <p>A <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a> that is fulfilled with an integer representing time in milliseconds.</p>
 
-<div class="hidden">
-<h2 id="Examples">Examples</h2>
-</div>
-
 <p>{{WebExtExamples}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.html
@@ -48,12 +48,6 @@ browser-compat: webextensions.api.captivePortal
 
 <p>{{Compat}}</p>
 
-<div class="hidden note">
-<p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>
-
-<p>If you need to update this content, edit <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a>, then shift-refresh this page to see your changes.</p>
-</div>
-
 <p>{{WebExtExamples("h2")}}</p>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
@@ -86,7 +86,7 @@ uninstalling.then(null, onCanceled);</pre>
  </div>
 
  <div class="hidden">
- <pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+<pre>// Copyright 2015 The Chromium Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
@@ -88,7 +88,7 @@ browser.pageAction.onClicked.addListener(function () {
 	</div>
 
 	<div class="hidden">
-	<pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+<pre>// Copyright 2015 The Chromium Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
@@ -52,12 +52,6 @@ browser-compat: webextensions.api.privacy.network
 
 <p>{{Compat}}</p>
 
-<div class="hidden note">
-<p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>
-
-<p>If you need to update this content, edit <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a>, then shift-refresh this page to see your changes.</p>
-</div>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Set the <code>webRTCIPHandlingPolicy</code> property:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.html
@@ -83,12 +83,6 @@ browser-compat: webextensions.api.privacy.websites
 
 <p>{{Compat}}</p>
 
-<div class="hidden note">
-<p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>
-
-<p>If you need to update this content, edit <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities</a>, then shift-refresh this page to see your changes.</p>
-</div>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Set the <code>hyperlinkAuditingEnabled</code> property.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.html
@@ -266,10 +266,7 @@ tags:
   &lt;button class="panel-section-footer-button default"&gt;Confirm&lt;/button&gt;
 &lt;/footer&gt;</pre>
 
-<div class="hidden">
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css">/* Global */
+<pre class="brush: css hidden">/* Global */
 html,
 body {
   background: white;
@@ -437,8 +434,7 @@ button.panel-section-tabs-button {
   z-index: 99;
 }</pre>
 
-<hr>
-<pre class="brush: css">/* Example specific – not part of chrome://browser/content/extension.css */
+<pre class="brush: css hidden">/* Example specific – not part of chrome://browser/content/extension.css */
 body {
   background: #fcfcfc;
   background-clip: padding-box;
@@ -460,7 +456,6 @@ html &gt; body {
 .icon-section-header {
   background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgdmlld0JveD0iMCAwIDMyIDMyIj48Y2lyY2xlIGZpbGw9IiMzNjM5NTkiIGN4PSIxNSIgY3k9IjE1IiByPSIxNSIvPjwvc3ZnPg==");
 }</pre>
-</div>
 
 <h4 id="Result">Result</h4>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

In Markdown we can only use the `"hidden"` class on code blocks.

The add-ons docs use `"hidden"` extensively to provide a hidden copyright message about Chrome. I think it makes sense to keep this as HTML, for the following reasons:
* we don't want to make it visible in the docs
* we don't want to remove it
* we never edit this text, so the benefit of Markdown doesn't apply

So in this PR I'm not removing any of the hidden elements that start with a string like "\n// Copyright 2015 The Chromium Authors." or ""\n// Copyright 2012 The Chromium Authors.".

But I'm removing all the others.
