### PR TITLE
Replace tools.ietf.org with datatracker.ietf.org

### DIFF
--- a/files/en-us/web/http/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/headers/clear-site-data/index.md
@@ -43,7 +43,7 @@ Clear-Site-Data: "*"
 
 ## Directives
 
-> **Note:** All directives must comply with the [quoted-string grammar](https://tools.ietf.org/html/rfc7230#section-3.2.6). A directive that does not include the double quotes is invalid.
+> **Note:** All directives must comply with the [quoted-string grammar](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6). A directive that does not include the double quotes is invalid.
 
 - `"cache"`
   - : Indicates that the server wishes to remove locally cached data (the browser cache, see [HTTP caching](/en-US/docs/Web/HTTP/Caching)) for the origin of the response URL. Depending on the browser, this might also clear out things like pre-rendered pages, script caches, WebGL shader caches, or address bar suggestions.

--- a/files/en-us/web/http/headers/content-encoding/index.md
+++ b/files/en-us/web/http/headers/content-encoding/index.md
@@ -58,7 +58,7 @@ Content-Encoding: deflate, gzip
     because of a patent issue (it expired in 2003).
 - `deflate`
   - : Using the [zlib](https://en.wikipedia.org/wiki/Zlib)
-    structure (defined in [RFC 1950](https://tools.ietf.org/html/rfc1950)) with the [_deflate_](https://en.wikipedia.org/wiki/DEFLATE) compression
+    structure (defined in [RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)) with the [_deflate_](https://en.wikipedia.org/wiki/DEFLATE) compression
     algorithm (defined in [RFC 1951](https://datatracker.ietf.org/doc/html/rfc1951)).
 - `br`
   - : A format using the [Brotli](https://en.wikipedia.org/wiki/Brotli)

--- a/files/jsondata/SpecData.json
+++ b/files/jsondata/SpecData.json
@@ -131,7 +131,7 @@
   },
   "Cookie Prefixes": {
     "name": "Cookie Prefixes",
-    "url": "https://tools.ietf.org/html/draft-west-cookie-prefixes-05",
+    "url": "https://datatracker.ietf.org/doc/html/draft-west-cookie-prefixes-05",
     "status": "Draft"
   },
   "Cookie Store API": {
@@ -936,7 +936,7 @@
   },
   "HSTS": {
     "name": "HTTP Strict Transport Security (HSTS)",
-    "url": "https://tools.ietf.org/html/rfc6797",
+    "url": "https://datatracker.ietf.org/doc/html/rfc6797",
     "status": "RFC"
   },
   "HTML Editing": {
@@ -1576,7 +1576,7 @@
   },
   "vCard": {
     "name": "vCard Format Specification",
-    "url": "https://tools.ietf.org/html/rfc6350",
+    "url": "https://datatracker.ietf.org/doc/html/rfc6350",
     "status": "RFC"
   },
   "Vibration API": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
tools.ietf.org is a HTTP Redirect to datatracker.ietf.org

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
https://github.com/mdn/yari/pull/4832

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->

- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
