### PR TITLE
[Markdown][Add-ons] Fix warnings

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.html
@@ -81,7 +81,7 @@ tags:
 <p>Background scripts run in the context of a special page called a background page. This gives them a <code><a href="/en-US/docs/Web/API/Window">window</a></code> global, along with all the standard DOM APIs provided by that object.</p>
 
 <div class="notecard warning">
-<p> In Firefox, background pages do not support the use of <code><a href="/en-US/docs/Web/API/Window/alert">alert()</a></code>, <code><a href="/en-US/docs/Web/API/Window/confirm">confirm()</a></code>, or <code><a href="/en-US/docs/Web/API/Window/prompt">prompt()</a></code>.</p>
+<p><strong>Warning:</strong> In Firefox, background pages do not support the use of <code><a href="/en-US/docs/Web/API/Window/alert">alert()</a></code>, <code><a href="/en-US/docs/Web/API/Window/confirm">confirm()</a></code>, or <code><a href="/en-US/docs/Web/API/Window/prompt">prompt()</a></code>.</p>
 </div>
 
 <h4 id="WebExtension_APIs">WebExtension APIs</h4>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.bookmarks.create
 <p>Creates a bookmark or folder as a child of the {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} with the specified <code>parentId</code>. To create a folder, omit or leave empty the {{WebExtAPIRef("bookmarks.CreateDetails", "CreateDetails", "url")}} parameter.</p>
 
 <div class="notecard warning">
-<p>If your extension tries to create a new bookmark in the bookmark tree's root node, it raises an error: "<em>The bookmark root cannot be modified</em>" and the bookmark won't be created.</p>
+<p><strong>Warning:</strong> If your extension tries to create a new bookmark in the bookmark tree's root node, it raises an error: "<em>The bookmark root cannot be modified</em>" and the bookmark won't be created.</p>
 </div>
 
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.bookmarks.move
 <p>The <strong><code>bookmarks.move()</code></strong> method moves the specified {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} to the specified destination within the tree of bookmarks. This lets you move a bookmark to a new folder and/or position within the folder.</p>
 
 <div class="notecard warning">
-<p>If your extension attempts to move a bookmark into the bookmarks tree root node, the call will raise an error with the message: "<em>The bookmark root cannot be modified</em>" and the move won't be completed.</p>
+<p><strong>Warning:</strong> If your extension attempts to move a bookmark into the bookmarks tree root node, the call will raise an error with the message: "<em>The bookmark root cannot be modified</em>" and the move won't be completed.</p>
 </div>
 
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.bookmarks.remove
 <p>The <strong><code>bookmarks.remove()</code></strong> method removes a single bookmark or an empty bookmark folder.</p>
 
 <div class="notecard warning">
-<p>If your extension attempts to remove a bookmark from the bookmarks tree root node, the call will raise an error with the message: "The bookmark root cannot be modified" and the bookmark won't be removed.</p>
+<p><strong>Warning:</strong> If your extension attempts to remove a bookmark from the bookmarks tree root node, the call will raise an error with the message: "The bookmark root cannot be modified" and the bookmark won't be removed.</p>
 </div>
 
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.bookmarks.removeTree
 <p>The <strong><code>bookmarks.removeTree()</code></strong> method recursively removes a bookmark folder and all of its contents.</p>
 
 <div class="notecard warning">
-<p>If your extension attempts to remove a bookmark tree from the bookmarks tree root node, the call will raise an error with the message: "The bookmark root cannot be modified" and the bookmark won't be removed.</p>
+<p><strong>Warning:</strong> If your extension attempts to remove a bookmark tree from the bookmarks tree root node, the call will raise an error with the message: "The bookmark root cannot be modified" and the bookmark won't be removed.</p>
 </div>
 
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.bookmarks.update
 <p><strong><code>bookmarks.update()</code></strong> updates the title and/or URL of a bookmark, or the name of a bookmark folder.</p>
 
 <div class="notecard warning">
-<p>If your extension attempts to update a bookmark in the bookmarks tree root node, the call will raise an error with the message: "The bookmark root cannot be modified" and the bookmark won't be updated.</p>
+<p><strong>Warning:</strong> If your extension attempts to update a bookmark in the bookmarks tree root node, the call will raise an error with the message: "The bookmark root cannot be modified" and the bookmark won't be updated.</p>
 </div>
 
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
@@ -71,9 +71,7 @@ then(onRemoved, onError);</pre>
 
 <p>Remove all cookies:</p>
 
