### PR TITLE
Update caching

### DIFF
--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -150,7 +150,7 @@ So you primarily use it with `max-age`.
 Cache-Control: max-age=604800, must-revalidate
 ```
 
-Cache Storage is allowed to reuse stale responses when it is disconnected from the origin server. `must-revalidate` is a way to avoid it (reusing stale response) and make sure it is validated to the origin server or 504 (Gateway Timeout) if it's impossible.
+Cache storage is allowed to reuse stale responses when disconnected from the origin server. `must-revalidate` is a way to avoid such reuse of stale responses, and to ensure either validation to the origin server occurs, or a 504 (Gateway Timeout) if that’s not possible.
 
 #### `proxy-revalidate`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -413,7 +413,7 @@ You can add a long `max-age` value, and `immutable`, because the content will ne
 Cache-Control: max-age=31536000, immutable
 ```
 
-When you update the library or edit the picture, new contents should have a new URL and caches aren't reused. It called **Cache Busting pattern**.
+When you update the library or edit the picture, new content should have a new URL, and caches aren't reused. That is called the “cache busting” pattern.
 
 Make sure that the HTML response itself should not be cached with a long `max-age`. `no-cache` could cause revalidation and the client will receive a new version of HTML and static assets correctly.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -204,7 +204,7 @@ You can use the `public` directive to unlock that restriction.
 Cache-Control: public, max-age=604800
 ```
 
-Note that, `s-maxage` or `must-revalidate` also unlock its restriction. In other cases, you don't need to add `public` for storing on shared cache storage.
+Note that, `s-maxage` or `must-revalidate` also unlock that restriction.
 
 If you aren't aware of the `Authorization` header on your site, or you are already using `s-maxage` or `must-revalidate` on your response, you don't need to use `public`.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -235,7 +235,7 @@ Note: [Google’s Web Light](https://support.google.com/webmasters/answer/621142
 
 #### `immutable`
 
-The `immutable` response directive indicates that the response will not be updated while it's been fresh.
+The `immutable` response directive indicates that the response will not be updated while it's fresh.
 
 ```
 Cache-Control: public, max-age=604800, immutable

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -139,7 +139,7 @@ Note that `no-cache` does not mean "don't cache". `no-cache` allows caches to st
 
 The `must-revalidate` response directive indicates that the response can be stored in cache storage and can be reused while fresh. Once it becomes stale, it must be validated with the origin server before reuse.
 
-So you primarily use it with `max-age`.
+Typically, `must-revalidate` is used with `max-age`.
 
 ```
 Cache-Control: max-age=604800, must-revalidate

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -322,7 +322,7 @@ Cache-Control: max-age=0
 
 ### `max-stale`
 
-`max-stale=N` request directive indicates that the client allows a stored response that is stale within N seconds.
+The `max-stale=N` request directive indicates that the client allows a stored response that is stale within _N_ seconds.
 
 ```
 Cache-Control: max-stale=3600

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -116,7 +116,7 @@ Age: 100
 
 #### `s-maxage`
 
-The `s-maxage` response directive has the same meaning as `max-age`, but only for the shared cache.
+The `s-maxage` response directive also indicate how long the response is fresh for (similar to `max-age`), but it is specific to shared caches, and they will ignore `max-age` when it is present. 
 
 ```
 Cache-Control: s-maxage=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -227,7 +227,7 @@ You can use `must-understand` when you respond with a newly defined status code.
 
 #### `no-transform`
 
-Some intermediaries transform contents for several reasons. For example, convert images to reduce transfer packets. But in some cases it can be unexpected behavior for the content provider.
+Some intermediaries transform contents for several reasons. For example, some convert images to reduce transfer packets. But in some cases it cause unexpected behavior for the content provider.
 
 `no-stransform` indicates that the intermediaries(regardless of whether it implements a cache) can't transform its contents.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -63,14 +63,15 @@ Cache-Control: only-if-cached
 Standard `Cache-Control` directives that the server can use in an HTTP response:
 
 ```
+Cache-Control: max-age=<seconds>
 Cache-Control: must-revalidate
+Cache-Control: must-understand
 Cache-Control: no-cache
 Cache-Control: no-store
 Cache-Control: no-transform
-Cache-Control: public
 Cache-Control: private
 Cache-Control: proxy-revalidate
-Cache-Control: max-age=<seconds>
+Cache-Control: public
 Cache-Control: s-maxage=<seconds>
 ```
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -436,7 +436,7 @@ Adding `no-cache` to the response causes revalidation to the server, so you can 
 Cache-Control: no-cache
 ```
 
-Most HTTP/1.0 caches don't support `no-cache` directives, so historically `max-age=0` was used as a workaround. But only `max-age=0` could reuse a stale response when cache storage disconnected from the origin server. `must-revalidate` could cover it. This is why the below request is equivalent to `no-cache`.
+Most HTTP/1.0 caches don't support `no-cache` directives, so historically `max-age=0` was used as a workaround. But only `max-age=0` could cause a stale response to be reused when cache storage disconnected from the origin server. `must-revalidate` addresses that. That’s why the example below is equivalent to `no-cache`.
 
 ```
 Cache-Control: max-age=0, must-revalidate

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -74,11 +74,11 @@ Note: Check the [compatibility table](#browser_compatibility) for their support;
 
 The following terms are used in this document; many but not all are from the specification.
 
-- `(HTTP) Caches`
+- `(HTTP) cache`
   - : Implementation which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.
-- `Shared Cache`
+- `Shared cache`
   - : Cache that exists between the origin server and clients (e.g. Proxy, CDN). It stores a single response and reuses it with multiple users — so developers should avoid storing personalized contents to be cached in the shared cache.
-- `Private Cache`
+- `Private cache`
   - : Cache that exists in the client. Also called _local cache_, or even just _browser cache_, etc. It can store and reuse personalized content for a single user.
 - `Store response`
   - : Store a response in caches when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -49,8 +49,8 @@ Caching directives follow the validation rules below:
 
 Standard `Cache-Control` directives are defined as follows.
 
-| Request        | Response         |
-| :------------- | :--------------- |
+| Request          | Response           |
+| :--------------- | :----------------- |
 | `max-age`        | `max-age`          |
 | `max-stale`      | -                  |
 | `min-fresh`      | -                  |

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -91,7 +91,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Revalidate response`
   - : Ask the origin server whether the stored response is still fresh or not. Usually it's done through a conditional request.
 - `Fresh response`
-  - : Indicates that the response is fresh. It usually means its response can be reusable for subsequent requests, but it depends on request directives.
+  - : Indicates that the response is fresh. This usually means the response can be reused for subsequent requests, depending on request directives.
 - `Stale response`
   - : Indicates that the response is stale. It usually means the response can't be reusable as-is. Cache storage isn't required to remove stale responses immediately, because revalidation could change the response from being stale to being fresh again.
 - `Age`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -87,7 +87,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Store response`
   - : Storing a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`
-  - : Reusing cached responses for following requests.
+  - : Reusing cached responses for subsequent requests.
 - `Revalidate response`
   - : Ask the origin server whether the stored response is still fresh or not. Usually it's done through a conditional request.
 - `Fresh response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -111,7 +111,7 @@ Cache-Control: max-age=604800
 
 Indicates that cache storage can store this response and reuse it for subsequent requests while it's fresh.
 
-Note that `max-age` is not the elapsed time since the response was received but response was generated on the origin server. So if the intermediate cache stores it for 100 seconds(for indicating that, intermediate cache adds an `Age` header to the response), browser local cache storage could reuse it `-100` seconds from `max-age`.
+Note that `max-age` is not the elapsed time since the response was received, but instead th elapsed time since he response was generated on the origin server. So if the intermediate cache stores it for 100 seconds (for indicating that, the intermediate cache adds an `Age` header to the response), the browser local cache storage could reuse it `-100` seconds from `max-age`.
 
 ```
 Cache-Control: max-age=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -80,7 +80,7 @@ The following terms are used in this document; many but not all are from the spe
 - `Cache Storage`
   - : Storage which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.
 - `Shared Cache`
-  - : Cache storage that exists between the origin server and clients (e.g. Proxy, CDN, Load Balancer, etc.) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
+  - : Cache storage that exists between the origin server and clients (e.g. Proxy, CDN) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`
   - : Cache storage that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
 - `Store response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -350,7 +350,7 @@ Note that the major browsers do not support requests with `min-fresh`.
 
 ### `no-transform`
 
-Same meaning that `no-transform` has for response, but for a request instead.
+Same meaning that `no-transform` has for a response, but for a request instead.
 
 ### `only-if-cached`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -288,7 +288,7 @@ After a period of time, the stored response became stale normally. It means that
 Cache-Control: no-cache
 ```
 
-It means that clients could always receive up-to-date responses even if cache storage stores fresh responses.
+`no-cache` means that clients could always receive up-to-date responses even if cache storage stores fresh responses.
 
 Browser usually adding `no-cache` to the request when user **Force Reloading** the page.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -229,7 +229,7 @@ You can use `must-understand` when you respond with a newly defined status code.
 
 Some intermediaries transform contents for various reasons. For example, some convert images to reduce transfer packets. But in some cases it cause unexpected behavior for the content provider.
 
-`no-stransform` indicates that the intermediaries(regardless of whether it implements a cache) can't transform its contents.
+`no-transform` indicates that any intermediary (regardless of whether it implements a cache) can't transform the response contents.
 
 Note: [Google’s Web Light](https://support.google.com/webmasters/answer/6211428) is one kind of such an intermediary. It converts images to minimize data for a cache store or slow connection, and supports `no-transform` as an opt-out option.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -304,7 +304,7 @@ Note that the major browsers do not support requests with `no-store`.
 
 ### `max-age`
 
-`max-age=N` request directive indicates that the client allows a stored response that is generated on the origin server within N seconds.
+The `max-age=N` request directive indicates that the client allows a stored response that is generated on the origin server within _N_ seconds.
 
 ```
 Cache-Control: max-age=3600

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -427,7 +427,7 @@ But for now, you can simply use `no-cache` instead.
 
 Unfortunately, there are no cache directives for clearing already-stored responses from caches.
 
-Imagine that client / caches stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
+Imagine that clients/caches store a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
 Alternatively, `Clear-Site-Data` can clear all cache from the browser. But be careful: that clears every stored response for a site — and only in browsers, not for a shared cache.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -274,7 +274,7 @@ The `stale-if-error` response directive indicates that the cache could reuse a s
 Cache-Control: max-age=604800, stale-if-error=86400
 ```
 
-In the example above, cache storage stores response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s) when server responses error status.
+In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s), whenever a server responds with an error.
 
 After a period of time, the stored response became stale normally. It means that the client will receive an error response as-is if the origin server sends it.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -407,9 +407,9 @@ Note: If `index.html` is controlled under Basic / Digest Authentication, files u
 
 For content that’s generated dynamically, or that’s static but updated often, you want a user to always receive the most up-to-date version.
 
-If you don't add a `Cache-Control` header because the response is not intended to be cached, that could cause an unexpected result. Cache storage is allowed to cache it heuristically, so if you have any requirements on caching, you should always indicate it explicitly, in the `Cache-Control` header.
+If you don't add a `Cache-Control` header because the response is not intended to be cached, that could cause an unexpected result. Cache storage is allowed to cache it heuristically — so if you have any requirements on caching, you should always indicate them explicitly, in the `Cache-Control` header.
 
-Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time or if the client already has a new one, just response `304 Not Modified`.
+Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time — or if the client already has a new one, just respond `304 Not Modified`.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -342,7 +342,7 @@ The `min-fresh=N` request directive indicates that the client allows a stored re
 Cache-Control: min-fresh=600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=3600` was stored on cache storage 51 minutes ago, that response couldn't be reused.
