### PR TITLE
[Markdown][Add-ons] Remove inline styles

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.html
@@ -27,7 +27,7 @@ tags:
  <dd>Make packaged content accessible to web pages and content scripts.</dd>
 </dl>
 
-<p><img alt="" src="webextension-anatomy.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="webextension-anatomy.png"></p>
 
 <p>See the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a></code> reference page for all the details.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.api.contextualIdentities
 
 <p>With the contextual identities feature, each contextual identity has a name, a color, and an icon. New tabs can be assigned to an identity, and the name, icon, and color will appear in the address bar. Internally, each identity gets its own cookie store which is not shared with other tabs.</p>
 
-<p><img alt="" src="containers.png" style="display: block; margin-left: auto; margin-right: auto;">Contextual identities are an experimental feature in Firefox and are only enabled by default in Firefox Nightly. To enable them in other versions of Firefox, set the <code>privacy.userContext.enabled</code> preference to <code>true</code>. Note that although contextual identities are available in Firefox for Android, there's no UI to work with them in this version of the browser.</p>
+<p><img alt="" src="containers.png">Contextual identities are an experimental feature in Firefox and are only enabled by default in Firefox Nightly. To enable them in other versions of Firefox, set the <code>privacy.userContext.enabled</code> preference to <code>true</code>. Note that although contextual identities are available in Firefox for Android, there's no UI to work with them in this version of the browser.</p>
 
 <p>Before Firefox 57, the <code>contextualIdentities</code> API is only available if the contextual identities feature is itself enabled. If an extension tried to use the <code>contextualIdentities</code> API without the feature being enabled, then method calls would resolve their promises with <code>false</code>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
@@ -22,7 +22,7 @@ browser-compat: webextensions.api.devtools.panels.ElementsPanel.createSidebarPan
 
 <p>The <code>createSidebarPane()</code> function adds a new pane to the sidebar. For example, the screenshot below shows a new pane titled "My pane", that displays a JSON object:</p>
 
-<p><img alt="" src="inspector-sidebar.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="inspector-sidebar.png"></p>
 
 <p>This function takes one argument, which is a string representing the pane's title. It returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that resolves to an <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane">ExtensionSidebarPane</a></code> object representing the new pane. You can use that object to define the pane's content and behavior.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.html
@@ -17,7 +17,7 @@ browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane
 
 <p>The <code>ExtensionSidebarPane</code> object represents a pane that an extension has added to the sidebar in the browser's HTML/CSS inspector.</p>
 
-<p><img alt="" src="inspector-sidebar.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="inspector-sidebar.png"></p>
 
 <p>To create an <code>ExtensionSidebarPane</code>, call the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/createSidebarPane">browser.devtools.panels.elements.createSidebarPane()</a></code> function.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
@@ -101,9 +101,9 @@ browser-compat: webextensions.api.find.find
 
   <p>For example, consider part of a web page that looks like this:</p>
 
-  <p><img alt="" src="rects-1.png" style="display: block; margin-left: auto; margin-right: auto;">If you search for "You may", the match needs to be described by two rectangles:</p>
+  <p><img alt="" src="rects-1.png">If you search for "You may", the match needs to be described by two rectangles:</p>
 
-  <p><img alt="" src="rects-2.png" style="display: block; margin-left: auto; margin-right: auto;">In this case, in the <code>RectData</code> that describes this match, <code>rectsAndTexts.rectList</code> and <code>rectsAndTexts.textList</code> will each have 2 items.</p>
+  <p><img alt="" src="rects-2.png">In this case, in the <code>RectData</code> that describes this match, <code>rectsAndTexts.rectList</code> and <code>rectsAndTexts.textList</code> will each have 2 items.</p>
 
   <ul>
    <li><code>textList[0]</code> will contain "You ", and <code>rectList[0]</code> will contain its bounding rectangle.</li>
