### PR TITLE
Updated format for DOM Exceptions

### DIFF
--- a/files/en-us/web/api/fetchevent/respondwith/index.md
+++ b/files/en-us/web/api/fetchevent/respondwith/index.md
@@ -90,12 +90,12 @@ A {{domxref("Response")}} or a {{jsxref("Promise")}} that resolves to a
 ### Exceptions
 
 - `NetworkError` {{domxref("DOMException")}}
-  - : Thrown if a network error is triggered on certain combinations of
+  - : Returned if a network error is triggered on certain combinations of
     {{domxref("Request.mode","FetchEvent.request.mode")}} and
     {{domxref("Response.type")}}  values, as hinted at in the "global rules"
     listed above.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the event has not been dispatched or `respondWith()` has
+  - : Returned if the event has not been dispatched or `respondWith()` has
     already been invoked.
 
 ## Examples

--- a/files/en-us/web/api/fetchevent/respondwith/index.md
+++ b/files/en-us/web/api/fetchevent/respondwith/index.md
@@ -89,13 +89,13 @@ A {{domxref("Response")}} or a {{jsxref("Promise")}} that resolves to a
 
 ### Exceptions
 
-- `NetworkError`
-  - : A network error is triggered on certain combinations of
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown if a network error is triggered on certain combinations of
     {{domxref("Request.mode","FetchEvent.request.mode")}} and
     {{domxref("Response.type")}}  values, as hinted at in the "global rules"
     listed above.
-- `InvalidStateError`
-  - : The event has not been dispatched or `respondWith()` has
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the event has not been dispatched or `respondWith()` has
     already been invoked.
 
 ## Examples

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -56,11 +56,11 @@ FileSystemWritableFileStream.write(data).then(...);
 ### Exceptions
 
 - `NotAllowedError` {{domxref("DOMException")}}
-  - : Thrown if {{domxref('PermissionStatus')}} is not granted.
+  - : Returned if {{domxref('PermissionStatus')}} is not granted.
 - `TypeError` {{domxref("DOMException")}}
-  - : Thrown if data is undefined, or if `position` or `size` aren't valid.
+  - : Returned if data is undefined, or if `position` or `size` aren't valid.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the `position` is set and larger than the bytes available.
+  - : Returned if the `position` is set and larger than the bytes available.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -55,12 +55,12 @@ FileSystemWritableFileStream.write(data).then(...);
 
 ### Exceptions
 
-- NotAllowedError
-  - : If {{domxref('PermissionStatus')}} is not granted.
-- TypeError
-  - : If data is undefined, or if `position` or `size` aren't valid.
-- InvalidStateError
-  - : If the `position` is set and larger than the bytes available.
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : Thrown if {{domxref('PermissionStatus')}} is not granted.
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if data is undefined, or if `position` or `size` aren't valid.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the `position` is set and larger than the bytes available.
 
 ## Examples
 

--- a/files/en-us/web/api/idbindex/count/index.md
+++ b/files/en-us/web/api/idbindex/count/index.md
@@ -41,11 +41,12 @@ are fired.
 
 This method may raise a {{domxref("DOMException")}} of one of the following types:
 
-| Exception                  | Description                                                       |
-| -------------------------- | ----------------------------------------------------------------- |
-| `TransactionInactiveError` | This {{domxref("IDBIndex")}}'s transaction is inactive.  |
-| `DataError`                | The key or key range provided contains an invalid key.            |
-| `InvalidStateError`        | The {{domxref("IDBIndex")}} has been deleted or removed. |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `DataError` {{domxref("DOMException")}}
+  - : Thrown if the key or key range provided contains an invalid key.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 ## Example
 

--- a/files/en-us/web/api/idbindex/get/index.md
+++ b/files/en-us/web/api/idbindex/get/index.md
@@ -46,11 +46,12 @@ operation are fired.
 
 This method may raise a {{domxref("DOMException")}} of one of the following types:
 
-| Exception                  | Description                                            |
-| -------------------------- | ------------------------------------------------------ |
-| `TransactionInactiveError` | This IDBIndex's transaction is inactive.               |
-| `DataError`                | The key or key range provided contains an invalid key. |
-| `InvalidStateError`        | The IDBIndex has been deleted or removed.              |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `DataError` {{domxref("DOMException")}}
+  - : Thrown if the key or key range provided contains an invalid key.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 ## Example
 

