### PR TITLE
[DOM Reference] Update CustomEvent interface reference

### DIFF
--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -13,7 +13,7 @@ The **`CustomEvent()`** constructor creates a new {{domxref("CustomEvent")}}.
 ## Syntax
 
 ```js
-event = new CustomEvent(typeArg, customEventInit);
+CustomEvent(typeArg, options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -23,7 +23,7 @@ CustomEvent(typeArg, options);
   - : A string representing the name of the event.
 - `options` {{optional_inline}}
 
-  - : A dictionary, having the following fields:
+  - : An object, with the following fields:
 
     - `"detail"`, optional and defaulting to `null`, of any type,
       containing an event-dependent value associated with the event.

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -2,45 +2,38 @@
 title: CustomEvent()
 slug: Web/API/CustomEvent/CustomEvent
 tags:
-  - API
   - Constructor
-  - CustomEvent
   - Reference
-  - events
 browser-compat: api.CustomEvent.CustomEvent
 ---
 {{APIRef("DOM")}}
 
-The **`CustomEvent()`** constructor creates a new
-{{domxref("CustomEvent")}}.
-
-{{AvailableInWorkers}}
+The **`CustomEvent()`** constructor creates a new {{domxref("CustomEvent")}}.
 
 ## Syntax
 
 ```js
- event = new CustomEvent(typeArg, customEventInit);
+event = new CustomEvent(typeArg, customEventInit);
 ```
 
 ### Parameters
 
 - `typeArg`
-  - : A {{domxref("DOMString")}} representing the name of the event.
+  - : A string representing the name of the event.
 - `customEventInit` {{optional_inline}}
 
-  - : A `CustomEventInit` dictionary, having the following fields:
+  - : A dictionary, having the following fields:
 
-    - `"detail"`, optional and defaulting to `null`, of type
-      any, that is an event-dependent value associated with the event.
+    - `"detail"`, optional and defaulting to `null`, of any type,
+      containing an event-dependent value associated with the event,
+      available to the handler using the {{domxref("CustomEvent.detail")}} property.
 
-    > **Note:** _The `CustomEventInit`\*\* dictionary also accepts fields
-    > from the {{domxref("Event.Event", "EventInit")}} dictionary._
+    - Any field that can be used in the init object of the {{domxref("Event.Event", "Event()")}} constructor._
 
 ### Return value
 
 A new `CustomEvent` object of the specified type, with any other properties
-configured according to the `CustomEventInit` dictionary (if one was
-provided).
+configured according to the dictionary if one was provided.
 
 ## Example
 
@@ -66,30 +59,6 @@ Additional examples can be found at [Creating and triggering events](/en-US/docs
 ## Browser compatibility
 
 {{Compat}}
-
-## Polyfill
-
-You can polyfill the `CustomEvent()` constructor functionality in Internet
-Explorer 9 and higher with the following code:
-
-```js
-(function () {
-
-  if ( typeof window.CustomEvent === "function" ) return false;
-
-  function CustomEvent ( event, params ) {
-    params = params || { bubbles: false, cancelable: false, detail: null };
-    var evt = document.createEvent( 'CustomEvent' );
-    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
-    return evt;
-   }
-
-  window.CustomEvent = CustomEvent;
-})();
-```
-
-Internet Explorer >= 9 adds a CustomEvent object to the window, but with correct
-implementations, this is a function.
 
 ## See also
 

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -20,7 +20,7 @@ CustomEvent(typeArg, options);
 
 - `typeArg`
   - : A string representing the name of the event.
-- `customEventInit` {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : A dictionary, having the following fields:
 

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -25,8 +25,8 @@ CustomEvent(typeArg, options);
   - : A dictionary, having the following fields:
 
     - `"detail"`, optional and defaulting to `null`, of any type,
-      containing an event-dependent value associated with the event,
-      available to the handler using the {{domxref("CustomEvent.detail")}} property.
+      containing an event-dependent value associated with the event.
+      This is available to the handler using the {{domxref("CustomEvent.detail")}} property.
 
     - Any field that can be used in the init object of the {{domxref("Event.Event", "Event()")}} constructor._
 

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -13,6 +13,7 @@ The **`CustomEvent()`** constructor creates a new {{domxref("CustomEvent")}}.
 ## Syntax
 
 ```js