@@ -228,7 +228,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) =&gt; {
 
 <p>In this example the extension uses <code>rectData</code> to "redact" the matches, by adding black DIVs over the top of their bounding rectangles:</p>
 
-<p><img alt="" src="redacted.png" style="display: block; margin-left: auto; margin-right: auto;">Note that in many ways this is a poor way to redact pages.</p>
+<p><img alt="" src="redacted.png">Note that in many ways this is a poor way to redact pages.</p>
 
 <p>The background script:</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
@@ -101,7 +101,7 @@ browser-compat: webextensions.api.menus.createProperties
 
 <div class="note"><strong>Acknowledgements</strong>
 
-<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-OnClickData" style="outline: 1px dotted currentcolor; outline-offset: 0px;"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
+<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-OnClickData"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.html
@@ -41,23 +41,23 @@ tags:
 
 <p>If you have created more than one context menu item or more than one tools menu item, then the items will be placed in a submenu. The submenu's parent will be labeled with the name of the extension. For example, here's an extension called "Menu demo" that's added two context menu items:</p>
 
-<p><img alt="" src="menus-1.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="menus-1.png"></p>
 
 <h2 id="Icons">Icons</h2>
 
 <p>If you've specified icons for your extension using the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons">"icons" manifest key</a>, your menu item will display the specified icon next to its label. The browser will try to choose a 16x16 pixel icon for a normal display or a 32x32 pixel icon for a high-density display:</p>
 
-<p><img alt="" src="menus-2.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="menus-2.png"></p>
 
 <p>Only for items in a submenu, you can specify custom icons by passing the <code>icons</code> option to {{WebExtAPIRef("menus.create()")}}:</p>
 
-<p><img alt="" src="menus-3.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="menus-3.png"></p>
 
 <h2 id="Example">Example</h2>
 
 <p>Here's a context menu containing 4 items: a normal item, two radio items with separators on each side, and a checkbox. The radio items are given custom icons.</p>
 
-<p><img alt="" src="menus-4.png" style="display: block; margin-left: auto; margin-right: auto;">You could create a submenu like this using code like:</p>
+<p><img alt="" src="menus-4.png">You could create a submenu like this using code like:</p>
 
 <pre class="brush: js">browser.menus.create({
   id: "remove-me",

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
@@ -68,7 +68,7 @@ browser-compat: webextensions.api.menus.OnClickData
 
 <div class="note"><strong>Acknowledgements</strong>
 
-<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-OnClickData" style="outline: 1px dotted currentcolor; outline-offset: 0px;"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
+<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/contextMenus#type-OnClickData"><code>chrome.contextMenus</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json"><code>context_menus.json</code></a> in the Chromium code.</p>
 </div>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.html
@@ -17,7 +17,7 @@ browser-compat: webextensions.api.notifications
 
 <p>The notification looks the same on all desktop operating systems. Something like:</p>
 
-<p><img alt="" src="notification.png" style="display: block; margin: 0 auto;"></p>
+<p><img alt="" src="notification.png"></p>
 
 <h2 id="Types">Types</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.pageAction
 
 <p>A <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions">page action</a> is a clickable icon inside the browser's address bar.</p>
 
-<p><img alt="" src="page-action.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="page-action.png"></p>
 
 <p>You can listen for clicks on the icon, or specify a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups">popup</a> that will open when the icon is clicked.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.html
@@ -34,11 +34,11 @@ tags:
  </li>
  <li>
   <p>Scroll down to the bottom of the page and under <strong>Certificates</strong> click or tap on <strong>Security Devices...<br>
-   <img alt="" src="device_manager.png" style="border: 1px solid black; display: block; margin: 0px auto;"></strong></p>
+   <img alt="" src="device_manager.png"></strong></p>
  </li>
  <li>
   <p>Click or tap the <strong>Load</strong> button<br>
-   <img alt="" src="load_device_driver.png" style="display: block; margin: 0 auto;"></p>
+   <img alt="" src="load_device_driver.png"></p>
  </li>
  <li>
   <p>Enter a name for the security module, such as "<em>My Client Database</em>"</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -19,7 +19,7 @@ browser-compat: webextensions.api.proxy.register
   <h4>Warning</h4>
   <p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
 
-  <p><img alt="" src="proxy_register_warning.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
+  <p><img alt="" src="proxy_register_warning.png"></p>
 </div>
 
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.proxy.unregister
   <h4>Warning</h4>
   <p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
 
-  <p><img alt="" src="proxy_unregister_warning.png" style="border: 1px solid black; display: block; margin: 0 auto;"></p>
+  <p><img alt="" src="proxy_unregister_warning.png"></p>
 </div>
 
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/working_with_userscripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/working_with_userscripts/index.html
@@ -42,7 +42,7 @@ tags:
 
 <p>In the following image, the extension will "eat" the content of pages whose domain name ends in .org. This is the default behavior for this extension.</p>
 
-<p><img alt="" src="userscriptexample.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
+<p><img alt="" src="userscriptexample.png"></p>
 
 <p>Nothing will happen until you click the <strong>Register script</strong> button. The button implements the user script according to the settings on this dialog. That means that you can experiment with the behavior of the script without having to implement an extensions yourself.</p>
 
@@ -101,7 +101,7 @@ tags:
 
 <p>Once the script has been registered, navigate to a page whose domain name ends in .org, and you will see something like this:</p>
 
-<p><img alt="" src="user_script_in_action.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
+<p><img alt="" src="user_script_in_action.png"></p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.html
@@ -20,7 +20,7 @@ browser-compat: webextensions.api.webNavigation
 
 <p>Each event corresponds to a particular stage in the navigation. The sequence of events is like this:</p>
 
-<p><img alt="" src="we-flow.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="we-flow.png"></p>
 
 <ul>
  <li>The primary flow is:

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.webRequest
 
 <p>Each event is fired at a particular stage of the request. The typical sequence of events is like this:</p>
 
-<p><img alt="" src="webrequest-flow.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="webrequest-flow.png"></p>
 
 <p>{{WebExtAPIRef("webRequest.onErrorOccurred", "onErrorOccurred")}} can be fired at any time during the request. Also, note that sometimes the sequence of events may differ from this: for example, in Firefox, on an <a href="/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security">HSTS</a> upgrade, the <code>onBeforeRedirect</code> event will be triggered immediately after <code>onBeforeRequest</code>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/browser_actions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_actions/index.html
@@ -8,7 +8,7 @@ tags:
 
 <p>A browser action is a button you can add to the browser toolbar. Users can click the button to interact with your extension.</p>
 
-<p><img alt="" src="browser-action.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="browser-action.png"></p>
 
 <p>There are two ways to specify a browser action: with a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups">popup</a>, or without a popup.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
@@ -17,7 +17,7 @@ tags:
 <div class="note">
 <p>Note that content scripts are blocked on the following domains:</p>
 
-<ul style="display: grid;">
+<ul>
  <li>accounts-static.cdn.mozilla.net</li>
  <li>accounts.firefox.com</li>
  <li>addons.cdn.mozilla.net</li>
@@ -225,7 +225,7 @@ window.confirm("Are you sure?"); // calls the original window.confirm()</pre>
 </div>
 
 <div class="notecard note">
-<p>In Chrome, starting with version 73, content scripts are subject to the same CORS policy as the page they are running within. Only backend scripts have elevated cross-domain privileges. See "<span id="sites-page-title" style="outline: none;"><a href="https://www.chromium.org/Home/chromium-security/extension-content-script-fetches">Changes to Cross-Origin Requests in Chrome Extension Content Scripts</a></span>".</p>
+<p>In Chrome, starting with version 73, content scripts are subject to the same CORS policy as the page they are running within. Only backend scripts have elevated cross-domain privileges. See <a href="https://www.chromium.org/Home/chromium-security/extension-content-script-fetches">Changes to Cross-Origin Requests in Chrome Extension Content Scripts</a>.</p>
 </div>
 
 <h2 id="Communicating_with_background_scripts">Communicating with background scripts</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
@@ -121,7 +121,7 @@ chrome.runtime.onMessage.addListener(notify);
 
 <p>In Firefox, a "Toolbox" is the name for a separate window containing a set of tools in a tabbed interface, like this:</p>
 
-<p><img alt="" src="browser-toolbox.png" style="display: block; margin-left: auto; margin-right: auto;">The above toolbox contains five tools, which you can switch between using the tabs at the top of the window: "Inspector", "Console", "Debugger", "Style Editor", and "Scratchpad". We'll be using only two of these tools: "Console" and "Debugger".</p>
+<p><img alt="" src="browser-toolbox.png">The above toolbox contains five tools, which you can switch between using the tabs at the top of the window: "Inspector", "Console", "Debugger", "Style Editor", and "Scratchpad". We'll be using only two of these tools: "Console" and "Debugger".</p>
 
 <h3 id="Viewing_log_output">Viewing log output</h3>
 
@@ -201,7 +201,7 @@ chrome.runtime.onMessage.addListener(notify);
 
 <p>The problem with debugging panels in general is that they are hidden when you click outside them. So the first step is to disable this behavior. In the Browser Toolbox, click the icon that looks like four little squares:</p>
 
-<p><img alt="" src="disable-autohide.png" style="display: block; margin-left: auto; margin-right: auto;">Now, when you open a panel in Firefox, it will stay open until you press Escape.</p>
+<p><img alt="" src="disable-autohide.png">Now, when you open a panel in Firefox, it will stay open until you press Escape.</p>
 
 <div class="notecard note">
 <p>Note that this change applies to <a href="/en-US/docs/Tools/Browser_Toolbox#debugging_popups">built-in browser popups</a>, like the Hamburger menu (<img alt="" src="hamburger.png" style="display: inline-block; vertical-align: middle;">), as well as extension popups.</p>
@@ -217,7 +217,7 @@ chrome.runtime.onMessage.addListener(notify);
 
 <h4 id="Select_the_popup's_frame">Select the popup's frame</h4>
 
-<p>The popup is loaded into its own frame. So next, select your popup's document with the Browser Toolbox's <a href="/en-US/docs/Tools/Browser_Toolbox#targeting_a_document">frame selection button</a>:<img alt="" src="frame-selection.png" style="display: block; margin-left: auto; margin-right: auto;">The document will be called something like</p>
+<p>The popup is loaded into its own frame. So next, select your popup's document with the Browser Toolbox's <a href="/en-US/docs/Tools/Browser_Toolbox#targeting_a_document">frame selection button</a>:<img alt="" src="frame-selection.png">The document will be called something like</p>
 
 <pre>moz-extension://&lt;some-uuid&gt;/path/to/your-popup.html</pre>
 

--- a/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
@@ -204,7 +204,7 @@ chrome.runtime.onMessage.addListener(notify);
 <p><img alt="" src="disable-autohide.png">Now, when you open a panel in Firefox, it will stay open until you press Escape.</p>
 
 <div class="notecard note">
-<p>Note that this change applies to <a href="/en-US/docs/Tools/Browser_Toolbox#debugging_popups">built-in browser popups</a>, like the Hamburger menu (<img alt="" src="hamburger.png" style="display: inline-block; vertical-align: middle;">), as well as extension popups.</p>
+<p>Note that this change applies to <a href="/en-US/docs/Tools/Browser_Toolbox#debugging_popups">built-in browser popups</a>, like the Hamburger menu, as well as extension popups.</p>
 
 <p>Also note that the change is persistent, even across browser restarts. We're working on addressing this in <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1251658">bug 1251658</a>, but until then you may prefer to re-enable autohide by clicking the button again before you close the Browser Toolbox.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.html
@@ -119,7 +119,7 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p>If you need to exchange messages between the content scripts running in the target window and a devtools document, it's a good idea to use the {{WebExtAPIRef("runtime.connect()")}} and {{WebExtAPIRef("runtime.onConnect")}} to set up a connection between the background page and the devtools document. The background page can then maintain a mapping between tab IDs and {{WebExtAPIRef("runtime.Port")}} objects, and use this to route messages between the two scopes.</p>
 
-<p><img alt="" src="devtools-content-scripts.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="devtools-content-scripts.png"></p>
 
 <h2 id="Limitations_of_the_devtools_APIs">Limitations of the devtools APIs</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/firefox_differentiators/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/firefox_differentiators/index.html
@@ -82,7 +82,7 @@ tags:
    <td>
     <p>Add advanced security capabilities <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11">using PKCS #11 security modules to source keys and certificates</a>.</p>
    </td>
-   <td style="text-align: center;"><img alt="Illustration of the certificate and key" src="certificate_key.png"></td>
+   <td><img alt="Illustration of the certificate and key" src="certificate_key.png"></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/mozilla/add-ons/webextensions/firefox_workflow_overview/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/firefox_workflow_overview/index.html
@@ -18,11 +18,11 @@ tags:
 <table>
  <tbody>
   <tr>
-   <td style="width: 200px; text-align: center;"><img alt="Firefox workflow prepare step graphic" src="firefox_workflow_prepare.png"></td>
-   <td style="width: 200px; text-align: center;"><img alt="Firefox workflow code step graphic" src="firefox_workflow_code.png"></td>
-   <td style="width: 200px; text-align: center;"><img alt="Firefox workflow publish step graphic" src="firefox_workflow_publish.png"></td>
-   <td style="width: 200px; text-align: center;"><img alt="Firefox workflow enhance step graphic" src="firefox_workflow_enhance.png"></td>
-   <td style="width: 200px; text-align: center;"><img alt="Firefox workflow retire step graphic" src="firefox_workflow_retire.png"></td>
+   <td><img alt="Firefox workflow prepare step graphic" src="firefox_workflow_prepare.png"></td>
+   <td><img alt="Firefox workflow code step graphic" src="firefox_workflow_code.png"></td>
+   <td><img alt="Firefox workflow publish step graphic" src="firefox_workflow_publish.png"></td>
+   <td><img alt="Firefox workflow enhance step graphic" src="firefox_workflow_enhance.png"></td>
+   <td><img alt="Firefox workflow retire step graphic" src="firefox_workflow_retire.png"></td>
   </tr>
   <tr>
    <td>

--- a/files/en-us/mozilla/add-ons/webextensions/index/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/index/index.html
@@ -8,4 +8,4 @@ tags:
 ---
 <div>{{AddonSidebar}}</div>
 
-<div style="overflow: auto;">{{Index("/en-US/docs/Mozilla/Add-ons/WebExtensions")}}</div>
+<div>{{Index("/en-US/docs/Mozilla/Add-ons/WebExtensions")}}</div>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.author
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.html
@@ -14,7 +14,7 @@ browser-compat: webextensions.manifest.background
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.browser_action
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 <table class="fullwidth-table standard-table">
 	<tbody>
 		<tr>
-			<th scope="row" style="width: 30%;">Type</th>
+			<th scope="row">Type</th>
 			<td><code>Object</code></td>
 		</tr>
 		<tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.chrome_url_overrides
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.manifest.commands
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.content_scripts
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Array</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.content_security_policy
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.default_locale
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.description
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.developer
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.manifest.devtools_page
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.manifest.dictionaries
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.homepage_url
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.icons
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.manifest.incognito
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.manifest_version
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Number</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/name/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.name
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.manifest.offline_enabled
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Boolean</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.omnibox
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.manifest.optional_permissions
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Array</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.manifest.options_page
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
@@ -17,7 +17,7 @@ browser-compat: webextensions.manifest.options_ui
 <table class="fullwidth-table standard-table">
 	<tbody>
 		<tr>
-			<th scope="row" style="width: 30%;">Type</th>
+			<th scope="row">Type</th>
 			<td><code>Object</code></td>
 		</tr>
 		<tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.page_action
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
@@ -15,7 +15,7 @@ browser-compat: webextensions.manifest.permissions
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Array</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -13,7 +13,7 @@ browser-compat: webextensions.manifest.protocol_handlers
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Array</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.short_name
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.html
@@ -10,7 +10,7 @@ browser-compat: webextensions.manifest.sidebar_action
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
@@ -14,7 +14,7 @@ browser-compat: webextensions.manifest.storage
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -1332,7 +1332,7 @@ browser-compat: webextensions.manifest.theme
 
 <p>It will give you a browser that looks like this:</p>
 
-<p><img alt="" src="theme.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="theme.png"></p>
 
 <p>In this screenshot, <code>"toolbar_vertical_separator"</code> is the white vertical line in the URL bar dividing the Reader Mode icon from the other icons.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.manifest.theme
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>
@@ -190,7 +190,7 @@ browser-compat: webextensions.manifest.theme
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <td style="background-color: white;">
+   <td>
     <p><img alt="Overview of the color properties and how they apply to Firefox UI components" src="themes_components_annotations.png"></p>
    </td>
   </tr>
@@ -420,7 +420,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="ntp_colors.png" style="display: block; margin: 0 auto;"></p>
+    <p><img alt="" src="ntp_colors.png"></p>
    </td>
   </tr>
   <tr>
@@ -443,7 +443,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="ntp_colors.png" style="display: block; margin: 0 auto;"></p>
+    <p><img alt="" src="ntp_colors.png"></p>
    </td>
   </tr>
   <tr>
@@ -581,7 +581,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="sidebar_colors.png" style="display: block; margin: 0 auto;"></p>
+    <p><img alt="" src="sidebar_colors.png"></p>
    </td>
   </tr>
   <tr>
@@ -599,7 +599,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="screen_shot_2018-09-16_at_6.13.31_pm.png" style="display: block; margin: 0px auto;"></p>
+    <p><img alt="" src="screen_shot_2018-09-16_at_6.13.31_pm.png"></p>
    </td>
   </tr>
   <tr>
@@ -618,7 +618,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="screen_shot_2018-10-04_at_11.15.46_am.png" style="display: block; margin: 0px auto;"></p>
+    <p><img alt="" src="screen_shot_2018-10-04_at_11.15.46_am.png"></p>
    </td>
   </tr>
   <tr>
@@ -641,7 +641,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="screen_shot_2018-10-04_at_11.22.41_am.png" style="display: block; margin: auto;"></p>
+    <p><img alt="" src="screen_shot_2018-10-04_at_11.22.41_am.png"></p>
    </td>
   </tr>
   <tr>
@@ -666,7 +666,7 @@ browser-compat: webextensions.manifest.theme
 }</pre>
     </details>
 
-    <p><img alt="" src="sidebar_colors.png" style="display: block; margin: 0 auto;"></p>
+    <p><img alt="" src="sidebar_colors.png"></p>
    </td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.manifest.theme_experiment
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
@@ -14,7 +14,7 @@ browser-compat: webextensions.manifest.user_scripts
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Object</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.version
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.version_name
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>String</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
@@ -12,7 +12,7 @@ browser-compat: webextensions.manifest.web_accessible_resources
 <table class="fullwidth-table standard-table">
  <tbody>
   <tr>
-   <th scope="row" style="width: 30%;">Type</th>
+   <th scope="row">Type</th>
    <td><code>Array</code></td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
@@ -29,7 +29,7 @@ browser-compat: webextensions.match_patterns.scheme
 <table class="fullwidth-table standard-table">
  <thead>
   <tr>
-   <th scope="col" style="width: 50%;">Form</th>
+   <th scope="col">Form</th>
    <th scope="col">Matches</th>
   </tr>
  </thead>
@@ -52,7 +52,7 @@ browser-compat: webextensions.match_patterns.scheme
 <table class="fullwidth-table standard-table">
  <thead>
   <tr>
-   <th scope="col" style="width: 50%;">Form</th>
+   <th scope="col">Form</th>
    <th scope="col">Matches</th>
   </tr>
  </thead>
@@ -101,9 +101,9 @@ browser-compat: webextensions.match_patterns.scheme
 <table class="fullwidth-table standard-table">
  <thead>
   <tr>
-   <th scope="col" style="width: 33%;">Pattern</th>
-   <th scope="col" style="width: 33%;">Example matches</th>
-   <th scope="col" style="width: 33%;">Example non-matches</th>
+   <th scope="col">Pattern</th>
+   <th scope="col">Example matches</th>
+   <th scope="col">Example non-matches</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.html
@@ -14,7 +14,7 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td style="width: 40%;"><a href="#native_messaging_manifests">Native messaging manifests</a></td>
+   <td><a href="#native_messaging_manifests">Native messaging manifests</a></td>
    <td>Enable a feature called <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">native messaging</a>, in which an extension can communicate with a native app installed on the device.</td>
   </tr>
   <tr>

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>After installing, the extension can exchange JSON messages with the native application. Use a set of functions in the {{WebExtAPIRef("runtime")}} API. On the native app side, messages are received using standard input (<code>stdin</code>) and sent using standard output (<code>stdout</code>).</p>
 
-<p><img alt="" src="native-messaging.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="native-messaging.png"></p>
 
 <p>Support for native messaging in extensions is mostly compatible with Chrome, with two main differences:</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_action/index.html
@@ -7,7 +7,7 @@ tags:
 <div>{{AddonSidebar}}</div>
 
 <p>Commonly referred to as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction">browser action</a>, this user interface option is a button added to the browser toolbar. Users click the button to interact with your extension.<br>
- <img alt="" src="browser-action.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+ <img alt="" src="browser-action.png"></p>
 
 <p>The toolbar button (browser action) is very like the address bar button (page action). For the differences, and guidance on when to use what, see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions#page_actions_and_browser_actions">Page actions and browser actions</a>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>In Firefox, the stylesheet can be seen at <code>chrome://browser/content/extension.css</code>. The extra stylesheet at <code>chrome://browser/content/extension-mac.css</code> is also included on OS X.</p>
 
-<p>Most styles are automatically applied, but some elements require you to add the <span style="white-space: nowrap;">non-standard</span> <code style="white-space: nowrap;">browser-style</code> class to get their styling, as detailed in the table below:</p>
+<p>Most styles are automatically applied, but some elements require you to add the non-standard <code>browser-style</code> class to get their styling, as detailed in the table below:</p>
 
 <table class="fullwidth-table standard-table">
  <thead>

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>The full list of supported contexts is available at {{WebExtAPIRef("menus.ContextType")}} and includes contexts outside of a web page, such as bookmark items in the browser UI. For example, the "<a href="https://github.com/Rob--W/bookmark-container-tab">Open bookmark in Container Tab</a>" extension adds a menu item that allows the user to open a bookmark URL in a new container tab:</p>
 
-<p><img alt="" src="extension_context_menu.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
+<p><img alt="" src="extension_context_menu.png"></p>
 
 <h2 id="Specifying_context_menu_items">Specifying context menu items</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.html
@@ -8,7 +8,7 @@ tags:
 
 <p><span class="seoSummary">This user interface option adds one or more items to a browser context menu.</span> This is the context menu available when a user right-clicks on a web page. Tabs can have context menus also, available through the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus">browser.menus API</a>.</p>
 
-<p><img alt="Example of content menu items added by a WebExtension, from the context-menu-demo example" src="context_menu_example.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="Example of content menu items added by a WebExtension, from the context-menu-demo example" src="context_menu_example.png"></p>
 
 <p>You would use this option to expose features that are relevant to specific browser or web page contexts. For example, you could show features to open a graphic editor when the user clicks on an image or offer a feature to save page content when part of a page is selected. You can add plain menu items, checkbox items, radio button groups, and separators to menus. Once a context menu item has been added using {{WebExtAPIRef("contextMenus.create")}} it's displayed in all browser tabs, but you can hide it by removing it with {{WebExtAPIRef("contextMenus.remove")}}.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>When an extension provides tools that are of use to developers, it's possible to add a UI for them to the browser's developer tools as a new panel.</p>
 
-<p><img alt='Simple example showing the addition of "My panel" to the Developer Tools tabs.' src="developer_panel_tab.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt='Simple example showing the addition of "My panel" to the Developer Tools tabs.' src="developer_panel_tab.png"></p>
 
 <h2 id="Specifying_a_developer_tools_panel">Specifying a developer tools panel</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/extension_pages/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/extension_pages/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p><span class="seoSummary">You can include HTML pages in your extension to provide forms, help, or any other content your extension needs.</span></p>
 
-<p><img alt="Example of a simple bundled page displayed as a detached panel." src="bundled_page_as_panel_small.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="Example of a simple bundled page displayed as a detached panel." src="bundled_page_as_panel_small.png"></p>
 
 <p>These pages also get access to the same privileged JavaScript APIs that are available to your extension's background scripts. However, they are in their own tab, with their own JavaScript event queue, their own globals, etc.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/index.html
@@ -19,7 +19,7 @@ tags:
   <tr>
    <th scope="col">UI option</th>
    <th scope="col">Description</th>
-   <th scope="col" style="width: 350px;">Example</th>
+   <th scope="col">Example</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/notifications/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/notifications/index.html
@@ -8,7 +8,7 @@ tags:
 
 <p><span class="seoSummary">Notifications allow you to communicate information about your extension or its content using the underlying operating system's notification service.</span></p>
 
-<p><img alt="" src="notify-shadowed.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="notify-shadowed.png"></p>
 
 <p>Notifications can include a call to action for the user, and your add-on can listen for the user clicking the notification or the notification closing.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/omnibox/index.html
@@ -9,7 +9,7 @@ tags:
 
 <p>Using the {{WebExtAPIRef("omnibox")}} API, extensions can customize the suggestions offered in the browser address bar's drop-down when the user enters a keyword.</p>
 
-<p><img alt="Example showing the result of the firefox_code_search WebExtension's customization of the address bar suggestions." src="omnibox_example_small.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="Example showing the result of the firefox_code_search WebExtension's customization of the address bar suggestions." src="omnibox_example_small.png"></p>
 
 <p>This enables your extension to, for example, search a library of free ebooks or, as in the example above, a repository of code examples.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>Commonly referred to as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction">page action</a> button, this user interface option is a button added to the browser address bar. Users click the button to interact with extensions.</p>
 
-<p><img alt="" src="address_bar_button.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="address_bar_button.png"></p>
 
 <h2 id="Page_actions_and_browser_actions">Page actions and browser actions</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/popups/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/popups/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>A popup is a dialog that's associated with a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action">toolbar button</a> or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions">address bar button</a>. This page describes popups in general, specifying them, debugging, resizing, and designing them, as well as examples of use.</p>
 
-<p><img alt="" src="page_action_popup.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="page_action_popup.png"></p>
 
 <p>When the user clicks the button, the popup is shown. When the user clicks anywhere outside the popup, the popup is closed. The popup can be closed programmatically by calling <code><a href="/en-US/docs/Web/API/Window/close">window.close()</a></code> from a script running in the popup. However, you can't open the popup programmatically from an extension's JavaScript; it can be opened only in response to a user action.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/sidebars/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/sidebars/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>The browser may include a number of built-in sidebars. For example, Firefox includes a sidebar for interacting with bookmarks:</p>
 
-<p><img alt="" src="bookmarks-sidebar.png" style="display: block; margin-left: auto; margin-right: auto;">Using the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action">sidebar_action</a></code> manifest.json key, an extension can add its own sidebar to the browser. It will be listed alongside the built-in sidebars, and the user will be able to open it using the same mechanism as for the built-in sidebars.</p>
+<p><img alt="" src="bookmarks-sidebar.png">Using the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action">sidebar_action</a></code> manifest.json key, an extension can add its own sidebar to the browser. It will be listed alongside the built-in sidebars, and the user will be able to open it using the same mechanism as for the built-in sidebars.</p>
 
 <p>Like a browser action popup, the sidebar's contents are specified as an HTML document. When the user opens the sidebar, the sidebar's document is loaded into every open browser window. Each window gets its own instance of the document. When new windows are opened, they get their own sidebar documents as well.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
@@ -411,7 +411,9 @@ browser.tabs.executeScript({file: "/content_scripts/beastify.js"})
 
 <p>Create a new directory called "beasts", and add the three images in that directory, with the appropriate names. You can get the images from <a href="https://github.com/mdn/webextensions-examples/tree/master/beastify/beasts">the GitHub repository</a>, or from here:</p>
 
-<p><img alt="" src="frog.jpg" style="display: inline-block; margin: 20px;"><img alt="" src="snake.jpg" style="display: inline-block; margin: 20px;"><img alt="" src="turtle.jpg" style="display: inline-block; margin: 20px;"></p>
+<p><img alt="" src="frog.jpg"></p>
+<p><img alt="" src="snake.jpg"></p>
+<p><img alt="" src="turtle.jpg"></p>
 
 <h2 id="Testing_it_out">Testing it out</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>You could visualise the overall structure of the extension like this:</p>
 
-<p><img alt="" src="untitled-1.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
+<p><img alt="" src="untitled-1.png"></p>
 
 <p>It's a simple extension, but shows many of the basic concepts of the WebExtensions API:</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

This PR removes inline styles from the add-ons docs.