--- a/files/en-us/web/api/idbindex/getall/index.md
+++ b/files/en-us/web/api/idbindex/getall/index.md
@@ -51,14 +51,13 @@ operation are fired.
 
 This method may raise a {{domxref("DOMException")}} of the following types:
 
-| Exception                  | Description                                                       |
-| -------------------------- | ----------------------------------------------------------------- |
-| `TransactionInactiveError` | This {{domxref("IDBIndex")}}'s transaction is inactive.  |
-| `InvalidStateError`        | The {{domxref("IDBIndex")}} has been deleted or removed. |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 A {{jsxref("TypeError")}} exception is thrown if the `count` parameter is
 not between `0` and `2^32> - 1` included.
-
 ## Example
 
 ```js

--- a/files/en-us/web/api/idbindex/getallkeys/index.md
+++ b/files/en-us/web/api/idbindex/getallkeys/index.md
@@ -43,10 +43,10 @@ operation are fired.
 
 This method may raise a {{domxref("DOMException")}} of the following types:
 
-| Exception                  | Description                                                         |
-| -------------------------- | ------------------------------------------------------------------- |
-| `TransactionInactiveError` | This {{domxref("IDBIndex")}}'s transaction is inactive.    |
-| `InvalidStateError`        | The {{domxref("IDBIndex")}} has been deleted or removed.   |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 A {{jsxref("TypeError")}} exception is thrown if the `count` parameter is
 not between `0` and `2^32 - 1` included.

--- a/files/en-us/web/api/idbindex/getkey/index.md
+++ b/files/en-us/web/api/idbindex/getkey/index.md
@@ -45,11 +45,12 @@ operation are fired.
 
 This method may raise a {{domxref("DOMException")}} of one of the following types:
 
-| Exception                  | Description                                            |
-| -------------------------- | ------------------------------------------------------ |
-| `TransactionInactiveError` | This IDBIndex's transaction is inactive.               |
-| `DataError`                | The key or key range provided contains an invalid key. |
-| `InvalidStateError`        | The IDBIndex has been deleted or removed.              |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `DataError` {{domxref("DOMException")}}
+  - : Thrown if the key or key range provided contains an invalid key.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 ## Example
 

--- a/files/en-us/web/api/idbindex/name/index.md
+++ b/files/en-us/web/api/idbindex/name/index.md
@@ -32,17 +32,17 @@ A {{domxref("DOMString")}} specifying a name for the index.
 
 ### Exceptions
 
-There are a several exceptions which can occur when you attempt to change an index's
+There are a several exceptions that can occur when you attempt to change an index's
 name.
 
-- `InvalidStateError`
-  - : The index, or its object store, has been deleted; or the current transaction is not
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the index, or its object store, has been deleted or if the current transaction is not
     an upgrade transaction. You can only rename indexes during upgrade transactions; that
     is, when the mode is `"versionchange"`.
-- `TransactionInactiveError`
-  - : The current transaction is not active.
-- `ConstraintError`
-  - : An index is already using the specified `name`.
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if the current transaction is not active.
+- `ConstraintError` {{domxref("DOMException")}}
+  - : Thrown if an index is already using the specified `name`.
 
 ## Example
 

--- a/files/en-us/web/api/idbindex/opencursor/index.md
+++ b/files/en-us/web/api/idbindex/opencursor/index.md
@@ -53,12 +53,14 @@ operation are fired.
 
 This method may raise a {{domxref("DOMException")}} of one of the following types:
 
-| Exception                  | Description                                                       |
-| -------------------------- | ----------------------------------------------------------------- |
-| `TransactionInactiveError` | This {{domxref("IDBIndex")}}'s transaction is inactive.  |
-| `TypeError`                | The value for the direction parameter is invalid.                 |
-| `DataError`                | The key or key range provided contains an invalid key.            |
-| `InvalidStateError`        | The {{domxref("IDBIndex")}} has been deleted or removed. |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if the value for the direction parameter is invalid.
+- `DataError` {{domxref("DOMException")}}
+  - : Thrown if the key or key range provided contains an invalid key.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 ## Example
 

--- a/files/en-us/web/api/idbindex/openkeycursor/index.md
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.md
@@ -57,12 +57,14 @@ operation are fired.
 
 This method may raise a {{domxref("DOMException")}} of one of the following types:
 
-| Exception                  | Description                                                       |
-| -------------------------- | ----------------------------------------------------------------- |
-| `TransactionInactiveError` | This {{domxref("IDBIndex")}}'s transaction is inactive.  |
-| `TypeError`                | The value for the direction parameter is invalid.                 |
-| `DataError`                | The key or key range provided contains an invalid key.            |
-| `InvalidStateError`        | The {{domxref("IDBIndex")}} has been deleted or removed. |
+- `TransactionInactiveError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if the value for the direction parameter is invalid.
+- `DataError` {{domxref("DOMException")}}
+  - : Thrown if the key or key range provided contains an invalid key.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
 ## Example
 

