### PR TITLE
Fixes #9433 - reduces emphasis on arrow function

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -35,7 +35,7 @@ As the `{{JSxRef("Promise.then", "Promise.prototype.then()")}}` and `{{JSxRef("P
 
 ![](promises.png)
 
-> **Note:** Several other languages have mechanisms for lazy evaluation and deferring a computation, which they also call "promises", e.g. Scheme. Promises in JavaScript represent processes that are already happening, which can be chained with callback functions. If you are looking to lazily evaluate an expression, consider the [arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) with no arguments: `f = () => expression` to create the lazily-evaluated expression, and `f()` to evaluate.
+> **Note:** Several other languages have mechanisms for lazy evaluation and deferring a computation, which they also call "promises", e.g. Scheme. Promises in JavaScript represent processes that are already happening, which can be chained with callback functions. If you are looking to lazily evaluate an expression, consider using a function with no arguments e.g. `f = () => expression` to create the lazily-evaluated expression, and `f()` to evaluate the expression immediately.
 
 > **Note:** A promise is said to be _settled_ if it is either fulfilled or rejected, but not pending. You will also hear the term _resolved_ used with promises — this means that the promise is settled or “locked-in” to match the state of another promise. [States and fates](https://github.com/domenic/promises-unwrapping/blob/master/docs/states-and-fates.md) contain more details about promise terminology.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The text implies that arrow functions alone lead to lazy evaluation when in fact, any function has the same effect

#### Motivation
The text misled one reader

#### Supporting details


#### Related issues
Fixes #9433

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
