### PR TITLE
Hoisting docs - clarify class hoisting

### DIFF
--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -6,28 +6,22 @@ tags:
   - Glossary
   - JavaScript
 ---
-JavaScript **Hoisting** refers to the process whereby the interpreter allocates memory for function, variable and class _declarations_ in their scope, prior to execution of the code.
-This allows them to be referenced before they are defined.
+JavaScript **Hoisting** refers to the process whereby the interpreter appears to move the _declaration_ of functions, variables or classes to the top of their scope, prior to execution of the code.
 
-For example, Javascript source code can use a function before defining what the function does, because the function is effectively made available from the top of their scope.
+Hoisting allows functions to be safely used in code before they are declared.
 
-Note however, that any initialization of a new _variable_ or _class_ will **not** happen until the original line of code in which it was initialized is executed:
-- Declarations made using `let`, `const` and `class` are not initialized as part of hoisting.
-- Declarations that are made using `var` are initialized with a default value of `undefined`.
-
-Conceptually hoisting is often presented as the interpreter "splitting variable declaration and initialization, and moving (just) the declarations to the top of the code".
-
-Hoisting can lead to unexpected errors if variables are read before their intended initialization.
-In particular `var`-declared variables are problematic because `undefined` is valid Javascript but likely to be the wrong value
-(reading an uninitialized variable created using  `let`, `const` or  `class` will throw a `ReferenceError`).
-For this reason variables should be declared and initialised before they are used, when possible.
+Variable and class _declarations_ are also hoisted, so they too can be referenced before they are declared.
+Note however that this can lead to unexpected errors, and is not generally recommended.
 
 > **Note:** The term hoisting is not used in any normative specification prose prior to [ECMAScript® 2015 Language Specification](https://www.ecma-international.org/ecma-262/6.0/index.html).
 > Hoisting was thought up as a general way of thinking about how execution contexts (specifically the creation and execution phases) work in JavaScript.
 
-## Technical example
 
-One of the advantages of JavaScript putting function declarations into memory before it executes any code segment is that it allows you to use a function before you declare it in your code. For example:
+## Function hoisting
+
+One of the advantages of hoisting is that it lets you use a function before you declare it in your code.
+
+The code snippet below shows how you would have to write your code if hoisting did not exist:
 
 ```js
 function catName(name) {
@@ -41,7 +35,7 @@ The result of the code above is: "My cat's name is Tiger"
 */
 ```
 
-The above code snippet is how you would expect to write the code for it to work. Now, let's see what happens when we call the function before we write it:
+Hoisting allows us to call the function before we write it.
 
 ```js
 catName("Chloe");
@@ -54,45 +48,51 @@ The result of the code above is: "My cat's name is Chloe"
 */
 ```
 
-Even though we call the function in our code first, before the function is written, the code still works, because this is how context execution works in JavaScript.
+## Variable hoisting
 
-Hoisting works well with other data types and variables.
-The variables can be initialized and used before they are declared.
+Hoisting works with variables too, so you can use a variable in code before it is declared and/or initialized.
 
-### Only declarations are hoisted
+However JavaScript only hoists declarations, not initializations!
+This means that initialization doesn't happen until the associated line of code is executed, even if the variable was originally initialized then declared, or declared and initialized in the same line.
 
-JavaScript only hoists declarations, not initializations.
-If a variable is used in code and then declared and initialized, the value when it is used will be its default initialization (`undefined` for a variable declared using `var`, otherwise uninitialized).
-For example:
+Until that point in the execution is reached the variable has its _default_ initialization (`undefined` for a variable declared using `var`, otherwise uninitialized).
+
+> **Note:** Conceptually variable hoisting is often presented as the interpreter "splitting variable declaration and initialization, and moving (just) the declarations to the top of the code".
+
+Below are some examples of using a variable before it is declared.
+
+### var hoisting
+
+Here we declare then initialize the value of a `var` after using it.
+The default initialization of the `var` is `undefined`.
 
 ```js
 console.log(num); // Returns 'undefined' from hoisted var declaration (not 6)
 var num; // Declaration
 num = 6; // Initialization
+console.log(num); // Returns 6 after the line with initialization is executed.
 ```
 
-The example below only has initialization.
-No hoisting happens so trying to read the variable results in `ReferenceError` exception.
+The same thing happens if we declare and initialize the variable in the same line.
 
 ```js
-console.log(num); // Throws ReferenceError exception
+console.log(num); // Returns 'undefined' from hoisted var declaration (not 6)
+var num = 6; // Initialization and declaration.
+console.log(num); // Returns 6 after the line with initialization is executed.
+```
+
+If we forget the declaration altogether (and only initialize the value) it isn't hoisted.
+Trying to read the variable before it is initialized results in `ReferenceError` exception.
+
+```js
+console.log(num); // Throws ReferenceError exception - interpreter doesn't know about `num`.
 num = 6; // Initialization
 ```
-
-Below are more examples demonstrating hoisting.
+ 
+Note however that initialization also causes declaration (if not already declared).
+The code snippet below will work, because even though it isn't hoisted, the variable is initialized and effectively declared before it is used.
 
 ```js
-// Example 1
-// Only y is hoisted
-
-x = 1; // Initialize x, and if not already declared, declare it - but no hoisting as there is no var in the statement.
-console.log(x + " " + y); // '1 undefined'
-// This prints value of y as undefined as JavaScript only hoists declarations
-var y = 2; // Declare and Initialize y
-
-// Example 2
-// No hoisting, but since initialization also causes declaration (if not already declared), variables are available.
-
 a = 'Cran'; // Initialize a
 b = 'berry'; // Initialize b
 
@@ -101,27 +101,52 @@ console.log(a + "" + b); // 'Cranberry'
 
 ### let and const hoisting
 
-Variables declared with `let` and `const` are also hoisted, but unlike for `var` the variables are not initialized with a default value of `undefined`.
-Until the line in which they are initialized is executed, any code that accesses these variables will throw an exception.
+Variables declared with `let` and `const` are also hoisted, but are not initialized with a default value.
+An exception will be thrown if a variable declared with `let` or `const` is read before it is initialized.
+
+```js
+console.log(num); // Throws ReferenceError exception as the variable value is uninitialized
+let num = 6; // Initialization
+```
+
+Note that it is the order in which code is _executed_ that matters, not the order in which it is written in the source file.
+The code will succceed provided the line that initializes the variable is executed before any line that reads it.
 
 For information and examples see [`let` > temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 
-### Function expression hoisting
 
-A [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) is not hoisted.
-
-The expression evaluates to a function, which is typically assigned to a variable that can then be used to call the function.
-In this case the variable declaration is hoisted and the function expression is its initialization, which is not evaluated until the relevant line is is executed.
-
-### class hoisting
+## class hoisting
 
 Classes defined using a [class declaration](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) are hoisted, which means that JavaScript has a reference the class.
 However the class is not intialized by default, so any code that uses it before the line in which it is initialized is executed will throw a `ReferenceError`.
 
-[Class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) are like function expressions: if assigned to a variable the variable may be hoisted, but the class expression itself is not.
+
+## Function and class expression hoisting
+
+[Function expressions](/en-US/docs/Web/JavaScript/Reference/Operators/function) and [class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) are not hoisted.
+
+The expressions evaluate to a function or class (respectively), which are typically assigned to a variable.
+In this case the variable declaration is hoisted and the expression is its initialization.
+Therefore the expressions are not evaluated until the relevant line is is executed.
 
 
 ## See also
 
 - [var statement](/en-US/docs/Web/JavaScript/Reference/Statements/var) — MDN
 - [function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function) — MDN
+
+
+
+
+// Bits to chuck
+
+/////
+
+
+
+
+In particular `var`-declared variables are problematic because `undefined` is valid Javascript but likely to be the wrong value
+(reading an uninitialized variable created using  `let`, `const` or  `class` will throw a `ReferenceError`).
+
+////
+

--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -132,21 +132,7 @@ Therefore the expressions are not evaluated until the relevant line is is execut
 
 ## See also
 
-- [var statement](/en-US/docs/Web/JavaScript/Reference/Statements/var) — MDN
-- [function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function) — MDN
-
-
-
-
-// Bits to chuck
-
-/////
-
-
-
-
-In particular `var`-declared variables are problematic because `undefined` is valid Javascript but likely to be the wrong value
-(reading an uninitialized variable created using  `let`, `const` or  `class` will throw a `ReferenceError`).
-
-////
-
+- [`var` statement](/en-US/docs/Web/JavaScript/Reference/Statements/var) — MDN
+- [`let` statement](/en-US/docs/Web/JavaScript/Reference/Statements/let) — MDN
+- [`const` statement](/en-US/docs/Web/JavaScript/Reference/Statements/const) — MDN
+- [`function` statement](/en-US/docs/Web/JavaScript/Reference/Statements/function) — MDN

--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -32,7 +32,7 @@ The result of the code above is: "My cat's name is Tiger"
 */
 ```
 
-Without hoisting you would have to write the same code like this:
+Without hoisting you would _have_ to write the same code like this:
 
 ```js
 function catName(name) {
@@ -40,6 +40,9 @@ function catName(name) {
 }
 
 catName("Tiger");
+/*
+The result of the code above is the same: "My cat's name is Tiger"
+*/
 ```
 
 
@@ -54,7 +57,7 @@ Until that point in the execution is reached the variable has its _default_ init
 
 > **Note:** Conceptually variable hoisting is often presented as the interpreter "splitting variable declaration and initialization, and moving (just) the declarations to the top of the code".
 
-Below are some examples of using a variable before it is declared.
+Below are some examples showing what can happen if you use a variable before it is declared.
 
 ### `var` hoisting
 
@@ -76,11 +79,11 @@ var num = 6; // Initialization and declaration.
 console.log(num); // Returns 6 after the line with initialization is executed.
 ```
 
-If we forget the declaration altogether (and only initialize the value) it isn't hoisted.
+If we forget the declaration altogether (and only initialize the value) the variable isn't hoisted.
 Trying to read the variable before it is initialized results in `ReferenceError` exception.
 
 ```js
-console.log(num); // Throws ReferenceError exception - interpreter doesn't know about `num`.
+console.log(num); // Throws ReferenceError exception - the interpreter doesn't know about `num`.
 num = 6; // Initialization
 ```
  

--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -108,9 +108,10 @@ For information and examples see [`let` > temporal dead zone](/en-US/docs/Web/Ja
 
 ### Function expression hoisting
 
-A [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) evaluates to a function, which is typically assigned to a variable that can then be used to call the function.
+A [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) is not hoisted.
 
-The variable itself is hoisted (and may have a default initialization depending on the type) but the expression itself is not evaluated until the line in which it is declared is executed.
+The expression evaluates to a function, which is typically assigned to a variable that can then be used to call the function.
+In this case the variable declaration is hoisted and the function expression is its initialization, which is not evaluated until the relevant line is is executed.
 
 ### class hoisting
 

--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -6,13 +6,24 @@ tags:
   - Glossary
   - JavaScript
 ---
-JavaScript **Hoisting** refers to the process whereby the interpreter allocates memory for variable and function declarations prior to execution of the code. Declarations that are made using `var` are initialized with a default value of `undefined`. Declarations made using `let` and `const` are not initialized as part of hoisting.
+JavaScript **Hoisting** refers to the process whereby the interpreter allocates memory for function, variable and class _declarations_ in their scope, prior to execution of the code.
+This allows them to be referenced before they are defined.
+
+For example, Javascript source code can use a function before defining what the function does, because the function is effectively made available from the top of their scope.
+
+Note however, that any initialization of a new _variable_ or _class_ will **not** happen until the original line of code in which it was initialized is executed:
+- Declarations made using `let`, `const` and `class` are not initialized as part of hoisting.
+- Declarations that are made using `var` are initialized with a default value of `undefined`.
 
 Conceptually hoisting is often presented as the interpreter "splitting variable declaration and initialization, and moving (just) the declarations to the top of the code".
-This allows variables to appear in code before they are defined.
-Note however, that any variable initialization in the original code will not happen until the line of code is executed.
 
-> **Note:** The term hoisting is not used in any normative specification prose prior to [ECMAScript® 2015 Language Specification](https://www.ecma-international.org/ecma-262/6.0/index.html). Hoisting was thought up as a general way of thinking about how execution contexts (specifically the creation and execution phases) work in JavaScript.
+Hoisting can lead to unexpected errors if variables are read before their intended initialization.
+In particular `var`-declared variables are problematic because `undefined` is valid Javascript but likely to be the wrong value
+(reading an uninitialized variable created using  `let`, `const` or  `class` will throw a `ReferenceError`).
+For this reason variables should be declared and initialised before they are used, when possible.
+
+> **Note:** The term hoisting is not used in any normative specification prose prior to [ECMAScript® 2015 Language Specification](https://www.ecma-international.org/ecma-262/6.0/index.html).
+> Hoisting was thought up as a general way of thinking about how execution contexts (specifically the creation and execution phases) work in JavaScript.
 
 ## Technical example
 
@@ -45,11 +56,13 @@ The result of the code above is: "My cat's name is Chloe"
 
 Even though we call the function in our code first, before the function is written, the code still works, because this is how context execution works in JavaScript.
 
-Hoisting works well with other data types and variables. The variables can be initialized and used before they are declared.
+Hoisting works well with other data types and variables.
+The variables can be initialized and used before they are declared.
 
 ### Only declarations are hoisted
 
-JavaScript only hoists declarations, not initializations. If a variable is used in code and then declared and initialized, the value when it is used will be its default initialization (`undefined` for a variable declared using `var`, otherwise uninitialized).
+JavaScript only hoists declarations, not initializations.
+If a variable is used in code and then declared and initialized, the value when it is used will be its default initialization (`undefined` for a variable declared using `var`, otherwise uninitialized).
 For example:
 
 ```js
@@ -58,7 +71,8 @@ var num; // Declaration
 num = 6; // Initialization
 ```
 
-The example below only has initialization. No hoisting happens so trying to read the variable results in `ReferenceError` exception.
+The example below only has initialization.
+No hoisting happens so trying to read the variable results in `ReferenceError` exception.
 
 ```js
 console.log(num); // Throws ReferenceError exception
@@ -85,12 +99,26 @@ b = 'berry'; // Initialize b
 console.log(a + "" + b); // 'Cranberry'
 ```
 
-### Let and const hoisting
+### let and const hoisting
 
 Variables declared with `let` and `const` are also hoisted, but unlike for `var` the variables are not initialized with a default value of `undefined`.
 Until the line in which they are initialized is executed, any code that accesses these variables will throw an exception.
 
 For information and examples see [`let` > temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
+### Function expression hoisting
+
+A [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) evaluates to a function, which is typically assigned to a variable that can then be used to call the function.
+
+The variable itself is hoisted (and may have a default initialization depending on the type) but the expression itself is not evaluated until the line in which it is declared is executed.
+
+### class hoisting
+
+Classes defined using a [class declaration](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) are hoisted, which means that JavaScript has a reference the class.
+However the class is not intialized by default, so any code that uses it before the line in which it is initialized is executed will throw a `ReferenceError`.
+
+[Class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) are like function expressions: if assigned to a variable the variable may be hoisted, but the class expression itself is not.
+
 
 ## See also
 

--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -11,7 +11,7 @@ JavaScript **Hoisting** refers to the process whereby the interpreter appears to
 Hoisting allows functions to be safely used in code before they are declared.
 
 Variable and class _declarations_ are also hoisted, so they too can be referenced before they are declared.
-Note however that this can lead to unexpected errors, and is not generally recommended.
+Note that doing so can lead to unexpected errors, and is not generally recommended.
 
 > **Note:** The term hoisting is not used in any normative specification prose prior to [ECMAScript® 2015 Language Specification](https://www.ecma-international.org/ecma-262/6.0/index.html).
 > Hoisting was thought up as a general way of thinking about how execution contexts (specifically the creation and execution phases) work in JavaScript.
@@ -21,7 +21,18 @@ Note however that this can lead to unexpected errors, and is not generally recom
 
 One of the advantages of hoisting is that it lets you use a function before you declare it in your code.
 
-The code snippet below shows how you would have to write your code if hoisting did not exist:
+```js
+catName("Tiger");
+
+function catName(name) {
+  console.log("My cat's name is " + name);
+}
+/*
+The result of the code above is: "My cat's name is Tiger"
+*/
+```
+
+Without hoisting you would have to write the same code like this:
 
 ```js
 function catName(name) {
@@ -29,24 +40,8 @@ function catName(name) {
 }
 
 catName("Tiger");
-
-/*
-The result of the code above is: "My cat's name is Tiger"
-*/
 ```
 
-Hoisting allows us to call the function before we write it.
-
-```js
-catName("Chloe");
-
-function catName(name) {
-  console.log("My cat's name is " + name);
-}
-/*
-The result of the code above is: "My cat's name is Chloe"
-*/
-```
 
 ## Variable hoisting
 
@@ -61,7 +56,7 @@ Until that point in the execution is reached the variable has its _default_ init
 
 Below are some examples of using a variable before it is declared.
 
-### var hoisting
+### `var` hoisting
 
 Here we declare then initialize the value of a `var` after using it.
 The default initialization of the `var` is `undefined`.
@@ -99,9 +94,9 @@ b = 'berry'; // Initialize b
 console.log(a + "" + b); // 'Cranberry'
 ```
 
-### let and const hoisting
+### `let` and `const` hoisting
 
-Variables declared with `let` and `const` are also hoisted, but are not initialized with a default value.
+Variables declared with `let` and `const` are also hoisted but, unlike `var`, are not initialized with a default value.
 An exception will be thrown if a variable declared with `let` or `const` is read before it is initialized.
 
 ```js
@@ -115,7 +110,7 @@ The code will succceed provided the line that initializes the variable is execut
 For information and examples see [`let` > temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 
 
-## class hoisting
+## `class` hoisting
 
 Classes defined using a [class declaration](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) are hoisted, which means that JavaScript has a reference the class.
 However the class is not intialized by default, so any code that uses it before the line in which it is initialized is executed will throw a `ReferenceError`.

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -13,7 +13,9 @@ browser-compat: javascript.classes
 ---
 {{JsSidebar("Classes")}}
 
-Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics.
+Classes are a template for creating objects.
+They encapsulate data with code to work on that data.
+Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics.
 
 ## Defining classes
 
@@ -21,7 +23,8 @@ Classes are in fact "special {{jsxref("Functions", "functions", "", "true")}}", 
 
 ### Class declarations
 
-One way to define a class is using a **class declaration**. To declare a class, you use the `class` keyword with the name of the class ("Rectangle" here).
+One way to define a class is using a **class declaration**.
+To declare a class, you use the `class` keyword with the name of the class ("Rectangle" here).
 
 ```js
 class Rectangle {
@@ -34,7 +37,8 @@ class Rectangle {
 
 #### Hoisting
 
-An important difference between **function declarations** and **class declarations** is that function declarations are {{Glossary("Hoisting", "hoisted")}} and class declarations are not. You first need to declare your class and then access it, otherwise code like the following will throw a {{jsxref("ReferenceError")}}:
+An important difference between **function declarations** and **class declarations** is that while functions can be called in code that appears before they are defined, classes must be defined before they can be constructed.
+Code like the following will throw a {{jsxref("ReferenceError")}}:
 
 ```js example-bad
 const p = new Rectangle(); // ReferenceError
@@ -42,9 +46,15 @@ const p = new Rectangle(); // ReferenceError
 class Rectangle {}
 ```
 
+This occurs because while the class is {{Glossary("Hoisting", "hoisted")}} its values are not initialized.
+
+
 ### Class expressions
 
-A **class expression** is another way to define a class. Class expressions can be named or unnamed. The name given to a named class expression is local to the class's body. However, it can be accessed via the {{jsxref("Function.name", "name")}} property.
+A **class expression** is another way to define a class.
+Class expressions can be named or unnamed.
+The name given to a named class expression is local to the class's body.
+However, it can be accessed via the {{jsxref("Function.name", "name")}} property.
 
 ```js
 // unnamed
@@ -68,11 +78,12 @@ console.log(Rectangle.name);
 // output: "Rectangle2"
 ```
 
-> **Note:** Class **expressions** are subject to the same hoisting restrictions as described in the {{anch("Class declarations")}} section.
+> **Note:** Class **expressions** must be declared before they can be used (they are subject to the same hoisting restrictions as described in the [class declarations](#class_declarations) section).
 
 ## Class body and method definitions
 
-The body of a class is the part that is in curly brackets `{}`. This is where you define class members, such as methods or constructor.
+The body of a class is the part that is in curly brackets `{}`.
+This is where you define class members, such as methods or constructor.
 
 ### Strict mode
 
@@ -80,7 +91,9 @@ The body of a class is executed in {{jsxref("Strict_mode", "strict mode", "", "t
 
 ### Constructor
 
-The {{jsxref("Classes/constructor", "constructor", "", "true")}} method is a special method for creating and initializing an object created with a `class`. There can only be one special method with the name "constructor" in a class. A {{jsxref("SyntaxError")}} will be thrown if the class contains more than one occurrence of a `constructor` method.
+The {{jsxref("Classes/constructor", "constructor", "", "true")}} method is a special method for creating and initializing an object created with a `class`.
+There can only be one special method with the name "constructor" in a class.
+A {{jsxref("SyntaxError")}} will be thrown if the class contains more than one occurrence of a `constructor` method.
 
 A constructor can use the `super` keyword to call the constructor of the super class.
 
@@ -141,7 +154,9 @@ console.log([...pentagon.getSides()]); // [1,2,3,4,5]
 
 ### Static methods and properties
 
-The {{jsxref("Classes/static", "static", "", "true")}} keyword defines a static method or property for a class. Static members (properties and methods) are called without instantiating their class and **cannot** be called through a class instance. Static methods are often used to create utility functions for an application, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
+The {{jsxref("Classes/static", "static", "", "true")}} keyword defines a static method or property for a class.
+Static members (properties and methods) are called without instantiating their class and **cannot** be called through a class instance.
+Static methods are often used to create utility functions for an application, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
 
 ```js
 class Point {
@@ -172,7 +187,8 @@ console.log(Point.distance(p1, p2)); // 7.0710678118654755
 
 ### Binding `this` with prototype and static methods
 
-When a static or prototype method is called without a value for {{jsxref("Operators/this", "this")}}, such as by assigning the method to a variable and then calling it, the `this` value will be `undefined` inside the method. This behavior will be the same even if the {{jsxref("Strict_mode", "\"use strict\"")}} directive isn't present, because code within the `class` body's syntactic boundary is always executed in strict mode.
+When a static or prototype method is called without a value for {{jsxref("Operators/this", "this")}}, such as by assigning the method to a variable and then calling it, the `this` value will be `undefined` inside the method.
+This behavior will be the same even if the {{jsxref("Strict_mode", "\"use strict\"")}} directive isn't present, because code within the `class` body's syntactic boundary is always executed in strict mode.
 
 ```js
 class Animal {
@@ -194,7 +210,8 @@ let eat = Animal.eat;
 eat(); // undefined
 ```
 
-If we rewrite the above using traditional function-based syntax in non–strict mode, then `this` method calls are automatically bound to the initial `this` value, which by default is the {{Glossary("Global_object", "global object")}}. In strict mode, autobinding will not happen; the value of `this` remains as passed.
+If we rewrite the above using traditional function-based syntax in non–strict mode, then `this` method calls are automatically bound to the initial `this` value, which by default is the {{Glossary("Global_object", "global object")}}.
+In strict mode, autobinding will not happen; the value of `this` remains as passed.
 
 ```js
 function Animal() { }
@@ -266,7 +283,8 @@ class Rectangle {
 }
 ```
 
-It's an error to reference private fields from outside of the class; they can only be read or written within the class body. By defining things that are not visible outside of the class, you ensure that your classes' users can't depend on internals, which may change from version to version.
+It's an error to reference private fields from outside of the class; they can only be read or written within the class body.
+By defining things that are not visible outside of the class, you ensure that your classes' users can't depend on internals, which may change from version to version.
 
 > **Note:** Private fields can only be declared up-front in a field declaration.
 
@@ -328,7 +346,8 @@ d.speak(); // Mitzie barks.
 // For similar methods, the child's method takes precedence over parent's method
 ```
 
-Note that classes cannot extend regular (non-constructible) objects. If you want to inherit from a regular object, you can instead use {{jsxref("Object.setPrototypeOf()")}}:
+Note that classes cannot extend regular (non-constructible) objects
+If you want to inherit from a regular object, you can instead use {{jsxref("Object.setPrototypeOf()")}}:
 
 ```js
 const Animal = {
@@ -352,9 +371,11 @@ d.speak(); // Mitzie makes a noise.
 
 ## Species
 
-You might want to return {{jsxref("Array")}} objects in your derived array class `MyArray`. The species pattern lets you override default constructors.
+You might want to return {{jsxref("Array")}} objects in your derived array class `MyArray`.
+The species pattern lets you override default constructors.
 
-For example, when using methods such as {{jsxref("Array.map", "map()")}} that returns the default constructor, you want these methods to return a parent `Array` object, instead of the `MyArray` object. The {{jsxref("Symbol.species")}} symbol lets you do this:
+For example, when using methods such as {{jsxref("Array.map", "map()")}} that returns the default constructor, you want these methods to return a parent `Array` object, instead of the `MyArray` object.
+The {{jsxref("Symbol.species")}} symbol lets you do this:
 
 ```js
 class MyArray extends Array {
@@ -371,7 +392,8 @@ console.log(mapped instanceof Array);   // true
 
 ## Super class calls with `super`
 
-The {{jsxref("Operators/super", "super")}} keyword is used to call corresponding methods of super class. This is one advantage over prototype-based inheritance.
+The {{jsxref("Operators/super", "super")}} keyword is used to call corresponding methods of super class.
+This is one advantage over prototype-based inheritance.
 
 ```js
 class Cat {
@@ -399,7 +421,9 @@ l.speak();
 
 ## Mix-ins
 
-Abstract subclasses or _mix-ins_ are templates for classes. An ECMAScript class can only have a single superclass, so multiple inheritance from tooling classes, for example, is not possible. The functionality must be provided by the superclass.
+Abstract subclasses or _mix-ins_ are templates for classes.
+An ECMAScript class can only have a single superclass, so multiple inheritance from tooling classes, for example, is not possible.
+The functionality must be provided by the superclass.
 
 A function with a superclass as input and a subclass extending that superclass as output can be used to implement mix-ins in ECMAScript:
 
@@ -422,7 +446,8 @@ class Bar extends calculatorMixin(randomizerMixin(Foo)) { }
 
 ## Re-running a class definition
 
-A class can't be redefined. Attempting to do so produces a `SyntaxError`.
+A class can't be redefined.
+Attempting to do so produces a `SyntaxError`.
 
 If you're experimenting with code in a web browser, such as the Firefox Web Console (**Tools** > **Web Developer** > **Web Console**) and you 'Run' a definition of a class with the same name twice, you'll get a `SyntaxError: redeclaration of let ClassName;`. (See further discussion of this issue in {{Bug(1428672)}}.) Doing something similar in Chrome Developer Tools gives you a message like `Uncaught SyntaxError: Identifier 'ClassName' has already been declared at <anonymous>:1:1`.
 

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -11,14 +11,11 @@ browser-compat: javascript.operators.function
 ---
 {{jsSidebar("Operators")}}
 
-The **`function`** keyword can be used to define a function
-inside an expression.
+The **`function`** keyword can be used to define a function inside an expression.
 
-You can also define functions using the {{jsxref("Function/Function", "Function")}}
-constructor and a {{jsxref("Statements/function", "function declaration", "", 1)}}.
+You can also define functions using the {{jsxref("Function/Function", "Function")}} constructor and a {{jsxref("Statements/function", "function declaration", "", 1)}}.
 
-{{EmbedInteractiveExample("pages/js/expressions-functionexpression.html",
-  "shorter")}}
+{{EmbedInteractiveExample("pages/js/expressions-functionexpression.html", "shorter")}}
 
 ## Syntax
 
@@ -30,13 +27,13 @@ function [name]([param1[, param2[, ..., paramN]]]) {
 }
 ```
 
-As of ES2015, you can also use {{jsxref("Functions/Arrow_functions", "arrow functions",
-  "", 1)}}.
+As of ES2015, you can also use {{jsxref("Functions/Arrow_functions", "arrow functions", "", 1)}}.
 
 ### Parameters
 
 - `name` {{optional_inline}}
-  - : The function name. Can be omitted, in which case the function is _anonymous_.
+  - : The function name.
+    Can be omitted, in which case the function is _anonymous_.
     The name is only local to the function body.
 - `paramN` {{optional_inline}}
   - : The name of an argument to be passed to the function.
@@ -45,20 +42,16 @@ As of ES2015, you can also use {{jsxref("Functions/Arrow_functions", "arrow func
 
 ## Description
 
-A function expression is very similar to and has almost the same syntax as a function
-declaration (see {{jsxref("Statements/function", "function")}} statement for details).
-The main difference between a function expression and a function declaration is the
-_function name_, which can be omitted in function expressions to create
-_anonymous_ functions. A function expression can be used as an [IIFE (Immediately Invoked Function Expression)](/en-US/docs/Glossary/IIFE)
-which runs as soon as it is defined. See also the chapter about {{jsxref("Functions",
-  "functions", "", 1)}} for more information.
+A function expression is very similar to and has almost the same syntax as a function declaration (see {{jsxref("Statements/function", "function")}} statement for details).
+The main difference between a function expression and a function declaration is the _function name_, which can be omitted in function expressions to create _anonymous_ functions.
+
+A function expression can be used as an [IIFE (Immediately Invoked Function Expression)](/en-US/docs/Glossary/IIFE) which runs as soon as it is defined.
+See also the chapter about {{jsxref("Functions", "functions", "", 1)}} for more information.
 
 ### Function expression hoisting
 
-Function expressions in JavaScript are not hoisted, unlike
-{{jsxref("Statements/function", "function declarations",
-  "#Function_declaration_hoisting", 1)}}. You can't use function expressions before you
-create them:
+Function expressions in JavaScript are not hoisted, unlike {{jsxref("Statements/function", "function declarations", "#Function_declaration_hoisting", 1)}}.
+You can't use function expressions before you create them:
 
 ```js
 console.log(notHoisted) // undefined
@@ -72,10 +65,9 @@ var notHoisted = function() {
 
 ### Named function expression
 
-If you want to refer to the current function inside the function body, you need to
-create a named function expression. **This name is then local only to the
-function body (scope)**. This also avoids using the non-standard
-{{jsxref("Functions/arguments/callee", "arguments.callee")}} property.
+If you want to refer to the current function inside the function body, you need to create a named function expression.
+**This name is then local only to the function body (scope)**.
+This also avoids using the non-standard {{jsxref("Functions/arguments/callee", "arguments.callee")}} property.
 
 ```js
 let math = {
@@ -91,12 +83,11 @@ let math = {
 math.factit(3) //3;2;1;
 ```
 
-The variable the function expression is assigned to will have a `name`
-property. The name doesn't change if it's assigned to a different variable. If function
-name is omitted, it will be the variable name (implicit name). If function name is
-present, it will be the function name (explicit name). This also applies to
-{{jsxref("Functions/Arrow_functions", "arrow functions")}} (arrows don't have a name so
-you can only give the variable an implicit name).
+The variable the function expression is assigned to will have a `name` property.
+The name doesn't change if it's assigned to a different variable.
+If function name is omitted, it will be the variable name (implicit name).
+If function name is present, it will be the function name (explicit name).
+This also applies to {{jsxref("Functions/Arrow_functions", "arrow functions")}} (arrows don't have a name so you can only give the variable an implicit name).
 
 ```js
 var foo = function() {}
@@ -117,8 +108,8 @@ console.log(bar === baz); // false (errors because baz == undefined)
 
 ### Creating an unnamed function
 
-The following example defines an unnamed function and assigns it to `x`. The
-function returns the square of its argument:
+The following example defines an unnamed function and assigns it to `x`.
+The function returns the square of its argument:
 
 ```js
 var x = function(y) {


### PR DESCRIPTION
Fixes #10046

This is intended to improve the hoisting docs, in particular with respect to classes.

It makes some points.
- Functions definitions are hoisted - ie you can call a function before it is defined. That is because for a function the declaration is the definition, and it is declarations that are hoisted.
- This differs from variables in which the declaration is where you define the existence/scope of the variable, and the initialization is separate - where you say what the reference points to.
- Function and class _expressions_ are not hoisted. More precisely an expression is evaluated and assigned to a variable. In this case the variable that gets hoisted but the expression evaluation doesn't happen until you get to the line where it is run.
- Classes are hoisted, but not their definition. Not 100% sure on what that means but my hope is that for practical purposes it tells people that they should try to define the class before constructing it. 
  - I am fairly sure this means the same as for variables - the declaration is hoisted so Javascript doesn't necessarily fall over when it sees the class being written to in appropriate ways elsewhere. However the constructor hasn't be run and any values are likely to be undefined (so reading can be a problem). Not sure what happens for statics. 
  - Now I read that back I know that I know nothing - but I hope it doesn't matter.
  
@ddbeck @wbamberg You might have a view on this. I am pretty sure it is structurally better and content-wise no worse than before.