--- a/files/en-us/web/api/idbtransaction/abort/index.md
+++ b/files/en-us/web/api/idbtransaction/abort/index.md
@@ -31,11 +31,8 @@ transaction.abort();
 
 ### Exceptions
 
-This method may raise a {{domxref("DOMException")}} of the following type:
-
-| **Exception**                                | **Description**                                        |
-| -------------------------------------------- | ------------------------------------------------------ |
-| {{exception("InvalidStateError")}} | The transaction has already been committed or aborted. |
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the transaction has already been committed or aborted.
 
 ## Example
 

--- a/files/en-us/web/api/idbtransaction/commit/index.md
+++ b/files/en-us/web/api/idbtransaction/commit/index.md
@@ -34,9 +34,8 @@ Void.
 
 ### Exceptions
 
-| **Exception**                                | **Description**                      |
-| -------------------------------------------- | ------------------------------------ |
-| {{exception("InvalidStateError")}} | The transaction state is not active. |
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the transaction state is not active.
 
 ## Examples
 

--- a/files/en-us/web/api/mediasource/duration/index.md
+++ b/files/en-us/web/api/mediasource/duration/index.md
@@ -35,34 +35,15 @@ A double. A value in seconds is expected.
 
 The following exceptions may be thrown when setting a new value for this property.
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidAccessError</code></td>
-      <td>
-        An attempt was made to set a duration value that was negative, or
-        <code>NaN</code>.
-      </td>
-    </tr>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        {{domxref("MediaSource.readyState")}} is not equal to
-        <code>open</code>, or one or more of the
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if an attempt was made to set a duration value that was negative or `NaN`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if {{domxref("MediaSource.readyState")}} is not equal to
+        `open`, or one or more of the
         {{domxref("SourceBuffer")}} objects in
         {{domxref("MediaSource.sourceBuffers")}} are being updated
         (i.e. their {{domxref("SourceBuffer.updating")}} property is
-        <code>true</code>.)
-      </td>
-    </tr>
-  </tbody>
-</table>
+      `true`.)
 
 ## Example
 

--- a/files/en-us/web/api/mediasource/endofstream/index.md
+++ b/files/en-us/web/api/mediasource/endofstream/index.md
@@ -51,27 +51,9 @@ mediaSource.endOfStream(endOfStreamError);
 
 ### Exceptions
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        {{domxref("MediaSource.readyState")}} is not equal to
-        <code>open</code>, or one or more of the
-        {{domxref("SourceBuffer")}} objects in
-        {{domxref("MediaSource.sourceBuffers")}} are being updated
-        (i.e. their {{domxref("SourceBuffer.updating")}} property is
-        <code>true</code>.)
-      </td>
-    </tr>
-  </tbody>
-</table>
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if {{domxref("MediaSource.readyState")}} is not equal to `open`, or one or more of the {{domxref("SourceBuffer")}} objects in {{domxref("MediaSource.sourceBuffers")}} are being updated (i.e. their {{domxref("SourceBuffer.updating")}} property is
+      `true`.)
 
 ## Example
 

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.md
@@ -36,10 +36,10 @@ A {{jsxref("Promise")}} resolving to void.
 
 ### Exceptions
 
-The promise is rejected when the following exception is encountered.
+The promise is rejected when an exception is encountered.
 
