### PR TITLE
In the API property page template, Value should be an H2

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -85,7 +85,7 @@ The summary paragraph — start by naming the property, saying what interface it
 This should ideally be 1 or 2 short sentences.
 You could copy most of this from the property's summary on the corresponding API reference page. Include whether it is read-only or not.
 
-### Value
+## Value
 
 Include a description of the property's value, including data type and what it represents.
 


### PR DESCRIPTION
We recently decided to remove the "Syntax" section for property pages, but keep the "Value" section only.

This was discussed in https://github.com/mdn/content/discussions/5992 and the meta-docs were updated in https://github.com/mdn/content/discussions/5992.

But after this change the "Value" heading should be promoted to H2 (since there's no longer a "Syntax" section for it to live inside. This PR makes that update.