-<div class="warning">
-<p><strong>Warning</strong><br>
- Using the API to remove all cookies will, simultaneously, clear all  local storage objects (including those of other extensions).<br>
+<div class="warning"><p><strong>Warning:</strong> Using the API to remove all cookies will, simultaneously, clear all local storage objects (including those of other extensions).<br>
  <br>
  If you want to clear all cookies without disrupting local storage facilities, use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies">browser.cookies</a> to loop through and remove the contents of all cookie stores.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.extension.getExtensionTabs
 <div>{{AddonSidebar()}}</div>
 
 <div class="warning">
-<p>This method has been deprecated. Use {{WebExtAPIRef("extension.getViews()")}} instead.</p>
+<p><strong>Warning:</strong> This method has been deprecated. Use {{WebExtAPIRef("extension.getViews()")}} instead.</p>
 </div>
 
 <p>Returns an array of the JavaScript <a href="/en-US/docs/Web/API/Window">Window</a> objects for each of the tabs running inside the current extension. If <code>windowId</code> is specified, returns only the Window objects of tabs attached to the specified window.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.api.extension.getURL
 
 
 <div class="warning">
-<p>This function is deprecated. Please use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL"><code>runtime.getURL</code></a>.</p>
+<p><strong>Warning:</strong> This function is deprecated. Please use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL"><code>runtime.getURL</code></a>.</p>
 </div>
 
 <p>Converts a relative path within an extension's install directory to a fully-qualified URL.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.extension.onRequest
 <div>{{AddonSidebar()}}</div>
 
 <div class="warning">
-<p><strong>Not implemented:</strong> This is not implemented in Firefox because it has been deprecated since Chrome 33. Please use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage">runtime.onMessage</a> instead.</p>
+<p><strong>Warning:</strong> This is not implemented in Firefox because it has been deprecated since Chrome 33. Please use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage">runtime.onMessage</a> instead.</p>
 </div>
 
 <p>Fired when a request is sent from either an extension process or a content script.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.extension.onRequestExternal
 <div>{{AddonSidebar()}}</div>
 
 <div class="warning">
-<p><strong>Not implemented:</strong> This is not implemented in Firefox because it has been deprecated since Chrome 33. Please use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal">runtime.onMessageExternal</a> instead.</p>
+<p><strong>Warning:</strong> This is not implemented in Firefox because it has been deprecated since Chrome 33. Please use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal">runtime.onMessageExternal</a> instead.</p>
 </div>
 
 <p>Fired when a request is sent from another extension.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.extension.sendRequest
 ---
 <div>{{AddonSidebar}}{{Deprecated_Header}}
 <div class="notecard warning">
-<p>This method has been deprecated. Use {{WebExtAPIRef("runtime.sendMessage")}} instead.</p>
+<p><strong>Warning:</strong> This method has been deprecated. Use {{WebExtAPIRef("runtime.sendMessage")}} instead.</p>
 </div>
 </div>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
@@ -24,7 +24,7 @@ browser-compat: webextensions.api.notifications.create
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>
 
 <div class="warning">
-<p>If you call <code>notifications.create()</code> more than once in rapid succession, Firefox may end up not displaying any notification at all.</p>
+<p><strong>Warning:</strong> If you call <code>notifications.create()</code> more than once in rapid succession, Firefox may end up not displaying any notification at all.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.html
@@ -44,7 +44,7 @@ tags:
   <p>Enter a name for the security module, such as "<em>My Client Database</em>"</p>
 
   <div class="notecard warning">
-  <p>Be careful about using international characters as there is currently a bug in Firefox where international characters may cause problems.</p>
+  <p><strong>Warning:</strong> Be careful about using international characters as there is currently a bug in Firefox where international characters may cause problems.</p>
   </div>
  </li>
  <li>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.html
@@ -41,8 +41,7 @@ browser-compat: webextensions.api.proxy
 <h2 id="Functions">Functions</h2>
 
 <div class="notecard warning">
