### PR TITLE
Update broken MutationObserver doc link

### DIFF
--- a/files/en-us/web/api/mutationobserver/index.md
+++ b/files/en-us/web/api/mutationobserver/index.md
@@ -84,6 +84,6 @@ observer.disconnect();
 - {{domxref('PerformanceObserver')}}
 - {{domxref('ResizeObserver')}}
 - {{domxref('IntersectionObserver')}}
-- [A brief overview](https://updates.html5rocks.com/2012/02/Detect-DOM-changes-with-Mutation-Observers)
+- [A brief overview](https://developers.google.com/web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers)
 - [A more in-depth discussion](https://hacks.mozilla.org/2012/05/dom-mutationobserver-reacting-to-dom-changes-without-killing-browser-performance/)
 - [A screencast by Chromium developer Rafael Weinstein](https://www.youtube.com/watch?v=eRZ4pO0gVWw)


### PR DESCRIPTION
#### Summary
html5rocks.com has moved to developers.google.com.  This fixes a broken link in MutationObserver.

#### Motivation
Fixing a broken link.

#### Supporting details
The old domain is still up, and redirects, but has an expired cert.  So it's better to update to the new address.

#### Related issues
N/A

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
