### PR TITLE
Clarify event stream “retry” field

### DIFF
--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -142,7 +142,7 @@ Each message received has some combination of the following fields, one per line
 - `id`
   - : The event ID to set the [`EventSource`](/en-US/docs/Web/API/EventSource) object's last event ID value.
 - `retry`
-  - : The reconnection time to use when attempting to send the event. This must be an integer, specifying the reconnection time in milliseconds. If a non-integer value is specified, the field is ignored.
+  - : The reconnection time. If the connection to the server is lost, the browser will wait for the specified time before attempting to reconnect. This must be an integer, specifying the reconnection time in milliseconds. If a non-integer value is specified, the field is ignored.
 
 All other field names are ignored.
 


### PR DESCRIPTION
#### Summary
Clarify that the retry field changes the browser’s reconnection delay.

#### Motivation
I was reading this documentation and was confused by the definition for retry because it says “attempting to send the event”, but the browser doesn’t send events and the server normally doesn’t care about the event it sends.

#### Supporting details
I found a clearer explaination of the behavior of retry on: https://html.spec.whatwg.org/multipage/server-sent-events.html#processField

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
