### PR TITLE
[Markdown][Add-ons] Remove "line-numbers" class

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.html
@@ -75,12 +75,12 @@ browser.browserAction.onClicked.addListener(openPage);</pre>
 
 <p>At this point the complete extension should look like this:</p>
 
-<pre class="line-numbers  language-html"><code class="language-html">button/
+<pre class="brush: plain">button/
     icons/
         page-16.png
         page-32.png
     background.js
-    manifest.json</code></pre>
+    manifest.json</pre>
 
 <p>Now <a href="https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/">install the extension</a> and click the button:</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
@@ -60,7 +60,7 @@ browser-compat: webextensions.api.browserAction.getTitle
 
 <p>This code switches the title between "this" and "that" each time the user clicks the browser action:</p>
 
-<pre class="brush: js line-numbers language-js">function toggleTitle(title) {
+<pre class="brush: js">function toggleTitle(title) {
   if (title == &quot;this&quot;) {
     browser.browserAction.setTitle({title: &quot;that&quot;});
   } else {

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
@@ -45,7 +45,7 @@ browser-compat: webextensions.api.browserAction.setIcon
 
   <p>Use a dictionary object to specify multiple <code>ImageData</code> objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If <code>imageData</code> is a dictionary, the value of each property is an <code>ImageData</code> object, and its name is its size, like this:</p>
 
-  <pre class="brush: json line-numbers  language-json">{
+  <pre class="brush: json">{
   16: image16,
   32: image32
 }</pre>
@@ -58,7 +58,7 @@ browser-compat: webextensions.api.browserAction.setIcon
 
   <p>Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If <code>path</code> is a dictionary, the value of each property is a relative path, and its name is its size, like this:</p>
 
-  <pre class="brush: json line-numbers  language-json">{
+  <pre class="brush: json">{
   16: &quot;path/to/image16.jpg&quot;,
   32: &quot;path/to/image32.jpg&quot;
 }</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
@@ -73,7 +73,7 @@ then(onRemoved, onError);
 
 <p>Remove all download and browsing history:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
@@ -78,7 +78,7 @@ then(onRemoved, onError);</pre>
  If you want to clear all cookies without disrupting local storage facilities, use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies">browser.cookies</a> to loop through and remove the contents of all cookie stores.</p>
 </div>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.browsingData.removeDownloads
 
 <p>Remove records of objects downloaded in the last week:</p>
 
-<pre class="brush: js line-numbers language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 
@@ -71,7 +71,7 @@ then(onRemoved, onError);</pre>
 
 <p>Remove all records of downloaded objects:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.browsingData.removeFormData
 
 <p>Remove form data saved in the last week:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 
@@ -71,7 +71,7 @@ then(onRemoved, onError);</pre>
 
 <p>Remove all saved form data:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.browsingData.removeHistory
 
 <p>Remove records of pages visited in the last week:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 
@@ -71,7 +71,7 @@ then(onRemoved, onError);</pre>
 
 <p>Remove all records of visited pages:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
@@ -51,7 +51,7 @@ browser-compat: webextensions.api.browsingData.removeLocalStorage
 
 <p>Remove all local storage:</p>
 
-<pre class="brush: js line-numbers  language-js">function onRemoved() {
+<pre class="brush: js">function onRemoved() {
   console.log(&quot;removed&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
@@ -62,7 +62,7 @@ browser.commands.onCommand.hasListener(listener)
 <div>Given a manifest.json entry like this:</div>
 
 
-<pre class="brush: json line-numbers language-json">&quot;commands&quot;: {
+<pre class="brush: json">&quot;commands&quot;: {
   &quot;toggle-feature&quot;: {
     &quot;suggested_key&quot;: {
       &quot;default&quot;: &quot;Ctrl+Shift+Y&quot;
@@ -75,7 +75,7 @@ browser.commands.onCommand.hasListener(listener)
 
 
 <div>
-<pre class="brush: js line-numbers language-js">browser.commands.onCommand.addListener(function(command) {
+<pre class="brush: js">browser.commands.onCommand.addListener(function(command) {
   if (command == &quot;toggle-feature&quot;) {
     console.log(&quot;toggling the feature!&quot;);
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
@@ -40,7 +40,7 @@ browser-compat: webextensions.api.cookies.CookieStore
 
 <p>In the following snippet, the {{WebExtAPIRef("cookies.getAllCookieStores()")}} method is used to retrieve all the cookie stores currently available in the browser, and print out each cookie store ID, and the tabs that currently share each cookie store.</p>
 
-<pre class="brush: js line-numbers  language-js">function logStores(cookieStores) {
+<pre class="brush: js">function logStores(cookieStores) {
   for(store of cookieStores) {
     console.log(`Cookie store: ${store.id}\n Tab IDs: ${store.tabIds}`);
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
@@ -78,7 +78,7 @@ browser.cookies.onChanged.hasListener(listener)
 
 <p>This example listens for <code>onChanged</code> events and logs details from the <code>changeInfo</code> argument:</p>
 
-<pre class="brush: js line-numbers  language-js">browser.cookies.onChanged.addListener(function(changeInfo) {
+<pre class="brush: js">browser.cookies.onChanged.addListener(function(changeInfo) {
   console.log('Cookie changed: ' +
               '\n * Cookie: ' + JSON.stringify(changeInfo.cookie) +
               '\n * Cause: ' + changeInfo.cause +

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
@@ -50,7 +50,7 @@ browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setObject
 
 <p>Create a new pane, and populate it with a JSON object. You could run this code in a script loaded by your extension's <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page">devtools page</a>.</p>
 
-<pre class="brush: js line-numbers  language-js">function onCreated(sidebarPane) {
+<pre class="brush: js">function onCreated(sidebarPane) {
   sidebarPane.setObject({
     someBool: true,
     someString: &quot;hello there&quot;,

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
@@ -41,7 +41,7 @@ browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setPage
 
 <p>Create a new pane, and populate it with an HTML page. You could run this code in a script loaded by your extension's <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page">devtools page</a>.</p>
 
-<pre class="brush: js line-numbers  language-js">function onCreated(sidebarPane) {
+<pre class="brush: js">function onCreated(sidebarPane) {
   sidebarPane.setPage('sidebar/sidebar.html');
 }
 </pre>

--- a/files/en-us/mozilla/add-ons/webextensions/api/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>You can access the APIs using the <code>browser</code> namespace:</p>
 
-<pre class="brush: js line-numbers language-js">function logTabs(tabs) {
+<pre class="brush: js">function logTabs(tabs) {
   console.log(tabs)
 }
 
@@ -20,7 +20,7 @@ browser.tabs.query({currentWindow: true}, logTabs)</pre>
 
 <p>Many of the APIs are asynchronous, returning a {{JSxRef("Promise")}}:</p>
 
-<pre class="brush: js line-numbers language-js">function logCookie(c) {
+<pre class="brush: js">function logCookie(c) {
   console.log(c)
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.html
@@ -45,7 +45,7 @@ browser-compat: webextensions.api.menus.refresh
 
 <p>This example listens for the context menu to be shown over a link, then updates the <code>openLabelledId</code> menu item with the link's hostname:</p>
 
-<pre class="brush: js line-numbers  language-js">function updateMenuItem(linkHostname) {
+<pre class="brush: js">function updateMenuItem(linkHostname) {
   browser.menus.update(openLabelledId, {
     title: `Open (${linkHostname})`
   });

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
@@ -44,7 +44,7 @@ browser-compat: webextensions.api.pageAction.setIcon
 
   <p>Use a dictionary object to specify multiple <code>ImageData</code> objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If <code>imageData</code> is a dictionary, the value of each property is an <code>ImageData</code> object, and its name is its size, like this:</p>
 
-  <pre class="brush: json line-numbers  language-json">{
+  <pre class="brush: json">{
   16: image16,
   32: image32
 }</pre>
@@ -57,7 +57,7 @@ browser-compat: webextensions.api.pageAction.setIcon
 
   <p>Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If <code>path</code> is a dictionary, the value of each property is a relative path, and its name is its size, like this:</p>
 
-  <pre class="brush: json line-numbers  language-json">{
+  <pre class="brush: json">{
   16: &quot;path/to/image16.jpg&quot;,
   32: &quot;path/to/image32.jpg&quot;
 }</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.html
@@ -49,7 +49,7 @@ browser-compat: webextensions.api.pkcs11.installModule
 
 <p>Installs a module, then lists its slots and list the tokens they contain:</p>
 
-<pre class="brush: js line-numbers  language-js">function onInstalled() {
+<pre class="brush: js">function onInstalled() {
   return browser.pkcs11.getModuleSlots(&quot;my_module&quot;);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
@@ -70,7 +70,7 @@ browser-compat: webextensions.api.runtime.connect
  <li>sends messages to the background script, using <code>myPort</code>, when the user clicks the document.</li>
 </ul>
 
-<pre class="brush: js line-numbers language-js">// content-script.js
+<pre class="brush: js">// content-script.js
 
 var myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.postMessage({greeting: "hello from content script"});
@@ -98,7 +98,7 @@ document.body.addEventListener("click", function() {
  <li>sends messages to the content script, using <code>portFromCS</code>, when the user clicks the extension's browser action.</li>
 </ul>
 
-<pre class="brush: js line-numbers language-js">// background-script.js
+<pre class="brush: js">// background-script.js
 
 var portFromCS;
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
@@ -65,7 +65,7 @@ browser.runtime.onConnect.hasListener(listener)
  <li>sends messages to the background script, using <code>myPort</code>, when the user clicks the document</li>
 </ul>
 
-<pre class="brush: js line-numbers language-js">// content-script.js
+<pre class="brush: js">// content-script.js
 
 var myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.postMessage({greeting: "hello from content script"});
@@ -93,7 +93,7 @@ document.body.addEventListener("click", function() {
  <li>sends messages to the content script, using <code>portFromCS</code>, when the user clicks the extension's browser action</li>
 </ul>
 
-<pre class="brush: js line-numbers language-js">// background-script.js
+<pre class="brush: js>// background-script.js
 
 var portFromCS;
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
@@ -93,7 +93,7 @@ document.body.addEventListener("click", function() {
  <li>sends messages to the content script, using <code>portFromCS</code>, when the user clicks the extension's browser action</li>
 </ul>
 
-<pre class="brush: js>// background-script.js
+<pre class="brush: js">// background-script.js
 
 var portFromCS;
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -110,7 +110,7 @@ browser-compat: webextensions.api.runtime.Port
  <li>sends messages to the background script, using <code>myPort</code>, when the user clicks the document.</li>
 </ul>
 
-<pre class="brush: js line-numbers language-js">// content-script.js
+<pre class="brush: js">// content-script.js
 
 var myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.postMessage({greeting: "hello from content script"});
@@ -138,7 +138,7 @@ document.body.addEventListener("click", function() {
  <li>sends messages to the content script, using <code>portFromCS</code>, when the user clicks the extension's browser action.</li>
 </ul>
 
-<pre class="brush: js line-numbers language-js">// background-script.js
+<pre class="brush: js">// background-script.js
 
 var portFromCS;
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
@@ -54,7 +54,7 @@ browser-compat: webextensions.api.runtime.sendNativeMessage
 
 <p>Here's a background script that sends a "ping" message to the "ping_pong" app and logs the response, whenever the user clicks the browser action:</p>
 
-<pre class="brush: js line-numbers">function onResponse(response) {
+<pre class="brush: js">function onResponse(response) {
   console.log(`Received ${response}`);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
@@ -54,7 +54,7 @@ browser-compat: webextensions.api.sidebarAction.setIcon
 
   <p>Use a dictionary object to specify multiple <code>ImageData</code> objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If <code>imageData</code> is a dictionary, the value of each property is an <code>ImageData</code> object, and its name is its size, like this:</p>
 
-  <pre class="brush: json line-numbers  language-json">{
+  <pre class="brush: json">{
   16: image16,
   32: image32
 }</pre>
@@ -67,7 +67,7 @@ browser-compat: webextensions.api.sidebarAction.setIcon
 
   <p>Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If <code>path</code> is a dictionary, the value of each property is a relative path, and its name is its size, like this:</p>
 
-  <pre class="brush: json line-numbers  language-json">{
+  <pre class="brush: json">{
   16: &quot;path/to/image16.jpg&quot;,
   32: &quot;path/to/image32.jpg&quot;
 }</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.webRequest.StreamFilter.error
 
 <p>This example adds an {{WebExtAPIRef("webRequest.StreamFilter.onerror", "onerror")}} listener which logs the value of <code>error</code>.</p>
 
-<pre class="brush: js line-numbers  language-js">function listener(details) {
+<pre class="brush: js">function listener(details) {
   let filter = browser.webRequest.filterResponseData(&quot;12345&quot;);
 
   filter.onerror = event =&gt; {

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
@@ -23,7 +23,7 @@ browser-compat: webextensions.api.webRequest.StreamFilter.onstart
 
 <p>This example will replace the page content with "replacement text":</p>
 
-<pre class="brush: js line-numbers  language-js">function listener(details) {
+<pre class="brush: js">function listener(details) {
   let filter = browser.webRequest.filterResponseData(details.requestId);
 
   filter.onstart = event =&gt; {

--- a/files/en-us/mozilla/add-ons/webextensions/browser_actions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_actions/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>You define the browser action's properties - icon, title, popup - using the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action">browser_action</a></code> key in manifest.json:</p>
 
-<pre class="brush: jsonon">&quot;browser_action&quot;: {
+<pre class="brush: json">&quot;browser_action&quot;: {
   &quot;default_icon&quot;: {
     &quot;19&quot;: &quot;button/geo-19.png&quot;,
     &quot;38&quot;: &quot;button/geo-38.png&quot;

--- a/files/en-us/mozilla/add-ons/webextensions/browser_actions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_actions/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>If you don't specify a popup, then when the user clicks the button an event is dispatched to the extension, which you can listen for using <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked" title="Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup."><code>browserAction.onClicked</code></a>:</p>
 
-<pre class="brush: js line-numbers  language-js">browser.browserAction.onClicked.addListener(handleClick);</pre>
+<pre class="brush: js">browser.browserAction.onClicked.addListener(handleClick);</pre>
 
 <p>If you do specify a popup, the click event is not dispatched: instead, the popup will be shown when the user clicks the button. The user will be able to interact with the popup and it will close automatically when the user clicks outside it.</p>
 
@@ -24,7 +24,7 @@ tags:
 
 <p>You define the browser action's properties - icon, title, popup - using the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action">browser_action</a></code> key in manifest.json:</p>
 
-<pre class="brush: json line-numbers  language-json">&quot;browser_action&quot;: {
+<pre class="brush: jsonon">&quot;browser_action&quot;: {
   &quot;default_icon&quot;: {
     &quot;19&quot;: &quot;button/geo-19.png&quot;,
     &quot;38&quot;: &quot;button/geo-38.png&quot;

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
@@ -24,7 +24,7 @@ browser-compat: webextensions.manifest.user_scripts
   <tr>
    <th scope="row">Example</th>
    <td>
-    <pre class="brush: json; line-numbers language-json">
+    <pre class="brush: json">
   "user_scripts": {
     "api_script": "apiscript.js",
   }

--- a/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.html
@@ -120,10 +120,10 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 
 <p>At this point the extension should look like this:</p>
 
-<pre class="line-numbers  language-html"><code class="language-html">modify-page/
+<pre class="brush: plain">modify-page/
     background.js
     manifest.json
-    page-eater.js</code></pre>
+    page-eater.js</pre>
 
 <p>Now <a href="https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/#reloading_a_temporary_add-on">reload the extension</a>, open a page (any page, this time) activate the context menu, and select "Eat this page":</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.html
@@ -149,7 +149,7 @@ tags:
 
 <p>For example:</p>
 
-<pre class="brush: json line-numbers  language-json">{
+<pre class="brush: json">{
   &quot;name&quot;: &quot;favourite-color-examples@mozilla.org&quot;,
   &quot;description&quot;: &quot;ignored&quot;,
   &quot;type&quot;: &quot;storage&quot;,
@@ -161,7 +161,7 @@ tags:
 
 <p>Given this JSON manifest, the <code>favourite-color-examples@mozilla.org</code> extension could access the data using code like this:</p>
 
-<pre class="brush: js line-numbers language-js">let storageItem = browser.storage.managed.get('color');
+<pre class="brush: js">let storageItem = browser.storage.managed.get('color');
 storageItem.then((res) =&gt; {
   console.log(`Managed color is: ${res.color}`);
 });</pre>
@@ -233,7 +233,7 @@ storageItem.then((res) =&gt; {
 
 <p>For example:</p>
 
-<pre class="brush: json line-numbers  language-json">{
+<pre class="brush: json">{
   "name": "my_module",
   "description": "My test module",
   "type": "pkcs11",
@@ -243,7 +243,7 @@ storageItem.then((res) =&gt; {
 
 <p>Given this JSON manifest, saved as <code>my_module.json</code>, the <code>my-extension@mozilla.org</code> extension could install the security module at <code>/path/to/libpkcs11testmodule.dylib</code> using code like this:</p>
 
-<pre class="brush: js line-numbers language-js">browser.pkcs11.installModule("my_module");</pre>
+<pre class="brush: js">browser.pkcs11.installModule("my_module");</pre>
 
 <h2 id="Manifest_location">Manifest location</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_action/index.html
@@ -27,7 +27,7 @@ tags:
 
 <p>There are two ways to specify a browser action: with or without a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups">popup</a>. If you don't specify a popup, when the user clicks the button an event is dispatched to the extension, which the extension listens for using <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked" title="Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup."><code>browserAction.onClicked</code></a>:</p>
 
-<pre class="brush: js line-numbers language-js">browser.browserAction.onClicked.addListener(handleClick);</pre>
+<pre class="brush: js">browser.browserAction.onClicked.addListener(handleClick);</pre>
 
 <p>If you specify a popup, the click event is not dispatched: instead, the popup is shown when the user clicks the button. The user is able to interact with the popup and it closes automatically when the user clicks outside it. See the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups">Popup</a> article for more details on creating and managing popups.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>Add the devtools page by including the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page">devtools_page</a></code> key in extension's <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a> and provide the location of the page's HTML file in the extension:</p>
 
-<pre class="brush: json line-numbers  language-json">&quot;devtools_page&quot;: &quot;devtools-page.html&quot;</pre>
+<pre class="brush: json">&quot;devtools_page&quot;: &quot;devtools-page.html&quot;</pre>
 
 <p>From the devtools page, call a script that will add the devtools panel:</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/notifications/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/notifications/index.html
@@ -33,7 +33,7 @@ browser.notifications.create({
 
 <p>If the notification includes a call to action, you can listen for the user clicking the notification to call the function to handle the action:</p>
 
-<pre class="brush: js line-numbers  language-js">browser.notifications.onClicked.addListener(handleClick);
+<pre class="brush: js">browser.notifications.onClicked.addListener(handleClick);
 </pre>
 
 <p>If you are issuing calls to action through notifications, you will also want to define the optional notification <code>id</code>, so you can figure out which call to action the user has selected.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/omnibox/index.html
@@ -17,11 +17,11 @@ tags:
 
 <p>You tell your extension that it is going to customize the address bar suggestions by including the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/omnibox">omnibox</a> key and definition of the trigger keyword in its <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest.json</a> file:</p>
 
-<pre class="brush: json line-numbers  language-json">  "omnibox": { "keyword" : "cs" }</pre>
+<pre class="brush: json">  "omnibox": { "keyword" : "cs" }</pre>
 
 <p>In the extension's background JavaScript file, using {{WebExtAPIRef("omnibox.setDefaultSuggestion()")}}, you can optionally define the first suggestion to be displayed in the address bar drop-down. Use this to provide a hint on how to use the feature:</p>
 
-<pre class="brush: js line-numbers  language-js">browser.omnibox.setDefaultSuggestion({
+<pre class="brush: js">browser.omnibox.setDefaultSuggestion({
   description: `Search the firefox codebase
     (e.g. "hello world" | "path:omnibox.js onInputChanged")`
 });</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.html
@@ -66,7 +66,7 @@ tags:
 
 <p>You define the page action's properties using the <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action">page_action</a></code> key in manifest.json:</p>
 
-<pre class="brush: json line-numbers  language-json">&quot;page_action&quot;: {
+<pre class="brush: json">&quot;page_action&quot;: {
   &quot;browser_style&quot;: true,
   &quot;default_icon&quot;: {
     &quot;19&quot;: &quot;button/geo-19.png&quot;,
@@ -82,7 +82,7 @@ tags:
 <ul>
  <li><strong>Without a popup:</strong> When the user clicks the button, an event is dispatched to the extension, which the extension listens for using <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked" title="Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup."><code>pageAction.onClicked</code></a>:</li>
  <li>
-  <pre class="brush: js line-numbers  language-js">browser.pageAction.onClicked.addListener(handleClick);</pre>
+  <pre class="brush: js">browser.pageAction.onClicked.addListener(handleClick);</pre>
  </li>
  <li><strong>With a popup:</strong> the <code>click</code> event is not dispatched. Instead, the popup appears when the user clicks the button. The user then interacts with the popup. When the user clicks outside of the popup, it closes automatically. See the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups">Popup </a>article for more details on creating and managing popups.</li>
 </ul>

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
@@ -111,7 +111,7 @@ cd beastify</pre>
 
 <p>If you choose to supply your own icon, It should be 48x48 pixels. You could also supply a 96x96 pixel icon, for high-resolution displays, and if you do this it will be specified as the <code>96</code> property of the <code>icons</code> object in manifest.json:</p>
 
-<pre class="brush: json line-numbers  language-json">&quot;icons&quot;: {
+<pre class="brush: json">&quot;icons&quot;: {
   &quot;48&quot;: &quot;icons/beasts-48.png&quot;,
   &quot;96&quot;: &quot;icons/beasts-96.png&quot;
 }</pre>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

The `line-numbers` class doesn't do anything any more and isn't supported in our Markdown, so this PR removes it. It also removes the useless `language-` classes, where they existed too.