### PR TITLE
Added more information to parseInt documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -46,7 +46,7 @@ An integer parsed from the given `string`.
 
 Or {{jsxref("NaN")}} when
 
-- the `radix` is smaller than `2` or bigger than
+- the `radix` modulo 32 is smaller than `2` or bigger than
   `36`, or
 - the first non-whitespace character cannot be converted to a number.
 

--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -46,7 +46,7 @@ An integer parsed from the given `string`.
 
 Or {{jsxref("NaN")}} when
 
-- the `radix` modulo 32 is smaller than `2` or bigger than
+- the `radix` modulo `2**32` is smaller than `2` or bigger than
   `36`, or
 - the first non-whitespace character cannot be converted to a number.
 


### PR DESCRIPTION

#### Summary
According to ECMAScript Documentation, the radix is converted using the internal method ToInt32 which applies modulo to any number greater than 2 ** 32.

#### Motivation
Readers of this documentation may find it surprising if they try something like parseInt("3ab", 4294967312) and it returns a valid integer, meanwhile according to this documentation, every radix greater than 32 return NaN. I  believe that detail is important for the reader of this documentation to know

#### Supporting details
https://tc39.es/ecma262/#sec-parseint-string-radix

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
