### PR TITLE
Fix Javascript RE for phone number

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -12,7 +12,9 @@ tags:
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}
 
-Regular expressions are patterns used to match character combinations in strings. In JavaScript, regular expressions are also objects. These patterns are used with the {{jsxref("RegExp.exec", "exec()")}} and {{jsxref("RegExp.test", "test()")}} methods of {{jsxref("RegExp")}}, and with the {{jsxref("String.match", "match()")}}, {{jsxref("String.matchAll", "matchAll()")}}, {{jsxref("String.replace", "replace()")}}, {{jsxref("String.replaceAll", "replaceAll()")}}, {{jsxref("String.search", "search()")}}, and {{jsxref("String.split", "split()")}} methods of {{jsxref("String")}}. This chapter describes JavaScript regular expressions.
+Regular expressions are patterns used to match character combinations in strings.
+In JavaScript, regular expressions are also objects. These patterns are used with the {{jsxref("RegExp.exec", "exec()")}} and {{jsxref("RegExp.test", "test()")}} methods of {{jsxref("RegExp")}}, and with the {{jsxref("String.match", "match()")}}, {{jsxref("String.matchAll", "matchAll()")}}, {{jsxref("String.replace", "replace()")}}, {{jsxref("String.replaceAll", "replaceAll()")}}, {{jsxref("String.search", "search()")}}, and {{jsxref("String.split", "split()")}} methods of {{jsxref("String")}}.
+This chapter describes JavaScript regular expressions.
 
 ## Creating a regular expression
 
@@ -24,7 +26,8 @@ You construct a regular expression in one of two ways:
     let re = /ab+c/;
     ```
 
-  Regular expression literals provide compilation of the regular expression when the script is loaded. If the regular expression remains constant, using this can improve performance.
+  Regular expression literals provide compilation of the regular expression when the script is loaded.
+  If the regular expression remains constant, using this can improve performance.
 
 - Or calling the constructor function of the {{jsxref("RegExp")}} object, as follows:
 
@@ -32,21 +35,29 @@ You construct a regular expression in one of two ways:
     let re = new RegExp('ab+c');
     ```
 
-  Using the constructor function provides runtime compilation of the regular expression. Use the constructor function when you know the regular expression pattern will be changing, or you don't know the pattern and are getting it from another source, such as user input.
+  Using the constructor function provides runtime compilation of the regular expression.
+  Use the constructor function when you know the regular expression pattern will be changing, or you don't know the pattern and are getting it from another source, such as user input.
 
 ## Writing a regular expression pattern
 