+CustomEvent(typeArg);
 CustomEvent(typeArg, options);
 ```
 

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -29,7 +29,7 @@ CustomEvent(typeArg, options);
       containing an event-dependent value associated with the event.
       This is available to the handler using the {{domxref("CustomEvent.detail")}} property.
 
-    - Any field that can be used in the init object of the {{domxref("Event.Event", "Event()")}} constructor._
+    - Any field that can be used in the init object of the {{domxref("Event.Event", "Event()")}} constructor.
 
 ### Return value
 

--- a/files/en-us/web/api/customevent/detail/index.md
+++ b/files/en-us/web/api/customevent/detail/index.md
@@ -2,29 +2,17 @@
 title: CustomEvent.detail
 slug: Web/API/CustomEvent/detail
 tags:
-  - API
-  - CustomEvent
-  - DOM
   - Property
   - Reference
-  - detail
+  - Read-only
 browser-compat: api.CustomEvent.detail
 ---
 {{APIRef("DOM")}}
 
-The **`detail`** readonly property of the
-{{domxref("CustomEvent")}} interface returns any data passed when initializing the
-event.
+The  read-only **`detail`** property of the {{domxref("CustomEvent")}} interface
+returns any data passed when initializing the event.
 
-{{AvailableInWorkers}}
-
-## Syntax
-
-```js
- let myDetail = customEventInstance.detail;
-```
-
-### Return value
+### Value
 
 Whatever data the event was initialized with.
 

--- a/files/en-us/web/api/customevent/detail/index.md
+++ b/files/en-us/web/api/customevent/detail/index.md
@@ -12,7 +12,7 @@ browser-compat: api.CustomEvent.detail
 The  read-only **`detail`** property of the {{domxref("CustomEvent")}} interface
 returns any data passed when initializing the event.
 
-### Value
+## Value
 
 Whatever data the event was initialized with.
 

--- a/files/en-us/web/api/customevent/detail/index.md
+++ b/files/en-us/web/api/customevent/detail/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CustomEvent.detail
 ---
 {{APIRef("DOM")}}
 
-The  read-only **`detail`** property of the {{domxref("CustomEvent")}} interface
+The read-only **`detail`** property of the {{domxref("CustomEvent")}} interface
 returns any data passed when initializing the event.
 
 ## Value

--- a/files/en-us/web/api/customevent/index.md
+++ b/files/en-us/web/api/customevent/index.md
@@ -2,11 +2,7 @@
 title: CustomEvent
 slug: Web/API/CustomEvent
 tags:
-  - API
-  - CustomEvent
-  - DOM
   - Interface
-  - NeedsExample
   - Reference
 browser-compat: api.CustomEvent
 ---
@@ -19,18 +15,18 @@ The **`CustomEvent`** interface represents events initialized by an application 
 ## Constructor
 
 - {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}
-  - : Creates a `CustomEvent`.
+  - : Creates a new `CustomEvent`.
 
 ## Properties
 
-_This interface inherits properties from its parent,_ {{domxref("Event")}}.
+_This interface inherits properties from its parent, {{domxref("Event")}}._
 
 - {{domxref("CustomEvent.detail")}} {{readonlyinline}}
-  - : Any data passed when initializing the event.
+  - : Returns any data passed when initializing the event.
 
 ## Methods
 
-_This interface inherits methods from its parent,_ {{domxref("Event")}}.
+_This interface inherits methods from its parent, {{domxref("Event")}}._
 
 - {{domxref("CustomEvent.initCustomEvent()")}} {{deprecated_inline}}
   - : Initializes a `CustomEvent` object. If the event has already being dispatched, this method does nothing.
@@ -43,25 +39,7 @@ _This interface inherits methods from its parent,_ {{domxref("Event")}}.
 
 {{Compat}}
 
-## Firing from privileged code to non-privileged code
-
-When firing a `CustomEvent` from privileged code (i.e. an extension) to non-privileged code (i.e. a webpage), security issues should be considered. Firefox and other Gecko applications restrict an object created in one context from being directly used for another, which will automatically prevent security holes, but these restrictions may also prevent your code from running as expected.
-
-While creating a `CustomEvent` object, you must create the object from the same [window](/en-US/docs/XUL/window). The `detail` attribute of your `CustomEvent` will be subjected to the same restrictions. `String` and `Array` values will be readable by the content without restrictions, but custom `Object` will not. While using a custom object, you will need to define the attributes of that object that are readable from the content script using [Components.utils.cloneInto()](/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.cloneInto).
-
-```js
-// doc is a reference to the content document
-function dispatchCustomEvent(doc) {
-  var eventDetail = Components.utils.cloneInto({foo: 'bar'}, doc.defaultView);
-  var myEvent = doc.defaultView.CustomEvent("mytype", eventDetail);
-  doc.dispatchEvent(myEvent);
-}
-```
-
-But one needs to keep in mind that exposing a function will allow the content script to run it with chrome privileges, which can open a security vulnerability.
-
 ## See also
 
 - {{domxref("Window.postMessage()")}}
-- [Interaction between privileged and non-privileged pages](/en-US/docs/Code_snippets/Interaction_between_privileged_and_non-privileged_pages)
 - [Creating and triggering events](/en-US/docs/Web/Events/Creating_and_triggering_events)

--- a/files/en-us/web/api/customevent/initcustomevent/index.md
+++ b/files/en-us/web/api/customevent/initcustomevent/index.md
@@ -13,7 +13,7 @@ The **`CustomEvent.initCustomEvent()`** method initializes a {{domxref("CustomEv
 If the event has already been dispatched, this method does nothing.
 
 Events initialized in this way must have been created with the {{domxref("Document.createEvent()")}} method.
-This method must be called to set the event before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}.
+This method must be called to set the event before it is dispatched using {{ domxref("EventTarget.dispatchEvent()") }}.
 Once dispatched, it doesn't do anything anymore.
 
 > **Note:** **Do not use this method anymore, as it is deprecated.**

--- a/files/en-us/web/api/customevent/initcustomevent/index.md
+++ b/files/en-us/web/api/customevent/initcustomevent/index.md
@@ -30,7 +30,7 @@ event.initCustomEvent(type, canBubble, cancelable, detail);
 ### Parameters
 
 - `type`
-  - : Is a string containing the name of the event.
+  - : A string containing the name of the event.
 - `canBubble`
   - : Is a boolean value indicating whether the event bubbles up through the DOM
     or not.

--- a/files/en-us/web/api/customevent/initcustomevent/index.md
+++ b/files/en-us/web/api/customevent/initcustomevent/index.md
@@ -37,7 +37,7 @@ event.initCustomEvent(type, canBubble, cancelable, detail);
 - `cancelable`
   - : Is a boolean value indicating whether the event is cancelable.
 - `detail`
-  - : Any data, that will be available to the handler through the {{domxref("CustomEvent.detail")}} property.
+  - : Any data that will be available to the handler through the {{domxref("CustomEvent.detail")}} property.
 
 ## Specifications
 

--- a/files/en-us/web/api/customevent/initcustomevent/index.md
+++ b/files/en-us/web/api/customevent/initcustomevent/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CustomEvent.initCustomEvent
 ---
 {{APIRef("DOM")}}{{Deprecated_header}}
 
-The **`CustomEvent.initCustomEvent()`** method initializes a `CustomEvent` object.
+The **`CustomEvent.initCustomEvent()`** method initializes a {{domxref("CustomEvent")}} object.
 If the event has already been dispatched, this method does nothing.
 
 Events initialized in this way must have been created with the {{domxref("Document.createEvent()")}} method.

--- a/files/en-us/web/api/customevent/initcustomevent/index.md
+++ b/files/en-us/web/api/customevent/initcustomevent/index.md
@@ -2,9 +2,6 @@
 title: CustomEvent.initCustomEvent()
 slug: Web/API/CustomEvent/initCustomEvent
 tags:
-  - API
-  - CustomEvent
-  - DOM
   - Deprecated
   - Method
   - Reference
@@ -12,14 +9,12 @@ browser-compat: api.CustomEvent.initCustomEvent
 ---
 {{APIRef("DOM")}}{{Deprecated_header}}
 
-The **`CustomEvent.initCustomEvent()`** method initializes a
-`CustomEvent` object. If the event has already been dispatched, this method
-does nothing.
+The **`CustomEvent.initCustomEvent()`** method initializes a `CustomEvent` object.
+If the event has already been dispatched, this method does nothing.
 
-Events initialized in this way must have been created with the {{
-  domxref("Document.createEvent()") }} method. This method must be called to set the event
-before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
-dispatched, it doesn't do anything anymore.
+Events initialized in this way must have been created with the {{domxref("Document.createEvent()")}} method.
+This method must be called to set the event before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}.
+Once dispatched, it doesn't do anything anymore.
 
 > **Note:** **Do not use this method anymore, as it is deprecated.**
 >
@@ -35,14 +30,14 @@ event.initCustomEvent(type, canBubble, cancelable, detail);
 ### Parameters
 
 - `type`
-  - : Is a {{domxref("DOMString")}} containing the name of the event.
-- _`canBubble`_
+  - : Is a string containing the name of the event.
+- `canBubble`
   - : Is a boolean value indicating whether the event bubbles up through the DOM
     or not.
 - `cancelable`
   - : Is a boolean value indicating whether the event is cancelable.
-- _`detail`_
-  - : The data passed when initializing the event.
+- `detail`
+  - : Any data, that will be available to the handler through the {{domxref("CustomEvent.detail")}} property.
 
 ## Specifications
 
@@ -55,5 +50,4 @@ event.initCustomEvent(type, canBubble, cancelable, detail);
 ## See also
 
 - {{domxref("CustomEvent")}}
-- The constructor to use instead of this deprecated method:
-  {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}.
+- The constructor to use instead of this deprecated method: {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}.


### PR DESCRIPTION
This is part of #9740.

- All properties and methods of `CustomEvent`are documented in the modern format.
- All are listed in the interface.
- I removed a polyfill for pre-IE9 browsers
- I removed some information about the security risks of using this in _privileged code_.