### PR TITLE
[Markdown][Add-ons] Remove reference-values class

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.alarms.Alarm
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>name</code></dt>
  <dd><code>string</code>. Name of this alarm. This is the name that was passed into the {{WebExtAPIRef('alarms.create()')}} call that created this alarm.</dd>
  <dt><code>scheduledTime</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
@@ -41,7 +41,7 @@ browser-compat: webextensions.api.alarms.create
  <p>The <code>alarmInfo</code> object may contain the following properties:</p>
  </dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>when</code>{{optional_inline}}</dt>
   <dd><code>double</code>. The time the alarm will fire first, given as <a href="https://en.wikipedia.org/wiki/Unix_time">milliseconds since the epoch</a>. To get the number of milliseconds between the epoch and the current time, use <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now">Date.now()</a></code>. If you specify <code>when</code>, don't specify <code>delayInMinutes</code>.</dd>
   <dt><code>delayInMinutes</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
@@ -44,7 +44,7 @@ browser.alarms.onAlarm.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>alarm</code></dt>
   <dd>{{WebExtAPIRef('alarms.Alarm')}}. The alarm that fired. Use <code>Alarm.name</code> to figure out which alarm fired.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.bookmarks.BookmarkTreeNode
 
 <p>An {{jsxref("object")}} with the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>children</code> {{optional_inline}}</dt>
  <dd>An {{jsxref("array")}} of {{WebExtAPIRef('bookmarks.BookmarkTreeNode')}} objects which represent the node's children. The list is ordered in the list in which the children appear in the user interface. This field is omitted if the node isn't a folder.</dd>
  <dt><code>dateAdded</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.bookmarks.CreateDetails
 
 <p>An {{jsxref("object")}} containing some combination of the following fields:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>index</code> {{optional_inline}}</dt>
  <dd>An integer {{jsxref("Number")}} which specifies the position at which to place the new bookmark under its parent. A value of 0 will put it at the top of the list.</dd>
  <dt><code>parentId</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.bookmarks.move
  <dt><code>destination</code></dt>
  <dd>An {{jsxref("object")}} which specifies the destination for the bookmark. This object must contain one or both of the following fields:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>parentId</code> {{optional_inline}}</dt>
   <dd>A {{jsxref("string")}} which specifies the ID of the destination folder. If this value is left out, the bookmark is moved to a new location within its current folder.</dd>
   <dt><code>index</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
@@ -49,12 +49,12 @@ browser.bookmarks.onChanged.hasListener(listener)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code>id</code></dt>
 		<dd><code>string</code>. ID of the item that changed.</dd>
 	</dl>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code>changeInfo</code></dt>
 		<dd><a href="#changeinfo"><code>object</code></a>. Object containing two properties: <code>title</code>, a string containing the item's title, and <code>url</code>, a string containing the item's URL. If the item is a folder, <code>url</code> is omitted.</dd>
 	</dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
@@ -44,12 +44,12 @@ browser.bookmarks.onChildrenReordered.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>id</code></dt>
   <dd><code>string</code>. ID of the folder whose children were reordered.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>reorderInfo</code></dt>
   <dd><a href="#reorderinfo"><code>object</code></a>. Object containing Additional objects.</dd>
  </dl>
@@ -60,7 +60,7 @@ browser.bookmarks.onChildrenReordered.hasListener(listener)
 
 <h3 id="reorderInfo">reorderInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>childIds</code></dt>
  <dd><code>array</code> of <code>string</code>. Array containing the IDs of all the bookmark items in this folder, in the order they now appear in the UI.</dd>
 </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
@@ -44,12 +44,12 @@ browser.bookmarks.onCreated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>id</code></dt>
   <dd><code>string</code>. The new bookmark item's ID.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>bookmark</code></dt>
   <dd>{{WebExtAPIRef('bookmarks.BookmarkTreeNode')}}. Information about the new bookmark item.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
@@ -44,12 +44,12 @@ browser.bookmarks.onMoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>id</code></dt>
   <dd><code>string</code>. ID of the item that was moved.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>moveInfo</code></dt>
   <dd><a href="#moveinfo"><code>object</code></a>. Object containing more details about the move.</dd>
  </dl>
@@ -60,7 +60,7 @@ browser.bookmarks.onMoved.hasListener(listener)
 
 <h3 id="moveInfo">moveInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>parentId</code></dt>
  <dd><code>string</code>. The new parent folder.</dd>
  <dt><code>index</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
@@ -44,12 +44,12 @@ browser.bookmarks.onRemoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>id</code></dt>
   <dd><code>string</code>. ID of the item that was removed.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>removeInfo</code></dt>
   <dd><a href="#removeinfo"><code>object</code></a>. More details about the removed item.</dd>
  </dl>
@@ -60,7 +60,7 @@ browser.bookmarks.onRemoved.hasListener(listener)
 
 <h3 id="removeInfo">removeInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>parentId</code></dt>
  <dd><code>string</code>. ID of the item's parent in the tree.</dd>
  <dt><code>index</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.bookmarks.search
  <p>If <code>query</code> is an <strong>object</strong>, it consists of zero or more of 3 properties: <code>query</code>, <code>title</code>, and <code>url</code>, which are described below. For a bookmark to match the query, all the properties' terms must be matched.</p>
  </dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>query</code> {{optional_inline}}</dt>
   <dd>A {{jsxref("string")}} specifying one or more terms to match against; the format is identical to the string form of the <code>query</code> parameter. If this isn't a string, an exception is thrown.</dd>
   <dt><code>url</code> {{optional_inline}}</dt>
@@ -49,7 +49,7 @@ browser-compat: webextensions.api.bookmarks.search
   </dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>title</code> {{optional_inline}}</dt>
   <dd>A {{jsxref("string")}} that must exactly match the bookmark tree node's title. Matching is case-sensitive.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.bookmarks.update
  <dt><code>changes</code></dt>
  <dd>An {{jsxref("object")}} specifying the changes to apply, with some combination of the following fields. Any items not specified aren't changed in the referenced bookmark or folder:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>title</code> {{optional_inline}}</dt>
   <dd>A {{jsxref("string")}} containing the new title of the bookmark, or the new name of the folder if <code>id</code> refers to a folder.</dd>
   <dt><code>url</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.browserAction.getBadgeBackgroundColor
 <dl>
  <dt><code>details</code></dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Specifies the tab to get the badge background color from.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.browserAction.getBadgeText
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Specifies the tab from which to get the badge text.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.browserAction.getBadgeTextColor
 <dl>
  <dt><code>details</code></dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Specifies the tab to get the badge text color from.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.browserAction.getPopup
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. The tab whose popup to get.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.browserAction.getTitle
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Specify the tab to get the title from.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.browserAction.isEnabled
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object optionally containing the <code>tabId</code> or <code>windowId</code> to check.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code> {{optional_inline}}</dt>
   <dd><code>integer</code>. ID of a tab to check.</dd>
   <dt><code>windowId</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
@@ -46,12 +46,12 @@ browser.browserAction.onClicked.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tab</code></dt>
   <dd>{{WebExtAPIRef('tabs.Tab')}}. The tab that was active when the icon was clicked.</dd>
   <dt><code>OnClickData</code></dt>
   <dd>An object containing information about the click.
-  <dl class="reference-values">
+  <dl>
    <dt><code>modifiers</code></dt>
    <dd>An <code>array</code>. The keyboard modifiers active at the time of the click, being one or more of <code>Shift</code>, <code>Alt</code>, <code>Command</code>, <code>Ctrl</code>, or <code>MacCtrl</code>.</dd>
    <dt><code>button</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.browserAction.setBadgeBackgroundColor
 <dl>
  <dt><code>details</code></dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>color</code></dt>
   <dd>The color, specified as one of:</dd>
   <dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.browserAction.setBadgeText
 <dl>
  <dt><code>details</code></dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>text</code></dt>
   <dd>
   <p><code>string</code> or <code>null</code>. Any number of characters can be passed, but only about four can fit in the space.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
@@ -28,7 +28,7 @@ browser-compat: webextensions.api.browserAction.setBadgeTextColor
 <dl>
  <dt><code>details</code></dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>color</code></dt>
   <dd>The color, specified as one of:</dd>
   <dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.browserAction.setIcon
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object containing either <code>imageData</code> or <code>path</code> properties, and optionally a <code>tabId</code> property.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>imageData</code>{{optional_inline}}</dt>
   <dd>
   <p><code>{{WebExtAPIRef('browserAction.ImageDataType')}}</code> or <code>object</code>. This is either a single <code>ImageData</code> object or a dictionary object.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
@@ -30,14 +30,14 @@ browser-compat: webextensions.api.browserAction.setPopup
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Sets the popup only for a specific tab. The popup is reset when the user navigates this tab to a new page.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Sets the popup only for the specified window.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>popup</code></dt>
   <dd>
   <p><code>string</code> or <code>null</code>. The HTML file to show in a popup, specified as a URL.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.html
@@ -28,7 +28,7 @@ browser-compat: webextensions.api.browserAction.setTitle
 <dl>
  <dt><code>details</code></dt>
  <dd><code>object</code>. The new title and optionally the ID of the tab or window to target.
- <dl class="reference-values">
+ <dl>
   <dt><code>title</code></dt>
   <dd>
   <p><code>string</code> or <code>null</code>. The string the browser action should display when moused over.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
@@ -29,7 +29,7 @@ browser-compat: webextensions.api.browsingData.DataTypeSet
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cache</code> {{optional_inline}}</dt>
  <dd><code>boolean</code>. The browser's cache.</dd>
  <dt><code>cookies</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.browsingData.RemovalOptions
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code> {{optional_inline}}</dt>
  <dd>
  <p><code>string</code>. This property only applies to cookies and indexedDB items. The removal is limited to items belonging to a specific <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore">cookie store</a> as specified by the ID.</p>
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.browsingData.RemovalOptions
  </dd>
 </dl>
 
-<dl class="reference-values">
+<dl>
  <dt><code>hostnames</code> {{optional_inline}}</dt>
  <dd>
  <p><code>Array</code> of <code>string</code>. This property only applies to cookies and local storage items. Only remove cookies and local storage items which are associated with these hostnames.</p>
@@ -44,7 +44,7 @@ browser-compat: webextensions.api.browsingData.RemovalOptions
 
  <p>This object may contain any of the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>unprotectedWeb</code> {{optional_inline}}</dt>
   <dd><code>boolean</code>. If present and <code>true</code>, remove data from normal web pages.</dd>
   <dt><code>protectedWeb</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
