### PR TITLE
Remove lineTo from roundedRect

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -472,13 +472,9 @@ function draw() {
 function roundedRect(ctx, x, y, width, height, radius) {
   ctx.beginPath();
   ctx.moveTo(x, y + radius);
-  ctx.lineTo(x, y + height - radius);
   ctx.arcTo(x, y + height, x + radius, y + height, radius);
-  ctx.lineTo(x + width - radius, y + height);
-  ctx.arcTo(x + width, y + height, x + width, y + height-radius, radius);
-  ctx.lineTo(x + width, y + radius);
+  ctx.arcTo(x + width, y + height, x + width, y + height - radius, radius);
   ctx.arcTo(x + width, y, x + width - radius, y, radius);
-  ctx.lineTo(x + radius, y);
   ctx.arcTo(x, y, x, y + radius, radius);
   ctx.stroke();
 }


### PR DESCRIPTION



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
lineTo methods in the roundedRect utility function are not really doing anything. Removing them does not affect the visual output and straight lines can already be drawn with the arcTo method when the radius is 0.  


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Having those lines of code that don't really do anything might confuse some beginners. I was following the tutorial myself and I was a bit confused as to why these methods are there when they don't affect the visual output when removed.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://codesandbox.io/s/mdn-canvas-tutorial-roundedrect-1we9z?file=/index.html

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
