### PR TITLE
Add reserved characters escaping example and Info for <pre> tag

### DIFF
--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -17,6 +17,8 @@ The **`<pre>`** [HTML](/en-US/docs/Web/HTML) element represents preformatted tex
 
 {{EmbedInteractiveExample("pages/tabbed/pre.html", "tabbed-standard")}}
 
+If you have to display reserved characters such as `<`, `>`, `&`, `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](/en-US/docs/Glossary/Entity).
+
 <table class="properties">
   <tbody>
     <tr>
@@ -82,9 +84,11 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 - {{htmlattrdef("wrap")}} {{non-standard_inline}}
   - : Is a _hint_ indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS {{Cssxref("white-space")}} instead.
 
-## Example
+## Examples
 
-### HTML
+### Basic Example
+
+#### HTML
 
 ```html
 <p>Using CSS to change the font color is easy.</p>
@@ -95,11 +99,26 @@ body {
 </pre>
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Basic_Example")}}
 
-> **Note:** If you have to display reserved characters such as `<`, `>`, `&`, `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](/en-US/docs/Glossary/Entity).
+### Escaping Reserved Characters
+
+#### HTML
+
+```html
+<pre>
+let i = 5;
+
+if( i &lt; 10 &amp;&amp; i &gt; 0 )
+  return &quot; Single Digit Number &quot;
+</pre>
+```
+
+#### Result
+
+{{EmbedLiveSample("Escaping_Reserved_Characters")}}
 
 ## Accessibility concerns
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -99,6 +99,8 @@ body {
 
 {{EmbedLiveSample("Example")}}
 
+> **Note:** If you have to display reserved characters such as `<`, `>`, `&`, `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](https://developer.mozilla.org/en-US/docs/Glossary/Entity).
+
 ## Accessibility concerns
 
 It is important to provide an alternate description for any images or diagrams created using preformatted text. The alternate description should clearly and concisely describe the image or diagram's content.
@@ -108,22 +110,23 @@ People experiencing low vision conditions and browsing with the aid of assistive
 A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of an {{htmlattrxref("id")}} and the [ARIA](/en-US/docs/Web/Accessibility/ARIA) `role` and `aria-labelledby` attributes allow the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
 
 ### Example
-
-    <figure role="img" aria-labelledby="cow-caption">
-      <pre>
+```html
+<figure role="img" aria-labelledby="cow-caption">
+  <pre>
       ___________________________
-    < I'm an expert in my field. >
+  &lt; I'm an expert in my field. &gt;
       ---------------------------
-             \   ^__^
-              \  (oo)\_______
-                 (__)\       )\/\
-                     ||----w |
-                     ||     ||
-      </pre>
-      <figcaption id="cow-caption">
-        A cow saying, "I'm an expert in my field." The cow is illustrated using preformatted text characters.
-      </figcaption>
-    </figure>
+          \   ^__^
+           \  (oo)\_______
+              (__)\       )\/\
+                  ||----w |
+                  ||     ||
+  </pre>
+  <figcaption id="cow-caption">
+    A cow saying, "I'm an expert in my field." The cow is illustrated using preformatted text characters.
+  </figcaption>
+</figure>
+```
 
 - [MDN Understanding WCAG, Guideline 1.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.1_—_providing_text_alternatives_for_non-text_content)
 - [H86: Providing text alternatives for ASCII art, emoticons, and leetspeak | W3C Techniques for WCAG 2.0](https://www.w3.org/TR/WCAG20-TECHS/H86.html)
@@ -139,4 +142,5 @@ A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}}
 ## See also
 
 - CSS: {{Cssxref('white-space')}}, {{Cssxref('word-break')}}
+- [HTML Entity](https://developer.mozilla.org/en-US/docs/Glossary/Entity)
 - Related element: {{HTMLElement("code")}}

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -103,7 +103,7 @@ body {
 
 {{EmbedLiveSample("Basic_Example")}}
 
-### Escaping Reserved Characters
+### Escaping reserved characters
 
 #### HTML
 
@@ -118,7 +118,7 @@ if( i &lt; 10 &amp;&amp; i &gt; 0 )
 
 #### Result
 
-{{EmbedLiveSample("Escaping_Reserved_Characters")}}
+{{EmbedLiveSample("Escaping_reserved_characters")}}
 
 ## Accessibility concerns
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -84,42 +84,6 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 - {{htmlattrdef("wrap")}} {{non-standard_inline}}
   - : Is a _hint_ indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS {{Cssxref("white-space")}} instead.
 
-## Examples
-
-### Basic Example
-
-#### HTML
-
-```html
-<p>Using CSS to change the font color is easy.</p>
-<pre>
-body {
-  color: red;
-}
-</pre>
-```
-
-#### Result
-
-{{EmbedLiveSample("Basic_Example")}}
-
-### Escaping reserved characters
-
-#### HTML
-
-```html
-<pre>
-let i = 5;
-
-if( i &lt; 10 &amp;&amp; i &gt; 0 )
-  return &quot; Single Digit Number &quot;
-</pre>
-```
-
-#### Result
-
-{{EmbedLiveSample("Escaping_reserved_characters")}}
-
 ## Accessibility concerns
 
 It is important to provide an alternate description for any images or diagrams created using preformatted text. The alternate description should clearly and concisely describe the image or diagram's content.
@@ -149,6 +113,43 @@ A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}}
 
 - [MDN Understanding WCAG, Guideline 1.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.1_—_providing_text_alternatives_for_non-text_content)
 - [H86: Providing text alternatives for ASCII art, emoticons, and leetspeak | W3C Techniques for WCAG 2.0](https://www.w3.org/TR/WCAG20-TECHS/H86.html)
+
+## Examples
+
+### Basic example
+
+#### HTML
+
+```html
+<p>Using CSS to change the font color is easy.</p>
+<pre>
+body {
+  color: red;
+}
+</pre>
+```
+
+#### Result
+
+{{EmbedLiveSample("Basic_example")}}
+
+### Escaping reserved characters
+
+#### HTML
+
+```html
+<pre>
+let i = 5;
+
+if( i &lt; 10 &amp;&amp; i &gt; 0 )
+  return &quot; Single Digit Number &quot;
+</pre>
+```
+
+#### Result
+
+{{EmbedLiveSample("Escaping_reserved_characters")}}
+
 
 ## Specifications
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -99,7 +99,7 @@ body {
 
 {{EmbedLiveSample("Example")}}
 
-> **Note:** If you have to display reserved characters such as `<`, `>`, `&`, `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](https://developer.mozilla.org/en-US/docs/Glossary/Entity).
+> **Note:** If you have to display reserved characters such as `<`, `>`, `&`, `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](/en-US/docs/Glossary/Entity).
 
 ## Accessibility concerns
 
@@ -142,5 +142,5 @@ A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}}
 ## See also
 
 - CSS: {{Cssxref('white-space')}}, {{Cssxref('word-break')}}
-- [HTML Entity](https://developer.mozilla.org/en-US/docs/Glossary/Entity)
+- [HTML Entity](/en-US/docs/Glossary/Entity)
 - Related element: {{HTMLElement("code")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- Add a note to escape reserved characters like `<`, `>`, `&`, `"` within the `<pre>` tag
- Update the example with HTML entity.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Open-source <3
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- Is there a macro for [HTML Entity](https://developer.mozilla.org/en-US/docs/Glossary/Entity) ?
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Closes #9149 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