-- {{exception("InvalidStateError")}}  if the context is not currently suspended or the
-  rendering has not started.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the context is not currently suspended or the rendering has not started.
 
 ## Specifications
 

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.md
@@ -39,7 +39,7 @@ A {{jsxref("Promise")}} resolving to void.
 The promise is rejected when an exception is encountered.
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the context is not currently suspended or the rendering has not started.
+  - : Returned if the context is not currently suspended or the rendering has not started.
 
 ## Specifications
 

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.md
@@ -45,7 +45,7 @@ A {{jsxref("Promise")}} resolving to void.
 The promise is rejected when any exception is encountered.
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the quantized frame number is one of the following:
+  - : Returned if the quantized frame number is one of the following:
     - a negative number
     - less than or equal to the current time
     - greater than or equal to the total render duration

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.md
@@ -44,13 +44,12 @@ A {{jsxref("Promise")}} resolving to void.
 
 The promise is rejected when any exception is encountered.
 
-{{exception("InvalidStateError")}} if the quantized frame number is one of the
-following:
-
-- a negative number
-- is less than or equal to the current time
-- is greater than or equal to the total render duration
-- is scheduled by another suspend for the same time
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the quantized frame number is one of the following:
+    - a negative number
+    - less than or equal to the current time
+    - greater than or equal to the total render duration
+    - scheduled by another suspend for the same time
 
 ## Specifications
 

--- a/files/en-us/web/api/oscillatornode/type/index.md
+++ b/files/en-us/web/api/oscillatornode/type/index.md
@@ -46,8 +46,8 @@ available values are:
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The value `custom` was specified. To set a custom waveform, just call
+- `InvalidStateError`  {{domxref("DOMException")}}
+  - : Thrown if the value `custom` was specified. To set a custom waveform, just call
     {{domxref("OscillatorNode.setPeriodicWave", "setPeriodicWave()")}}. Doing so
     automatically sets the type for you.
 

--- a/files/en-us/web/api/rtcdatachannel/send/index.md
+++ b/files/en-us/web/api/rtcdatachannel/send/index.md
@@ -53,7 +53,7 @@ RTCDataChannel.send(data);
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown when the data channel has not finished establishing its own connection (that is, its
-    {{domxref("RTCDataChannel.readyState", "readyState")}} is `"connecting")`. The data channel
+    {{domxref("RTCDataChannel.readyState", "readyState")}} is `connecting`). The data channel
     must establish its own connection because it uses a transport channel separate from that of the media content. This error occurs without sending or buffering the `data`.
 - `NetworkError` {{domxref("DOMException")}}
   - : Thrown when the specified `data` would need to be buffered, and there isn't room for

