### PR TITLE
fix double backticks in forbidden_header_name guide

### DIFF
--- a/files/en-us/glossary/forbidden_header_name/index.md
+++ b/files/en-us/glossary/forbidden_header_name/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 A **forbidden header name** is the name of any [HTTP header](/en-US/docs/Web/HTTP/Headers) that cannot be modified programmatically; specifically, an HTTP **request** header name (in contrast with a {{Glossary("Forbidden response header name")}}).
 
-Modifying such headers is forbidden because the user agent retains full control over them. Names starting with \``Sec-`\` are reserved for creating new headers safe from {{glossary("API","APIs")}} using [Fetch](/en-US/docs/Web/API/Fetch_API) that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.
+Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `Sec-` are reserved for creating new headers safe from {{glossary("API","APIs")}} using [Fetch](/en-US/docs/Web/API/Fetch_API) that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.
 
 Forbidden header names start with `Proxy-` or `Sec-`, or are one of the following names:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The [forbidden header name page](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) has an issue in the 2nd paragraph with double backticks. `Sec-` is rendered as \``Sec-`\`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Make it look clean (?), and uniform with the way it's displayed in the following paragraph.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
It looks like #9630 introduced this, which apparently converted HTML files to markdown, but it seems that the issue existed before as: \``<code>Sec-</code>`\`. I couldn't find when this was actually introduced.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
