### PR TITLE
Clarify that Object is below null in the prototype chain

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -14,7 +14,7 @@ JavaScript is a bit confusing for developers experienced in class-based language
 
 When it comes to inheritance, JavaScript only has one construct: objects. Each object has a private property which holds a link to another object called its **prototype**. That prototype object has a prototype of its own, and so on until an object is reached with `null` as its prototype. By definition, `null` has no prototype, and acts as the final link in this **prototype chain**.
 
-Nearly all objects in JavaScript are instances of {{jsxref("Object")}} which sits on the top of a prototype chain.
+Nearly all objects in JavaScript are instances of {{jsxref("Object")}} which sits just below `null` on the top of a prototype chain.
 
 While this confusion is often considered to be one of JavaScript's weaknesses, the prototypal inheritance model itself is, in fact, more powerful than the classic model. It is, for example, fairly trivial to build a classic model on top of a prototypal model.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Clarifies that Object is below null in the prototype chain

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
When I first read "Nearly all objects in JavaScript are instances of Object **which sits on the top of a prototype chain**" (emphasis added), I was confused, because the previous sentence states that `null` is the final link in prototype chains. I had to open up the browser console and look at {}.__proto__.__proto__ to see that `null` is indeed the prototype of Object, rather than this being an exception to `null` being the final link.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