--- a/files/en-us/web/api/rtcdatachannel/send/index.md
+++ b/files/en-us/web/api/rtcdatachannel/send/index.md
@@ -51,16 +51,15 @@ RTCDataChannel.send(data);
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : Since the data channel uses a separate transport channel from the media content, it
-    must establish its own connection; if it hasn't finished doing so (that is, its
-    {{domxref("RTCDataChannel.readyState", "readyState")}} is `"connecting")`,
-    this error occurs without sending or buffering the `data`.
-- `NetworkError`
-  - : The specified `data` would need to be buffered, and there isn't room for
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown when the data channel has not finished establishing its own connection (that is, its
+    {{domxref("RTCDataChannel.readyState", "readyState")}} is `"connecting")`. The data channel
+    must establish its own connection because it uses a transport channel separate from that of the media content. This error occurs without sending or buffering the `data`.
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown when the specified `data` would need to be buffered, and there isn't room for
     it in the buffer. In this scenario, the underlying transport is immediately closed.
-- `TypeError`
-  - : The specified `data` is too large for the other peer to receive. Since
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if the specified `data` is too large for the other peer to receive. Since
     there are multiple techniques for breaking up large data into smaller pieces for
     transfer, it's possible to encounter scenarios in which the other peer does not
     support the same ones. For example, if one peer is a modern browser that supports

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -63,13 +63,13 @@ When the promise is fulfilled, the fulfillment handler receives a value of
 If the returned promise is rejected, one of the following exceptions is provided to the
 rejection handler:
 
-- `InvalidModificationError`
-  - : Replacing the `RTCRtpSender`'s current track with the new one
+- `InvalidModificationError` {{domxref("DOMException")}}
+  - : Thrown if replacing the `RTCRtpSender`'s current track with the new one
     would require negotiation.
-- `InvalidStateError`
-  - : The track on which this method was called is stopped rather than running.
-- `TypeError`
-  - : The new track's `kind` doesn't match the original track.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the track on which this method was called is stopped rather than running.
+- `TypeError` {{domxref("DOMException")}}
+  - : Thrown if the new track's `kind` doesn't match the original track.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -64,12 +64,12 @@ If the returned promise is rejected, one of the following exceptions is provided
 rejection handler:
 
 - `InvalidModificationError` {{domxref("DOMException")}}
-  - : Thrown if replacing the `RTCRtpSender`'s current track with the new one
+  - : Returned if replacing the `RTCRtpSender`'s current track with the new one
     would require negotiation.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the track on which this method was called is stopped rather than running.
+  - : Returned if the track on which this method was called is stopped rather than running.
 - `TypeError` {{domxref("DOMException")}}
-  - : Thrown if the new track's `kind` doesn't match the original track.
+  - : Returned if the new track's `kind` doesn't match the original track.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -65,27 +65,23 @@ property is updated with the given parameters.
 If an error occurs, the returned promise is rejected with the appropriate exception
 from the list below.
 
-- `InvalidModificationError`
-
-  - : One of the following problems was detected:
-
+- `InvalidModificationError` {{domxref("DOMException")}}
+  - : Thrown if one of the following problems is detected:
     - The number of encodings specified in the `parameters` object's
       {{domxref("RTCRtpSendParameters.encodings", "encodings")}} property does not match
       the number of encodings currently listed for the `RTCRtpSender`. You
-      cannot change the number of encoding options once the sender has been created.
+      cannot change the number of encoding options after the sender has been created.
     - The order of the specified `encodings` has changed from the current
       list's order.
     - An attempt has been made to alter a property that cannot be changed after the
       sender is first created.
-
-- `InvalidStateError`
-  - : The transceiver of which the `RTCRtpSender` is a part is not running, or
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the transceiver, of which the `RTCRtpSender` is a part, is not running or
     has no parameters to set.
-- `OperationError`
-  - : Any error condition which occurs that isn't covered by one of the other error codes
-    results in an `OperationError`.
-- `RangeError`
-  - : The value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy",
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown if an error occurs that does not match the ones specified here.
+- `RangeError` {{domxref("DOMException")}}
+  - : Thrown if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy",
     "scaleResolutionDownBy")}} is less than 1.0, which would result in scaling up rather
     than down, which is not allowed; or one or more of the specified encodings'
     {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} values is less

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -66,7 +66,7 @@ If an error occurs, the returned promise is rejected with the appropriate except
 from the list below.
 
 - `InvalidModificationError` {{domxref("DOMException")}}
-  - : Thrown if one of the following problems is detected:
+  - : Returned if one of the following problems is detected:
     - The number of encodings specified in the `parameters` object's
       {{domxref("RTCRtpSendParameters.encodings", "encodings")}} property does not match
       the number of encodings currently listed for the `RTCRtpSender`. You
@@ -76,12 +76,12 @@ from the list below.
     - An attempt has been made to alter a property that cannot be changed after the
       sender is first created.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the transceiver, of which the `RTCRtpSender` is a part, is not running or
+  - : Returned if the transceiver, of which the `RTCRtpSender` is a part, is not running or
     has no parameters to set.
 - `OperationError` {{domxref("DOMException")}}
-  - : Thrown if an error occurs that does not match the ones specified here.
+  - : Returned if an error occurs that does not match the ones specified here.
 - `RangeError` {{domxref("DOMException")}}
-  - : Thrown if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy",
+  - : Returned if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy",
     "scaleResolutionDownBy")}} is less than 1.0, which would result in scaling up rather
     than down, which is not allowed; or one or more of the specified encodings'
     {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} values is less

--- a/files/en-us/web/api/rtcrtpsender/setstreams/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setstreams/index.md
@@ -45,8 +45,8 @@ None.
 
 ### Exceptions
 
-- `InvalidStateError`
-  - : The sender's connection is closed.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the sender's connection is closed.
 
 ## Description
 

