### PR TITLE
Updated format for DOM Exceptions

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/start/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.md
@@ -57,11 +57,11 @@ AudioBufferSourceNode.start([when][, offset][, duration]);
 
 ### Exceptions
 
-- `TypeError`
-  - : A negative value was specified for one or more of the three time parameters. Please
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if a negative value was specified for one or more of the three time parameters. Please
     don't attempt to tamper with the laws of temporal physics.
-- `InvalidStateError`
-  - : `start()` has already been called. You can only call this function once
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `start()` has already been called. You can only call this function once
     during the lifetime of an `AudioBufferSourceNode`.
 
 ## Examples

--- a/files/en-us/web/api/audiodecoder/decode/index.md
+++ b/files/en-us/web/api/audiodecoder/decode/index.md
@@ -30,9 +30,9 @@ AudioDecoder.decode(chunk)
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `InvalidStateError`
+- `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("AudioDecoder.state","state")}} is not `"configured"`.
-- {{domxref("DOMException")}} `DataError`
+- `DataError` {{domxref("DOMException")}}
   - : Thrown if the `chunk` is unable to be decoded due to relying on other frames for decoding.
 
 ## Examples

--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -29,8 +29,10 @@ A {{jsxref("Promise")}} that resolves with undefined.
 
 ### Exceptions
 
+If an error occurs, the promise will resolve with one of the following exceptions:
+
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the Promise is rejected because the {{domxref("AudioDecoder.state","state")}} is not `"configured"`.
+  - : Returned if the Promise is rejected because the {{domxref("AudioDecoder.state","state")}} is not `configured`.
 
 ## Examples
 

--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -29,8 +29,8 @@ A {{jsxref("Promise")}} that resolves with undefined.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `InvalidStateError`
-  - : The Promise rejected because the {{domxref("AudioDecoder.state","state")}} is not `"configured"`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the Promise is rejected because the {{domxref("AudioDecoder.state","state")}} is not `"configured"`.
 
 ## Examples
 

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.md
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.md
@@ -47,8 +47,8 @@ A new {{domxref("ChannelMergerNode")}} object instance.
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : An option such as `channelCount` or `channelCountMode` has been given an invalid value.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if an option such as `channelCount` or `channelCountMode` has been given an invalid value.
 
 ## Example
 

--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -38,8 +38,8 @@ DataTransferItemList.remove(index);
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The drag data store is not in read/write mode, so the item can't be removed.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the drag data store is not in read/write mode and so the item cannot be removed.
 
 ## Example
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -39,12 +39,12 @@ A {{jsxref("promise")}} that resolves with an object containing the following me
 
 ### Exceptions
 
-If an error occurs, the promise will resolve with one of the following exceptions:
+If an error occurs, the promise will resolve with following exception:
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if `close` is true, meaning {{domxref("ImageDecoder.close()","close()")}} has already been called.
-- `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the requested frame does not exist.
+  - : Returned if any of the following conditions apply:
+    - `close` is true, meaning {{domxref("ImageDecoder.close()","close()")}} has already been called.
+    - The requested frame does not exist.
 
 ## Examples
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -39,12 +39,12 @@ A {{jsxref("promise")}} that resolves with an object containing the following me
 
 ### Exceptions
 
-If an error occurs the promise will resolve with one of the following exceptions:
+If an error occurs, the promise will resolve with one of the following exceptions:
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if `close` is true, meaning {{domxref("ImageDecoder.close()","close()")}} has already been called.
+  - : Returned if `close` is true, meaning {{domxref("ImageDecoder.close()","close()")}} has already been called.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the requested frame does not exist.
+  - : Returned if the requested frame does not exist.
 
 ## Examples
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -41,9 +41,9 @@ A {{jsxref("promise")}} that resolves with an object containing the following me
 
 If an error occurs the promise will resolve with one of the following exceptions:
 
-- {{domxref("DOMException")}} `InvalidStateError`
+- `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if `close` is true, meaning {{domxref("ImageDecoder.close()","close()")}} has already been called.
-- {{domxref("DOMException")}} `InvalidStateError`
+- `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the requested frame does not exist.
 
 ## Examples

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.md
@@ -72,8 +72,8 @@ _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 
 ## Exceptions
 
