### PR TITLE
Add a little style fixes to Array.filter page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -49,7 +49,7 @@ filter(function callbackFn(element, index, array) { ... }, thisArg)
     - `index`{{optional_inline}}
       - : The index of the current element being processed in the array.
     - `array`{{optional_inline}}
-      - : The array `filter()` was called upon.
+      - : The array on which `filter()` was called.
 
 - `thisArg`{{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -49,7 +49,7 @@ filter(function callbackFn(element, index, array) { ... }, thisArg)
     - `index`{{optional_inline}}
       - : The index of the current element being processed in the array.
     - `array`{{optional_inline}}
-      - : The array `filter` was called upon.
+      - : The array `filter()` was called upon.
 
 - `thisArg`{{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.
@@ -68,7 +68,7 @@ A new array with the elements that pass the test. If no elements pass the test, 
 2.  the index of the element
 3.  the Array object being traversed
 
-If a `thisArg` parameter is provided to `filter`, it will be used as the callback's `this` value. Otherwise, the value `undefined` will be used as its `this` value. The `this` value ultimately observable by `callback` is determined according to [the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
+If a `thisArg` parameter is provided to `filter`, it will be used as the callback's `this` value. Otherwise, the value `undefined` will be used as its `this` value. The `this` value ultimately observable by `callbackFn` is determined according to [the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
 
 `filter()` does not mutate the array on which it is called.
 


### PR DESCRIPTION
#### Summary
I unified uses of filter method name at page. And fix callback name at one place.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error