### PR TITLE
Fix true/false inversion in aria busy page

### DIFF
--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -25,9 +25,9 @@ The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the
 A {{domxref("DOMString")}} with one of the following values:
 
 - `"true"`
-  - : There are no expected updates for the element.
-- `"false"`
   - : The element is being updated.
+- `"false"`
+  - : There are no expected updates for the element.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -29,9 +29,9 @@ ElementInternals.ariaBusy = ariaBusy;
 A {{domxref("DOMString")}} with one of the following values:
 
 - `"true"`
-  - : There are no expected updates for the element.
-- `"false"`
   - : The element is being updated.
+- `"false"`
+  - : There are no expected updates for the element.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The description for the true / false values were inverted. I fixed that.

#### Supporting details
https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-busy

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
