### PR TITLE
Mark DOMContentLoaded as non-cancelable

### DIFF
--- a/files/en-us/web/api/document/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.md
@@ -21,7 +21,7 @@ The **`DOMContentLoaded`** event fires when the initial HTML document has been c
     </tr>
     <tr>
       <th scope="row">Cancelable</th>
-      <td>Yes (although specified as a simple event that isn't cancelable)</td>
+      <td>No</td>
     </tr>
     <tr>
       <th scope="row">Interface</th>

--- a/files/en-us/web/api/window/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/window/domcontentloaded_event/index.md
@@ -21,7 +21,7 @@ The **`DOMContentLoaded`** event fires when the initial HTML document has been c
     </tr>
     <tr>
       <th scope="row">Cancelable</th>
-      <td>Yes (although specified as a simple event that isn't cancelable)</td>
+      <td>No</td>
     </tr>
     <tr>
       <th scope="row">Interface</th>


### PR DESCRIPTION
- [x] Fixes a typo, bug, or other error

As defined in the spec https://html.spec.whatwg.org/multipage/parsing.html#stop-parsing and as implementations seems to do, despite what the current note in the table says
