### PR TITLE
[Markdown][Add-ons] Deal with tables

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -31,7 +31,7 @@ browser-compat: webextensions.api.runtime.Port
 
 <p>You need to use different connection APIs for different sorts of connections, as detailed in the table below.</p>
 
-<table class="fullwidth-table standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Connection type</th>

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.html
@@ -39,8 +39,15 @@ tags:
  <dt><code>value</code></dt>
  <dd>The value of the setting. The type of this property is determined by the particular setting.</dd>
  <dt><code>levelOfControl</code></dt>
- <dd><code>string</code>. This represents the way the setting is currently controlled. You can use it to check whether you can modify the setting. See <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set">BrowserSetting.set()</a></code> for details. Its value may be any of the following:
- <table class="fullwidth-table standard-table">
+ <dd><p><code>string</code>. This represents the way the setting is currently controlled. You can use it to check whether you can modify the setting. See <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set">BrowserSetting.set()</a></code> for details. Its value may be any of the following:</p>
+
+ <table class="standard-table">
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
   <tbody>
    <tr>
     <td><code>"not_controllable"</code></td>

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
@@ -53,8 +53,14 @@ BrowserSetting.onChange.hasListener(listener)
    <dt><code>value</code></dt>
    <dd>The new value of the setting. The type of this property is determined by the particular setting.</dd>
    <dt><code>levelOfControl</code></dt>
-   <dd><code>string</code>. This represents the way the setting is currently controlled. You can use it to check whether you can modify the setting. See <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set">BrowserSetting.set()</a></code> for details. Its value may be any of the following:
-   <table class="fullwidth-table standard-table">
+   <dd><p><code>string</code>. This represents the way the setting is currently controlled. You can use it to check whether you can modify the setting. See <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set">BrowserSetting.set()</a></code> for details. Its value may be any of the following:</p>
+   <table class="standard-table">
+     <thead>
+       <tr>
+         <th>Value</th>
+         <th>Description</th>
+       </tr>
+     </thead>
     <tbody>
      <tr>
       <td><code>"not_controllable"</code></td>

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
@@ -26,7 +26,7 @@ browser-compat: webextensions.match_patterns.scheme
 
 <p>The <em>scheme</em> component may take one of two forms:</p>
 
-<table class="fullwidth-table standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Form</th>
@@ -49,7 +49,7 @@ browser-compat: webextensions.match_patterns.scheme
 
 <p>The <em>host</em> component may take one of three forms:</p>
 
-<table class="fullwidth-table standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Form</th>
@@ -378,7 +378,7 @@ browser-compat: webextensions.match_patterns.scheme
 
 <h3 id="Invalid_match_patterns">Invalid match patterns</h3>
 
-<table class="fullwidth-table standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Invalid pattern</th>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

This PR is all about tables. Specifically, it includes:
* an analysis of how table conversion went in /Mozilla/Add-ons
* a few fixes to make some tables convertible

The background is that the Markdown syntax for tables is pretty limited (https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#tables), and many of MDN's tables are not convertible to Markdown. So our policy here is basically: convert tables to Markdown when we can, and use HTML otherwise.

In /Mozilla/Add-ons, we have 77 tables, and zero of them get converted to Markdown.  I've checked through all of these, and:

* *Most* of these tables are in the manifest.json section (e.g. https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/author) and these tables are inherently non-convertible.
* Most of the rest are also unconvertible for legit reasons (they have header columns, they contain block elements, they are too wide, ...)

There are a few that would be convertible with a little tweaking,and that's what this PR contains.

We might decide that, given that so few tables are convertible in this section of the docs, it would be better to keep all tables as HTML, and in that case we should just close this PR.