+In the case above, if the response with `Cache-Control: max-age=3600` was stored in cache storage 51 minutes ago, the cache couldn't reuse that response.
 
 Clients could use this header when the user requires not only it's fresh but also it wouldn't update for a period of time.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -283,7 +283,7 @@ The `no-cache` request directive asks caches to validate the response with the o
 Cache-Control: no-cache
 ```
 
-`no-cache` means that clients could always receive up-to-date responses even if cache storage stores fresh responses.
+`no-cache` allows clients to request the most up-to-date response even if the cache has a fresh response.
 
 Browser usually add `no-cache` to requests when users are **force reloading** a page.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -65,7 +65,7 @@ Standard `Cache-Control` directives are defined as follows.
 |                  | `private`          |
 |                  | `public`           |
 
-Extension `Cache-Control` directives are not part of the core HTTP caching standards document. Check the [compatibility table](#browser_compatibility) for their support; user-agents that don't recognize them should ignore them.
+Extension `Cache-Control` directives are not part of the core HTTP caching standards document. Check the [compatibility table](#browser_compatibility) for their support; user agents that don't recognize them should ignore them.
 
 | Request          | Response                 |
 | :--------------- | :----------------------- |

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -264,7 +264,7 @@ In the example above, cache storage stores a response and it's been fresh for 7 
 
 Revalidation will make the cache be fresh again, so it appears to the client that it was always fresh during that period.
 
-If no request happened during that period, cache became stale and the next request will revalidate normally.
+If no request happened during that period, the cache became stale and the next request will revalidate normally.
 
 #### `stale-if-error`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -262,7 +262,7 @@ Cache-Control: max-age=604800, stale-while-revalidate=86400
 
 In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s). During that period of time (1 day), the cache reuses the response and at the same time revalidates it to the origin server too.
 
-Revalidation will make the cache to be fresh again, so it appears to the client that it was always fresh during that period.
+Revalidation will make the cache be fresh again, so it appears to the client that it was always fresh during that period.
 
 If no request happened during that period, cache became stale and the next request will revalidate normally.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -77,7 +77,7 @@ The following terms are used in this document; many but not all are from the spe
 - `(HTTP) Caches`
   - : Implementation which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.
 - `Shared Cache`
-  - : Caches that exists between the origin server and clients (e.g. Proxy, CDN) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
+  - : Cache that exists between the origin server and clients (e.g. Proxy, CDN). It stores a single response and reuses it with multiple users — so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`
   - : Caches that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
 - `Store response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Cache-Control
 
 {{HTTPSidebar}}
 
-The **`Cache-Control`** HTTP header fields hold _directives_ (instructions) for [caching](/en-US/docs/Web/HTTP/Caching) in both requests and responses. This header can be used to control caching not only in browsers, but also in shared caches (e.g. Proxies, CDNs).
+The **`Cache-Control`** HTTP header field holds _directives_ (instructions) in both requests and responses that control [caching](/en-US/docs/Web/HTTP/Caching) in browsers and shared caches (e.g. Proxies, CDNs).
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -67,11 +67,11 @@ Standard `Cache-Control` directives are defined as follows.
 
 Extension `Cache-Control` directives are not part of the core HTTP caching standards document. Check the [compatibility table](#browser_compatibility) for their support; user-agents that don't recognize them should ignore them.
 
-| Request        | Response               |
-| :------------- | :--------------------- |
-|                | immutable              |
-|                | stale-while-revalidate |
-| stale-if-error | stale-if-error         |
+| Request          | Response                 |
+| :--------------- | :----------------------- |
+|                  | `immutable`              |
+|                  | `stale-while-revalidate` |
+| `stale-if-error` | `stale-if-error`         |
 
 ## Vocabulary
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -448,7 +448,7 @@ But for now, you can simply use `no-cache` instead.
 
 Unfortunately, there are no cache directives for clearing already stored responses from cache storage.
 
-Imagine that if client / cache storage stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
+Imagine that client / cache storage stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
 Alternatively, `Clear-Site-Data` can clear all cache from the browser if supported. But be careful that it clears every stored response on site, and only for browsers, not a shared cache.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -130,7 +130,7 @@ Cache-Control: s-maxage=604800
 
 #### `no-cache`
 
-The `no-cache` response directive indicates that the response can be stored in cache storage, but must be validated to the origin server before reusing (even when disconnected from the origin server).
+The `no-cache` response directive indicates that the response can be stored in cache storage, but must be validated to the origin server before reuse (even when disconnected from the origin server).
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -109,7 +109,7 @@ The `max-age=N` response directive indicates that the response remains fresh unt
 Cache-Control: max-age=604800
 ```
 
-Cache Storage can store this response and reuse it for the following request while it's fresh.
+Indicates that cache storage can store this response and reuse it for subsequent requests while it's fresh.
 
 Note that `max-age` is not the elapsed time since the response was received but response was generated on the origin server. So if the intermediate cache stores it for 100 seconds(for indicating that, intermediate cache adds an `Age` header to the response), browser local cache storage could reuse it `-100` seconds from `max-age`.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -426,7 +426,7 @@ Note: If `index.html` is controlled under Basic / Digest Authentication, files u
 
 ### Up-to-date contents always
 
-If contents are generated dynamically, or it's static but updated often, you want a user to receive up-to-date contents every moment.
+For content that’s generated dynamically, or that’s static but updated often, you want a user to always receive the most up-to-date version.
 
 In case you don't add no `Cache-Control` header because it's not intended to be cached, it could cause an unexpected result. Cache Storage is allowed to cache it heuristically, so if you have any thoughts on caching, you should always indicate it via the `Cache-Control` header explicitly.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -122,7 +122,6 @@ The `s-maxage` response directive also indicate how long the response is fresh f
 Cache-Control: s-maxage=604800
 ```
 
-`s-maxage` can be used to control the shared cache separate from the private cache.
 
 #### `no-cache`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -49,29 +49,26 @@ Caching directives follow the validation rules below:
 
 Standard `Cache-Control` directives are defined as follows.
 
-| Request          | Response           |
-| :--------------- | :----------------- |
-| `max-age`        | `max-age`          |
-| `max-stale`      | -                  |
-| `min-fresh`      | -                  |
-| -                | `s-maxage`         |
-| `no-cache`       | `no-cache`         |
-| `no-store`       | `no-store`         |
-| `no-transform`   | `no-transform`     |
-| `only-if-cached` | -                  |
-| -                | `must-revalidate`  |
-| -                | `proxy-revalidate` |
-| -                | `must-understand`  |
-| -                | `private`          |
-| -                | `public`           |
-
-Extension `Cache-Control` directives are not part of the core HTTP caching standards document. Check the [compatibility table](#browser_compatibility) for their support; user agents that don't recognize them should ignore them.
-
 | Request          | Response                 |
 | :--------------- | :----------------------- |
+| `max-age`        | `max-age`                |
+| `max-stale`      | -                        |
+| `min-fresh`      | -                        |
+| -                | `s-maxage`               |
+| `no-cache`       | `no-cache`               |
+| `no-store`       | `no-store`               |
+| `no-transform`   | `no-transform`           |
+| `only-if-cached` | -                        |
+| -                | `must-revalidate`        |
+| -                | `proxy-revalidate`       |
+| -                | `must-understand`        |
+| -                | `private`                |
+| -                | `public`                 |
 | -                | `immutable`              |
 | -                | `stale-while-revalidate` |
 | `stale-if-error` | `stale-if-error`         |
+
+Note: Check the [compatibility table](#browser_compatibility) for their support; user agents that don't recognize them should ignore them.
 
 ## Vocabulary
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -290,7 +290,7 @@ Cache-Control: no-cache
 
 `no-cache` means that clients could always receive up-to-date responses even if cache storage stores fresh responses.
 
-Browser usually adding `no-cache` to the request when user **Force Reloading** the page.
+Browser usually add `no-cache` to the request when users are **force reloading** a page.
 
 ### `no-store`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -154,7 +154,7 @@ Cache storage is allowed to reuse stale responses when disconnected from the ori
 
 #### `proxy-revalidate`
 
-`proxy-revalidate` response directive is the `must-revalidate` only for shared caches.
+The `proxy-revalidate` response directive is the equivalent of `must-revalidate` only for shared caches.
 
 #### `no-store`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -180,7 +180,7 @@ Cache-Control: private
 
 You should add the `private` directive for user-personalized content — in particular, responses received after login, and sessions managed via cookies.
 
-If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal  information to leak.
+If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal information to leak.
 
 `no-store` may seem to work fine for avoiding leaks, but is semantically different from `private`. To avoiding leaking personal information, it's better to use both `private` and `no-store`.
 
@@ -241,7 +241,7 @@ The `immutable` response directive indicates that the response will not be updat
 Cache-Control: public, max-age=604800, immutable
 ```
 
-A modern best practice for static resources is to include version/hashes in their URLs, while never modifying the resources, but instead, when necessary, _updating_ the resources with never versions that have new version-numbers/hashes, so that their URLs). That’s called the **cache-busting** pattern.
+A modern best practice for static resources is to include version/hashes in their URLs, while never modifying the resources, but instead, when necessary, _updating_ the resources with newer versions that have new version-numbers/hashes, so that their URLs). That’s called the **cache-busting** pattern.
 
 ```
 <script src=https://example.com/react.0.0.0.js></script>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -318,7 +318,7 @@ Many browsers use this directive for **reloading**, as explained below.
 Cache-Control: max-age=0
 ```
 
-`max-age=0` is a workaround for `no-cache`, because many old (HTTP/1.0) cache implementations don't support `no-cache`. Recently browsers are still using `max-age=0` in reloading — for backward compatibility — and alternatively using `no-cache` to cause a force reload.
+`max-age=0` is a workaround for `no-cache`, because many old (HTTP/1.0) cache implementations don't support `no-cache`. Recently browsers are still using `max-age=0` in "reloading" — for backward compatibility — and alternatively using `no-cache` to cause a "force reloading".
 
 ### `max-stale`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -136,7 +136,7 @@ The `no-cache` response directive indicates that the response can be stored in c
 Cache-Control: no-cache
 ```
 
-If you want a client to always get the latest content, and/or if your server supports Conditional Requests, it's a directive to use.
+If you want a client to always get the latest content, and/or if your server supports conditional requests, `no-cache` is the directive to use.
 
 Note that, it's such a common mistake to consider `no-cache` as "don't cache". `no-cache` allows storing but validating before reusing. If your "dont' cache" means "don't store", `no-store` is the directive to use.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -126,7 +126,7 @@ The `s-maxage` response directive has the same meaning as `max-age`, but only fo
 Cache-Control: s-maxage=604800
 ```
 
-It can be used to separate a control for Private/Shared cache.
+`s-maxage` can be used to control the private cache and shared cache separately.
 
 #### `no-cache`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -311,7 +311,7 @@ Cache-Control: max-stale=3600
 
 In the case above, if the response with `Cache-Control: max-age=604800` was stored on caches 3 hours ago, the cache couldn't reuse that response.
 
-Clients could use this header when the origin server is down or too slow and could accept cached responses from caches even if it's a bit old.
+Clients can use this header when the origin server is down or too slow and can accept cached responses from caches even if they are a bit old.
 
 Note that the major browsers do not support requests with `max-stale`.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -428,7 +428,7 @@ Note: If `index.html` is controlled under Basic / Digest Authentication, files u
 
 For content that’s generated dynamically, or that’s static but updated often, you want a user to always receive the most up-to-date version.
 
-In case you don't add no `Cache-Control` header because it's not intended to be cached, it could cause an unexpected result. Cache Storage is allowed to cache it heuristically, so if you have any thoughts on caching, you should always indicate it via the `Cache-Control` header explicitly.
+If you don't add a `Cache-Control` header because the response is not intended to be cached, that could cause an unexpected result. Cache storage is allowed to cache it heuristically, so if you have any requirements on caching, you should always indicate it explicitly, in the `Cache-Control` header.
 
 Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time or if the client already has a new one, just response 503.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -126,7 +126,7 @@ Cache-Control: s-maxage=604800
 
 #### `no-cache`
 
-The `no-cache` response directive indicates that the response can be stored in caches, but must be validated with the origin server before each reuse -- even when the cache is disconnected from the origin server.
+The `no-cache` response directive indicates that the response can be stored in caches, but must be validated with the origin server before each reuse — even when the cache is disconnected from the origin server.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -429,7 +429,7 @@ Unfortunately, there are no cache directives for clearing already-stored respons
 
 Imagine that clients/caches store a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
