### PR TITLE
WebExtensions: Fix conflicting behavior explanation across browsers for "homepage_url" and "developer.url".

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.manifest.homepage_url
 
 <p>URL for the extension's home page.</p>
 
-<p>If the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer">developer</a> key is supplied and it contains the "url" property, this will override the homepage_url key.</p>
+<p>If both <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer">developer</a> key is supplied and it contains the "url" property and "homepage_url" is defined. Mozilla Firefox will favor "developer.url" while Opera favors "homepage_url".</p>
 
 <p>This is a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization#internationalizing_manifest.json">localizable property</a>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
@@ -31,7 +31,8 @@ browser-compat: webextensions.manifest.homepage_url
 
 <p>URL for the extension's home page.</p>
 
-<p>If both <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer">developer</a> key is supplied and it contains the "url" property and "homepage_url" is defined. Mozilla Firefox will favor "developer.url" while Opera favors "homepage_url".</p>
+<p>If a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer">developer</a> key containing the "url" property and "homepage_url" are defined, Firefox uses "developer.url" while Opera uses "homepage_url". 
+Chrome and Safari do not support the "developer" key.</p>
 
 <p>This is a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization#internationalizing_manifest.json">localizable property</a>.</p>
 


### PR DESCRIPTION
Fix conflicting behavior explanation across browsers for "homepage_url" and "developer.url".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Better explained the behavior of conflicting homepage_url with developer.url in manifest.json of webExtensions.

#### Motivation
Fix untrue statement about conflicting behavior in Opera.

#### Supporting details
The Opera behavior has been tested in the latest Opera Desktop version. While the behavior in Firefox has been taken from what was already mentioned in MDN.

This PR…
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error