### PR TITLE
Adding a note about the option to return a Promise instead of using the sendResponse() function

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -145,7 +145,7 @@ function handleFarewell(request, sender) {
   return false;
 }
 
-browser.runtime.onMessage.addListener(handleGreeting);</pre>
+browser.runtime.onMessage.addListener(handleGreeting);
 browser.runtime.onMessage.addListener(handleFarewell);</pre>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -112,13 +112,41 @@ window.addEventListener("click", notifyBackgroundPage);</pre>
 
 <pre class="brush: js">// background-script.js
 
-function handleMessage(request, sender, sendResponse) {
+async function handleMessage(request, sender) {
   console.log("Message from the content script: " +
     request.greeting);
-  sendResponse({response: "Response from background script"});
+  return {response: "Response from background script"};
 }
 
 browser.runtime.onMessage.addListener(handleMessage);</pre>
+
+If you pass an <code>async</code> function to <code>addListener()</code> as shown in the example above, the listener will return a Promise for every message it receives,
+preventing other listeners from responding. If you want to declare multiple {{WebExtAPIRef('runtime.onMessage')}} listeners and have each respond to messages of a certain type,
+you must define the listener as a non-<code>async</code> function, and return a Promise only for the messages the listener is meant to respond to — and otherwise return false or
+undefined:
+
+<pre class="brush: js">// background-script.js
+
+function handleGreeting(request, sender) {
+  if (request.greeting) {
+    console.log("Greeting from the content script: " +
+      request.greeting);
+    return Promise.resolve({response: "Greeting from background script"});
+  }
+  return false;
+}
+
+function handleFarewell(request, sender) {
+  if (request.farewell) {
+    console.log("Farewell from the content script: " +
+      request.farewell);
+    return Promise.resolve({response: "Farewell from background script"});
+  }
+  return false;
+}
+
+browser.runtime.onMessage.addListener(handleGreeting);</pre>
+browser.runtime.onMessage.addListener(handleFarewell);</pre>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -112,41 +112,17 @@ window.addEventListener("click", notifyBackgroundPage);</pre>
 
 <pre class="brush: js">// background-script.js
 
-async function handleMessage(request, sender) {
+function handleMessage(request, sender, sendResponse) {
   console.log("Message from the content script: " +
     request.greeting);
-  return {response: "Response from background script"};
+  sendResponse({response: "Response from background script"});
 }
 
 browser.runtime.onMessage.addListener(handleMessage);</pre>
 
-If you pass an <code>async</code> function to <code>addListener()</code> as shown in the example above, the listener will return a Promise for every message it receives,
-preventing other listeners from responding. If you want to declare multiple {{WebExtAPIRef('runtime.onMessage')}} listeners and have each respond to messages of a certain type,
-you must define the listener as a non-<code>async</code> function, and return a Promise only for the messages the listener is meant to respond to — and otherwise return false or
-undefined:
-
-<pre class="brush: js">// background-script.js
-
-function handleGreeting(request, sender) {
-  if (request.greeting) {
-    console.log("Greeting from the content script: " +
-      request.greeting);
-    return Promise.resolve({response: "Greeting from background script"});
-  }
-  return false;
-}
-
-function handleFarewell(request, sender) {
-  if (request.farewell) {
-    console.log("Farewell from the content script: " +
-      request.farewell);
-    return Promise.resolve({response: "Farewell from background script"});
-  }
-  return false;
-}
-
-browser.runtime.onMessage.addListener(handleGreeting);
-browser.runtime.onMessage.addListener(handleFarewell);</pre>
+<p><strong>Note:</strong>
+Examples showing an alternative implementation, not using the <code>sendResponse()</code> function but instead returning a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> (which is the preferred way for Firefox Add-ons), can be found in the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples">examples section</a> of the {{WebExtAPIRef('runtime.onMessage')}} listener.  
+</p> 
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -121,7 +121,7 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p><strong>Note:</strong>
-Examples showing an alternative implementation, not using the <code>sendResponse()</code> function but instead returning a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> (which is the preferred way for Firefox Add-ons), can be found in the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples">examples section</a> of the {{WebExtAPIRef('runtime.onMessage')}} listener.  
+Instead of using <code>sendResponse()</code>, returning a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> is the recommended approach for Firefox add-ons. Examples using a Promise are available in the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples">examples section</a> of the {{WebExtAPIRef('runtime.onMessage')}} listener.
 </p> 
 
 <p>{{WebExtExamples}}</p>


### PR DESCRIPTION
sendResponse() is deprecated

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

The sendResponse() function is deprecated and should no longer be used. This PR changes the used examples to return a Promise and shows the two possible ways to do it.

<!-- ✍️ In a sentence or two, describe your changes -->

I removed usage of sendResponse() in the example and let the handler return a Promise. Once as being an async function and always returning a Promise, which is fine if only one such listener is registered, which is 99% use-case out there, but also pointing out how to do it if multiple listeners are used.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I am the lead add-on reviewer for Thunderbird and I get sendResponse() in reviews a lot and developers pointed me to this page showing them the deprecated usage.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