-Alternatively, `Clear-Site-Data` can clear all cache from the browser. But be careful: that clears every stored response for a site — and only in browsers, not for a shared cache.
+Alternatively, `Clear-Site-Data` can clear a browser cache for a site. But be careful: that clears every stored response for a site — and only in browsers, not for a shared cache.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -228,7 +228,7 @@ You can use `must-understand` when you respond with a newly defined status code.
 
 Some intermediaries transform contents for various reasons. For example, some convert images to reduce transfer packets. But in some cases it causes unexpected behavior for the content provider.
 
-`no-transform` indicates that any intermediary (regardless of whether it implements a cache) can't transform the response contents.
+`no-transform` indicates that any intermediary (regardless of whether it implements a cache) shouldn't transform the response contents.
 
 Note: [Google’s Web Light](https://support.google.com/webmasters/answer/6211428) is one kind of such an intermediary. It converts images to minimize data for a cache store or slow connection, and supports `no-transform` as an opt-out option.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -137,7 +137,7 @@ Note that `no-cache` does not mean "don't cache". `no-cache` allows caches to st
 
 #### `must-revalidate`
 
-The `must-revalidate` response directive indicates that the response can be stored in cache storage and can be reused while it's been fresh. But once it becomes stale, it must be validated to the origin server before reuse.
+The `must-revalidate` response directive indicates that the response can be stored in cache storage and can be reused while fresh. Once it becomes stale, it must be validated with the origin server before reuse.
 
 So you primarily use it with `max-age`.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -271,7 +271,7 @@ Cache-Control: no-cache
 
 `no-cache` allows clients to request the most up-to-date response even if the cache has a fresh response.
 
-Browser usually add `no-cache` to requests when users are **force reloading** a page.
+Browsers usually add `no-cache` to requests when users are **force reloading** a page.
 
 ### `no-store`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -180,7 +180,7 @@ Cache-Control: private
 
 You should add the `private` directive for user-personalized content — in particular, responses received after login, and sessions managed via cookies.
 
-If you forgot to add this to personalized contents, it can be stored in a shared cache and used by multiple users, resulting in personal information leak incidents.
+If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal  information to leak.
 
 `no-store` seems to work fine for avoiding it, but these are semantically different. It's better to use `private` for private contents and `no-store` for avoiding storing private cache too.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -206,7 +206,7 @@ Cache-Control: public, max-age=604800
 
 Note that, `s-maxage` or `must-revalidate` also unlock that restriction.
 
-If you aren't aware of the `Authorization` header on your site, or you are already using `s-maxage` or `must-revalidate` on your response, you don't need to use `public`.
+If you a request doesn’t have an `Authorization` header, or you are already using `s-maxage` or `must-revalidate` in the response, then you don't need to use `public`.
 
 #### `must-understand`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -228,8 +228,8 @@ A modern best practice for static resources is to include version/hashes in thei
 <script src=https://example.com/react.0.0.0.js></script>
 ```
 
-When a user reloads the browser, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources even when a user reloads the browser, because they're never modified.
-`immutable` tells caches that its response is immutable while it's fresh, and avoids these kinds of unnecessary conditional requests to the server.
+When a user reloads the browser, the browser will send conditional requests for validating to the origin server. But it's not necessary to revalidate those kinds of static resources even when a user reloads the browser, because they're never modified.
+`immutable` tells a cache that the response is immutable while it's fresh, and avoids those kinds of unnecessary conditional requests to the server.
 
 When you use a cache-busting pattern for resources and apply them to a long `max-age`, you can also add `immutable` to avoid revalidation.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -358,7 +358,7 @@ The client indicates for cache storage to obtain an already-cached response. If 
 
 ## Use Cases
 
-### Preventing cache storage
+### Preventing storing
 
 If you don’t want a response stored in cache storage, use the `no-store` directive.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -154,7 +154,7 @@ Cache storage is allowed to reuse stale responses when disconnected from the ori
 
 #### `proxy-revalidate`
 
-The `proxy-revalidate` response directive is the equivalent of `must-revalidate` only for shared caches.
+The `proxy-revalidate` response directive is the equivalent of `must-revalidate`, but specifically for shared caches only.
 
 #### `no-store`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -172,7 +172,7 @@ Cache-Control: no-store, private
 
 #### `private`
 
-`private` response directive indicates that the response can be stored only in a private cache. (e.g. Browser local cache storage)
+the `private` response directive indicates that the response can be stored only in a private cache (e.g. local cache storage in browsers).
 
 ```
 Cache-Control: private

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -145,7 +145,7 @@ Typically, `must-revalidate` is used with `max-age`.
 Cache-Control: max-age=604800, must-revalidate
 ```
 
-Cache storage is allowed to reuse stale responses when disconnected from the origin server. `must-revalidate` is a way to avoid such reuse of stale responses, and to ensure either validation to the origin server occurs, or a 504 (Gateway Timeout) if that’s not possible.
+HTTP allows caches to reuse stale responses when they are disconnected from the origin server. `must-revalidate` is a way to prevent that, so that the cache either revalidates the stored response with the origin server, or if that's not possible it generates a 504 (Gateway Timeout) response.
 
 #### `proxy-revalidate`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -182,7 +182,7 @@ You should add the `private` directive for user-personalized content — in part
 
 If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal  information to leak.
 
-`no-store` may seems to work fine for avoiding leaks, but is semantically different from `private`. To avoiding leaking personal information, it's better to use both `private` and `no-store`.
+`no-store` may seem to work fine for avoiding leaks, but is semantically different from `private`. To avoiding leaking personal information, it's better to use both `private` and `no-store`.
 
 ```
 Cache-Control: private, no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -178,7 +178,7 @@ The `private` response directive indicates that the response can be stored only 
 Cache-Control: private
 ```
 
-You should add this directive for user-personalized contents. Usually, pages after login and session managed via Cookie are the candidate to add.
+You should add the `private` directive for user-personalized content — in particular, responses received after login, and sessions managed via cookies.
 
 If you forgot to add this to personalized contents, it can be stored in a shared cache and used by multiple users, resulting in personal information leak incidents.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -142,7 +142,7 @@ Note that a common mistake is to consider `no-cache` to mean "don't cache". Howe
 
 #### `must-revalidate`
 
-`must-revalidate` response directive indicates that the response can be stored in the cache storage and can be reused while it's been fresh. But once it becomes stale, validates it to the origin server before reusing.
+The `must-revalidate` response directive indicates that the response can be stored in cache storage and can be reused while it's been fresh. But once it becomes stale, it must be validated to the origin server before reuse.
 
 So you basically use it with `max-age`.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -83,7 +83,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Shared Cache`
   - : Cache storage that exists between the origin server and clients (e.g. Proxy, CDN, Load Balancer, etc.) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`
-  - : Cache storage that exists in the client. On the other words Local Cache, Browser Cache etc. It can store and reuse personalized content for a single user.
+  - : Cache storage that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
 - `Store response`
   - : Storing a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -247,7 +247,7 @@ A modern best practice for static resources is to include version/hashes in thei
 <script src=https://example.com/react.0.0.0.js></script>
 ```
 
-When a resource is reloaded, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources, because they're never modified.
+When user reloads the browser, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources even when user realods the browser, because they're never modified.
 `immutable` tells cache storage that its response is immutable while it's fresh, and avoids these kinds of unnecessary conditional requests to the server.
 
 When you use a cache-busting pattern for resources and apply them to a long `max-age`, you can also add `immutable` to avoid revalidation.

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -335,7 +335,7 @@ Same meaning that `no-transform` has for a response, but for a request instead.
 
 ### `only-if-cached`
 
-The client indicates for caches to obtain an already-cached response. If caches has stored a response, it’s reused.
+The client indicates that cache should obtain an already-cached response. If a cache has stored a response, it’s reused.
 
 ## Use Cases
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -223,7 +223,7 @@ Cache-Control: must-understand, no-store
 If the cache storage doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
 If the cache storage supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
 
-You can use it when you respond with a newly defined status code.
+You can use `must-understand` when you respond with a newly defined status code.
 
 #### `no-transform`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -87,7 +87,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Store response`
   - : Storing a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`
-  - : Reusing cached responses for subsequent requests.
+  - : Reuse cached responses for subsequent requests.
 - `Revalidate response`
   - : Ask the origin server whether the stored response is still fresh or not. Usually it's done through a conditional request.
 - `Fresh response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -222,7 +222,7 @@ You can use `must-understand` when you respond with a newly defined status code.
 
 #### `no-transform`
 
-Some intermediaries transform contents for various reasons. For example, some convert images to reduce transfer packets. But in some cases it causes unexpected behavior for the content provider.
+Some intermediaries transform content for various reasons. For example, some convert images to reduce transfer size. In some cases, this is undesirable for the content provider.
 
 `no-transform` indicates that any intermediary (regardless of whether it implements a cache) shouldn't transform the response contents.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -75,7 +75,7 @@ Extension `Cache-Control` directives are not part of the core HTTP caching stand
 
 ## Vocabulary
 
-When talking about Caching, there is sometimes confusion because the word _Cache_ is both a noun and a verb (e.g. "Caching cache in the cache).
+When talking about caching, there is sometimes confusion because the word _cache_ is both a noun and a verb (e.g. "Caching cache in the cache).
 Therefore, several terms are used in the specification to clarify the explanation.
 
 - `Cache Storage`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -396,7 +396,7 @@ For example:
 <img src=/assets/hero.png width=900 height=400>
 ```
 
-The React version will change when you update the library, and hero.png also changes when you edit the picture. So it's hard to store in cache via `max-age`.
+The React library version will change when you update the library, and `hero.png` will also change when you edit the picture. So those are hard to store in a cache with `max-age`.
 
 In that case, including the library version of JS and the hash of the picture in the url could solve the problem.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -289,7 +289,7 @@ Browser usually add `no-cache` to requests when users are **force reloading** a 
 
 ### `no-store`
 
-The `no-store` request directive indicates that the client requires that no caches can store its request and corresponding response — even if the origin server's response could be cacheable.
+The `no-store` request directive allows a client to request that caches refrain from storing the request and corresponding response — even if the origin server's response could be stored.
 
 ```
 Cache-Control: no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -91,7 +91,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Revalidate response`
   - : Ask the origin server whether the stored response is still fresh or not. Usually it's done through a conditional request.
 - `Fresh response`
-  - : Indicates that the response is fresh. It usually means its response can be reusable for following requests, but it depends on request directives.
+  - : Indicates that the response is fresh. It usually means its response can be reusable for subsequent requests, but it depends on request directives.
 - `Stale response`
   - : Indicates that the response is stale. It usually means its response can't be reusable as-is. Cache Storage isn't required to remove stale response immediately because revalidation could make stale to fresh again.
 - `Age`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -171,12 +171,6 @@ You should add the `private` directive for user-personalized content — in part
 
 If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal information to leak.
 
-`no-store` may seem to work fine for avoiding leaks, but is semantically different from `private`. To avoid leaking personal information, it's better to use both `private` and `no-store`.
-
-```
-Cache-Control: private, no-store
-```
-
 #### `public`
 
 Responses for requests with `Authorization` header fields must not be stored in a shared cache. But the `public` directive will cause such responses to be stored in a shared cache.

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -273,7 +273,7 @@ The `stale-if-error` response directive indicates that the cache could reuse a s
 Cache-Control: max-age=604800, stale-if-error=86400
 ```
 
-In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s), whenever a server responds with an error.
+In the example above, the response is fresh for 7 days (604800s). After 7 days it becomes stale, but it can be used for an extra 1 day (86400s) if the server responds with an error.
 
 After a period of time, the stored response became stale normally. That means the client will receive an error response as-is if the origin server sends it.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -41,7 +41,7 @@ The **`Cache-Control`** HTTP header field holds _directives_ (instructions) — 
 
 Caching directives follow the validation rules below:
 
-- Case-insensitive, but lowercase is recommended, since some implementations do not recognise uppercase directives.
+- Case-insensitive — but lowercase is recommended, since some implementations do not recognize uppercase directives.
 - Multiple directives are comma-separated.
 - Some directives have an optional argument.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -312,7 +312,7 @@ Cache-Control: max-age=3600
 
 In the case above, if the response with `Cache-Control: max-age=604800` was stored in cache storage 3 hours ago, the cache couldn't reuse that response.
 
-Many browsers use this directive for **Reloading** as below.
+Many browsers use this directive for **reloading**, as explained below.
 
 ```
 Cache-Control: max-age=0

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -214,7 +214,7 @@ The `must-understand` response directive indicates that cache storage should sto
 
 When a server sends a new status code in a response which has some requirements based on status code, it can cause some trouble when cache storage stores it without understanding those requirements.
 
-`must-understand` should be coupled with `no-store` for falling back behavior.
+`must-understand` should be coupled with `no-store, for fallback behavior.
 
 ```
 Cache-Control: must-understand, no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -164,7 +164,7 @@ The `no-store` response directive indicates that any cache storage of any kind (
 Cache-Control: no-store
 ```
 
-But it's not a reliable or sufficient mechanism for ensuring privacy. For example if you want user personalized responses not to store any cache storage for avoiding reused in other users (cause information leak), you should add `private` directive too.
+But `no-store` is not on its own a reliable or sufficient mechanism for ensuring privacy. For example, if you want user-personalized responses to not be stored in any cache storage — for avoiding reuse by other users (and therefore, information leaks) — you should add the `private` directive too.
 
 ```
 Cache-Control: no-store, private

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -360,7 +360,7 @@ Client indicates for cache storage to obtain an already cached response. If cach
 
 ### Preventing cache storage
 
-If you intend not to store responses in cache storage, you can use the `no-store` directive.
+If you don’t want a response stored in cache storage, use the `no-store` directive.
 
 ```
 Cache-Control: no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -212,7 +212,7 @@ If a request doesn’t have an `Authorization` header, or you are already using 
 
 The `must-understand` response directive indicates that cache storage should store the response only if it understands the requirements for caching based on status code.
 
-When a server responds to a new status code in response which has some requirements for status code, it can cause some trouble when cache storage stores it without understanding its requirements.
+When a server sends a new status code in a response which has some requirements based on status code, it can cause some trouble when cache storage stores it without understanding those requirements.
 
 `must-understand` should be coupled with `no-store` for falling back behavior.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -282,7 +282,7 @@ After a period of time, the stored response became stale normally. It means that
 
 ### `no-cache`
 
-`no-cache` request directive indicates that the client requires the cache and that every response should be validated by the origin server before reusing it.
+The `no-cache` request directive indicates that the client requires the cache — and every response — should be validated by the origin server before reusing the response.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -367,12 +367,6 @@ Note that `no-cache` means "it can be stored but don't reuse before validating",
 Cache-Control: no-cache
 ```
 
-But if you don’t want a response stored in a shared cache **because it's personalized for the user** (e.g. using cookies, the `Authorization` header, etc), you should consider using the `private` directive too.
-
-```
-Cache-Control: no-store, private
-```
-
 In theory, if directives are conflicted, the most restrictive directive should be honored. So the example below is basically meaningless, because `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
 
 ```plain example-bad

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -75,8 +75,7 @@ Extension `Cache-Control` directives are not part of the core HTTP caching stand
 
 ## Vocabulary
 
-When talking about caching, there is sometimes confusion because the word _cache_ is both a noun and a verb (e.g. "Caching cache in the cache).
-Therefore, several terms are used in the specification to clarify the explanation.
+The following terms are used in this document; many but not all are from the specification.
 
 - `Cache Storage`
   - : Storage which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -328,7 +328,7 @@ The `max-stale=N` request directive indicates that the client allows a stored re
 Cache-Control: max-stale=3600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=604800` was stored on cache storage 3 hours ago, cache couldn't reuse that response.
+In the case above, if the response with `Cache-Control: max-age=604800` was stored on cache storage 3 hours ago, the cache couldn't reuse that response.
 
 Clients could use this header when the origin server is down or too slow and could accept cached responses from cache storage even if it's a bit old.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -227,7 +227,7 @@ You can use `must-understand` when you respond with a newly defined status code.
 
 #### `no-transform`
 
-Some intermediaries transform contents for several reasons. For example, some convert images to reduce transfer packets. But in some cases it cause unexpected behavior for the content provider.
+Some intermediaries transform contents for various reasons. For example, some convert images to reduce transfer packets. But in some cases it cause unexpected behavior for the content provider.
 
 `no-stransform` indicates that the intermediaries(regardless of whether it implements a cache) can't transform its contents.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -138,7 +138,7 @@ Cache-Control: no-cache
 
 If you want a client to always get the latest content, and/or if your server supports conditional requests, `no-cache` is the directive to use.
 
-Note that, it's such a common mistake to consider `no-cache` as "don't cache". `no-cache` allows storing but validating before reusing. If your "dont' cache" means "don't store", `no-store` is the directive to use.
+Note that a common mistake is to consider `no-cache` to mean "don't cache". However, `no-cache` actually allows storing but validating before reusing. If the sense of "don't cache" that you want is actually "don't store", then `no-store` is the directive to use.
 
 #### `must-revalidate`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -386,7 +386,7 @@ Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
 
 ### Caching static assets with “cache busting”
 
-When you build static assets with versioning / hashing mechanisms. Adding version/hash to the filename or query string is a good way to manage caching.
+When you build static assets with versioning / hashing mechanisms, adding a version/hash to the filename or query string is a good way to manage caching.
 
 For example,
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -125,7 +125,7 @@ Cache-Control: s-maxage=604800
 
 #### `no-cache`
 
-The `no-cache` response directive indicates that the response can be stored in cache storage, but must be validated to the origin server before reuse (even when disconnected from the origin server).
+The `no-cache` response directive indicates that the response can be stored in cache storage, but must be validated with the origin server before each reuse -- even when the cache is disconnected from the origin server.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -448,7 +448,7 @@ But for now, you can simply use `no-cache` instead.
 
 Unfortunately, there are no cache directives for clearing already stored responses from cache storage.
 
-Imagine that if client / cache storage stores a fresh response for the path, no request flight to the server. There is nothing a server could do to that path.
+Imagine that if client / cache storage stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
 Alternatively, `Clear-Site-Data` can clear all cache from the browser if supported. But be careful that it clears every stored response on site, and only for browsers, not a shared cache.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -93,7 +93,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Fresh response`
   - : Indicates that the response is fresh. It usually means its response can be reusable for subsequent requests, but it depends on request directives.
 - `Stale response`
-  - : Indicates that the response is stale. It usually means its response can't be reusable as-is. Cache Storage isn't required to remove stale response immediately because revalidation could make stale to fresh again.
+  - : Indicates that the response is stale. It usually means the response can't be reusable as-is. Cache storage isn't required to remove stale responses immediately, because revalidation could change the response from being stale to being fresh again.
 - `Age`
   - : The time since response has been generated. It is a criterion for whether a response is fresh or stale.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -51,19 +51,19 @@ Standard `Cache-Control` directives are defined as follows.
 
 | Request        | Response         |
 | :------------- | :--------------- |
-| max-age        | max-age          |
-| max-stale      | -                |
-| min-fresh      | -                |
-| -              | s-maxage         |
-| no-cache       | no-cache         |
-| no-store       | no-store         |
-| no-transform   | no-transform     |
-| only-if-cached | -                |
-|                | must-revalidate  |
-|                | proxy-revalidate |
-|                | must-understand  |
-|                | private          |
-|                | public           |
+| `max-age`        | `max-age`          |
+| `max-stale`      | -                  |
+| `min-fresh`      | -                  |
+| -                | `s-maxage`         |
+| `no-cache`       | `no-cache`         |
+| `no-store`       | `no-store`         |
+| `no-transform`   | `no-transform`     |
+| `only-if-cached` | -                  |
+|                  | `must-revalidate`  |
+|                  | `proxy-revalidate` |
+|                  | `must-understand`  |
+|                  | `private`          |
+|                  | `public`           |
 
 Extension `Cache-Control` directives are not part of the core HTTP caching standards document. Check the [compatibility table](#browser_compatibility) for their support; user-agents that don't recognize them should ignore them.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -347,7 +347,7 @@ If you don’t want a response stored in caches, use the `no-store` directive.
 Cache-Control: no-store
 ```
 
-Note that `no-cache` means "it can be stored but don't reuse before validating", so it's not for preventing to store a response.
+Note that `no-cache` means "it can be stored but don't reuse before validating" — so it's not for preventing a response from being stored.
 
 ```plain example-bad
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -133,7 +133,7 @@ Cache-Control: no-cache
 
 If you want caches to always check for content updates while reusing stored content when it hasn't changed, `no-cache` is the directive to use. It does this by requiring caches to revalidate each request with the origin server.
 
-Note that a common mistake is to consider `no-cache` to mean "don't cache". However, `no-cache` actually allows storing but validating before reusing. If the sense of "don't cache" that you want is actually "don't store", then `no-store` is the directive to use.
+Note that `no-cache` does not mean "don't cache". `no-cache` allows caches to store a response, but requires them to revalidate it before reuse. If the sense of "don't cache" that you want is actually "don't store", then `no-store` is the directive to use.
 
 #### `must-revalidate`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -388,7 +388,7 @@ Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
 
 When you build static assets with versioning / hashing mechanisms, adding a version/hash to the filename or query string is a good way to manage caching.
 
-For example,
+For example:
 
 ```html
 <!-- index.html —>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -79,7 +79,7 @@ The following terms are used in this document; many but not all are from the spe
 - `Shared Cache`
   - : Cache that exists between the origin server and clients (e.g. Proxy, CDN). It stores a single response and reuses it with multiple users — so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`
-  - : Caches that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
+  - : Cache that exists in the client. Also called _local cache_, or even just _browser cache_, etc. It can store and reuse personalized content for a single user.
 - `Store response`
   - : Store a response in caches when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -294,7 +294,7 @@ Browser usually adding `no-cache` to the request when user **Force Reloading** t
 
 ### `no-store`
 
-`no-store` request directive indicates that the client requires that every cache can't store its request and corresponding response. Even if the origin server's response could be cacheable.
+The `no-store` request directive indicates that the client requires that no caches can store its request and corresponding response — even if the origin server's response could be cacheable.
 
 ```
 Cache-Control: no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -378,7 +378,7 @@ But if you don’t want a response stored in a shared cache **because it's perso
 Cache-Control: no-store, private
 ```
 
-In theory, if directives are conflicted, the most restrictive directive should be honored. So the above is basically meaningless, because `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
+In theory, if directives are conflicted, the most restrictive directive should be honored. So the example below is basically meaningless, because `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
 
 ```plain example-bad
 Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -42,7 +42,7 @@ Caching directives follow the validation rules below:
 
 - Case-insensitive, but lowercase is recommended.
 - Multiple directives are comma-separated.
-- Some directives have an optional argument, which can be either a _token_ or a _quoted-string_. (See spec for definitions)
+- Some directives have an optional argument.
 
 ### Cache request directives
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -430,7 +430,7 @@ For content that’s generated dynamically, or that’s static but updated often
 
 If you don't add a `Cache-Control` header because the response is not intended to be cached, that could cause an unexpected result. Cache storage is allowed to cache it heuristically, so if you have any requirements on caching, you should always indicate it explicitly, in the `Cache-Control` header.
 
-Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time or if the client already has a new one, just response 503.
+Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -268,7 +268,7 @@ If no request happened during that period, the cache became stale and the next r
 
 #### `stale-if-error`
 
-`stale-if-error` response directive indicates that the cache could reuse a stale response while origin server responses error (500, 502, 503, or 504).
+The `stale-if-error` response directive indicates that the cache could reuse a stale response when an origin server responds with an error (500, 502, 503, or 504).
 
 ```
 Cache-Control: max-age=604800, stale-if-error=86400

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -198,7 +198,7 @@ Cache-Control: public
 
 In general, when pages are under Basic Auth or Digest Auth, the browser sends requests with the `Authorization` header. That means the response is access-controlled for restricted users (who have accounts), and it's fundamentally not shared-cacheable, even if it has `max-age`.
 
-You can use `public` directives to unlock its restriction.
+You can use the `public` directive to unlock that restriction.
 
 ```
 Cache-Control: public, max-age=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -398,7 +398,7 @@ For example:
 
 The React library version will change when you update the library, and `hero.png` will also change when you edit the picture. So those are hard to store in a cache with `max-age`.
 
-In that case, including the library version of JS and the hash of the picture in the url could solve the problem.
+In such a case, you could address the caching needs by using a specific, numbered version of the library, and including hash of the picture in its URL.
 
 ```html
 <!-- index.html —>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -59,18 +59,18 @@ Standard `Cache-Control` directives are defined as follows.
 | `no-store`       | `no-store`         |
 | `no-transform`   | `no-transform`     |
 | `only-if-cached` | -                  |
-|                  | `must-revalidate`  |
-|                  | `proxy-revalidate` |
-|                  | `must-understand`  |
-|                  | `private`          |
-|                  | `public`           |
+| -                | `must-revalidate`  |
+| -                | `proxy-revalidate` |
+| -                | `must-understand`  |
+| -                | `private`          |
+| -                | `public`           |
 
 Extension `Cache-Control` directives are not part of the core HTTP caching standards document. Check the [compatibility table](#browser_compatibility) for their support; user agents that don't recognize them should ignore them.
 
 | Request          | Response                 |
 | :--------------- | :----------------------- |
-|                  | `immutable`              |
-|                  | `stale-while-revalidate` |
+| -                | `immutable`              |
+| -                | `stale-while-revalidate` |
 | `stale-if-error` | `stale-if-error`         |
 
 ## Vocabulary

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -325,7 +325,7 @@ Cache-Control: min-fresh=600
 
 In the case above, if the response with `Cache-Control: max-age=3600` was stored in caches 51 minutes ago, the cache couldn't reuse that response.
 
-Clients could use this header when the user requires not only it's fresh but also it wouldn't update for a period of time.
+Clients can use this header when the user requires the response to not only be fresh, but also requires that it  won't be updated for a period of time.
 
 Note that the major browsers do not support requests with `min-fresh`.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -222,7 +222,7 @@ The `immutable` response directive indicates that the response will not be updat
 Cache-Control: public, max-age=604800, immutable
 ```
 
-A modern best practice for static resources is to include version/hashes in their URLs, while never modifying the resources, but instead, when necessary, _updating_ the resources with newer versions that have new version-numbers/hashes, so that their URLs). That’s called the **cache-busting** pattern.
+A modern best practice for static resources is to include version/hashes in their URLs, while never modifying the resources — but instead, when necessary, _updating_ the resources with newer versions that have new version-numbers/hashes, so that their URLs are different. That’s called the **cache-busting** pattern.
 
 ```
 <script src=https://example.com/react.0.0.0.js></script>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -430,7 +430,7 @@ For content that’s generated dynamically, or that’s static but updated often
 
 If you don't add a `Cache-Control` header because the response is not intended to be cached, that could cause an unexpected result. Cache storage is allowed to cache it heuristically, so if you have any requirements on caching, you should always indicate it explicitly, in the `Cache-Control` header.
 
-Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time.
+Adding `no-cache` to the response causes revalidation to the server, so you can serve a fresh response every time or if the client already has a new one, just response `304 Not Modified`.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -367,10 +367,14 @@ Note that `no-cache` means "it can be stored but don't reuse before validating",
 Cache-Control: no-cache
 ```
 
-In theory, if directives are conflicted, the most restrictive directive should be honored. So the example below is basically meaningless, because `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
+In theory, if directives are conflicted, the most restrictive directive should be honored. So the example below is basically meaningless, because `private`, `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
 
 ```plain example-bad
+# conflicted
 Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
+
+# equivalant to
+Cache-Control: no-store
 ```
 
 ### Caching static assets with “cache busting”

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -79,7 +79,7 @@ When talking about caching, there is sometimes confusion because the word _cache
 Therefore, several terms are used in the specification to clarify the explanation.
 
 - `Cache Storage`
-  - : The storage which holds requests and responses for reusing in the subsequent requests.
+  - : Storage which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.
 - `Shared Cache`
   - : Cache storage that exists between the origin server and clients (e.g. Proxy, CDN, Load Balancer, etc.) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -195,8 +195,6 @@ If a request doesn’t have an `Authorization` header, or you are already using 
 
 The `must-understand` response directive indicates that caches should store the response only if it understands the requirements for caching based on status code.
 
-When a server sends a new status code in a response which has some requirements based on status code, it can cause some trouble when caches stores it without understanding those requirements.
-
 `must-understand` should be coupled with `no-store`, for fallback behavior.
 
 ```
@@ -204,9 +202,8 @@ Cache-Control: must-understand, no-store
 ```
 
 If the caches doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
-If the caches supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
 
-You can use `must-understand` when you respond with a newly defined status code.
+If the caches supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
 
 #### `no-transform`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -159,12 +159,6 @@ The `no-store` response directive indicates that any cache storage of any kind (
 Cache-Control: no-store
 ```
 
-But `no-store` is not on its own a reliable or sufficient mechanism for ensuring privacy. For example, if you want user-personalized responses to not be stored in any cache storage — for avoiding reuse by other users (and therefore, information leaks) — you should add the `private` directive too.
-
-```
-Cache-Control: no-store, private
-```
-
 #### `private`
 
 The `private` response directive indicates that the response can be stored only in a private cache (e.g. local cache storage in browsers).

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -354,7 +354,7 @@ Same meaning with `no-transform` on response but on request.
 
 ### `only-if-cached`
 
-Client indicates for cache storage to obtain an already cached response. If cache storage has stored response it reuses, or respond 504 Gateway Timeout if not.
+The client indicates for cache storage to obtain an already-cached response. If cache storage has stored a response, it’s reused.
 
 ## Use Cases
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -210,7 +210,7 @@ If a request doesn’t have an `Authorization` header, or you are already using 
 
 #### `must-understand`
 
-`must-understand` response directive indicates that the cache storage should store response even if it understands the requirements for caching on status code.'
+The `must-understand` response directive indicates that cache storage should store the response only if it understands the requirements for caching based on status code.
 
 When a server responds to a new status code in response which has some requirements for status code, it can cause some trouble when cache storage stores it without understanding its requirements.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -241,7 +241,7 @@ The `immutable` response directive indicates that the response will not be updat
 Cache-Control: public, max-age=604800, immutable
 ```
 
-In the modern way, static resources include version/hashes in its URL and are never modified (If modification happens, it will have another version/hashes and the URL will change too). It called **cache-busting** pattern.
+A modern best practice for static resources is to include version/hashes in their URLs, while never modifying the resources, but instead, when necessary, _updating_ the resources with never versions that have new version-numbers/hashes, so that their URLs). That’s called the **cache-busting** pattern.
 
 ```
 <script src=https://example.com/react.0.0.0.js></script>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -318,7 +318,7 @@ Many browsers use this directive for **reloading**, as explained below.
 Cache-Control: max-age=0
 ```
 
