### PR TITLE
Fixes #9041: Updates api and removes obsolete note

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -331,18 +331,18 @@ If you get errors, check that you've added all the dependencies and the tests as
 Gulp comes with a `watch()` function that you can use to watch your files and run tests whenever you save a file. For example, try adding the following to the bottom of your `gulpfile.js`:
 
 ```js
-gulp.task('watch', function(){
-  gulp.watch('src/*.html', ['html']);
-  gulp.watch('src/*.css', ['css']);
-  gulp.watch('src/*.js', ['js']);
-});
+function watch() {
+  gulp.watch('src/*.html', html)
+  gulp.watch('src/*.css', css)
+  gulp.watch('src/*.js', js)
+}
+
+exports.watch = watch;
 ```
 
 Now try entering the `gulp watch` command into your terminal. Gulp will now watch your directory, and run the appropriate tasks whenever you save a change to an HTML, CSS, or JavaScript file.
 
 > **Note:** The `*` character is a wildcard character — here we're saying "run these tasks when any files of these types are saved. You could also use wildcards in your main tasks, for example `gulp.src('src/*.css')` would grab all your CSS files and then run piped tasks on them.
-
-> **Note:** One problem with our watch command above is that our CSSLint/Autoprefixer combination throws full-blown errors when a CSS error is encountered, which stops the watch working. You'll have to restart the watch once a CSS error is encountered, or find another way to do this.
 
 There's a lot more you can do with Gulp. The [Gulp plugin directory](https://gulpjs.com/plugins/) has literally thousands of plugins to search through.
 


### PR DESCRIPTION
#### Summary
Gulp updated [their api](https://gulpjs.com/docs/en/getting-started/creating-tasks) and mdn docs became out of date. While I have matched the api, I was unable to verify the note deprecation from the [relevant docs](https://gulpjs.com/docs/en/getting-started/watching-files).

#### Motivation
Fixes #9041 , syncs mdn content to official

#### Supporting details
https://gulpjs.com/docs/en/getting-started/creating-tasks

#### Related issues
Fixes #9041

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