--- a/files/en-us/web/api/serialport/getsignals/index.md
+++ b/files/en-us/web/api/serialport/getsignals/index.md
@@ -37,9 +37,9 @@ Returns a {{jsxref("Promise")}} that resolves with an object containing the foll
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
+  - : Returned if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Thrown if the signals on the device could not be set.
+  - : Returned if the signals on the device could not be set.
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/getsignals/index.md
+++ b/files/en-us/web/api/serialport/getsignals/index.md
@@ -36,10 +36,10 @@ Returns a {{jsxref("Promise")}} that resolves with an object containing the foll
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `"InvalidStateError"`
-  - : Indicates that the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
-- {{domxref("DOMException")}} `NetworkError`
-  - : Indicates that one of the signals on the device could not be set.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown if the signals on the device could not be set.
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/open/index.md
+++ b/files/en-us/web/api/serialport/open/index.md
@@ -42,10 +42,10 @@ A {{jsxref("Promise")}}.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `"InvalidStateError"`
-  - : Indicates that the port is already open.
-- {{domxref("DOMException")}} `NetworkError`
-  - : Indicates that the attempt to open the port failed.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the port is already open.
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown if the attempt to open the port failed.
 
 ## Examples
 

--- a/files/en-us/web/api/serialport/open/index.md
+++ b/files/en-us/web/api/serialport/open/index.md
@@ -43,9 +43,9 @@ A {{jsxref("Promise")}}.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the port is already open.
+  - : Returned if the port is already open.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Thrown if the attempt to open the port failed.
+  - : Returned if the attempt to open the port failed.
 
 ## Examples
 

--- a/files/en-us/web/api/serialport/setsignals/index.md
+++ b/files/en-us/web/api/serialport/setsignals/index.md
@@ -38,10 +38,10 @@ A {{jsxref("Promise")}}.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `"InvalidStateError"`
-  - : Indicates that the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
-- {{domxref("DOMException")}} `NetworkError`
-  - : Indicates that one of the signals on the device could not be set.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown if the signals on the device could not be set.
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/setsignals/index.md
+++ b/files/en-us/web/api/serialport/setsignals/index.md
@@ -39,9 +39,9 @@ A {{jsxref("Promise")}}.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
+  - : Returned if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Thrown if the signals on the device could not be set.
+  - : Returned if the signals on the device could not be set.
 
 ## Specifications
 

--- a/files/en-us/web/api/sourcebuffer/abort/index.md
+++ b/files/en-us/web/api/sourcebuffer/abort/index.md
@@ -35,25 +35,11 @@ None.
 
 ### Exceptions
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        The {{domxref("MediaSource.readyState")}} property of the
-        parent media source is not equal to <code>open</code>, or this
-        <code>SourceBuffer</code> has been removed from the
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("MediaSource.readyState")}} property of the
+        parent media source is not equal to `open`, or this
+        `SourceBuffer` has been removed from the
         {{domxref("MediaSource")}}.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Example
 

--- a/files/en-us/web/api/sourcebuffer/appendwindowend/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendwindowend/index.md
@@ -38,35 +38,16 @@ A double, indicating the end time of the append window, in seconds.
 
 ### Exceptions
 
-The following exceptions may be thrown when setting a new value for this property.
+The following exceptions may be thrown when setting a new value for this property:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidAccessError</code></td>
-      <td>
-        An attempt was made to set the value to less than or equal to
-        {{domxref("SourceBuffer.appendWindowStart")}}, or
-        <code>NaN</code>.
-      </td>
-    </tr>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        This {{domxref("SourceBuffer")}} object is being updated (i.e.
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if an attempt was made to set the value to less than or equal to
+        {{domxref("SourceBuffer.appendWindowStart")}} or `Nan`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("SourceBuffer")}} object is being updated (i.e.
         its {{domxref("SourceBuffer.updating")}} property is
         currently <code>true</code>), or this <code>SourceBuffer</code> has been
         removed from the {{domxref("MediaSource")}}.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Example
 

--- a/files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
@@ -39,35 +39,17 @@ A double, indicating the start time of the append window, in seconds.
 
 ### Exceptions
 
-The following exceptions may be thrown when setting a new value for this property.
+The following exceptions may be thrown when setting a new value for this property:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidAccessError</code></td>
-      <td>
-        An attempt was made to set the value to less than 0, or a value greater
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if an attempt was made to set the value to less than 0 or to a value greater
         than or equal to
         {{domxref("SourceBuffer.appendWindowEnd")}}.
-      </td>
-    </tr>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        This {{domxref("SourceBuffer")}} object is being updated (i.e.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if this {{domxref("SourceBuffer")}} object is being updated (i.e.
         its {{domxref("SourceBuffer.updating")}} property is
-        currently <code>true</code>), or this <code>SourceBuffer</code> has been
+        currently `true`), or this `SourceBuffer` has been
         removed from the {{domxref("MediaSource")}}.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Example
 

