### PR TITLE
[Markdown][Add-ons] Remove non-heading IDs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
@@ -39,7 +39,7 @@ browser-compat: webextensions.api.bookmarks.getRecent
 
 <h2 id="Examples">Examples</h2>
 
-<p id="Find_the_most_recently_added_bookmark">This example logs the URL for the most recently added bookmark:</p>
+<p>This example logs the URL for the most recently added bookmark:</p>
 
 <pre class="brush: js">function onFulfilled(bookmarks) {
   for (bookmark of bookmarks) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
@@ -55,7 +55,7 @@ browser-compat: webextensions.api.clipboard.setImageData
 
 <p>Copy a remote image:</p>
 
-<pre class="brush: js" id="ct-71"><span class="quote">// requires:
+<pre class="brush: js"><span class="quote">// requires:
 // * the host permission for "<a href="https://cdn.mdn.mozilla.net/" rel="nofollow">https://cdn.mdn.mozilla.net/</a>*"
 // * the API permission "clipboardWrite"
 
@@ -65,7 +65,7 @@ fetch('<a href="https://cdn.mdn.mozilla.net/static/img/favicon144.png" rel="nofo
 
 <p><span class="quote">Copy an image that was bundled with the extension:</span></p>
 
-<pre class="brush: js" id="ct-70">// requires <span class="quote">the API permission </span>"clipboardWrite"
+<pre class="brush: js">// requires <span class="quote">the API permission </span>"clipboardWrite"
 
 fetch(browser.runtime.getURL('image.png'))
 .then(response =&gt; response.arrayBuffer())

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
@@ -94,7 +94,7 @@ var registered = register(defaultHosts, defaultCode);</pre>
 
 <p>This code registers the JS file at content_scripts/example.js:</p>
 
-<pre class="brush: js" id="ct-3">const scriptObj = await browser.contentScripts.register({
+<pre class="brush: js">const scriptObj = await browser.contentScripts.register({
   "js": [{file: "/content_scripts/example.js"}],
   "matches": ["&lt;all_urls&gt;"],
   "allFrames": true,

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
@@ -31,19 +31,19 @@ browser-compat: webextensions.api.notifications.NotificationOptions
 <dl class="reference-values">
  <dt><code>type</code></dt>
  <dd>{{WebExtAPIRef("notifications.TemplateType")}}. The type of notification you want. Depending on your choice here, certain other properties are either mandatory or are not permitted.</dd>
- <dt><a id="message"><code>message</code></a></dt>
+ <dt><code>message</code></dt>
  <dd><code>string</code>. The notification's main content.</dd>
- <dt><a id="title"><code>title</code></a></dt>
+ <dt><code>title</code></dt>
  <dd><code>string</code>. The notification's title.</dd>
- <dt><a id="iconUrl"><code>iconUrl</code></a>{{optional_inline}}</dt>
- <dd><code>string</code>. A URL pointing to an icon to display in the notification. The URL can be: a data URL, a blob URL, a http or https URL, or the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#relative_urls">relative URL</a> of a file within the extension.</dd>
- <dt><a id="contextMessage"><code>contextMessage</code></a>{{optional_inline}}</dt>
+ <dt><code>iconUrl</code>{{optional_inline}}</dt>
+ <dd><code>string</code>. A URL pointing to an icon to display in the notification. The URL can be: a data URL, a blob URL, a http or https URL, or the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#relative_urls">relative URL of a file within the extension.</dd>
+ <dt><code>contextMessage</code>{{optional_inline}}</dt>
  <dd><code>string</code>. Supplementary content to display.</dd>
- <dt><a id="priority"><code>priority</code></a>{{optional_inline}}</dt>
+ <dt><code>priority</code>{{optional_inline}}</dt>
  <dd><code>number</code>. The notification's priority: may be 0, 1, or 2. Defaults to 0 if omitted.</dd>
- <dt><a id="eventTime"><code>eventTime</code></a>{{optional_inline}}</dt>
+ <dt><code>eventTime</code>{{optional_inline}}</dt>
  <dd><code>number</code>. A timestamp for the notification in <a href="https://en.wikipedia.org/wiki/Unix_time">milliseconds since the epoch</a>.</dd>
- <dt><a id="buttons"><code>buttons</code></a>{{optional_inline}}</dt>
+ <dt><code>buttons</code>{{optional_inline}}</dt>
  <dd><code>array</code> of <code>button</code>. An array of up to 2 buttons to include in the notification. You can listen for button clicks using {{WebExtAPIRef("notifications.onButtonClicked")}}. Each button is specified as an object with the following properties:</dd>
  <dd>
  <dl class="reference-values">
@@ -53,13 +53,13 @@ browser-compat: webextensions.api.notifications.NotificationOptions
   <dd><code>string</code>. URL pointing to an icon for the button.</dd>
  </dl>
  </dd>
- <dt><a id="imageUrl"><code>imageUrl</code></a></dt>
+ <dt><code>imageUrl</code></dt>
  <dd>
  <p><code>string</code>. A URL pointing to an image to use in the notification. The URL can be: a data URL, a blob URL, or the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#relative_urls">relative URL</a> of a file within the extension.</p>
 
  <p><em>This property is only permitted if <code>type</code> is <code>"image"</code>. In this case, it is mandatory if the <code>NotificationOptions</code> is used in {{WebExtAPIRef("notifications.create()")}}, and optional if it is used in {{WebExtAPIRef("notifications.update()")}}.</em></p>
  </dd>
- <dt><a id="items"><code>items</code></a></dt>
+ <dt><code>items</code></dt>
  <dd><code>array</code> of <code>item</code>. An array of items to include in the notification. Depending on the settings for the operating system's notification mechanism, some of the items you provide might not be displayed. Each item is specified as an object with the following properties:</dd>
  <dd>
  <dl class="reference-values">
@@ -69,7 +69,7 @@ browser-compat: webextensions.api.notifications.NotificationOptions
   <dd><code>string</code>. Message to display in the item.</dd>
  </dl>
  <em>This property is only permitted if <code>type</code> is <code>"list"</code>. In this case, it is mandatory if the <code>NotificationOptions</code> is used in {{WebExtAPIRef("notifications.create()")}}, and optional if it is used in {{WebExtAPIRef("notifications.update()")}}.</em></dd>
- <dt><a id="progress"><code>progress</code></a></dt>
+ <dt><code>progress</code></dt>
  <dd><code>integer</code>. An integer between 0 and 100, used to represent the current progress in a progress indicator.</dd>
  <dd><em>This property is only permitted if <code>type</code> is <code>"progress"</code>. In this case, it is mandatory if the <code>NotificationOptions</code> is used in {{WebExtAPIRef("notifications.create()")}}, and optional if it is used in {{WebExtAPIRef("notifications.update()")}}.</em></dd>
 </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
@@ -27,26 +27,26 @@ browser-compat: webextensions.api.notifications.TemplateType
  <li><code>"basic"</code>: the notification includes:
 
   <ul>
-   <li>a title (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#title">NotificationOptions.title</a></code>)</li>
-   <li>a message (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#message">NotificationOptions.message</a></code>)</li>
-   <li>an icon (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#iconurl">NotificationOptions.iconUrl</a></code>){{optional_inline}}</li>
-   <li>an extra message (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#contextmessage">NotificationOptions.contextMessage</a></code>){{optional_inline}}</li>
-   <li>up to two buttons (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#buttons">NotificationOptions.buttons</a></code>){{optional_inline}}</li>
+   <li>a title (<code>NotificationOptions.title</code>)</li>
+   <li>a message (<code>NotificationOptions.message</code>)</li>
+   <li>an icon (<code>NotificationOptions.iconUrl</code>){{optional_inline}}</li>
+   <li>an extra message (<code>NotificationOptions.contextMessage</code>){{optional_inline}}</li>
+   <li>up to two buttons (<code>NotificationOptions.buttons</code>){{optional_inline}}</li>
   </ul>
  </li>
  <li><code>"image"</code>: everything in <code>"basic"</code> and also:
   <ul>
-   <li>an image (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#imageurl">NotificationOptions.imageUrl</a></code>)</li>
+   <li>an image (<code>NotificationOptions.imageUrl</code>)</li>
   </ul>
  </li>
  <li><code>"list"</code>: everything in <code>"basic"</code> and also:
   <ul>
-   <li>a list of items (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#items">NotificationOptions.items</a></code>)</li>
+   <li>a list of items (<code>NotificationOptions.items</code>)</li>
   </ul>
  </li>
  <li><code>"progress"</code>: everything in <code>"basic"</code> and also:
   <ul>
-   <li>a progress indicator (<code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions#progress">NotificationOptions.progress</a></code>)</li>
+   <li>a progress indicator (<code>NotificationOptions.progress</code>)</li>
   </ul>
  </li>
 </ul>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -81,7 +81,7 @@ browser.runtime.onMessage.addListener((message) =&gt; {
 
 <p>For example:</p>
 
-<pre class="brush: js" id="ct-0">const proxySpecification = [
+<pre class="brush: js">const proxySpecification = [
   {
     type: "socks",
     host: "foo.com",

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.html
@@ -21,7 +21,7 @@ browser-compat: webextensions.api.tabs.printPreview
 <div>An extension can detect when print preview has been closed by listening to the <a href="/en-US/docs/Web/API/Window/afterprint_event">afterprint</a> event:</div>
 
 <div>
-<pre class="brush: js no-line-numbers" id="ct-13">window.addEventListener("afterprint", resumeFunction, false);</pre>
+<pre class="brush: js no-line-numbers">window.addEventListener("afterprint", resumeFunction, false);</pre>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.html
@@ -24,27 +24,27 @@ browser-compat: webextensions.api.webNavigation.TransitionType
 <p>Values of this type are strings. Possible values are:</p>
 
 <dl>
- <dt><a id="value-link"></a>"link"</dt>
+ <dt>"link"</dt>
  <dd>The user clicked a link in another page.</dd>
- <dt><a id="value-typed"></a>"typed"</dt>
+ <dt>"typed"</dt>
  <dd>The user typed the URL into the address bar. This is also used if the user started typing into the address bar, then selected a URL from the suggestions it offered. See also "generated".</dd>
- <dt><a id="value-auto_bookmark"></a>"auto_bookmark"</dt>
+ <dt>"auto_bookmark"</dt>
  <dd>The user clicked a bookmark or an item in the browser history.</dd>
- <dt><a id="value-auto_subframe"></a>"auto_subframe"</dt>
+ <dt>"auto_subframe"</dt>
  <dd>Any nested iframes that are automatically loaded by their parent.</dd>
- <dt><a id="value-manual_subframe"></a>"manual_subframe"</dt>
+ <dt>"manual_subframe"</dt>
  <dd>Any nested iframes that are loaded as an explicit user action. Loading such an iframe will generate an entry in the back/forward navigation list.</dd>
- <dt><a id="value-generated"></a>"generated"</dt>
+ <dt>"generated"</dt>
  <dd>The user started typing in the address bar, then clicked on a suggested entry that didn't contain a URL.</dd>
- <dt><a id="value-start_page"></a>"start_page"</dt>
+ <dt>"start_page"</dt>
  <dd>The page was passed to the command line or is the start page.</dd>
- <dt><a id="value-form_submit"></a>"form_submit"</dt>
+ <dt>"form_submit"</dt>
  <dd>The user submitted a form. Note that in some situations, such as when a form uses a script to submit its contents, submitting a form does not result in this transition type.</dd>
- <dt><a id="value-reload"></a>"reload"</dt>
+ <dt>"reload"</dt>
  <dd>The user reloaded the page, using the Reload button or by pressing Enter in the address bar. This is also used for session restore and reopening closed tabs.</dd>
- <dt><a id="value-keyword"></a>"keyword"</dt>
+ <dt>"keyword"</dt>
  <dd>The URL was generated using a <a href="https://support.mozilla.org/en-US/kb/how-search-from-address-bar">keyword search</a> configured by the user.</dd>
- <dt><a id="value-keyword_generated"></a>"keyword_generated"</dt>
+ <dt>"keyword_generated"</dt>
  <dd>Corresponds to a visit generated for a keyword.</dd>
 </dl>
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
@@ -114,11 +114,11 @@ setCookie.then(logCookie, logError);</pre>
 <dl>
   <dt>Notifications API</dt>
   <dd>
-    <p id="notifications_incompatibilities">These incompatibilities are present in {{WebExtAPIRef("notifications")}}:</p>
+    <p>These incompatibilities are present in {{WebExtAPIRef("notifications")}}:</p>
     <ul>
      <li>
       <p>For <code>notifications.create()</code>, with <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType">type</a> "basic"</code>:</p>
-    
+
       <dl>
        <dt>In Firefox</dt>
        <dd><code>iconUrl</code> is optional.</dd>
@@ -128,7 +128,7 @@ setCookie.then(logCookie, logError);</pre>
      </li>
      <li>
       <p>When the user clicks on a notification:</p>
-    
+
       <dl>
        <dt>In Firefox</dt>
        <dd>The notification is cleared immediately.</dd>
@@ -138,7 +138,7 @@ setCookie.then(logCookie, logError);</pre>
      </li>
      <li>
       <p>If you call <code>notifications.create()</code> more than once in rapid succession:</p>
-    
+
       <ul>
        <li>In Firefox, the notifications may not display at all. Waiting to make subsequent calls until within the <code>chrome.notifications.create()</code> callback function is not a sufficient delay to prevent this.</li>
       </ul>
@@ -148,8 +148,8 @@ setCookie.then(logCookie, logError);</pre>
 
   <dt>Proxy API</dt>
   <dd>
-    <p id="proxy_incompatibilities">Firefox's {{WebExtAPIRef("proxy")}} API followed a completely different design from Chrome's Proxy API.</p>
-    
+    <p>Firefox's {{WebExtAPIRef("proxy")}} API followed a completely different design from Chrome's Proxy API.</p>
+
     <dl>
      <dt>In Chrome</dt>
      <dd>An extension can register a PAC file, but can also define explicit proxying rules.</dd>
@@ -163,27 +163,27 @@ setCookie.then(logCookie, logError);</pre>
   <dt>Tabs API</dt>
   <dd>
 
-    <p id="tabs_incompatibilities">These incompatibilities are present in {{WebExtAPIRef("tabs")}}:</p>
-    
+    <p>These incompatibilities are present in {{WebExtAPIRef("tabs")}}:</p>
+
     <ul>
      <li>
       <p>When using <code>tabs.executeScript()</code> or <code>tabs.insertCSS()</code>:</p>
-    
+
       <dl>
        <dt>In Firefox</dt>
        <dd>Relative URLs passed are resolved relative to the current page URL.</dd>
        <dt>In Chrome</dt>
        <dd>These URLs are resolved relative to the extension's base URL.</dd>
       </dl>
-    
+
       <p>To work cross-browser, you can specify the path as an absolute URL, starting at the extension's root, like this:</p>
-    
+
       <pre class="brush: none;">/path/to/script.js
     </pre>
      </li>
      <li>
       <p>When :</p>
-    
+
       <dl>
        <dt>In Firefox</dt>
        <dd>Querying tabs by URL with <code>tabs.query()</code> requires the <code>"tabs"</code> permission.</dd>
@@ -193,7 +193,7 @@ setCookie.then(logCookie, logError);</pre>
      </li>
      <li>
       <p>When calling <code>tabs.remove()</code>:</p>
-    
+
       <dl>
        <dt>In Firefox</dt>
        <dd>The <code>tabs.remove()</code> promise is fulfilled after the <code>beforeunload</code> event.</dd>
@@ -206,8 +206,8 @@ setCookie.then(logCookie, logError);</pre>
 
   <dt>WebRequest API</dt>
   <dd>
-    <p id="web_request_incompatibilities">These incompatibilities are present in {{WebExtAPIRef("webRequest")}}:</p>
-    
+    <p>These incompatibilities are present in {{WebExtAPIRef("webRequest")}}:</p>
+
     <dl>
       <dt>In Firefox</dt>
       <dd>
@@ -235,7 +235,7 @@ setCookie.then(logCookie, logError);</pre>
     <ul>
      <li>
       <p>When using <code>browser.webRequest.*</code>:</p>
-    
+
       <dl>
        <dt>In Firefox (starting from Firefox 52)</dt>
        <dd>Some of the <code>browser.webRequest.*</code> APIs allow returning Promises that resolves <code>webRequest.BlockingResponse</code> asynchronously.</dd>
@@ -248,7 +248,7 @@ setCookie.then(logCookie, logError);</pre>
 
 
   <dt>Windows API</dt>
-  <dd> 
+  <dd>
     <dl>
      <dt>In Firefox</dt>
      <dd><code>onFocusChanged</code> of the {{WebExtAPIRef("windows")}} API, will trigger multiple times for a given focus change.</dd>
@@ -261,7 +261,7 @@ setCookie.then(logCookie, logError);</pre>
   <dl>
     <dt>DeclarativeContent API</dt>
     <dd>
-      <p id="declarative_content_incompatibilities">Chrome's <a href="https://developer.chrome.com/extensions/declarativeContent" name="dec">declarativeContent</a> API <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435864">has not yet been implemented</a> in Firefox:</p>     
+      <p>Chrome's <a href="https://developer.chrome.com/extensions/declarativeContent" name="dec">declarativeContent</a> API <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435864">has not yet been implemented</a> in Firefox:</p>
       <dl>
        <dt>In Firefox</dt>
        <dd>In addition, Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1323433#c16">will not be supporting</a> the <code>declarativeContent.RequestContentScript</code> API (which is rarely used, and is unavailable in stable releases of Chrome).</dd>
@@ -279,15 +279,15 @@ setCookie.then(logCookie, logError);</pre>
      <dd>URLs in injected CSS files are resolved relative to <em>the page they are injected into</em>.</dd>
     </dl>
   </dd>
-    
+
   <dt>Additional incompatibilities</dt>
-  <dd>  
+  <dd>
     <dl>
      <dt>In Firefox</dt>
      <dd>Background pages do not support using <a href="/en-US/docs/Web/API/Window/alert"><code>alert()</code></a>, <a href="/en-US/docs/Web/API/Window/confirm"><code>confirm()</code></a>, or <a href="/en-US/docs/Web/API/Window/prompt"><code>prompt()</code></a>.</dd>
     </dl>
-  </dd> 
-  
+  </dd>
+
   <dt>web_accessible_resources</dt>
   <dd>
     <dl>
@@ -297,7 +297,7 @@ setCookie.then(logCookie, logError);</pre>
      <dd>Resources are assigned a random UUID that changes for every instance of Firefox: <code>moz-extension://«<var>random-UUID</var>»/«<var>path/to/resource</var>»</code>. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.</dd>
     </dl>
   </dd>
-    
+
   <dt>Manifest "key" property</dt>
   <dd>
     <dl>
@@ -307,38 +307,38 @@ setCookie.then(logCookie, logError);</pre>
      <dd>Since Firefox uses random UUIDs for <code>web_accessible_resources</code>, this property is unsupported.</dd>
     </dl>
   </dd>
-    
+
   <dt>Content script requests happen in the context of extension, not content page</dt>
-  <dd>  
+  <dd>
     <dl>
      <dt>In Chrome</dt>
      <dd>When a content script makes a request (for example, using <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch"><code>fetch()</code></a>) to a relative URL (like <code>/api</code>), it will be sent to <code>https://example.com/api</code>.</dd>
      <dt>In Firefox</dt>
      <dd>When a content script makes a request, you <em>must</em> provide absolute URLs.</dd>
     </dl>
-  </dd>  
+  </dd>
 
   <dt>Sharing variables between content scripts</dt>
-  <dd>      
+  <dd>
     <dl>
      <dt>In Firefox</dt>
      <dd>You cannot share variables between content scripts by assigning them to <code>this.{variableName}</code> in one script and then attempting to access them using <code>window.{variableName}</code> in another. This is a limitation created by the sandbox environment in Firefox. This limitation may be removed, see {{bug(1208775)}}.</dd>
     </dl>
-  </dd>   
+  </dd>
 
   <dt>Content script lifecycle during navigation</dt>
-  <dd>      
+  <dd>
     <dl>
      <dt>In Chrome</dt>
      <dd>Content scripts are destroyed when the user navigates away from a web page. If the user then returns to the page through history, by clicking the back button, the content script is injected into the web page again.</dd>
      <dt>In Firefox</dt>
      <dd>
      <p>Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets <code>window.prop1 = "prop"</code>  and the user then navigates away and returns to the page <code>window.prop1</code> is undefined. This issue is tracked in {{bug(1525400)}} .</p>
-    
+
      <p>To mimic the behavior of Chrome, listen for the <a href="/en-US/docs/Web/API/Window/pageshow_event">pageshow</a> and <a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a> events. Then simulate the injection or destruction of the content script.</p>
      </dd>
     </dl>
-  </dd>  
+  </dd>
 
   <dt>"per-tab" zoom behavior</dt>
   <dd>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.html
@@ -160,7 +160,7 @@ browser-compat: webextensions.manifest.browser_action
    </td>
   </tr>
   <tr>
-   <td><a id="theme_icons"><code>theme_icons</code></a></td>
+   <td><code>theme_icons</code></td>
    <td><code>Array</code></td>
    <td>
     <p>This property enables you to specify different icons for themes depending on whether Firefox detects that the theme uses dark or light text.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -18,7 +18,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 		</tr>
 		<tr>
 			<th scope="row">Mandatory</th>
-			<td>Usually, no (but see also <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when-do-you-need-an-add-on-id">When do you need an Add-on ID?</a>). Mandatory if the extension ID cannot be determined, see <a href="#browser_specific_settings_gecko_id"><code>browser_specific_settings.gecko.id</code></a>.</td>
+			<td>Usually, no (but see also <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when-do-you-need-an-add-on-id">When do you need an Add-on ID?</a>). Mandatory if the extension ID cannot be determined, see <a href="#firefox_gecko_properties"><code>browser_specific_settings.gecko.id</code></a>.</td>
 		</tr>
 		<tr>
 			<th scope="row">Example</th>
@@ -45,7 +45,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 <p>Firefox stores its browser specific settings in the <code>gecko</code> subkey, which has the following properties:</p>
 
 <dl>
-	<dt id="browser_specific_settings_gecko_id"><code>id</code></dt>
+	<dt><code>id</code></dt>
 	<dd>Is the extension ID. Optional since Firefox 48, where the extension ID is derived from the extension's signature. Mandatory if the extension is unsigned (and not loaded via <code>about:debugging</code>). See <a href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/">Extensions and the Add-on ID</a> to see when you need to specify an add-on ID.</dd>
 	<dt><code>strict_min_version</code></dt>
 	<dd>Minimum version of Gecko to support. Versions containing a "*" are not valid in this field. Defaults to "42a1".</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
@@ -57,7 +57,11 @@ browser-compat: webextensions.manifest.content_security_policy
 
 <h3 id="Valid_examples">Valid examples</h3>
 
-<p>Allow remote scripts from "https://example.com": <sup>(<em>see note</em> <a href="#examplenote_1">1</a>)</sup></p>
+<div class="note">
+  <p><strong>Note:</strong> Valid examples demonstrate the correct use of keys in CSP. However, extensions with 'unsafe-eval', remote script, blob, or remote sources in their CSP are not allowed for Firefox extensions as per the <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">add-on policies</a> and due to major security issues.</p>
+</div>
+
+<p>Allow remote scripts from "https://example.com":</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https://example.com; object-src 'self'"</pre>
 
@@ -107,8 +111,6 @@ browser-compat: webextensions.manifest.content_security_policy
 <p>Directive includes the unsupported keyword <code>'unsafe-inline'</code>:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' 'unsafe-inline'; object-src 'self'"</pre>
-
-<p><span id="exampleNote_1">1. <em>Note: Valid examples display the correct use of keys in CSP. However, extensions with 'unsafe-eval', remote script, blob, or remote sources in their CSP are not allowed for Firefox extensions as per the <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">add-on policies</a> and due to major security issues.</em></span></p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -1266,7 +1266,7 @@ browser-compat: webextensions.manifest.theme
 
 <h2 id="Examples">Examples</h2>
 
-<p id="docs-internal-guid-f85f22a2-6854-24d7-769b-8a47c376e2f2">A basic theme must define an image to add to the header, the accent color to use in the header, and the color of text used in the header:</p>
+<p>A basic theme must define an image to add to the header, the accent color to use in the header, and the color of text used in the header:</p>
 
 <pre class="brush: json" dir="ltr"> "theme": {
    "images": {
@@ -1309,7 +1309,7 @@ browser-compat: webextensions.manifest.theme
    }
  }</pre>
 
-<p><a id="example-screenshot">The following example uses most of the different values for <code>theme.colors</code>:</a></p>
+<p>The following example uses most of the different values for <code>theme.colors</code>:</p>
 
 <pre class="brush: json">  "theme": {
     "images": {

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/extension_pages/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/extension_pages/index.html
@@ -52,7 +52,7 @@ let creating = browser.windows.create(createData);</pre>
 
 <p>By default, pages you open in this way will be stored in the user's history, just like normal web pages. If you don't want to have this behavior, use {{WebExtAPIRef("history.deleteUrl()")}} to remove the browser's record:</p>
 
-<pre class="brush: js" id="ct-4">function onVisited(historyItem) {
+<pre class="brush: js">function onVisited(historyItem) {
   if (historyItem.url == browser.extension.getURL(myPage)) {
     browser.history.deleteUrl({url: historyItem.url});
   }


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

In Markdown the only elements that get ID attributes are headings. This PR removes all IDs from the add-ons docs that are not attached to headings, with 2 exceptions:

* the ID at: https://github.com/mdn/content/blob/1e8e154e89acfefa6c73b6bfcde8992d0e70198b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html#L228

...which is being fixed in https://github.com/mdn/content/pull/9850 as it also has an inline style

* the IDs in the table at: https://github.com/mdn/content/blob/1e8e154e89acfefa6c73b6bfcde8992d0e70198b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html#L49

...this table will not be convertible to Markdown anyway, and these cross-links look pretty useful. (It would be better to break up this table and make each key a separate section in the doc, with its own heading, but I think that is out of scope for this work.)

I've done my best to check for internal links to these IDs, and made any links point somewhere fairly sensible.