-  <h4>Warning</h4>
-  <p>You should not use these methods ({{WebExtAPIRef("proxy.register()")}} or {{WebExtAPIRef("proxy.unregister()")}}) to register and remove an extended <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register#pac_file_specification">Proxy Auto-Configuration (PAC) file</a>. They were deprecated in Firefox 68 and removed in Firefox 71.</p>
+  <p><strong>Warning:</strong> You should not use these methods ({{WebExtAPIRef("proxy.register()")}} or {{WebExtAPIRef("proxy.unregister()")}}) to register and remove an extended <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register#pac_file_specification">Proxy Auto-Configuration (PAC) file</a>. They were deprecated in Firefox 68 and removed in Firefox 71.</p>
 </div>
 
 <dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -16,8 +16,7 @@ browser-compat: webextensions.api.proxy.register
 <p>{{AddonSidebar()}} {{deprecated_header}}</p>
 
 <div class="notecard warning">
-  <h4>Warning</h4>
-  <p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
+  <p><strong>Warning:</strong> This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
 
   <p><img alt="" src="proxy_register_warning.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
@@ -17,8 +17,7 @@ browser-compat: webextensions.api.proxy.unregister
 <div>{{deprecated_header}}</div>
 
 <div class="notecard warning">
-  <h4>Warning</h4>
-  <p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
+  <p><strong>Warning:</strong> This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
 
   <p><img alt="" src="proxy_unregister_warning.png" style="border: 1px solid black; display: block; margin: 0 auto;"></p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.runtime.onMessage
 </ul>
 
 <div class="warning">
-<p>Returning a <code>Promise</code> is now preferred, as <code>sendResponse()</code> <a href="https://github.com/mozilla/webextension-polyfill/issues/16#issuecomment-296693219">will be removed from the W3C spec</a>.</p>
+<p><strong>Warning:</strong> Returning a <code>Promise</code> is now preferred, as <code>sendResponse()</code> <a href="https://github.com/mozilla/webextension-polyfill/issues/16#issuecomment-296693219">will be removed from the W3C spec</a>.</p>
 
 <p>The popular <a href="https://github.com/mozilla/webextension-polyfill">webextension-polyfill</a> library has already removed the <code>sendResponse()</code> function from its implementation.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
@@ -47,7 +47,7 @@ browser-compat: webextensions.api.storage.StorageArea.get
 <p>If managed storage is not set, <code>undefined</code> will be returned.</p>
 
 <div class="warning">
-<p><strong>Caution:</strong> When used within a content script in Firefox versions prior to 52, the Promise returned by <code>browser.storage.local.get()</code> is fulfilled with an Array containing one Object. The Object in the Array contains the <code>keys</code> found in the storage area, as described above.</p>
+<p><strong>Warning:</strong> When used within a content script in Firefox versions prior to 52, the Promise returned by <code>browser.storage.local.get()</code> is fulfilled with an Array containing one Object. The Object in the Array contains the <code>keys</code> found in the storage area, as described above.</p>
 
 <p>The Promise is correctly fulfilled with an Object when used in the background context (background scripts, popups, options pages, etc.).</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -49,7 +49,9 @@ browser-compat: webextensions.api.tabs.create
   <dd><code>boolean</code>. Whether the tab should be pinned. Defaults to <code>false</code>.</dd>
   <dt><code>selected</code>{{optional_inline}}</dt>
   <dd><code>boolean</code>. Whether the tab should become the selected tab in the window. Defaults to <code>true</code>.
-  <div class="warning">This property is deprecated, and is not supported in Firefox. Use <code>active</code> instead.</div>
+  <div class="warning">
+    <p><strong>Warning:</strong> This property is deprecated, and is not supported in Firefox. Use <code>active</code> instead.</p>
+  </div>
   </dd>
   <dt><code>title</code> {{optional_inline}}</dt>
   <dd><code>string</code>. The title of the tab. Allowed only if the tab is created with <code>discarded</code> set to <code>true</code>.</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.html
@@ -17,7 +17,7 @@ browser-compat: webextensions.api.tabs.getSelected
 <div>{{AddonSidebar()}}</div>
 
 <div class="warning">
-<p>This method has been deprecated. Use {{WebExtAPIRef("tabs.query", "tabs.query({active: true})")}} instead.</p>
+<p><strong>Warning:</strong> This method has been deprecated. Use {{WebExtAPIRef("tabs.query", "tabs.query({active: true})")}} instead.</p>
 </div>
 
 <p>Gets the tab that is selected in the specified window.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