-A regular expression pattern is composed of simple characters, such as `/abc/`, or a combination of simple and special characters, such as `/ab*c/` or `/Chapter (\d+)\.\d*/`. The last example includes parentheses, which are used as a memory device. The match made with this part of the pattern is remembered for later use, as described in [Using groups](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges#using_groups).
+A regular expression pattern is composed of simple characters, such as `/abc/`, or a combination of simple and special characters, such as `/ab*c/` or `/Chapter (\d+)\.\d*/`.
+The last example includes parentheses, which are used as a memory device.
+The match made with this part of the pattern is remembered for later use, as described in [Using groups](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges#using_groups).
 
 > **Note:** If you are already familiar with the forms of a regular expression, you may also read [the cheatsheet](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet) for a quick lookup for a specific pattern/construct.
 
 ### Using simple patterns
 
-Simple patterns are constructed of characters for which you want to find a direct match. For example, the pattern `/abc/` matches character combinations in strings only when the exact sequence `"abc"` occurs (all characters together and in that order). Such a match would succeed in the strings `"Hi, do you know your abc's?"` and `"The latest airplane designs evolved from slabcraft."` In both cases the match is with the substring `"abc"`. There is no match in the string `"Grab crab"` because while it contains the substring `"ab c"`, it does not contain the exact substring `"abc"`.
+Simple patterns are constructed of characters for which you want to find a direct match. For example, the pattern `/abc/` matches character combinations in strings only when the exact sequence `"abc"` occurs (all characters together and in that order).
+Such a match would succeed in the strings `"Hi, do you know your abc's?"` and `"The latest airplane designs evolved from slabcraft."`.
+In both cases the match is with the substring `"abc"`.
+There is no match in the string `"Grab crab"` because while it contains the substring `"ab c"`, it does not contain the exact substring `"abc"`.
 
 ### Using special characters
 
-When the search for a match requires something more than a direct match, such as finding one or more b's, or finding white space, you can include special characters in the pattern. For example, to match _a single `"a"` followed by zero or more `"b"`s followed by `"c"`_, you'd use the pattern `/ab*c/`: the `*` after `"b"` means "0 or more occurrences of the preceding item." In the string `"cbbabbbbcdebc"`, this pattern will match the substring `"abbbbc"`.
+When the search for a match requires something more than a direct match, such as finding one or more b's, or finding white space, you can include special characters in the pattern.
+For example, to match _a single `"a"` followed by zero or more `"b"`s followed by `"c"`_, you'd use the pattern `/ab*c/`: the `*` after `"b"` means "0 or more occurrences of the preceding item."
+In the string `"cbbabbbbcdebc"`, this pattern will match the substring `"abbbbc"`.
 
 The following pages provide lists of the different special characters that fit into each category, along with descriptions and examples.
 
@@ -155,13 +166,17 @@ If you want to look at all the special characters that can be used in regular ex
 
 ### Escaping
 
-If you need to use any of the special characters literally (actually searching for a `"*"`, for instance), you must escape it by putting a backslash in front of it. For instance, to search for `"a"` followed by `"*"` followed by `"b"`, you'd use `/a\*b/` — the backslash "escapes" the `"*"`, making it literal instead of special.
+If you need to use any of the special characters literally (actually searching for a `"*"`, for instance), you must escape it by putting a backslash in front of it.
+For instance, to search for `"a"` followed by `"*"` followed by `"b"`, you'd use `/a\*b/` — the backslash "escapes" the `"*"`, making it literal instead of special.
 
-Similarly, if you're writing a regular expression literal and need to match a slash ("/"), you need to escape that (otherwise, it terminates the pattern). For instance, to search for the string "/example/" followed by one or more alphabetic characters, you'd use `/\/example\/[a-z]+/i`—the backslashes before each slash make them literal.
+Similarly, if you're writing a regular expression literal and need to match a slash ("/"), you need to escape that (otherwise, it terminates the pattern).
+For instance, to search for the string "/example/" followed by one or more alphabetic characters, you'd use `/\/example\/[a-z]+/i`—the backslashes before each slash make them literal.
 
-To match a literal backslash, you need to escape the backslash. For instance, to match the string "C:\\" where "C" can be any letter, you'd use `/[A-Z]:\\/` — the first backslash escapes the one after it, so the expression searches for a single literal backslash.
+To match a literal backslash, you need to escape the backslash.
+For instance, to match the string "C:\\" where "C" can be any letter, you'd use `/[A-Z]:\\/` — the first backslash escapes the one after it, so the expression searches for a single literal backslash.
 
-If using the `RegExp` constructor with a string literal, remember that the backslash is an escape in string literals, so to use it in the regular expression, you need to escape it at the string literal level. `/a\*b/` and `new RegExp("a\\*b")` create the same expression, which searches for "a" followed by a literal "\*" followed by "b".
+If using the `RegExp` constructor with a string literal, remember that the backslash is an escape in string literals, so to use it in the regular expression, you need to escape it at the string literal level.
+`/a\*b/` and `new RegExp("a\\*b")` create the same expression, which searches for "a" followed by a literal "\*" followed by "b".
 
 If escape strings are not already part of your pattern you can add them using {{jsxref('String.replace')}}:
 
@@ -171,13 +186,15 @@ function escapeRegExp(string) {
 }
 ```
 
-The "g" after the regular expression is an option or flag that performs a global search, looking in the whole string and returning all matches. It is explained in detail below in [Advanced Searching With Flags](#advanced_searching_with_flags).
+The "g" after the regular expression is an option or flag that performs a global search, looking in the whole string and returning all matches.
+It is explained in detail below in [Advanced Searching With Flags](#advanced_searching_with_flags).
 
 _Why isn't this built into JavaScript?_ There is a proposal to add such a function to RegExp, but it was [rejected by TC39.](https://github.com/benjamingr/RegExp.escape/issues/37)
 
 ### Using parentheses
 
-Parentheses around any part of the regular expression pattern causes that part of the matched substring to be remembered. Once remembered, the substring can be recalled for other use. See [Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges#using_groups) for more details.
+Parentheses around any part of the regular expression pattern causes that part of the matched substring to be remembered.
+Once remembered, the substring can be recalled for other use. See [Groups and ranges](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges#using_groups) for more details.
 
 ## Using regular expressions in JavaScript
 
@@ -194,7 +211,9 @@ Regular expressions are used with the {{jsxref("RegExp")}} methods {{jsxref("Reg
 | {{jsxref("String.replaceAll", "replaceAll()")}} | Executes a search for all matches in a string, and replaces the matched substrings with a replacement substring. |
 | {{jsxref("String.split", "split()")}}                 | Uses a regular expression or a fixed string to break a string into an array of substrings.                       |
 
-When you want to know whether a pattern is found in a string, use the `test()` or `search()` methods; for more information (but slower execution) use the `exec()` or `match()` methods. If you use `exec()` or `match()` and if the match succeeds, these methods return an array and update properties of the associated regular expression object and also of the predefined regular expression object, `RegExp`. If the match fails, the `exec()` method returns `null` (which coerces to `false`).
+When you want to know whether a pattern is found in a string, use the `test()` or `search()` methods; for more information (but slower execution) use the `exec()` or `match()` methods.
+If you use `exec()` or `match()` and if the match succeeds, these methods return an array and update properties of the associated regular expression object and also of the predefined regular expression object, `RegExp`.
+If the match fails, the `exec()` method returns `null` (which coerces to `false`).
 
 In the following example, the script uses the `exec()` method to find a match in a string.
 
@@ -260,27 +279,26 @@ With these scripts, the match succeeds and returns the array and updates the pro
     <tr>
       <td rowspan="2"><code>myRe</code></td>
       <td><code>lastIndex</code></td>
-      <td>
-        The index at which to start the next match. (This property is set only
-        if the regular expression uses the g option, described in
-        <a href="#advanced_searching_with_flags"
-          >Advanced Searching With Flags</a
-        >.)
+      <td>The index at which to start the next match.
+        (This property is set only if the regular expression uses the g option, described in
+        <a href="#advanced_searching_with_flags">Advanced Searching With Flags</a>.)
       </td>
       <td><code>5</code></td>
     </tr>
     <tr>
       <td><code>source</code></td>
       <td>
-        The text of the pattern. Updated at the time that the regular expression
-        is created, not executed.
+        The text of the pattern. Updated at the time that the regular expression is created, not executed.
       </td>
       <td><code>'d(b+)d'</code></td>
     </tr>
   </tbody>
 </table>
 
-As shown in the second form of this example, you can use a regular expression created with an object initializer without assigning it to a variable. If you do, however, every occurrence is a new regular expression. For this reason, if you use this form without assigning it to a variable, you cannot subsequently access the properties of that regular expression. For example, assume you have this script:
+As shown in the second form of this example, you can use a regular expression created with an object initializer without assigning it to a variable.
+If you do, however, every occurrence is a new regular expression.
+For this reason, if you use this form without assigning it to a variable, you cannot subsequently access the properties of that regular expression.
+For example, assume you have this script:
 
 ```js
 var myRe = /d(b+)d/g;
@@ -299,11 +317,13 @@ console.log('The value of lastIndex is ' + /d(b+)d/g.lastIndex);
 // "The value of lastIndex is 0"
 ```
 
-The occurrences of `/d(b+)d/g` in the two statements are different regular expression objects and hence have different values for their `lastIndex` property. If you need to access the properties of a regular expression created with an object initializer, you should first assign it to a variable.
+The occurrences of `/d(b+)d/g` in the two statements are different regular expression objects and hence have different values for their `lastIndex` property.
+If you need to access the properties of a regular expression created with an object initializer, you should first assign it to a variable.
 
 ### Advanced searching with flags
 
-Regular expressions have optional flags that allow for functionality like global searching and case-insensitive searching. These flags can be used separately or together in any order, and are included as part of the regular expression.
+Regular expressions have optional flags that allow for functionality like global searching and case-insensitive searching.
+These flags can be used separately or together in any order, and are included as part of the regular expression.
 
 | Flag | Description                                                                                                                                         | Corresponding property                                                                                 |
 | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
@@ -354,11 +374,15 @@ var re = new RegExp('\\w+\\s', 'g');
 
 and get the same result.
 
-The `m` flag is used to specify that a multiline input string should be treated as multiple lines. If the `m` flag is used, `^` and `$` match at the start or end of any line within the input string instead of the start or end of the entire string.
+The `m` flag is used to specify that a multiline input string should be treated as multiple lines.
+If the `m` flag is used, `^` and `$` match at the start or end of any line within the input string instead of the start or end of the entire string.
 
 #### Using the global search flag with exec()
 
-The behavior associated with the `g` flag is different when the `.exec()` method is used. The roles of "class" and "argument" get reversed: In the case of `.match()`, the string class (or data type) owns the method and the regular expression is just an argument, while in the case of `.exec()`, it is the regular expression that owns the method, with the string being the argument. Contrast this _`str.match(re)`_ versus _`re.exec(str)`_. The `g` flag is used with the **`.exec()`** method to get iterative progression.
+The behavior associated with the `g` flag is different when the `.exec()` method is used.
+The roles of "class" and "argument" get reversed: In the case of `.match()`, the string class (or data type) owns the method and the regular expression is just an argument, while in the case of `.exec()`, it is the regular expression that owns the method, with the string being the argument.
+Contrast this _`str.match(re)`_ versus _`re.exec(str)`_.
+The `g` flag is used with the **`.exec()`** method to get iterative progression.
 
 ```js
 var xArray; while(xArray = re.exec(str)) console.log(xArray);
@@ -377,15 +401,20 @@ var xArray; while(xArray = re.exec(str)) console.log(xArray);
 
 ### Using special characters to verify input
 
-In the following example, the user is expected to enter a phone number. When the user presses the "Check" button, the script checks the validity of the number. If the number is valid (matches the character sequence specified by the regular expression), the script shows a message thanking the user and confirming the number. If the number is invalid, the script informs the user that the phone number is not valid.
+In the following example, the user is expected to enter a phone number.
+When the user presses the "Check" button, the script checks the validity of the number.
+If the number is valid (matches the character sequence specified by the regular expression), the script shows a message thanking the user and confirming the number.
+If the number is invalid, the script informs the user that the phone number is not valid.
 
 The regular expression looks for:
 
-1.  three numeric characters `\d{3}` OR `|` a left parenthesis `\(`, followed by three digits `\d{3}`, followed by a close parenthesis `\)`, in a non-capturing group `(?:)`
-2.  followed by one dash, forward slash, or decimal point in a capturing group `()`
-3.  followed by three digits `\d{3}`
-4.  followed by the match remembered in the (first) captured group `\1`
-5.  followed by four digits `\d{4}`
+1. the beginning of the line of data: `^`
+2. followed by three numeric characters `\d{3}` OR `|` a left parenthesis `\(`, followed by three digits `\d{3}`, followed by a close parenthesis `\)`, in a non-capturing group `(?:)`
+3. followed by one dash, forward slash, or decimal point in a capturing group `()`
+4. followed by three digits `\d{3}`
+5. followed by the match remembered in the (first) captured group `\1`
+6. followed by four digits `\d{4}`
+7. followed by the end of the line of data: `$`
 
 The `click` event activated when the user presses <kbd>Enter</kbd> sets the value of `phoneInput.value`.
 
@@ -407,7 +436,7 @@ The `click` event activated when the user presses <kbd>Enter</kbd> sets the valu
 #### JavaScript
 
 ```js
-var re = /(?:\d{3}|\(\d{3}\))([-\/\.])\d{3}\1\d{4}/;
+var re = /^(?:\d{3}|\(\d{3}\))([-\/\.])\d{3}\1\d{4}$/;
 function testInfo(phoneInput) {
   var OK = re.exec(phoneInput.value);
   var out = document.querySelector('#out');


### PR DESCRIPTION
Fixes #9971

This fixes RE to check for data start and end markers - otherwise the RE finds the phone number format anywhere in the string. Obviously there are other ways of doing this, but this is the simplest.

Also did some layout stuff. 