-- `InvalidStateError`
-  - : The stream specified by the `mediaStream` parameter does not contain any audio tracks.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the stream specified by the `mediaStream` parameter does not contain any audio tracks.
 
 ## Usage notes
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
@@ -47,8 +47,8 @@ whose media is obtained from the specified source stream.
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The specified {{domxref("MediaStream")}} doesn't have any audio tracks.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the specified {{domxref("MediaStream")}} does not contain any audio tracks.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -122,7 +122,7 @@ should update any existing code to use the {{jsxref("Promise")}}-based version o
 
 ### Return value
 
-A {{jsxref("Promise")}} which is fulfilled when the candidate has been successfully
+A {{jsxref("Promise")}} that is fulfilled when the candidate has been successfully
 added to the remote peer's description by the ICE agent. The promise does not receive any input parameters.
 
 ### Exceptions
@@ -132,16 +132,14 @@ When an error occurs while attempting to add the ICE candidate, the
 below as the {{domxref("DOMException.name", "name")}} attribute in the specified
 {{domxref("DOMException")}} object passed to the rejection handler.
 
-- `TypeError`
-  - : The specified candidate's {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} and
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if the specified candidate's {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} and
     {{domxref("RTCIceCandidate.sdpMLineIndex", "sdpMLineIndex")}} are both `null`.
-- `InvalidStateError`
-  - : The `RTCPeerConnection` currently has no remote peer established
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the `RTCPeerConnection` currently has no remote peer established
     ({{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} is `null`).
-- `OperationError`
-
-  - : This can happen for a number of reasons:
-
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown in one of the following situations:
     - The value specified for {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} is
       non-`null` and doesn't match the media description ID of any
       media description included within the

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -133,25 +133,23 @@ below as the {{domxref("DOMException.name", "name")}} attribute in the specified
 {{domxref("DOMException")}} object passed to the rejection handler.
 
 - `TypeError` {{domxref("DOMException")}}
-  - : Thrown if the specified candidate's {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} and
+  - : Returned if the specified candidate's {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} and
     {{domxref("RTCIceCandidate.sdpMLineIndex", "sdpMLineIndex")}} are both `null`.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the `RTCPeerConnection` currently has no remote peer established
+  - : Returned if the `RTCPeerConnection` currently has no remote peer established
     ({{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} is `null`).
 - `OperationError` {{domxref("DOMException")}}
-  - : Thrown in one of the following situations:
+  - : Returned in one of the following situations:
     - The value specified for {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} is
       non-`null` and doesn't match the media description ID of any
       media description included within the
       {{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}}.
-    - The specified value of {{domxref("RTCIceCandidate.sdpMLineIndex",
-				"sdpMLineIndex")}} is greater than or equal to the number of media
+    - The specified value of {{domxref("RTCIceCandidate.sdpMLineIndex", "sdpMLineIndex")}} is greater than or equal to the number of media
       descriptions included in the remote description.
     - The specified {{domxref("RTCIceCandidate.usernameFragment", "ufrag")}}
       doesn't match the `ufrag` field in any of the remote
       descriptions being considered.
-    - One or more of the values in the {{domxref("RTCIceCandidate",
-				"candidate")}} string are invalid or could not be parsed.
+    - One or more of the values in the {{domxref("RTCIceCandidate", "candidate")}} string are invalid or could not be parsed.
     - Attempting to add the candidate fails for any reason.
 
 ## Examples

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
@@ -57,11 +57,11 @@ The {{domxref("RTCRtpSender")}} object which will be used to transmit the media 
 
 ### Exceptions
 
-- `InvalidAccessError`
-  - : The specified track (or all of its underlying streams) is already part of the
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if the specified track (or all of its underlying streams) is already part of the
     {{domxref("RTCPeerConnection")}}.
-- `InvalidStateError`
-  - : The {{domxref("RTCPeerConnection")}} is closed.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("RTCPeerConnection")}} is closed.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
@@ -96,26 +96,23 @@ included; otherwise, the defaults listed above are established.
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The {{domxref("RTCPeerConnection")}} is closed.
-- `TypeError`
-
-  - : This can happen in a couple of situations:
-
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("RTCPeerConnection")}} is closed.
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown in the following situations:
     - The label and/or protocol string is too long; these cannot be longer than 65,535
       bytes (bytes, rather than characters).
     - The `id` is 65535. While this is a valid unsigned 16-bit value, it's
       not a permitted value for `id`.
