### PR TITLE
Add text-decoration/text-underline links

### DIFF
--- a/files/en-us/web/css/text-decoration/index.md
+++ b/files/en-us/web/css/text-decoration/index.md
@@ -121,5 +121,6 @@ The `text-decoration` property is specified as one or more space-separated value
 
 ## See also
 
-- The individual text-decoration properties are {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, and {{cssxref("text-decoration-style")}}.
+- The individual text-decoration properties are {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-style")}}, and {{cssxref("text-decoration-thickness")}}.
+- The {{cssxref("text-decoration-skip-ink")}}, {{cssxref("text-underline-offset")}}, and {{cssxref("text-underline-position")}} properties also affect text-decoration, but are not included in the shorthand.
 - The {{cssxref("list-style")}} attribute controls the appearance of items in HTML {{HTMLElement("ol")}} and {{HTMLElement("ul")}} lists.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Updates the *see also* links to include: `text-decoration-thickness`, `text-decoration-skip-ink`, `text-underline-offset`, and `text-underline-position`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Readers looking to change text-decoration related properties will usually go to the shorthand page for an overview of what is possible. The last three links are not in shorthand but are still relevant to text-decoration. Without these links, they might otherwise never discover these properties. 
Meanwhile, adding `text-decoration-thickness` to the individual pages see-also links was to keep things consistent.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
