### PR TITLE
[Markdown][Add-ons] Fix chrome incompatibilities page

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
@@ -22,15 +22,15 @@ tags:
  <li>
   <p>Javascript APIs:</p>
   <ul>
-   <li><strong>In Chrome:</strong> JavaScript APIs are accessed under the <code>chrome</code> namespace. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=798169">Chrome bug 798169</a>)</li>
    <li><strong>In Firefox and Edge:</strong> JavaScript APIs are accessed under the <code>browser</code> namespace.</li>
+   <li><strong>In Chrome:</strong> JavaScript APIs are accessed under the <code>chrome</code> namespace. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=798169">Chrome bug 798169</a>)</li>
   </ul>
  </li>
  <li>
   <p>Asynchronous APIs:</p>
   <ul>
+    <li><strong>In Firefox:</strong> Asynchronous APIs are implemented using promises.</li>
     <li><strong>In Chrome and Edge:</strong> Asynchronous APIs are implemented using callbacks. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=328932">Chrome bug 328932</a>)</li>
-      <li><strong>In Firefox:</strong> Asynchronous APIs are implemented using promises.</li>
   </ul>
  </li>
 </ul>
@@ -41,29 +41,19 @@ tags:
 
 <h3><em>chrome.*</em> and <em>browser.*</em> namespace</h3>
 
-<p><strong>In Chrome:</strong> Extensions access privileged JavaScript APIs using the <code>chrome</code> namespace.</p>
-<pre class="brush: js">chrome.browserAction.setIcon({path: "path/to/icon.png"});</pre>
-
-<p><strong>In Firefox:</strong> The equivalent APIs are accessed using the <code>browser</code> namespace.
-<pre class="brush: js">browser.browserAction.setIcon({path: "path/to/icon.png"});</pre>
+<ul>
+  <li><strong>In Firefox:</strong> The equivalent APIs are accessed using the <code>browser</code> namespace.
+  <pre class="brush: js">browser.browserAction.setIcon({path: "path/to/icon.png"});</pre>
+  </li>
+  <li><strong>In Chrome:</strong> Extensions access privileged JavaScript APIs using the <code>chrome</code> namespace.
+    <pre class="brush: js">chrome.browserAction.setIcon({path: "path/to/icon.png"});</pre>
+  </li>
+</ul>
 
 <h3>Callbacks and promises</h3>
 
-<p><strong>In Chrome:</strong> Asynchronous APIs use callbacks to return values, and {{WebExtAPIRef("runtime.lastError")}} to communicate errors.</p>
-<pre class="brush: js">function logCookie(c) {
-  if (chrome.runtime.lastError) {
-    console.error(chrome.runtime.lastError);
-  } else {
-    console.log(c);
-  }
-}
-
-chrome.cookies.set(
-  {url: "https://developer.mozilla.org/"},
-  logCookie
-);</pre>
-
-<p><strong>In Firefox:</strong> Asynchronous APIs use <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a> to return values instead.</p>
+<ul>
+  <li><strong>In Firefox:</strong> Asynchronous APIs use <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a> to return values instead.
 <pre class="brush: js">function logCookie(c) {
   console.log(c);
 }
@@ -76,6 +66,22 @@ let setCookie = browser.cookies.set(
   {url: "https://developer.mozilla.org/"}
 );
 setCookie.then(logCookie, logError);</pre>
+  </li>
+  <li><strong>In Chrome:</strong> Asynchronous APIs use callbacks to return values, and {{WebExtAPIRef("runtime.lastError")}} to communicate errors.
+<pre class="brush: js">function logCookie(c) {
+  if (chrome.runtime.lastError) {
+    console.error(chrome.runtime.lastError);
+  } else {
+    console.log(c);
+  }
+}
+
+chrome.cookies.set(
+  {url: "https://developer.mozilla.org/"},
+  logCookie
+);</pre>
+  </li>
+</ul>
 
 <h3 id="Firefox_supports_both_the_chrome_and_browser_namespaces">Firefox supports both the <em>chrome</em> and <em>browser</em> namespaces</h3>
 
@@ -151,33 +157,35 @@ setCookie.then(logCookie, logError);</pre>
 
 <h4>WebRequest API</h4>
 
-<p><strong>In Firefox:</strong></p>
 <ul>
