### PR TITLE
Add missing variable declaration keyword

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -22,7 +22,7 @@ The **`for await...of` statement** creates a loop iterating over async iterable 
 ## Syntax
 
 ```js
-for await (variable of iterable) {
+for await (const variable of iterable) {
   statement
 }
 ```


### PR DESCRIPTION
#### Summary
I'm fixing an invalid example that is missing a variable declaration keyword. I chose `const` but this could as easily be `let`.

#### Motivation
I want to make the example valid for other copy/pasters out there 😄 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