@@ -35,7 +35,7 @@ browser-compat: webextensions.api.browsingData.settings
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with an object containing the settings information. This object has three properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>options</code></dt>
  <dd><code>{{WebExtAPIRef("browsingData.RemovalOptions")}}</code>. A <code>RemovalOptions</code> object describing the removal options currently selected.</dd>
  <dt><code>dataToRemove</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.html
@@ -42,7 +42,7 @@ browser.captivePortal.onConnectivityAvailable.hasListener(listener)
  <dd>
  <p>Function that is called when this event occurs. The function is passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>status</code></dt>
   <dd><code>string</code> The status of the service, being one of <code>captive</code> if there is an unlocked captive portal present or <code>clear</code> if no captive portal is detected.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.html
@@ -42,7 +42,7 @@ browser.captivePortal.onStateChanged.hasListener(listener)
  <dd>
  <p>Function that is called when this event occurs. The function is passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd>
   <p><code>string</code> The captive portal state, being one of <code>unknown</code>, <code>not_captive</code>, <code>unlocked_portal</code>, or <code>locked_portal</code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.commands.Command
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>name</code>{{optional_inline}}</dt>
  <dd><code>string</code>. Name of this command. This will be passed into the {{WebExtAPIRef('commands.onCommand')}} event listener.</dd>
  <dt><code>description</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
@@ -46,7 +46,7 @@ browser.commands.onCommand.hasListener(listener)
  <dd>
  <p>Function that will be called when a user enters the command's shortcut. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code></dt>
   <dd><code>string</code>. Name of the command. This matches the name given to the command in its <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands">manifest.json entry</a>.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.commands.update
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code></dt>
   <dd><code>string</code>. The name of the command to update. This must match the name of an existing command, as given for example in the <code>name</code> property of the {{WebExtAPIRef("commands.Command")}} object.</dd>
   <dt><code>description</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.contentScripts.register
 
  <p>The <code>RegisteredContentScriptOptions</code> object has the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>allFrames</code>{{optional_inline}}</dt>
   <dd>Same as <code>all_frames</code> in the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts">content_scripts</a></code> key.</dd>
   <dt><code>css</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.contextualIdentities.ContextualIdentity
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. The cookie store ID for the identity. Since contextual identities don't share cookie stores, this serves as a unique identifier.</dd>
  <dt><code>color</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.contextualIdentities.create
  <dd>
  <p><code>object</code>. An object containing properties for the new contextual identity. This contains the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code></dt>
   <dd>
   <p><code>string</code>. The name of the new identity. This will be displayed in the browser's UI, enabling them to open a new tab belonging to the identity. It will also be displayed in the URL bar for tabs belonging to this identity.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.html
@@ -43,7 +43,7 @@ browser.contextualIdentities.onCreated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>changeInfo</code></dt>
   <dd><code>object</code>. An object that contains a single property, <code>contextualIdentity</code>, which is a {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} object, representing the identity that was created.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.html
@@ -43,7 +43,7 @@ browser.contextualIdentities.onRemoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>changeInfo</code></dt>
   <dd><code>object</code>. An object that contains a single property, <code>contextualIdentity</code>, which is a {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} object representing the identity that was removed.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.html
