### PR TITLE
Does scale support length/percentage value?

### DIFF
--- a/files/en-us/web/css/scale/index.md
+++ b/files/en-us/web/css/scale/index.md
@@ -42,9 +42,9 @@ scale: unset;
 
 - Single number value
   - : A {{CSSxRef("&lt;number&gt;")}} specifying a scale factor to make the affected element scale by the same factor along both the X and Y axes. Equivalent to a `scale()` (2D scaling) function with a single value specified.
-- Two length/percentage values
+- Two number values
   - : Two {{CSSxRef("&lt;number&gt;")}}s that specify the X and Y axis scaling values (respectively) of a 2D scale. Equivalent to a `scale()` (2D scaling) function with two values specified.
-- Three length/percentage values
+- Three number values
   - : Three {{CSSxRef("&lt;number&gt;")}}s that specify the X, Y, and Z axis scaling values (respectively) of a 3D scale. Equivalent to a `scale3d()` (3D scaling) function.
 - `none`
   - : Specifies that no scaling should be applied.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I don't think scale supports length and percentage values so in that case we are suppose to make use of number rather than length/percentage.

If it supports please correct me.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
