### PR TITLE
Correct mistake in defer attr behavior description

### DIFF
--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -135,7 +135,7 @@ While the browser builds the DOM tree, this process occupies the main thread. 
 <script src="anotherscript.js" async></script>
 ```
 
-In this example, while the main thread is parsing the HTML and CSS, the preload scanner will find the scripts and image, and start downloading them as well. To ensure the script doesn't block the process, add the `async` attribute, or the `defer` attribute if JavaScript parsing and execution order is not important.
+In this example, while the main thread is parsing the HTML and CSS, the preload scanner will find the scripts and image, and start downloading them as well. To ensure the script doesn't block the process, add the `async` attribute, or the `defer` attribute if JavaScript parsing and execution order is important.
 
 Waiting to obtain CSS doesn't block HTML parsing or downloading, but it does block JavaScript, because JavaScript is often used to query CSS properties’ impact on elements.
 


### PR DESCRIPTION
#### Summary

Following [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer) and other different sources:
> Scripts with the `defer` attribute will execute in the order in which they appear in the document.


#### Related issues
Fixes https://github.com/mdn/translated-content/issues/2520

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