-
-- `SyntaxError`
-  - : Values were specified for both the `maxPacketLifeTime` and
-    `maxRetransmits` options. You may only specify a non-`null`
-    value for one of these.
-- `ResourceInUse`
-  - : An `id` was specified, but another {{domxref("RTCDataChannel")}} is
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if values were specified for both the `maxPacketLifeTime` and
+    `maxRetransmits` options. You may specify a non-`null`
+    value for only one of these.
+- `ResourceInUse` {{domxref("DOMException")}}
+  - : Thrown if an `id` was specified, but another {{domxref("RTCDataChannel")}} is
     already using the same value.
-- `OperationError`
-  - : Either the specified `id` is already in use or, if no `id` was
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown if either the specified `id` is already in use, or if no `id` was
     specified, the WebRTC layer was unable to automatically generate an ID because all IDs
     are in use.
 

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
@@ -82,13 +82,13 @@ These exceptions are returned by rejecting the returned promise. Your rejection 
 should examine the received exception to determine which occurred.
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the `RTCPeerConnection` is closed.
+  - : Returned if the `RTCPeerConnection` is closed.
 - `NotReadableError` {{domxref("DOMException")}}
-  - : Thrown if no certificate or set of certificates was provided for securing the connection, and
+  - : Returned if no certificate or set of certificates was provided for securing the connection, and
     `createOffer()` was unable to create a new one. Since all WebRTC
     connections are required to be secured, that results in an error.
 - `OperationError` {{domxref("DOMException")}}
-  - : Thrown if examining the state of the system to determine resource availability in order to
+  - : Returned if examining the state of the system to determine resource availability in order to
     generate the offer failed for some reason.
 
 ## Example

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
@@ -81,14 +81,14 @@ signaling server to a remote peer.
 These exceptions are returned by rejecting the returned promise. Your rejection handler
 should examine the received exception to determine which occurred.
 
-- `InvalidStateError`
-  - : The `RTCPeerConnection` is closed.
-- `NotReadableError`
-  - : No certificate or set of certificates was provided for securing the connection, and
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the `RTCPeerConnection` is closed.
+- `NotReadableError` {{domxref("DOMException")}}
+  - : Thrown if no certificate or set of certificates was provided for securing the connection, and
     `createOffer()` was unable to create a new one. Since all WebRTC
     connections are required to be secured, that results in an error.
-- `OperationError`
-  - : Examining the state of the system to determine resource availability in order to
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown if examining the state of the system to determine resource availability in order to
     generate the offer failed for some reason.
 
 ## Example

--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.md
@@ -46,8 +46,8 @@ pc.removeTrack(sender);
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The connection is not open.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the connection is not open.
 
 ## Example
 

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -50,21 +50,21 @@ RTCPeerConnection.setConfiguration(configuration);
 
 ### Exceptions
 
-- `InvalidAccessError`
-  - : One or more of the URLs specified in `configuration.iceServers` is a
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if one or more of the URLs specified in `configuration.iceServers` is a
     {{Glossary("TURN")}} server, but complete login information is not provided (that is,
     either the {{domxref("RTCIceServer.username")}} or
     {{domxref("RTCIceServer.credentials")}} is missing). This prevents successful login to
     the server.
-- `InvalidModificationError`
-  - : The `configuration` includes changed identity information, but the
+- `InvalidModificationError` {{domxref("DOMException")}}
+  - : Thrown if the `configuration` includes changed identity information, but the
     connection already has identity information specified. This happens if
     `configuration.peerIdentity` or `configuration.certificates` is
     set and their values differ from the current configuration.
