### PR TITLE
PageMacro: Remove from CSS @media

### DIFF
--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -43,11 +43,100 @@ For a discussion of media query syntax, please see [Using media queries](/en-US/
 
 ### Media types
 
-{{page("/en-US/docs/Web/CSS/Media_Queries/Using_media_queries", "Media types")}}
+_Media types_ describe the general category of a device.
+Except when using the `not` or `only` logical operators, the media type is optional and the `all` type is implied.
+
+- `all`
+  - : Suitable for all devices.
+- `print`
+  - : Intended for paged material and documents viewed on a screen in print preview mode. (Please see [paged media](/en-US/docs/Web/CSS/Paged_Media) for information about formatting issues that are specific to these formats.)
+- `screen`
+  - : Intended primarily for screens.
+- `speech`
+  - : Intended for speech synthesizers.
+
+> **Note:** CSS2.1 and [Media Queries 3](https://drafts.csswg.org/mediaqueries-3/#background) defined several additional media types (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, and `aural`), but they were deprecated in [Media Queries 4](http://dev.w3.org/csswg/mediaqueries/#media-types) and shouldn't be used.
+> The `aural` type has been replaced by `speech`, which is similar.
 
 ### Media features
 
-{{page("/en-US/docs/Web/CSS/Media_Queries/Using_media_queries","Media features")}}
+_Media features_ describe specific characteristics of the {{glossary("user agent")}}, output device, or environment.
+Media feature expressions test for their presence or value, and are entirely optional. Each media feature expression must be surrounded by parentheses.
+
+- {{cssxref("@media/any-hover", "any-hover")}}
+  - : Does any available input mechanism allow the user to hover over elements?
+    Added in Media Queries Level 4.
+- {{cssxref("@media/any-pointer", "any-pointer")}}
+  - : Is any available input mechanism a pointing device, and if so, how accurate is it?
+    Added in Media Queries Level 4.
+- {{cssxref("@media/aspect-ratio", "aspect-ratio")}}
+  - : Width-to-height aspect ratio of the viewport
+- {{cssxref("@media/color", "color")}}
+  - : Number of bits per color component of the output device, or zero if the device isn't color
+- {{cssxref("@media/color-gamut", "color-gamut")}}
+  - : Approximate range of colors that are supported by the user agent and output device.
+    Added in Media Queries Level 4.
+- {{cssxref("@media/color-index", "color-index")}}
+  - : Number of entries in the output device's color lookup table, or zero if the device does not use such a table
+- {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}}  {{deprecated_inline}}
+  - : Width-to-height aspect ratio of the output device.
+    Deprecated in Media Queries Level 4.
+- {{cssxref("@media/device-height", "device-height")}} {{deprecated_inline}}  
+  - : Height of the rendering surface of the output device.
+    Deprecated in Media Queries Level 4.
+- {{cssxref("@media/device-width", "device-width")}} {{deprecated_inline}}
+  - : Width of the rendering surface of the output device. Deprecated in Media Queries Level 4.
+- {{cssxref("@media/display-mode", "display-mode")}}
+  - : The display mode of the application, as specified in the web app manifest's [`display`](/en-US/docs/Web/Manifest#display) member.
+    Defined in the [Web App Manifest spec](https://w3c.github.io/manifest/#the-display-mode-media-feature).
+- {{cssxref("@media/forced-colors", "forced-colors")}}
+  - : Detect whether user agent restricts color palette.
+    Added in Media Queries Level 5.
+- {{cssxref("@media/grid", "grid")}}
+  - : Does the device use a grid or bitmap screen?
+- {{cssxref("@media/height", "height")}}
+  - : Height of the viewport.
+- {{cssxref("@media/hover", "hover")}}
+  - : Does the primary input mechanism allow the user to hover over elements?
+    Added in Media Queries Level 4.
+- {{cssxref("@media/inverted-colors", "inverted-colors")}}
+  - : Is the user agent or underlying OS inverting colors?
+    Added in Media Queries Level 5.
+- {{cssxref("@media/monochrome", "monochrome")}}
+  - : Bits per pixel in the output device's monochrome frame buffer, or zero if the device isn't monochrome.
+- {{cssxref("@media/orientation", "orientation")}}
+  - : Orientation of the viewport.
+- {{cssxref("@media/overflow-block", "overflow-block")}}
+  - : How does the output device handle content that overflows the viewport along the block axis?
+    Added in Media Queries Level 4.
+- {{cssxref("@media/overflow-inline", "overflow-inline")}}
+  - : Can content that overflows the viewport along the inline axis be scrolled?
+    Added in Media Queries Level 4.
+- {{cssxref("@media/pointer", "pointer")}}
+  - : Is the primary input mechanism a pointing device, and if so, how accurate is it?
+    Added in Media Queries Level 4.
+- {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}
+  - : Detect if the user prefers a light or dark color scheme.
+    Added in Media Queries Level 5.
+- {{cssxref("@media/prefers-contrast", "prefers-contrast")}}
+  - : Detects if the user has requested the system increase or decrease the amount of contrast between adjacent colors.
+    Added in Media Queries Level 5.
+- {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}
+  - : The user prefers less motion on the page.
+    Added in Media Queries Level 5.
+- {{cssxref("@media/resolution", "resolution")}}
+  - : Pixel density of the output device.
+- {{cssxref("@media/scripting", "scripting")}}
+  - : Detects whether scripting (i.e. JavaScript) is available.
+    Added in Media Queries Level 5.  
+- {{cssxref("@media/update-frequency", "update")}}
+  - : How frequently the output device can modify the appearance of content.
+    Added in Media Queries Level 4.
+- {{cssxref("@media/width", "width")}}
+  - : Width of the viewport including width of scrollbar.
+
+
+
 
 ## Accessibility concerns
 

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -55,7 +55,7 @@ Except when using the `not` or `only` logical operators, the media type is optio
 - `speech`
   - : Intended for speech synthesizers.
 
-> **Note:** CSS2.1 and [Media Queries 3](https://drafts.csswg.org/mediaqueries-3/#background) defined several additional media types (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, and `aural`), but they were deprecated in [Media Queries 4](http://dev.w3.org/csswg/mediaqueries/#media-types) and shouldn't be used.
+> **Note:** CSS2.1 and [Media Queries 3](https://drafts.csswg.org/mediaqueries-3/#background) defined several additional media types (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, and `aural`), but they were deprecated in [Media Queries 4](https://dev.w3.org/csswg/mediaqueries/#media-types) and shouldn't be used.
 > The `aural` type has been replaced by `speech`, which is similar.
 
 ### Media features
@@ -136,6 +136,30 @@ Media feature expressions test for their presence or value, and are entirely opt
   - : Width of the viewport including width of scrollbar.
 
 
+### Logical operators
+
+The _logical operators_ `not`, `and`, and `only` can be used to compose a complex media query.
+You can also combine multiple media queries into a single rule by separating them with commas.
+
+- `and`
+  - : Used for combining multiple media features together into a single media query, requiring each chained feature to return `true` for the query to be `true`.
+    It is also used for joining media features with media types.
+- `not`
+  - : Used to negate a media query, returning `true` if the query would otherwise return `false`.
+    If present in a comma-separated list of queries, it will only negate the specific query to which it is applied.
+    If you use the `not` operator, you _must also_ specify a media type.
+
+    > **Note:** In Level 3, the `not` keyword can't be used to negate an individual media feature expression, only an entire media query.
+- `only`
+  - : Applies a style only if an entire query matches.
+    It is useful for preventing older browsers from applying selected styles.
+    When not using `only`, older browsers would interpret the query `screen and (max-width: 500px)` as `screen`, ignoring the remainder of the query, and applying its styles on all screens.
+    If you use the `only` operator, you _must also_ specify a media type.
+- `,` (comma)
+  - : Commas are used to combine multiple media queries into a single rule.
+    Each query in a comma-separated list is treated separately from the others
+     Thus, if any of the queries in a list is `true`, the entire media statement returns `true`.
+     In other words, lists behave like a logical `or` operator.
 
 
 ## Accessibility concerns

--- a/files/en-us/web/css/media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries/index.md
@@ -32,7 +32,7 @@ A media query computes to true when the media type (if specified) matches the de
 
 ### Media types
 
-_Media types_ describe the general category of a device. Except when using the `not` or `only` logical operators, the media type is optional and the `all` type will be implied.
+_Media types_ describe the general category of a device. Except when using the `not` or `only` logical operators, the media type is optional and the `all` type is implied.
 
 - `all`
   - : Suitable for all devices.
@@ -47,7 +47,8 @@ _Media types_ describe the general category of a device. Except when using the `
 
 ### Media features
 
-_Media features_ describe specific characteristics of the {{glossary("user agent")}}, output device, or environment. Media feature expressions test for their presence or value, and are entirely optional. Each media feature expression must be surrounded by parentheses.
+_Media features_ describe specific characteristics of the {{glossary("user agent")}}, output device, or environment.
+Media feature expressions test for their presence or value, and are entirely optional. Each media feature expression must be surrounded by parentheses.
 
 | Name                                                                                                              | Summary                                                                                                                          | Notes                                                                                                   |
 | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |

--- a/files/en-us/web/css/media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries/index.md
@@ -24,139 +24,98 @@ Media queries are used for the following:
 
 ## Syntax
 
-A media query is composed of an optional _media type_ and any number of _media feature_ expressions. Multiple queries can be combined in various ways by using _logical operators_. Media queries are case-insensitive.
+A media query is composed of an optional _media type_ and any number of _media feature_ expressions, which may optionally be combined in various ways using _logical operators_.
+Media queries are case-insensitive.
 
-A media query computes to true when the media type (if specified) matches the device on which a document is being displayed _and_ all media feature expressions compute as true. Queries involving unknown media types are always false.
+- [Media types](/en-US/docs/Web/CSS/@media#media_types) define the broad category of device for which the media query applies: `all`, `print`, `screen`, `speech`.
+  
+  The type is optional (assumed to be `all`) except when using the `not` or `only` logical operators.
+- [Media feature](/en-US/docs/Web/CSS/@media#media_features) describe a specific characterisic of the {{glossary("user agent")}}, output device, or environment: {{cssxref("@media/any-hover", "any-hover")}}, {{cssxref("@media/any-pointer", "any-pointer")}}, {{cssxref("@media/aspect-ratio", "aspect-ratio")}}, {{cssxref("@media/color", "color")}}, {{cssxref("@media/color-gamut", "color-gamut")}}, {{cssxref("@media/color-index", "color-index")}}, {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}} {{deprecated_inline}}, {{cssxref("@media/device-height", "device-height")}} {{deprecated_inline}}, {{cssxref("@media/device-width", "device-width")}} {{deprecated_inline}}, {{cssxref("@media/display-mode", "display-mode")}}, {{cssxref("@media/forced-colors", "forced-colors")}}, {{cssxref("@media/grid", "grid")}}, {{cssxref("@media/height", "height")}}, {{cssxref("@media/hover", "hover")}}, {{cssxref("@media/inverted-colors", "inverted-colors")}}, {{cssxref("@media/monochrome", "monochrome")}}, {{cssxref("@media/orientation", "orientation")}}, {{cssxref("@media/overflow-block", "overflow-block")}}, {{cssxref("@media/overflow-inline", "overflow-inline")}}, {{cssxref("@media/pointer", "pointer")}}, {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}, {{cssxref("@media/prefers-contrast", "prefers-contrast")}}, {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}, {{cssxref("@media/resolution", "resolution")}}, {{cssxref("@media/scripting", "scripting")}}, {{cssxref("@media/update-frequency", "update")}}, {{cssxref("@media/width", "width")}}
 
-> **Note:** A style sheet with a media query attached to its {{HTMLElement("link")}} tag [will still download](https://scottjehl.github.io/CSS-Download-Tests/) even if the query returns false, the download will happen but the priority of downloading will be much less. Nevertheless, its contents will not apply unless and until the result of the query changes to true. You can read why this happens in Tomayac's blog [Why Browser Download Stylesheet with Non-Matching Media Queries](https://medium.com/@tomayac/why-browsers-download-stylesheets-with-non-matching-media-queries-eb61b91b85a2).
+  For example, the {{cssxref("@media/hover", "hover")}} feature allows a query to test against whether the device supports hovering over elements. 
+  Media feature expressions test for their presence or value, and are entirely optional.
+  Each media feature expression must be surrounded by parentheses.
 
-### Media types
+- [Logical operators](/en-US/docs/Web/CSS/@media#logical_operators) can be used to compose a complex media query: `not`, `and`, and `only`.
+  You can also combine multiple media queries into a single rule by separating them with commas.
 
-_Media types_ describe the general category of a device. Except when using the `not` or `only` logical operators, the media type is optional and the `all` type is implied.
+A media query computes to `true` when the media type (if specified) matches the device on which a document is being displayed _and_ all media feature expressions compute as true.
+Queries involving unknown media types are always false.
 
-- `all`
-  - : Suitable for all devices.
-- `print`
-  - : Intended for paged material and documents viewed on a screen in print preview mode. (Please see [paged media](/en-US/docs/Web/CSS/Paged_Media) for information about formatting issues that are specific to these formats.)
-- `screen`
-  - : Intended primarily for screens.
-- `speech`
-  - : Intended for speech synthesizers.
+> **Note:** A style sheet with a media query attached to its {{HTMLElement("link")}} tag [will still download](https://scottjehl.github.io/CSS-Download-Tests/) even if the query returns `false`, the download will happen but the priority of downloading will be much lower.
+> Nevertheless, its contents will not apply unless and until the result of the query changes to `true`.
+> You can read why this happens in Tomayac's blog [Why Browser Download Stylesheet with Non-Matching Media Queries](https://medium.com/@tomayac/why-browsers-download-stylesheets-with-non-matching-media-queries-eb61b91b85a2).
 
-> **Note:** CSS2.1 and [Media Queries 3](https://drafts.csswg.org/mediaqueries-3/#background) defined several additional media types (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, and `aural`), but they were deprecated in [Media Queries 4](http://dev.w3.org/csswg/mediaqueries/#media-types) and shouldn't be used. The `aural` type has been replaced by `speech`, which is similar.
-
-### Media features
-
-_Media features_ describe specific characteristics of the {{glossary("user agent")}}, output device, or environment.
-Media feature expressions test for their presence or value, and are entirely optional. Each media feature expression must be surrounded by parentheses.
-
-| Name                                                                                                              | Summary                                                                                                                          | Notes                                                                                                   |
-| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| {{cssxref("@media/any-hover", "any-hover")}}                                                      | Does any available input mechanism allow the user to hover over elements?                                                        | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/any-pointer", "any-pointer")}}                                                  | Is any available input mechanism a pointing device, and if so, how accurate is it?                                               | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/aspect-ratio", "aspect-ratio")}}                                              | Width-to-height aspect ratio of the viewport                                                                                     |                                                                                                         |
-| {{cssxref("@media/color", "color")}}                                                                  | Number of bits per color component of the output device, or zero if the device isn't color                                       |                                                                                                         |
-| {{cssxref("@media/color-gamut", "color-gamut")}}                                                  | Approximate range of colors that are supported by the user agent and output device                                               | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/color-index", "color-index")}}                                                  | Number of entries in the output device's color lookup table, or zero if the device does not use such a table                     |                                                                                                         |
-| {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}} {{deprecated_inline}} | Width-to-height aspect ratio of the output device                                                                                | Deprecated in Media Queries Level 4.                                                                    |
-| {{cssxref("@media/device-height", "device-height")}} {{deprecated_inline}}                 | Height of the rendering surface of the output device                                                                             | Deprecated in Media Queries Level 4.                                                                    |
-| {{cssxref("@media/device-width", "device-width")}} {{deprecated_inline}}                 | Width of the rendering surface of the output device                                                                              | Deprecated in Media Queries Level 4.                                                                    |
-| {{cssxref("@media/display-mode", "display-mode")}}                                              | The display mode of the application, as specified in the web app manifest's [`display`](/en-US/docs/Web/Manifest#display) member | Defined in the [Web App Manifest spec](https://w3c.github.io/manifest/#the-display-mode-media-feature). |
-| {{cssxref("@media/forced-colors", "forced-colors")}}                                              | Detect whether user agent restricts color palette                                                                                | Added in Media Queries Level 5.                                                                         |
-| {{cssxref("@media/grid", "grid")}}                                                                      | Does the device use a grid or bitmap screen?                                                                                     |                                                                                                         |
-| {{cssxref("@media/height", "height")}}                                                              | Height of the viewport                                                                                                           |                                                                                                         |
-| {{cssxref("@media/hover", "hover")}}                                                                  | Does the primary input mechanism allow the user to hover over elements?                                                          | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/inverted-colors", "inverted-colors")}}                                      | Is the user agent or underlying OS inverting colors?                                                                             | Added in Media Queries Level 5.                                                                         |
-| {{cssxref("@media/monochrome", "monochrome")}}                                                      | Bits per pixel in the output device's monochrome frame buffer, or zero if the device isn't monochrome                            |                                                                                                         |
-| {{cssxref("@media/orientation", "orientation")}}                                                  | Orientation of the viewport                                                                                                      |                                                                                                         |
-| {{cssxref("@media/overflow-block", "overflow-block")}}                                          | How does the output device handle content that overflows the viewport along the block axis?                                      | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/overflow-inline", "overflow-inline")}}                                      | Can content that overflows the viewport along the inline axis be scrolled?                                                       | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/pointer", "pointer")}}                                                              | Is the primary input mechanism a pointing device, and if so, how accurate is it?                                                 | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}                          | Detect if the user prefers a light or dark color scheme                                                                          | Added in Media Queries Level 5.                                                                         |
-| {{cssxref("@media/prefers-contrast", "prefers-contrast")}}                                      | Detects if the user has requested the system increase or decrease the amount of contrast between adjacent colors                 | Added in Media Queries Level 5.                                                                         |
-| {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}                      | The user prefers less motion on the page                                                                                         | Added in Media Queries Level 5.                                                                         |
-| {{cssxref("@media/resolution", "resolution")}}                                                      | Pixel density of the output device                                                                                               |                                                                                                         |
-| {{cssxref("@media/scripting", "scripting")}}                                                      | Detects whether scripting (i.e. JavaScript) is available                                                                         | Added in Media Queries Level 5.                                                                         |
-| {{cssxref("@media/update-frequency", "update")}}                                                  | How frequently the output device can modify the appearance of content                                                            | Added in Media Queries Level 4.                                                                         |
-| {{cssxref("@media/width", "width")}}                                                                  | Width of the viewport including width of scrollbar                                                                               |                                                                                                         |
-
-### Logical operators
-
-The _logical operators_ `not`, `and`, and `only` can be used to compose a complex media query. You can also combine multiple media queries into a single rule by separating them with commas.
-
-#### `and`
-
-The `and` operator is used for combining multiple media features together into a single media query, requiring each chained feature to return true for the query to be true. It is also used for joining media features with media types.
-
-#### `not`
-
-The `not` operator is used to negate a media query, returning true if the query would otherwise return false. If present in a comma-separated list of queries, it will only negate the specific query to which it is applied. If you use the `not` operator, you _must also_ specify a media type.
-
-> **Note:** In Level 3, the `not` keyword can't be used to negate an individual media feature expression, only an entire media query.
-
-#### `only`
-
-The `only` operator is used to apply a style only if an entire query matches, and is useful for preventing older browsers from applying selected styles. When not using `only`, older browsers would interpret the query `screen and (max-width: 500px)` as `screen`, ignoring the remainder of the query, and applying its styles on all screens. If you use the `only` operator, you _must also_ specify a media type.
-
-#### `,` (comma)
-
-Commas are used to combine multiple media queries into a single rule. Each query in a comma-separated list is treated separately from the others. Thus, if any of the queries in a list is true, the entire media statement returns true. In other words, lists behave like a logical `or` operator.
 
 ## Targeting media types
 
-Media types describe the general category of a given device. Although websites are commonly designed with screens in mind, you may want to create styles that target special devices such as printers or audio-based screenreaders. For example, this CSS targets printers:
+Media types describe the general category of a given device.
+Although websites are commonly designed with screens in mind, you may want to create styles that target special devices such as printers or audio-based screenreaders.
+For example, this CSS targets printers:
 
 ```css
 @media print { ... }
 ```
 
-You can also target multiple devices. For instance, this `@media` rule uses two media queries to target both screen and print devices:
+You can also target multiple devices.
+For instance, this `@media` rule uses two media queries to target both screen and print devices:
 
 ```css
 @media screen, print { ... }
 ```
 
-See [Media types](#Media_types) for a list of all media types. Because they describe devices in only very broad terms, just a few are available; to target more specific attributes, use _media features_ instead.
+See [media type](/en-US/docs/Web/CSS/@media#media_types) for a list of all media types.
+Because they describe devices in only very broad terms, just a few are available; to target more specific attributes, use _media features_ instead.
 
 ## Targeting media features
 
-Media features describe the specific characteristics of a given {{glossary("user agent")}}, output device, or environment. For instance, you can apply specific styles to widescreen monitors, computers that use mice, or to devices that are being used in low-light conditions. This example applies styles when the user's _primary_ input mechanism (such as a mouse) can hover over elements:
+Media features describe the specific characteristics of a given {{glossary("user agent")}}, output device, or environment.
+For instance, you can apply specific styles to widescreen monitors, computers that use mice, or to devices that are being used in low-light conditions.
+This example applies styles when the user's _primary_ input mechanism (such as a mouse) can hover over elements:
 
 ```css
 @media (hover: hover) { ... }
 ```
 
-Many media features are _range features_, which means they can be prefixed with "min-" or "max-" to express "minimum condition" or "maximum condition" constraints. For example, this CSS will apply styles only if your browser's {{glossary("viewport")}} width is equal to or narrower than 12450px:
+Many media features are _range features_, which means they can be prefixed with "min-" or "max-" to express "minimum condition" or "maximum condition" constraints.
+For example, this CSS will apply styles only if your browser's {{glossary("viewport")}} width is equal to or narrower than 12450px:
 
 ```css
 @media (max-width: 12450px) { ... }
 ```
 
-If you create a media feature query without specifying a value, the nested styles will be used as long as the feature's value is not zero (or `none`, in Level 4). For example, this CSS will apply to any device with a color screen:
+If you create a media feature query without specifying a value, the nested styles will be used as long as the feature's value is not zero (or `none`, in Level 4).
+For example, this CSS will apply to any device with a color screen:
 
 ```css
 @media (color) { ... }
 ```
 
-If a feature doesn't apply to the device on which the browser is running, expressions involving that media feature are always false. For example, the styles nested inside the following query will never be used, because no speech-only device has a screen aspect ratio:
+If a feature doesn't apply to the device on which the browser is running, expressions involving that media feature are always false.
+For example, the styles nested inside the following query will never be used, because no speech-only device has a screen aspect ratio:
 
 ```css
 @media speech and (aspect-ratio: 11/5) { ... }
 ```
 
-For more [media feature](#media_features) examples, please see the reference page for each specific feature.
+For more [Media feature](/en-US/docs/Web/CSS/@media#media_features) examples, please see the reference page for each specific feature.
 
 ## Creating complex media queries
 
-Sometimes you may want to create a media query that depends on multiple conditions. This is where the _logical operators_ come in: `not`, `and`, and `only`. Furthermore, you can combine multiple media queries into a _comma-separated list_; this allows you to apply the same styles in different situations.
+Sometimes you may want to create a media query that depends on multiple conditions. This is where the _logical operators_ come in: `not`, `and`, and `only`.
+Furthermore, you can combine multiple media queries into a _comma-separated list_; this allows you to apply the same styles in different situations.
 
-In the previous example, we've already seen the `and` operator used to group a media _type_ with a media _feature_. The `and` operator can also combine multiple media features into a single media query. The `not` operator, meanwhile, negates a media query, basically reversing its normal meaning. The `only` operator prevents older browsers from applying the styles.
+In the previous example, we've already seen the `and` operator used to group a media _type_ with a media _feature_.
+The `and` operator can also combine multiple media features into a single media query. The `not` operator, meanwhile, negates a media query, basically reversing its normal meaning.
+The `only` operator prevents older browsers from applying the styles.
 
-> **Note:** In most cases, the `all` media type is used by default when no other type is specified. However, if you use the `not` or `only` operators, you must explicitly specify a media type.
+> **Note:** In most cases, the `all` media type is used by default when no other type is specified.
+However, if you use the `not` or `only` operators, you must explicitly specify a media type.
 
 ### Combining multiple types or features
 
-The `and` keyword combines a media feature with a media type _or_ other media features. This example combines two media features to restrict styles to landscape-oriented devices with a width of at least 30 ems:
+The `and` keyword combines a media feature with a media type _or_ other media features.
+This example combines two media features to restrict styles to landscape-oriented devices with a width of at least 30 ems:
 
 ```css
 @media (min-width: 30em) and (orientation: landscape) { ... }
@@ -170,17 +129,22 @@ To limit the styles to devices with a screen, you can chain the media features t
 
 ### Testing for multiple queries
 
-You can use a comma-separated list to apply styles when the user's device matches any one of various media types, features, or states. For instance, the following rule will apply its styles if the user's device has either a minimum height of 680px _or_ is a screen device in portrait mode:
+You can use a comma-separated list to apply styles when the user's device matches any one of various media types, features, or states.
+For instance, the following rule will apply its styles if the user's device has either a minimum height of 680px _or_ is a screen device in portrait mode:
 
 ```css
 @media (min-height: 680px), screen and (orientation: portrait) { ... }
 ```
 
-Taking the above example, if the user had a printer with a page height of 800px, the media statement would return true because the first query would apply. Likewise, if the user were on a smartphone in portrait mode with a viewport height of 480px, the second query would apply and the media statement would still return true.
+Taking the above example, if the user had a printer with a page height of 800px, the media statement would return true because the first query would apply.
+Likewise, if the user were on a smartphone in portrait mode with a viewport height of 480px, the second query would apply and the media statement would still return true.
 
 ### Inverting a query's meaning
 
-The `not` keyword inverts the meaning of an entire media query. It will only negate the specific media query it is applied to. (Thus, it will not apply to every media query in a comma-separated list of media queries.) The `not` keyword can't be used to negate an individual feature query, only an entire media query. The `not` is evaluated last in the following query:
+The `not` keyword inverts the meaning of an entire media query. It will only negate the specific media query it is applied to.
+(Thus, it will not apply to every media query in a comma-separated list of media queries.)
+The `not` keyword can't be used to negate an individual feature query, only an entire media query.
+The `not` is evaluated last in the following query:
 
 ```css
 @media not all and (monochrome) { ... }
@@ -212,7 +176,8 @@ As another example, the following media query:
 
 ### Improving compatibility with older browsers
 
-The `only` keyword prevents older browsers that do not support media queries with media features from applying the given styles. _It has no effect on modern browsers._
+The `only` keyword prevents older browsers that do not support media queries with media features from applying the given styles.
+_It has no effect on modern browsers._
 
 ```css
 @media only screen and (color) { ... }
@@ -220,9 +185,11 @@ The `only` keyword prevents older browsers that do not support media queries wit
 
 ## Syntax improvements in Level 4
 
-The Media Queries Level 4 specification includes some syntax improvements to make media queries using features that have a "range" type, for example width or height, less verbose. Level 4 adds a _range context_ for writing such queries. For example, using the `max-` functionality for width we might write the following:
+The Media Queries Level 4 specification includes some syntax improvements to make media queries using features that have a "range" type, for example width or height, less verbose.
+Level 4 adds a _range context_ for writing such queries. For example, using the `max-` functionality for width we might write the following:
 
-> **Note:** The Media Queries Level 4 specification has reasonable support in modern browsers, but some media features are not well supported. See the [`@media` browser compatibility table](/en-US/docs/Web/CSS/@media#Browser_compatibility) for more details.
+> **Note:** The Media Queries Level 4 specification has reasonable support in modern browsers, but some media features are not well supported.
+> See the [`@media` browser compatibility table](/en-US/docs/Web/CSS/@media#Browser_compatibility) for more details.
 
 ```css
 @media (max-width: 30em) { ... }
@@ -258,7 +225,8 @@ Using `not()` around a media feature negates that feature in the query. For exam
 
 ### Testing for multiple features with `or`
 
-You can use `or` to test for a match among more than one feature, resolving to `true` if any of the features are true. For example, the following query tests for devices that have a monochrome display or hover capability:
+You can use `or` to test for a match among more than one feature, resolving to `true` if any of the features are true.
+For example, the following query tests for devices that have a monochrome display or hover capability:
 
 ```css
 @media (not (color)) or (hover) { ... }


### PR DESCRIPTION
This is part of the action to remove page macros in #3196

The CSS [@media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media) was importing the media types and media features section from [using media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries). 

This copies the text across instead. The big table of media types is converted to a  definition list, which is more in line with other reference docs.

@wbamberg I hate the duplication here because they really must always be the same for this case ... but anyhow. Do you think I should update the table in "Using" docs to match the new definition list format? If I did this I would probably mark the info about spec version things came in as in italic.