-It's a work around for `no-cache` because many old (HTTP/1.0) cache implementations don't support `no-cache`. Recently browsers are still using `max-age=0` in Readling for backward compatibility and using `no-cache` for Force Reload alternatively.
+`max-age=0` is a workaround for `no-cache`, because many old (HTTP/1.0) cache implementations don't support `no-cache`. Recently browsers are still using `max-age=0` in reloading — for backward compatibility — and alternatively using `no-cache` to cause a force reload.
 
 ### `max-stale`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -282,7 +282,7 @@ After a period of time, the stored response became stale normally. That means th
 
 ### `no-cache`
 
-The `no-cache` request directive indicates that the client requires the cache — and every response — should be validated by the origin server before reusing the response.
+The `no-cache` request directive indicates that the client requires that the cache — and every response — should be validated by the origin server before reusing the response.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -107,7 +107,7 @@ Cache-Control: max-age=604800
 
 Indicates that cache storage can store this response and reuse it for subsequent requests while it's fresh.
 
-Note that `max-age` is not the elapsed time since the response was received, but instead the elapsed time since the response was generated on the origin server. So if the intermediate cache stores it for 100 seconds (for indicating that, the intermediate cache adds an `Age` header to the response), the browser local cache storage could reuse it `-100` seconds from `max-age`.
+Note that `max-age` is not the elapsed time since the response was received, but instead the elapsed time since the response was generated on the origin server. So if the other cache(s) on the path the response takes store it for 100 seconds (indicated using the `Age` response header field), the browser cache would deduct 100 seconds from its freshness lifetime.
 
 ```
 Cache-Control: max-age=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -144,7 +144,7 @@ Note that a common mistake is to consider `no-cache` to mean "don't cache". Howe
 
 The `must-revalidate` response directive indicates that the response can be stored in cache storage and can be reused while it's been fresh. But once it becomes stale, it must be validated to the origin server before reuse.
 
-So you basically use it with `max-age`.
+So you primarily use it with `max-age`.
 
 ```
 Cache-Control: max-age=604800, must-revalidate

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -372,7 +372,7 @@ Note that `no-cache` means "it can be stored but don't reuse before validating",
 Cache-Control: no-cache
 ```
 
-But if you intend it can't be stored in a shared cache **because it's personalized for the user** (e.g. using Cookie, Authorization, etc), you should consider using the `private` directive too.
+But if you don’t want a response stored in a shared cache **because it's personalized for the user** (e.g. using cookies, the `Authorization` header, etc), you should consider using the `private` directive too.
 
 ```
 Cache-Control: no-store, private

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -422,7 +422,7 @@ Make sure that the HTML response itself should not be cached with a long `max-ag
 Cache-Control: no-cache
 ```
 