--- a/files/en-us/web/api/sourcebuffer/mode/index.md
+++ b/files/en-us/web/api/sourcebuffer/mode/index.md
@@ -58,36 +58,18 @@ A {{domxref("DOMString")}}.
 
 ### Exceptions
 
-The following exceptions may be thrown when setting a new value for this property.
+The following exceptions may be thrown when setting a new value for this property:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidAccessError</code></td>
-      <td>
-        An attempt was made to set the value to <code>segments</code> when the
-        initial value is <code>sequence</code>.
-      </td>
-    </tr>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        The {{domxref("SourceBuffer")}} object is being updated (i.e.
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Thrown if an attempt was made to set the value to `segments` when the
+        initial value is `sequence`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the {{domxref("SourceBuffer")}} object is being updated (i.e.
         its {{domxref("SourceBuffer.updating")}} property is
-        currently <code>true</code>), the last media segment appended to this
-        <code>SourceBuffer</code> is incomplete, or this
-        <code>SourceBuffer</code> has been removed from the
+        currently `true`), the last media segment appended to this
+        `SourceBuffer` is incomplete, or this
+        `SourceBuffer` has been removed from the
         {{domxref("MediaSource")}}.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Example
 

--- a/files/en-us/web/api/sourcebuffer/timestampoffset/index.md
+++ b/files/en-us/web/api/sourcebuffer/timestampoffset/index.md
@@ -36,30 +36,16 @@ A double, with the offset amount expressed in seconds.
 
 ### Exceptions
 
-The following exceptions may be thrown when setting a new value for this property.
+The following exception may be thrown when setting a new value for this property:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Explanation</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>InvalidStateError</code></td>
-      <td>
-        One or more of the {{domxref("SourceBuffer")}} objects in
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if one or more of the {{domxref("SourceBuffer")}} objects in
         {{domxref("MediaSource.sourceBuffers")}} are being updated
         (i.e. their {{domxref("SourceBuffer.updating")}} property is
-        currently <code>true</code>), a media segment inside the
-        <code>SourceBuffer</code> is currently being parsed, or this
-        <code>SourceBuffer</code> has been removed from the
+        currently `true`), a media segment inside the
+        `SourceBuffer` is currently being parsed, or this
+        `SourceBuffer` has been removed from the
         {{domxref("MediaSource")}}.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Example
 

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -75,15 +75,15 @@ passing into it a {{domxref("DOMException")}} whose `name` is one of the
 following:
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the requested session mode is `immersive-vr` but there is already an
+  - : Returned if the requested session mode is `immersive-vr` but there is already an
     immersive VR session either currently active or in the process of being set up. There
     can only be one immersive VR session at a time.
 - `NotSupportedError` {{domxref("DOMException")}}
-  - : Thrown if there is no WebXR-compatible device available, or the device does not support the
+  - : Returned if there is no WebXR-compatible device available, or the device does not support the
     specified `sessionMode`; this can also be thrown if any of the
     _required_ options are unsupported.
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if permission to enter the specified XR mode is denied. This can happen for a number
+  - : Returned if permission to enter the specified XR mode is denied. This can happen for a number
     of reasons, which are covered in more detail in [Permissions and security](/en-US/docs/Web/API/WebXR_Device_API/Permissions_and_security).
 
 ## Session features

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -74,16 +74,16 @@ This method doesn't throw true exceptions; instead, it rejects the returned prom
 passing into it a {{domxref("DOMException")}} whose `name` is one of the
 following:
 
-- `InvalidStateError`
-  - : The requested session mode is `immersive-vr` but there is already an
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the requested session mode is `immersive-vr` but there is already an
     immersive VR session either currently active or in the process of being set up. There
     can only be one immersive VR session at a time.
-- `NotSupportedError`
-  - : There is no WebXR-compatible device available, or the device does not support the
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : Thrown if there is no WebXR-compatible device available, or the device does not support the
     specified `sessionMode`; this can also be thrown if any of the
     _required_ options are unsupported.
-- `SecurityError`
-  - : Permission to enter the specified XR mode is denied. This can happen for a number
+- `SecurityError` {{domxref("DOMException")}}
+  - : Thrown if permission to enter the specified XR mode is denied. This can happen for a number
     of reasons, which are covered in more detail in [Permissions and security](/en-US/docs/Web/API/WebXR_Device_API/Permissions_and_security).
 
 ## Session features