@@ -17,7 +17,7 @@ browser-compat: webextensions.api.tabs.onActiveChanged
 <div>{{AddonSidebar()}}</div>
 
 <div class="warning">
-<p>This event is deprecated. Use {{WebExtAPIRef("tabs.onActivated")}} instead.</p>
+<p><strong>Warning:</strong> This event is deprecated. Use {{WebExtAPIRef("tabs.onActivated")}} instead.</p>
 </div>
 
 <p>Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to {{WebExtAPIRef('tabs.onUpdated')}} events to be notified when a URL is set.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
@@ -16,7 +16,9 @@ browser-compat: webextensions.api.tabs.onHighlightChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div class="warning">This event is deprecated. Use {{WebExtAPIRef("tabs.onHighlighted")}} instead.</div>
+<div class="warning">
+  <p><strong>Warning:</strong> This event is deprecated. Use {{WebExtAPIRef("tabs.onHighlighted")}} instead.</p>
+</div>
 
 <p>Fired when the highlighted or selected tabs in a window changes.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
@@ -16,7 +16,9 @@ browser-compat: webextensions.api.tabs.onSelectionChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div class="warning">This event is deprecated. Use {{WebExtAPIRef("tabs.onActivated")}} instead.</div>
+<div class="warning">
+  <p><strong>Warning:</strong> This event is deprecated. Use {{WebExtAPIRef("tabs.onActivated")}} instead.</p>
+</div>
 
 <p>Fires when the selected tab in a window changes.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.html
@@ -17,7 +17,7 @@ browser-compat: webextensions.api.tabs.sendRequest
 <div>{{AddonSidebar()}}</div>
 
 <div class="warning">
-<p>This method has been deprecated. Use {{WebExtAPIRef("tabs.sendMessage()")}} instead.</p>
+<p><strong>Warning:</strong> This method has been deprecated. Use {{WebExtAPIRef("tabs.sendMessage()")}} instead.</p>
 </div>
 
 <p>Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The {{WebExtAPIRef('extension.onRequest')}} event is fired in each content script running in the specified tab for the current extension.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.html
@@ -25,7 +25,7 @@ browser-compat: webextensions.api.userScripts
 </ul>
 
 <div class="notecard warning">
-<p>This API requires the presence of the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts">user_scripts</a></code> key in the manifest.json, even if no API script is specified. For example. <code>user_scripts: {}</code>.</p>
+<p><strong>Warning:</strong> This API requires the presence of the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts">user_scripts</a></code> key in the manifest.json, even if no API script is specified. For example. <code>user_scripts: {}</code>.</p>
 </div>
 
 <p>To use the API, call <code>{{WebExtAPIRef("userScripts.register","register()")}}</code> passing in an object defining the scripts to register. The method returns a Promise that is resolved with a <code>{{WebExtAPIRef("userScripts.RegisteredUserScript","RegisteredUserScript")}}</code> object.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
