### PR TITLE
remove a few words from the title

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-activedescendant/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-activedescendant attribute'
+title: 'aria-activedescendant'
 slug: web/Accessibility/ARIA/Attributes/aria-activedescendant
 tags: 
   - Accessibility

--- a/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-autocomplete attribute'
+title: 'aria-autocomplete'
 slug: web/Accessibility/ARIA/Attributes/aria-autocomplete
 tags: 
   - Accessibility

--- a/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-braillelabel attribute'
+title: 'aria-braillelabel'
 slug: web/Accessibility/ARIA/Attributes/aria-braillelabel
 tags: 
   - Accessibility

--- a/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-brailleroledescription attribute'
+title: 'aria-brailleroledescription'
 slug: web/Accessibility/ARIA/Attributes/aria-brailleroledescription
 tags: 
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-busy attribute'
+title: 'aria-busy'
 slug: Web/Accessibility/ARIA/Attributes/aria-busy
 tags: 
   - Accessibility

--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-checked attribute'
+title: 'aria-checked'
 slug: web/Accessibility/ARIA/Attributes/aria-checked
 tags: 
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: aria-colindextext attribute'
+title: 'aria-colindextext'
 slug: Web/Accessibility/ARIA/Attributes/aria-colindextext
 tags: 
   - Accessibility


### PR DESCRIPTION
Renamed all the merged aria attribute titles to remove ARIA and attributes so it fits nicely on the sidebar
- [ ] Adds a new document
- [X] Rewrites (a small part) a document
- [ ] Fixes a typo, bug, or other error