### PR DESCRIPTION
#### Summary
Fixes for #9456 to make the format of DOM Exceptions consistent.

Updated the following files:

1. - [x] files/en-us/web/api/serialport/open/index.md
2. - [x] files/en-us/web/api/serialport/setsignals/index.md
3. - [x] files/en-us/web/api/serialport/getsignals/index.md
4. - [x] files/en-us/web/api/idbindex/opencursor/index.md
5. - [x] files/en-us/web/api/idbindex/get/index.md
6. - [x] files/en-us/web/api/idbindex/getkey/index.md
7. - [x] files/en-us/web/api/idbindex/openkeycursor/index.md
8. - [x] files/en-us/web/api/idbindex/name/index.md
9. - [x] files/en-us/web/api/idbindex/getall/index.md
10. - [x] files/en-us/web/api/idbindex/count/index.md
11. - [x] files/en-us/web/api/idbindex/getallkeys/index.md
12. - [x] files/en-us/web/api/offlineaudiocontext/suspend/index.md
13. - [x] files/en-us/web/api/offlineaudiocontext/resume/index.md
14. - [x] files/en-us/web/api/mediasource/duration/index.md
15. - [x] files/en-us/web/api/mediasource/endofstream/index.md
16. - [x] files/en-us/web/api/xrsystem/requestsession/index.md
In the starting paragraph in the 'Exceptions' section, can this:
"This method doesn't throw true exceptions; instead, it rejects the returned promise, passing into it a {{domxref("DOMException")}} whose `name` is one of the
following:"
be replaced with:
"The promise is rejected if an exception is encountered." for the sake of consistency?
(https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession)
17. - [x] files/en-us/web/api/oscillatornode/type/index.md
18. - [x] files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
19. - [x] files/en-us/web/api/sourcebuffer/appendwindowend/index.md
20. - [x] files/en-us/web/api/sourcebuffer/timestampoffset/index.md
21. - [x] files/en-us/web/api/sourcebuffer/mode/index.md
22. - [x] files/en-us/web/api/sourcebuffer/abort/index.md
23. - [x] files/en-us/web/api/idbtransaction/commit/index.md
24. - [x] files/en-us/web/api/idbtransaction/abort/index.md
25. - [x] files/en-us/web/api/fetchevent/respondwith/index.md
26. - [x] files/en-us/web/api/rtcrtpsender/setstreams/index.md
27. - [x] files/en-us/web/api/rtcrtpsender/setparameters/index.md
28. - [x] files/en-us/web/api/rtcrtpsender/replacetrack/index.md
29. - [x] files/en-us/web/api/filesystemwritablefilestream/write/index.md
30. - [x] files/en-us/web/api/rtcdatachannel/send/index.md

#### No 'Exceptions' Section
- [files/en-us/web/api/mediarecordererrorevent/error/index.md](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorderErrorEvent/error)
Should the 'Value' section be changed to 'Exceptions' and the errors listed be formatted as DOM Exceptions?
- [files/en-us/web/api/dommatrixreadonly/index.md](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly)


#### Ok As Is
DOM Exceptions in the following files are already in the required format:
- [files/en-us/web/api/mediasource/addsourcebuffer/index.md
](https://developer.mozilla.org/en-US/docs/Web/API/MediaSource/addSourceBuffer)
- [files/en-us/web/api/sourcebuffer/changetype/index.md
](https://developer.mozilla.org/en-US/docs/Web/API/SourceBuffer/changeType)
- [files/en-us/web/api/idbtransaction/objectstore/index.md](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/objectStore)
- [files/en-us/web/api/remoteplayback/watchavailability/index.md](https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback/watchAvailability)
- [files/en-us/web/api/remoteplayback/prompt/index.md](https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback/prompt)
- [files/en-us/web/api/remoteplayback/cancelwatchavailability/index.md
](https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback/cancelWatchAvailability)
- [files/en-us/web/api/baseaudiocontext/createiirfilter/index.md](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createIIRFilter)
- [files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.md
](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode)

#### File Does not Exist
[files/en-us/web/api/sourcebuffer/trackdefaults/index.md](https://developer.mozilla.org/en-US/docs/Web/API/sourcebuffer/trackdefaults)