@@ -43,7 +43,7 @@ browser.contextualIdentities.onUpdated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>changeInfo</code></dt>
   <dd><code>object</code>. An object that contains a single property, <code>contextualIdentity</code>, which is a {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} object representing the identity whose properties were updated.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.contextualIdentities.query
  <dd>
  <p><code>object</code>. An object that can be used to filter the contextual identities returned. This may contain any of the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code> {{optional_inline}}</dt>
   <dd><code>string</code>. Return only contextual identities with this name.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.contextualIdentities.update
  <dd>
  <p><code>object</code>. An object containing new values for the properties that you wish to change. This may contain any of the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code> {{optional_inline}}</dt>
   <dd>
   <p><code>string</code>. A new name for the identity. This will be displayed in the browser's UI, enabling them to open a new tab in the identity. It will also be displayed in the URL bar for tabs belonging to this identity.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.cookies.Cookie
 
 <p>Values of this type are objects, which can contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>domain</code></dt>
  <dd>A <code>string</code> representing the domain the cookie belongs to (e.g. "www.google.com", "example.com").</dd>
  <dt><code>expirationDate</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.cookies.CookieStore
 
 <p>Values of this type are objects, which can contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>id</code></dt>
  <dd>A <code>string</code> representing the unique identifier for the cookie store.</dd>
  <dt><code>incognito</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.cookies.get
  <dt><code>details</code></dt>
  <dd>An <code>object</code> containing details that can be used to match a cookie to be retrieved. It can include the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstPartyDomain</code>{{optional_inline}}</dt>
   <dd>A <code>string</code> representing the first-party domain with which the cookie to retrieve is associated. This property must be supplied if the browser has first-party isolation enabled. See <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation">First-party isolation</a>.</dd>
   <dt><code>name</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.cookies.getAll
  <dt><code>details</code></dt>
  <dd>An <code>object</code> containing details that can be used to match cookies to be retrieved. Included properties are as follows (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie#type">Cookie type</a> for more information on these):</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>domain</code>{{optional_inline}}</dt>
   <dd>A <code>string</code> representing a domain that cookies must be associated with (they can be associated either with this exact domain or one of its subdomains).</dd>
   <dt><code>firstPartyDomain</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
@@ -53,11 +53,11 @@ browser.cookies.onChanged.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>changeInfo</code></dt>
   <dd>An <code>object</code> containing details of the change that occurred. Its properties are as follows:</dd>
   <dd>
-  <dl class="reference-values">
+  <dl>
    <dt><code>removed</code></dt>
    <dd>A <code>boolean</code> that is set to <code>true</code> if a cookie was removed, and false if not.</dd>
    <dt><code>cookie</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.cookies.remove
  <dt><code>details</code></dt>
  <dd>An <code>object</code> containing information to identify the cookie to remove. It contains the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstPartyDomain</code>{{optional_inline}}</dt>
   <dd>A <code>string</code> representing the first-party domain with which the cookie to remove is associated. This property must be supplied if the browser has first-party isolation enabled. See <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation">First-party isolation</a>.</dd>
   <dt><code>name</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.cookies.set
  <dt><code>details</code></dt>
  <dd>An <code>object</code> containing the details of the cookie you wish to set. It can have the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>domain</code>{{optional_inline}}</dt>
   <dd>A <code>string</code> representing the domain of the cookie. If omitted, the cookie becomes a host-only cookie.</dd>
   <dt><code>expirationDate</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
@@ -59,7 +59,7 @@ browser-compat: webextensions.api.devtools.inspectedWindow.eval
  <dt><code>options</code>{{optional_inline}}</dt>
  <dd><code>object</code>. Options for the function (Note that Firefox does not yet support this options), as follows:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>frameURL</code>{{optional_inline}}</dt>
   <dd><code>string</code>. The URL of the frame in which to evaluate the expression. If this is omitted, the expression is evaluated in the main frame of the window.</dd>
   <dt><code>useContentScriptContext</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
@@ -29,7 +29,7 @@ browser-compat: webextensions.api.devtools.inspectedWindow.reload
  <dt><code>reloadOptions</code>{{optional_inline}}</dt>
  <dd><code>object</code>. Options for the function, as follows:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>ignoreCache</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. If true, this makes the reload ignore the browser cache (as if the user had pressed Shift+Ctrl+R).</dd>
   <dt><code>userAgent</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
@@ -42,7 +42,7 @@ browser.devtools.network.onNavigated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>string</code>. The new URL for the window.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
@@ -47,7 +47,7 @@ browser.devtools.network.onRequestFinished.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>request</code></dt>
   <dd><code>object</code>. An object representing the request. This object is a single <a href="http://www.softwareishard.com/blog/har-12-spec/#entries">HAR entry</a> object. It also defines an asynchronous <code>getContent()</code> method, which returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that resolves with an array of two elements. The first element is the HTTP response body as a string, while the second element is the <a href="/en-US/docs/Glossary/MIME_type">MIME type</a> of the HTTP response also as a string.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
@@ -43,7 +43,7 @@ browser.devtools.panels.onThemeChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>themeName</code></dt>
   <dd><code>string</code>. Name of the new theme: this will be one of the permitted values for <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/themeName">devtools.panels.themeName</a></code>.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.downloads.BooleanDelta
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>current</code>{{optional_inline}}</dt>
  <dd>A <code>boolean</code> representing the current boolean value.</dd>
  <dt><code>previous</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.downloads.DoubleDelta
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>current</code>{{optional_inline}}</dt>
  <dd>A <code>number</code> representing the current double value.</dd>
  <dt><code>previous</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.downloads.download
  <dt><code>options</code></dt>
  <dd>An <code>object</code> specifying what file you wish to download, and any other preferences you wish to set concerning the download. It can contain the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>allowHttpErrors</code>{{optional_inline}}</dt>
   <dd>A <code>boolean</code> flag that enables downloads to continue even if they encounter HTTP errors. Using this flag, for example, enables the download of server error pages. Default value <code>false</code>. When set to:
   <ul>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.downloads.DownloadItem
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>byExtensionId</code>{{optional_inline}}</dt>
  <dd>A <code>string</code> representing the ID of the extension that triggered the download (if it was triggered by an extension). This does not change once set. If the download was not triggered by an extension this is undefined.</dd>
  <dt><code>byExtensionName</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.downloads.DownloadQuery
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code>{{optional_inline}}</dt>
  <dd>The cookie store ID of the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities">contextual identity</a> in which the download took place.</dd>
  <dt><code>query</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.downloads.getFileIcon
  <dt><code>options</code>{{optional_inline}}</dt>
  <dd>An options <code>object</code> representing preferences for the icon to be retrieved. It can take the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>size</code>{{optional_inline}}</dt>
   <dd>An <code>integer</code> representing the size of the icon. The returned icon's size will be the provided size squared (in pixels). If omitted, the default size for the icon is 32x32 pixels.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
@@ -46,7 +46,7 @@ browser.downloads.onChanged.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. This function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>downloadDelta</code></dt>
   <dd>An <a href="#downloaddelta"><code>object</code></a> representing the {{WebExtAPIRef('downloads.DownloadItem')}} object that changed, and the status of all the properties that changed in it.</dd>
  </dl>
@@ -59,7 +59,7 @@ browser.downloads.onChanged.hasListener(listener)
 
 <p>The <code>downloadDelta</code> object has the following properties available:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>id</code></dt>
  <dd>An <code>integer</code> representing the <code>id</code> of the {{WebExtAPIRef('downloads.DownloadItem')}} that changed.</dd>
  <dt><code>url</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
@@ -46,7 +46,7 @@ browser.downloads.onCreated.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. This function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>downloadItem</code></dt>
   <dd>The {{WebExtAPIRef('downloads.DownloadItem')}} object in question.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
@@ -46,7 +46,7 @@ browser.downloads.onErased.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. This function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>downloadId</code></dt>
   <dd>An <code>integer</code> representing the <code>id</code> of the {{WebExtAPIRef('downloads.DownloadItem')}} that was erased.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.downloads.StringDelta
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>current</code>{{optional_inline}}</dt>
  <dd>A <code>string</code> representing the current string value.</dd>
  <dt><code>previous</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.events.Rule
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>id</code>{{optional_inline}}</dt>
  <dd><code>string</code>. Optional identifier that allows referencing this rule.</dd>
  <dt><code>tags</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
@@ -25,7 +25,7 @@ browser-compat: webextensions.api.events.UrlFilter
 
 <p>However, note that these last two patterns will not match the last component of the hostname, because no implicit dot is added at the end of the hostname. So for example, <code>"org."</code> will match "https://borg.com" but not "https://example.org". To match these patterns, use <code>hostSuffix</code>.</p>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>hostContains</code>{{optional_inline}}</dt>
 	<dd><code>string</code>. Matches if the <a href="/en-US/docs/Web/API/HTMLAnchorElement/hostname">hostname</a> of the URL (without protocol or port – see <code>schemes</code> and <code>ports</code>) contains the given string.
 	<ul>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.extension.getViews
  <dt><code>fetchProperties</code>{{optional_inline}}</dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>type</code>{{optional_inline}}</dt>
   <dd><code>string</code>. An {{WebExtAPIRef('extension.ViewType')}} indicating the type of view to get. If omitted, this function returns all views.</dd>
   <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
@@ -52,17 +52,17 @@ chrome.extension.onRequest.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>request</code></dt>
   <dd><code>any</code>. The request sent by the calling script.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sender</code></dt>
   <dd>{{WebExtAPIRef('runtime.MessageSender')}}.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sendResponse</code></dt>
   <dd><code>function</code>. Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response. If you have more than one <code>onRequest</code> listener in the same document, then only one may send a response.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
@@ -52,17 +52,17 @@ chrome.extension.onRequestExternal.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>request</code></dt>
   <dd><code>any</code>. The request sent by the calling script.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sender</code></dt>
   <dd>{{WebExtAPIRef('runtime.MessageSender')}}.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sendResponse</code></dt>
   <dd><code>function</code>. Function to call when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.extensionTypes.ImageDetails
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>format</code>{{optional_inline}}</dt>
  <dd>{{WebExtAPIRef('extensionTypes.ImageFormat')}}. The format of the resulting image. Default is <code>"png"</code>.</dd>
  <dt><code>quality</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
@@ -35,14 +35,14 @@ browser-compat: webextensions.api.find.find
 
 <h3 id="Parameters">Parameters</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>queryphrase</code></dt>
  <dd><code>string</code>. The text to search for.</dd>
  <dt><code>options</code>{{optional_inline}}</dt>
  <dd>
  <p><code>object</code>. An object specifying additional options. It may take any of the following properties, all optional:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab to search. Defaults to the active tab.</dd>
   <dt><code>caseSensitive</code></dt>
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.find.find
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with an object containing up to three properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>count</code></dt>
  <dd><code>integer</code>. The number of results found.</dd>
  <dt><code>rangeData</code>{{optional_inline}}</dt>
@@ -72,7 +72,7 @@ browser-compat: webextensions.api.find.find
 
  <p>Each <code>RangeData</code> contains the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>framePos</code></dt>
   <dd>The index of the frame containing the match. 0 corresponds to the parent window. Note that the order of objects in the <code>rangeData</code> array will sequentially line up with the order of frame indexes: for example, <code>framePos</code> for the first sequence of <code>rangeData</code> objects will be 0, <code>framePos</code> for the next sequence will be 1, and so on.</dd>
   <dt><code>startTextNodePos</code></dt>
@@ -91,7 +91,7 @@ browser-compat: webextensions.api.find.find
 
  <p>Each <code>RectData</code> object contains rectangle data for a single match. It has two properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>rectsAndTexts</code></dt>
   <dd>An object containing two properties, both arrays:
   <ul>

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.html
@@ -29,12 +29,12 @@ browser-compat: webextensions.api.find.highlightResults
 
 <h3 id="Parameters">Parameters</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>options</code>{{optional_inline}}</dt>
  <dd>
  <p><code>object</code>. An object specifying additional options. It may take any of the following properties, all optional:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab to highlight. Defaults to the active tab.</dd>
   <dt><code>rangeIndex</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.history.addUrl
  <dt><code>details</code></dt>
  <dd><code>object</code>. Object containing the URL to add.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>string</code>. The URL to add.</dd>
   <dt><code>title</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.history.deleteRange
  <dt><code>range</code></dt>
  <dd><code>object</code>. Specification of the time range for which to delete visits.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>startTime</code></dt>
   <dd><code>number</code> or <code>string</code> or <code>object</code>. A value indicating a date and time. This can be represented as: a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a></code> object, an <a href="https://www.iso.org/iso/home/standards/iso8601.htm">ISO 8601 date string</a>, or the number of <a href="https://en.wikipedia.org/wiki/Unix_time">milliseconds since the epoch</a>. Specifies the start time for the range.</dd>
   <dt><code>endTime</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.history.deleteUrl
  <dt><code>details</code></dt>
  <dd><code>object</code>. Object containing the URL whose visits to remove.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>string</code>. The URL whose visits should be removed.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.history.getVisits
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>string</code>. The URL for which to retrieve visit information.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.history.HistoryItem
 
 <p>This is an object with the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>id</code></dt>
  <dd><code>string</code>. Unique identifier for the item.</dd>
  <dt><code>url</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
@@ -48,7 +48,7 @@ browser.history.onTitleChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed an object with the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>String</code>. URL of the page visited.</dd>
   <dt><code>title</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
@@ -44,7 +44,7 @@ browser.history.onVisited.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>result</code></dt>
   <dd>
   <p>{{WebExtAPIRef('history.HistoryItem')}}. An object representing the item in the browser's history.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
@@ -50,7 +50,7 @@ browser.history.onVisitRemoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following argument:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>removed</code></dt>
   <dd><code>object</code>. Details of the removal. This is an object containing two properties: a boolean <code>allHistory</code> and an array <code>urls</code>.</dd>
   <dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.history.search
  <dt><code>query</code></dt>
  <dd>An object which indicates what to look for in the browser's history. This object has the following fields:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>text</code></dt>
   <dd><code>string</code>. Search history items by URL and title. The string is split up into separate search terms at space boundaries. Each search term is matched case-insensitively against the history item's URL and title. The history item will be returned if all search terms match.</dd>
   <dd>For example, consider this item:</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.history.VisitItem
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>id</code></dt>
  <dd><code>string</code>. The unique identifier for the {{WebExtAPIRef("history.HistoryItem")}} associated with this visit.</dd>
  <dt><code>visitId</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
@@ -37,13 +37,13 @@ browser-compat: webextensions.api.i18n.detectLanguage
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with a result object. The result object has two properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>isReliable</code></dt>
  <dd><code>boolean</code>. Whether the language was detected reliably.</dd>
  <dt><code>languages</code></dt>
  <dd><code>array</code> of objects, each of which has two properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>language</code></dt>
   <dd>{{WebExtAPIRef('i18n.LanguageCode')}}. The detected language.</dd>
   <dt><code>percentage</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
@@ -53,7 +53,7 @@ browser-compat: webextensions.api.identity.launchWebAuthFlow
  <dt><code>details</code></dt>
  <dd><code>object</code>. Options for the flow, containing the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd>
   <p><code>string</code>. The URL offered by the OAuth2 service provider to get an access token. The details of this URL should be given in the documentation for the service provider in question, but the URL parameters should always include:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
@@ -50,7 +50,7 @@ browser.idle.onStateChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>newState</code></dt>
   <dd>{{WebExtAPIRef('idle.IdleState')}}. The new idle state.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.management.ExtensionInfo
 
 <p>It is an object with the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>description</code></dt>
  <dd><code>string</code>. The add-on's description, taken from the manifest.json <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description">description</a> key.</dd>
  <dt><code>disabledReason</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
@@ -44,7 +44,7 @@ browser.management.onDisabled.hasListener(listener)
  <dd>
  <p>Callback function that will be called when this event occurs. The function will be passed the following argument:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>info</code></dt>
   <dd><code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo">ExtensionInfo</a></code>: info about the add-on that was disabled.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
@@ -44,7 +44,7 @@ browser.management.onEnabled.hasListener(listener)
  <dd>
  <p>Callback function that will be called when this event occurs. The function will be passed the following argument:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>info</code></dt>
   <dd><code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo">ExtensionInfo</a></code>: info about the add-on that was enabled.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
@@ -44,7 +44,7 @@ browser.management.onInstalled.hasListener(listener)
  <dd>
  <p>Callback function that will be called when this event occurs. The function will be passed the following argument:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>info</code></dt>
   <dd><code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo">ExtensionInfo</a></code>: info about the add-on that was installed.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
@@ -44,7 +44,7 @@ browser.management.onUninstalled.hasListener(listener)
  <dd>
  <p>Callback function that will be called when this event occurs. The function will be passed the following argument:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>info</code></dt>
   <dd><code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo">ExtensionInfo</a></code>: info about the add-on that was uninstalled.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.management.uninstallSelf
  <dt><code>options{{optional_inline}}</code></dt>
  <dd><code>object</code>. Object which may two properties, both optional:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>showConfirmDialog{{optional_inline}}</code></dt>
   <dd>Boolean. If <code>showConfirmDialog</code> is <code>true</code>, the browser will show a dialog asking the user to confirm that the add-on should be uninstalled. Defaults to <code>false</code>.</dd>
   <dt><code>dialogMessage{{optional_inline}}</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
@@ -35,7 +35,7 @@ browser-compat: webextensions.api.menus.create
  <dt><code>createProperties</code></dt>
  <dd><code>object</code>. Properties for the new menu item.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>checked</code> {{optional_inline}}</dt>
   <dd><code>boolean</code>. The initial state of a checkbox or radio item: <code>true</code> for selected and <code>false</code> for unselected. Only one radio item can be selected at a time in a given group of radio items.</dd>
   <dt><code>command</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
@@ -14,7 +14,7 @@ browser-compat: webextensions.api.menus.createProperties
 
 <p>An <code>object</code> passed to the  {{WebExtAPIRef("menus.create()", "menus.create()")}} or  {{WebExtAPIRef("menus.update()", "menus.update()")}} methods to describe the properties of the new or updated menu item.</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>checked</code> {{optional_inline}}</dt>
  <dd><code>boolean</code>. The initial state of a checkbox or radio item: <code>true</code> for selected and <code>false</code> for unselected. Only one radio item can be selected at a time in a given group of radio items.</dd>
  <dt><code>command</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.menus.OnClickData
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>bookmarkId</code> {{optional_inline}}</dt>
  <dd><code>string</code>. The ID of the bookmark where the context menu was clicked.</dd>
  <dt><code>button</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
@@ -46,12 +46,12 @@ browser.menus.onClicked.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>info</code></dt>
   <dd>{{WebExtAPIRef('menus.OnClickData')}}. Information about the item clicked and the context where the click happened.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tab</code></dt>
   <dd>{{WebExtAPIRef('tabs.Tab')}}. The details of the tab where the click took place. If the click did not take place in or on a tab, this parameter will be missing.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.html
@@ -100,7 +100,7 @@ browser.menus.onShown.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>info</code></dt>
   <dd>
   <p><code>Object</code>. This is just like the {{WebExtAPIRef('menus.OnClickData')}} object, except it contains two extra properties:</p>
@@ -116,7 +116,7 @@ browser.menus.onShown.hasListener(listener)
   </dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tab</code></dt>
   <dd>{{WebExtAPIRef('tabs.Tab')}}. The details of the tab where the click took place. If the click did not take place in or on a tab, this parameter will be missing.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.menus.update
  <dd><code>integer</code> or <code>string</code>. The ID of the item to update.</dd>
  <dt><code>updateProperties</code></dt>
  <dd><code>object</code>. The properties to update. The same as the <code>createProperties</code> object passed to {{WebExtAPIRef("menus.create()", "menus.create()")}}, except that <code>id</code> can't be set. In addition, <code>icons</code> can only be changed on menu commands, not on the top-level context menu. The top-level icon matches the extension's primary icon as declared in the extension's manifest file.
- <dl class="reference-values">
+ <dl>
   <dt><code>checked</code> {{optional_inline}}</dt>
   <dd><code>boolean</code>. The initial state of a checkbox or radio item: <code>true</code> for selected and <code>false</code> for unselected. Only one radio item can be selected at a time in a given group of radio items.</dd>
   <dt><code>command</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
@@ -28,7 +28,7 @@ browser-compat: webextensions.api.notifications.NotificationOptions
 
 <p>The first three properties - <code>type</code>, <code>title</code>, <code>message</code> - are mandatory in {{WebExtAPIRef("notifications.create()")}}, but optional in {{WebExtAPIRef("notifications.update()")}}. Firefox currently: only supports the <code>type</code>, <code>title</code>, <code>message</code>, and <code>iconUrl</code> properties; and the only supported value for <code>type</code> is <code>'basic'</code>.</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>type</code></dt>
  <dd>{{WebExtAPIRef("notifications.TemplateType")}}. The type of notification you want. Depending on your choice here, certain other properties are either mandatory or are not permitted.</dd>
  <dt><a id="message"><code>message</code></a></dt>
@@ -46,7 +46,7 @@ browser-compat: webextensions.api.notifications.NotificationOptions
  <dt><a id="buttons"><code>buttons</code></a>{{optional_inline}}</dt>
  <dd><code>array</code> of <code>button</code>. An array of up to 2 buttons to include in the notification. You can listen for button clicks using {{WebExtAPIRef("notifications.onButtonClicked")}}. Each button is specified as an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>title</code></dt>
   <dd><code>string</code>. Title for the button.</dd>
   <dt><code>iconUrl</code>{{optional_inline}}</dt>
@@ -62,7 +62,7 @@ browser-compat: webextensions.api.notifications.NotificationOptions
  <dt><a id="items"><code>items</code></a></dt>
  <dd><code>array</code> of <code>item</code>. An array of items to include in the notification. Depending on the settings for the operating system's notification mechanism, some of the items you provide might not be displayed. Each item is specified as an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>title</code></dt>
   <dd><code>string</code>. Title to display in the item.</dd>
   <dt><code>message</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
@@ -44,7 +44,7 @@ browser.notifications.onButtonClicked.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>notificationId</code></dt>
   <dd><code>string</code>. ID of the notification whose button was clicked.</dd>
   <dt><code>buttonIndex</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
@@ -44,7 +44,7 @@ browser.notifications.onClicked.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>notificationId</code></dt>
   <dd><code>string</code>. ID of the notification that the user clicked.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
@@ -44,7 +44,7 @@ browser.notifications.onClosed.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>notificationId</code></dt>
   <dd><code>string</code>. ID of the notification that closed.</dd>
   <dt><code>byUser</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
@@ -44,7 +44,7 @@ browser.notifications.onShown.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>notificationId</code></dt>
   <dd><code>string</code>. ID of the notification that has been shown.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
@@ -22,7 +22,7 @@ browser-compat: webextensions.api.omnibox.OnInputEnteredDisposition
 
 <p>Values of this type are strings. They may take any one of the following values:</p>
 
-<dl class="reference-values">
+<dl>
  <dt>"currentTab"</dt>
  <dd>Open the selection in the current tab.</dd>
  <dt>"newForegroundTab"</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
@@ -22,7 +22,7 @@ browser-compat: webextensions.api.omnibox.SuggestResult
 
 <p>Values of this type are objects. They have the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>content</code></dt>
  <dd>This is the value that will appear in the address bar itself when the user highlights this suggestion in the drop-down list. This is also the string sent to the {{WebExtAPIRef("omnibox.onInputEntered")}} event listener if the user selects this suggestion. If the string is the same as what the user has already typed, this entry will not appear in the drop-down list.</dd>
  <dt><code>description</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.pageAction.getPopup
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab whose popup you want to get.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.pageAction.getTitle
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab containing the page action whose title you want to get.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.pageAction.isShown
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object containing the <code>tabId</code> to check.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab to check.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
@@ -46,12 +46,12 @@ browser.pageAction.onClicked.hasListener(listener)
 	<dd>
 	<p>A function that will be called when this event occurs. The function is passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code>tab</code></dt>
 		<dd>A {{WebExtAPIRef('tabs.Tab')}} object representing the tab whose page action was clicked.</dd>
 		<dt><code>OnClickData</code></dt>
 		<dd>An object containing information about the click.
-		<dl class="reference-values">
+		<dl>
 			<dt><code>modifiers</code></dt>
 			<dd>An <code>array</code>. The keyboard modifiers active at the time of the click, being one or more of <code>Shift</code>, <code>Alt</code>, <code>Command</code>, <code>Ctrl</code>, or <code>MacCtrl</code>.</dd>
 			<dt><code>button</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.pageAction.setIcon
  <dd>
  <p><code>object</code>. An object containing either <code>imageData</code> or <code>path</code> properties, and a <code>tabId</code> property.</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>imageData</code>{{optional_inline}}</dt>
   <dd>
   <p><code>{{WebExtAPIRef('pageAction.ImageDataType')}}</code> or <code>object</code>. This is either a single <code>ImageData</code> object or a dictionary object.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
@@ -30,7 +30,7 @@ browser-compat: webextensions.api.pageAction.setPopup
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab for which you want to set the popup.</dd>
   <dt><code>popup</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
@@ -30,7 +30,7 @@ browser-compat: webextensions.api.pageAction.setTitle
  <dt><code>details</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab whose title you want to set.</dd>
   <dt><code>title</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
@@ -42,7 +42,7 @@ browser.permissions.onAdded.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>permissions</code></dt>
   <dd>{{WebExtAPIRef("permissions.Permissions")}} object containing the permissions that were granted.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
@@ -42,7 +42,7 @@ browser.permissions.onRemoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>permissions</code></dt>
   <dd>{{WebExtAPIRef("permissions.Permissions")}} object containing the permissions that were removed.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.permissions.Permissions
 
 <p>An {{jsxref("object")}} with the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>origins</code>{{optional_inline}}</dt>
  <dd>An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>, representing <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permissions</a>.</dd>
  <dt><code>permissions</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.html
@@ -44,7 +44,7 @@ browser.proxy.onError.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>newState</code></dt>
   <dd><code>Object</code>. An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a> object representing the error.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.proxy.ProxyInfo
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>type</code></dt>
  <dd>
  <p><code>string</code>. This describes whether to proxy at all, and if so, what kind of proxy to use. It may take one of the following values:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.proxy.RequestDetails
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. The cookie store ID of the current context.</dd>
  <dt><code>documentUrl</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
@@ -43,7 +43,7 @@ browser-compat: webextensions.api.runtime.connect
  <dt><code>connectInfo</code>{{optional_inline}}</dt>
  <dd><code>object</code>. Details of the connection:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code>{{optional_inline}}</dt>
   <dd><code>string</code>. Will be passed into {{WebExtAPIRef("runtime.onConnect")}} for processes that are listening for the connection event.</dd>
   <dt><code>includeTlsChannelId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.runtime.MessageSender
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>tab</code>{{optional_inline}}</dt>
  <dd>{{WebExtAPIRef('tabs.Tab')}}. The {{WebExtAPIRef('tabs.Tab')}} which opened the connection. This property will only be present when the connection was opened from a tab (including content scripts).</dd>
  <dt><code>frameId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
@@ -44,7 +44,7 @@ browser.runtime.onConnect.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>port</code></dt>
   <dd>A {{WebExtAPIRef('runtime.Port')}} object connecting the current script to the other context it is connecting to.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
@@ -48,7 +48,7 @@ browser.runtime.onConnectExternal.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>port</code></dt>
   <dd>A {{WebExtAPIRef('runtime.Port')}} object connecting the current script to the other extension it is connecting to.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
@@ -46,11 +46,11 @@ browser.runtime.onInstalled.hasListener(listener)
  <dd>
  <p>The callback function called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd>An object with the following properties:</dd>
   <dd>
-  <dl class="reference-values">
+  <dl>
    <dt><code>id</code>{{optional_inline}}</dt>
    <dd><code>string</code>. The ID of the imported shared module extension that updated. This is present only if the <code>reason</code> value is <code>shared_module_update</code>.</dd>
    <dt><code>previousVersion</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -87,7 +87,7 @@ browser.runtime.onMessage.hasListener(<var>listener</var>)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code><var>message</var></code></dt>
   <dd><code>object</code>. The message itself. This is a serializable object (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#data_cloning_algorithm">Data cloning algorithm</a>).</dd>
   <dt><code><var>sender</var></code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
@@ -55,17 +55,17 @@ browser.runtime.onMessageExternal.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>message</code></dt>
   <dd><code>object</code>. The message itself. This is a JSON-ifiable object.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sender</code></dt>
   <dd>A {{WebExtAPIRef('runtime.MessageSender')}} object representing the sender of the message.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sendResponse</code></dt>
   <dd>
   <p>A function to call, at most once, to send a response to the message. The function takes a single argument, which may be any JSON-ifiable object. This argument is passed back to the message sender.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
@@ -44,7 +44,7 @@ browser.runtime.onRestartRequired.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>reason</code></dt>
   <dd>A {{WebExtAPIRef('runtime.OnRestartRequiredReason')}} value — the reason that the event is being dispatched.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
@@ -52,7 +52,7 @@ browser.runtime.onUpdateAvailable.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><code>object</code>. Contains a single property, a string named <code>version</code>, which represents the version number of the update.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.runtime.PlatformInfo
 
 <p>Values of this type are objects, which contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>os</code></dt>
  <dd>{{WebExtAPIRef('runtime.PlatformOs')}}. The platform's operating system.</dd>
  <dt><code>arch</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -67,7 +67,7 @@ browser-compat: webextensions.api.runtime.Port
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>name</code></dt>
  <dd><code>string</code>. The port's name, defined in the {{WebExtAPIRef("runtime.connect()")}} or {{WebExtAPIRef("tabs.connect()")}} call that created it. If this port is connected to a native application, its name is the name of the native application.</dd>
  <dt><code>disconnect</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.runtime.requestUpdateCheck
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with two arguments:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>status</code></dt>
  <dd>A {{WebExtAPIRef('runtime.RequestUpdateCheckStatus')}} value — the result of the update check.</dd>
  <dt><code>details</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -48,7 +48,7 @@ browser-compat: webextensions.api.runtime.sendMessage
  <dd><code>any</code>. An object that can be structured clone serialized (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#data_cloning_algorithm">Data cloning algorithm</a>).</dd>
  <dt><code>options</code>{{optional_inline}}</dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>includeTlsChannelId</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Whether the TLS channel ID will be passed into {{WebExtAPIRef('runtime.onMessageExternal')}} for processes that are listening for the connection event.</dd>
   <dd>This option is only supported in Chromium-based browsers.</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.search.search
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with an <a href="Web/JavaScript/Reference/Global_Objects/array">array</a> of search engine objects. Each search engine object may contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>name</code></dt>
  <dd><code>string</code>. The search engine's name.</dd>
  <dt><code>isDefault</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.html
@@ -30,12 +30,12 @@ browser-compat: webextensions.api.search.search
 
 <h3 id="Parameters">Parameters</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>searchProperties</code></dt>
  <dd>
  <p><code>object</code>. An object with the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>query</code></dt>
   <dd><code>string</code>. The search query.</dd>
   <dt><code>engine</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.sessions.Filter
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>maxResults</code>{{optional_inline}}</dt>
  <dd><code>number</code>. The maximum number of results to return.</dd>
 </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.sessions.Session
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>lastModified</code></dt>
  <dd><code>number</code>. The time the tab or window was closed, in <a href="https://en.wikipedia.org/wiki/Unix_time">milliseconds since the epoch</a>.</dd>
  <dt><code>tab</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.sidebarAction.getPanel
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Get the panel for the sidebar specific to the given tab.</dd>
   <dt><code>windowId</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.sidebarAction.getTitle
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. Get the title for the sidebar specific to the given tab.</dd>
   <dt><code>windowId</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.sidebarAction.isOpen
 	<dt><code>details</code></dt>
 	<dd><code>object</code>. An object optionally containing the <code>windowId</code> to check.</dd>
 	<dd>
-	<dl class="reference-values">
+	<dl>
 		<dt><code>windowId</code> {{optional_inline}}</dt>
 		<dd><code>integer</code>. ID of a browser window to check. If omitted defaults to {{WebExtAPIRef("windows.WINDOW_ID_CURRENT")}}, which refers to the topmost browser window.</dd>
 	</dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
@@ -47,7 +47,7 @@ browser-compat: webextensions.api.sidebarAction.setIcon
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>imageData</code>{{optional_inline}}</dt>
   <dd>
   <p><code>{{WebExtAPIRef('sidebarAction.ImageDataType')}}</code> or <code>object</code>. This is either a single <code>ImageData</code> object or a dictionary object.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.sidebarAction.setPanel
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>panel</code></dt>
   <dd><code>string</code> or <code>null</code>. The panel to load into the sidebar, specified as a URL pointing to an HTML document, or <code>null</code>, or an empty string.</dd>
   <dd>This can point to a file packaged within the extension (for example, created using {{WebExtAPIRef("runtime.getURL")}}), or a remote document (e.g. <code>https://example.org/</code>). It must be a valid URL.</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.sidebarAction.setTitle
  <dt><code>details</code></dt>
  <dd><code>object</code>. An object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>title</code></dt>
   <dd><code>string</code> or <code>null</code>. The sidebar's new title.</dd>
   <dd>If <code>title</code> is an empty string, the used title will be the extension name, but {{WebExtAPIRef("sidebarAction.getTitle")}} will still provide the empty string.</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.html
@@ -44,7 +44,7 @@ browser.storage.onChanged.hasListener(<var>listener</var>)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code><var>changes</var></code></dt>
   <dd><code>object</code>. Object describing the change. This contains one property for each key that changed. The name of the property is the name of the key that changed, and its value is a {{WebExtAPIRef('storage.StorageChange')}} object describing the change to that item.</dd>
   <dt><code><var>areaName</var></code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.storage.StorageChange
 
 <p><code>StorageChange</code> objects contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>oldValue</code>{{optional_inline}}</dt>
  <dd>The old value of the item, if there was an old value. This can be any data type.</dd>
  <dt><code>newValue</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.html
@@ -36,7 +36,7 @@ browser-compat: webextensions.api.tabs.connect
  <dd><code>integer</code>. ID of the tab whose content scripts we want to connect to.</dd>
  <dt><code>connectInfo</code>{{optional_inline}}</dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>name</code>{{optional_inline}}</dt>
   <dd><code>string</code>. Will be passed into {{WebExtAPIRef("runtime.onConnect")}} event listeners in content scripts belonging to this extension and running in the specified tab.</dd>
   <dt><code>frameId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.tabs.create
  <dt><code>createProperties</code></dt>
  <dd><code>object</code>. Properties to give the new tab. To learn more about these properties, see the {{WebExtAPIRef("tabs.Tab")}} documentation.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>active</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Whether the tab should become the active tab in the window. If <code>false</code>, it has no effect. Does not affect whether the window is focused (see {{WebExtAPIRef('windows.update')}}). Defaults to <code>true</code>.</dd>
   <dt><code>cookieStoreId</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
@@ -35,7 +35,7 @@ browser-compat: webextensions.api.tabs.duplicate
  <dt><code>duplicateProperties</code> <span class="inlineIndicator optional optionalInline">Optional</span></dt>
  <dd><code>object</code>. An object describing how the tab is duplicated. It contains the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code><var>index</var></code> <span class="inlineIndicator optional optionalInline">Optional</span></dt>
   <dd><code>integer</code>. The position of the new tab in the window. The value is constrained to the range zero to the number of tabs in the window.</dd>
   <dt><code><var>active</var></code> <span class="inlineIndicator optional optionalInline">Optional</span></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.tabs.executeScript
 	<p>It contains the following properties:</p>
 	</dd>
 	<dd>
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>allFrames</var></code> {{optional_inline}}</dt>
 		<dd><code>boolean</code>. If <code>true</code>, the code will be injected into all frames of the current page.
 		<p>If <code>true</code> and <code><var>frameId</var></code> is set, then it will raise an error. (<code><var>frameId</var></code> and <code><var>allFrames</var></code> are mutually exclusive.)</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.tabs.highlight
  <dt><code>highlightInfo</code></dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>windowId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. ID of the window that contains the tabs.</dd>
   <dt><code>populate</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
@@ -46,7 +46,7 @@ browser-compat: webextensions.api.tabs.insertCSS
  <dt><code>details</code></dt>
  <dd>An object describing the CSS to insert. It contains the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>allFrames</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. If <code>true</code>, the CSS will be injected into all frames of the current page. If it is <code>false</code>, CSS is only injected into the top frame. Defaults to <code>false</code>.</dd>
   <dt><code>code</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.tabs.move
  <dt><code>moveProperties</code></dt>
  <dd><code>object</code>. An object that specifies where to move the tab(s).</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>windowId</code>{{optional_inline}}</dt>
   <dd><code>integer</code>. The ID of the window to which you want to move the tab(s). If you omit this, then each tab in <code>tabIds</code> will be moved to <code>index</code> in its current window. If you include this, and <code>tabIds</code> contains more than one tab, then the first tab in <code>tabIds</code> will be moved to <code>index</code>, and the other tabs will follow it in the order given in <code>tabIds</code>.</dd>
   <dt><code>index</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.tabs.MutedInfo
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>extensionId</code>{{optional_inline}}</dt>
  <dd><code>string</code>. The ID of the extension that last changed the muted state. Not set if an extension was not the reason the muted state last changed.</dd>
  <dt><code>muted</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.html
@@ -44,7 +44,7 @@ browser.tabs.onActivated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>activeInfo</code></dt>
   <dd><a href="#activeinfo"><code>object</code></a>. ID of the tab that was made active, and ID of its window.</dd>
  </dl>
@@ -55,7 +55,7 @@ browser.tabs.onActivated.hasListener(listener)
 
 <h3 id="activeInfo">activeInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>previousTabId</code></dt>
  <dd><code>integer</code>. The ID of the previous activated tab, if that tab is still open.</dd>
  <dt><code>tabId</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
@@ -49,12 +49,12 @@ browser.tabs.onActiveChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab that has become active.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>selectInfo</code></dt>
   <dd><a href="#selectinfo"><code>object</code></a>.</dd>
  </dl>
@@ -65,7 +65,7 @@ browser.tabs.onActiveChanged.hasListener(listener)
 
 <h3 id="selectInfo">selectInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>windowId</code></dt>
  <dd><code>integer</code>. The ID of the window containing the selected tab.</dd>
 </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.html
@@ -44,12 +44,12 @@ browser.tabs.onAttached.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab that was attached to a new window.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>attachInfo</code></dt>
   <dd><a href="#attachinfo"><code>object</code></a>. ID of the new window, and index of the tab within it.</dd>
  </dl>
@@ -60,7 +60,7 @@ browser.tabs.onAttached.hasListener(listener)
 
 <h3 id="attachInfo">attachInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>newWindowId</code></dt>
  <dd><code>integer</code>. ID of the new window.</dd>
  <dt><code>newPosition</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.html
@@ -46,7 +46,7 @@ browser.tabs.onCreated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tab</code></dt>
   <dd>{{WebExtAPIRef('tabs.Tab')}}. Details of the tab that was created.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.html
@@ -44,12 +44,12 @@ browser.tabs.onDetached.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab that was detached.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>detachInfo</code></dt>
   <dd><a href="#detachinfo"><code>object</code></a>. ID of the previous window, and index of the tab within it.</dd>
  </dl>
@@ -60,7 +60,7 @@ browser.tabs.onDetached.hasListener(listener)
 
 <h3 id="detachInfo">detachInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>oldWindowId</code></dt>
  <dd><code>integer</code>. ID of the previous window.</dd>
  <dt><code>oldPosition</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
@@ -47,7 +47,7 @@ browser.tabs.onHighlightChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>selectInfo</code></dt>
   <dd><a href="#selectinfo"><code>object</code></a>.</dd>
  </dl>
@@ -58,7 +58,7 @@ browser.tabs.onHighlightChanged.hasListener(listener)
 
 <h3 id="selectInfo">selectInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>windowId</code></dt>
  <dd><code>integer</code>. The window whose tabs changed.</dd>
  <dt><code>tabIds</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.html
@@ -46,7 +46,7 @@ browser.tabs.onHighlighted.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>highlightInfo</code></dt>
   <dd><a href="#highlightinfo"><code>object</code></a>. ID(s) of the highlighted tabs, and ID of their window.</dd>
  </dl>
@@ -57,7 +57,7 @@ browser.tabs.onHighlighted.hasListener(listener)
 
 <h3 id="highlightInfo">highlightInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>windowId</code></dt>
  <dd><code>integer</code>. ID of the window whose tabs changed.</dd>
  <dt><code>tabIds</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.html
@@ -46,12 +46,12 @@ browser.tabs.onMoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab the user moved.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>moveInfo</code></dt>
   <dd><a href="#moveinfo"><code>object</code></a>. Information about the move.</dd>
  </dl>
@@ -62,7 +62,7 @@ browser.tabs.onMoved.hasListener(listener)
 
 <h3 id="moveInfo">moveInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>windowId</code></dt>
  <dd><code>integer</code>. ID of this tab's window.</dd>
  <dt><code>fromIndex</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.html
@@ -44,12 +44,12 @@ browser.tabs.onRemoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab that closed.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>removeInfo</code></dt>
   <dd><a href="#removeinfo"><code>object</code></a>. The tab's window ID, and a boolean indicating whether the window is also being closed.</dd>
  </dl>
@@ -60,7 +60,7 @@ browser.tabs.onRemoved.hasListener(listener)
 
 <h3 id="removeInfo">removeInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>windowId</code></dt>
  <dd><code>integer</code>. The window whose tab is closed.</dd>
  <dt><code>isWindowClosing</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.html
@@ -46,12 +46,12 @@ browser.tabs.onReplaced.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>addedTabId</code></dt>
   <dd><code>integer</code>. ID of the replacement tab.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>removedTabId</code></dt>
   <dd><code>integer</code>. ID of the tab that was replaced.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
@@ -47,12 +47,12 @@ browser.tabs.onSelectionChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab that has become active.</dd>
  </dl>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>selectInfo</code></dt>
   <dd><a href="#selectinfo"><code>object</code></a>.</dd>
  </dl>
@@ -63,7 +63,7 @@ browser.tabs.onSelectionChanged.hasListener(listener)
 
 <h3 id="selectInfo">selectInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>windowId</code></dt>
  <dd><code>integer</code>. The ID of the window the selected tab changed inside of.</dd>
 </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
@@ -48,7 +48,7 @@ browser.tabs.onUpdated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. ID of the tab that was updated.</dd>
   <dt><code>changeInfo</code></dt>
@@ -61,7 +61,7 @@ browser.tabs.onUpdated.hasListener(listener)
  <dd>
  <p><code>object</code>. A set of filters that restricts the events that will be sent to this listener. This is an object which may have one or more of the following properties. Events will only be sent if they satisfy all the filters given.</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>urls</code></dt>
   <dd><code>Array</code>. An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>. Fire the event only for tabs whose current <code>url</code> property matches any one of the patterns.</dd>
   <dt><code>properties</code></dt>
@@ -101,7 +101,7 @@ browser.tabs.onUpdated.hasListener(listener)
 
 <p>Lists the changes to the state of the tab that was updated. To learn more about these properties, see the {{WebExtAPIRef("tabs.Tab")}} documentation.</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>attention</code> {{optional_inline}}</dt>
  <dd><code>boolean</code>. Indicates whether the tab is drawing attention. For example, when the tab displays a modal dialog, <code>attention</code> will be <code>true</code>.</dd>
  <dt><code>audible</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.html
@@ -44,7 +44,7 @@ browser.tabs.onZoomChange.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>ZoomChangeInfo</code></dt>
   <dd><a href="#zoomchangeinfo"><code>object</code></a>. Information about the zoom event.</dd>
  </dl>
@@ -55,7 +55,7 @@ browser.tabs.onZoomChange.hasListener(listener)
 
 <h3 id="ZoomChangeInfo">ZoomChangeInfo</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>tabId</code></dt>
  <dd><code>integer</code>. ID of the tab that was zoomed.</dd>
  <dt><code>oldZoomFactor</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.tabs.PageSettings
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>edgeBottom</code>{{optional_inline}}</dt>
  <dd><code>number</code>. The spacing between the bottom of the footers and the bottom edge of the paper (inches). Default: 0.</dd>
  <dt><code>edgeLeft</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.html
@@ -33,7 +33,7 @@ browser-compat: webextensions.api.tabs.query
 
  <p>See the {{WebExtAPIRef("tabs.Tab")}} documentation to learn more about these properties.</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>active</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Whether the tabs are active in their windows.</dd>
   <dt><code>audible</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.tabs.reload
  <dd><code>integer</code>. The ID of the tab to reload. Defaults to the selected tab of the current window.</dd>
  <dt><code>reloadProperties</code>{{optional_inline}}</dt>
  <dd><code>object</code>.
- <dl class="reference-values">
+ <dl>
   <dt><code>bypassCache</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Bypass the local web cache. Default is <code>false</code>.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.tabs.removeCSS
  <dd><code>integer</code>. The ID of the tab from which to remove the CSS. Defaults to the active tab of the current window.</dd>
  <dt><code>details</code></dt>
  <dd>An object describing the CSS to remove from the page. It contains the following properties:
- <dl class="reference-values">
+ <dl>
   <dt><code>allFrames</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. If <code>true</code>, the code will be removed from all frames of the current page. If it is <code>false</code>, code is only removed from the top frame. Defaults to <code>false</code>.</dd>
   <dt><code>code</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
@@ -44,7 +44,7 @@ browser-compat: webextensions.api.tabs.sendMessage
  <dt><code><var>options</var></code> {{optional_inline}}</dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code><var>frameId</var></code> {{optional_inline}}</dt>
   <dd><code>integer</code>. Sends the message to a specific frame identified by <code><var>frameId</var></code> instead of all frames in the tab. Whether the content script is executed in all frames depends on the <code>all_frames</code> setting in the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts"><code>content_scripts</code></a> section of <code>manifest.json</code>.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.tabs.Tab
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>active</code></dt>
  <dd>
  <p><code>boolean</code>. Whether the tab is active in its window. This may be true even if the tab's window is not currently focused.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
@@ -37,7 +37,7 @@ browser-compat: webextensions.api.tabs.update
  <dt><code>updateProperties</code></dt>
  <dd><code>object</code>. The set of properties to update for this tab. To learn more about these properties, see the {{WebExtAPIRef("tabs.Tab")}} documentation.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>active</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Whether the tab should become active. Does not affect whether the window is focused (see {{WebExtAPIRef('windows.update')}}). If <code>true</code>, non-active highlighted tabs will stop being highlighted. If <code>false</code>, does nothing.</dd>
   <dt><code>autoDiscardable</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.tabs.ZoomSettings
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>defaultZoomFactor</code>{{optional_inline}}</dt>
  <dd><code>number</code>. The default zoom level for the current tab. Note that this is only used in {{WebExtAPIRef("tabs.getZoomSettings")}}.</dd>
  <dt><code>mode</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.html
@@ -48,12 +48,12 @@ browser.theme.onUpdated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>updateInfo</code></dt>
   <dd>
   <p><code>object</code>. An object containing two properties:</p>
 
-  <dl class="reference-values">
+  <dl>
    <dt><code>theme</code></dt>
    <dd><code>object</code>. If the event fired because an extension-supplied theme was removed, this will be an empty object. If it fired because an extension-supplied theme was applied, then it will be a {{WebExtAPIRef("theme.Theme")}} object representing the theme that was applied.</dd>
    <dt><code>windowId</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.topSites.get
  <dt><code>options</code></dt>
  <dd><code>object</code>. Options to modify the list of pages returned. This may include any of the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>includeBlocked</code> {{optional_inline}}</dt>
   <dd><code>Boolean</code>. Include pages that the user has removed from the "New Tab" page. Defaults to <code>false</code>.</dd>
   <dt><code>includeFavicon</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.topSites.MostVisitedURL
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>favicon</code> {{optional_inline}}</dt>
  <dd><code>String</code>. A data: URL containing the favicon for the page, if <code>includeFavicon</code> was given in {{WebExtAPIRef("topSites.get()")}} and the favicon was available.</dd>
  <dt><code>title</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
@@ -46,10 +46,10 @@ BrowserSetting.onChange.hasListener(listener)
  <dd>
  <p>A callback function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd>An <code>object</code> containing details of the change that occurred. Its properties are as follows:
-  <dl class="reference-values">
+  <dl>
    <dt><code>value</code></dt>
    <dd>The new value of the setting. The type of this property is determined by the particular setting.</dd>
    <dt><code>levelOfControl</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.html
@@ -48,7 +48,7 @@ tags:
  <dt><code>details</code></dt>
  <dd>An object that must contain the following property:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>value</code></dt>
   <dd><code>any</code>. The value you want to change the setting to. Its type depends on the particular setting.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.html
@@ -46,11 +46,11 @@ browser.userScripts.onBeforeScript.hasListener(listener)
  <dd>
  <p>A function that is called when this event occurs. The function is passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>script</code></dt>
   <dd>An <code>object</code> that represents the user script that matched a web page. Its properties and methods are as follows:</dd>
   <dd>
-  <dl class="reference-values">
+  <dl>
    <dt><code>defineGlobals</code></dt>
    <dd>A method that exports an object containing properties and methods available globally to the user script sandbox. This method must be called synchronously to guarantee that the user script has not executed.</dd>
    <dt><code>export</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.html
@@ -35,7 +35,7 @@ await registeredUserScript.unregister();</pre>
  <p><br>
   The <code>UserScriptOptions</code> object has the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>scriptMetadata</code> {{Optional_Inline}}</dt>
   <dd>A <code>JSON</code> object containing arbitrary metadata properties associated with the registered user scripts. However, while arbitrary, the object must be serializable, so it is compatible with <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">the structured clone algorithm.</a> This metadata is used to pass details from the script to the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts">API script</a></code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts"></a>. For example, providing details of a subset of the APIs that need to be injected by the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts">API script</a></code>. The API  does not use this metadata,</dd>
   <dt><code>allFrames</code> {{Optional_Inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.webNavigation.getAllFrames
  <dt><code>details</code></dt>
  <dd><code>object</code>. Information about the tab to retrieve all frames from.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab.</dd>
  </dl>
@@ -43,7 +43,7 @@ browser-compat: webextensions.api.webNavigation.getAllFrames
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with an array of objects, each of which has the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>errorOccurred</code></dt>
  <dd><code>boolean</code>. True if the last navigation in this frame was interrupted by an error, i.e. the {{WebExtAPIRef("webNavigation.onErrorOccurred", "onErrorOccurred")}} event fired.</dd>
  <dt><code>processId</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.webNavigation.getFrame
  <dt><code>details</code></dt>
  <dd><code>object</code>. Information about the frame to retrieve information about.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>tabId</code></dt>
   <dd><code>integer</code>. The ID of the tab in which the frame is.</dd>
   <dt><code>processId</code> {{optional_inline}}</dt>
@@ -47,7 +47,7 @@ browser-compat: webextensions.api.webNavigation.getFrame
 
 <p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with an object containing the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>errorOccurred</code></dt>
  <dd><code>boolean</code>. True if the last navigation in this frame was interrupted by an error, i.e. the {{WebExtAPIRef("webNavigation.onErrorOccurred", "onErrorOccurred")}} event fired.</dd>
  <dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onBeforeNavigate.hasListener(<var>listener</var>)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>details</var></code></dt>
 		<dd><a href="#details"><code>object</code></a>. Details about the navigation event.</dd>
 	</dl>
@@ -62,7 +62,7 @@ browser.webNavigation.onBeforeNavigate.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>tabId</code></dt>
 	<dd><code>integer</code>. The ID of the tab in which the navigation is about to occur.</dd>
 	<dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onCommitted.hasListener(<var>listener</var>)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>details</var></code></dt>
 		<dd><a href="#details"><code>object</code></a>. Details about the navigation event.</dd>
 	</dl>
@@ -62,7 +62,7 @@ browser.webNavigation.onCommitted.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>tabId</code></dt>
 	<dd><code>integer</code>. The ID of the tab in which the navigation is about to occur.</dd>
 	<dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onCompleted.hasListener(<var>listener</var>)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>details</var></code></dt>
 		<dd><a href="#details"><code>object</code></a>. Details about the navigation event.</dd>
 	</dl>
@@ -62,7 +62,7 @@ browser.webNavigation.onCompleted.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>tabId</code></dt>
 	<dd><code>integer</code>. The ID of the tab in which the navigation has occurred.</dd>
 	<dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.html
@@ -56,7 +56,7 @@ browser.webNavigation.onCreatedNavigationTarget.hasListener(<var>listener</var>)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>details</var></code></dt>
 		<dd><a href="#details"><code>object</code></a>. Details about the navigation event. See <a href="#details">details</a> below.</dd>
 	</dl>
@@ -71,7 +71,7 @@ browser.webNavigation.onCreatedNavigationTarget.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>sourceFrameId</code></dt>
 	<dd><code>integer</code>. ID of the frame from which the navigation is initiated. <code>0</code> indicates that the frame is the tab's top-level browsing context, not a nested {{HTMLElement("iframe")}}. A positive value indicates that navigation is initiated from a nested iframe. Frame IDs are unique for a given tab and process.</dd>
 	<dt><code>sourceProcessId</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onDOMContentLoaded.hasListener(<var>listener</var>)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>details</var></code></dt>
 		<dd><a href="#details"><code>object</code></a>. Details about the navigation event.</dd>
 	</dl>
@@ -62,7 +62,7 @@ browser.webNavigation.onDOMContentLoaded.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>tabId</code></dt>
 	<dd><code>integer</code>. The ID of the tab in which the navigation has occurred.</dd>
 	<dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.html
@@ -50,12 +50,12 @@ browser.webNavigation.onErrorOccurred.hasListener(<var>listener</var>)
 
 	<p>The <code><var>listener</var></code> function will be called with the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code>details</code></dt>
 		<dd>
 		<p><a href="#details"><code>object</code></a>. Details about the navigation event. <strong><code>details</code></strong> has the following properties:</p>
 
-		<dl class="reference-values">
+		<dl>
 			<dt><code>tabId</code></dt>
 			<dd><code>integer</code>. The ID of the tab in which the navigation was happening.</dd>
 			<dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onHistoryStateUpdated.hasListener(<var>listener</var>)
 	<dd>
 	<p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
-	<dl class="reference-values">
+	<dl>
 		<dt><code><var>details</var></code></dt>
 		<dd><a href="#details"><code>object</code></a>. Details about the navigation event.</dd>
 	</dl>
@@ -62,7 +62,7 @@ browser.webNavigation.onHistoryStateUpdated.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
 	<dt><code>tabId</code></dt>
 	<dd><code>integer</code>. The ID of the tab in which the navigation is about to occur.</dd>
 	<dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onReferenceFragmentUpdated.hasListener(<var>listener</var>
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code><var>details</var></code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the navigation event.</dd>
  </dl>
@@ -62,7 +62,7 @@ browser.webNavigation.onReferenceFragmentUpdated.hasListener(<var>listener</var>
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>tabId</code></dt>
  <dd><code>integer</code>. The ID of the tab in which the navigation is about to occur.</dd>
  <dt><code>url</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.html
@@ -47,7 +47,7 @@ browser.webNavigation.onTabReplaced.hasListener(<var>listener</var>)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code><var>details</var></code></dt>
   <dd><a href="#details"><code>object</code></a>.</dd>
  </dl>
@@ -58,7 +58,7 @@ browser.webNavigation.onTabReplaced.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>replacedTabId</code></dt>
  <dd><code>integer</code>. The ID of the tab that was replaced.</dd>
  <dt><code>tabId</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.html
@@ -25,11 +25,11 @@ browser-compat: webextensions.api.webRequest.BlockingResponse
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>authCredentials</code>{{optional_inline}}</dt>
  <dd><code>object</code>. If set, the request is made using the given credentials. You can only set this property in {{WebExtAPIRef("webRequest.onAuthRequired", "onAuthRequired")}}. The <code>authCredentials</code> property is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>username</code></dt>
   <dd><code>string</code>. Username to supply.</dd>
   <dt><code>password</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
@@ -22,12 +22,12 @@ browser-compat: webextensions.api.webRequest.CertificateInfo
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>fingerprint</code></dt>
  <dd>
  <p><code>Object</code>. An object with the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sha1</code></dt>
   <dd><code>String</code>. SHA-1 hash of the certificate's DER encoding.</dd>
   <dt><code>sha256</code></dt>
@@ -52,7 +52,7 @@ browser-compat: webextensions.api.webRequest.CertificateInfo
  <dd>
  <p><code>Object</code>. An object containing the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>sha256</code></dt>
   <dd><code>String</code>. Base64 encoded SHA-256 hash of the DER-encoded <a href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.7">public key info</a>.</dd>
  </dl>
@@ -61,7 +61,7 @@ browser-compat: webextensions.api.webRequest.CertificateInfo
  <dd>
  <p><code>Object</code>. Validity period for the certificate. An object containing the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>start</code></dt>
   <dd><code>Number</code>. The start of the certificate's validity period, in <a class="external external-icon" href="https://en.wikipedia.org/wiki/Unix_time" rel="noopener">milliseconds since the epoch</a>.</dd>
   <dt><code>end</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.html
@@ -38,7 +38,7 @@ browser-compat: webextensions.api.webRequest.getSecurityInfo
  <dt><code>options</code></dt>
  <dd><code>object</code>. An object which may contain any of the following properties, all optional:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>certificateChain</code> {{optional_inline}}</dt>
   <dd><code>boolean</code>. If <code>true</code>, the {{WebExtAPIRef("webRequest.SecurityInfo", "SecurityInfo")}} object returned will include the entire certificate chain up to and including the trust root. If <code>false</code>,  it will include only the server certificate. Defaults to <code>false</code>.</dd>
   <dt><code>rawDER</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.webRequest.HttpHeaders
 
 <p>An <code>array</code> of <code>object</code>s. Each object has the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>name</code></dt>
  <dd><code>string</code>. Name of the HTTP header.</dd>
  <dt><code>value</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.html
@@ -96,7 +96,7 @@ browser.webRequest.onAuthRequired.hasListener(<var>listener</var>)
  <dd>
  <p>A function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code><var>details</var></code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -124,12 +124,12 @@ browser.webRequest.onAuthRequired.hasListener(<var>listener</var>)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>challenger</code></dt>
  <dd>
  <p><code>object</code>. The server requesting authentication. This is an object with the following properties:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>host</code></dt>
   <dd><code>string</code>. The server's <a href="https://en.wikipedia.org/wiki/Hostname#Internet_hostnames">hostname</a>.<br>
   <strong>Warning</strong>: Unlike Chrome, Firefox will return the requested host instead of the proxy requesting the authentication, even if <code>isProxy</code> is <code>true</code>.</dd>
@@ -184,7 +184,7 @@ browser.webRequest.onAuthRequired.hasListener(<var>listener</var>)
  <dt><code>requestId</code></dt>
  <dd><code>string</code>. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
  </dl>
  </dd>
  <dt><code>responseHeaders</code>{{optional_inline}}</dt>
@@ -208,7 +208,7 @@ browser.webRequest.onAuthRequired.hasListener(<var>listener</var>)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.html
@@ -50,7 +50,7 @@ browser.webRequest.onBeforeRedirect.hasListener(listener)
  <dd>
  <p>A function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -70,7 +70,7 @@ browser.webRequest.onBeforeRedirect.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -146,7 +146,7 @@ browser.webRequest.onBeforeRedirect.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
@@ -63,7 +63,7 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -86,7 +86,7 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -94,7 +94,7 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
  <dt><code>frameAncestors</code></dt>
  <dd><code>array</code>. Contains information for each document in the frame hierarchy up to the top-level document. The first element in the array contains information about the immediate parent of the document being requested, and the last element contains information about the top-level document. If the load is actually for the top-level document, then this array is empty.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>string</code>. The URL that the document was loaded from.</dd>
   <dt><code>frameId</code></dt>
@@ -148,7 +148,7 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
  <dt><code>requestBody</code>{{optional_inline}}</dt>
  <dd><code>object</code>. Contains the HTTP request body data. Only provided if <code>extraInfoSpec</code> contains <code>"requestBody"</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>error</code>{{optional_inline}}</dt>
   <dd><code>string</code>. This is set if any errors were encountered when obtaining request body data.</dd>
   <dt><code>formData</code>{{optional_inline}}</dt>
@@ -173,7 +173,7 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.html
@@ -70,7 +70,7 @@ browser.webRequest.onBeforeSendHeaders.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details of the request. This will include request headers if you have included <code>"requestHeaders"</code> in <code>extraInfoSpec</code>.</dd>
  </dl>
@@ -93,7 +93,7 @@ browser.webRequest.onBeforeSendHeaders.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -159,7 +159,7 @@ browser.webRequest.onBeforeSendHeaders.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
@@ -50,7 +50,7 @@ browser.webRequest.onCompleted.hasListener(listener)
  <dd>
  <p>A function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -70,7 +70,7 @@ browser.webRequest.onCompleted.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -144,7 +144,7 @@ browser.webRequest.onCompleted.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.html
@@ -53,7 +53,7 @@ browser.webRequest.onErrorOccurred.hasListener(listener)
  <dd>
  <p>A function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -66,7 +66,7 @@ browser.webRequest.onErrorOccurred.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -136,7 +136,7 @@ browser.webRequest.onErrorOccurred.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.html
@@ -58,7 +58,7 @@ browser.webRequest.onHeadersReceived.hasListener(listener)
  <dd>
  <p>The function called when this event occurs. The function is passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details of the request. This will include response headers if you have included <code>"responseHeaders"</code> in <code>extraInfoSpec</code>.</dd>
  </dl>
@@ -81,7 +81,7 @@ browser.webRequest.onHeadersReceived.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -89,7 +89,7 @@ browser.webRequest.onHeadersReceived.hasListener(listener)
  <dt><code>frameAncestors</code></dt>
  <dd><code>array</code>. Information for each document in the frame hierarchy up to the top-level document. The first element in the array contains information about the immediate parent of the document being requested, and the last element contains information about the top-level document. If the load is for the top-level document, then this array is empty.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>url</code></dt>
   <dd><code>string</code>. The URL that the document was loaded from.</dd>
   <dt><code>frameId</code></dt>
@@ -165,7 +165,7 @@ browser.webRequest.onHeadersReceived.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.html
@@ -50,7 +50,7 @@ browser.webRequest.onResponseStarted.hasListener(listener)
  <dd>
  <p>A function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -70,7 +70,7 @@ browser.webRequest.onResponseStarted.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -144,7 +144,7 @@ browser.webRequest.onResponseStarted.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
@@ -50,7 +50,7 @@ browser.webRequest.onSendHeaders.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>details</code></dt>
   <dd><a href="#details"><code>object</code></a>. Details about the request. See <code><a href="#details">details</a></code> below.</dd>
  </dl>
@@ -70,7 +70,7 @@ browser.webRequest.onSendHeaders.hasListener(listener)
 
 <h3 id="details">details</h3>
 
-<dl class="reference-values">
+<dl>
  <dt><code>cookieStoreId</code></dt>
  <dd><code>string</code>. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity.</dd>
  <dt><code>documentUrl</code></dt>
@@ -136,7 +136,7 @@ browser.webRequest.onSendHeaders.hasListener(listener)
  <dt><code>urlClassification</code></dt>
  <dd><code>object</code>. The type of tracking associated with the request, if with the request has been classified by <a class="external external-icon" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" rel="noopener">Firefox Tracking Protection</a>. This is an object with the following properties:</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>firstParty</code></dt>
   <dd><code>array</code> of <code>strings</code>. Classification flags for the request's first party.</dd>
   <dt><code>thirdParty</code></dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.webRequest.RequestFilter
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>urls</code></dt>
  <dd><code>array</code> of <code>string</code>. An array of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a>. The listener will only be called for requests whose targets match any of the given patterns. Only requests made using HTTP or HTTPS will trigger events, other protocols (such as data: and file:) supported by pattern matching do not trigger events. <code>view-source:</code> requests may be matched based on its inner URL.</dd>
  <dt><code>types</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.webRequest.SecurityInfo
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>certificates</code></dt>
  <dd><code>Array</code> of {{WebExtAPIRef("webRequest.CertificateInfo", "CertificateInfo")}}. If {{WebExtAPIRef("webRequest.getSecurityInfo()")}} was called with the <code>certificateChain</code> option present and set to <code>true</code>, this will contain a <code>CertificateInfo</code> object for every certificate in the chain, from the server certificate up to and including the trust root.</dd>
  <dd>Otherwise it will contain a single <code>CertificateInfo</code> object, for the server certificate.</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.webRequest.UploadData
 
 <p>Values of this type are objects. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>bytes</code>{{optional_inline}}</dt>
  <dd><code>any</code>. An ArrayBuffer with a copy of the data.</dd>
  <dt><code>file</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
@@ -42,7 +42,7 @@ browser-compat: webextensions.api.windows.create
  <dt><code>createData</code> {{optional_inline}}</dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>allowScriptsToClose</code> {{optional_inline}}</dt>
   <dd>
   <p><code>boolean</code>. When the window is opened, it will contain a single tab, or more than one tab if <code>url</code> is given and includes an array containing more than one URL. By default scripts running in these pages are not allowed to close their tab using <code><a href="/en-US/docs/Web/API/Window/close">window.close()</a></code>.  If you include <code>allowScriptsToClose</code> and set it to <code>true</code> , then this default behavior is changed, so scripts can close their tabs. Note that:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.windows.get
  <dd><code>integer</code>. The ID of the window object you want returned.</dd>
  <dt><code>getInfo</code>{{optional_inline}}</dt>
  <dd><code>object</code>. Contains options to filter the type of window.
- <dl class="reference-values">
+ <dl>
   <dt><code>populate</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. If <code>true</code>, the {{WebExtAPIRef('windows.Window')}} object will have a <code>tabs</code> property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs open in the window. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>"tabs"</code> permission or a matching <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permission</a>.</dd>
   <dt><code>windowTypes</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.windows.getAll
  <dt><code>getInfo</code>{{optional_inline}}</dt>
  <dd><code>object</code>. This controls what {{WebExtAPIRef('windows.Window')}} objects are retrieved.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>populate</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Defaults to <code>false</code>. If set to <code>true</code>, each {{WebExtAPIRef('windows.Window')}} object will have a <code>tabs</code> property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in that window. The <code>Tab</code> objects will contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties only if the extension's manifest file includes the <code>"tabs"</code> permission or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permissions</a> that match the tab's URL.</dd>
   <dt><code>windowTypes</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
@@ -34,7 +34,7 @@ browser-compat: webextensions.api.windows.getCurrent
  <dt><code>getInfo</code>{{optional_inline}}</dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>populate</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. If true, the {{WebExtAPIRef('windows.Window')}} object will have a <code>tabs</code> property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in the window. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>"tabs"</code> permission or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permissions</a> that match the tab's URL.</dd>
   <dt><code>windowTypes</code>{{deprecated_inline}}{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
@@ -32,7 +32,7 @@ browser-compat: webextensions.api.windows.getLastFocused
  <dt><code>getInfo</code>{{optional_inline}}</dt>
  <dd><code>object</code>.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>populate</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. If <code>true</code>, the {{WebExtAPIRef('windows.Window')}} object will have a <code>tabs</code> property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in the window. The <code>Tab</code> objects only contain the <code>url</code>, <code>title</code> and <code>favIconUrl</code> properties if the extension's manifest file includes the <code>"tabs"</code> permission or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permissions</a> matching the tab's URL.</dd>
   <dt><code>windowTypes</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.html
@@ -44,7 +44,7 @@ browser.windows.onCreated.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>window</code></dt>
   <dd>A {{WebExtAPIRef('windows.Window')}} object containing details of the window that was created.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
@@ -48,7 +48,7 @@ browser.windows.onFocusChanged.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>windowId</code></dt>
   <dd><code>integer</code>. ID of the newly focused window.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.html
@@ -44,7 +44,7 @@ browser.windows.onRemoved.hasListener(listener)
  <dd>
  <p>Function that will be called when this event occurs. The function will be passed the following arguments:</p>
 
- <dl class="reference-values">
+ <dl>
   <dt><code>windowId</code></dt>
   <dd><code>integer</code>. ID of the window that was closed.</dd>
  </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.html
@@ -35,7 +35,7 @@ browser-compat: webextensions.api.windows.update
  <dt><code>updateInfo</code></dt>
  <dd><code>object</code>. Object containing the properties to update.</dd>
  <dd>
- <dl class="reference-values">
+ <dl>
   <dt><code>drawAttention</code> {{optional_inline}}</dt>
   <dd><code>boolean</code>. If <code>true</code>, causes the window to be displayed in a manner that draws the user's attention to the window, without changing the focused window. The effect lasts until the user changes focus to the window. This option has no effect if the window already has focus. Set to <code>false</code> to cancel a previous <code>drawAttention</code> request.</dd>
   <dt><code>focused</code> {{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.windows.Window
 
 <p>Values of this type are <code>objects</code>. They contain the following properties:</p>
 
-<dl class="reference-values">
+<dl>
  <dt><code>alwaysOnTop</code></dt>
  <dd><code>boolean</code>. Whether the window is set to be always on top.</dd>
  <dt><code>focused</code></dt>
@@ -30,7 +30,7 @@ browser-compat: webextensions.api.windows.Window
  <dd><code>integer</code>. The height of the window, including the frame, in pixels.</dd>
 </dl>
 
-<dl class="reference-values">
+<dl>
  <dt><code>id</code>{{optional_inline}}</dt>
  <dd><code>integer</code>. The ID of the window. Window IDs are unique within a browser session.</dd>
  <dt><code>incognito</code></dt>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

The add-ons docs add a `reference-values` class to some `<dl>` elements. This used to do something, but doesn't any more, and we can't represent it in Markdown anyway, so I'm removing it.
