### PR TITLE
Adding aria-hidden to switch control to avoid confusion

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.html
@@ -82,8 +82,8 @@ tags:
 
 <pre class="brush: html">&lt;button role="switch" aria-checked="true"
       id="speakerPower" class="switch"&gt;
-  &lt;span&gt;off&lt;/span&gt;
-  &lt;span&gt;on&lt;/span&gt;
+  &lt;span aria-hidden="true"&gt;off&lt;/span&gt;
+  &lt;span aria-hidden="true"&gt;on&lt;/span&gt;
 &lt;/button&gt;
 &lt;label for="speakerPower" class="switch"&gt;Speaker power&lt;/label&gt;
 </pre>


### PR DESCRIPTION
#### Summary

The button is automatically labelled by its content. The label element does not change that but, for example in VoiceOver on Safari, attaches the label text to the content, which results in an announcement like “off on Speaker power, on” (the last “on” coming from the ARIA status).

#### Motivation

The current example is misleading.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
