### PR TITLE
[Markdown][Add-ons] Fix dl regression

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
@@ -35,8 +35,8 @@ browser-compat: webextensions.api.cookies.Cookie
  <dt><code>name</code></dt>
  <dd>A <code>string</code> representing the name of the cookie.</dd>
  <dt><code>partitionKey</code>{{optional_inline}}</dt>
- <dd>An <code>object</code> representing the description of the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#Storage_partitioning">storage partition</a> containing the cookie. This object is omitted (null) if the cookie is not in partitioned storage. This object contains:
-   <dl class="reference-values">
+ <dd><p>An <code>object</code> representing the description of the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#Storage_partitioning">storage partition</a> containing the cookie. This object is omitted (null) if the cookie is not in partitioned storage. This object contains the following properties:</p>
+   <dl>
    <dt><code>topLevelSite</code></dt>
    <dd>A <code>string</code> representing the first-party URL of the cookie's storage partition, if the cookie is in storage that is partitioned by top-level site.</dd>
    </dl>


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/9842.

This PR fixes a `<dl>` so it is Markdown-convertible. This was fixed before but got un-fixed by https://github.com/mdn/content/pull/9382.