- <li>Requests can be redirected only if their original URL uses the <code>http:</code> or <code>https:</code> scheme.</li>
- <li>The <code>activeTab</code> permission does not allow intercepting network requests in the current tab. (See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1617479">bug 1617479</a>)</li>
- <li>Events are not fired for system requests (for example, extension upgrades or searchbar suggestions).
-  <ul>
-   <li><strong>From Firefox 57 onwards:</strong> Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.</li>
-  </ul>
- </li>
- <li>If an extension wants to redirect a public (e.g., HTTPS) URL to an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages">extension page</a>, the extension's <code>manifest.json</code> file must contain a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources"><code>web_accessible_resources</code></a> key with the URL of the extension page.
-  <ul>
-   <li>
-    <div class="notecard note">
-    <p><strong>Note:</strong> <em>Any</em> website may then link or redirect to that URL, and extensions should treat any input (POST data, for example) as if it came from an untrusted source, just as a normal web page should.</p>
-    </div>
-   </li>
-  </ul>
- </li>
+  <li><strong>In Firefox:</strong>
+    <ul>
+     <li>Requests can be redirected only if their original URL uses the <code>http:</code> or <code>https:</code> scheme.</li>
+     <li>The <code>activeTab</code> permission does not allow intercepting network requests in the current tab. (See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1617479">bug 1617479</a>)</li>
+     <li>Events are not fired for system requests (for example, extension upgrades or searchbar suggestions).
+      <ul>
+       <li><strong>From Firefox 57 onwards:</strong> Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.</li>
+      </ul>
+     </li>
+     <li>If an extension wants to redirect a public (e.g., HTTPS) URL to an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages">extension page</a>, the extension's <code>manifest.json</code> file must contain a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources"><code>web_accessible_resources</code></a> key with the URL of the extension page.
+      <ul>
+       <li>
+        <div class="notecard note">
+        <p><strong>Note:</strong> <em>Any</em> website may then link or redirect to that URL, and extensions should treat any input (POST data, for example) as if it came from an untrusted source, just as a normal web page should.</p>
+        </div>
+       </li>
+      </ul>
+     </li>
+     <li>Some of the <code>browser.webRequest.*</code> APIs allow returning Promises that resolves <code>webRequest.BlockingResponse</code> asynchronously.</li>
+    </ul>
+  <li><strong>In Chrome:</strong> Only <code>webRequest.onAuthRequired</code> supports asynchronous <code>webRequest.BlockingResponse</code> via supplying <code>'asyncBlocking'</code>.</li>
 </ul>
-
-<p><strong>In Firefox (starting from Firefox 52):</strong> Some of the <code>browser.webRequest.*</code> APIs allow returning Promises that resolves <code>webRequest.BlockingResponse</code> asynchronously.</p>
-
-<p><strong>In Chrome:</strong> Only <code>webRequest.onAuthRequired</code> supports asynchronous <code>webRequest.BlockingResponse</code> via supplying <code>'asyncBlocking'</code>.</p>
 
 <h4>Windows API</h4>
 
-<p><strong>In Firefox:</strong> <code>onFocusChanged</code> of the {{WebExtAPIRef("windows")}} API, will trigger multiple times for a given focus change.</p>
+<ul>
+  <li><strong>In Firefox:</strong> <code>onFocusChanged</code> of the {{WebExtAPIRef("windows")}} API, will trigger multiple times for a given focus change.</li>
+</ul>
 
 <h3 id="Unsupported_APIs">Unsupported APIs</h3>
 
@@ -189,53 +197,65 @@ setCookie.then(logCookie, logError);</pre>
 
 <h3 id="Miscellaneous_incompatibilities">Miscellaneous incompatibilities</h3>
 
-<h4>URLs in CSS:</h4>
+<h4>URLs in CSS</h4>
 
-<p><strong>In Firefox</strong>: URLs in injected CSS files are resolved relative to <em>the CSS file itself</em>.</p>
-
-<p><strong>In Chrome</strong>: URLs in injected CSS files are resolved relative to <em>the page they are injected into</em>.</p>
+<ul>
+  <li><strong>In Firefox:</strong> URLs in injected CSS files are resolved relative to <em>the CSS file itself</em>.</li>
+  <li><strong>In Chrome:</strong> URLs in injected CSS files are resolved relative to <em>the page they are injected into</em>.</li>
+</ul>
 
 <h4>Support for dialogs in background pages</h4>
 
-<p><strong>In Firefox:</strong> <a href="/en-US/docs/Web/API/Window/alert"><code>alert()</code></a>, <a href="/en-US/docs/Web/API/Window/confirm"><code>confirm()</code></a>, and <a href="/en-US/docs/Web/API/Window/prompt"><code>prompt()</code></a> are not supported in background pages:</p>
+<ul>
+  <li><strong>In Firefox:</strong> <a href="/en-US/docs/Web/API/Window/alert"><code>alert()</code></a>, <a href="/en-US/docs/Web/API/Window/confirm"><code>confirm()</code></a>, and <a href="/en-US/docs/Web/API/Window/prompt"><code>prompt()</code></a> are not supported in background pages:</li>
+</ul>
 
-<h4>web_accessible_resources:</h4>
+<h4>web_accessible_resources</h4>
 
-<p><strong>In Firefox:</strong> Resources are assigned a random UUID that changes for every instance of Firefox: <code>moz-extension://«<var>random-UUID</var>»/«path»</code>. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.</p>
+<ul>
+  <li><strong>In Firefox:</strong> Resources are assigned a random UUID that changes for every instance of Firefox: <code>moz-extension://«<var>random-UUID</var>»/«path»</code>. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.</li>
+  <li><strong>In Chrome:</strong> When a resource is listed in <code>web_accessible_resources</code>, it is accessible as <code>chrome-extension://«your-extension-id»/«path»</code>. The extension ID is fixed for a given extension.</li>
+</ul>
 
-<p><strong>In Chrome</strong>: When a resource is listed in <code>web_accessible_resources</code>, it is accessible as <code>chrome-extension://«your-extension-id»/«path»</code>. The extension ID is fixed for a given extension.</p>
+<h4>Manifest "key" property</h4>
 
-<h4>Manifest "key" property:</h4>
+<ul>
+  <li><strong>In Firefox:</strong> Since Firefox uses random UUIDs for <code>web_accessible_resources</code>, this property is unsupported.</li>
+  <li><strong>In Chrome:</strong> When working with an unpacked extension, the manifest may include a <a href="https://developer.chrome.com/extensions/manifest/key"><code>"key"</code> property</a> to pin the extension ID across different machines. This is mainly useful when working with <code>web_accessible_resources</code>.</li>
+</ul>
 
-<p><strong>In Firefox</strong>: Since Firefox uses random UUIDs for <code>web_accessible_resources</code>, this property is unsupported.</p>
+<h4>Content script HTTP(S) requests</h4>
 
-<p><strong>In Chrome</strong>: When working with an unpacked extension, the manifest may include a <a href="https://developer.chrome.com/extensions/manifest/key"><code>"key"</code> property</a> to pin the extension ID across different machines. This is mainly useful when working with <code>web_accessible_resources</code>.</p>
+<ul>
+  <li><strong>In Firefox:</strong> When a content script makes an HTTP(S) request, you <em>must</em> provide absolute URLs.</li>
+  <li><strong>In Chrome:</strong> When a content script makes a request (for example, using <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch"><code>fetch()</code></a>) to a relative URL (like <code>/api</code>), it will be sent to <code>https://example.com/api</code>.</li>
+</ul>
 
-<h4>Content script HTTP(S) requests:</h4>
+<h4>Sharing variables between content scripts</h4>
 
-<p><strong>In Firefox</strong>: When a content script makes an HTTP(S) request, you <em>must</em> provide absolute URLs.</p>
+<ul>
+  <li><strong>In Firefox:</strong> You cannot share variables between content scripts by assigning them to <code>this.{variableName}</code> in one script and then attempting to access them using <code>window.{variableName}</code> in another. This is a limitation created by the sandbox environment in Firefox. This limitation may be removed, see {{bug(1208775)}}.</li>
+</ul>
 
-<p><strong>In Chrome</strong>: When a content script makes a request (for example, using <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch"><code>fetch()</code></a>) to a relative URL (like <code>/api</code>), it will be sent to <code>https://example.com/api</code>.</p>
+<h4>Content script lifecycle during navigation</h4>
 
-<h4>Sharing variables between content scripts:</h4>
+<ul>
+  <li>
+    <p><strong>In Firefox:</strong> Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets <code>window.prop1 = "prop"</code>  and the user then navigates away and returns to the page <code>window.prop1</code> is undefined. This issue is tracked in {{bug(1525400)}}.</p>
 
-<p><strong>In Firefox</strong>: You cannot share variables between content scripts by assigning them to <code>this.{variableName}</code> in one script and then attempting to access them using <code>window.{variableName}</code> in another. This is a limitation created by the sandbox environment in Firefox. This limitation may be removed, see {{bug(1208775)}}.</p>
-
-<h4>Content script lifecycle during navigation:</h4>
-
-<p><strong>In Firefox</strong>: Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets <code>window.prop1 = "prop"</code>  and the user then navigates away and returns to the page <code>window.prop1</code> is undefined. This issue is tracked in {{bug(1525400)}}.</p>
-
-<p>To mimic the behavior of Chrome, listen for the <a href="/en-US/docs/Web/API/Window/pageshow_event">pageshow</a> and <a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a> events. Then simulate the injection or destruction of the content script.</p></li>
-
-<p><strong>In Chrome</strong>: Content scripts are destroyed when the user navigates away from a web page. If the user then returns to the page through history, by clicking the back button, the content script is injected into the web page again.</p>
+    <p>To mimic the behavior of Chrome, listen for the <a href="/en-US/docs/Web/API/Window/pageshow_event">pageshow</a> and <a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a> events. Then simulate the injection or destruction of the content script.</p>
+  </li>
+  <li><strong>In Chrome:</strong> Content scripts are destroyed when the user navigates away from a web page. If the user then returns to the page through history, by clicking the back button, the content script is injected into the web page again.</li>
+</ul>
 
 <h4>"per-tab" zoom behavior</h4>
 
+<ul>
+  <li><strong>In Firefox:</strong> The zoom level persists across page loads and navigation within the tab.</li>
+  <li><strong>In Chrome:</strong> Zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.</li>
+</ul>
+
 <p>See {{WebExtAPIRef("tabs.ZoomSettingsScope")}}.</p>
-
-<p><strong>In Firefox</strong>: The zoom level persists across page loads and navigation within the tab.</p>
-
-<p><strong>In Chrome</strong>: Zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.</p>
 
 <h2 id="manifest.json_keys">manifest.json keys</h2>
 
@@ -257,21 +277,25 @@ setCookie.then(logCookie, logError);</pre>
 
 <h3 id="allowed_extensions">allowed_extensions</h3>
 
-<p><strong>In Firefox:</strong> The manifest key is called <code>allowed_extensions</code>.</p>
-
-<p><strong>In Chrome:</strong> The manifest key is called <code>allowed_origins</code> instead.</p>
+<ul>
+  <li><strong>In Firefox:</strong> The manifest key is called <code>allowed_extensions</code>.</li>
+  <li><strong>In Chrome:</strong> The manifest key is called <code>allowed_origins</code> instead.</li>
+</ul>
 
 <h3 id="App_manifest_location">App manifest location</h3>
 
-<p><strong>In Chrome:</strong> The app manifest is expected in a different place. See <a href="https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location">Native messaging host location</a> in the Chrome docs.</p>
+<ul>
+  <li><strong>In Chrome:</strong> The app manifest is expected in a different place. See <a href="https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location">Native messaging host location</a> in the Chrome docs.</li>
+</ul>
 
 <h2 id="Data_cloning_algorithm">Data cloning algorithm</h2>
 
 <p>Some extension APIs allow an extension to send data from one part of the extension to another, such as {{WebExtAPIRef("runtime.sendMessage()")}}, {{WebExtAPIRef("tabs.sendMessage()")}}, {{WebExtAPIRef("runtime.onMessage")}}, the <code>postMessage()</code> method of {{WebExtAPIRef("runtime.port")}}, and {{WebExtAPIRef("tabs.executeScript()")}}.</p>
 
-<p><strong>In Firefox:</strong> The <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">Structured clone algorithm</a> is used.</p>
-
-<p><strong>In Chrome:</strong> The <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description">JSON serialization algorithm</a> is used. It may switch to structured cloning in the future (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=248548">issue 248548</a>).</p>
+<ul>
+  <li><strong>In Firefox:</strong> The <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">Structured clone algorithm</a> is used.</li>
+  <li><strong>In Chrome:</strong> The <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description">JSON serialization algorithm</a> is used. It may switch to structured cloning in the future (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=248548">issue 248548</a>).</li>
+</ul>
 
 <p>The Structured clone algorithm supports more types than the JSON serialization algorithm. A notable exception are (DOM) objects with a <code>toJSON</code> method. DOM objects are not cloneable nor JSON-serializable by default, but with a <code>toJSON()</code> method, these can be JSON-serialized (but still not cloned with the structured cloning algorithm). Examples of JSON-serializable objects that are not structured cloneable include instances of {{domxref("URL")}} and {{domxref("PerformanceEntry")}}.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
@@ -189,11 +189,13 @@ chrome.cookies.set(
 
 <h3 id="Unsupported_APIs">Unsupported APIs</h3>
 
-<h4>declarativeContent API</h4>
+<h4>DeclarativeContent API</h4>
 
-<p>Chrome's <a href="https://developer.chrome.com/extensions/declarativeContent">declarativeContent</a> API <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435864">has not yet been implemented</a> in Firefox:</p>
-
-<p>In addition, Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1323433#c16">will not be supporting</a> the <code>declarativeContent.RequestContentScript</code> API (which is rarely used, and is unavailable in stable releases of Chrome).</p>
+<ul>
+  <li>
+    <p><strong>In Firefox:</strong> Chrome's <a href="https://developer.chrome.com/extensions/declarativeContent">declarativeContent</a> API <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435864">has not yet been implemented</a>. In addition, Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1323433#c16">will not be supporting</a> the <code>declarativeContent.RequestContentScript</code> API (which is rarely used, and is unavailable in stable releases of Chrome).</p>
+  </li>
+</ul>
 
 <h3 id="Miscellaneous_incompatibilities">Miscellaneous incompatibilities</h3>
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
@@ -21,23 +21,17 @@ tags:
  </li>
  <li>
   <p>Javascript APIs:</p>
-
-  <dl>
-   <dt>In Chrome</dt>
-   <dd>JavaScript APIs are accessed under the <code>chrome</code> namespace. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=798169">Chrome bug 798169</a>)</dd>
-   <dt>In Firefox and Edge</dt>
-   <dd>They are accessed under the <code>browser</code> namespace.</dd>
-  </dl>
+  <ul>
+   <li><strong>In Chrome:</strong> JavaScript APIs are accessed under the <code>chrome</code> namespace. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=798169">Chrome bug 798169</a>)</li>
+   <li><strong>In Firefox and Edge:</strong> JavaScript APIs are accessed under the <code>browser</code> namespace.</li>
+  </ul>
  </li>
  <li>
   <p>Asynchronous APIs:</p>
-
-  <dl>
-   <dt>In Chrome and Edge</dt>
-   <dd>Asynchronous APIs are implemented using callbacks. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=328932">Chrome bug 328932</a>)</dd>
-   <dt>In Firefox</dt>
-   <dd>Asynchronous APIs are implemented using promises.</dd>
-  </dl>
+  <ul>
+    <li><strong>In Chrome and Edge:</strong> Asynchronous APIs are implemented using callbacks. (cf. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=328932">Chrome bug 328932</a>)</li>
+      <li><strong>In Firefox:</strong> Asynchronous APIs are implemented using promises.</li>
+  </ul>
  </li>
 </ul>
 
@@ -45,25 +39,18 @@ tags:
 
 <h2 id="JavaScript_APIs">JavaScript APIs</h2>
 
-<h3 id="Callbacks_and_the_chrome.*_namespace">Callbacks and the <em>chrome.*</em> namespace</h3>
+<h3><em>chrome.*</em> and <em>browser.*</em> namespace</h3>
 
-<dl>
- <dt>In Chrome</dt>
- <dd>Extensions access privileged JavaScript APIs using the <code>chrome</code> namespace.
- <pre class="brush: js">chrome.browserAction.setIcon({path: "path/to/icon.png"});</pre>
- </dd>
- <dt>In Firefox (via the WebExtension API)</dt>
- <dd>The equivalent APIs are accessed using the <code>browser</code> namespace.
- <pre class="brush: js">browser.browserAction.setIcon({path: "path/to/icon.png"});</pre>
- </dd>
-</dl>
+<p><strong>In Chrome:</strong> Extensions access privileged JavaScript APIs using the <code>chrome</code> namespace.</p>
+<pre class="brush: js">chrome.browserAction.setIcon({path: "path/to/icon.png"});</pre>
 
-<p>Many of the APIs are asynchronous.</p>
+<p><strong>In Firefox:</strong> The equivalent APIs are accessed using the <code>browser</code> namespace.
+<pre class="brush: js">browser.browserAction.setIcon({path: "path/to/icon.png"});</pre>
 
-<dl>
- <dt>In Chrome</dt>
- <dd>Asynchronous APIs use callbacks to return values, and {{WebExtAPIRef("runtime.lastError")}} to communicate errors.
- <pre class="brush: js">function logCookie(c) {
+<h3>Callbacks and promises</h3>
+
+<p><strong>In Chrome:</strong> Asynchronous APIs use callbacks to return values, and {{WebExtAPIRef("runtime.lastError")}} to communicate errors.</p>
+<pre class="brush: js">function logCookie(c) {
   if (chrome.runtime.lastError) {
     console.error(chrome.runtime.lastError);
   } else {
@@ -75,10 +62,9 @@ chrome.cookies.set(
   {url: "https://developer.mozilla.org/"},
   logCookie
 );</pre>
- </dd>
- <dt>In Firefox (via the WebExtension API)</dt>
- <dd>Asynchronous APIs use <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a> to return values instead.
- <pre class="brush: js">function logCookie(c) {
+
+<p><strong>In Firefox:</strong> Asynchronous APIs use <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a> to return values instead.</p>
+<pre class="brush: js">function logCookie(c) {
   console.log(c);
 }
 
@@ -90,8 +76,6 @@ let setCookie = browser.cookies.set(
   {url: "https://developer.mozilla.org/"}
 );
 setCookie.then(logCookie, logError);</pre>
- </dd>
-</dl>
 
 <h3 id="Firefox_supports_both_the_chrome_and_browser_namespaces">Firefox supports both the <em>chrome</em> and <em>browser</em> namespaces</h3>
 
@@ -111,248 +95,148 @@ setCookie.then(logCookie, logError);</pre>
 
 <p>The rest of this section describes compatibility issues that are not already captured in the tables.</p>
 
-<dl>
-  <dt>Notifications API</dt>
-  <dd>
-    <p>These incompatibilities are present in {{WebExtAPIRef("notifications")}}:</p>
-    <ul>
-     <li>
-      <p>For <code>notifications.create()</code>, with <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType">type</a> "basic"</code>:</p>
+<h4>Notifications API</h4>
 
-      <dl>
-       <dt>In Firefox</dt>
-       <dd><code>iconUrl</code> is optional.</dd>
-       <dt>In Chrome</dt>
-       <dd><code>iconUrl</code> is required.</dd>
-      </dl>
-     </li>
-     <li>
-      <p>When the user clicks on a notification:</p>
+<p>For <code>notifications.create()</code>, with <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType">type</a> "basic"</code>:</p>
 
-      <dl>
-       <dt>In Firefox</dt>
-       <dd>The notification is cleared immediately.</dd>
-       <dt>In Chrome</dt>
-       <dd>This is not the case.</dd>
-      </dl>
-     </li>
-     <li>
-      <p>If you call <code>notifications.create()</code> more than once in rapid succession:</p>
+<ul>
+  <li><strong>In Firefox</strong>: <code>iconUrl</code> is optional.</li>
+  <li><strong>In Chrome</strong>: <code>iconUrl</code> is required.</li>
+</ul>
 
-      <ul>
-       <li>In Firefox, the notifications may not display at all. Waiting to make subsequent calls until within the <code>chrome.notifications.create()</code> callback function is not a sufficient delay to prevent this.</li>
-      </ul>
-     </li>
-    </ul>
-  </dd>
+<p>When the user clicks on a notification:</p>
+<ul>
+  <li><strong>In Firefox</strong>: The notification is cleared immediately.</li>
+  <li><strong>In Chrome</strong>: This is not the case.</li>
+</ul>
 
-  <dt>Proxy API</dt>
-  <dd>
-    <p>Firefox's {{WebExtAPIRef("proxy")}} API followed a completely different design from Chrome's Proxy API.</p>
+<p>If you call <code>notifications.create()</code> more than once in rapid succession:</p>
+<ul>
+  <li><strong>In Firefox</strong>: In Firefox, the notifications may not display at all. Waiting to make subsequent calls until within the <code>chrome.notifications.create()</code> callback function is not a sufficient delay to prevent this.</li>
+</ul>
 
-    <dl>
-     <dt>In Chrome</dt>
-     <dd>An extension can register a PAC file, but can also define explicit proxying rules.</dd>
-     <dt>In Firefox</dt>
-     <dd>The proxy API only supports the PAC file approach (since this is also possible using extended PAC files).
-     <div class="notecard note"><strong>Note:</strong> Because this API is incompatible with Chrome's <code>proxy</code> API, the Firefox proxy API is only available through the <code>browser</code> namespace.</div>
-     </dd>
-    </dl>
-  </dd>
+<h4>Proxy API</h4>
 
-  <dt>Tabs API</dt>
-  <dd>
+<p>Firefox's {{WebExtAPIRef("proxy")}} API followed a completely different design from Chrome's Proxy API.</p>
+<ul>
+  <li><strong>In Firefox</strong>: An extension can register a PAC file.</li>
+  <li><strong>In Chrome</strong>: An extension can register a PAC file, but can also define explicit proxying rules.</li>
+</ul>
 
-    <p>These incompatibilities are present in {{WebExtAPIRef("tabs")}}:</p>
+<p>Because this API is incompatible with Chrome's <code>proxy</code> API, the Firefox proxy API is only available through the <code>browser</code> namespace.</p>
 
-    <ul>
-     <li>
-      <p>When using <code>tabs.executeScript()</code> or <code>tabs.insertCSS()</code>:</p>
+<h4>Tabs API</h4>
 
-      <dl>
-       <dt>In Firefox</dt>
-       <dd>Relative URLs passed are resolved relative to the current page URL.</dd>
-       <dt>In Chrome</dt>
-       <dd>These URLs are resolved relative to the extension's base URL.</dd>
-      </dl>
+<p>When using <code>tabs.executeScript()</code> or <code>tabs.insertCSS()</code>:</p>
+<ul>
+  <li><strong>In Firefox</strong>: Relative URLs passed are resolved relative to the current page URL.</li>
+  <li><strong>In Chrome</strong>: These URLs are resolved relative to the extension's base URL.</li>
+</ul>
 
-      <p>To work cross-browser, you can specify the path as an absolute URL, starting at the extension's root, like this:</p>
+<p>To work cross-browser, you can specify the path as an absolute URL, starting at the extension's root, like this:</p>
 
-      <pre class="brush: plain;">/path/to/script.js
-    </pre>
-     </li>
-     <li>
-      <p>When :</p>
+<pre class="brush: plain">/path/to/script.js</pre>
 
-      <dl>
-       <dt>In Firefox</dt>
-       <dd>Querying tabs by URL with <code>tabs.query()</code> requires the <code>"tabs"</code> permission.</dd>
-       <dt>In Chrome</dt>
-       <dd>querying tabs by URL with <code>tabs.query()</code> It's possible without the <code>"tabs"</code> permission, but will limit results to tabs whose URLs match host permissions.</dd>
-      </dl>
-     </li>
-     <li>
-      <p>When calling <code>tabs.remove()</code>:</p>
+<p>When querying tabs by URL <code>tabs.query()</code>:</p>
+<ul>
+  <li><strong>In Firefox</strong>: Extensions must have the <code>"tabs"</code> permission.</li>
+  <li><strong>In Chrome</strong>: Extensions do not need the <code>"tabs"</code> permission, but only tabs whose URLs match the extension's host permissions will be included in the results.</li>
+</ul>
 
-      <dl>
-       <dt>In Firefox</dt>
-       <dd>The <code>tabs.remove()</code> promise is fulfilled after the <code>beforeunload</code> event.</dd>
-       <dt>In Chrome</dt>
-       <dd>The callback does not wait for <code>beforeunload</code>.</dd>
-      </dl>
-     </li>
-    </ul>
-  </dd>
+<p>When calling <code>tabs.remove()</code>:</p>
+<ul>
+  <li><strong>In Firefox</strong>: The <code>tabs.remove()</code> promise is fulfilled after the <code>beforeunload</code> event.</li>
+  <li><strong>In Chrome</strong>: The callback does not wait for <code>beforeunload</code>.</li>
+</ul>
 
-  <dt>WebRequest API</dt>
-  <dd>
-    <p>These incompatibilities are present in {{WebExtAPIRef("webRequest")}}:</p>
+<h4>WebRequest API</h4>
 
-    <dl>
-      <dt>In Firefox</dt>
-      <dd>
-        <ul>
-         <li>Requests can be redirected only if their original URL uses the <code>http:</code> or <code>https:</code> scheme.</li>
-         <li>The <code>activeTab</code> permission does not allow intercepting network requests in the current tab. (See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1617479">bug 1617479</a>)</li>
-         <li>Events are not fired for system requests (for example, extension upgrades or searchbar suggestions).
-          <ul>
-           <li><strong>From Firefox 57 onwards:</strong> Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.</li>
-          </ul>
-         </li>
-         <li>If an extension wants to redirect a public (e.g., HTTPS) URL to an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages">extension page</a>, the extension's <code>manifest.json</code> file must contain a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources"><code>web_accessible_resources</code></a> key with the URL of the extension page.
-          <ul>
-           <li>
-            <div class="notecard note">
-            <p><strong>Note:</strong> <em>Any</em> website may then link or redirect to that URL, and extensions should treat any input (POST data, for example) as if it came from an untrusted source, just as a normal web page should.</p>
-            </div>
-           </li>
-          </ul>
-         </li>
-        </ul>
-      </dd>
-    </dl>
+<p><strong>In Firefox:</strong></p>
+<ul>
+ <li>Requests can be redirected only if their original URL uses the <code>http:</code> or <code>https:</code> scheme.</li>
+ <li>The <code>activeTab</code> permission does not allow intercepting network requests in the current tab. (See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1617479">bug 1617479</a>)</li>
+ <li>Events are not fired for system requests (for example, extension upgrades or searchbar suggestions).
+  <ul>
+   <li><strong>From Firefox 57 onwards:</strong> Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.</li>
+  </ul>
+ </li>
+ <li>If an extension wants to redirect a public (e.g., HTTPS) URL to an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages">extension page</a>, the extension's <code>manifest.json</code> file must contain a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources"><code>web_accessible_resources</code></a> key with the URL of the extension page.
+  <ul>
+   <li>
+    <div class="notecard note">
+    <p><strong>Note:</strong> <em>Any</em> website may then link or redirect to that URL, and extensions should treat any input (POST data, for example) as if it came from an untrusted source, just as a normal web page should.</p>
+    </div>
+   </li>
+  </ul>
+ </li>
+</ul>
 
-    <ul>
-     <li>
-      <p>When using <code>browser.webRequest.*</code>:</p>
+<p><strong>In Firefox (starting from Firefox 52):</strong> Some of the <code>browser.webRequest.*</code> APIs allow returning Promises that resolves <code>webRequest.BlockingResponse</code> asynchronously.</p>
 
-      <dl>
-       <dt>In Firefox (starting from Firefox 52)</dt>
-       <dd>Some of the <code>browser.webRequest.*</code> APIs allow returning Promises that resolves <code>webRequest.BlockingResponse</code> asynchronously.</dd>
-       <dt>In Chrome</dt>
-       <dd>Only <code>webRequest.onAuthRequired</code> supports asynchronous <code>webRequest.BlockingResponse</code> via supplying <code>'asyncBlocking'</code>.</dd>
-      </dl>
-     </li>
-    </ul>
-  </dd>
+<p><strong>In Chrome:</strong> Only <code>webRequest.onAuthRequired</code> supports asynchronous <code>webRequest.BlockingResponse</code> via supplying <code>'asyncBlocking'</code>.</p>
 
+<h4>Windows API</h4>
 
-  <dt>Windows API</dt>
-  <dd>
-    <dl>
-     <dt>In Firefox</dt>
-     <dd><code>onFocusChanged</code> of the {{WebExtAPIRef("windows")}} API, will trigger multiple times for a given focus change.</dd>
-    </dl>
-  </dd>
-</dl>
+<p><strong>In Firefox:</strong> <code>onFocusChanged</code> of the {{WebExtAPIRef("windows")}} API, will trigger multiple times for a given focus change.</p>
 
 <h3 id="Unsupported_APIs">Unsupported APIs</h3>
 
-  <dl>
-    <dt>DeclarativeContent API</dt>
-    <dd>
-      <p>Chrome's <a href="https://developer.chrome.com/extensions/declarativeContent">declarativeContent</a> API <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435864">has not yet been implemented</a> in Firefox:</p>
-      <dl>
-       <dt>In Firefox</dt>
-       <dd>In addition, Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1323433#c16">will not be supporting</a> the <code>declarativeContent.RequestContentScript</code> API (which is rarely used, and is unavailable in stable releases of Chrome).</dd>
-      </dl>
-  </dl>
+<h4>declarativeContent API</h4>
+
+<p>Chrome's <a href="https://developer.chrome.com/extensions/declarativeContent">declarativeContent</a> API <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435864">has not yet been implemented</a> in Firefox:</p>
+
+<p>In addition, Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1323433#c16">will not be supporting</a> the <code>declarativeContent.RequestContentScript</code> API (which is rarely used, and is unavailable in stable releases of Chrome).</p>
 
 <h3 id="Miscellaneous_incompatibilities">Miscellaneous incompatibilities</h3>
-<dl>
-  <dt>URLs in CSS</dt>
-  <dd>
-    <dl>
-     <dt>In Firefox</dt>
-     <dd>URLs in injected CSS files are resolved relative to <em>the CSS file itself</em>.</dd>
-     <dt>In Chrome</dt>
-     <dd>URLs in injected CSS files are resolved relative to <em>the page they are injected into</em>.</dd>
-    </dl>
-  </dd>
 
-  <dt>Additional incompatibilities</dt>
-  <dd>
-    <dl>
-     <dt>In Firefox</dt>
-     <dd>Background pages do not support using <a href="/en-US/docs/Web/API/Window/alert"><code>alert()</code></a>, <a href="/en-US/docs/Web/API/Window/confirm"><code>confirm()</code></a>, or <a href="/en-US/docs/Web/API/Window/prompt"><code>prompt()</code></a>.</dd>
-    </dl>
-  </dd>
+<h4>URLs in CSS:</h4>
 
-  <dt>web_accessible_resources</dt>
-  <dd>
-    <dl>
-     <dt>In Chrome</dt>
-     <dd>When a resource is listed in <code>web_accessible_resources</code>, it is accessible as <code>chrome-extension://«<var>your-extension-id</var>»/«<var>path/to/resource</var>»</code>. The extension ID is fixed for a given extension.</dd>
-     <dt>In Firefox</dt>
-     <dd>Resources are assigned a random UUID that changes for every instance of Firefox: <code>moz-extension://«<var>random-UUID</var>»/«<var>path/to/resource</var>»</code>. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.</dd>
-    </dl>
-  </dd>
+<p><strong>In Firefox</strong>: URLs in injected CSS files are resolved relative to <em>the CSS file itself</em>.</p>
 
-  <dt>Manifest "key" property</dt>
-  <dd>
-    <dl>
-     <dt>In Chrome</dt>
-     <dd>When working with an unpacked extension, the manifest may include a <a href="https://developer.chrome.com/extensions/manifest/key"><code>"key"</code> property</a> to pin the extension ID across different machines. This is mainly useful when working with <code>web_accessible_resources</code>.</dd>
-     <dt>In Firefox</dt>
-     <dd>Since Firefox uses random UUIDs for <code>web_accessible_resources</code>, this property is unsupported.</dd>
-    </dl>
-  </dd>
+<p><strong>In Chrome</strong>: URLs in injected CSS files are resolved relative to <em>the page they are injected into</em>.</p>
 
-  <dt>Content script requests happen in the context of extension, not content page</dt>
-  <dd>
-    <dl>
-     <dt>In Chrome</dt>
-     <dd>When a content script makes a request (for example, using <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch"><code>fetch()</code></a>) to a relative URL (like <code>/api</code>), it will be sent to <code>https://example.com/api</code>.</dd>
-     <dt>In Firefox</dt>
-     <dd>When a content script makes a request, you <em>must</em> provide absolute URLs.</dd>
-    </dl>
-  </dd>
+<h4>Support for dialogs in background pages</h4>
 
-  <dt>Sharing variables between content scripts</dt>
-  <dd>
-    <dl>
-     <dt>In Firefox</dt>
-     <dd>You cannot share variables between content scripts by assigning them to <code>this.{variableName}</code> in one script and then attempting to access them using <code>window.{variableName}</code> in another. This is a limitation created by the sandbox environment in Firefox. This limitation may be removed, see {{bug(1208775)}}.</dd>
-    </dl>
-  </dd>
+<p><strong>In Firefox:</strong> <a href="/en-US/docs/Web/API/Window/alert"><code>alert()</code></a>, <a href="/en-US/docs/Web/API/Window/confirm"><code>confirm()</code></a>, and <a href="/en-US/docs/Web/API/Window/prompt"><code>prompt()</code></a> are not supported in background pages:</p>
 
-  <dt>Content script lifecycle during navigation</dt>
-  <dd>
-    <dl>
-     <dt>In Chrome</dt>
-     <dd>Content scripts are destroyed when the user navigates away from a web page. If the user then returns to the page through history, by clicking the back button, the content script is injected into the web page again.</dd>
-     <dt>In Firefox</dt>
-     <dd>
-     <p>Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets <code>window.prop1 = "prop"</code>  and the user then navigates away and returns to the page <code>window.prop1</code> is undefined. This issue is tracked in {{bug(1525400)}} .</p>
+<h4>web_accessible_resources:</h4>
 
-     <p>To mimic the behavior of Chrome, listen for the <a href="/en-US/docs/Web/API/Window/pageshow_event">pageshow</a> and <a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a> events. Then simulate the injection or destruction of the content script.</p>
-     </dd>
-    </dl>
-  </dd>
+<p><strong>In Firefox:</strong> Resources are assigned a random UUID that changes for every instance of Firefox: <code>moz-extension://«<var>random-UUID</var>»/«path»</code>. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.</p>
 
-  <dt>"per-tab" zoom behavior</dt>
-  <dd>
-    <p>See {{WebExtAPIRef("tabs.ZoomSettingsScope")}}</p>
-    <dl>
-     <dt>In Chrome</dt>
-     <dd>Zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.</dd>
-     <dt>In Firefox</dt>
-     <dd>
-     <p>The zoom level persists across page loads and navigation within the tab. in Chrome-based browsers</p>
-     </dd>
-    </dl>
-  </dd>
-</dl>
+<p><strong>In Chrome</strong>: When a resource is listed in <code>web_accessible_resources</code>, it is accessible as <code>chrome-extension://«your-extension-id»/«path»</code>. The extension ID is fixed for a given extension.</p>
+
+<h4>Manifest "key" property:</h4>
+
+<p><strong>In Firefox</strong>: Since Firefox uses random UUIDs for <code>web_accessible_resources</code>, this property is unsupported.</p>
+
+<p><strong>In Chrome</strong>: When working with an unpacked extension, the manifest may include a <a href="https://developer.chrome.com/extensions/manifest/key"><code>"key"</code> property</a> to pin the extension ID across different machines. This is mainly useful when working with <code>web_accessible_resources</code>.</p>
+
+<h4>Content script HTTP(S) requests:</h4>
+
+<p><strong>In Firefox</strong>: When a content script makes an HTTP(S) request, you <em>must</em> provide absolute URLs.</p>
+
+<p><strong>In Chrome</strong>: When a content script makes a request (for example, using <a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch"><code>fetch()</code></a>) to a relative URL (like <code>/api</code>), it will be sent to <code>https://example.com/api</code>.</p>
+
+<h4>Sharing variables between content scripts:</h4>
+
+<p><strong>In Firefox</strong>: You cannot share variables between content scripts by assigning them to <code>this.{variableName}</code> in one script and then attempting to access them using <code>window.{variableName}</code> in another. This is a limitation created by the sandbox environment in Firefox. This limitation may be removed, see {{bug(1208775)}}.</p>
+
+<h4>Content script lifecycle during navigation:</h4>
+
+<p><strong>In Firefox</strong>: Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets <code>window.prop1 = "prop"</code>  and the user then navigates away and returns to the page <code>window.prop1</code> is undefined. This issue is tracked in {{bug(1525400)}}.</p>
+
+<p>To mimic the behavior of Chrome, listen for the <a href="/en-US/docs/Web/API/Window/pageshow_event">pageshow</a> and <a href="/en-US/docs/Web/API/Window/pagehide_event">pagehide</a> events. Then simulate the injection or destruction of the content script.</p></li>
+
+<p><strong>In Chrome</strong>: Content scripts are destroyed when the user navigates away from a web page. If the user then returns to the page through history, by clicking the back button, the content script is injected into the web page again.</p>
+
+<h4>"per-tab" zoom behavior</h4>
+
+<p>See {{WebExtAPIRef("tabs.ZoomSettingsScope")}}.</p>
+
+<p><strong>In Firefox</strong>: The zoom level persists across page loads and navigation within the tab.</p>
+
+<p><strong>In Chrome</strong>: Zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.</p>
+
 <h2 id="manifest.json_keys">manifest.json keys</h2>
 
 <p>The main <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json"><code>manifest.json</code></a> page includes a table describing browser support for <code>manifest.json</code> keys. Where there are caveats around support for a given key, this is indicated in the table with an asterisk "*" and in the reference page for the key, the caveats are explained.</p>
@@ -363,46 +247,32 @@ setCookie.then(logCookie, logError);</pre>
 
 <h3 id="Connection-based_messaging_arguments">Connection-based messaging arguments</h3>
 
-<dl>
- <dt>On Linux and Mac</dt>
- <dd>Chrome passes one argument to the native app, which is the origin of the extension that started it, in the form: <code>chrome-extension://«<var>extensionID/</var>»</code> (trailing slash required). This enables the app to identify the extension.</dd>
- <dt>On Windows</dt>
- <dd>
- <p>Chrome passes two arguments:</p>
+<p><strong>On Linux and Mac:</strong> Chrome passes one argument to the native app, which is the origin of the extension that started it, in the form: <code>chrome-extension://«<var>extensionID/</var>»</code> (trailing slash required). This enables the app to identify the extension.</p>
 
- <ol>
-  <li>The origin of the extension</li>
-  <li>A handle to the Chrome native window that started the app</li>
- </ol>
- </dd>
-</dl>
+<p><strong>On Windows:</strong> Chrome passes two arguments:</p>
+<ol>
+ <li>The origin of the extension</li>
+ <li>A handle to the Chrome native window that started the app</li>
+</ol>
+
 
 <h3 id="allowed_extensions">allowed_extensions</h3>
 
-<dl>
- <dt>In Firefox</dt>
- <dd>The manifest key is called <code>allowed_extensions</code>.</dd>
- <dt>In Chrome</dt>
- <dd>The manifest key is called <code>allowed_origins</code> instead.</dd>
-</dl>
+<p><strong>In Firefox:</strong> The manifest key is called <code>allowed_extensions</code>.</p>
+
+<p><strong>In Chrome:</strong> The manifest key is called <code>allowed_origins</code> instead.</p>
 
 <h3 id="App_manifest_location">App manifest location</h3>
 
-<dl>
- <dt>In Chrome</dt>
- <dd>The app manifest is expected in a different place. See <a href="https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location">Native messaging host location</a> in the Chrome docs.</dd>
-</dl>
+<p><strong>In Chrome:</strong> The app manifest is expected in a different place. See <a href="https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location">Native messaging host location</a> in the Chrome docs.</p>
 
 <h2 id="Data_cloning_algorithm">Data cloning algorithm</h2>
 
 <p>Some extension APIs allow an extension to send data from one part of the extension to another, such as {{WebExtAPIRef("runtime.sendMessage()")}}, {{WebExtAPIRef("tabs.sendMessage()")}}, {{WebExtAPIRef("runtime.onMessage")}}, the <code>postMessage()</code> method of {{WebExtAPIRef("runtime.port")}}, and {{WebExtAPIRef("tabs.executeScript()")}}.</p>
 
-<dl>
- <dt>In Firefox</dt>
- <dd>The <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">Structured clone algorithm</a> is used.</dd>
- <dt>In Chrome</dt>
- <dd>The <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description">JSON serialization algorithm</a> is used. It may switch to structured cloning in the future (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=248548">issue 248548</a>).</dd>
-</dl>
+<p><strong>In Firefox:</strong> The <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">Structured clone algorithm</a> is used.</p>
+
+<p><strong>In Chrome:</strong> The <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description">JSON serialization algorithm</a> is used. It may switch to structured cloning in the future (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=248548">issue 248548</a>).</p>
 
 <p>The Structured clone algorithm supports more types than the JSON serialization algorithm. A notable exception are (DOM) objects with a <code>toJSON</code> method. DOM objects are not cloneable nor JSON-serializable by default, but with a <code>toJSON()</code> method, these can be JSON-serialized (but still not cloned with the structured cloning algorithm). Examples of JSON-serializable objects that are not structured cloneable include instances of {{domxref("URL")}} and {{domxref("PerformanceEntry")}}.</p>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

The "Chrome incompatibilities" page (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities) contained some `<dl>` elements which would not be convertible into our Markdown `<dl>`. It would have been possible to hack them so they would be convertible, but I thought this page was quite difficult to understand so I have had a go at reworking the markup at the same time.

I hope you think it is at least not any worse!