-- `InvalidStateError`
-  - : The {{domxref("RTCPeerConnection")}} is closed.
-- `SyntaxError`
-  - : One or more of the URLs provided in the `configuration.iceServers` list
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("RTCPeerConnection")}} is closed.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if one or more of the URLs provided in the `configuration.iceServers` list
     is invalid.
 
 ## Example

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
@@ -121,12 +121,12 @@ called; in case of failure, the `errorCallback` will be called.
 When using the deprecated callback-based version of `setLocalDescription()`,
 the following exceptions may occur:
 
-- `InvalidStateError` {{deprecated_inline}}
-  - : The connection's {{domxref("RTCPeerConnection.signalingState", "signalingState")}}
+- `InvalidStateError` {{domxref("DOMException")}} {{deprecated_inline}}
+  - : Thrown if the connection's {{domxref("RTCPeerConnection.signalingState", "signalingState")}}
     is `"closed"`, indicating that the connection is not currently open, so
     negotiation cannot take place.
-- `InvalidSessionDescriptionError` {{deprecated_inline}}
-  - : The {{domxref("RTCSessionDescription")}} specified by the
+- `InvalidSessionDescriptionError` {{domxref("DOMException")}} {{deprecated_inline}}
+  - : Thrown if the {{domxref("RTCSessionDescription")}} specified by the
     `sessionDescription` parameter is invalid.
 
 ## Examples

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
@@ -120,7 +120,7 @@ by `setRemoteDescription()`:
 - `RTCError` {{domxref("DOMException")}}
   - : Returned with the {{domxref("RTCError.errorDetail",
 		"errorDetail")}} set to `sdp-syntax-error` if the
