### PR TITLE
Typo in Animation constructor's timeline param

### DIFF
--- a/files/en-us/web/api/animation/animation/index.md
+++ b/files/en-us/web/api/animation/animation/index.md
@@ -29,7 +29,7 @@ var animation = new Animation([effect][, timeline]);
 
 ## Examples
 
-In the [Follow the White Rabbit example](http://codepen.io/rachelnabors/pen/eJyWzm/?editors=0010), the `Animation()` constructor is used to create an `Animation` for the `rabbitDownKeyframes` using the document's `timeline`:
+In the [Follow the White Rabbit example](https://codepen.io/rachelnabors/pen/eJyWzm/?editors=0010), the `Animation()` constructor is used to create an `Animation` for the `rabbitDownKeyframes` using the document's `timeline`:
 
 ```js
 var rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);

--- a/files/en-us/web/api/animation/animation/index.md
+++ b/files/en-us/web/api/animation/animation/index.md
@@ -25,7 +25,7 @@ var animation = new Animation([effect][, timeline]);
 - `effect` {{optional_inline}}
   - : The target effect, as an object based on the {{domxref("AnimationEffect")}} interface, to assign to the animation. Although in the future other effects such as `SequenceEffect`s or `GroupEffect`s might be possible, the only kind of effect currently available is {{domxref("KeyframeEffect")}}. This can be `null` (which is the default) to indicate that there should be no effect applied.
 - `timeline` {{optional_inline}}
-  - : Specifies the `timeline` with which to associate the animation, as an object of a type based on the {{domxref("AnimationTimeline")}} interface. Currently the only timeline type available is {{domxref("DocumentTimeline")}}, but in the future there my be timelines associated with gestures or scrolling, for example. The default value is {{domxref("Document.timeline")}}, but this can be set to `null` as well.
+  - : Specifies the `timeline` with which to associate the animation, as an object of a type based on the {{domxref("AnimationTimeline")}} interface. Currently the only timeline type available is {{domxref("DocumentTimeline")}}, but in the future there may be timelines associated with gestures or scrolling, for example. The default value is {{domxref("Document.timeline")}}, but this can be set to `null` as well.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This fixes a simple typo ("my" -> "may") in https://developer.mozilla.org/en-US/docs/Web/API/Animation/Animation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
N/A
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
