### PR TITLE
Add other reasons for `TypeError` that `fetch` throws

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -176,9 +176,7 @@ fetch('https://example.com/', { headers });
     </tr>
     <tr>
       <td>
-        Invalid url/scheme or
-        using un-supported schemes by fetch or
-        using un-supported schemes for particular request mode
+        Invalid url/scheme, or using a scheme that fetch does not supported, or using a scheme that is not supported for a particular request mode.
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -201,7 +201,7 @@ fetch('https://example.com/', {
       </td>
     </tr>
     <tr>
-      <td>In valid modes- navigate and websocket</td>
+      <td>Invalid modes (<code>navigate</code> and <code>websocket</code></td>
       <td>
         <pre>
 fetch('https://example.com/', { mode: 'navigate' })

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -191,7 +191,7 @@ fetch('https://user:password@example.com/')
         </pre>
       </td>
     <tr>
-      <td>Invalid referrer url-</td>
+      <td>Invalid referrer URL</td>
       <td>
         <pre>
 fetch('https://example.com/', {

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -234,8 +234,7 @@ fetch('https://example.com/', { method: 'CONNECT' })
     </tr>
     <tr>
       <td>
-        If request mode is "no-cors" and the request method is other than
-        CORS-safe-listed method (GET, HEAD, or POST)
+        If request mode is "no-cors" and the request method is not a CORS-safe-listed method (GET, HEAD, or POST)
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -247,7 +247,7 @@ fetch('https://example.com/', {
     </tr>
     <tr>
       <td>
-        If request method is GET or HEAD and the body is non-null or not undefined.
+        If the request method is GET or HEAD and the body is non-null or not undefined.
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -137,7 +137,7 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
   - : The request was aborted due to a call to the {{domxref("AbortController")}}
     {{domxref("AbortController.abort", "abort()")}} method.
 - `TypeError`
-  - : The error can occur because of one of the following reasons-
+  - : Can occur for the following reasons:
 
 <table>
   <thead>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -210,7 +210,7 @@ fetch('https://example.com/', { mode: 'navigate' })
     </tr>
     <tr>
       <td>
-        If the request cache mode is "only-if-cached" and the request mode is other than "same-origin"
+        If the request cache mode is "only-if-cached" and the request mode is other than "same-origin".
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -176,7 +176,7 @@ fetch('https://example.com/', { headers });
     </tr>
     <tr>
       <td>
-        Invalid URL or scheme, or using a scheme that fetch does not supported, or using a scheme that is not supported for a particular request mode.
+        Invalid URL or scheme, or using a scheme that fetch does not support, or using a scheme that is not supported for a particular request mode.
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -234,7 +234,7 @@ fetch('https://example.com/', { method: 'CONNECT' })
     </tr>
     <tr>
       <td>
-        If request mode is "no-cors" and the request method is not a CORS-safe-listed method (GET, HEAD, or POST)
+        If the request mode is "no-cors" and the request method is not a CORS-safe-listed method (GET, HEAD, or POST)
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -144,7 +144,6 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
     <tr>
       <th scope="col">Reason</th>
       <th scope="col">Failing examples</th>
-      <th scope="col">Passing examples</th>
     </tr>
   </thead>
   <tbody>
@@ -160,11 +159,10 @@ const headers = {
 fetch('https://example.com/', { headers });
         </pre>
       </td>
-      <td></td>
     </tr>
     <tr>
       <td>
-        Invalid header value- the header object must contain exactly two elements.
+        Invalid header value- the header object must contain exactly two elements
       </td>
       <td>
         <pre>
@@ -175,15 +173,97 @@ const headers = [
 fetch('https://example.com/', { headers });
         </pre>
       </td>
+    </tr>
+    <tr>
+      <td>
+        Invalid url/scheme or
+        using un-supported schemes by fetch or
+        using un-supported schemes for particular request mode
+      </td>
       <td>
         <pre>
-const headers = [
-    ["Content-Type", "application/json"],
-    ["Accept", "*"],
-];
-fetch('https://example.com/', { headers });
+fetch('blob://example.com/', { mode: 'cors' })
         </pre>
       </td>
+    </tr>
+      <td>Url includes credentials</td>
+      <td>
+        <pre>
+fetch('https://user:password@example.com/')
+        </pre>
+      </td>
+    <tr>
+      <td>Invalid referrer url-</td>
+      <td>
+        <pre>
+fetch('https://example.com/', {
+  referrer: './abc\u0000df'
+})
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>In valid modes- navigate and websocket</td>
+      <td>
+        <pre>
+fetch('https://example.com/', { mode: 'navigate' })
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        If the request cache mode is "only-if-cached" and the request mode is other than "same-origin"
+      </td>
+      <td>
+        <pre>
+fetch('https://example.com/', {
+  cache: 'only-if-cached',
+  mode: 'no-cors'
+})
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        If request method is an invalid name token or one of forbidden headers-
+        CONNECT, TRACE or TRACK
+      </td>
+      <td>
+        <pre>
+fetch('https://example.com/', { method: 'CONNECT' })
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        If request mode is "no-cors" and the request method is other than
+        CORS-safe-listed method (GET, HEAD, or POST)
+      </td>
+      <td>
+        <pre>
+fetch('https://example.com/', {
+  method: 'CONNECT',
+  mode: 'no-cors'
+})
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        If request method is GET or HEAD and body is non-null or not undefined
+      </td>
+      <td>
+        <pre>
+fetch('https://example.com/', {
+  method: 'GET',
+  body: new FormData()
+})
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>if fetch throws a network error</td>
+      <td></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -223,7 +223,7 @@ fetch('https://example.com/', {
     </tr>
     <tr>
       <td>
-        If request method is an invalid name token or one of forbidden headers-
+        If the request method is an invalid name token or one of forbidden headers.
         CONNECT, TRACE or TRACK
       </td>
       <td>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -247,7 +247,7 @@ fetch('https://example.com/', {
     </tr>
     <tr>
       <td>
-        If request method is GET or HEAD and body is non-null or not undefined
+        If request method is GET or HEAD and the body is non-null or not undefined.
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -148,7 +148,7 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
   </thead>
   <tbody>
     <tr>
-      <td>Invalid header names</td>
+      <td>Invalid header name</td>
       <td>
         <pre>
 // space in "C ontent-Type"

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -176,7 +176,7 @@ fetch('https://example.com/', { headers });
     </tr>
     <tr>
       <td>
-        Invalid url/scheme, or using a scheme that fetch does not supported, or using a scheme that is not supported for a particular request mode.
+        Invalid URL or scheme, or using a scheme that fetch does not supported, or using a scheme that is not supported for a particular request mode.
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -162,7 +162,7 @@ fetch('https://example.com/', { headers });
     </tr>
     <tr>
       <td>
-        Invalid header value- the header object must contain exactly two elements
+        Invalid header value. The header object must contain exactly two elements.
       </td>
       <td>
         <pre>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -259,7 +259,7 @@ fetch('https://example.com/', {
       </td>
     </tr>
     <tr>
-      <td>if fetch throws a network error</td>
+      <td>If fetch throws a network error.</td>
       <td></td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -137,7 +137,56 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
   - : The request was aborted due to a call to the {{domxref("AbortController")}}
     {{domxref("AbortController.abort", "abort()")}} method.
 - `TypeError`
-  - : The specified URL string includes user credentials that should instead be passed with an {{HTTPHeader("Authorization")}} header, or a `NetworkError` has happened (this can include [CORS errors](/en-US/docs/Web/HTTP/CORS/Errors)).
+  - : The error can occur because of one of the following reasons-
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Reason</th>
+      <th scope="col">Failing examples</th>
+      <th scope="col">Passing examples</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Invalid header names</td>
+      <td>
+        <pre>
+// space in "C ontent-Type"
+const headers = {
+    "C ontent-Type": "text/xml",
+    "Breaking-Bad": "<3"
+};
+fetch('https://example.com/', { headers });
+        </pre>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>
+        Invalid header value- the header object must contain exactly two elements.
+      </td>
+      <td>
+        <pre>
+const headers = [
+    ["Content-Type", "text/html", "extra"],
+    ["Accept"],
+];
+fetch('https://example.com/', { headers });
+        </pre>
+      </td>
+      <td>
+        <pre>
+const headers = [
+    ["Content-Type", "application/json"],
+    ["Accept", "*"],
+];
+fetch('https://example.com/', { headers });
+        </pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Examples
 

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -184,7 +184,7 @@ fetch('blob://example.com/', { mode: 'cors' })
         </pre>
       </td>
     </tr>
-      <td>Url includes credentials</td>
+      <td>URL includes credentials</td>
       <td>
         <pre>
 fetch('https://user:password@example.com/')

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -201,7 +201,7 @@ fetch('https://example.com/', {
       </td>
     </tr>
     <tr>
-      <td>Invalid modes (<code>navigate</code> and <code>websocket</code></td>
+      <td>Invalid modes (<code>navigate</code> and <code>websocket</code>)</td>
       <td>
         <pre>
 fetch('https://example.com/', { mode: 'navigate' })


### PR DESCRIPTION
#### Summary
Add all the reasons due to ill-formed requests that will result in `TypeError`

#### Supporting details
There were a total of 36 occurrences of `TypeError` in the spec. I listed most of them. The remaining are unlikely to occur while calling `fetch`. Please let me know if they should be included too. These remaining occurrences are-
1. > If chunk is not a `Uint8Array` object, then set `continueAlgorithm` to this step: run `processBodyError` given a `TypeError`. [Ref](https://fetch.spec.whatwg.org/#ref-for-incrementally-read-loop)
2. > If stream is readable, error stream with a `TypeError`. [Ref](https://fetch.spec.whatwg.org/#http-network-fetch) (Step 19.2.4)
3. > If `keepalive` is true, then throw a `TypeError`. [Ref]() (Step 6 #ReadableStream)
4. > If object is disturbed or locked, then throw a `TypeError`. [Ref]() (Step 6 #ReadableStream)
5. > If `inputOrInitBody` is non-null and `inputOrInitBody`’s source is `null`, then [Ref](https://fetch.spec.whatwg.org/#dom-request) (Step 38.1)
6. > If `initBody` is `null` and `inputBody` is non-null, then: [Ref](https://fetch.spec.whatwg.org/#dom-request) (Step 40.1)


There are some other occurrences too. But they are results of methods of other classes like `Header`, `Request` which are not used while calling `fetch`. For example (including but not limited to)-
* `Header.prototype.delete` method.
* `Request` constructor (those steps which are guaranteed to be correct while calling `fetch`)
* `Request.prototype.clone`
* `Response.prototype.redirect`

There are some other reasons (possibly more than 10), which occurs because of **network-error**. I have not listed them in this PR. In my opinion, there should be a separate page altogether since there are many reasons which will result in `TypeError`. Let me know how to proceed further.

#### Related issues
Fixes #5545

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error