### PR TITLE
Push API: Remove old information about Chrome limitation

### DIFF
--- a/files/en-us/web/api/push_api/index.md
+++ b/files/en-us/web/api/push_api/index.md
@@ -29,7 +29,7 @@ The service worker will be started as necessary to handle incoming push messages
 
 Each subscription is unique to a service worker. The endpoint for the subscription is a unique [capability URL](https://www.w3.org/TR/capability-urls/): knowledge of the endpoint is all that is necessary to send a message to your application. The endpoint URL therefore needs to be kept secret, or other applications might be able to send push messages to your application.
 
-Activating a service worker to deliver a push message can result in increased resource usage, particularly of the battery. Different browsers have different schemes for handling this, there is currently no standard mechanism. Firefox allows a limited number (quota) of push messages to be sent to an application, although Push messages that generate notifications are exempt from this limit. The limit is refreshed each time the site is visited. In comparison, Chrome applies no limit, but requires that every push message causes a notification to be displayed.
+Activating a service worker to deliver a push message can result in increased resource usage, particularly of the battery. Different browsers have different schemes for handling this, there is currently no standard mechanism. Firefox allows a limited number (quota) of push messages to be sent to an application, although Push messages that generate notifications are exempt from this limit. The limit is refreshed each time the site is visited. In Chrome there are no limits.
 
 ## Interfaces
 


### PR DESCRIPTION
#### Summary
There are no any valid sources with information about limitations for push-messages (in Chrome browser). Only old post at `developers.google.com`.

#### Motivation
I was updating RU-version of this page and decided to check. 

#### Supporting details
- [Old post with limits description](https://developers.google.com/web/updates/2015/03/push-notifications-on-the-open-web):
  > You have to show a notification when you receive a push message.
- [New Web Push doc](https://developers.google.com/web/fundamentals/push-notifications) (you can find this link on top old post) without any information about conditions for push messages.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
