### PR TITLE
fix(html/element) full title on all remaining elements

### DIFF
--- a/files/en-us/web/html/element/area/index.md
+++ b/files/en-us/web/html/element/area/index.md
@@ -1,5 +1,5 @@
 ---
-title: <area>
+title: '<area>: The Image Map Area element'
 slug: Web/HTML/Element/area
 tags:
   - Content

--- a/files/en-us/web/html/element/col/index.md
+++ b/files/en-us/web/html/element/col/index.md
@@ -1,5 +1,5 @@
 ---
-title: <col>
+title: '<col>: The Table Column element'
 slug: Web/HTML/Element/col
 tags:
   - Element

--- a/files/en-us/web/html/element/colgroup/index.md
+++ b/files/en-us/web/html/element/colgroup/index.md
@@ -1,5 +1,5 @@
 ---
-title: <colgroup>
+title: '<colgroup>: The Table Column Group element'
 slug: Web/HTML/Element/colgroup
 tags:
   - Element

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: <form>
+title: '<form>: The Form element'
 slug: Web/HTML/Element/form
 tags:
   - Element

--- a/files/en-us/web/html/element/label/index.md
+++ b/files/en-us/web/html/element/label/index.md
@@ -1,5 +1,5 @@
 ---
-title: <label>
+title: '<label>: The Input Label element'
 slug: Web/HTML/Element/label
 tags:
   - Element

--- a/files/en-us/web/html/element/legend/index.md
+++ b/files/en-us/web/html/element/legend/index.md
@@ -1,5 +1,5 @@
 ---
-title: <legend>
+title: '<legend>: The Field Set Legend element'
 slug: Web/HTML/Element/legend
 tags:
   - Element

--- a/files/en-us/web/html/element/map/index.md
+++ b/files/en-us/web/html/element/map/index.md
@@ -1,5 +1,5 @@
 ---
-title: <map>
+title: '<map>: The Image Map element'
 slug: Web/HTML/Element/map
 tags:
   - Element

--- a/files/en-us/web/html/element/menu/index.md
+++ b/files/en-us/web/html/element/menu/index.md
@@ -1,5 +1,5 @@
 ---
-title: <menu>
+title: '<menu>: The Menu element'
 slug: Web/HTML/Element/menu
 tags:
   - Element

--- a/files/en-us/web/html/element/noscript/index.md
+++ b/files/en-us/web/html/element/noscript/index.md
@@ -1,5 +1,5 @@
 ---
-title: <noscript>
+title: '<noscript>: The Noscript element'
 slug: Web/HTML/Element/noscript
 tags:
   - Element

--- a/files/en-us/web/html/element/object/index.md
+++ b/files/en-us/web/html/element/object/index.md
@@ -1,5 +1,5 @@
 ---
-title: <object>
+title: '<object>: The External Object element'
 slug: Web/HTML/Element/object
 tags:
   - Element

--- a/files/en-us/web/html/element/optgroup/index.md
+++ b/files/en-us/web/html/element/optgroup/index.md
@@ -1,5 +1,5 @@
 ---
-title: <optgroup>
+title: '<optgroup>: The Option Group element'
 slug: Web/HTML/Element/optgroup
 tags:
   - Element

--- a/files/en-us/web/html/element/slot/index.md
+++ b/files/en-us/web/html/element/slot/index.md
@@ -1,5 +1,5 @@
 ---
-title: <slot>
+title: '<slot>: The Web Component Slot element'
 slug: Web/HTML/Element/slot
 tags:
   - Element

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -1,5 +1,5 @@
 ---
-title: <textarea>
+title: '<textarea>: The Textarea element'
 slug: Web/HTML/Element/textarea
 tags:
   - Element

--- a/files/en-us/web/html/element/th/index.md
+++ b/files/en-us/web/html/element/th/index.md
@@ -1,5 +1,5 @@
 ---
-title: <th>
+title: '<th>: The Table Header element'
 slug: Web/HTML/Element/th
 tags:
   - Element


### PR DESCRIPTION
#### Summary
for sake of consistency, added the full name to all remaining element titles (which are not deprecated)

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error