-Note: If index.html is controlled under Basic / Digest Authentication, files under `/assets` are not stored in the shared cache. If `/assets/` files are suitable for shared cache to be stored, you also need one of `public`, `s-maxage` or `must-revalidate`.
+Note: If `index.html` is controlled under Basic / Digest Authentication, files under `/assets` are not stored in the shared cache. If `/assets/` files are suitable for storing in a shared cache, you also need one of `public`, `s-maxage` or `must-revalidate`.
 
 ### Up-to-date contents always
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -85,6 +85,26 @@ Cache-Control: stale-while-revalidate=<seconds>
 Cache-Control: stale-if-error=<seconds>
 ```
 
+## Vocabulary 
+
+When talking about Caching, there is sometimes confusion because the word *Cache* is both a noun and a verb (e.g. "Caching cache in the cache).
+Therefore, several terms are used in the specification to clarify the explanation.
+
+- `Cache Storage`
+  - : The storage who stores request/response in it for reusing in following request. It's in Browser, Proxy, CDN, Loadbalancer etc.
+- `Store response`
+  - : Storing response in Cache Storage when it's cachable. But it's not always reused as-is. (Usually "Cache" means it)
+- `Reuse response`
+  - : Reusing cached response for following request.
+- `Revalidate response`
+  - : Ask origin server whether stored response is still fresh or not. Usually it's done through a conditional request.
+- `Fresh response`
+  - : Indicates that the response is fresh. It usually means its response can be reusable for following request, but it's depends on request directives.
+- `Stale response`
+  - : Indeicates that the response is stale. It usually means its response can't be reusable as-is. Cache Storage doesn't required to remove stale response immediately because revalidation could make stale to fresh again.
+- `Age`
+  - : The time since response has generated. It is a criterion for whether a response is fresh or stale.
+
 ## Directives
 
 ### Cacheability

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -260,7 +260,7 @@ The `stale-while-revalidate` response directive indicates that the cache could r
 Cache-Control: max-age=604800, stale-while-revalidate=86400
 ```
 
-In the example above, cache storage stores response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s). During this period of time (1 day), cache reuses the response and at the same time revalidates it to the origin server too.
+In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s). During that period of time (1 day), the cache reuses the response and at the same time revalidates it to the origin server too.
 
 Revalida will make the cache to be fresh again, so it appears to the client that it was always fresh during that period.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -95,7 +95,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Stale response`
   - : Indicates that the response is stale. It usually means the response can't be reusable as-is. Cache storage isn't required to remove stale responses immediately, because revalidation could change the response from being stale to being fresh again.
 - `Age`
-  - : The time since response has been generated. It is a criterion for whether a response is fresh or stale.
+  - : The time since a response was generated. It is a criterion for whether a response is fresh or stale.
 
 ## Directives
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -74,14 +74,14 @@ Note: Check the [compatibility table](#browser_compatibility) for their support;
 
 The following terms are used in this document; many but not all are from the specification.
 
-- `Cache Storage`
-  - : Storage which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.
+- `(HTTP) Caches`
+  - : Implementation which holds requests and responses for reusing in subsequent requests. May be either a shared or private cache.
 - `Shared Cache`
-  - : Cache storage that exists between the origin server and clients (e.g. Proxy, CDN) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
+  - : Caches that exists between the origin server and clients (e.g. Proxy, CDN) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`
-  - : Cache storage that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
+  - : Caches that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
 - `Store response`
