### PR TITLE
[DOM Reference] Update EventTarget interface reference

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -15,17 +15,17 @@ Common targets are {{domxref("Element")}}, or its children, {{domxref("Document"
 but the target may be any object that supports events (such as {{domxref("XMLHttpRequest")}}).
 
 > **Warning:** The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
-> - It allows adding more than a single handler for an event. This is particularly
+> - It allows adding more than one handler for an event. This is particularly
 >   useful for libraries, JavaScript modules, or any other kind of
 >   code that needs to work well with other libraries or extensions.
-> - Contrarily to using an `onXYZ` property, it gives you finer-grained control of the phase when the listener is activated (capturing vs. bubbling).
+> - In contrast to using an `onXYZ` property, it gives you finer-grained control of the phase when the listener is activated (capturing vs. bubbling).
 > - It works on any event target, not just HTML or SVG elements.
 
 The method `addEventListener()` works by adding a function, or an object that implements
 {{domxref("EventListener")}}, to the list of event listeners for the specified event type
-on the {{domxref("EventTarget")}} on which it's called. If the function, or the object, are already in the list of event listeners for this target, they are not added a second time.
+on the {{domxref("EventTarget")}} on which it's called. If the function or object, is already in the list of event listeners for this target, they are not added a second time.
 
-They do not need to be removed manually with the {{domxref("EventTarget.removeEventListener", "removeEventListener()")}} method.
+They do not need to be removed manually with {{domxref("EventTarget.removeEventListener", "removeEventListener()")}}.
 
 > **Note:** Two identical anonymous functions are considered as different for `addEventListener` and the second one will _also_ be added to the list of event listener for that target.
 >
@@ -39,7 +39,7 @@ If an event listener is added to an {{domxref("EventTarget")}} from inside anoth
 that is during the processing of the event,
 that event will not trigger the new listener.
 However, the new listener may be triggered during a later stage of event flow,
-such as the bubbling phase.
+such as during the bubbling phase.
 
 ## Syntax
 
@@ -80,7 +80,7 @@ target.addEventListener(type, listener, useCapture);
         generate a console warning.
         See [Improving scrolling performance with passive listeners](#improving_scrolling_performance_with_passive_listeners) to learn more.
     - `signal`
-      - : An {{domxref("AbortSignal")}}. The listener will be removed when the given `AbortSignal`'s {{domxref("AbortController/abort()", "abort()")}} method is called.
+      - : An {{domxref("AbortSignal")}}. The listener will be removed when the given `AbortSignal` object's {{domxref("AbortController/abort()", "abort()")}} method is called.
 
 - `useCapture` {{optional_inline}}
 
@@ -281,7 +281,7 @@ function modifyText() {
 }
 ```
 
-In the above example just above, we modify the code in the previous example such that after the second row's content changes to "three", we call `abort()` from the {{domxref("AbortController")}} we passed to the `addEventListener()` call. That results in the value remaining as "three" forever — because we no longer have any code listening for a click event.
+In the example above, we modify the code in the previous example such that after the second row's content changes to "three", we call `abort()` from the {{domxref("AbortController")}} we passed to the `addEventListener()` call. That results in the value remaining as "three" forever because we no longer have any code listening for a click event.
 
 #### Result
 
@@ -637,7 +637,7 @@ to pass them any data, much less to get any data back from them after they execu
 Event listeners only take one argument,
 the [Event Object](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_objects),
 which is automatically passed to the listener, and the return value is ignored.
-So how can we get data in and back out of them again? There are a number of
+So how can we get data in and back out of them? There are a number of
 good methods for doing this.
 
 #### Getting data into an event listener using "this"

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -2,37 +2,44 @@
 title: EventTarget.addEventListener()
 slug: Web/API/EventTarget/addEventListener
 tags:
-  - API
-  - AccessOuterData
-  - DOM
-  - Detecting Events
-  - Event Handlers
-  - Event Listener
-  - EventTarget
-  - JavaScript
   - Method
-  - PassingData
-  - Receiving Events
   - Reference
-  - addEventListener
-  - attachEvent
-  - events
-  - mselementresize
 browser-compat: api.EventTarget.addEventListener
 ---
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
-The {{domxref("EventTarget")}} method
-**`addEventListener()`** sets up a function that will be
-called whenever the specified event is delivered to the target.
+The **`addEventListener()`** method of the {{domxref("EventTarget")}} interface
+sets up a function that will be called whenever the specified event is delivered to the target.
 
-Common targets
-are {{domxref("Element")}}, {{domxref("Document")}}, and {{domxref("Window")}}, but the
-target may be any object that supports events (such as {{domxref("XMLHttpRequest")}}).
+Common targets are {{domxref("Element")}}, or its children, {{domxref("Document")}}, and {{domxref("Window")}},
+but the target may be any object that supports events (such as {{domxref("XMLHttpRequest")}}).
 
-`addEventListener()` works by adding a function or an object that implements
-{{domxref("EventListener")}} to the list of event listeners for the specified event type
-on the {{domxref("EventTarget")}} on which it's called.
+> **Warning:** The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
+> - It allows adding more than a single handler for an event. This is particularly
+>   useful for libraries, JavaScript modules, or any other kind of
+>   code that needs to work well with other libraries or extensions.
+> - Contrarily to using an `onXYZ` property, it gives you finer-grained control of the phase when the listener is activated (capturing vs. bubbling).
+> - It works on any event target, not just HTML or SVG elements.
+
+The method `addEventListener()` works by adding a function, or an object that implements
+{{domxref("EventListener")}}, to the list of event listeners for the specified event type
+on the {{domxref("EventTarget")}} on which it's called. If the function, or the object, are already in the list of event listeners for this target, they are not added a second time.
+
+They do not need to be removed manually with the {{domxref("EventTarget.removeEventListener", "removeEventListener()")}} method.
+
+> **Note:** Two identical anonymous functions are considered as different for `addEventListener` and the second one will _also_ be added to the list of event listener for that target.
+>
+> Indeed, anonymous functions are not identical even if defined using
+> the _same_ unchanging source-code called repeatedly, **even if in a loop**.
+>
+> Repeatedly defining the same unnamed function in such cases can be
+> problematic. (See [Memory issues](#memory_issues), below.)
+
+If an event listener is added to an {{domxref("EventTarget")}} from inside another listener,
+that is during the processing of the event,
+that event will not trigger the new listener.
+However, the new listener may be triggered during a later stage of event flow,
+such as the bubbling phase.
 
 ## Syntax
 
@@ -40,14 +47,12 @@ on the {{domxref("EventTarget")}} on which it's called.
 target.addEventListener(type, listener);
 target.addEventListener(type, listener, options);
 target.addEventListener(type, listener, useCapture);
-target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUntrusted is Firefox only
 ```
 
 ### Parameters
 
 - `type`
-  - : A case-sensitive string representing the [event
-    type](/en-US/docs/Web/Events) to listen for.
+  - : A case-sensitive string representing the [event type](/en-US/docs/Web/Events) to listen for.
 - `listener`
   - : The object that receives a notification (an object that implements the
     {{domxref("Event")}} interface) when an event of the specified type occurs. This must
@@ -56,7 +61,7 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
     {{anch("The event listener callback")}} for details on the callback itself.
 - `options` {{optional_inline}}
 
-  - : An options object specifies characteristics about the event listener. The available
+  - : An object that specifies characteristics about the event listener. The available
     options are:
 
     - `capture`
@@ -68,18 +73,14 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
         should be invoked at most once after being added. If `true`, the
         `listener` would be automatically removed when invoked.
     - `passive`
-      - : A boolean value that, if `true`, indicates that the function
+      - : A boolean value that, if `true`, indicates that the function
         specified by `listener` will never call
         {{domxref("Event.preventDefault", "preventDefault()")}}. If a passive listener
         does call `preventDefault()`, the user agent will do nothing other than
-        generate a console warning. See [Improving scrolling performance with
-        passive listeners](#improving_scrolling_performance_with_passive_listeners) to learn more.
+        generate a console warning.
+        See [Improving scrolling performance with passive listeners](#improving_scrolling_performance_with_passive_listeners) to learn more.
     - `signal`
-      - : An {{domxref("AbortSignal")}}. The listener will be removed when the given `AbortSignal`’s {{domxref("AbortController/abort()", "abort()")}} method is called.
-    - `mozSystemGroup` {{non-standard_inline}}
-      - : A boolean value indicating that the listener should be added to the
-        system group. Available only in code running in XBL or in the
-        {{glossary("chrome")}} of the Firefox browser.
+      - : An {{domxref("AbortSignal")}}. The listener will be removed when the given `AbortSignal`'s {{domxref("AbortController/abort()", "abort()")}} method is called.
 
 - `useCapture` {{optional_inline}}
 
@@ -90,14 +91,11 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
     bubbling and capturing are two ways of propagating events that occur in an element
     that is nested within another element, when both elements have registered a handle for
     that event. The event propagation mode determines the order in which elements receive
-    the event. See [DOM
-    Level 3 Events](https://www.w3.org/TR/DOM-Level-3-Events/#event-flow) and [JavaScript Event
-    order](https://www.quirksmode.org/js/events_order.html#link4) for a detailed explanation. If not specified,
-    `useCapture` defaults to `false`.
+    the event. See [DOM Level 3 Events](https://www.w3.org/TR/DOM-Level-3-Events/#event-flow) and [JavaScript Event order](https://www.quirksmode.org/js/events_order.html#link4) for a detailed explanation.
+    If not specified, `useCapture` defaults to `false`.
 
-    > **Note:** For event listeners attached to the event target, the event is in the target phase,
-    > rather than the capturing and bubbling phases.
-    > Event listeners in the “capturing” phase are called before event listeners in any non-capturing phases.
+    > **Note:** For event listeners attached to the event target, the event is in the target phase, rather than the capturing and bubbling phases.
+    > Event listeners in the _capturing_ phase are called before event listeners in any non-capturing phases.
 
 - `wantsUntrusted` {{optional_inline}} {{Non-standard_inline}}
   - : A Firefox (Gecko)-specific parameter. If `true`, the listener receives
@@ -107,15 +105,15 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
 
 ### Return value
 
-`undefined`
+None.
 
 ## Usage notes
 
 ### The event listener callback
 
-The event listener can be specified as either a callback function or an object that
-implements {{domxref("EventListener")}}, whose {{domxref("EventListener.handleEvent()",
-  "handleEvent()")}} method serves as the callback function.
+The event listener can be specified as either a callback function or
+an object that implements {{domxref("EventListener")}},
+whose {{domxref("EventListener.handleEvent()", "handleEvent()")}} method serves as the callback function.
 
 The callback function itself has the same parameters and return value as the
 `handleEvent()` method; that is, the callback accepts a single parameter: an
@@ -206,8 +204,7 @@ If you'd prefer, you can use a third-party library like [Modernizr](https://mode
 
 You can learn more from the article about
 [`EventListenerOptions`](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection)
-from the [Web Incubator Community
-Group](https://wicg.github.io/admin/charter.html).
+from the [Web Incubator Community Group](https://wicg.github.io/admin/charter.html).
 
 ## Examples
 
@@ -284,7 +281,7 @@ function modifyText() {
 }
 ```
 
-In the above example just above, we modify the code in the previous example such that after the second row’s content changes to "three", we call `abort()` from the {{domxref("AbortController")}} we passed to the `addEventListener()` call. That results in the value remaining as "three" forever — because we no longer have any code listening for a click event.
+In the above example just above, we modify the code in the previous example such that after the second row's content changes to "three", we call `abort()` from the {{domxref("AbortController")}} we passed to the `addEventListener()` call. That results in the value remaining as "three" forever — because we no longer have any code listening for a click event.
 
 #### Result
 
@@ -484,43 +481,6 @@ that not all browsers have supported historically. See {{anch("Safely detecting 
 
 ## Other notes
 
-### Why use addEventListener()?
-
-`addEventListener()` is the way to register an event listener as specified
-in W3C DOM. The benefits are as follows:
-
-- It allows adding more than a single handler for an event. This is particularly
-  useful for {{Glossary("AJAX")}} libraries, JavaScript modules, or any other kind of
-  code that needs to work well with other libraries/extensions.
-- It gives you finer-grained control of the phase when the listener is activated
-  (capturing vs. bubbling).
-- It works on any DOM element, not just HTML elements.
-
-The alternative, [older way to register
-event listeners](#older_way_to_register_event_listeners), is described below.
-
-### Adding a listener during event dispatch
-
-If an {{domxref("EventListener")}} is added to an {{domxref("EventTarget")}} while it
-is processing an event, that event does not trigger the listener. However, that same
-listener may be triggered during a later stage of event flow, such as the bubbling
-phase.
-
-### Multiple identical event listeners
-
-If multiple identical `EventListener`s are registered on the same
-`EventTarget` with the same parameters, the duplicate instances are
-discarded. They do not cause the `EventListener` to be called twice, and they
-do not need to be removed manually with the
-{{domxref("EventTarget.removeEventListener()", "removeEventListener()")}} method.
-
-Note, however that when using an anonymous function as the handler, such listeners will
-NOT be identical, because anonymous functions are not identical even if defined using
-the SAME unchanging source-code called repeatedly, even if in a loop.
-
-However, repeatedly defining the same named function in such cases can be more
-problematic. (See [Memory issues](#memory_issues), below.)
-
 ### The value of "this" within the handler
 
 It is often desirable to reference the element on which the event handler was fired,
@@ -674,9 +634,10 @@ myObject.register();
 
 It may seem that event listeners are like islands, and that it is extremely difficult
 to pass them any data, much less to get any data back from them after they execute.
-Event listeners only take one argument, the [Event
-Object](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_objects), which is automatically passed to the listener, and the return value is
-ignored. So how can we get data in and back out of them again? There are a number of
+Event listeners only take one argument,
+the [Event Object](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_objects),
+which is automatically passed to the listener, and the return value is ignored.
+So how can we get data in and back out of them again? There are a number of
 good methods for doing this.
 
 #### Getting data into an event listener using "this"
@@ -690,7 +651,7 @@ const myButton = document.getElementById('my-button-id');
 const someString = 'Data';
 
 myButton.addEventListener('click', function () {
-  console.log(this);  // Expected Value: 'Data'
+  console.log(this); // Expected Value: 'Data'
 }.bind(someString));
 ```
 
@@ -730,7 +691,7 @@ console.log(someString);  // Expected Value: 'Data' (will never output 'Data Aga
 
 #### Getting data into and out of an event listener using objects
 
-Unlike most functions in JavaScript, objects are retained in memory as long as a
+Unlike most functions in JavaScript, objects are retained in memory as long as a
 variable referencing them exists in memory. This, and the fact that objects can have
 properties, and that they can be passed around by reference, makes them likely
 candidates for sharing data among scopes. Let's explore this.
@@ -779,143 +740,6 @@ can respond to the change).
 > **Note:** Because objects are stored in variables by reference, you can
 > return an object from a function to keep it alive (preserve it in memory so you don't
 > lose the data) after that function stops executing.
-
-### Legacy Internet Explorer and attachEvent
-
-In Internet Explorer versions before IE 9, you have to use
-`attachEvent()`, rather than the standard
-`addEventListener()`. For IE, we modify the preceding example to:
-
-```js
-if (el.addEventListener) {
-  el.addEventListener('click', modifyText, false);
-} else if (el.attachEvent)  {
-  el.attachEvent('onclick', modifyText);
-}
-```
-
-There is a drawback to `attachEvent()`: The value of `this` will
-be a reference to the `window` object, instead of the element on which it was
-fired.
-
-The `attachEvent()` method could be paired with the `onresize`
-event to detect when certain elements in a web page were resized. The proprietary
-`mselementresize` event, when paired with the `addEventListener`
-method of registering event handlers, provides similar functionality as
-`onresize`, firing when certain HTML elements are resized.
-
-### Polyfill
-
-You can work around `addEventListener()`,
-`removeEventListener()`, {{domxref("Event.preventDefault()")}}, and
-{{domxref("Event.stopPropagation()")}} not being supported by Internet Explorer 8 by
-using the following code at the beginning of your script. The code supports the use of
-`handleEvent()` and also the {{event("DOMContentLoaded")}} event.
-
-> **Note:** `useCapture` is not supported, as IE 8 does not
-> have any alternative method. The following code only adds IE 8 support. This IE 8
-> polyfill only works in standards mode: a doctype declaration is required.
-
-```js
-(function() {
-  if (!Event.prototype.preventDefault) {
-    Event.prototype.preventDefault=function() {
-      this.returnValue=false;
-    };
-  }
-  if (!Event.prototype.stopPropagation) {
-    Event.prototype.stopPropagation=function() {
-      this.cancelBubble=true;
-    };
-  }
-  if (!Element.prototype.addEventListener) {
-    var eventListeners=[];
-
-    var addEventListener=function(type,listener /*, useCapture (will be ignored) */) {
-      var self=this;
-      var wrapper=function(e) {
-        e.target=e.srcElement;
-        e.currentTarget=self;
-        if (typeof listener.handleEvent != 'undefined') {
-          listener.handleEvent(e);
-        } else {
-          listener.call(self,e);
-        }
-      };
-      if (type=="DOMContentLoaded") {
-        var wrapper2=function(e) {
-          if (document.readyState=="complete") {
-            wrapper(e);
-          }
-        };
-        document.attachEvent("onreadystatechange",wrapper2);
-        eventListeners.push({object:this,type:type,listener:listener,wrapper:wrapper2});
-
-        if (document.readyState=="complete") {
-          var e=new Event();
-          e.srcElement=window;
-          wrapper2(e);
-        }
-      } else {
-        this.attachEvent("on"+type,wrapper);
-        eventListeners.push({object:this,type:type,listener:listener,wrapper:wrapper});
-      }
-    };
-    var removeEventListener=function(type,listener /*, useCapture (will be ignored) */) {
-      var counter=0;
-      while (counter<eventListeners.length) {
-        var eventListener=eventListeners[counter];
-        if (eventListener.object==this && eventListener.type==type && eventListener.listener==listener) {
-          if (type=="DOMContentLoaded") {
-            this.detachEvent("onreadystatechange",eventListener.wrapper);
-          } else {
-            this.detachEvent("on"+type,eventListener.wrapper);
-          }
-          eventListeners.splice(counter, 1);
-          break;
-        }
-        ++counter;
-      }
-    };
-    Element.prototype.addEventListener=addEventListener;
-    Element.prototype.removeEventListener=removeEventListener;
-    if (HTMLDocument) {
-      HTMLDocument.prototype.addEventListener=addEventListener;
-      HTMLDocument.prototype.removeEventListener=removeEventListener;
-    }
-    if (Window) {
-      Window.prototype.addEventListener=addEventListener;
-      Window.prototype.removeEventListener=removeEventListener;
-    }
-  }
-})();
-```
-
-### Older way to register event listeners
-
-`addEventListener()` was introduced with the DOM 2 [Events](https://www.w3.org/TR/DOM-Level-2-Events) specification. Before then,
-event listeners were registered as follows:
-
-```js
-// Passing a function reference — do not add '()' after it, which would call the function!
-el.onclick = modifyText;
-
-// Using a function expression
-element.onclick = function() {
-  // ... function logic ...
-};
-```
-
-This method replaces the existing `click` event listener(s) on the element
-if there are any. Other events and associated event handlers such as `blur`
-(`onblur`) and `keypress` (`onkeypress`) behave
-similarly.
-
-Because it was essentially part of {{glossary("DOM", "DOM 0")}}, this technique for
-adding event listeners is very widely supported and requires no special cross-browser
-code. It is used to register event listeners dynamically when very old browsers (like IE
-<=8) must be supported; see the table below for details on browser support for
-`addEventListener`.
 
 ### Memory issues
 

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -2,63 +2,51 @@
 title: EventTarget.dispatchEvent()
 slug: Web/API/EventTarget/dispatchEvent
 tags:
-  - API
-  - DOM
-  - DOM Element Methods
-  - Gecko
   - Method
+  - Reference
 browser-compat: api.EventTarget.dispatchEvent
 ---
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
-Dispatches an {{domxref("Event")}} at the specified
-{{domxref("EventTarget")}}, (synchronously) invoking the affected
+The **`dispatchEvent()`** method of the {{domxref("EventTarget")}} actually send an {{domxref("Event")}} at the object, (synchronously) invoking the affected
 {{domxref("EventListener")}}s in the appropriate order. The normal event processing
 rules (including the capturing and optional bubbling phase) also apply to events
 dispatched manually with `dispatchEvent()`.
 
+Calling the `dispatchEvent()` method is the last step to _fire an event_. The event
+should have already been created and initialized using an [Event constructor](/en-US/docs/Web/API/Event/Event).
+
+> **Note:** When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
+
+Unlike "native" events, which are fired by the browser and invoke event handlers
+asynchronously via the [event loop](/en-US/docs/Web/JavaScript/EventLoop),
+`dispatchEvent()` invokes event handlers _synchronously_. All applicable event
+handlers will execute and return before the code continues on after the call to
+`dispatchEvent()`.
+
 ## Syntax
 
 ```js
-cancelled = !target.dispatchEvent(event)
+cancelled = target.dispatchEvent(event)
 ```
 
 ### Parameter
 
-- `event` is the {{domxref("Event")}} object to be dispatched.
-- `target` is used to initialize the {{domxref("Event.target")}}
-  and determine which event listeners to invoke.
+- `event` is the {{domxref("Event")}} object to be dispatched. Its {{domxref("Event.target")}} property will be set to the current object.
 
-### Return Value
+### Return value
 
-- The return value is `false` if `event` is
-  cancelable and at least one of the event handlers which received
-  `event` called {{domxref("Event.preventDefault()")}}. Otherwise
-  it returns `true`.
-
-The `dispatchEvent()` method throws `UNSPECIFIED_EVENT_TYPE_ERR`
-if the event's type was not specified by initializing the event before the method was
-called, or if the event's type is `null` or an empty string.
+- The return value is `false` if `event` is cancelable and at least one of the event handlers which received `event` called {{domxref("Event.preventDefault()")}}.
+  Otherwise it returns `true`.
 
 ### Exceptions
 
-Exceptions thrown by event handlers are reported as uncaught exceptions. The event
-handlers run on a nested callstack; they block the caller until they complete, but
-exceptions do not propagate to the caller.
+- `InvalidStateError` {{domxref("DomException")}}
+  - : Thrown if the event's type was not specified by initializing the event before the method was called.
 
-## Notes
-
-Unlike "native" events, which are fired by the DOM and invoke event handlers
-asynchronously via the [event loop](/en-US/docs/Web/JavaScript/EventLoop),
-`dispatchEvent()` invokes event handlers synchronously. All applicable event
-handlers will execute and return before the code continues on after the call to
-`dispatchEvent()`.
-
-`dispatchEvent()` is the last step of the create-init-dispatch process,
-which is used for dispatching events into the implementation's event model. The event
-can be created using [Event constructor](/en-US/docs/Web/API/Event/Event).
-
-See also the [Event object reference](/en-US/docs/Web/API/Event).
+> **Warning:** Exceptions thrown by event handlers are reported as uncaught exceptions. The event
+> handlers run on a nested callstack; they block the caller until they complete, but
+> exceptions do not propagate to the caller.
 
 ## Example
 
@@ -71,3 +59,7 @@ See [Creating and triggering events](/en-US/docs/Web/Events/Creating_and_trigger
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- The [Event object reference](/en-US/docs/Web/API/Event)

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -8,12 +8,12 @@ browser-compat: api.EventTarget.dispatchEvent
 ---
 {{APIRef("DOM")}}
 
-The **`dispatchEvent()`** method of the {{domxref("EventTarget")}} actually send an {{domxref("Event")}} at the object, (synchronously) invoking the affected
+The **`dispatchEvent()`** method of the {{domxref("EventTarget")}} sends an {{domxref("Event")}} to the object, (synchronously) invoking the affected
 {{domxref("EventListener")}}s in the appropriate order. The normal event processing
 rules (including the capturing and optional bubbling phase) also apply to events
 dispatched manually with `dispatchEvent()`.
 
-Calling the `dispatchEvent()` method is the last step to _fire an event_. The event
+Calling `dispatchEvent()` is the last step to _firing an event_. The event
 should have already been created and initialized using an [Event constructor](/en-US/docs/Web/API/Event/Event).
 
 > **Note:** When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
@@ -42,7 +42,7 @@ cancelled = target.dispatchEvent(event)
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DomException")}}
-  - : Thrown if the event's type was not specified by initializing the event before the method was called.
+  - : Thrown if the event's type was not specified during event initialization.
 
 > **Warning:** Exceptions thrown by event handlers are reported as uncaught exceptions. The event
 > handlers run on a nested callstack; they block the caller until they complete, but

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -21,8 +21,7 @@ should have already been created and initialized using an [Event constructor](/e
 Unlike "native" events, which are fired by the browser and invoke event handlers
 asynchronously via the [event loop](/en-US/docs/Web/JavaScript/EventLoop),
 `dispatchEvent()` invokes event handlers _synchronously_. All applicable event
-handlers will execute and return before the code continues on after the call to
-`dispatchEvent()`.
+handlers are called and return before `dispatchEvent()` returns.
 
 ## Syntax
 

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -27,7 +27,7 @@ handlers will execute and return before the code continues on after the call to
 ## Syntax
 
 ```js
-cancelled = target.dispatchEvent(event)
+target.dispatchEvent(event)
 ```
 
 ### Parameter

--- a/files/en-us/web/api/eventtarget/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.md
@@ -2,22 +2,20 @@
 title: EventTarget()
 slug: Web/API/EventTarget/EventTarget
 tags:
-  - API
   - Constructor
-  - DOM
-  - DOM Events
-  - EventTarget
+  - Reference
 browser-compat: api.EventTarget.EventTarget
 ---
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
-The **`EventTarget()`** constructor creates a new
-{{domxref("EventTarget")}} object instance.
+The **`EventTarget()`** constructor creates a new {{domxref("EventTarget")}} object instance.
+
+> **Note:** It is fairly rare to explicitely call this constructor. Most of the time, this constructor is used inside the constructor of an object extending the {{domxref("EventTarget")}} interface, using the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super") keyword.
 
 ## Syntax
 
 ```js
-var myEventTarget = new EventTarget();
+new EventTarget();
 ```
 
 ### Parameters
@@ -26,14 +24,14 @@ None.
 
 ### Return value
 
-An instance of the {{domxref("EventTarget")}} object.
+An newly-created instance of the {{domxref("EventTarget")}} object.
 
 ## Examples
 
 ```js
 class MyEventTarget extends EventTarget {
   constructor(mySecret) {
-    super();
+    super();
     this._secret = mySecret;
   }
 

--- a/files/en-us/web/api/eventtarget/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.md
@@ -10,7 +10,7 @@ browser-compat: api.EventTarget.EventTarget
 
 The **`EventTarget()`** constructor creates a new {{domxref("EventTarget")}} object instance.
 
-> **Note:** It is fairly rare to explicitely call this constructor. Most of the time, this constructor is used inside the constructor of an object extending the {{domxref("EventTarget")}} interface, using the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super") keyword.
+> **Note:** It is fairly rare to explicitely call this constructor. Most of the time, this constructor is used inside the constructor of an object extending the {{domxref("EventTarget")}} interface, using the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) keyword.
 
 ## Syntax
 

--- a/files/en-us/web/api/eventtarget/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.md
@@ -24,7 +24,7 @@ None.
 
 ### Return value
 
-An newly-created instance of the {{domxref("EventTarget")}} object.
+A new instance of the {{domxref("EventTarget")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/index.md
@@ -2,18 +2,18 @@
 title: EventTarget
 slug: Web/API/EventTarget
 tags:
-  - API
-  - DOM
-  - DOM Events
-  - EventTarget
   - Interface
+  - Reference
 browser-compat: api.EventTarget
 ---
-{{ApiRef("DOM Events")}}
+{{ApiRef("DOM")}}
 
-**`EventTarget`** is a DOM interface implemented by objects that can receive events and may have listeners for them.
+The **`EventTarget`** interface is implemented by objects that can receive events and may have listeners for them.
+ In other words, any target of events implements the 3 methods associated with this interface.
 
-{{domxref("Element")}}, {{domxref("Document")}}, and {{domxref("Window")}} are the most common event targets, but other objects can be event targets, too. For example {{domxref("XMLHttpRequest")}}, {{domxref("AudioNode")}}, {{domxref("AudioContext")}}, and others.
+{{domxref("Element")}}, and its children, as well as {{domxref("Document")}} and {{domxref("Window")}}, are the most common event targets,
+but other objects can be event targets, too.
+For example {{domxref("XMLHttpRequest")}}, {{domxref("AudioNode")}}, {{domxref("AudioContext")}} are also event targets.
 
 Many event targets (including elements, documents, and windows) also support setting [event handlers](/en-US/docs/Web/Events/Event_handlers) via `onevent` properties and attributes.
 
@@ -26,55 +26,12 @@ Many event targets (including elements, documents, and windows) also support set
 
 ## Methods
 
-- {{domxref("EventTarget.addEventListener()", "<var>EventTarget</var>.addEventListener()")}}
+- {{domxref("EventTarget.addEventListener()")}}
   - : Registers an event handler of a specific event type on the `EventTarget`.
-- {{domxref("EventTarget.removeEventListener()", "<var>EventTarget</var>.removeEventListener()")}}
+- {{domxref("EventTarget.removeEventListener()")}}
   - : Removes an event listener from the `EventTarget`.
-- {{domxref("EventTarget.dispatchEvent()", "<var>EventTarget</var>.dispatchEvent()")}}
+- {{domxref("EventTarget.dispatchEvent()")}}
   - : Dispatches an event to this `EventTarget`.
-
-## Example
-
-### Simple implementation of EventTarget
-
-```js
-var EventTarget = function() {
-  this.listeners = {};
-};
-
-EventTarget.prototype.listeners = null;
-EventTarget.prototype.addEventListener = function(type, callback) {
-  if (!(type in this.listeners)) {
-    this.listeners[type] = [];
-  }
-  this.listeners[type].push(callback);
-};
-
-EventTarget.prototype.removeEventListener = function(type, callback) {
-  if (!(type in this.listeners)) {
-    return;
-  }
-  var stack = this.listeners[type];
-  for (var i = 0, l = stack.length; i < l; i++) {
-    if (stack[i] === callback){
-      stack.splice(i, 1);
-      return;
-    }
-  }
-};
-
-EventTarget.prototype.dispatchEvent = function(event) {
-  if (!(event.type in this.listeners)) {
-    return true;
-  }
-  var stack = this.listeners[event.type].slice();
-
-  for (var i = 0, l = stack.length; i < l; i++) {
-    stack[i].call(this, event);
-  }
-  return !event.defaultPrevented;
-};
-```
 
 ## Specifications
 
@@ -86,6 +43,6 @@ EventTarget.prototype.dispatchEvent = function(event) {
 
 ## See also
 
-- [Event reference](/en-US/docs/Web/Events) - the events available in the platform.
+- [Event reference](/en-US/docs/Web/Events) – the events available in the platform.
 - [Introduction to events](/en-US/docs/Learn/JavaScript/Building_blocks/Events)
 - {{domxref("Event")}} interface

--- a/files/en-us/web/api/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/index.md
@@ -9,11 +9,11 @@ browser-compat: api.EventTarget
 {{ApiRef("DOM")}}
 
 The **`EventTarget`** interface is implemented by objects that can receive events and may have listeners for them.
- In other words, any target of events implements the 3 methods associated with this interface.
+ In other words, any target of events implements the three methods associated with this interface.
 
 {{domxref("Element")}}, and its children, as well as {{domxref("Document")}} and {{domxref("Window")}}, are the most common event targets,
 but other objects can be event targets, too.
-For example {{domxref("XMLHttpRequest")}}, {{domxref("AudioNode")}}, {{domxref("AudioContext")}} are also event targets.
+For example {{domxref("XMLHttpRequest")}}, {{domxref("AudioNode")}}, and {{domxref("AudioContext")}} are also event targets.
 
 Many event targets (including elements, documents, and windows) also support setting [event handlers](/en-US/docs/Web/Events/Event_handlers) via `onevent` properties and attributes.
 

--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.md
@@ -2,34 +2,38 @@
 title: EventTarget.removeEventListener()
 slug: Web/API/EventTarget/removeEventListener
 tags:
-  - API
-  - DOM
-  - DOM Element Methods
-  - EventTarget
-  - Gecko
   - Method
   - Reference
-  - browser compatibility
-  - removeEventListener
 browser-compat: api.EventTarget.removeEventListener
 ---
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
-The
-**`EventTarget.removeEventListener()`** method removes from
-the {{domxref("EventTarget")}} an event listener previously registered with
-{{domxref("EventTarget.addEventListener()")}}. The event listener to be removed is
-identified using a combination of the event type, the event listener function itself,
-and various optional options that may affect the matching process; see
-{{anch("Matching event listeners for removal")}}
+The **`removeEventListener()`** method of the {{domxref("EventTarget")}} interface
+removes from the target an event listener previously registered with {{domxref("EventTarget.addEventListener()")}}.
+The event listener to be removed is identified using a combination of the event type,
+the event listener function itself, and various optional options that may affect the matching process;
+see {{anch("Matching event listeners for removal")}}.
 
-Note that event listeners can also be removed by passing an {{domxref("AbortSignal")}} to an {{domxref("EventTarget/addEventListener()", "addEventListener()")}} and then later calling {{domxref("AbortController/abort()", "abort()")}} on the controller owning the signal.
+Calling `removeEventListener()` with arguments that do not identify any
+currently registered {{domxref("EventListener")}} on the `EventTarget` has no
+effect.
+
+If an {{domxref("EventListener")}} is removed from an {{domxref("EventTarget")}} while
+it is processing an event, it will not be triggered by the current actions. An
+{{domxref("EventListener")}} will not be invoked for the event it was registered for
+after being removed. However, it can be reattached.
+
+> **Warning:** If a listener is registered twice, one with the _capture_ flag set and one without, you must remove each one separately.
+  > Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.
+
+Event listeners can also be removed by passing an {{domxref("AbortSignal")}} to an {{domxref("EventTarget/addEventListener()", "addEventListener()")}} and then later calling {{domxref("AbortController/abort()", "abort()")}} on the controller owning the signal.
 
 ## Syntax
 
 ```js
-target.removeEventListener(type, listener[, options]);
-target.removeEventListener(type, listener[, useCapture]);
+target.removeEventListener(type, listener);
+target.removeEventListener(type, listener, options);
+target.removeEventListener(type, listener, useCapture);
 ```
 
 ### Parameters
@@ -45,27 +49,20 @@ target.removeEventListener(type, listener[, useCapture]);
 
     The available options are:
 
-    - `capture`: A boolean value which indicates that
+    - `capture`: A boolean value which indicates that
       events of this type will be dispatched to the registered
-      `listener` before being dispatched to any
+      `listener` before being dispatched to any
       {{domxref("EventTarget")}} beneath it in the DOM tree.
-    - {{non-standard_inline}} `mozSystemGroup`: A
-      boolean value available only for code running in XBL or in Firefox's
-      chrome which indicates if the listener will be added to the system group.
 
 - `useCapture` {{optional_inline}}
 
-  - : Specifies whether the {{domxref("EventListener")}} to be removed is registered as a
+  - : A boolean value that specifies whether the {{domxref("EventListener")}} to be removed is registered as a
     capturing listener or not. If this parameter is absent, a default value of
     `false` is assumed.
 
-    If a listener is registered twice, one with capture and one without, you must remove
-    each one separately. Removal of a capturing listener does not affect a non-capturing
-    version of the same listener, and vice versa.
-
 ### Return value
 
-{{jsxref("undefined")}}
+None.
 
 ### Matching event listeners for removal
 
@@ -128,17 +125,6 @@ you have specific reasons otherwise, it's probably wise to use the same values u
 the call to `addEventListener()` when calling
 `removeEventListener()`.
 
-## Notes
-
-If an {{domxref("EventListener")}} is removed from an {{domxref("EventTarget")}} while
-it is processing an event, it will not be triggered by the current actions. An
-{{domxref("EventListener")}} will not be invoked for the event it was registered for
-after being removed. However, it can be reattached.
-
-Calling `removeEventListener()` with arguments that do not identify any
-currently registered {{domxref("EventListener")}} on the `EventTarget` has no
-effect.
-
 ## Example
 
 This example shows how to add a `mouseover`-based event listener that
@@ -151,25 +137,25 @@ const mouseOverTarget = document.getElementById('mouse-over-target')
 
 let toggle = false;
 function makeBackgroundYellow() {
-    if (toggle) {
-        body.style.backgroundColor = 'white';
-    } else {
-        body.style.backgroundColor = 'yellow';
-    }
+    if (toggle) {
+        body.style.backgroundColor = 'white';
+    } else {
+        body.style.backgroundColor = 'yellow';
+    }
 
-    toggle = !toggle;
+    toggle = !toggle;
 }
 
 clickTarget.addEventListener('click',
-    makeBackgroundYellow,
-    false
+    makeBackgroundYellow,
+    false
 );
 
 mouseOverTarget.addEventListener('mouseover', function () {
-    clickTarget.removeEventListener('click',
-        makeBackgroundYellow,
-        false
-    );
+    clickTarget.removeEventListener('click',
+        makeBackgroundYellow,
+        false
+    );
 });
 ```
 
@@ -180,67 +166,6 @@ mouseOverTarget.addEventListener('mouseover', function () {
 ## Browser compatibility
 
 {{Compat}}
-
-## Polyfill to support older browsers
-
-`addEventListener()` and `removeEventListener()` are not present
-in older browsers. You can work around this by inserting the following code at the
-beginning of your scripts, allowing the use of `addEventListener()` and
-`removeEventListener()` in implementations that do not natively support it.
-However, this method will not work on Internet Explorer 7 or earlier, since extending
-the `Element.prototype` was not supported until Internet Explorer 8.
-
-```js
-if (!Element.prototype.addEventListener) {
-  var oListeners = {};
-  function runListeners(oEvent) {
-    if (!oEvent) { oEvent = window.event; }
-    for (var iLstId = 0, iElId = 0, oEvtListeners = oListeners[oEvent.type]; iElId < oEvtListeners.aEls.length; iElId++) {
-      if (oEvtListeners.aEls[iElId] === this) {
-        for (iLstId; iLstId < oEvtListeners.aEvts[iElId].length; iLstId++) { oEvtListeners.aEvts[iElId][iLstId].call(this, oEvent); }
-        break;
-      }
-    }
-  }
-  Element.prototype.addEventListener = function (sEventType, fListener /*, useCapture (will be ignored!) */) {
-    if (oListeners.hasOwnProperty(sEventType)) {
-      var oEvtListeners = oListeners[sEventType];
-      for (var nElIdx = -1, iElId = 0; iElId < oEvtListeners.aEls.length; iElId++) {
-        if (oEvtListeners.aEls[iElId] === this) { nElIdx = iElId; break; }
-      }
-      if (nElIdx === -1) {
-        oEvtListeners.aEls.push(this);
-        oEvtListeners.aEvts.push([fListener]);
-        this["on" + sEventType] = runListeners;
-      } else {
-        var aElListeners = oEvtListeners.aEvts[nElIdx];
-        if (this["on" + sEventType] !== runListeners) {
-          aElListeners.splice(0);
-          this["on" + sEventType] = runListeners;
-        }
-        for (var iLstId = 0; iLstId < aElListeners.length; iLstId++) {
-          if (aElListeners[iLstId] === fListener) { return; }
-        }
-        aElListeners.push(fListener);
-      }
-    } else {
-      oListeners[sEventType] = { aEls: [this], aEvts: [ [fListener] ] };
-      this["on" + sEventType] = runListeners;
-    }
-  };
-  Element.prototype.removeEventListener = function (sEventType, fListener /*, useCapture (will be ignored!) */) {
-    if (!oListeners.hasOwnProperty(sEventType)) { return; }
-    var oEvtListeners = oListeners[sEventType];
-    for (var nElIdx = -1, iElId = 0; iElId < oEvtListeners.aEls.length; iElId++) {
-      if (oEvtListeners.aEls[iElId] === this) { nElIdx = iElId; break; }
-    }
-    if (nElIdx === -1) { return; }
-    for (var iLstId = 0, aElListeners = oEvtListeners.aEvts[nElIdx]; iLstId < aElListeners.length; iLstId++) {
-      if (aElListeners[iLstId] === fListener) { aElListeners.splice(iLstId, 1); }
-    }
-  };
-}
-```
 
 ## See also
 


### PR DESCRIPTION
This is part of #9740 

This revamps the `EventTarget` interface and its children.

To the reviewers:
- Some parts of `EventTarget.addEventListener()`, the two sections _Usage notes_ and _Other notes_ actually belong to a guide. I kept them and they will be removed in Phase 2, once we deal with the DOM-related articles (I don't want to lose information for the moment) Note that I've moved out of these sections and (put into the introduction the information) I think belongs in the article.
- In `EventTarget.removeEventListener()` I kept the _Matching event listeners for removal_ that is interesting but belongs to a guide. I will move it out in Phase 2 too. 

