### PR TITLE
Update the standard for callbacks in syntax sections

### DIFF
--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -138,10 +138,10 @@ filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function callbackFn(currentValue) { ... })
-filter(function callbackFn(currentValue, index) { ... })
-filter(function callbackFn(currentValue, index, array){ ... })
-filter(function callbackFn(currentValue, index, array) { ... }, thisArg)
+filter(function(currentValue) { ... })
+filter(function(currentValue, index) { ... })
+filter(function(currentValue, index, array){ ... })
+filter(function(currentValue, index, array) { ... }, thisArg)
 ```
 
 ##### Syntax for arbitrary number of parameters


### PR DESCRIPTION
Over in https://github.com/mdn/content/pull/9547, @dangduomg changed the syntax section for `reduce()` to use a function expression.

It looks like a good change to me, and @Elchi3 (who mostly drove the new syntax sections) agreed. But if we want to do it this way we should update the meta-docs, which is what this PR does.