-  - : Store a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
+  - : Store a response in caches when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`
   - : Reuse cached responses for subsequent requests.
 - `Revalidate response`
@@ -105,7 +105,7 @@ The `max-age=N` response directive indicates that the response remains fresh unt
 Cache-Control: max-age=604800
 ```
 
-Indicates that cache storage can store this response and reuse it for subsequent requests while it's fresh.
+Indicates that caches can store this response and reuse it for subsequent requests while it's fresh.
 
 Note that `max-age` is not the elapsed time since the response was received, but instead the elapsed time since the response was generated on the origin server. So if the other cache(s) on the path the response takes store it for 100 seconds (indicated using the `Age` response header field), the browser cache would deduct 100 seconds from its freshness lifetime.
 
@@ -125,7 +125,7 @@ Cache-Control: s-maxage=604800
 
 #### `no-cache`
 
-The `no-cache` response directive indicates that the response can be stored in cache storage, but must be validated with the origin server before each reuse -- even when the cache is disconnected from the origin server.
+The `no-cache` response directive indicates that the response can be stored in caches, but must be validated with the origin server before each reuse -- even when the cache is disconnected from the origin server.
 
 ```
 Cache-Control: no-cache
@@ -137,7 +137,7 @@ Note that `no-cache` does not mean "don't cache". `no-cache` allows caches to st
 
 #### `must-revalidate`
 
-The `must-revalidate` response directive indicates that the response can be stored in cache storage and can be reused while fresh. Once it becomes stale, it must be validated with the origin server before reuse.
+The `must-revalidate` response directive indicates that the response can be stored in caches and can be reused while fresh. Once it becomes stale, it must be validated with the origin server before reuse.
 
 Typically, `must-revalidate` is used with `max-age`.
 
@@ -153,7 +153,7 @@ The `proxy-revalidate` response directive is the equivalent of `must-revalidate`
 
 #### `no-store`
 
-The `no-store` response directive indicates that any cache storage of any kind (private or shared) should not store this response.
+The `no-store` response directive indicates that any caches of any kind (private or shared) should not store this response.
 
 ```
 Cache-Control: no-store
@@ -161,7 +161,7 @@ Cache-Control: no-store
 
 #### `private`
 
-The `private` response directive indicates that the response can be stored only in a private cache (e.g. local cache storage in browsers).
+The `private` response directive indicates that the response can be stored only in a private cache (e.g. local caches in browsers).
 
 ```
 Cache-Control: private
@@ -193,9 +193,9 @@ If a request doesn’t have an `Authorization` header, or you are already using 
 
 #### `must-understand`
 
-The `must-understand` response directive indicates that cache storage should store the response only if it understands the requirements for caching based on status code.
+The `must-understand` response directive indicates that caches should store the response only if it understands the requirements for caching based on status code.
 
-When a server sends a new status code in a response which has some requirements based on status code, it can cause some trouble when cache storage stores it without understanding those requirements.
+When a server sends a new status code in a response which has some requirements based on status code, it can cause some trouble when caches stores it without understanding those requirements.
 
 `must-understand` should be coupled with `no-store`, for fallback behavior.
 
@@ -203,8 +203,8 @@ When a server sends a new status code in a response which has some requirements 
 Cache-Control: must-understand, no-store
 ```
 
-If the cache storage doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
-If the cache storage supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
+If the caches doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
+If the caches supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
 
 You can use `must-understand` when you respond with a newly defined status code.
 
@@ -231,7 +231,7 @@ A modern best practice for static resources is to include version/hashes in thei
 ```
 
 When a user reloads the browser, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources even when a user reloads the browser, because they're never modified.
-`immutable` tells cache storage that its response is immutable while it's fresh, and avoids these kinds of unnecessary conditional requests to the server.
+`immutable` tells caches that its response is immutable while it's fresh, and avoids these kinds of unnecessary conditional requests to the server.
 
 When you use a cache-busting pattern for resources and apply them to a long `max-age`, you can also add `immutable` to avoid revalidation.
 
@@ -293,7 +293,7 @@ The `max-age=N` request directive indicates that the client allows a stored resp
 Cache-Control: max-age=3600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=604800` was stored in cache storage 3 hours ago, the cache couldn't reuse that response.
+In the case above, if the response with `Cache-Control: max-age=604800` was stored in caches 3 hours ago, the cache couldn't reuse that response.
 
 Many browsers use this directive for **reloading**, as explained below.
 
@@ -311,9 +311,9 @@ The `max-stale=N` request directive indicates that the client allows a stored re
 Cache-Control: max-stale=3600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=604800` was stored on cache storage 3 hours ago, the cache couldn't reuse that response.
+In the case above, if the response with `Cache-Control: max-age=604800` was stored on caches 3 hours ago, the cache couldn't reuse that response.
 
-Clients could use this header when the origin server is down or too slow and could accept cached responses from cache storage even if it's a bit old.
+Clients could use this header when the origin server is down or too slow and could accept cached responses from caches even if it's a bit old.
 
 Note that the major browsers do not support requests with `max-stale`.
 
@@ -325,7 +325,7 @@ The `min-fresh=N` request directive indicates that the client allows a stored re
 Cache-Control: min-fresh=600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=3600` was stored in cache storage 51 minutes ago, the cache couldn't reuse that response.
+In the case above, if the response with `Cache-Control: max-age=3600` was stored in caches 51 minutes ago, the cache couldn't reuse that response.
 
 Clients could use this header when the user requires not only it's fresh but also it wouldn't update for a period of time.
 
@@ -337,13 +337,13 @@ Same meaning that `no-transform` has for a response, but for a request instead.
 
 ### `only-if-cached`
 
-The client indicates for cache storage to obtain an already-cached response. If cache storage has stored a response, it’s reused.
+The client indicates for caches to obtain an already-cached response. If caches has stored a response, it’s reused.
 
 ## Use Cases
 
 ### Preventing storing
 
-If you don’t want a response stored in cache storage, use the `no-store` directive.
+If you don’t want a response stored in caches, use the `no-store` directive.
 
 ```
 Cache-Control: no-store
@@ -417,7 +417,7 @@ Adding `no-cache` to the response causes revalidation to the server, so you can 
 Cache-Control: no-cache
 ```
 
-Most HTTP/1.0 caches don't support `no-cache` directives, so historically `max-age=0` was used as a workaround. But only `max-age=0` could cause a stale response to be reused when cache storage disconnected from the origin server. `must-revalidate` addresses that. That’s why the example below is equivalent to `no-cache`.
+Most HTTP/1.0 caches don't support `no-cache` directives, so historically `max-age=0` was used as a workaround. But only `max-age=0` could cause a stale response to be reused when caches disconnected from the origin server. `must-revalidate` addresses that. That’s why the example below is equivalent to `no-cache`.
 
 ```
 Cache-Control: max-age=0, must-revalidate
@@ -427,9 +427,9 @@ But for now, you can simply use `no-cache` instead.
 
 ### Clearing an already-stored cache
 
-Unfortunately, there are no cache directives for clearing already-stored responses from cache storage.
+Unfortunately, there are no cache directives for clearing already-stored responses from caches.
 
-Imagine that client / cache storage stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
+Imagine that client / caches stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
 Alternatively, `Clear-Site-Data` can clear all cache from the browser. But be careful: that clears every stored response for a site — and only in browsers, not for a shared cache.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -85,7 +85,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Private Cache`
   - : Cache storage that exists in the client. Also called _local cache_, or even just _browser cache_ etc. It can store and reuse personalized content for a single user.
 - `Store response`
-  - : Storing a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
+  - : Store a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`
   - : Reuse cached responses for subsequent requests.
 - `Revalidate response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -415,7 +415,7 @@ Cache-Control: max-age=31536000, immutable
 
 When you update the library or edit the picture, new content should have a new URL, and caches aren't reused. That is called the “cache busting” pattern.
 
-Make sure that the HTML response itself should not be cached with a long `max-age`. `no-cache` could cause revalidation and the client will receive a new version of HTML and static assets correctly.
+Use a long `max-age` to make sure that the HTML response itself is not cached. `no-cache` could cause revalidation, and the client will correctly receive a new version of the HTML response and static assets.
 
 ```
 # /index.html

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -358,7 +358,7 @@ Client indicates for cache storage to obtain an already cached response. If cach
 
 ## Use Cases
 
-### Preventing storing in cache
+### Preventing cache storage
 
 If you intend not to store responses in cache storage, you can use the `no-store` directive.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -310,7 +310,7 @@ Note that the major browsers do not support requests with `no-store`.
 Cache-Control: max-age=3600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=604800` was stored on cache storage 3 hours ago, cache couldn't reuse that response.
+In the case above, if the response with `Cache-Control: max-age=604800` was stored in cache storage 3 hours ago, the cache couldn't reuse that response.
 
 Many browsers use this directive for **Reloading** as below.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Cache-Control
 
 {{HTTPSidebar}}
 
-The **`Cache-Control`** HTTP header field holds _directives_ (instructions) in both requests and responses that control [caching](/en-US/docs/Web/HTTP/Caching) in browsers and shared caches (e.g. Proxies, CDNs).
+The **`Cache-Control`** HTTP header field holds _directives_ (instructions) — in both requests and responses — that control [caching](/en-US/docs/Web/HTTP/Caching) in browsers and shared caches (e.g. Proxies, CDNs).
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -342,7 +342,7 @@ Note that the major browsers do not support requests with `max-stale`.
 Cache-Control: min-fresh=600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=3600` was stored on cache storage 51 minutes ago, cache couldn't reuse that response.
+In the case above, if the response with `Cache-Control: max-age=3600` was stored on cache storage 51 minutes ago, that response couldn't be reused.
 
 Clients could use this header when the user requires not only it's fresh but also it wouldn't update for a period of time.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -401,7 +401,7 @@ Use a long `max-age` to make sure that the HTML response itself is not cached. `
 Cache-Control: no-cache
 ```
 
-Note: If `index.html` is controlled under Basic / Digest Authentication, files under `/assets` are not stored in the shared cache. If `/assets/` files are suitable for storing in a shared cache, you also need one of `public`, `s-maxage` or `must-revalidate`.
+Note: If `index.html` is controlled under Basic Authentication or Digest Authentication, files under `/assets` are not stored in the shared cache. If `/assets/` files are suitable for storing in a shared cache, you also need one of `public`, `s-maxage` or `must-revalidate`.
 
 ### Up-to-date contents always
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Cache-Control
 
 {{HTTPSidebar}}
 
-The **`Cache-Control`** HTTP header fields hold _directives_ (instructions) for [caching](/en-US/docs/Web/HTTP/Caching) in both requests and responses. This header can be used to control caching not only in the browser, but also in shared caches (e.g. Proxy, CDN, Load-Balancer etc).
+The **`Cache-Control`** HTTP header fields hold _directives_ (instructions) for [caching](/en-US/docs/Web/HTTP/Caching) in both requests and responses. This header can be used to control caching not only in browsers, but also in shared caches (e.g. Proxies, CDNs).
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -278,7 +278,7 @@ After a period of time, the stored response became stale normally. That means th
 
 ### `no-cache`
 
-The `no-cache` request directive indicates that the client requires that the cache — and every response — should be validated by the origin server before reusing the response.
+The `no-cache` request directive requests that the response should be validated by the origin server before reuse.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -450,7 +450,7 @@ Unfortunately, there are no cache directives for clearing already stored respons
 
 Imagine that client / cache storage stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
-Alternatively, `Clear-Site-Data` can clear all cache from the browser if supported. But be careful that it clears every stored response on site, and only for browsers, not a shared cache.
+Alternatively, `Clear-Site-Data` can clear all cache from the browser. But be careful: that clears every stored response for a site — and only in browsers, not for a shared cache.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -206,7 +206,7 @@ Cache-Control: public, max-age=604800
 
 Note that, `s-maxage` or `must-revalidate` also unlock that restriction.
 
-If you a request doesn’t have an `Authorization` header, or you are already using `s-maxage` or `must-revalidate` in the response, then you don't need to use `public`.
+If a request doesn’t have an `Authorization` header, or you are already using `s-maxage` or `must-revalidate` in the response, then you don't need to use `public`.
 
 #### `must-understand`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -196,7 +196,7 @@ Responses for requests with `Authorization` header fields should normally not be
 Cache-Control: public
 ```
 
