### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -282,7 +282,7 @@ Browsers don't all support the same video formats; you can provide multiple sour
 ```html
 <video controls>
   <source src="myVideo.webm" type="video/webm">
-   <source src="myVideo.mp4" type="video/mp4">
+  <source src="myVideo.mp4" type="video/mp4">
   <p>Your browser doesn't support HTML5 video. Here is
      a <a href="myVideo.mp4">link to the video</a> instead.</p>
 </video>

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -281,8 +281,8 @@ Browsers don't all support the same video formats; you can provide multiple sour
 
 ```html
 <video controls>
-  <source src="myVideo.mp4" type="video/mp4">
   <source src="myVideo.webm" type="video/webm">
+   <source src="myVideo.mp4" type="video/mp4">
   <p>Your browser doesn't support HTML5 video. Here is
      a <a href="myVideo.mp4">link to the video</a> instead.</p>
 </video>
@@ -373,14 +373,15 @@ This example builds on the last one, offering three different sources for the me
 <video width="620" controls
   poster="https://upload.wikimedia.org/wikipedia/commons/e/e8/Elephants_Dream_s5_both.jpg" >
   <source
-    src="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
-    type="video/mp4">
-  <source
     src="https://archive.org/download/ElephantsDream/ed_hd.ogv"
     type="video/ogg">
   <source
     src="https://archive.org/download/ElephantsDream/ed_hd.avi"
     type="video/avi">
+  <source
+    src="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
+    type="video/mp4">
+
   Your browser doesn't support HTML5 video tag.
 </video>
 ```


### PR DESCRIPTION
Re-ordered the video sources so mp4 is last (the browser selects the first source it accepts. since mp4 is *nearly* universal, the other sources are never used)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Placing the mp4 source first means that the other vide versions generated are never used.  It should be last since mp4 boasts nearly universal support.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The text says that the first supported source is what is used by the browser, but the order shown in the examples was counter intuitive to that text.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
