### PR TITLE
Remove notes about TextEncoder previously supporting other encodings

### DIFF
--- a/files/en-us/web/api/textencoder/textencoder/index.md
+++ b/files/en-us/web/api/textencoder/textencoder/index.md
@@ -17,7 +17,7 @@ The **`TextEncoder()`** constructor returns a newly created
 ## Syntax
 
 ```js
-var encoder = new TextEncoder();
+new TextEncoder();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/textencoder/textencoder/index.md
+++ b/files/en-us/web/api/textencoder/textencoder/index.md
@@ -12,31 +12,17 @@ browser-compat: api.TextEncoder.TextEncoder
 {{APIRef("Encoding API")}}
 
 The **`TextEncoder()`** constructor returns a newly created
-utf-8 {{DOMxRef("TextEncoder")}} object.
+{{DOMxRef("TextEncoder")}} object that will generate a byte stream with UTF-8 encoding.
 
 ## Syntax
 
 ```js
-encoder = new TextEncoder();
+var encoder = new TextEncoder();
 ```
 
 ### Parameters
 
-- `TextEncoder()` takes no parameters since Firefox 48 and Chrome 53
-
-> **Note:** Prior to Firefox 48 and Chrome 53, an encoding type label was
-> accepted as a paramer to the `TextEncoder` object, since then both browsers
-> have removed support for any encoder type other than `utf-8`, to match the
-> [spec](https://www.w3.org/TR/encoding/#dom-textencoder). Any type label
-> passed into the `TextEncoder` constructor will now be ignored and a
-> `utf-8` `TextEncoder` will be created.
-
-### Exceptions
-
-- `TextEncoder()` throws no exceptions since Firefox 48 and Chrome 53
-
-> **Note:** Prior to Firefox 48 and Chrome 53 an exception would be thrown
-> for an unknown encoding type.
+None.
 
 ## Specifications
 


### PR DESCRIPTION
Since the modern use of new TextEncoder() also works on older browsers,
there's nothing developers need to do differently.