-In general, when pages are under Basic Auth or Digest Auth, the browser sends requests with the `Authorization` header. It means that it is access controlled for restricted users (who have accounts), and it's fundamentally not shared cacheable even if it has `max-age`.
+In general, when pages are under Basic Auth or Digest Auth, the browser sends requests with the `Authorization` header. That means the response is access-controlled for restricted users (who have accounts), and it's fundamentally not shared-cacheable, even if it has `max-age`.
 
 You can use `public` directives to unlock its restriction.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -120,7 +120,7 @@ Age: 100
 
 #### `s-maxage`
 
-`s-maxage` response directive indicates the same meaning as `max-age` but only for Shared Cache.
+The `s-maxage` response directive has the same meaning as `max-age`, but only for the shared cache.
 
 ```
 Cache-Control: s-maxage=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -243,7 +243,7 @@ Cache-Control: max-age=604800, stale-while-revalidate=86400
 
 In the example above, the response is fresh for 7 days (604800s). After 7 days, it becomes stale but the cache is allowed to reuse it for any requests that are made in the following day (86400s) — provided that they revalidate the response in the background.
 
-Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during that period -- effectively hiding the latency penalty of revalidation from them.
+Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during that period — effectively hiding the latency penalty of revalidation from them.
 
 If no request happened during that period, the cache became stale and the next request will revalidate normally.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -194,7 +194,7 @@ If a request doesn’t have an `Authorization` header, or you are already using 
 
 #### `must-understand`
 
-The `must-understand` response directive indicates that caches should store the response only if it understands the requirements for caching based on status code.
+The `must-understand` response directive indicates that a cache should store the response only if it understands the requirements for caching based on status code.
 
 `must-understand` should be coupled with `no-store`, for fallback behavior.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -79,7 +79,7 @@ When talking about caching, there is sometimes confusion because the word _cache
 Therefore, several terms are used in the specification to clarify the explanation.
 
 - `Cache Storage`
-  - : The storage who stores request/response in it for reusing in the following request.
+  - : The storage which holds requests and responses for reusing in the subsequent requests.
 - `Shared Cache`
   - : Cache storage that exists between the origin server and clients. (e.g. Proxy, CDN, Load Balancer etc.) It stores a single response and reuses it to multiple users, so developers should avoid storing personalized contents to be cached in shared cache.
 - `Private Cache`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -249,7 +249,7 @@ If no request happened during that period, the cache became stale and the next r
 
 #### `stale-if-error`
 
-The `stale-if-error` response directive indicates that the cache could reuse a stale response when an origin server responds with an error (500, 502, 503, or 504).
+The `stale-if-error` response directive indicates that the cache can reuse a stale response when an origin server responds with an error (500, 502, 503, or 504).
 
 ```
 Cache-Control: max-age=604800, stale-if-error=86400

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -444,7 +444,7 @@ Cache-Control: max-age=0, must-revalidate
 
 But for now, you can simply use `no-cache` instead.
 
-### Clearing already stored cache
+### Clearing an already-stored cache
 
 Unfortunately, there are no cache directives for clearing already stored responses from cache storage.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -85,7 +85,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Private Cache`
   - : Cache storage that exists in the client. On the other words Local Cache, Browser Cache etc. It can store and reuse personalized content for a single user.
 - `Store response`
-  - : Storing response in Cache Storage when it's cacheable. But it's not always reused as-is. (Usually "Cache" means it)
+  - : Storing a response in cache storage when it's cacheable. But it's not always reused as-is. (Usually "cache" means storing a response.)
 - `Reuse response`
   - : Reusing cached responses for following requests.
 - `Revalidate response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -182,7 +182,7 @@ You should add the `private` directive for user-personalized content — in part
 
 If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal  information to leak.
 
-`no-store` seems to work fine for avoiding it, but these are semantically different. It's better to use `private` for private contents and `no-store` for avoiding storing private cache too.
+`no-store` may seems to work fine for avoiding leaks, but is semantically different from `private`. To avoiding leaking personal information, it's better to use both `private` and `no-store`.
 
 ```
 Cache-Control: private, no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -276,7 +276,7 @@ Cache-Control: max-age=604800, stale-if-error=86400
 
 In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s), whenever a server responds with an error.
 
-After a period of time, the stored response became stale normally. It means that the client will receive an error response as-is if the origin server sends it.
+After a period of time, the stored response became stale normally. That means the client will receive an error response as-is if the origin server sends it.
 
 ## Request Directives
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -261,7 +261,7 @@ Cache-Control: max-age=604800, stale-while-revalidate=86400
 
 In the example above, the response is fresh for 7 days (604800s). After 7 days, it becomes stale but the cache is allowed to reuse it for any requests that are made in the following day (86400s), provided that they revalidate the response in the background.
 
-Revalidation will make the cache be fresh again, so it appears to the client that it was always fresh during that period.
+Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during that period -- effectively hiding the latency penalty of revalidation from them.
 
 If no request happened during that period, the cache became stale and the next request will revalidate normally.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -190,7 +190,7 @@ Cache-Control: private, no-store
 
 #### `public`
 
-Response for Request with `Authorization` header fields should not be stored on shared cache. But `public` will accept it to store on shared cache.
+Responses for requests with `Authorization` header fields should normally not be stored in a shared cache. But the `public` directive will cause such responses to be stored in a shared cache.
 
 ```
 Cache-Control: public

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -366,7 +366,7 @@ If you don’t want a response stored in cache storage, use the `no-store` direc
 Cache-Control: no-store
 ```
 
-Note that `no-cache` means "it can be stored but don't reuse before validating" so it's not for preventing storing cache.
+Note that `no-cache` means "it can be stored but don't reuse before validating", so it's not for preventing cache storage.
 
 ```plain example-bad
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -350,7 +350,7 @@ Note that the major browsers do not support requests with `min-fresh`.
 
 ### `no-transform`
 
-Same meaning with `no-transform` on response but on request.
+Same meaning that `no-transform` has for response, but for a request instead.
 
 ### `only-if-cached`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -446,7 +446,7 @@ But for now, you can simply use `no-cache` instead.
 
 ### Clearing an already-stored cache
 
-Unfortunately, there are no cache directives for clearing already stored responses from cache storage.
+Unfortunately, there are no cache directives for clearing already-stored responses from cache storage.
 
 Imagine that client / cache storage stores a fresh response for a path, with no request flight to the server. There is nothing a server could do to that path.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -259,7 +259,7 @@ The `stale-while-revalidate` response directive indicates that the cache could r
 Cache-Control: max-age=604800, stale-while-revalidate=86400
 ```
 
-In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s). During that period of time (1 day), the cache reuses the response and at the same time revalidates it to the origin server too.
+In the example above, the response is fresh for 7 days (604800s). After 7 days, it becomes stale but the cache is allowed to reuse it for any requests that are made in the following day (86400s), provided that they revalidate the response in the background.
 
 Revalidation will make the cache be fresh again, so it appears to the client that it was always fresh during that period.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -126,7 +126,7 @@ The `s-maxage` response directive has the same meaning as `max-age`, but only fo
 Cache-Control: s-maxage=604800
 ```
 
-`s-maxage` can be used to control the private cache and shared cache separately.
+`s-maxage` can be used to control the shared cache separate from the private cache.
 
 #### `no-cache`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -130,7 +130,7 @@ Cache-Control: s-maxage=604800
 
 #### `no-cache`
 
-`no-cache` response directive indicates that the response can be stored in the cache storage, but validates it to the origin server before reusing (even when disconnected to the origin server).
+The `no-cache` response directive indicates that the response can be stored in cache storage, but must be validated to the origin server before reusing (even when disconnected from the origin server).
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -220,7 +220,7 @@ When a server sends a new status code in a response which has some requirements 
 Cache-Control: must-understand, no-store
 ```
 
-if the cache storage doesn't support `must-understand` will ignore it. only `no-store` remains and response isn't stored.
+If the cache storage doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
 if the cache storage supports `must-understand`, it stores responses with understanding of cache requirements for its status code.
 
 You can use it when you respond with a newly defined status code.

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -247,7 +247,7 @@ A modern best practice for static resources is to include version/hashes in thei
 <script src=https://example.com/react.0.0.0.js></script>
 ```
 
-Browsers will send conditional requests for validating to the origin server when it is reloaded. But it's not necessary to revalidate these kinds of static resources because they're never modified.
+When a resource is reloaded, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources, because they're never modified.
 `immutable` tells cache storage that its response is immutable while it's fresh, and avoids these kinds of unnecessary conditional requests to the server.
 
 When you use a cache-busting pattern for resources and apply them to a long `max-age`, you can also add `immutable` to avoid revalidation.

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -93,7 +93,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Fresh response`
   - : Indicates that the response is fresh. This usually means the response can be reused for subsequent requests, depending on request directives.
 - `Stale response`
-  - : Indicates that the response is stale. It usually means the response can't be reusable as-is. Cache storage isn't required to remove stale responses immediately, because revalidation could change the response from being stale to being fresh again.
+  - : Indicates that the response is stale. It usually means the response can't be reused as-is. Cache storage isn't required to remove stale responses immediately, because revalidation could change the response from being stale to being fresh again.
 - `Age`
   - : The time since a response was generated. It is a criterion for whether a response is fresh or stale.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -285,7 +285,7 @@ Cache-Control: no-cache
 
 `no-cache` means that clients could always receive up-to-date responses even if cache storage stores fresh responses.
 
-Browser usually add `no-cache` to the request when users are **force reloading** a page.
+Browser usually add `no-cache` to requests when users are **force reloading** a page.
 
 ### `no-store`
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -103,7 +103,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 
 #### `max-age`
 
-`max-age=N` response directive indicates that the response is Fresh until N seconds since response has been generated.
+The `max-age=N` response directive indicates that the response remains fresh until _N_ seconds after the response is generated.
 
 ```
 Cache-Control: max-age=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -366,7 +366,7 @@ If you don’t want a response stored in cache storage, use the `no-store` direc
 Cache-Control: no-store
 ```
 
-Note that `no-cache` means "it can be stored but don't reuse before validating", so it's not for preventing cache storage.
+Note that `no-cache` means "it can be stored but don't reuse before validating", so it's not for preventing to store a response.
 
 ```plain example-bad
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -172,7 +172,7 @@ Cache-Control: no-store, private
 
 #### `private`
 
-the `private` response directive indicates that the response can be stored only in a private cache (e.g. local cache storage in browsers).
+The `private` response directive indicates that the response can be stored only in a private cache (e.g. local cache storage in browsers).
 
 ```
 Cache-Control: private

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Cache-Control
 
 {{HTTPSidebar}}
 
-The **`Cache-Control`** HTTP header fields holds _directives_ (instructions) for [caching](/en-US/docs/Web/HTTP/Caching) in both requests and responses. This header can be used to control caching not only in the browser, but also in shared caches (e.g. Proxy, CDN, Load-Balancer etc).
+The **`Cache-Control`** HTTP header fields hold _directives_ (instructions) for [caching](/en-US/docs/Web/HTTP/Caching) in both requests and responses. This header can be used to control caching not only in the browser, but also in shared caches (e.g. Proxy, CDN, Load-Balancer etc).
 
 <table class="properties">
   <tbody>
@@ -182,7 +182,7 @@ You should add the `private` directive for user-personalized content — in part
 
 If you forget to add `private` to a response with personalized content, then that response can be stored in a shared cache and end up being used by multiple users, which can cause personal information to leak.
 
-`no-store` may seem to work fine for avoiding leaks, but is semantically different from `private`. To avoiding leaking personal information, it's better to use both `private` and `no-store`.
+`no-store` may seem to work fine for avoiding leaks, but is semantically different from `private`. To avoid leaking personal information, it's better to use both `private` and `no-store`.
 
 ```
 Cache-Control: private, no-store
