### PR TITLE
Updated format for DOM Exceptions

### DIFF
--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -30,9 +30,9 @@ AudioEncoder.encode(data);
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `InvalidStateError`
+- `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("AudioEncoder.state","state")}} is not `"configured"`.
-- {{domxref("DOMException")}} `TypeError`
+- `TypeError` {{domxref("DOMException")}}
   - : Thrown if the `AudioData` object has been {{Glossary("Transferable Objects","transferred")}}.
 
 ## Examples

--- a/files/en-us/web/api/audioencoder/flush/index.md
+++ b/files/en-us/web/api/audioencoder/flush/index.md
@@ -29,8 +29,8 @@ A {{jsxref("Promise")}} that resolves with undefined.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `InvalidStateError`
-  - : The Promise rejected because the {{domxref("AudioEncoder.state","state")}} is not `"configured"`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the Promise is rejected because the {{domxref("AudioEncoder.state","state")}} is not `"configured"`.
 
 ## Examples
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -92,8 +92,7 @@ one of the following types:
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the method was not called from a
-        `versionchange` transaction callback. For older WebKit
-        browsers, you must first call {{APIRef("IDBVersionChangeRequest.setVersion")}}.
+        `versionchange` transaction callback.
 - `TransactionInactiveError` {{domxref("DOMException")}}
   - : Thrown if a request is made on a source database that does not exist
         (for example, when the database has been deleted or removed). In Firefox previous to version 41,

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -102,9 +102,7 @@ one of the following types:
 - `ConstraintError` {{domxref("DOMException")}}
   - : Thrown if an object store with the given name (based on a case-sensitive comparison)
         already exists in the connected database.
-- <a href="/en-US/docs/Web/API/IDBDatabaseException#non_transient_err"
-            >`InvalidAccessError`</a
-          >
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if `autoIncrement` is set to true and `keyPath` is
         either an empty string or an array containing an empty string.
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -90,56 +90,23 @@ A new {{domxref("IDBObjectStore")}}.
 This method may raise a {{domxref("DOMException")}} with a {{domxref("DOMError")}} of
 one of the following types:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        Occurs if the method was not called from a
-        <code>versionchange</code> transaction callback. For older WebKit
-        browsers, you must call
-        {{
-        APIRef("IDBVersionChangeRequest.setVersion")}}
-        first.
-      </td>
-    </tr>
-    <tr>
-      <td><code>TransactionInactiveError</code></td>
-      <td>
-        Occurs if a request is made on a source database that doesn't exist
-        (e.g. has been deleted or removed.) In Firefox previous to version 41,
-        an <code>InvalidStateError</code> was raised in this case as well, which
-        was misleading; this has now been fixed (see {{Bug("1176165")}}.)
-      </td>
-    </tr>
-    <tr>
-      <td><code>ConstraintError</code></td>
-      <td>
-        An object store with the given name (based on case-sensitive comparison)
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the method was not called from a
+        `versionchange` transaction callback. For older WebKit
+        browsers, you must first call {{APIRef("IDBVersionChangeRequest.setVersion")}}.
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if a request is made on a source database that does not exist
+        (for example, when the database has been deleted or removed). In Firefox previous to version 41,
+        an `InvalidStateError` was raised in this case as well, which
+        was misleading; this has now been fixed (see {{Bug("1176165")}}).
+- `ConstraintError` {{domxref("DOMException")}}
+  - : Thrown if an object store with the given name (based on a case-sensitive comparison)
         already exists in the connected database.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code
-          ><a href="/en-US/docs/Web/API/IDBDatabaseException#non_transient_err"
-            >InvalidAccessError</a
-          ></code
-        >
-      </td>
-      <td>
-        If <code>autoIncrement</code> is set to true and <code>keyPath</code> is
+- <a href="/en-US/docs/Web/API/IDBDatabaseException#non_transient_err"
+            >`InvalidAccessError`</a
+          >
+  - : Thrown if `autoIncrement` is set to true and `keyPath` is
         either an empty string or an array containing an empty string.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Example
 

--- a/files/en-us/web/api/idbdatabase/transaction/index.md
+++ b/files/en-us/web/api/idbdatabase/transaction/index.md
@@ -109,9 +109,9 @@ An {{domxref("IDBTransaction")}} object.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBDatabase.close", "close()")}} method has previously been called on this {{domxref("IDBDatabase")}} instance.
 - `NotFoundError` {{domxref("DOMException")}}
-  - : Thrown if tn object store specified in the 'storeNames' parameter has been deleted or removed.
+  - : Thrown if an object store specified in the 'storeNames' parameter has been deleted or removed.
 - `TypeError` {{domxref("DOMException")}}
-  - : Thrown if the value for the `mode`parameter is invalid.
+  - : Thrown if the value for the `mode` parameter is invalid.
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if the function was called with an empty list of store names.
 

--- a/files/en-us/web/api/mediarecorder/pause/index.md
+++ b/files/en-us/web/api/mediarecorder/pause/index.md
@@ -40,10 +40,10 @@ MediaRecorder.pause()
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The `MediaRecorder` is currently `"inactive"`; you can't pause
-    recording if it's not active. If you call `pause()` while already paused,
-    it silently does nothing.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the `MediaRecorder` is currently `"inactive"`; you cannot pause
+    the recording if the `MediaRecorder` is not active. If you call `pause()` while already paused,
+    the method silently does nothing.
 
 ## Example
 

--- a/files/en-us/web/api/mediarecorder/start/index.md
+++ b/files/en-us/web/api/mediarecorder/start/index.md
@@ -28,7 +28,7 @@ record the entire duration of the media into a single `Blob` (or until you
 call {{domxref("MediaRecorder.requestData", "requestData()")}}), or you can specify the
 number of milliseconds to record at a time. Then, each time that amount of media has
 been recorded, an event will be delivered to let you act upon the recorded media, while
-a new `Blob` is created to record the next slice of the media
+a new `Blob` is created to record the next slice of the media.
 
 Assuming the `MediaRecorder`'s {{domxref("MediaRecorder.state", "state")}}
 is `inactive`, `start()` sets the `state`  to
@@ -76,23 +76,23 @@ object. You can implement the {{domxref("MediaRecorder.onerror", "onerror")}} ev
 handler to respond to these errors.
 
 - `InvalidModificationError` {{domxref("DOMException")}}
-  - : The number of tracks on the stream being recorded has changed. You can't add or
+  - : Thrown if the number of tracks on the stream being recorded has changed. You cannot add or
     remove tracks while recording media.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : The `MediaRecorder` is not in the `inactive` state; you can't
-    start recording media if it's already being recorded. See the
+  - : Thrown if the `MediaRecorder` is not in the `inactive` state; you cannot
+    start recording media if it is already being recorded. See the
     {{domxref("MediaRecorder.state", "state")}} property.
 - `NotSupportedError` {{domxref("DOMException")}}
-  - : The media stream you're attempting to record is inactive, or one or more of the
-    stream's tracks is in a format that can't be recorded using the current configuration.
+  - : Thrown if the media stream you are attempting to record is inactive, or one or more of the
+    stream's tracks is in a format that cannot be recorded using the current configuration.
 - `SecurityError` {{domxref("DOMException")}}
-  - : The {{domxref("MediaStream")}} is configured to disallow recording. This may be the
+  - : Thrown if the {{domxref("MediaStream")}} is configured to disallow recording. This may be the
     case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia",
     "getUserMedia()")}} when the user denies permission to use an input device. This
-    exception may also be delivered as an {{event("error")}} event if
+    exception may also be thrown as an {{event("error")}} event if
     the security options for the source media change after recording begins.
 - `UnknownError` {{domxref("DOMException")}}
-  - : Something else went wrong during the recording process.
+  - : Thrown if something else went wrong during the recording process.
 
 ## Example
 

--- a/files/en-us/web/api/mediarecorder/start/index.md
+++ b/files/en-us/web/api/mediarecorder/start/index.md
@@ -89,7 +89,7 @@ handler to respond to these errors.
   - : Thrown if the {{domxref("MediaStream")}} is configured to disallow recording. This may be the
     case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia",
     "getUserMedia()")}} when the user denies permission to use an input device. This
-    exception may also be thrown as an {{event("error")}} event if
+    exception may also be delivered as an {{event("error")}} event if
     the security options for the source media change after recording begins.
 - `UnknownError` {{domxref("DOMException")}}
   - : Thrown if something else went wrong during the recording process.

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -43,10 +43,10 @@ A {{jsxref("Promise")}} that resolves with an {{domxref("XRLightProbe")}} object
 Rather than throwing true exceptions, `requestLightProbe()` rejects the
 returned promise with a {{domxref("DOMException")}}, specifically, one of the following:
 
-- `NotSupportedError`
-  - : Returned if `lighting-estimation` is not an enabled feature in {{domxref("XRSystem.requestSession()")}} or if the `reflectionFormat` is not `srgb8` or the `preferredReflectionFormat`.
-- `InvalidStateError`
-  - : Returned if the session has already ended.
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : Thrown if `lighting-estimation` is not an enabled feature in {{domxref("XRSystem.requestSession()")}} or if the `reflectionFormat` is not `srgb8` or the `preferredReflectionFormat`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the session has already ended.
 
 ## Examples
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -46,14 +46,14 @@ None.
   - : Thrown in any of the following situations:
     - The {{domxref("XRSession")}} has already ended, so you cannot change its render state.
     - The `baseLayer` was created by an  `XRSession`  other than the one on which  `updateRenderState()`  was called.
-    - The `inlineVerticalFieldOfView` option was set, but the session is immersive and therefore does not allow this property to be used.
+    - The `inlineVerticalFieldOfView` option was set, but the session is immersive, and therefore, does not allow this property to be used.
 
 - `NotSupportedError` {{domxref("DOMException")}}
-  - : Thrown if:
+  - : Thrown in any of the following situations:
     - The `layers` option is used in a session that has been created without the `layers` feature.
-    - The `baseLayer` and `layers` option are both specified.
+    - Both the `baseLayer` and `layers` options are specified.
 
-- `TypeError` {{domref("DOMException")}}
+- `TypeError` {{domxref("DOMException")}}
   - : Thrown if the `layers` option contains duplicate instances.
 
 ## Examples

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
@@ -36,11 +36,8 @@ A newly-created {{domxref("XRWebGLBinding")}}.
 
 ### Exceptions
 
-- `InvalidStateError`
-
-  - : The new `XRWebGLBinding` could not be created due to one of a number of
-    possible state errors:
-
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the new `XRWebGLBinding` could not be created due to one of the following situations:
     - The {{domxref("XRSession")}} specified by `session` has already been
       stopped.
     - The specified WebGL context, `context`, [has


### PR DESCRIPTION
#### Summary
Fixes for #9456 to make the format of DOM Exceptions consistent.

Updated the following files:

1. - [x] files/en-us/web/api/xrsession/requestlightprobe/index.md
2. - [x] files/en-us/web/api/xrsession/updaterenderstate/index.md
3. - [x] files/en-us/web/api/mediarecorder/pause/index.md (plus removed contractions like 'can't' and 'it's' and replaced pronouns)
4. - [x] files/en-us/web/api/mediarecorder/start/index.md (plus minor edits)
5. - [x] files/en-us/web/api/audioencoder/encode/index.md
6. - [x] files/en-us/web/api/audioencoder/flush/index.md (plus minor edit)
7. - [x] files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
8. - [x] [files/en-us/web/api/idbdatabase/transaction/index.md](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/transaction) (minor typo fix, it was already in the required format)
9. - [x] files/en-us/web/api/idbdatabase/createobjectstore/index.md  (plus minor edits)
I have converted the Exceptions table to list. In the 'InvalidStateError', there is a link:  {{APIRef("IDBVersionChangeRequest.setVersion")}}. However, the page https://developer.mozilla.org/en-US/docs/Web/API/IDBVersionChangeRequest does not exist. How does this need to be fixed?

#### Questions
- [files/en-us/web/api/mediarecorder/onerror/index.md](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/onerror)
Should the 'Value' section be changed to 'Exceptions' and the errors listed be formatted as DOM Exceptions?
- [files/en-us/web/api/paymentrequest/show/index.md](https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show)
In the 'Exceptions' section, should 'Returned' (for all exception descriptions) be updated to 'Thrown' to maintain consistency?
- [files/en-us/web/api/idbrequest/index.md](https://developer.mozilla.org/en-US/docs/Web/API/IDBRequest)
There is no 'Exceptions' section here. Are there any other changes required? 
- [files/en-us/web/api/idbrequest/error/index.md](https://developer.mozilla.org/en-US/docs/Web/API/IDBRequest/error)
There is no 'Exceptions' section here. Should the 'Value' section be changed to 'Exceptions', the table updated to list, and the errors be formatted as DOM Exceptions?
- [files/en-us/web/api/idbrequest/result/index.md](https://developer.mozilla.org/en-US/docs/Web/API/IDBRequest/result)
There is no Exceptions section here. Are there any other changes required?

#### Ok As Is

DOM Exceptions in the following files are already in the required format:
- [files/en-us/web/api/audioencoder/configure/index.md](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure)
- [files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md](https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLBinding/getDepthInformation)
- [files/en-us/web/api/idbdatabase/deleteobjectstore/index.md](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/deleteObjectStore)




