### PR TITLE
Add page for Array_withSorted_argument type error message

### DIFF
--- a/files/en-us/web/javascript/reference/errors/array_withsorted_argument/index.md
+++ b/files/en-us/web/javascript/reference/errors/array_withsorted_argument/index.md
@@ -1,0 +1,50 @@
+---
+title: 'TypeError: non-function passed to Array.prototype.withSorted'
+slug: Web/JavaScript/Reference/Errors/Array_withSorted_argument
+tags:
+  - Error
+  - Errors
+  - JavaScript
+  - TypeError
+---
+{{jsSidebar("Errors")}}
+
+The JavaScript exception "invalid Array.prototype.withSorted argument" occurs when the argument of {{jsxref("Array.prototype.withSorted()")}} isn't either {{jsxref("undefined")}} or a function which compares its operands.
+
+## Message
+
+```html
+TypeError: argument is not a function object (Edge)
+TypeError: invalid Array.prototype.withSorted argument (Firefox)
+```
+
+## Error type
+
+{{jsxref("TypeError")}}
+
+## What went wrong?
+
+The argument of {{jsxref("Array.prototype.withSorted()")}} is expected to be either {{jsxref("undefined")}} or a function which compares its operands.
+
+## Examples
+
+### Invalid cases
+
+```js example-bad
+let a = [1, 3, 2].withSorted(5);  // TypeError
+
+var cmp = { asc: (x, y) => x >= y, dsc: (x, y) => x <= y };
+let a = [1, 3, 2].withSorted(cmp[this.key] || 'asc');  // TypeError
+```
+
+### Valid cases
+
+```js example-good
+let a = [1, 3, 2].withSorted();   // [1, 2, 3]
+
+var cmp = { asc: (x, y) => x >= y, dsc: (x, y) => x <= y };
+let a = [1, 3, 2].withSorted(cmp[this.key || 'asc']); // [1, 2, 3]
+```
+### Note
+
+The `Array.prototype.withSorted` method is part of a [proposal](https://github.com/tc39/proposal-change-array-by-copy) that will be added in the future.

--- a/files/en-us/web/javascript/reference/errors/array_withsorted_argument/index.md
+++ b/files/en-us/web/javascript/reference/errors/array_withsorted_argument/index.md
@@ -45,6 +45,3 @@ let a = [1, 3, 2].withSorted();   // [1, 2, 3]
 var cmp = { asc: (x, y) => x >= y, dsc: (x, y) => x <= y };
 let a = [1, 3, 2].withSorted(cmp[this.key || 'asc']); // [1, 2, 3]
 ```
-### Note
-
-The `Array.prototype.withSorted` method is part of a [proposal](https://github.com/tc39/proposal-change-array-by-copy) that will be added in the future.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add page for Array_withSorted_argument type error message

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
[Bug 1729563](https://bugzilla.mozilla.org/show_bug.cgi?id=1729563) adds a new `Array.prototype.withSorted()` method. This method can throw a type error that is similar to the one thrown by `Array.prototype.sort()` when the function argument is not callable, but the name is different to reflect that the method being erroneously called is `withSorted()`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [X] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