@@ -227,7 +227,7 @@ You can use `must-understand` when you respond with a newly defined status code.
 
 #### `no-transform`
 
-Some intermediaries transform contents for various reasons. For example, some convert images to reduce transfer packets. But in some cases it cause unexpected behavior for the content provider.
+Some intermediaries transform contents for various reasons. For example, some convert images to reduce transfer packets. But in some cases it causes unexpected behavior for the content provider.
 
 `no-transform` indicates that any intermediary (regardless of whether it implements a cache) can't transform the response contents.
 
@@ -247,7 +247,7 @@ A modern best practice for static resources is to include version/hashes in thei
 <script src=https://example.com/react.0.0.0.js></script>
 ```
 
-When user reloads the browser, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources even when user realods the browser, because they're never modified.
+When a user reloads the browser, browsers will send conditional requests for validating to the origin server. But it's not necessary to revalidate these kinds of static resources even when a user reloads the browser, because they're never modified.
 `immutable` tells cache storage that its response is immutable while it's fresh, and avoids these kinds of unnecessary conditional requests to the server.
 
 When you use a cache-busting pattern for resources and apply them to a long `max-age`, you can also add `immutable` to avoid revalidation.
@@ -398,7 +398,7 @@ For example:
 
 The React library version will change when you update the library, and `hero.png` will also change when you edit the picture. So those are hard to store in a cache with `max-age`.
 
-In such a case, you could address the caching needs by using a specific, numbered version of the library, and including hash of the picture in its URL.
+In such a case, you could address the caching needs by using a specific, numbered version of the library, and including the hash of the picture in its URL.
 
 ```html
 <!-- index.html —>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -111,7 +111,7 @@ Cache-Control: max-age=604800
 
 Indicates that cache storage can store this response and reuse it for subsequent requests while it's fresh.
 
-Note that `max-age` is not the elapsed time since the response was received, but instead th elapsed time since he response was generated on the origin server. So if the intermediate cache stores it for 100 seconds (for indicating that, the intermediate cache adds an `Age` header to the response), the browser local cache storage could reuse it `-100` seconds from `max-age`.
+Note that `max-age` is not the elapsed time since the response was received, but instead the elapsed time since the response was generated on the origin server. So if the intermediate cache stores it for 100 seconds (for indicating that, the intermediate cache adds an `Age` header to the response), the browser local cache storage could reuse it `-100` seconds from `max-age`.
 
 ```
 Cache-Control: max-age=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -336,7 +336,7 @@ Note that the major browsers do not support requests with `max-stale`.
 
 ### `min-fresh`
 
-`min-fresh=N` request directive indicates that the client allows a stored response that is fresh for at least N seconds.
+The `min-fresh=N` request directive indicates that the client allows a stored response that is fresh for at least _N_ seconds.
 
 ```
 Cache-Control: min-fresh=600

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -262,7 +262,7 @@ Cache-Control: max-age=604800, stale-while-revalidate=86400
 
 In the example above, cache storage stores a response and it's been fresh for 7 days (604800s). After 7 days, it became stale but the cache could reuse it for an extra 1 day (86400s). During that period of time (1 day), the cache reuses the response and at the same time revalidates it to the origin server too.
 
-Revalida will make the cache to be fresh again, so it appears to the client that it was always fresh during that period.
+Revalidation will make the cache to be fresh again, so it appears to the client that it was always fresh during that period.
 
 If no request happened during that period, cache became stale and the next request will revalidate normally.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -277,7 +277,7 @@ After a period of time, the stored response became stale normally. That means th
 
 ### `no-cache`
 
-The `no-cache` request directive requests that the response should be validated by the origin server before reuse.
+The `no-cache` request directive asks caches to validate the response with the origin server before reuse.
 
 ```
 Cache-Control: no-cache

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -241,7 +241,7 @@ The `stale-while-revalidate` response directive indicates that the cache could r
 Cache-Control: max-age=604800, stale-while-revalidate=86400
 ```
 
-In the example above, the response is fresh for 7 days (604800s). After 7 days, it becomes stale but the cache is allowed to reuse it for any requests that are made in the following day (86400s), provided that they revalidate the response in the background.
+In the example above, the response is fresh for 7 days (604800s). After 7 days, it becomes stale but the cache is allowed to reuse it for any requests that are made in the following day (86400s) — provided that they revalidate the response in the background.
 
 Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during that period -- effectively hiding the latency penalty of revalidation from them.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -384,7 +384,7 @@ In theory, if directives are conflicted, the most restrictive directive should b
 Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
 ```
 
-### Caching static assets with Cache Busting
+### Caching static assets with “cache busting”
 
 When you build static assets with versioning / hashing mechanisms. Adding version/hash to the filename or query string is a good way to manage caching.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -365,7 +365,7 @@ Cache-Control: no-store
 
 ### Caching static assets with “cache busting”
 
-When you build static assets with versioning / hashing mechanisms, adding a version/hash to the filename or query string is a good way to manage caching.
+When you build static assets with versioning/hashing mechanisms, adding a version/hash to the filename or query string is a good way to manage caching.
 
 For example:
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -131,7 +131,7 @@ The `no-cache` response directive indicates that the response can be stored in c
 Cache-Control: no-cache
 ```
 
-If you want a client to always get the latest content, and/or if your server supports conditional requests, `no-cache` is the directive to use.
+If you want caches to always check for content updates while reusing stored content when it hasn't changed, `no-cache` is the directive to use. It does this by requiring caches to revalidate each request with the origin server.
 
 Note that a common mistake is to consider `no-cache` to mean "don't cache". However, `no-cache` actually allows storing but validating before reusing. If the sense of "don't cache" that you want is actually "don't store", then `no-store` is the directive to use.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -158,7 +158,7 @@ The `proxy-revalidate` response directive is the equivalent of `must-revalidate`
 
 #### `no-store`
 
-`no-store` response directive indicates that every (private/shared) cache storage should not store this response.
+The `no-store` response directive indicates that any cache storage of any kind (private or shared) should not store this response.
 
 ```
 Cache-Control: no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -41,7 +41,7 @@ The **`Cache-Control`** HTTP header fields hold _directives_ (instructions) for 
 
 Caching directives follow the validation rules below:
 
-- Case-insensitive, but lowercase is recommended.
+- Case-insensitive, but lowercase is recommended, since some implementations do not recognise uppercase directives.
 - Multiple directives are comma-separated.
 - Some directives have an optional argument.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -117,7 +117,7 @@ Age: 100
 
 #### `s-maxage`
 
-The `s-maxage` response directive also indicate how long the response is fresh for (similar to `max-age`), but it is specific to shared caches, and they will ignore `max-age` when it is present. 
+The `s-maxage` response directive also indicates how long the response is fresh for (similar to `max-age`) — but it is specific to shared caches, and they will ignore `max-age` when it is present. 
 
 ```
 Cache-Control: s-maxage=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -190,7 +190,7 @@ Cache-Control: private, no-store
 
 #### `public`
 
-Responses for requests with `Authorization` header fields should normally not be stored in a shared cache. But the `public` directive will cause such responses to be stored in a shared cache.
+Responses for requests with `Authorization` header fields must not be stored in a shared cache. But the `public` directive will cause such responses to be stored in a shared cache.
 
 ```
 Cache-Control: public

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -94,6 +94,7 @@ The following terms are used in this document; many but not all are from the spe
   - : The time since a response was generated. It is a criterion for whether a response is fresh or stale.
 
 ## Directives
+This section lists directives that affect caching — both response directives and request directives.
 
 ### Response Directives
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -378,7 +378,7 @@ But if you don’t want a response stored in a shared cache **because it's perso
 Cache-Control: no-store, private
 ```
 
-In theory, if directives are conflicted, the most restrictive directive should be honored. So it's basically meaningless because `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
+In theory, if directives are conflicted, the most restrictive directive should be honored. So the above is basically meaningless, because `no-cache`, `max-age=0` and `must-revalidate` conflict with `no-store`.
 
 ```plain example-bad
 Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -235,7 +235,7 @@ Note: [Google’s Web Light](https://support.google.com/webmasters/answer/621142
 
 #### `immutable`
 
-`immutable` response directive indicates that the response will not be updated while it's been fresh.
+The `immutable` response directive indicates that the response will not be updated while it's been fresh.
 
 ```
 Cache-Control: public, max-age=604800, immutable

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -214,7 +214,7 @@ The `must-understand` response directive indicates that cache storage should sto
 
 When a server sends a new status code in a response which has some requirements based on status code, it can cause some trouble when cache storage stores it without understanding those requirements.
 
-`must-understand` should be coupled with `no-store, for fallback behavior.
+`must-understand` should be coupled with `no-store`, for fallback behavior.
 
 ```
 Cache-Control: must-understand, no-store

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -81,7 +81,7 @@ Therefore, several terms are used in the specification to clarify the explanatio
 - `Cache Storage`
   - : The storage which holds requests and responses for reusing in the subsequent requests.
 - `Shared Cache`
-  - : Cache storage that exists between the origin server and clients. (e.g. Proxy, CDN, Load Balancer etc.) It stores a single response and reuses it to multiple users, so developers should avoid storing personalized contents to be cached in shared cache.
+  - : Cache storage that exists between the origin server and clients (e.g. Proxy, CDN, Load Balancer, etc.) It stores a single response and reuses it with multiple users, so developers should avoid storing personalized contents to be cached in the shared cache.
 - `Private Cache`
   - : Cache storage that exists in the client. On the other words Local Cache, Browser Cache etc. It can store and reuse personalized content for a single user.
 - `Store response`

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -221,7 +221,7 @@ Cache-Control: must-understand, no-store
 ```
 
 If the cache storage doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
-if the cache storage supports `must-understand`, it stores responses with understanding of cache requirements for its status code.
+If the cache storage supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
 
 You can use it when you respond with a newly defined status code.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -254,7 +254,7 @@ When you use a cache-busting pattern for resources and apply them to a long `max
 
 #### `stale-while-revalidate`
 
-`stale-while-revalidate` response directive indicates that the cache could reuse a stale response while it revalidates it to cache.
+The `stale-while-revalidate` response directive indicates that the cache could reuse a stale response while it revalidates it to a cache.
 
 ```
 Cache-Control: max-age=604800, stale-while-revalidate=86400

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -406,7 +406,7 @@ In that case, including the library version of JS and the hash of the picture in
 <img src=/assets/hero.png?hash=deadbeef width=900 height=400>
 ```
 
-You can add long `max-age` and `immutable` because contents will never change.
+You can add a long `max-age` value, and `immutable`, because the content will never change.
 
 ```
 # /assets/*

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -202,9 +202,9 @@ The `must-understand` response directive indicates that a cache should store the
 Cache-Control: must-understand, no-store
 ```
 
-If the caches doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
+If a cache doesn't support `must-understand`, it will be ignored. If `no-store` is also present, the response isn't stored.
 
-If the caches supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
+If a cache supports `must-understand`, it stores the response with an understanding of cache requirements based on its status code.
 
 #### `no-transform`
 


### PR DESCRIPTION
#### Summary

- close #8668
- update `max-age` explanation related to `no-cache`
- it requires explain the word of **cache** cause misread
  - "caching a cache to the cache" problem
  -  Replace it using "Storing Response", "Reusing Response" explicitly
  - adding Vocabulary section
- rewriting each directives align with Vocabulary
- adding newly defined `must-understand` in the same manner
- rewriting Examples with a same manner
  - rename it use cases
  - adding 'clearing already stored cache' as @mnot mentions
- Totally rewrite

#### TODO

Which I can also support is..

- [ ] Update [Caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching) section too.
- [ ] Translate them in Japanese

#### Motivation

- Correcting Cache-Control section
- Update it align with current httpbis draft (which will published as RFC soon)

#### Supporting details

- https://httpwg.org/http-core/draft-ietf-httpbis-cache-latest.html

#### Metadata

- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error



CCing @mnot , @hamishwillee , @sideshowbarker