### PR TITLE
CSP: block-all-mixed-content - add reason

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -18,9 +18,11 @@ browser-compat: http.headers.csp.Content-Security-Policy.block-all-mixed-content
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`block-all-mixed-content`** directive prevents loading any assets over HTTP when the page uses HTTPS.
 
-All [mixed content](/en-US/docs/Web/Security/Mixed_content) resource requests are blocked, including both active and passive mixed content. This also applies to {{HTMLElement("iframe")}} documents, ensuring the entire page is mixed content-free.
+All [mixed content](/en-US/docs/Web/Security/Mixed_content) resource requests are blocked, including both active and passive mixed content.
+This also applies to {{HTMLElement("iframe")}} documents, ensuring the entire page is mixed content-free.
 
-> **Note:** The {{CSP("upgrade-insecure-requests")}} directive is evaluated before `block-all-mixed-content`. If the former is set, the latter does nothing, so set one directive or the other – not both, unless you want to force HTTPS on older browsers that do not force it after a redirect to HTTP.
+> **Note:** The {{CSP("upgrade-insecure-requests")}} directive is evaluated before `block-all-mixed-content`.
+> If the former is set, the latter does nothing, so set one directive or the other – not both, unless you want to force HTTPS on older browsers that do not force it after a redirect to HTTP.
 
 ## Syntax
 
@@ -36,7 +38,8 @@ Content-Security-Policy: block-all-mixed-content;
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
 ```
 
-To disallow http assets on a more granular level, you can also set individual directives to `https:`. For example, to disallow nonsecure HTTP images:
+To disallow http assets on a more granular level, you can also set individual directives to `https:`.
+For example, to disallow nonsecure HTTP images:
 
 ```
 Content-Security-Policy: img-src https:
@@ -44,7 +47,8 @@ Content-Security-Policy: img-src https:
 
 ## Specifications
 
-Not part of any current specification. Used to be defined in the outdated [Mixed Content Level 1](https://www.w3.org/TR/mixed-content/#block-all-mixed-content) specification.
+Not part of any current specification.
+Used to be defined in the outdated [Mixed Content Level 1](https://www.w3.org/TR/mixed-content/#block-all-mixed-content) specification.
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -14,6 +14,8 @@ browser-compat: http.headers.csp.Content-Security-Policy.block-all-mixed-content
 ---
 {{HTTPSidebar}}{{deprecated_header}}
 
+> **Warning:** This directive is marked as obsolete in the specification: all mixed content is now blocked if it can't be autoupgraded.
+
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`block-all-mixed-content`** directive prevents loading any assets over HTTP when the page uses HTTPS.
 
 All [mixed content](/en-US/docs/Web/Security/Mixed_content) resource requests are blocked, including both active and passive mixed content. This also applies to {{HTMLElement("iframe")}} documents, ensuring the entire page is mixed content-free.


### PR DESCRIPTION
Fixes #9889

Adds a note about why CSP: `block-all-mixed-content` is deprecated, 