@@ -463,7 +463,7 @@ window.addEventListener("message", function(event) {
 <p>For a complete working example of this, <a href="https://mdn.github.io/webextensions-examples/content-script-page-script-messaging.html">visit the demo page on GitHub</a> and follow the instructions.</p>
 
 <div class="warning">
-<p><strong>Be very careful when interacting with untrusted web content in this manner!</strong> Extensions are privileged code which can have powerful capabilities and hostile web pages can easily trick them into accessing those capabilities.</p>
+<p><strong>Warning:</strong> Be very careful when interacting with untrusted web content in this manner! Extensions are privileged code which can have powerful capabilities and hostile web pages can easily trick them into accessing those capabilities.</p>
 
 <p>To give a trivial example, suppose the content script code that receives the message does something like this:</p>
 
@@ -538,7 +538,7 @@ In page script, window.y: undefined</pre>
 <p>The same applies to <code><a href="/en-US/docs/Web/API/setTimeout">setTimeout()</a></code>, <code><a href="/en-US/docs/Web/API/setInterval">setInterval()</a></code>, and <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">Function()</a></code>.</p>
 
 <div class="notecard warning">
-<p><strong>Be very careful when running code in the context of the page!</strong> </p>
+<p><strong>Warning:</strong> Be very careful when running code in the context of the page!</p>
 
 <p>The page's environment is controlled by potentially malicious web pages, which can redefine objects you interact with to behave in unexpected ways:</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
@@ -178,7 +178,7 @@ chrome.runtime.onMessage.addListener(notify);
 </div>
 
 <div class="notecard warning">
-<p>Enabling worker debugging in Toolbox Options will disable Browser Content Toolbox debugging, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1236892">Bug 1236892</a> should address this.</p>
+<p><strong>Warning:</strong> Enabling worker debugging in Toolbox Options will disable Browser Content Toolbox debugging, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1236892">Bug 1236892</a> should address this.</p>
 </div>
 
 <p>{{EmbedYouTube("xAt3Q0PgJP4")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/examples/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/examples/index.html
@@ -12,7 +12,7 @@ tags:
 <p>These examples work in Firefox Nightly: most work in earlier versions of Firefox, but check the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">strict_min_version</a> key in the extension's manifest.json to make sure.</p>
 
 <div class="notecard warning">
-<p>Some examples work only on specific domains or pages. Details of any restrictions are provided in each example's readme file. None of the examples work in private browsing windows by default, see <a href="https://support.mozilla.org/en-US/kb/extensions-private-browsing#w_enabling-or-disabling-extensions-in-private-windows">Extensions in Private Browsing</a> for details.</p>
+<p><strong>Warning:</strong> Some examples work only on specific domains or pages. Details of any restrictions are provided in each example's readme file. None of the examples work in private browsing windows by default, see <a href="https://support.mozilla.org/en-US/kb/extensions-private-browsing#w_enabling-or-disabling-extensions-in-private-windows">Extensions in Private Browsing</a> for details.</p>
 </div>
 
 <p>To try these examples, clone the repository then:</p>
@@ -24,7 +24,7 @@ tags:
 </ol>
 
 <div class="warning">
-<p><strong>Important</strong>: Please do not submit these WebExtension examples to addons.mozilla.org (AMO); you do not have to sign the add-on WebExtension examples to run them. Follow the steps above.</p>
+<p><strong>Warning:</strong> Please do not submit these WebExtension examples to addons.mozilla.org (AMO); you do not have to sign the add-on WebExtension examples to run them. Follow the steps above.</p>
 </div>
 
 <p>If you want to contribute to the repository, <a href="https://github.com/mdn/webextensions-examples/blob/master/CONTRIBUTING.md">send us a pull request.</a></p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -77,7 +77,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 <h3 id="Microsoft_Edge_properties">Microsoft Edge properties</h3>
 
 <div class="notecard warning">
-<p><strong>Warning</strong>: Adding Edge-specific properties to the manifest caused an error prior to Firefox 69 which can prevent the extension from installing.</p>
+<p><strong>Warning:</strong> Adding Edge-specific properties to the manifest caused an error prior to Firefox 69 which can prevent the extension from installing.</p>
 </div>
 
 <p>Microsoft Edge stores its browser specific settings in the <code>edge</code> subkey, which has the following properties:</p>
@@ -97,7 +97,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 <h3 id="Safari_properties">Safari properties</h3>
 
 <div class="notecard warning">
-<p><strong>Warning</strong>: Adding Safari-specific properties to the manifest caused an error prior to Firefox 69 which can prevent the extension from installing.</p>
+<p><strong>Warning:</strong> Adding Safari-specific properties to the manifest caused an error prior to Firefox 69 which can prevent the extension from installing.</p>
 </div>
 
 <p>Safari stores its browser specific settings in the <code>safari</code> subkey, which has the following properties:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.html
@@ -33,8 +33,9 @@ browser-compat: webextensions.manifest.options_page
  </tbody>
 </table>
 
-<div>{{Deprecated_Header}}
-<div class="notecard warning">This manifest key has been deprecated. Use <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui">options_ui</a></code> instead.</div>
+<div>{{Deprecated_Header}}</div>
+<div class="notecard warning">
+  <p><strong>Warning:</strong> This manifest key has been deprecated. Use <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui">options_ui</a></code> instead.</p>
 </div>
 
 <p>Use the <code>options_page</code> key to define an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages">options page</a> for your extension.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -140,7 +140,7 @@ browser-compat: webextensions.manifest.theme
    <td><code>String</code></td>
    <td>
     <div class="notecard warning">
-    <p><code>headerURL</code> has been removed in Firefox 70. You will begin to get warnings in Firefox 65 and later if you load a theme that uses this property. Use <code>theme_frame</code> instead.</p>
+    <p><strong>Warning:</strong> <code>headerURL</code> has been removed in Firefox 70. You will begin to get warnings in Firefox 65 and later if you load a theme that uses this property. Use <code>theme_frame</code> instead.</p>
     </div>
 
     <p>The URL of a foreground image to be added to the header area and anchored to the upper right corner of the header area.</p>
@@ -170,7 +170,7 @@ browser-compat: webextensions.manifest.theme
    <td><code>Array </code>of <code>String</code></td>
    <td>
     <div class="warning">
-    <p>The <code>additional_backgrounds</code> property is experimental. It is currently accepted in release versions of Firefox, but its behavior is subject to change. It is not supported in Firefox for Android.</p>
+    <p><strong>Warning:</strong> The <code>additional_backgrounds</code> property is experimental. It is currently accepted in release versions of Firefox, but its behavior is subject to change. It is not supported in Firefox for Android.</p>
     </div>
 
     <p>An array of URLs for additional background images to be added to the header area and displayed behind the <code>"theme_frame":</code> image. These images layer the first image in the array on top, the last image in the array at the bottom.</p>
@@ -230,7 +230,7 @@ browser-compat: webextensions.manifest.theme
    </td>
    <td>
     <div class="notecard warning">
-    <p><code>accentcolor</code> has been removed in Firefox 70. You will begin to get warnings in Firefox 65 and later if you load a theme that uses this property. Use the <code>frame</code> property instead.</p>
+    <p><strong>Warning:</strong> <code>accentcolor</code> has been removed in Firefox 70. You will begin to get warnings in Firefox 65 and later if you load a theme that uses this property. Use the <code>frame</code> property instead.</p>
     </div>
 
     <p>The color of the header area background, displayed in the part of the header not covered or visible through the images specified in <code>"headerURL"</code> and <code>"additional_backgrounds"</code>.</p>
@@ -673,7 +673,7 @@ browser-compat: webextensions.manifest.theme
    <td><code>tab_background_separator</code> {{Deprecated_Inline}}</td>
    <td>
     <div class="notecard warning">
-    <p><code>tab_background_separator</code> is not supported starting with Firefox 89.
+    <p><strong>Warning:</strong> <code>tab_background_separator</code> is not supported starting with Firefox 89.
     </div>
     <p>The color of the vertical separator of the background tabs.</p>
 
@@ -813,7 +813,7 @@ browser-compat: webextensions.manifest.theme
    <td><code>textcolor</code> {{Deprecated_Inline}}</td>
    <td>
     <div class="notecard warning">
-    <p><code>textcolor</code> has been removed in Firefox 70. You will begin to get warnings in Firefox 65 and later if you load a theme that uses this property. Use <code>tab_background_text</code> instead.</p>
+    <p><strong>Warning:</strong> <code>textcolor</code> has been removed in Firefox 70. You will begin to get warnings in Firefox 65 and later if you load a theme that uses this property. Use <code>tab_background_text</code> instead.</p>
     </div>
 
     <p>The color of the text displayed in the header area.</p>
@@ -1019,7 +1019,7 @@ browser-compat: webextensions.manifest.theme
    <td><code>toolbar_field_separator</code> {{Deprecated_Inline}}</td>
    <td>
     <div class="notecard warning">
-    <p><code>toolbar_field_separator</code> is not supported starting with Firefox 89.
+    <p><strong>Warning:</strong> <code>toolbar_field_separator</code> is not supported starting with Firefox 89.
     </div>
     <p>The color of separators inside the URL bar. In Firefox 58 this was implemented as <code>toolbar_vertical_separator</code>.</p>
 
@@ -1169,7 +1169,7 @@ browser-compat: webextensions.manifest.theme
 <p>Additionally, this key accepts various properties that are aliases for one of the properties above. These are provided for compatibility with Chrome. If an alias is given, and the non-alias version is also given, then the value will be taken from the non-alias version.</p>
 
 <div class="notecard warning">
-<p>Beginning Firefox 70, the following properties are removed: <code>accentcolor</code> and <code>textcolor</code>. Use <code>frame</code> and <code>tab_background_text</code> instead. Using these values in themes loaded into Firefox 65 or later will raise warnings.</p>
+<p><strong>Warning:</strong> Beginning Firefox 70, the following properties are removed: <code>accentcolor</code> and <code>textcolor</code>. Use <code>frame</code> and <code>tab_background_text</code> instead. Using these values in themes loaded into Firefox 65 or later will raise warnings.</p>
 </div>
 
 <table class="fullwidth-table standard-table">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
@@ -70,7 +70,7 @@ browser-compat: webextensions.manifest.theme_experiment
 
 <div class="cl-preview-section">
 <div class="notecard warning">
-<p>This feature is experimental and could be subject to change.</p>
+<p><strong>Warning:</strong> This feature is experimental and could be subject to change.</p>
 </div>
 </div>
 

--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.html
@@ -264,7 +264,7 @@ HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\PKCS11Modules\<var>&lt;name&gt;</var></pre>
 <p>The key should have a single default value, which is the path to the manifest.</p>
 
 <div class="notecard warning">
-<p><strong>As of Firefox 64:</strong> The 32-bit registry view (<a href="https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system">Wow6432Node) </a>will be checked first for these keys, followed by the "native" registry view. Use whichever is appropriate for your application.</p>
+<p><strong>Warning:</strong> As of Firefox 64, the 32-bit registry view (<a href="https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system">Wow6432Node) </a>will be checked first for these keys, followed by the "native" registry view. Use whichever is appropriate for your application.</p>
 
 <p><strong>For Firefox 63 and older:</strong> This key should <em>not</em> be created under <a href="https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system">Wow6432Node</a>, even if the app is 32-bit. Previous versions of the browser will always look for the key under the "native" view of the registry, not the 32-bit emulation. To ensure that the key is created in the "native" view, you can pass the <code>KEY_WOW64_64KEY</code> or <code>KEY_WOW64_32KEY</code> flags into <code>RegCreateKeyEx</code>. See <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384129(v=vs.85).aspx">Accessing an Alternate Registry View</a>.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.html
@@ -19,7 +19,7 @@ tags:
 </div>
 
 <div class="notecard warning">
-<p>As an extension developer you should consider that scripts running in arbitrary web pages are hostile code whose aim is to steal the user's personal information, damage their computer, or attack them in some other way.</p>
+<p><strong>Warning:</strong> As an extension developer you should consider that scripts running in arbitrary web pages are hostile code whose aim is to steal the user's personal information, damage their computer, or attack them in some other way.</p>
 
 <p>The isolation between content scripts and scripts loaded by web pages is intended to make it more difficult for hostile web pages to do this.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.html
@@ -23,7 +23,7 @@ tags:
 <p>When considering using <code>browser_style: true</code>, you need to test your extension with various themes (built-in or from AMO) to make sure that the extension UI behaves the way you expect it to.</p>
 
 <div class="notecard warning">
-<p>When <code>browser_style: true</code> is included in your web extension's manifest, text selection in your extension's UI is disabled except in input controls. If this will cause a problem, include browser_style:false instead.</p>
+<p><strong>Warning:</strong> When <code>browser_style: true</code> is included in your web extension's manifest, text selection in your extension's UI is disabled except in input controls. If this will cause a problem, include browser_style:false instead.</p>
 </div>
 
 <div class="notecard note">

--- a/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.html
@@ -65,7 +65,7 @@ cd borderify</pre>
 </ul>
 
 <div class="warning">
-<p><a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when_do_you_need_an_add-on_id">In some situations you need to specify an ID for your extension</a>. If you do need to specify an add-on ID, include the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">browser_specific_settings</a></code> key in <code>manifest.json</code> and set its <code>gecko.id</code> property:</p>
+<p><strong>Warning:</strong> <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when_do_you_need_an_add-on_id">In some situations you need to specify an ID for your extension</a>. If you do need to specify an add-on ID, include the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">browser_specific_settings</a></code> key in <code>manifest.json</code> and set its <code>gecko.id</code> property:</p>
 
 <pre class="brush: json">"browser_specific_settings": {
   "gecko": {


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

This PR fixes warnings in the add-ons docs, so they can be converted to Markdown.