### PR TITLE
Add deprecation replacement info to navigator.platform

### DIFF
--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -13,22 +13,16 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }} {{Deprecated_Header}}
 
-Returns a string representing the platform of the browser. The specification allows
-browsers to always return the empty string, so don't rely on this property to get a
-reliable answer.
+> **Note:** The recommended alternative to this property is {{domxref("NavigatorUAData.platform")}}, which is returned from {{domxref("Navigator.userAgentData")}}.
 
-## Syntax
+Returns a string representing the platform of the browser.
+The specification allows browsers to always return the empty string, so don't rely on this property to get a reliable answer.
 
-```js
-platform = navigator.platform
-```
 
-### Value
+## Value
 
-A {{domxref("DOMString")}} identifying the platform on which the browser is running, or
-an empty string if the browser declines to (or is unable to) identify the platform.
-`platform` is a string that must be an empty string or a string representing
-the platform on which the browser is executing.
+A {{domxref("DOMString")}} identifying the platform on which the browser is running, or an empty string if the browser declines to (or is unable to) identify the platform.
+`platform` is a string that must be an empty string or a string representing the platform on which the browser is executing.
 
 For example: "`MacIntel`", "`Win32`", "`FreeBSD i386`", "`WebTV OS`"
 
@@ -40,9 +34,8 @@ console.log(navigator.platform);
 
 ## Usage notes
 
-Most browsers, including Chrome, Edge, and Firefox 63 and later, return
-`"Win32"` even if running on a 64-bit version of Windows. Internet Explorer
-and versions of Firefox prior to version 63 still report `"Win64"`.
+Most browsers, including Chrome, Edge, and Firefox 63 and later, return `"Win32"` even if running on a 64-bit version of Windows.
+Internet Explorer and versions of Firefox prior to version 63 still report `"Win64"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/navigatoruadata/platform/index.md
+++ b/files/en-us/web/api/navigatoruadata/platform/index.md
@@ -13,15 +13,10 @@ browser-compat: api.NavigatorUAData.platform
 
 The **`platform`** read-only property of the {{domxref("NavigatorUAData")}} interface returns the platform brand information.
 
-## Syntax
+## Value
 
-```js
-let platform = NavigatorUAData.platform;
-```
-
-### Value
-
-A {{domxref("DOMString","string")}} containing the platform brand. For example, `"Windows"`.
+A {{domxref("DOMString","string")}} containing the platform brand.
+For example, `"Windows"`.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #9980

It is generally useful to know what you should use in deprecated APIs. This proves a a cross link to the client user hint data. 
I also removed Syntax sections leaving only the `Value`, which I believe is the way this is done for properties now.