### PR TITLE
[Markdown][Add-ons] Remove sup

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.html
@@ -179,7 +179,8 @@ tags:
     <p><a href="https://extensionworkshop.com/documentation/develop/web-ext-command-reference/">web-ext</a></p>
    </td>
    <td>
-    <p>Automatic, a few seconds<sup>1</sup></p>
+    <p>Automatic, a few seconds.</p>
+    <p>A manual review of the extension takes place after publication, which may result in the extension being suspended where issues that need fixing are found.</p>
    </td>
    <td>
     <p>Yes</p>
@@ -238,8 +239,6 @@ tags:
   </tr>
  </tbody>
 </table>
-
-<p><sup>1</sup> A manual review of the extension takes place after publication, which may result in the extension being suspended where issues that need fixing are found.</p>
 
 <h3 id="Other_considerations">Other considerations</h3>
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

We don't have a Markdown representation for `<sup>`. It's OK to keep the HTML for these elements, but good to remove them if we can. In this case it seemed OK to me to move the note into the table.