-    {{Glossary("SDP")}} specified by {{domxref("RTCSessionDescription.sdp")}}. The
+    {{Glossary("SDP")}} specified by {{domxref("RTCSessionDescription.sdp")}} is not valid. The
     error object's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property
     indicates the line number within the SDP on which the syntax error was detected.
 - `TypeError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
@@ -105,9 +105,9 @@ The following exceptions are reported to the rejection handler for the promise r
 by `setRemoteDescription()`:
 
 - `InvalidAccessError` {{domxref("DOMException")}}
-  - : Thrown if the content of the description is invalid.
+  - : Returned if the content of the description is invalid.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the {{domxref("RTCPeerConnection")}} is closed, or it's in a state that is not
+  - : Returned if the {{domxref("RTCPeerConnection")}} is closed, or it's in a state that is not
     compatible with the specified description's
     {{domxref("RTCSessionDescription.type", "type")}}. For example, this exception is thrown if the
     `type` is `rollback` and the signaling state is one of
@@ -116,15 +116,15 @@ by `setRemoteDescription()`:
     roll back a connection that's either fully established or is in the final stage of
     becoming connected.
 - `OperationError` {{domxref("DOMException")}}
-  - : Thrown if an error does not match the ones specified here. This includes identity validation errors.
+  - : Returned if an error does not match the ones specified here. This includes identity validation errors.
 - `RTCError` {{domxref("DOMException")}}
-  - : Thrown with the {{domxref("RTCError.errorDetail",
+  - : Returned with the {{domxref("RTCError.errorDetail",
 		"errorDetail")}} set to `sdp-syntax-error` if the
     {{Glossary("SDP")}} specified by {{domxref("RTCSessionDescription.sdp")}}. The
     error object's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property
     indicates the line number within the SDP on which the syntax error was detected.
 - `TypeError` {{domxref("DOMException")}}
-  - : Thrown if the specified `RTCSessionDescriptionInit` or
+  - : Returned if the specified `RTCSessionDescriptionInit` or
     `RTCSessionDescription` object is missing the
     {{domxref("RTCSessionDescription.type", "type")}} property, or no description
     parameter was provided at all.

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
@@ -104,28 +104,27 @@ connection). The promise fulfillment handler receives no input parameters.
 The following exceptions are reported to the rejection handler for the promise returned
 by `setRemoteDescription()`:
 
-- `InvalidAccessError`
-  - : The content of the description is invalid.
-- `InvalidStateError`
-  - : The {{domxref("RTCPeerConnection")}} is closed, or it's in a state which isn't
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if the content of the description is invalid.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("RTCPeerConnection")}} is closed, or it's in a state that is not
     compatible with the specified description's
-    {{domxref("RTCSessionDescription.type", "type")}}. For example, if the
+    {{domxref("RTCSessionDescription.type", "type")}}. For example, this exception is thrown if the
     `type` is `rollback` and the signaling state is one of
     `stable`, `have-local-pranswer`, or
-    `have-remote-pranswer`, this exception is thrown, because you can't
+    `have-remote-pranswer` because you cannot
     roll back a connection that's either fully established or is in the final stage of
     becoming connected.
-- `OperationError`
-  - : Any errors that occur which don't match the others specifeid here are reported as
-    `OperationError`. This includes identity validation errors.
-- `RTCError`
-  - : An `RTCError` with the {{domxref("RTCError.errorDetail",
-		"errorDetail")}} set to `sdp-syntax-error` is reported if the
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown if an error does not match the ones specified here. This includes identity validation errors.
+- `RTCError` {{domxref("DOMException")}}
+  - : Thrown with the {{domxref("RTCError.errorDetail",
+		"errorDetail")}} set to `sdp-syntax-error` if the
     {{Glossary("SDP")}} specified by {{domxref("RTCSessionDescription.sdp")}}. The
     error object's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property
     indicates the line number within the SDP on which the syntax error was detected.
-- `TypeError`
-  - : The specified `RTCSessionDescriptionInit` or
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if the specified `RTCSessionDescriptionInit` or
     `RTCSessionDescription` object is missing the
     {{domxref("RTCSessionDescription.type", "type")}} property, or no description
     parameter was provided at all.


### PR DESCRIPTION
#### Summary
Fixes for #9456 to make the format of DOM Exceptions consistent.

Updated the following files:

1. - [x] files/en-us/web/api/imagedecoder/decode/index.md
2 errors are listed in the 'Exceptions' section and both have the same name! This definietly needs to be fixed. (https://developer.mozilla.org/en-US/docs/Web/API/ImageDecoder/decode)
2. - [x] files/en-us/web/api/channelmergernode/channelmergernode/index.md
3. - [x] files/en-us/web/api/datatransferitemlist/remove/index.md
4. - [x] files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md (plus edits)
The first sentence in the RTCError DOMException seems incomplete. ("Thrown with the errorDetail set to sdp-syntax-error if the SDP specified by RTCSessionDescription.sdp.") (https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setRemoteDescription)
5. - [x] files/en-us/web/api/audiodecoder/decode/index.md
6. - [x] files/en-us/web/api/audiodecoder/flush/index.md
7. - [x] files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md (plus edits)
8. - [x] files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
9. - [x] files/en-us/web/api/rtcpeerconnection/removetrack/index.md
10. - [x] files/en-us/web/api/rtcpeerconnection/createoffer/index.md
11. - [x] files/en-us/web/api/rtcpeerconnection/addtrack/index.md
12. - [x] files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
13. - [x] files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
14. - [x] files/en-us/web/api/audiobuffersourcenode/start/index.md
15. - [x] files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
16. - [x] files/en-us/web/api/mediastreamaudiosourcenode/index.md



#### No 'Exceptions' Section

- [files/en-us/web/api/rtcpeerconnection/addstream/index.md](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream)
- [files/en-us/web/api/htmlinputelement/stepup/index.md](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/stepUp)
- [files/en-us/web/api/htmlinputelement/stepdown/index.md](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/stepDown)
- [files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.md](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setIdentityProvider)
- [files/en-us/web/api/rtcpeerconnection/removestream/index.md](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeStream)

#### Ok As Is
DOM Exceptions in the following files are already in the required format:

- [files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData)
- [files/en-us/web/api/audiodecoder/configure/index.md](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder/configure)



