### PR TITLE
Missing variable declaration on keydown example.

### DIFF
--- a/files/en-us/web/api/document/keydown_event/index.md
+++ b/files/en-us/web/api/document/keydown_event/index.md
@@ -54,6 +54,8 @@ This example logs the {{domxref("KeyboardEvent.code")}} value whenever you press
 ```
 
 ```js
+const log = document.getElementById('log');
+
 document.addEventListener('keydown', logKey);
 
 function logKey(e) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
In the example provided for the keydown event is missing a variable declaration.
The new code is also present in the example keypress.

#### Motivation
The example is incomplete.

#### Supporting details
keydown -> https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event
keypress -> https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

