### PR TITLE
Remove all remaining TemplateLink macro instances + layout

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/en-us/mdn/contribute/howto/write_a_new_entry_in_the_glossary/index.md
@@ -15,42 +15,58 @@ tags:
 ---
 {{MDNSidebar}}
 
-This article explains how to add and link to entries in the [MDN Web Docs glossary](/en-US/docs/Glossary). It also provides guidelines about glossary entry layout and content. The glossary provides definitions for all the terms, jargon, abbreviations, and acronyms you'll come across when reading MDN content about the web and web development.
+This article explains how to add and link to entries in the [MDN Web Docs glossary](/en-US/docs/Glossary).
+It also provides guidelines about glossary entry layout and content.
+The glossary provides definitions for all the terms, jargon, abbreviations, and acronyms you'll come across when reading MDN content about the web and web development.
 
-It's possible that the glossary will never be complete because the web is always changing. By contributing new entries or fixing problems, you can help us update the glossary and fill-in gaps.
+It's possible that the glossary will never be complete because the web is always changing.
+By contributing new entries or fixing problems, you can help us update the glossary and fill-in gaps.
 
-Contributing to the glossary is an easy way to help make the web more understandable for everyone. You don't need high level technical skills. Glossary entries are intended to be straightforward and brief.
+Contributing to the glossary is an easy way to help make the web more understandable for everyone.
+You don't need high level technical skills.
+Glossary entries are intended to be straightforward and brief.
 
 ## How to write an entry
 
-First, choose what topic you'd like to write a glossary entry for. If you're looking for topics that need a glossary entry, check the [list of undocumented terms](/en-US/docs/Glossary#contribute_to_the_glossary) at the end of the [Glossary landing page](/en-US/docs/Glossary).
+First, choose what topic you'd like to write a glossary entry for.
+If you're looking for topics that need a glossary entry, check the [list of undocumented terms](/en-US/docs/Glossary#contribute_to_the_glossary) at the end of the [Glossary landing page](/en-US/docs/Glossary).
 
 If you have an idea for a new glossary entry, [create a new page](https://github.com/mdn/content#adding-a-new-document) for it underneath the [glossary landing page](https://github.com/mdn/content/tree/main/files/en-us/glossary).
 
 ### Write a summary
 
-The first paragraph of any glossary page is a simple and short description of the term. Preferably, this should be no more than two sentences. Make sure anyone reading the description can immediately understand the defined term.
+The first paragraph of any glossary page is a simple and short description of the term.
+Preferably, this should be no more than two sentences.
+Make sure anyone reading the description can immediately understand the defined term.
 
-> **Note:** Please don't copy-and-paste from other definitions or content on the Internet. (And especially not Wikipedia, since its range of license versions is smaller and incompatible with MDN.) Your glossary entry should be original content.
+> **Note:** Please don't copy-and-paste from other definitions or content on the Internet.
+> (And especially not Wikipedia, since its range of license versions is smaller and incompatible with MDN.) Your glossary entry should be original content.
 
 #### Writing a good glossary entry
 
-Add a few extra paragraphs if you must, but it's easy to find yourself writing an entire article. Writing an article is fine, but please don't create it in/for the glossary. If you aren't sure where to put your article, feel free to [reach out to discuss it](/en-US/docs/MDN/Contribute/Getting_started#step_4_ask_for_help).
+Add a few extra paragraphs if you must, but it's easy to find yourself writing an entire article.
+Writing an article is fine, but please don't create it in/for the glossary.
+If you aren't sure where to put your article, feel free to [reach out to discuss it](/en-US/docs/MDN/Contribute/Getting_started#step_4_ask_for_help).
 
 There are a few simple guidelines to consider for writing a better glossary entry:
 
-- When you use terms in the glossary's description of the term or when you use abbreviation, you should create appropriate links. Often, this just involves creating links to other pages in the glossary.
-- Use appropriate related terms (with links) in the glossary entry, if it can be done without making the article difficult to follow. Having a good network of related and useful links makes a page—or set of pages—much easier to use.
-- Think about the search terms you would choose if you wanted to find this page. Try to use all the words you would use to search for the term, but without making the glossary entry nonsensical, long, or difficult to read.
+- When you use terms in the glossary's description of the term or when you use abbreviation, you should create appropriate links.
+  Often, this just involves creating links to other pages in the glossary.
+- Use appropriate related terms (with links) in the glossary entry, if it can be done without making the article difficult to follow.
+  Having a good network of related and useful links makes a page—or set of pages—much easier to use.
+- Think about the search terms you would choose if you wanted to find this page.
+  Try to use all the words you would use to search for the term, but without making the glossary entry nonsensical, long, or difficult to read.
 
 ### Expand with links
 
-A glossary entry should always end with a _Learn more_ section. This section should contain links to help the reader move forward: discovering more details; learning to use the relevant technology.
+A glossary entry should always end with a _Learn more_ section.
+This section should contain links to help the reader move forward: discovering more details; learning to use the relevant technology.
 
 It is good practice to organize the links into three groups:
 
 - General knowledge
-  - : These links provide higher-level information about the term or topic. For example: a link to a relevant [Wikipedia](https://wikipedia.org/) page.
+  - : These links provide higher-level information about the term or topic.
+    For example: a link to a relevant [Wikipedia](https://wikipedia.org/) page.
 - Technical reference
   - : These links offer in-depth technical information, on MDN Web Docs or other sites.
 - Learn about it
@@ -58,13 +74,15 @@ It is good practice to organize the links into three groups:
 
 ## Dealing with disambiguation
 
-Some terms can have multiple meanings depending upon context. To resolve ambiguity, follow these guidelines:
+Some terms can have multiple meanings depending upon context.
+To resolve ambiguity, follow these guidelines:
 
-- The term's main page must be a disambiguation page containing the {{TemplateLink("GlossaryDisambiguation")}} macro.
+- The term's main page must be a disambiguation page containing the [`GlossaryDisambiguation`](https://github.com/mdn/yari/blob/main/kumascript/macros/GlossaryDisambiguation.ejs)  macro.
 - The term has subpages that define the term for different contexts.
 
-Let's illustrate this with an example. The term _signature_ can have different meanings in at least two different contexts: security and function.
+Let's illustrate this with an example.
+The term _signature_ can have different meanings in at least two different contexts: security and function.
 
-1.  The page [Glossary/Signature](/en-US/docs/Glossary/Signature) is the disambiguation page with the {{TemplateLink("GlossaryDisambiguation")}} macro.
-2.  The page [Glossary/Signature/Security](/en-US/docs/Glossary/Signature/Security) is the page defining a signature in a security context.
-3.  The page [Glossary/Signature/Function](/en-US/docs/Glossary/Signature/Function) is the page defining a function signature.
+1. The page [Glossary/Signature](/en-US/docs/Glossary/Signature) is the disambiguation page with the [`GlossaryDisambiguation`](https://github.com/mdn/yari/blob/main/kumascript/macros/GlossaryDisambiguation.ejs) macro.
+2. The page [Glossary/Signature/Security](/en-US/docs/Glossary/Signature/Security) is the page defining a signature in a security context.
+3. The page [Glossary/Signature/Function](/en-US/docs/Glossary/Signature/Function) is the page defining a function signature.

--- a/files/en-us/mdn/guidelines/conventions_definitions/index.md
+++ b/files/en-us/mdn/guidelines/conventions_definitions/index.md
@@ -19,41 +19,53 @@ This article defines some conventions and definitions that are commonly used on 
 **Deprecated** and **obsolete** are common terms associated with technologies and specifications, but what do they mean?
 
 - Deprecated
-  - : On MDN, the term **deprecated** is used to mark an API or technology that is no longer recommended, but is still implemented and may still work. More recently, we've updated it to the definition used in our [browser-compat-data project](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#status-information), which is that "the feature is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality."
+  - : On MDN, the term **deprecated** is used to mark an API or technology that is no longer recommended, but is still implemented and may still work.
+    More recently, we've updated it to the definition used in our [browser-compat-data project](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#status-information), which is that "the feature is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality."
 - Obsolete
-  - : On MDN, the term **obsolete** was used to mark an API or technology that is not only no longer recommended, but also no longer implemented in browsers. This was, however, confusing — it is similar to **deprecated**, and the distinction is not very helpful (you still shouldn't use it in a production site). We are, therefore, not using it anymore, and any instances you come across should be removed/replaced by the term **deprecated**.
+  - : On MDN, the term **obsolete** was used to mark an API or technology that is not only no longer recommended, but also no longer implemented in browsers.
+    This was, however, confusing — it is similar to **deprecated**, and the distinction is not very helpful (you still shouldn't use it in a production site).
+    We are, therefore, not using it anymore, and any instances you come across should be removed/replaced by the term **deprecated**.
 
 ### Experimental
 
-**Experimental** can mean different things depending on the context you hear or read it in. When a technology is described as experimental on MDN, it means that the technology is nascent and immature, and currently in the process of being added to the Web platform (or considered for addition).
+**Experimental** can mean different things depending on the context you hear or read it in.
+When a technology is described as experimental on MDN, it means that the technology is nascent and immature, and currently in the process of being added to the Web platform (or considered for addition).
 
 One or both of these will be true:
 
 - It is implemented and enabled by default in less than two modern major browsers.
 - Its defining spec is likely to change significantly, in backwards-incompatible ways (i.e. it may break existing code that relies on the feature).
 
-If one or both of these definitions is true, then you should think carefully before you start using that technology in any kind of production project (i.e. not just a demo or experiment). See also the definition of experimental in our [browser-compat-data project](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#status-information).
+If one or both of these definitions is true, then you should think carefully before you start using that technology in any kind of production project (i.e. not just a demo or experiment).
+See also the definition of experimental in our [browser-compat-data project](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#status-information).
 
 Conversely, an item is no longer experimental when:
 
 - It is implemented in two or more major browsers; or
 - Its defining spec is unlikely to change in ways that will break the web.
 
-The _or_ is important here — usually if a technology is supported across several major browsers, the spec will be stable, but this is not always the case. And some technologies will have a stable spec and be well-used, but have no native support in browsers ([IMSC](/en-US/docs/Related/IMSC), for example).
+The _or_ is important here — usually if a technology is supported across several major browsers, the spec will be stable, but this is not always the case.
+And some technologies will have a stable spec and be well-used, but have no native support in browsers ([IMSC](/en-US/docs/Related/IMSC), for example).
 
 ### Archived pages
 
-Archived pages are pages that are stored in the MDN [Archive of obsolete content](/en-US/docs/Archive). These pages contain information out-of-date enough that it is not directly useful to anyone anymore.
+Archived pages are pages that are stored in the MDN [Archive of obsolete content](/en-US/docs/Archive).
+These pages contain information out-of-date enough that it is not directly useful to anyone anymore.
 
-Most commonly, these concern Mozilla projects that have been discontinued and shouldn't be relied on anymore. But we don't delete them because they form a useful historical record, and some of the patterns or ideas contained within might be useful for future work. A good example is the [B2G (Firefox OS) project](/en-US/docs/Archive/B2G_OS).
+Most commonly, these concern Mozilla projects that have been discontinued and shouldn't be relied on anymore.
+But we don't delete them because they form a useful historical record, and some of the patterns or ideas contained within might be useful for future work.
+A good example is the [B2G (Firefox OS) project](/en-US/docs/Archive/B2G_OS).
 
 #### When should a page be archived?
 
-A page should be archived if it fits the above description. To archive a page, you should use the "Move page feature" (_Advanced > Move this article_) to move the page into the Archive page tree (/en-US/docs/Archive). You might not have the permissions to use this feature, and before you start archiving pages you should discuss it with the MDN community first — talk to us on our [Discourse forum](https://discourse.mozilla.org/c/mdn).
+A page should be archived if it fits the above description.
+To archive a page, you should use the "Move page feature" (_Advanced > Move this article_) to move the page into the Archive page tree (/en-US/docs/Archive).
+You might not have the permissions to use this feature, and before you start archiving pages you should discuss it with the MDN community first — talk to us on our [Discourse forum](https://discourse.mozilla.org/c/mdn).
 
 ### Deleted pages
 
-Deleted pages are pages that have been explicitly deleted from MDN — see for example the [`SharedKeyframeList`](/en-US/docs/Web/API/SharedKeyframeList) interface and [`SharedKeyframeList()`](/en-US/docs/Web/API/SharedKeyframeList/SharedKeyframeList) constructor. These pages contain information that is not useful in any way anymore, and/or might be incorrect to the point where keeping it available might be confusing or bad for people to know.
+Deleted pages are pages that have been explicitly deleted from MDN — see for example the [`SharedKeyframeList`](/en-US/docs/Web/API/SharedKeyframeList) interface and [`SharedKeyframeList()`](/en-US/docs/Web/API/SharedKeyframeList/SharedKeyframeList) constructor.
+These pages contain information that is not useful in any way anymore, and/or might be incorrect to the point where keeping it available might be confusing or bad for people to know.
 
 These might be:
 
@@ -65,11 +77,14 @@ These might be:
 
 #### When should a page be deleted?
 
-A page should be deleted if it fits the above description. To delete a page, you should use the "Delete this page feature" (_Advanced > Delete this page_) to delete the page. You will probably not have the permissions to use this feature, and when thinking about deleting pages you should discuss it with the MDN community first — talk to us on our [Discourse forum](https://discourse.mozilla.org/c/mdn).
+A page should be deleted if it fits the above description.
+To delete a page, you should use the "Delete this page feature" (_Advanced > Delete this page_) to delete the page.
+You will probably not have the permissions to use this feature, and when thinking about deleting pages you should discuss it with the MDN community first — talk to us on our [Discourse forum](https://discourse.mozilla.org/c/mdn).
 
 ### When to document new technologies
 
-On MDN, we are constantly looking to document new web standards technologies as appropriate. We try to strike a balance between publishing the documentation early enough so developers can learn about new features as soon as they need to, and publishing it late enough so that the technology is mature and stable so the docs won't need constant updates or rapid removal.
+On MDN, we are constantly looking to document new web standards technologies as appropriate.
+We try to strike a balance between publishing the documentation early enough so developers can learn about new features as soon as they need to, and publishing it late enough so that the technology is mature and stable so the docs won't need constant updates or rapid removal.
 
 In general, our definition of the earliest we'll consider documenting a new technology is:
 
@@ -94,76 +109,119 @@ You should not consider documenting a new technology if it:
 
 ### When something is removed from the specification
 
-Sometimes during the development of a new specification, or over the course of the evolution of living standards such as HTML, new elements, methods, properties, and so forth are added to the specification, stay there for a while, then get removed again. Sometimes this happens very quickly, and sometimes these new items remain in the specification for months or even years before being removed. This can make it tricky to decide how to handle the removal of the item from the spec. Here are some guidelines to help you decide what to do.
+Sometimes during the development of a new specification, or over the course of the evolution of living standards such as HTML, new elements, methods, properties, and so forth are added to the specification, stay there for a while, then get removed again.
+Sometimes this happens very quickly, and sometimes these new items remain in the specification for months or even years before being removed.
+This can make it tricky to decide how to handle the removal of the item from the spec.
+Here are some guidelines to help you decide what to do.
 
 > **Note:** For the purposes of this discussion, the word "item" is used to mean anything which can be part of a specification: an element or an attribute of an element, an interface or any individual method, property, or other member of an interface, and so forth.
 
 - If the item was _never_ implemented in a release version of _any_ browser—even behind a preference or flag—delete any references to the item from the documentation.
 
-  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), delete that page. If the removed item is an interface, this means removing any subpages describing the properties and methods on that interface as well.
-  - Remove the item from any lists of properties, attributes, methods, and so forth. For methods of an interface, that means to remove it from the "Methods" section on the interface's overview page, for example.
-  - Search the text of the overview page for that interface, element, etc. for any references to the removed item. Remove those references, being sure not to leave weird grammar issues or other problems with the text. This may mean not just deleting words but rewriting a sentence or paragraph to make more sense. It may also mean removing entire sections of content if the description of the item's use is lengthy.
-  - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology. Remove those references, being sure not to leave weird grammar issues or other problems with the text. This may mean not just deleting words but rewriting a sentence or paragraph to make more sense. It may also mean removing entire sections of content if the description of the item's use is lengthy.
-  - Search MDN for references to the removed item, in case there are discussions elsewhere. It's unlikely that there are, since if it was never implemented, it's unlikely to be widely discussed. Remove those mentions as well.
-  - If the [Browser Compatibility Data repository's](https://github.com/mdn/browser-compat-data) JSON files contain data for the removed items, delete those objects from the JSON code and submit a PR with that change, explaining why in the commit message and the PR description. Be careful to check that you don't break the JSON syntax while doing this.
+  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), delete that page.
+    If the removed item is an interface, this means removing any subpages describing the properties and methods on that interface as well.
+  - Remove the item from any lists of properties, attributes, methods, and so forth.
+    For methods of an interface, that means to remove it from the "Methods" section on the interface's overview page, for example.
+  - Search the text of the overview page for that interface, element, etc. for any references to the removed item.
+    Remove those references, being sure not to leave weird grammar issues or other problems with the text.
+    This may mean not just deleting words but rewriting a sentence or paragraph to make more sense.
+    It may also mean removing entire sections of content if the description of the item's use is lengthy.
+  - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology.
+    Remove those references, being sure not to leave weird grammar issues or other problems with the text.
+    This may mean not just deleting words but rewriting a sentence or paragraph to make more sense.
+    It may also mean removing entire sections of content if the description of the item's use is lengthy.
+  - Search MDN for references to the removed item, in case there are discussions elsewhere.
+    It's unlikely that there are, since if it was never implemented, it's unlikely to be widely discussed.
+    Remove those mentions as well.
+  - If the [Browser Compatibility Data repository's](https://github.com/mdn/browser-compat-data) JSON files contain data for the removed items, delete those objects from the JSON code and submit a PR with that change, explaining why in the commit message and the PR description.
+    Be careful to check that you don't break the JSON syntax while doing this.
 
-- If the item was implemented in any release version of any one or more browsers—but _only_ behind a preference or flag—do not delete the item from the documentation immediately. Instead, mark the item as deprecated as follows:
+- If the item was implemented in any release version of any one or more browsers—but _only_ behind a preference or flag—do not delete the item from the documentation immediately.
+  Instead, mark the item as deprecated as follows:
 
-  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), add the {{TemplateLink("deprecated_header")}} macro to the top of the page and add the {{tag("Deprecated")}} tag to the page's list of tags.
-  - On the overview page for the element, interface, or API, find the list of items which includes the item that's been removed from the specification and add the {{TemplateLink("deprecated_inline")}} macro after the item's name in that list.
-  - Search the informative text of the overview page for that interface, element, etc. for any references to the removed item. Add warning boxes in appropriate places with text along the lines of "\[whatever] has been removed from the specification and will be removed from browsers soon. See \[link to page] for a new way to do this."
+  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), add the [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs) macro to the top of the page and add the {{tag("Deprecated")}} tag to the page's list of tags.
+  - On the overview page for the element, interface, or API, find the list of items which includes the item that's been removed from the specification and add the [`deprecated_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Inline.ejs) macro after the item's name in that list.
+  - Search the informative text of the overview page for that interface, element, etc. for any references to the removed item.
+    Add warning boxes in appropriate places with text along the lines of "\[whatever] has been removed from the specification and will be removed from browsers soon.
+    See \[link to page] for a new way to do this."
   - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology. Add similar warnings.
-  - Search MDN for references to the removed item, in case there are discussions elsewhere. Add similar warning boxes there as well.
+  - Search MDN for references to the removed item, in case there are discussions elsewhere.
+    Add similar warning boxes there as well.
   - At some point in the future, a decision may be made to actually remove the item from the documentation; we don't normally do this but if the item was especially unutilized or uninteresting, we may decide to do so.
   - Update any relevant entries in the [Browser Compatibility Data repo](https://github.com/mdn/browser-compat-data) to reflect the obsolescence of the item(s) affected.
 
 - If the item was implemented in one or more release builds of browsers—without requiring a preference or flag to be changed—mark the item as deprecated, as follows:
 
-  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), add the {{TemplateLink("deprecated_header")}} macro to the top of the page and add the {{tag("Deprecated")}} tag to the page's list of tags.
-  - On the overview page for the element, interface, or API, find the list of items which includes the item that's been removed from the specification and add the {{TemplateLink("deprecated_inline")}} macro after the item's name in that list.
-  - Search the informative text of the overview page for that interface, element, etc. for any references to the removed item. Add warning boxes in appropriate places with text along the lines of "\[whatever] has been removed from the specification and is deprecated. It may be removed from browsers in the future, so you should not use it. See \[link to page] for a new way to do this."
+  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), add the [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs) macro to the top of the page and add the {{tag("Deprecated")}} tag to the page's list of tags.
+  - On the overview page for the element, interface, or API, find the list of items which includes the item that's been removed from the specification and add the [`deprecated_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Inline.ejs) macro after the item's name in that list.
+  - Search the informative text of the overview page for that interface, element, etc. for any references to the removed item.
+    Add warning boxes in appropriate places with text along the lines of "\[whatever] has been removed from the specification and is deprecated.
+    It may be removed from browsers in the future, so you should not use it.
+    See \[link to page] for a new way to do this."
   - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology. Add similar warnings.
-  - Search MDN for references to the removed item, in case there are discussions elsewhere. Add similar warning boxes there as well.
-  - It's unlikely that these items will be removed from the documentation anytime soon, if ever. It's possible, however, that some or all of the material may be moved to the [Archive](/en-US/docs/Archive) section of the site.
+  - Search MDN for references to the removed item, in case there are discussions elsewhere.
+    Add similar warning boxes there as well.
+  - It's unlikely that these items will be removed from the documentation anytime soon, if ever.
+    It's possible, however, that some or all of the material may be moved to the [Archive](/en-US/docs/Archive) section of the site.
   - Update any relevant entries in the [Browser Compatibility Data repo](https://github.com/mdn/browser-compat-data) to reflect the deprecation of the item(s) affected.
 
-Please use common sense with wording of warning messages and other changes to text suggested by the guidelines above. Different items will require different wording and handling of the situation. When in doubt, feel free to ask for advice on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix), or on the [MDN Web Docs discussion forum](https://discourse.mozilla.org/c/mdn).
+Please use common sense with wording of warning messages and other changes to text suggested by the guidelines above.
+Different items will require different wording and handling of the situation.
+When in doubt, feel free to ask for advice on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix), or on the [MDN Web Docs discussion forum](https://discourse.mozilla.org/c/mdn).
 
 ### Copying content within MDN
 
-Sometimes, you need to reuse the same text on multiple pages (or you want to use one page's content as a template for another page). You have three options:
+Sometimes, you need to reuse the same text on multiple pages (or you want to use one page's content as a template for another page).
+You have three options:
 
 - If you want to copy an entire page:
 
-  1.  While viewing the page you want to copy, on the **Advanced** (gear) menu, choose  **[Clone this page](/en-US/docs/MDN/Contribute/Howto/Create_and_edit_pages#clone_of_an_existing_page)**. This opens the editor UI for a new page, with the contents of the cloned page already populated.
-  2.  Enter a new **Title** and **Slug** for the cloned page.
-  3.  Edit the contents of the page as needed, and save as usual.
+  1. While viewing the page you want to copy, on the **Advanced** (gear) menu, choose  **[Clone this page](/en-US/docs/MDN/Contribute/Howto/Create_and_edit_pages#clone_of_an_existing_page)**.
+     This opens the editor UI for a new page, with the contents of the cloned page already populated.
+  2. Enter a new **Title** and **Slug** for the cloned page.
+  3. Edit the contents of the page as needed, and save as usual.
 
-- If you want to copy just part of a page, **don't just visit the page and copy from it**. This introduces unwanted additional bits of HTML into the destination page, and somebody will have to clean that up, you or another editor. Nobody wants that. To copy part of an MDN page to another page:
+- If you want to copy just part of a page, **don't just visit the page and copy from it**.
+  This introduces unwanted additional bits of HTML into the destination page, and somebody will have to clean that up, you or another editor.
+  Nobody wants that.
+  To copy part of an MDN page to another page:
 
-  1.  On the source page, click the **Edit** button on the source page.
-  2.  **Copy the content you want to reuse from within the editor UI.**
-  3.  Click **Discard** to exit the editor UI for that page.
-  4.  Open the editor UI for page where you want to paste.
-  5.  Paste the content from the clipboard.
+  1. On the source page, click the **Edit** button on the source page.
+  2. **Copy the content you want to reuse from within the editor UI.**
+  3. Click **Discard** to exit the editor UI for that page.
+  4. Open the editor UI for page where you want to paste.
+  5. Paste the content from the clipboard.
 
-  > **Note:** Chrome does not generally include the classes applied to content when copying and pasting across documents in our editor. You need to review the content after doing this and re-apply the lost styles. Check tables, syntax boxes, syntax highlighting, and hidden sections of content in particular.
+  > **Note:** Chrome does not generally include the classes applied to content when copying and pasting across documents in our editor.
+  > You need to review the content after doing this and re-apply the lost styles.
+  > Check tables, syntax boxes, syntax highlighting, and hidden sections of content in particular.
 
-- Sometimes you literally want to use the same content on many pages. In this case, you might be best off placing the content in one page, then using the {{TemplateLink("Page")}} macro to transclude the material from one page into another. This way, whenever the text on the source page is updated, the destination page will update as well (that is, this will happen on a forced-refresh or when the target page goes through a scheduled rebuild).
+- Sometimes you literally want to use the same content on many pages.
+  In this case, you might be best off placing the content in one page, then using the [`page`](https://github.com/mdn/yari/blob/main/kumascript/macros/page.ejs) macro to transclude the material from one page into another.
+  This way, whenever the text on the source page is updated, the destination page will update as well (that is, this will happen on a forced-refresh or when the target page goes through a scheduled rebuild).
 
 #### Copying content from elsewhere
 
-Often, there is useful content about a topic somewhere on the web besides on MDN. However, copying such content can be fraught with difficulties, both legal and technical.
+Often, there is useful content about a topic somewhere on the web besides on MDN.
+However, copying such content can be fraught with difficulties, both legal and technical.
 
-On the technical level, search engines typically penalize a site in their rankings for reproducing content available elsewhere. Therefore, it is preferable to have original content on MDN, to enhance the search engine ranking of MDN's content. You can link to the existing content from MDN.
+On the technical level, search engines typically penalize a site in their rankings for reproducing content available elsewhere.
+Therefore, it is preferable to have original content on MDN, to enhance the search engine ranking of MDN's content.
+You can link to the existing content from MDN.
 
 On the legal level, you must be authorized to contribute the content, and it must be licensed and attributed in a way that is compatible with [MDN's license](/en-US/docs/MDN/About#copyrights_and_licenses).
 
 - **If you created the existing content** (for your own purposes and not as work-for-hire), and you are willing to contribute it to MDN under MDN's license, this is the easiest case, and you are free to contribute the content.
-- **If the copyright for the content belongs to someone else**, it must be licensed and attributed compatibly with MDN's license. It is often not easy for someone who is not a lawyer to determine what licenses are compatible. To be on the safe side, contact a member of the [MDN staff team](https://wiki.mozilla.org/MDN#Staff_Team), who may consult Mozilla's Legal team for guidance if necessary.
+- **If the copyright for the content belongs to someone else**, it must be licensed and attributed compatibly with MDN's license.
+  It is often not easy for someone who is not a lawyer to determine what licenses are compatible.
+  To be on the safe side, contact a member of the [MDN staff team](https://wiki.mozilla.org/MDN#Staff_Team), who may consult Mozilla's Legal team for guidance if necessary.
 
 #### How to communicate a spec conflict
 
-Note that sometimes (but rarely) there is a conflict between different spec versions (usually W3C versus WHATWG), e.g. one version might have a feature listed as deprecated, while the other doesn't. In such cases, consider what the reality is — i.e. what browsers are actually doing — and write an "important" note to summarize that latest status. For example, as of Jan 2019 the [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) global attribute has a conflict, which was summarized like so:
+Note that sometimes (but rarely) there is a conflict between different spec versions (usually W3C versus WHATWG), e.g. one version might have a feature listed as deprecated, while the other doesn't.
+In such cases, consider what the reality is — i.e. what browsers are actually doing — and write an "important" note to summarize that latest status.
+For example, as of Jan 2019 the [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) global attribute has a conflict, which was summarized like so:
 
-> **Warning:** Spec conflict: The [WHATWG spec lists `inputmode`](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode), and modern browsers are working towards supporting it. The [W3C HTML 5.2 spec](https://www.w3.org/TR/html52/index.html#contents) however no longer lists it (i.e. marks it as obsolete). You should consider the WHATWG definition as correct, until a consensus is reached.=
+> **Warning:** Spec conflict: The [WHATWG spec lists `inputmode`](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode), and modern browsers are working towards supporting it.
+> The [W3C HTML 5.2 spec](https://www.w3.org/TR/html52/index.html#contents) however no longer lists it (i.e. marks it as obsolete).
+> You should consider the WHATWG definition as correct, until a consensus is reached.=

--- a/files/en-us/mdn/guidelines/video/index.md
+++ b/files/en-us/mdn/guidelines/video/index.md
@@ -8,48 +8,67 @@ tags:
 ---
 {{MDNSidebar}}
 
-MDN Web Docs is not a very video-heavy site, but there are certain places where video content makes sense to use as part of an article. This article discusses when including videos in MDN articles is appropriate, and provides tips on how to create simple but effective videos on a budget.
+MDN Web Docs is not a very video-heavy site, but there are certain places where video content makes sense to use as part of an article.
+This article discusses when including videos in MDN articles is appropriate, and provides tips on how to create simple but effective videos on a budget.
 
 ## When to use video on MDN
 
 There are several arguments against using video content for technical documentation, particularly reference material and advanced level guides:
 
-- Video is linear. People don’t tend to read online documentation in a linear fashion, starting at the start and reading through to the end. [They scan](https://www.sensible.com/chapter.html). Video is really hard to scan — it forces the user to consume the content start-to-finish.
-- Video is less information-dense than text. It takes longer to consume a video explaining something than it does to read the equivalent instructions.
+- Video is linear.
+  People don’t tend to read online documentation in a linear fashion, starting at the start and reading through to the end.
+  [They scan](https://www.sensible.com/chapter.html).
+  Video is really hard to scan — it forces the user to consume the content start-to-finish.
+- Video is less information-dense than text.
+  It takes longer to consume a video explaining something than it does to read the equivalent instructions.
 - Video is big in terms of file size, and therefore more expensive and less performant than text.
-- Video has accessibility problems: it’s more expensive to produce generally than text,  but especially to localize, or make usable by screen reader users.
+- Video has accessibility problems: it’s more expensive to produce generally than text, but especially to localize, or make usable by screen reader users.
 - Following on from the last point, video is much harder to edit/update/maintain than text content.
 
 > **Note:** It’s worth keeping these problems in mind, even when you are making videos, so you can try to alleviate some of them.
 
-There are many popular video sites that provide a lot of video tutorials. MDN isn't a video-driven site, but video does have a place on MDN in certain contexts.
+There are many popular video sites that provide a lot of video tutorials.
+MDN isn't a video-driven site, but video does have a place on MDN in certain contexts.
 
-We tend to most commonly use video when describing some kind of instruction sequence or multi-step workflow that would be hard to describe concisely in words: _"do this, then do that, then this will happen"_. It is especially useful when trying to describe processes that cross over multiple applications or windows, and include GUI interactions that might not be simple to describe: _"now click on the button near the top-left that looks a bit like a duck"_.
+We tend to most commonly use video when describing some kind of instruction sequence or multi-step workflow that would be hard to describe concisely in words: _"do this, then do that, then this will happen"_.
+It is especially useful when trying to describe processes that cross over multiple applications or windows, and include GUI interactions that might not be simple to describe: _"now click on the button near the top-left that looks a bit like a duck"_.
 
-In such cases it is often more effective to just **show** what you mean. We most commonly use videos when explaining features of the [Firefox DevTools](/en-US/docs/Tools).
+In such cases it is often more effective to just **show** what you mean.
+We most commonly use videos when explaining features of the [Firefox DevTools](/en-US/docs/Tools).
 
 ## What should MDN videos look like?
 
 Videos for MDN should be:
 
-- **Short**: Try to keep videos under 30 seconds, ideally under 20 seconds. This is short enough not to make big demands on peoples’ attention spans.
-- **Simple**: Try to make the workflow simple, 2-4 distinct pieces. This makes them easier to follow.
-- **Silent**: Audio makes videos much more engaging, but they are much more time-consuming to make. Also, having to explain what you’re doing makes the videos much longer, and adds to the costs (both financial and in terms of time) of localization.
+- **Short**: Try to keep videos under 30 seconds, ideally under 20 seconds.
+  This is short enough not to make big demands on peoples’ attention spans.
+- **Simple**: Try to make the workflow simple, 2-4 distinct pieces.
+  This makes them easier to follow.
+- **Silent**: Audio makes videos much more engaging, but they are much more time-consuming to make.
+  Also, having to explain what you’re doing makes the videos much longer, and adds to the costs (both financial and in terms of time) of localization.
 
-To explain something more complex, you can use a blend of short videos and screenshots, interspersed with text. The text can help reinforce the points made in the video, and the user can rely on the text or the video as they choose. See [Working with the Animation Inspector](/en-US/docs/Tools/Page_Inspector/How_to/Work_with_animations#animation_inspector) for a good example.
+To explain something more complex, you can use a blend of short videos and screenshots, interspersed with text.
+The text can help reinforce the points made in the video, and the user can rely on the text or the video as they choose.
+See [Working with the Animation Inspector](/en-US/docs/Tools/Page_Inspector/How_to/Work_with_animations#animation_inspector) for a good example.
 
 In addition, you should consider the following tips:
 
-- The video will end up being uploaded to YouTube before embedding. We'd recommend a 16:9 aspect ratio for this use, so that it fills up the entire viewing frame and you don't end up with ugly black bars on the top and bottom (or left and right) of your video. So for example, you might choose a resolution of 1024×576, 1152×648, or 1280×720.
+- The video will end up being uploaded to YouTube before embedding.
+  We'd recommend a 16:9 aspect ratio for this use, so that it fills up the entire viewing frame and you don't end up with ugly black bars on the top and bottom (or left and right) of your video.
+  So for example, you might choose a resolution of 1024×576, 1152×648, or 1280×720.
 - Record the video in HD, so that it looks better when uploaded.
-- For DevTools videos, it is often a good idea to choose a contrasting theme to the page content, for example choose the dark theme if the example webpage is light-themed. It is easier to see what is going on, and where the DevTools start and the page ends.
+- For DevTools videos, it is often a good idea to choose a contrasting theme to the page content, for example choose the dark theme if the example webpage is light-themed.
+  It is easier to see what is going on, and where the DevTools start and the page ends.
 - For DevTools videos, zoom in the DevTools as much as you can while still showing everything you want to show and making it look OK.
 - Make sure the thing you are trying to demonstrate isn't covered up by the mouse cursor.
 - Consider whether or not it would be useful to configure the screen recording tool to add a visual indicator of mouse clicks.
 
 ## Video tools
 
-You'll need some kind of a tool for recording the video. These range from free to expensive, and simple to complex. If you are already experienced in creating video content, then great. If not, then we'd recommend that you start with a simple tool and then work up to something more complex if you start to enjoy creating video and want to create more interesting productions.
+You'll need some kind of a tool for recording the video.
+These range from free to expensive, and simple to complex.
+If you are already experienced in creating video content, then great.
+If not, then we'd recommend that you start with a simple tool and then work up to something more complex if you start to enjoy creating video and want to create more interesting productions.
 
 The following table provides some recommendations for good starter tools.
 
@@ -64,15 +83,16 @@ The following table provides some recommendations for good starter tools.
 
 ### QuickTime tips
 
-If you are using macOS, you should have QuickTime Player available. This actually provides pretty easy simple recording facilities too:
+If you are using macOS, you should have QuickTime Player available.
+This actually provides pretty easy simple recording facilities too:
 
-1.  Choose _File_ > _New Screen Recording_ from the main menu.
-2.  In the _Screen Recording_ box, hit the record button (the red round button).
-3.  Drag a rectangle round the area of the screen you want to record.
-4.  Press the _Start Recording_ button.
-5.  Perform whatever actions you want to record.
-6.  Press the _Stop_ button.
-7.  Choose _File_ > _Export As..._ > _1080p_ from the main menu to save as hi definition.
+1. Choose _File_ > _New Screen Recording_ from the main menu.
+2. In the _Screen Recording_ box, hit the record button (the red round button).
+3. Drag a rectangle round the area of the screen you want to record.
+4. Press the _Start Recording_ button.
+5. Perform whatever actions you want to record.
+6. Press the _Stop_ button.
+7. Choose _File_ > _Export As..._ > _1080p_ from the main menu to save as hi definition.
 
 ### Other resources
 
@@ -86,25 +106,32 @@ the following subsections describe the general steps you'd want to follow to cre
 
 First, plan the flow you want to capture: consider the best points to start and end.
 
-Make sure the desktop background and your browser profile are clean. Plan the size and positioning of browser windows, especially if you will be using multiple windows.
+Make sure the desktop background and your browser profile are clean.
+Plan the size and positioning of browser windows, especially if you will be using multiple windows.
 
 Plan carefully what you are actually going to record, and practice the steps a few times before recording them:
 
-- Don't start a video in the middle of a process — consider whether the viewer has enough context for your actions to make sense to them. In a short DevTools video for example, it is a good idea to start by opening the DevTools to allow the viewer to get oriented.
-- Consider what your actions are, slow down, and make them obvious. Whenever you have to perform an action (say, click an icon), take it slow and make it obvious, so for example:
+- Don't start a video in the middle of a process — consider whether the viewer has enough context for your actions to make sense to them.
+  In a short DevTools video for example, it is a good idea to start by opening the DevTools to allow the viewer to get oriented.
+- Consider what your actions are, slow down, and make them obvious.
+  Whenever you have to perform an action (say, click an icon), take it slow and make it obvious, so for example:
 
   - Move the mouse over the icon
   - Highlight or zoom (not always, depending on whether it feels needed)
   - Pause for a beat
   - Click the icon
 
-- Plan zoom levels for the parts of the UI that you’re going to show. Not everyone will be able to view your video in high definition. You will be able to zoom particular parts in post-production, but it’s a good idea to zoom the app beforehand as well.
+- Plan zoom levels for the parts of the UI that you’re going to show.
+  Not everyone will be able to view your video in high definition.
+  You will be able to zoom particular parts in post-production, but it’s a good idea to zoom the app beforehand as well.
 
 > **Note:** Don’t zoom so far that the UIs you are showing start to look unfamiliar or ugly.
 
 ### Recording
 
-When recording the workflow you want to show, go through the flow smoothly and steadily. Pause for a second or two when you are at key moments — for example, about to click on a button. Make sure the mouse pointer doesn’t obscure any icons or text that are important to what you are trying to demonstrate.
+When recording the workflow you want to show, go through the flow smoothly and steadily.
+Pause for a second or two when you are at key moments — for example, about to click on a button.
+Make sure the mouse pointer doesn’t obscure any icons or text that are important to what you are trying to demonstrate.
 
 Remember to pause for a second or two at the end, to show the result of the flow.
 
@@ -112,12 +139,15 @@ Remember to pause for a second or two at the end, to show the result of the flow
 
 ### Post-production
 
-You’ll be able to highlight key moments in post-production. A highlight can consist of a couple of things, which you’ll often combine:
+You’ll be able to highlight key moments in post-production.
+A highlight can consist of a couple of things, which you’ll often combine:
 
 - Zoom in on parts of the screen.
 - Fade the background.
 
-Highlight key moments of the workflow, especially where the detail is hard to see: clicking on a particular icon or entering a particular URL, for example. Aim for the highlight to last for 1-2 seconds. It’s a good idea to add a short transition (200-300 milliseconds) at the starts and ends of the highlights.
+Highlight key moments of the workflow, especially where the detail is hard to see: clicking on a particular icon or entering a particular URL, for example.
+Aim for the highlight to last for 1-2 seconds.
+It’s a good idea to add a short transition (200-300 milliseconds) at the starts and ends of the highlights.
 
 Use some restraint here: don’t make the video a constant procession of zooming in and out, or viewers will get seasick.
 
@@ -125,16 +155,23 @@ Crop the video to the desired aspect ratio, if required.
 
 ### Uploading
 
-Videos currently have to be uploaded to YouTube to be displayed on MDN, for example the [mozhacks](https://www.youtube.com/user/mozhacks/videos) channel. Ask a member of MDN staff to upload the video if you don't have somewhere appropriate to put it.
+Videos currently have to be uploaded to YouTube to be displayed on MDN, for example the [mozhacks](https://www.youtube.com/user/mozhacks/videos) channel.
+Ask a member of MDN staff to upload the video if you don't have somewhere appropriate to put it.
 
 > **Note:** Mark the video as "unlisted" if it doesn’t make sense out of the context of the page (if it’s a short video, then it probably doesn't).
 
 ### Embedding
 
-Once uploaded, you can embed the video in the page using the {{TemplateLink("EmbedYouTube")}} macro. This is used by inserting the following in your page at the position you want the video to appear:
+Once uploaded, you can embed the video in the page using the [`EmbedYouTube`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedYouTube.ejs) macro.
+This is used by inserting the following in your page at the position you want the video to appear:
 
-\\{{EmbedYouTube("you-tube-url-slug")}}
+```
+\{{EmbedYouTube("you-tube-url-slug")}}
+```
 
-The single property taken by the macro call is the string of characters at the end of the video URL, not the whole URL. For example, the video embedded in our [Page inspector 3-pane mode](/en-US/docs/Tools/Page_Inspector/3-pane_mode) article is available at https\://www\.youtube.com/watch?v=ELS2OOUvxIw, so the required macro call looks like this:
+The single property taken by the macro call is the string of characters at the end of the video URL, not the whole URL.
+For example, the video embedded in our [Page inspector 3-pane mode](/en-US/docs/Tools/Page_Inspector/3-pane_mode) article is available at https\://www\.youtube.com/watch?v=ELS2OOUvxIw, so the required macro call looks like this:
 
-\\{{EmbedYouTube("ELS2OOUvxIw")}}
+```
+\{{EmbedYouTube("ELS2OOUvxIw")}}
+```

--- a/files/en-us/mdn/guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.md
@@ -14,17 +14,24 @@ tags:
 ---
 {{MDNSidebar}}
 
-To present documentation in an organized, standardized, and easy-to-read manner, the MDN Web Docs style guide describes how text should be organized, spelled, formatted, and so on. These are guidelines rather than strict rules. We are more interested in content than formatting, so don't feel obligated to learn the style guide before contributing. Do not be upset or surprised, however, if an industrious volunteer later edits your work to conform to this guide.
+To present documentation in an organized, standardized, and easy-to-read manner, the MDN Web Docs style guide describes how text should be organized, spelled, formatted, and so on.
+These are guidelines rather than strict rules.
+We are more interested in content than formatting, so don't feel obligated to learn the style guide before contributing.
+Do not be upset or surprised, however, if an industrious volunteer later edits your work to conform to this guide.
 
-The language aspects of this guide apply primarily to English-language documentation. Other languages may have (and are welcome to create) style guides. These should be published as subpages of the localization team's page.
+The language aspects of this guide apply primarily to English-language documentation.
+Other languages may have (and are welcome to create) style guides.
+These should be published as subpages of the localization team's page.
 
 ## Basics
 
-The best place to start in any extensive publishing style guide is with some very basic text standards to help keep documentation consistent. The following sections outline some of these basics to help you.
+The best place to start in any extensive publishing style guide is with some very basic text standards to help keep documentation consistent.
+The following sections outline some of these basics to help you.
 
 ### Page titles
 
-Page titles are used in search results and are also used to structure the page hierarchy in the breadcrumb list at the top of the page. The page title (which is displayed at the top of the page and in the search results) can be different from the page "slug", which is the portion of the page's URL following "`<locale>/docs/`".
+Page titles are used in search results and are also used to structure the page hierarchy in the breadcrumb list at the top of the page.
+The page title (which is displayed at the top of the page and in the search results) can be different from the page "slug", which is the portion of the page's URL following "`<locale>/docs/`".
 
 #### Title and heading capitalization
 
@@ -33,17 +40,22 @@ Page titles and section headings should use sentence-style capitalization (only 
 - **Correct**: "A new method for creating JavaScript rollovers"
 - **Incorrect**: "A New Method for Creating JavaScript Rollovers"
 
-We have many older pages that were written before this style rule was established. Feel free to update them as needed if you like. We're gradually getting to them.
+We have many older pages that were written before this style rule was established.
+Feel free to update them as needed if you like.
+We're gradually getting to them.
 
 #### Choosing titles and slugs
 
-Page slugs should be kept short. When creating a new level of hierarchy, the new level's component in the slug should just be a word or two.
+Page slugs should be kept short.
+When creating a new level of hierarchy, the new level's component in the slug should just be a word or two.
 
 Page titles, on the other hand, may be as long as you like, within reason, and they should be descriptive.
 
 #### Creating new subtrees
 
-When you need to add some articles about a topic or subject area, you will typically do so by creating a landing page, then adding subpages for each of the individual articles. The landing page should open with a paragraph or two describing the topic or technology, then provide a list of the subpages with descriptions of each page. You can automate the insertion of pages into the list using some macros we've created.
+When you need to add some articles about a topic or subject area, you will typically do so by creating a landing page, then adding subpages for each of the individual articles.
+The landing page should open with a paragraph or two describing the topic or technology, then provide a list of the subpages with descriptions of each page.
+You can automate the insertion of pages into the list using some macros we've created.
 
 For example, consider the [JavaScript](/en-US/docs/Web/JavaScript) guide, which is structured as follows:
 
@@ -56,43 +68,60 @@ Try to avoid putting your article at the top of the hierarchy, which slows the s
 
 ### General article content guidelines
 
-When writing any document, it's important to know how much to say. If you ramble on too long, or provide excessive detail, the article becomes tedious to read and it will rarely be used. Getting the amount of coverage right is important for several reasons. Among those reasons: ensure that the reader finds the information they truly need, and provide enough quality material for search engines to adequately analyze and rank the article.
+When writing any document, it's important to know how much to say.
+If you ramble on too long, or provide excessive detail, the article becomes tedious to read and it will rarely be used.
+Getting the amount of coverage right is important for several reasons.
+Among those reasons: ensure that the reader finds the information they truly need, and provide enough quality material for search engines to adequately analyze and rank the article.
 
-We'll discuss the former (providing the information the reader may need) here. To learn more about ensuring that pages are properly classified and ranked by search engines, see the article [How to write for SEO on MDN](/en-US/docs/MDN/Contribute/Howto/Write_for_SEO).
+We'll discuss the former (providing the information the reader may need) here.
+To learn more about ensuring that pages are properly classified and ranked by search engines, see the article [How to write for SEO on MDN](/en-US/docs/MDN/Contribute/Howto/Write_for_SEO).
 
-The goal is to write pages that include all the information that readers may need without going into too much detail. Following are some recommendations to achieve this.
+The goal is to write pages that include all the information that readers may need without going into too much detail.
+Following are some recommendations to achieve this.
 
 #### Consider your audience
 
-Keep in mind that these are guidelines. Some of these tips may not apply in every case. Certainly keep your article's audience in mind. For example, an article on advanced network techniques likely doesn't need to go into as much detail about basic networking concepts as the typical article on networking.
+Keep in mind that these are guidelines.
+Some of these tips may not apply in every case.
+Certainly keep your article's audience in mind.
+For example, an article on advanced network techniques likely doesn't need to go into as much detail about basic networking concepts as the typical article on networking.
 
 #### Provide a useful summary
 
-Make sure the article's summary—that is, the opening paragraph or paragraphs before the first heading—provides enough information to adequately inform readers of the article's contents. This way a reader can determine quickly whether the article is relevant to their concerns.
+Make sure the article's summary—that is, the opening paragraph or paragraphs before the first heading—provides enough information to adequately inform readers of the article's contents.
+This way a reader can determine quickly whether the article is relevant to their concerns.
 
-In a guide or tutorial, the summary should inform the reader of the topics that are covered as well as of what requisite knowledge the reader is expected to have, if any. It should mention the technologies and/or APIs that are being documented or discussed, with links to related information, and it should offer hints to situations in which the article's contents might be useful.
+In a guide or tutorial, the summary should inform the reader of the topics that are covered as well as of what requisite knowledge the reader is expected to have, if any.
+It should mention the technologies and/or APIs that are being documented or discussed, with links to related information, and it should offer hints to situations in which the article's contents might be useful.
 
 ##### Example: Too short!
 
-This example of a summary is far too short. It leaves out too much information, such as what it means exactly to "stroke" text, where the text is drawn, and so forth.
+This example of a summary is far too short.
+It leaves out too much information, such as what it means exactly to "stroke" text, where the text is drawn, and so forth.
 
 **`CanvasRenderingContext2D.strokeText()`** draws a string.
 
 ##### Example: Too long!
 
-Here, we've updated the summary, but now it's far too long. Too much detail is included, and the text delves too deeply into describing other methods and properties.
+Here, we've updated the summary, but now it's far too long.
+Too much detail is included, and the text delves too deeply into describing other methods and properties.
 
 Instead, the summary should focus on the `strokeText()` method, and should refer to the appropriate guides where the other details are described.
 
-When called, the Canvas 2D API method **`CanvasRenderingContext2D.strokeText()`** strokes the characters in the specified string beginning at the coordinates specified, using the current pen color. In the terminology of computer graphics, "stroking" text means to draw the outlines of the glyphs in the string without filling in the contents of each character with color.
+When called, the Canvas 2D API method **`CanvasRenderingContext2D.strokeText()`** strokes the characters in the specified string beginning at the coordinates specified, using the current pen color.
+In the terminology of computer graphics, "stroking" text means to draw the outlines of the glyphs in the string without filling in the contents of each character with color.
 
 The text is drawn using the context's current font as specified in the context's {{domxref("CanvasRenderingContext2D.font", "font")}} property.
 
-The placement of the text relative to the specified coordinates are determined by the context's `textAlign`, `textBaseline`, and `direction` properties. `textAlign` controls the placement of the string relative to the X coordinate specified; if the value is `"center"`, then the string is drawn starting at `x - (stringWidth / 2)`, placing the specified X-coordinate in the middle of the string. If the value is `"left"`, the string is drawn starting at the specified value of `x`. And if `textAlign` is `"right"`, the text is drawn such that it ends at the specified X-coordinate.
+The placement of the text relative to the specified coordinates are determined by the context's `textAlign`, `textBaseline`, and `direction` properties.
+`textAlign` controls the placement of the string relative to the X coordinate specified; if the value is `"center"`, then the string is drawn starting at `x - (stringWidth / 2)`, placing the specified X-coordinate in the middle of the string.
+If the value is `"left"`, the string is drawn starting at the specified value of `x`.
+And if `textAlign` is `"right"`, the text is drawn such that it ends at the specified X-coordinate.
 
 (etc etc etc...)
 
-You can, optionally, provide a fourth parameter that lets you specify a maximum width for the string, in pixels. If you provide this parameter, the text is compressed horizontally or scaled (or otherwise adjusted) to fit inside a space that wide when being drawn.
+You can, optionally, provide a fourth parameter that lets you specify a maximum width for the string, in pixels.
+If you provide this parameter, the text is compressed horizontally or scaled (or otherwise adjusted) to fit inside a space that wide when being drawn.
 
 You can call the **`fillText()`** method to draw a string's characters as filled with color instead of only drawing the outlines of the characters.
 
@@ -100,13 +129,15 @@ You can call the **`fillText()`** method to draw a string's characters as filled
 
 Here we see a much better overview for the `strokeText()` method.
 
-The {{domxref("CanvasRenderingContext2D")}} method **`strokeText()`**, part of the [Canvas 2D API](/en-US/docs/Web/API/Canvas_API), strokes—that is, draws the outlines of—the characters of a specified string, anchored at the position indicated by the given X and Y coordinates. The text is drawn using the context's current {{domxref("CanvasRenderingContext2D.font", "font")}}, and is justified and aligned according to the {{domxref("CanvasRenderingContext2D.textAlign", "textAlign")}}, {{domxref("CanvasRenderingContext2D.textBaseline", "textBaseline")}}, and {{domxref("CanvasRenderingContext2D.direction", "direction")}} properties.
+The {{domxref("CanvasRenderingContext2D")}} method **`strokeText()`**, part of the [Canvas 2D API](/en-US/docs/Web/API/Canvas_API), strokes—that is, draws the outlines of—the characters of a specified string, anchored at the position indicated by the given X and Y coordinates.
+The text is drawn using the context's current {{domxref("CanvasRenderingContext2D.font", "font")}}, and is justified and aligned according to the {{domxref("CanvasRenderingContext2D.textAlign", "textAlign")}}, {{domxref("CanvasRenderingContext2D.textBaseline", "textBaseline")}}, and {{domxref("CanvasRenderingContext2D.direction", "direction")}} properties.
 
 For more details and further examples, see {{SectionOnPage("/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Drawing_graphics", "Text")}} in the Learning Area as well as our main article on the subject, [Drawing text](/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_text).
 
 #### Include all relevant examples
 
-It's important to ensure that you use examples to clarify what every parameter is used for, and to clarify any edge cases that may exist. You should also use examples to demonstrate solutions for common tasks, and you should use examples to demonstrate solutions to problems that may arise.
+It's important to ensure that you use examples to clarify what every parameter is used for, and to clarify any edge cases that may exist.
+You should also use examples to demonstrate solutions for common tasks, and you should use examples to demonstrate solutions to problems that may arise.
 
 In general it is expected that most of the pages will include examples, and that most of them will include more than one example.
 
@@ -114,39 +145,54 @@ Each example should be preceded by text explaining what the example does and any
 
 ##### Code Examples
 
-Each piece of code should include an explanation of how it works. Keep in mind that it may make sense to break up a large piece of code into smaller portions so they can be described individually.
+Each piece of code should include an explanation of how it works.
+Keep in mind that it may make sense to break up a large piece of code into smaller portions so they can be described individually.
 
 The text following each piece of code should explain anything relevant, using an appropriate level of detail:
 
 - If the code is very simple and doesn't really use anything directly related to the API being documented, you need only give a quick summary of what it is and why it's there.
 - If the code is intricate, uses the API being documented, or is technically creative, you should provide a more detailed explanation.
 
-When adding [live samples](/en-US/docs/MDN/Structures/Live_samples), it's helpful to be aware that all of the {{HTMLElement("pre")}} blocks in the area that contains the sample are concatenated together before running the example, which lets you break any or all of the HTML, CSS, and JavaScript into multiple segments, each optionally with its own descriptions, headings, and so forth. This makes documenting code incredibly powerful and flexible.
+When adding [live samples](/en-US/docs/MDN/Structures/Live_samples), it's helpful to be aware that all of the {{HTMLElement("pre")}} blocks in the area that contains the sample are concatenated together before running the example, which lets you break any or all of the HTML, CSS, and JavaScript into multiple segments, each optionally with its own descriptions, headings, and so forth.
+This makes documenting code incredibly powerful and flexible.
 
 #### Overly-short articles are hard to find
 
-If an article is "thin"—that is, too short—it may not be indexed properly (or at all) by search engines. As a rule of thumb, the article's body text should be at least 250–300 words. Don't artificially inflate a page, but treat this guideline as a minimum target length when possible.
+If an article is "thin"—that is, too short—it may not be indexed properly (or at all) by search engines.
+As a rule of thumb, the article's body text should be at least 250–300 words.
+Don't artificially inflate a page, but treat this guideline as a minimum target length when possible.
 
 ### Headings
 
-When a new paragraph starts a new section, a header should be added. Use heading levels in decreasing order: {{HTMLElement("h2")}} then {{HTMLElement("h3")}} then {{HTMLElement("h4")}}, without skipping levels.
+When a new paragraph starts a new section, a header should be added.
+Use heading levels in decreasing order: {{HTMLElement("h2")}} then {{HTMLElement("h3")}} then {{HTMLElement("h4")}}, without skipping levels.
 
-H2 is the highest level allowed because H1 is reserved for the page title. If you need more than three or four levels of headers, consider breaking up the article into several smaller articles with a landing page.
+H2 is the highest level allowed because H1 is reserved for the page title.
+If you need more than three or four levels of headers, consider breaking up the article into several smaller articles with a landing page.
 
 #### Heading dos and don'ts
 
-- **Don't create single subsections.** Don't subdivide a topic into a single subtopic. It's either two subheadings or more, or none at all.
-- **Don't use styles and classes within headings.** This includes the {{HTMLElement("code")}} element for code terms. So don't make a heading "Using the `SuperAmazingThing` interface". It should instead just be "Using the SuperAmazingThing interface".
+- **Don't create single subsections.** Don't subdivide a topic into a single subtopic.
+  It's either two subheadings or more, or none at all.
+- **Don't use styles and classes within headings.** This includes the {{HTMLElement("code")}} element for code terms.
+  So don't make a heading "Using the `SuperAmazingThing` interface".
+  It should instead just be "Using the SuperAmazingThing interface".
 - **Avoid using macros within headings** (except for certain macros that are specifically designed to be used in headings).
-- **Don't create "bumping heads."** These are headings followed immediately by a subheading, with no content text in between. This doesn't look good, and leaves readers without any explanatory text at the beginning of the outer section.
+- **Don't create "bumping heads."** These are headings followed immediately by a subheading, with no content text in between.
+  This doesn't look good, and leaves readers without any explanatory text at the beginning of the outer section.
 
 ### Lists
 
-Lists should be formatted and structured uniformly across all pages. Individual list items should be written with suitable punctuation, regardless of the list format. However, depending on the type of the list you are creating, you will want to adjust your writing as described in the sections below.
+Lists should be formatted and structured uniformly across all pages.
+Individual list items should be written with suitable punctuation, regardless of the list format.
+However, depending on the type of the list you are creating, you will want to adjust your writing as described in the sections below.
 
 #### Bulleted lists
 
-Bulleted lists should be used to group related pieces of concise information. Each item in the list should follow a similar sentence structure. Phrases and sentences in bulleted lists should include standard punctuation. A period must appear at the end of each sentence in a bulleted list, including the item's final sentence, just as would be expected in a paragraph.
+Bulleted lists should be used to group related pieces of concise information.
+Each item in the list should follow a similar sentence structure.
+Phrases and sentences in bulleted lists should include standard punctuation.
+A period must appear at the end of each sentence in a bulleted list, including the item's final sentence, just as would be expected in a paragraph.
 
 An example of a correctly structured bulleted list:
 
@@ -156,23 +202,30 @@ In this example we should include:
 - A similar condition, with a brief explanation.
 - Yet another condition, with some further explanation.
 
-Note how the same sentence structure repeats from bullet to bullet. In this example, each bullet point states a condition followed by a comma and a brief explanation, and each item in the list ends with a period.
+Note how the same sentence structure repeats from bullet to bullet.
+In this example, each bullet point states a condition followed by a comma and a brief explanation, and each item in the list ends with a period.
 
 #### Numbered lists
 
-Numbered lists are used primarily to enumerate steps in a set of instructions. Because instructions can be complex, clarity is a priority, especially if the text in each list item is lengthy. As with bulleted lists, follow standard punctuation usage.
+Numbered lists are used primarily to enumerate steps in a set of instructions.
+Because instructions can be complex, clarity is a priority, especially if the text in each list item is lengthy.
+As with bulleted lists, follow standard punctuation usage.
 
 An example of a correctly structured numbered list:
 
 In order to correctly structure a numbered list, you should:
 
-1.  Open with a heading or brief paragraph to introduce the instructions. It's important to provide the user with context before beginning the instructions.
-2.  Start creating your instructions, and keep each step in its own numbered item. Your instructions may be quite extensive, so it is important to write clearly and use correct punctuation.
-3.  After you have finished your instructions, follow the numbered list with a brief closing summary or explanation about the expected outcome upon completion.
+1. Open with a heading or brief paragraph to introduce the instructions.
+   It's important to provide the user with context before beginning the instructions.
+2. Start creating your instructions, and keep each step in its own numbered item.
+   Your instructions may be quite extensive, so it is important to write clearly and use correct punctuation.
+3. After you have finished your instructions, follow the numbered list with a brief closing summary or explanation about the expected outcome upon completion.
 
-This is an example of writing a closing explanation. We have created a short numbered list that provides instructive steps to produce a numbered list with the correct formatting.
+This is an example of writing a closing explanation.
+We have created a short numbered list that provides instructive steps to produce a numbered list with the correct formatting.
 
-Note how the items in numbered lists read like short paragraphs. Because numbered lists are routinely used for instructional purposes, or to walk someone through an orderly procedure, be sure to keep each item focused: one numbered item per step.
+Note how the items in numbered lists read like short paragraphs.
+Because numbered lists are routinely used for instructional purposes, or to walk someone through an orderly procedure, be sure to keep each item focused: one numbered item per step.
 
 ### Text formatting and styles
 
@@ -182,15 +235,19 @@ Use the **"Formatting Styles"** drop-down list to apply predefined styles to sel
 
 > **Warning:** Similarly, the **"Warning Box"** style creates warning boxes like this.
 
-Unless specifically instructed, _do not_ use the HTML `style` attribute to manually apply a style. If you can't do it using a predefined class, ask for help in the [MDN discussion forum](https://discourse.mozilla.org/c/mdn).
+Unless specifically instructed, _do not_ use the HTML `style` attribute to manually apply a style.
+If you can't do it using a predefined class, ask for help in the [MDN discussion forum](https://discourse.mozilla.org/c/mdn).
 
 ### Code sample style and formatting
 
-> **Note:** This section deals with the styling/formatting of code as it appears on an MDN article. If you want guidelines on actually writing code examples, see our [Code sample guidelines](/en-US/docs/MDN/Guidelines/Code_guidelines).
+> **Note:** This section deals with the styling/formatting of code as it appears on an MDN article.
+> If you want guidelines on actually writing code examples, see our [Code sample guidelines](/en-US/docs/MDN/Guidelines/Code_guidelines).
 
 #### Tabs and line breaks
 
-Use two spaces per tab in all code examples. Indent the code cleanly, with open-brace ("`{`") characters on the same line as the statement that opens the block. For example:
+Use two spaces per tab in all code examples.
+Indent the code cleanly, with open-brace ("`{`") characters on the same line as the statement that opens the block.
+For example:
 
 ```js
 if (condition) {
@@ -200,7 +257,9 @@ if (condition) {
 }
 ```
 
-Long lines shouldn't be allowed to stretch off horizontally to the extent that they require horizontal scrolling to read. Instead, break long lines at natural breaking points. Some examples follow:
+Long lines shouldn't be allowed to stretch off horizontally to the extent that they require horizontal scrolling to read.
+Instead, break long lines at natural breaking points.
+Some examples follow:
 
 ```js
 if (class.CONDITION || class.OTHER_CONDITION || class.SOME_OTHER_CONDITION
@@ -214,9 +273,11 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 
 #### Inline code formatting
 
-Use the {{HTMLElement("code")}} tags to mark up function names, variable names, and method names. For example: "the `frenchText()` function".
+Use the {{HTMLElement("code")}} tags to mark up function names, variable names, and method names.
+For example: "the `frenchText()` function".
 
-**Method names should be followed by a pair of parentheses.** For example, `doSomethingUseful()`. The parentheses help differentiate methods from other code terms.
+**Method names should be followed by a pair of parentheses.** For example, `doSomethingUseful()`.
+The parentheses help differentiate methods from other code terms.
 
 #### Syntax highlighting
 
@@ -224,22 +285,29 @@ A line or multiple lines of code should be formatted using [syntax highlighting]
 
 #### Styling mentions of HTML elements
 
-There are specific rules to follow when writing about HTML elements. These rules produce consistent descriptions of elements and their components. They also ensure correct linking to detailed documentation.
+There are specific rules to follow when writing about HTML elements.
+These rules produce consistent descriptions of elements and their components.
+They also ensure correct linking to detailed documentation.
 
 - Element names
-  - : Use the {{TemplateLink("HTMLElement")}} macro, which creates a link to the page for that element. For example, writing \\{{HTMLElement("title")}} produces "{{HTMLElement("title")}}". If you don't want to create a link, **enclose the name in angle brackets** and use the "Inline Code" style (e.g., `<title>`).
+  - : Use the [`HTMLElement`](https://github.com/mdn/yari/blob/main/kumascript/macros/HTMLElement.ejs) macro, which creates a link to the page for that element.
+    For example, writing `\{{HTMLElement("title")}}` produces "{{HTMLElement("title")}}".
+    If you don't want to create a link, **enclose the name in angle brackets** and use the "Inline Code" style (e.g., `<title>`).
 - Attribute names
-  - : Use "Inline Code" style to put attribute names in `code font`. Additionally, put them in **`bold face`** when the attribute is mentioned in association with an explanation of what it does, or the first time it is used in the article.
+  - : Use "Inline Code" style to put attribute names in `code font`.
+    Additionally, put them in **`bold face`** when the attribute is mentioned in association with an explanation of what it does, or the first time it is used in the article.
 - Attribute definitions
-  - : Use the {{TemplateLink("htmlattrdef")}} macro (e.g., \\{{htmlattrdef("type")}}) for the definition term, so that it can be linked to from other pages easily by using the {{TemplateLink("htmlattrxref")}} macro (e.g., \\{{htmlattrxref("type","element")}}) to reference attribute definitions.
+  - : Use the [`htmlattrdef`](https://github.com/mdn/yari/tree/main/kumascript/macros/htmlattrdef.ejs)  macro (e.g., `\{{htmlattrdef("type")}})` for the definition term, so that it can be linked to from other pages easily by using the [`htmlattrxref`](https://github.com/mdn/yari/blob/main/kumascript/macros/htmlattrxref.ejs) macro (e.g., `\{{htmlattrxref("type","element")}}`) to reference attribute definitions.
 - Attribute values
-  - : Use the "Inline Code" style to apply `<code>` to attribute values, and don't use quotation marks around string values, unless needed by the syntax of a code sample. **For example:** "When the `type` attribute of an `<input>` element is set to `email` or `tel` ..."
+  - : Use the "Inline Code" style to apply `<code>` to attribute values, and don't use quotation marks around string values, unless needed by the syntax of a code sample.
+    **For example:** "When the `type` attribute of an `<input>` element is set to `email` or `tel` ..."
 
 ### Latin abbreviations
 
 #### In notes and parentheses
 
-- Common Latin abbreviations (etc., i.e., e.g.) may be used in parenthetical expressions and notes. Use periods in these abbreviations, followed by a comma or other appropriate punctuation.
+- Common Latin abbreviations (etc., i.e., e.g.) may be used in parenthetical expressions and notes.
+  Use periods in these abbreviations, followed by a comma or other appropriate punctuation.
 
   - **Correct**: Web browsers (e.g., Firefox) can be used ...
   - **Incorrect**: Web browsers e.g. Firefox can be used ...
@@ -267,9 +335,11 @@ There are specific rules to follow when writing about HTML elements. These rules
 | N.B.   | _nota bene_      | note well               |
 | P.S.   | _post scriptum_  | postscript              |
 
-> **Note:** Always consider whether it's truly beneficial to use a Latin abbreviation. Some of these are used so rarely that many readers will either confuse or fail to understand their meanings.
+> **Note:** Always consider whether it's truly beneficial to use a Latin abbreviation.
+> Some of these are used so rarely that many readers will either confuse or fail to understand their meanings.
 >
-> Also, be sure that _you_ use them correctly, if you choose to do so. For example, be careful not to confuse "e.g." with "i.e.", which is a common error.
+> Also, be sure that _you_ use them correctly, if you choose to do so.
+> For example, be careful not to confuse "e.g." with "i.e.", which is a common error.
 
 ### Acronyms and abbreviations
 
@@ -308,11 +378,15 @@ The contraction "vs." is preferred.
 
 Use standard English capitalization rules in body text, and capitalize "World Wide Web." It is acceptable to use lower case for "web" (used alone or as a modifier) and "internet".
 
-<div class="note"><p><strong>Note</strong>: This guideline is a change from a previous version of this guide, so you may find many instances of "Web" and "Internet" on MDN.</p><p>Feel free to change these as you are making other changes, but editing an article just to change capitalization is not necessary.</p></div>
+> **Note:** This guideline is a change from a previous version of this guide, so you may find many instances of "Web" and "Internet" on MDN.
+> Feel free to change these as you are making other changes, but editing an article just to change capitalization is not necessary.
 
-Keyboard keys should use sentence-style capitalization, not all-caps capitalization. For example, "<kbd>Enter</kbd>" not "<kbd>ENTER</kbd>". The only exception is that you can use "<kbd>ESC</kbd>" to abbreviate the "<kbd>Escape</kbd>" key.
+Keyboard keys should use sentence-style capitalization, not all-caps capitalization.
+For example, "<kbd>Enter</kbd>" not "<kbd>ENTER</kbd>".
+The only exception is that you can use "<kbd>ESC</kbd>" to abbreviate the "<kbd>Escape</kbd>" key.
 
-Certain words should always be capitalized (such as trademarks which include capital letters), or words derived from the name of a person (unless it's being used within code, and code’s syntax requires lower-casing). Some examples:
+Certain words should always be capitalized (such as trademarks which include capital letters), or words derived from the name of a person (unless it's being used within code, and code’s syntax requires lower-casing).
+Some examples:
 
 - Boolean (named for English mathematician and logician {{interwiki("wikipedia", "George Boole")}})
 - JavaScript (a trademark of Oracle Corporation, it should always be written as trademarked)
@@ -338,7 +412,9 @@ Hyphenated compounds should be used when the last letter of the prefix is a vowe
 
 ### Inclusive language
 
-MDN has a wide and diverse audience. We strongly encourage keeping text as inclusive as possible. Here are some alternatives to common terms used in documentation:
+MDN has a wide and diverse audience.
+We strongly encourage keeping text as inclusive as possible.
+Here are some alternatives to common terms used in documentation:
 
 - Avoid using the terms **master** and **slave** and instead **main** and **replica**
 - Replace **whitelist** and **blacklist** with **allowlist** and **denylist**
@@ -348,7 +424,8 @@ MDN has a wide and diverse audience. We strongly encourage keeping text as inclu
 
 #### Gender-neutral language
 
-It is best to use gender-neutral language in any writing where gender is irrelevant to the subject matter. For example, if you are talking about the actions of a specific man, using "he"/"his" is fine; but if the subject is a person of either gender, "he"/"his" isn't appropriate.
+It is best to use gender-neutral language in any writing where gender is irrelevant to the subject matter. 
+or example, if you are talking about the actions of a specific man, using "he"/"his" is fine; but if the subject is a person of either gender, "he"/"his" isn't appropriate.
 
 Let's take the following example:
 
@@ -356,7 +433,8 @@ _A confirmation dialog appears, asking the user if he allows the Web page to mak
 
 _A confirmation dialog appears, asking the user if she allows the Web page to make use of her Web cam._
 
-Both versions are gender-specific. To fix this, use gender-neutral pronouns:
+Both versions are gender-specific.
+To fix this, use gender-neutral pronouns:
 
 _A confirmation dialog appears, asking the user if they allow the Web page to make use of their Web cam._
 
@@ -374,7 +452,9 @@ _A confirmation dialog appears, requesting the user's permission for web cam acc
 
 _A confirmation dialog box appears, which asks the user for permission to use the web cam._
 
-This last example of dealing with the problem is arguably better. Not only is it grammatically more correct, but removes some of the complexity associated with dealing with genders across different languages that may have wildly different gender rules. This solution can make translation easier for both readers and localizers.
+This last example of dealing with the problem is arguably better.
+Not only is it grammatically more correct, but removes some of the complexity associated with dealing with genders across different languages that may have wildly different gender rules.
+This solution can make translation easier for both readers and localizers.
 
 ### Numbers and numerals
 
@@ -392,14 +472,16 @@ Alternately, you can use the YYYY/MM/DD format.
 
 #### Decades
 
-For decades, use the format "1990s". Don't use an apostrophe.
+For decades, use the format "1990s".
+Don't use an apostrophe.
 
 - **Correct**: 1990s
 - **Incorrect**: 1990's
 
 #### Plurals of numerals
 
-For plurals of numerals add "s". Don't use an apostrophe.
+For plurals of numerals add "s".
+Don't use an apostrophe.
 
 - **Correct**: 486s
 - **Incorrect**: 486's
@@ -415,7 +497,8 @@ In running text, use commas only in five-digit and larger numbers.
 
 #### Serial comma
 
-**Use the serial comma**. The serial (also known as "Oxford") comma is the comma that appears before the conjunction in a series of three or more items.
+**Use the serial comma**.
+The serial (also known as "Oxford") comma is the comma that appears before the conjunction in a series of three or more items.
 
 - **Correct**: I will travel on trains, planes, and automobiles.
 - **Incorrect**: I will travel on trains, planes and automobiles.
@@ -426,8 +509,8 @@ In running text, use commas only in five-digit and larger numbers.
 
 There are a couple of reasons for this.
 
-1.  We need to choose one or the other for consistency.
-2.  If curly quotes or apostrophes make their way into code snippets—even inline ones—readers may copy and paste them, expecting them to function (which they will not).
+1. We need to choose one or the other for consistency.
+2. If curly quotes or apostrophes make their way into code snippets—even inline ones—readers may copy and paste them, expecting them to function (which they will not).
 
 - **Correct**: Please don't use "curly quotes."
 - **Incorrect**: Please don’t use “curly quotes.”
@@ -436,7 +519,9 @@ There are a couple of reasons for this.
 
 Use American-English spelling.
 
-In general, use the first entry at [Dictionary.com](https://www.dictionary.com/), unless that entry is listed as a variant spelling or as being primarily used in a non-American form of English. For example, if you [look up "behavior"](https://www.dictionary.com/browse/behavior), you find the phrase "Chiefly British" followed by a link to the American standard form, "[behavior](https://dictionary.reference.com/browse/behavior)". Do not use variant spellings.
+In general, use the first entry at [Dictionary.com](https://www.dictionary.com/), unless that entry is listed as a variant spelling or as being primarily used in a non-American form of English.
+For example, if you [look up "behavior"](https://www.dictionary.com/browse/behavior), you find the phrase "Chiefly British" followed by a link to the American standard form, "[behavior](https://dictionary.reference.com/browse/behavior)".
+Do not use variant spellings.
 
 - **Correct**: localize, behavior
 - **Incorrect**: localise, behaviour
@@ -445,7 +530,8 @@ In general, use the first entry at [Dictionary.com](https://www.dictionary.com/)
 
 #### HTML elements
 
-Use "elements" to refer to HTML and XML elements, rather than "tags". In addition, they should almost always be wrapped in "<>", and should be in the {{HTMLElement("code")}} style.
+Use "elements" to refer to HTML and XML elements, rather than "tags".
+In addition, they should almost always be wrapped in "<>", and should be in the {{HTMLElement("code")}} style.
 
 When you reference a given element for the first time in a section, you should use the {{TemplateLink("HTMLElement")}} macro to create a link to the documentation for the element (unless you're writing within that element's reference document page).
 
@@ -454,28 +540,34 @@ When you reference a given element for the first time in a section, you should u
 
 #### Parameters vs. arguments
 
-The preferred term on MDN is **parameters**. Please avoid the term "arguments" for consistency whenever possible.
+The preferred term on MDN is **parameters**.
+Please avoid the term "arguments" for consistency whenever possible.
 
 #### User interface actions
 
-In task sequences, describe user interface actions using the imperative mood. Identify the user interface element by its label and type.
+In task sequences, describe user interface actions using the imperative mood.
+Identify the user interface element by its label and type.
 
 - **Correct**: Click the Edit button.
 - **Incorrect**: Click Edit.
 
 ### Voice
 
-While the active voice is preferred, the passive voice is also acceptable, given the informal feel of our content. Try to be consistent, though.
+While the active voice is preferred, the passive voice is also acceptable, given the informal feel of our content.
+Try to be consistent, though.
 
 ## Other references
 
 ### Preferred style guides
 
-If you have questions about usage and style not covered here, we recommend referring to the [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/)—or, failing that, the [Chicago Manual of Style](https://www.amazon.com/Chicago-Manual-Style-16th/dp/0226104206). An [unofficial crib sheet for the Chicago Manual of Style](https://faculty.cascadia.edu/cma/HIST148/cmscrib.pdf) is available online.
+If you have questions about usage and style not covered here, we recommend referring to the [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/)—or, failing that, the [Chicago Manual of Style](https://www.amazon.com/Chicago-Manual-Style-16th/dp/0226104206).
+An [unofficial crib sheet for the Chicago Manual of Style](https://faculty.cascadia.edu/cma/HIST148/cmscrib.pdf) is available online.
 
 ### Preferred dictionary
 
-For questions of spelling, please refer to [Dictionary.com](https://www.dictionary.com/). The spelling checker for this site uses American English. Please do not use variant spellings (e.g., use _color_ rather than _colour_).
+For questions of spelling, please refer to [Dictionary.com](https://www.dictionary.com/).
+The spelling checker for this site uses American English.
+Please do not use variant spellings (e.g., use _color_ rather than _colour_).
 
 We will be expanding the guide over time, so if you have specific questions that aren't covered in this document, [please get in touch](/en-US/docs/MDN/Contribute/Getting_started#step_4_ask_for_help), so we know what should be added.
 

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -7,15 +7,14 @@ tags:
 ---
 {{MDNSidebar}}
 
-> **Warning:** Don't delete this page. It's used by
-> [mdn/yari](https://github.com/mdn/yari) for its automation.
+> **Warning:** Don't delete this page. It's used by [mdn/yari](https://github.com/mdn/yari) for its automation.
 
 ## About this page
 
 The **kitchensink** is a page that _attempts_ to incorporate every possible content element and Yari macro.
 
-This page attempts to be the complete intersection of every other page. No in terms of the text but in terms of the
-styles and macros. Let's start with some notes...
+This page attempts to be the complete intersection of every other page. No in terms of the text but in terms of the styles and macros.
+Let's start with some notes...
 
 Text that uses the `<kbd>` tag: <kbd>Shift</kbd>
 
@@ -120,25 +119,17 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/Guide/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >,
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >, palpable content.
+        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>,
+        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content">phrasing content</a>, palpable content.
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >Phrasing content</a
-        >.
+        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content">Phrasing content</a>.
       </td>
     </tr>
     <tr>
@@ -148,18 +139,13 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
     <tr>
       <th scope="row">Permitted parents</th>
       <td>
-        Any element that accepts
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >.
+        Any element that accepts <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content">phrasing content</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >No corresponding role</a
-        >
+        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">No corresponding role</a>
       </td>
     </tr>
     <tr>
@@ -175,8 +161,7 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
 
 <table class="fullwidth-table">
   <caption>
-    Values for the content of
-    <code>&#x3C;meta name="viewport"></code>
+    Values for the content of <code>&#x3C;meta name="viewport"></code>
   </caption>
   <thead>
     <tr>
@@ -208,17 +193,15 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
       <td><code>auto</code>, <code>contain</code> or <code>cover</code></td>
       <td>
         <p>
-          The <code>auto</code> value doesn’t affect the initial layout
-          viewport, and the whole web page is viewable.
+          The <code>auto</code> value doesn’t affect the initial layout viewport, and the whole web page is viewable.
         </p>
         <p>
           The <code>contain</code> value means that the viewport is scaled to
           fit the largest rectangle inscribed within the display.
         </p>
         <p>
-          The <code>cover</code> value means that the viewport is scaled to fill
-          the device display. It is highly recommended to make use of the
-          <a href="/en-US/docs/Web/CSS/env()">safe area inset</a> variables to
+          The <code>cover</code> value means that the viewport is scaled to fill the device display.
+          It is highly recommended to make use of the <a href="/en-US/docs/Web/CSS/env()">safe area inset</a> variables to
           ensure that important content doesn't end up outside the display.
         </p>
       </td>
@@ -239,12 +222,13 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
 
 An {{Glossary("HTTP")}} error code meaning "Bad Gateway".
 
-A {{Glossary("Server", "server")}} can act as a gateway or proxy (go-between) between a client (like your Web browser) and another, upstream server. When you request to access a {{Glossary("URL")}}, the gateway server can relay your request to the upstream server. "502" means that the upstream server has returned an invalid response.
+A {{Glossary("Server", "server")}} can act as a gateway or proxy (go-between) between a client (like your Web browser) and another, upstream server.
+When you request to access a {{Glossary("URL")}}, the gateway server can relay your request to the upstream server.
+"502" means that the upstream server has returned an invalid response.
 
 - JavaScript {{jsxref("Array")}} on MDN
 
-Listening for mouse movement is even easier than listening for key
-presses: all we need is the listener for the {{event("mousemove")}} event.
+Listening for mouse movement is even easier than listening for key presses: all we need is the listener for the {{event("mousemove")}} event.
 ...just below the `keyup event`:
 
 ## Browser compatibility
@@ -253,7 +237,9 @@ presses: all we need is the listener for the {{event("mousemove")}} event.
 
 ## Axis-Aligned Bounding Box
 
-One of the simpler forms of collision detection is between two rectangles that are axis aligned — meaning no rotation. The algorithm works by ensuring there is no gap between any of the 4 sides of the rectangles. Any gap means a collision does not exist.
+One of the simpler forms of collision detection is between two rectangles that are axis aligned — meaning no rotation.
+The algorithm works by ensuring there is no gap between any of the 4 sides of the rectangles.
+Any gap means a collision does not exist.
 
 ```js
 var rect1 = {x: 5, y: 5, width: 50, height: 50}
@@ -318,7 +304,7 @@ this.color("blue");
 - [Accessibility resources at MDN](/en-US/docs/Web/Accessibility)
 - {{Interwiki("wikipedia", "Web accessibility")}} on Wikipedia
 
-The {{TemplateLink("AvailableInWorkers")}} macro inserts a localised note box indicating that a feature is available in a [Web worker](/en-US/docs/Web/API/Web_Workers_API) context.
+The [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macros/AvailableInWorkers.ejs) macro inserts a localised note box indicating that a feature is available in a [Web worker](/en-US/docs/Web/API/Web_Workers_API) context.
 
 {{AvailableInWorkers}}
 
@@ -336,8 +322,10 @@ The {{TemplateLink("AvailableInWorkers")}} macro inserts a localised note box in
 <!---->
 
 - Create a {{htmlelement("canvas")}} element and set its `width` and `height` attributes to the original, smaller resolution.
-- Set its CSS {{cssxref("width")}} and {{cssxref("height")}} properties to be 2x or 4x the value of the HTML `width` and `height`. If the canvas was created with a 128 pixel width, for example, we would set the CSS `width` to `512px` if we wanted a 4x scale.
-- Set the {{htmlelement("canvas")}} element's `image-rendering` CSS property to some value that does not make the image blurry. Either `crisp-edges` or `pixelated` will work. Check out the {{cssxref("image-rendering")}} article for more information on the differences between these values, and which prefixes to use depending on the browser.
+- Set its CSS {{cssxref("width")}} and {{cssxref("height")}} properties to be 2x or 4x the value of the HTML `width` and `height`.
+  If the canvas was created with a 128 pixel width, for example, we would set the CSS `width` to `512px` if we wanted a 4x scale.
+- Set the {{htmlelement("canvas")}} element's `image-rendering` CSS property to some value that does not make the image blurry.
+  Either `crisp-edges` or `pixelated` will work. Check out the {{cssxref("image-rendering")}} article for more information on the differences between these values, and which prefixes to use depending on the browser.
 
 <!---->
 

--- a/files/en-us/mdn/structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/structures/banners_and_notices/index.md
@@ -8,24 +8,33 @@ tags:
 ---
 {{MDNSidebar}}
 
-Sometimes, an article needs a special notice added to it. This might happen if the page covers deprecated technology or other material that shouldn't be used in production code. This article covers the most common such cases and what to do.
+Sometimes, an article needs a special notice added to it.
+This might happen if the page covers deprecated technology or other material that shouldn't be used in production code.
+This article covers the most common such cases and what to do.
 
 ## How to add notice boxes
 
 In most cases, you apply these notices by adding a macro call to inject an appropriate banner into the page content, and by adding a tag to the page's list of tags.
 
-To do this, you insert the macro call at the top of the article, and add the new tag to the list. Once you've done that, raise a pull request and get your changes reviewed and merged. From then on, an appropriate banner will appear on the page, and any macros that reference page tags when looking for up-to-date articles will know that the page you've updated is deprecated, or whatever.
+To do this, you insert the macro call at the top of the article, and add the new tag to the list.
+Once you've done that, raise a pull request and get your changes reviewed and merged.
+From then on, an appropriate banner will appear on the page, and any macros that reference page tags when looking for up-to-date articles will know that the page you've updated is deprecated, or whatever.
 
 > **Note:** To learn more about editing, see our [content repo README](https://github.com/mdn/content).
 
-Sometimes, you might want to flag just a single item in a list of items, or in a table, as obsolete, deprecated, or the like. There are special versions of each of the following macros for that; change "\_header" to "\_inline" to the end of the macro's name.
+Sometimes, you might want to flag just a single item in a list of items, or in a table, as obsolete, deprecated, or the like.
+There are special versions of each of the following macros for that; change "\_header" to "\_inline" to the end of the macro's name.
 
 ## Deprecated content
 
-Deprecated content is content that covers a technology or idea that is in the process of becoming obsolete. It's no longer recommended, and is expected to be removed from browsers in the relatively near future. You can mark pages as deprecated using the {{TemplateLink("deprecated_header")}} macro. Just like with obsolete content, you can specify the Gecko version in which the technology was deprecated as a parameter, if the technology is Gecko-specific.
+Deprecated content is content that covers a technology or idea that is in the process of becoming obsolete.
+It's no longer recommended, and is expected to be removed from browsers in the relatively near future.
+You can mark pages as deprecated using the [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs) macro.
+Just like with obsolete content, you can specify the Gecko version in which the technology was deprecated as a parameter, if the technology is Gecko-specific.
 
 You should also add the tag "Deprecated" to the page.
 
 ## Non-standard content
 
-Non-standard content is any content not yet part of a Web standard; this includes any technology that isn't even proposed as a draft specification, even if it's implemented by multiple browsers. You should use the {{TemplateLink("non-standard_header")}} macro on these pages, and tag the pages with "Non-standard".
+Non-standard content is any content not yet part of a Web standard; this includes any technology that isn't even proposed as a draft specification, even if it's implemented by multiple browsers.
+You should use the [`non-standard_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Non-standard_Header.ejs) macro on these pages, and tag the pages with "Non-standard".

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
@@ -9,22 +9,26 @@ tags:
 ---
 {{MDNSidebar}}
 
-This page lists many of the general-purpose macros created for use on MDN. For additional how-to information on using these macros, see [Using macros](/en-US/docs/MDN/Structures/Macros).
+This page lists many of the general-purpose macros created for use on MDN.
+For additional how-to information on using these macros, see [Using macros](/en-US/docs/MDN/Structures/Macros).
 
-See [Other macros](/en-US/docs/MDN/Structures/Macros/Other) for information on macros that are infrequently used, are used only in special contexts, or are deprecated. See the [CSS style guide](/en-US/docs/MDN/Guidelines/CSS_style_guide) for styles available for your use.
+See [Other macros](/en-US/docs/MDN/Structures/Macros/Other) for information on macros that are infrequently used, are used only in special contexts, or are deprecated.
+See the [CSS style guide](/en-US/docs/MDN/Guidelines/CSS_style_guide) for styles available for your use.
 
 ## Linking
 
 MDN provides a number of link macros for easing the creation of links to reference pages, glossary entries, and other topics.
 
-Link macros are recommended over normal HTML links because they are succint and translation-friendly. For example a glossary or reference link created using a macro does not need to be translated: in other locales it will automatically link to the correct version of the file.
+Link macros are recommended over normal HTML links because they are succint and translation-friendly.
+For example a glossary or reference link created using a macro does not need to be translated: in other locales it will automatically link to the correct version of the file.
 
 ### Glossary links
 
-The [`Glossary`](https://github.com/mdn/yari/tree/master/kumascript/macros/Glossary.ejs) macro creates a link to a specified term's entry in the MDN [glossary](/en-US/docs/Glossary). This macro accepts one required parameter and one optional parameter:
+The [`Glossary`](https://github.com/mdn/yari/tree/master/kumascript/macros/Glossary.ejs) macro creates a link to a specified term's entry in the MDN [glossary](/en-US/docs/Glossary).
+This macro accepts one required parameter and one optional parameter:
 
-1.  The term's name (such as "HTML"): `\{{Glossary("HTML")}}` yields {{Glossary("HTML")}}
-2.  Optional: The text to display in the article instead of the term name: `\{{Glossary("CSS", "Cascading Style Sheets")}}` yields {{Glossary("CSS", "Cascading Style Sheets")}}
+1. The term's name (such as "HTML"): `\{{Glossary("HTML")}}` yields {{Glossary("HTML")}}
+2. Optional: The text to display in the article instead of the term name: `\{{Glossary("CSS", "Cascading Style Sheets")}}` yields {{Glossary("CSS", "Cascading Style Sheets")}}
 
 ### Links to in-page sections
 
@@ -37,7 +41,9 @@ The [`Glossary`](https://github.com/mdn/yari/tree/master/kumascript/macros/Gloss
 
 There are macros for locale-independent linking to pages in specific reference areas of MDN: Javascript, CSS, HTML elements, SVG etc.
 
-The macros are easy to use. Minimally all you need to do is specify the name of the item to link to in the first argument. Most macros will also take a second argument allowing you to change the display text (documentation can be found at the links in the left-most column below).
+The macros are easy to use.
+Minimally all you need to do is specify the name of the item to link to in the first argument.
+Most macros will also take a second argument allowing you to change the display text (documentation can be found at the links in the left-most column below).
 
 <table class="standard-table">
   <thead>
@@ -50,112 +56,69 @@ The macros are easy to use. Minimally all you need to do is specify the name of 
   <tbody>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/cssxref.ejs"
-          >CSSxRef</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/cssxref.ejs">CSSxRef</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/CSS/Reference">CSS Reference</a>
-        (/Web/CSS/Reference)
+        <a href="/en-US/docs/Web/CSS/Reference">CSS Reference</a> (/Web/CSS/Reference)
       </td>
       <td>
-        <code>\{{CSSxRef("cursor")}}</code> results in
-        {{CSSxRef("cursor")}}.
+        <code>\{{CSSxRef("cursor")}}</code> results in {{CSSxRef("cursor")}}.
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/DOMxRef.ejs"
-          >DOMxRef</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/DOMxRef.ejs">DOMxRef</a>
       </td>
       <td><a href="/en-US/docs/Web/API">DOM Reference</a> (/Web/API)</td>
       <td>
-        <code>\{{DOMxRef("Document")}}</code> or
-        <code>\{{DOMxRef("document")}}</code> results in
-        {{DOMxRef("Document")}},<br /><code
-          >\{{DOMxRef("document.getElementsByName()")}}</code
-        >
-        result in {{DOMxRef("document.getElementsByName()")}}<br /><code
-          >\{{DOMxRef("Node")}}</code
-        >
-        result in {{DOMxRef("Node")}}.<br />You can change the display text
-        using a second parameter:
-        <code
-          >\{{DOMxRef("document.getElementsByName()","getElementsByName()")}}</code
-        >
-        results in
-        {{DOMxRef("document.getElementsByName()","getElementsByName()")}}.
+        <code>\{{DOMxRef("Document")}}</code> or <code>\{{DOMxRef("document")}}</code> results in {{DOMxRef("Document")}},<br />
+        <code>\{{DOMxRef("document.getElementsByName()")}}</code> result in {{DOMxRef("document.getElementsByName()")}}<br />
+        <code>\{{DOMxRef("Node")}}</code> result in {{DOMxRef("Node")}}.<br />
+        You can change the display text using a second parameter: <code>\{{DOMxRef("document.getElementsByName()","getElementsByName()")}}</code> results in{{DOMxRef("document.getElementsByName()","getElementsByName()")}}.
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTMLElement.ejs"
-          >HTMLElement</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTMLElement.ejs">HTMLElement</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/HTML/Element">HTML Elements reference</a>
-        (/Web/HTML/Element)
+        <a href="/en-US/docs/Web/HTML/Element">HTML Elements reference</a> (/Web/HTML/Element)
       </td>
       <td>
-        <code>\{{HTMLElement("select")}}</code> results in
-        {{HTMLElement("select")}}
+        <code>\{{HTMLElement("select")}}</code> results in {{HTMLElement("select")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/htmlattrxref.ejs"
-          >HTMLAttrxRef</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/htmlattrxref.ejs"
+          >HTMLAttrxRef</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/HTML/Global_attributes"
-          >HTML global attribute description</a
-        >
-        if you only specify the attribute name.<br />Attribute associated with a
-        specific HTML element if you specify an attribute name and an element
-        name.
+        <a href="/en-US/docs/Web/HTML/Global_attributes">HTML global attribute description</a>
+        if you only specify the attribute name.<br />Attribute associated with a specific HTML element if you specify an attribute name and an element name.
       </td>
       <td>
-        <code>\{{HTMLAttrxRef("lang")}} </code>links to the global
-        attribute description {{HTMLAttrxRef("lang")}}.<br /><code
-          >\{{HTMLAttrxRef("type","input")}}</code
-        >
-        result in a link to the {{htmlattrxref("type","input")}}
-        attribute (on the {{HTMLElement("input")}} element).
+        <code>\{{HTMLAttrxRef("lang")}} </code>links to the global attribute description {{HTMLAttrxRef("lang")}}.<br />
+        <code>\{{HTMLAttrxRef("type","input")}}</code> result in a link to the {{htmlattrxref("type","input")}} attribute (on the {{HTMLElement("input")}} element).
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/jsxref.ejs"
-          >JSxRef</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/jsxref.ejs">JSxRef</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/JavaScript/Reference">JavaScript reference</a>
-        (/Web/JavaScript/Reference).
+        <a href="/en-US/docs/Web/JavaScript/Reference">JavaScript reference</a> (/Web/JavaScript/Reference).
       </td>
       <td>
-        <code>\{{JSxRef("Promise")}}</code> results in
-        {{JSxRef("Promise")}}
+        <code>\{{JSxRef("Promise")}}</code> results in {{JSxRef("Promise")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGAttr.ejs"
-          >SVGAttr</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGAttr.ejs">SVGAttr</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/SVG/Attribute">SVG attribute reference</a>
-        (/Web/SVG/Attribute).
+        <a href="/en-US/docs/Web/SVG/Attribute">SVG attribute reference</a> (/Web/SVG/Attribute).
       </td>
       <td>
         <code>\{{SVGAttr("d")}}</code> results in {{SVGAttr("d")}}
@@ -164,75 +127,51 @@ The macros are easy to use. Minimally all you need to do is specify the name of 
     <tr>
       <td>
         <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGElement.ejs"
-          >SVGElement</a
-        >
+          href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGElement.ejs">SVGElement</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/SVG/Attribute">SVG Element reference</a>
-        (/Web/SVG/Element).
+        <a href="/en-US/docs/Web/SVG/Attribute">SVG Element reference</a> (/Web/SVG/Element).
       </td>
       <td>
-        <code>\{{SVGElement("view")}}</code> results in
-        {{SVGElement("view")}}
+        <code>\{{SVGElement("view")}}</code> results in {{SVGElement("view")}}
       </td>
     </tr>
     <tr>
       <td>
-        <code
-          ><a
-            href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPHeader.ejs"
-            >HTTPHeader</a
-          ></code
-        >
+        <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPHeader.ejs">HTTPHeader</a></code>
       </td>
       <td>
-        <a href="/en-US/docs/Web/HTTP/Headers">HTTP headers</a>
-        (/Web/HTTP/Headers).
+        <a href="/en-US/docs/Web/HTTP/Headers">HTTP headers</a> (/Web/HTTP/Headers).
       </td>
       <td>
-        <code>\{{HTTPHeader("ACCEPT")}}</code> results in
-        {{HTTPHeader("ACCEPT")}}
+        <code>\{{HTTPHeader("ACCEPT")}}</code> results in {{HTTPHeader("ACCEPT")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPMethod.ejs"
-          >HTTPMethod</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPMethod.ejs">HTTPMethod</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/HTTP/Methods">HTTP request methods</a>
-        (/Web/HTTP/Methods).
+        <a href="/en-US/docs/Web/HTTP/Methods">HTTP request methods</a> (/Web/HTTP/Methods).
       </td>
       <td>
-        <code>\{{HTTPMethod("HEAD")}}</code> results in
-        {{HTTPMethod("HEAD")}}
+        <code>\{{HTTPMethod("HEAD")}}</code> results in {{HTTPMethod("HEAD")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPStatus.ejs"
-          >HTTPStatus</a
-        >
+        <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPStatus.ejs">HTTPStatus</a>
       </td>
       <td>
-        <a href="/en-US/docs/Web/HTTP/Status">HTTP response status codes</a>
-        (/Web/HTTP/Status)
+        <a href="/en-US/docs/Web/HTTP/Status">HTTP response status codes</a> (/Web/HTTP/Status)
       </td>
       <td>
-        <code>\{{HTTPStatus("404")}}</code> results in
-        {{HTTPStatus("404")}}
+        <code>\{{HTTPStatus("404")}}</code> results in {{HTTPStatus("404")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a
-          href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs"
-          >Event</a
-        >.
+        <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs">Event</a>.
       </td>
       <td>
         <a href="/en-US/docs/Web/Events">Events reference</a> (/Web/Events)
@@ -240,10 +179,8 @@ The macros are easy to use. Minimally all you need to do is specify the name of 
       <td>
         <div class="note">
           <p>
-            <strong>Note:</strong> This macro is not particularly useful because
-            events are now under their associated DOM element. So to link to the
-            wheel event you would use
-            <code>\{{DOMxRef("Document.wheel_event")}}</code>:
+            <strong>Note:</strong> This macro is not particularly useful because events are now under their associated DOM element.
+            So to link to the wheel event you would use<code>\{{DOMxRef("Document.wheel_event")}}</code>:
             {{DOMxRef("Document.wheel_event")}}
           </p>
         </div>
@@ -256,12 +193,17 @@ The macros are easy to use. Minimally all you need to do is specify the name of 
 
 - Bugs
 
-  - [`bug`](https://github.com/mdn/yari/tree/master/kumascript/macros/bug.ejs) allows you to link to a bug on bugzilla.mozilla.org easily using this syntax: `\{{Bug(123456)}}`. This gives you: {{Bug(123456)}}.
-  - [`WebkitBug`](https://github.com/mdn/yari/tree/master/kumascript/macros/WebkitBug.ejs) inserts a link to a bug in the WebKit bug database. For example, `\{{WebkitBug(31277)}}` inserts {{WebkitBug(31277)}}.
+  - [`bug`](https://github.com/mdn/yari/tree/master/kumascript/macros/bug.ejs) allows you to link to a bug on bugzilla.mozilla.org easily using this syntax: `\{{Bug(123456)}}`.
+    This gives you: {{Bug(123456)}}.
+  - [`WebkitBug`](https://github.com/mdn/yari/tree/master/kumascript/macros/WebkitBug.ejs) inserts a link to a bug in the WebKit bug database.
+    For example, `\{{WebkitBug(31277)}}` inserts {{WebkitBug(31277)}}.
 
 ### Navigation aids for multi-page guides
 
-[`Previous`](https://github.com/mdn/yari/tree/master/kumascript/macros/Previous.ejs), [`Next`](https://github.com/mdn/yari/tree/master/kumascript/macros/Next.ejs), and [`PreviousNext`](https://github.com/mdn/yari/tree/master/kumascript/macros/PreviousNext.ejs) provide navigation controls for articles which are part of sequences. For the single-way templates, the only parameter needed is the wiki location of the previous or next article in the sequence. For [`PreviousNext`](https://github.com/mdn/yari/tree/master/kumascript/macros/PreviousNext.ejs), the two parameters needed are the wiki locations of the appropriate articles. The first parameter is for the previous article and the second is for the next article.
+[`Previous`](https://github.com/mdn/yari/tree/master/kumascript/macros/Previous.ejs), [`Next`](https://github.com/mdn/yari/tree/master/kumascript/macros/Next.ejs), and [`PreviousNext`](https://github.com/mdn/yari/tree/master/kumascript/macros/PreviousNext.ejs) provide navigation controls for articles which are part of sequences.
+For the single-way templates, the only parameter needed is the wiki location of the previous or next article in the sequence.
+For [`PreviousNext`](https://github.com/mdn/yari/tree/master/kumascript/macros/PreviousNext.ejs), the two parameters needed are the wiki locations of the appropriate articles.
+The first parameter is for the previous article and the second is for the next article.
 
 ## Code samples
 
@@ -269,11 +211,13 @@ The macros are easy to use. Minimally all you need to do is specify the name of 
 
 - [`EmbedLiveSample`](https://github.com/mdn/yari/tree/master/kumascript/macros/EmbedLiveSample.ejs) lets you embed the output of a code sample on a page, as described in [Live samples](/en-US/docs/MDN/Structures/Live_samples).
 - [`LiveSampleLink`](https://github.com/mdn/yari/tree/master/kumascript/macros/LiveSampleLink.ejs) creates a link to a page containing the output of a code sample on a page, as described in [Live samples](/en-US/docs/MDN/Structures/Live_samples).
-- {{TemplateLink("EmbedGHLiveSample")}} allows to embed live samples from GitHub pages. You can get more information at [GitHub live samples](/en-US/docs/MDN/Structures/Code_examples#github_live_samples).
+- [`EmbedGHLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedGHLiveSample.ejs) allows to embed live samples from GitHub pages.
+  You can get more information at [GitHub live samples](/en-US/docs/MDN/Structures/Code_examples#github_live_samples).
 
 ## Sidebar generation
 
-There are templates for almost every large collection of pages. They typically link back to the main page of the reference/guide/tutorial (this is often needed because our breadcrumbs sometimes can't do this) and put the article in the appropriate category.
+There are templates for almost every large collection of pages.
+They typically link back to the main page of the reference/guide/tutorial (this is often needed because our breadcrumbs sometimes can't do this) and put the article in the appropriate category.
 
 - [`CSSRef`](https://github.com/mdn/yari/tree/master/kumascript/macros/CSSRef.ejs) generates the sidebar for CSS reference pages.
 - [`HTMLRef`](https://github.com/mdn/yari/tree/master/kumascript/macros/HTMLRef.ejs) generates the sidebar for HTML reference pages.
@@ -285,7 +229,8 @@ There are templates for almost every large collection of pages. They typically l
 
 [`optional_inline`](https://github.com/mdn/yari/tree/master/kumascript/macros/optional_inline.ejs) and [`ReadOnlyInline`](https://github.com/mdn/yari/tree/master/kumascript/macros/ReadOnlyInline.ejs) are used in API documentation, usually when describing the list of properties of an object or parameters of a function.
 
-Usage: `\{{Optional_Inline}}` or `\{{ReadOnlyInline}}`. Example:
+Usage: `\{{Optional_Inline}}` or `\{{ReadOnlyInline}}`.
+Example:
 
 - `isCustomObject`{{ReadOnlyInline}}
   - : Indicates, if `true`, that the object is a custom one.
@@ -336,16 +281,22 @@ Usage: `\{{Optional_Inline}}` or `\{{ReadOnlyInline}}`. Example:
 
 ### Page or section header indicators
 
-These templates have the same semantics as their inline counterparts described above. The templates should be placed directly underneath the main page title (or breadcrumb navigation if available) in the reference page. They can also be used to mark up a section on a page.
+These templates have the same semantics as their inline counterparts described above.
+The templates should be placed directly underneath the main page title (or breadcrumb navigation if available) in the reference page.
+They can also be used to mark up a section on a page.
 
 - [`non-standard_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Non-standard_Header.ejs): `\{{Non-standard_Header}}` {{Non-standard_Header}}
-- [`SeeCompatTable`](https://github.com/mdn/yari/tree/master/kumascript/macros/SeeCompatTable.ejs) should be used on pages that document [experimental features](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental). Example: `\{{SeeCompatTable}}` {{SeeCompatTable}}
+- [`SeeCompatTable`](https://github.com/mdn/yari/tree/master/kumascript/macros/SeeCompatTable.ejs) should be used on pages that document [experimental features](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental).
+  Example: `\{{SeeCompatTable}}` {{SeeCompatTable}}
 - [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs): `\{{Deprecated_Header}}` {{Deprecated_Header}}
-- [`secureContext_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/secureContext_header.ejs). Should be used on main pages like interface pages, API overview pages, and API entry points (e.g. `navigator.xyz`) but usually not on sub-pages like method and property pages. Example: `\{{SecureContext_Header}}` {{SecureContext_Header}}
+- [`secureContext_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/secureContext_header.ejs).
+  Should be used on main pages like interface pages, API overview pages, and API entry points (e.g. `navigator.xyz`) but usually not on sub-pages like method and property pages.
+  Example: `\{{SecureContext_Header}}` {{SecureContext_Header}}
 
 ### Indicating that a feature is available in web workers
 
-The [`AvailableInWorkers`](https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs) macro inserts a localized note box indicating that a feature is available in a [Web worker](/en-US/docs/Web/API/Web_Workers_API) context. You can use the argument `notservice` to indicate that a feature works in web workers except for service workers.
+The [`AvailableInWorkers`](https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs) macro inserts a localized note box indicating that a feature is available in a [Web worker](/en-US/docs/Web/API/Web_Workers_API) context.
+You can use the argument `notservice` to indicate that a feature works in web workers except for service workers.
 
 ##### Syntax
 

--- a/files/en-us/mdn/structures/macros/other/index.md
+++ b/files/en-us/mdn/structures/macros/other/index.md
@@ -31,22 +31,27 @@ We have an assortment of macros that can be used to automatically generate the c
 
 ### Quicklinks
 
-We have some macros specifically designed to create [quicklinks](/en-US/docs/MDN/Structures/Quicklinks):
+We have macros specifically designed to create [quicklinks](/en-US/docs/MDN/Structures/Quicklinks):
 
-- The [`MakeSimpleQuicklinks`](https://github.com/mdn/yari/tree/master/kumascript/macros/MakeSimpleQuicklinks.ejs) macro creates a flat list of links in the quicklinks box. Give it a set of paths to destination pages as its input arguments. Each link's text is the page title, and each link has a tooltip derived from the page summary.
-- [`QuickLinksWithSubpages`](https://github.com/mdn/yari/tree/master/kumascript/macros/QuickLinksWithSubpages.ejs) creates a set of quicklinks comprised of the pages below the current page (or specified page, if one is given). Up to two total levels of depth are generated.
+- [`QuickLinksWithSubpages`](https://github.com/mdn/yari/tree/master/kumascript/macros/QuickLinksWithSubpages.ejs) creates a set of quicklinks comprised of the pages below the current page (or specified page, if one is given).
+Up to two total levels of depth are generated.
 
 ### Transclusion
 
-**Transclusion** is the embedding of part or all of one page into another. Exercise caution when using this macro, to ensure that the transcluded content makes sense in the context of the page it is embedded into.
+**Transclusion** is the embedding of part or all of one page into another.
+
+> **Warning:** Do not use this feature/macro.
+> We are in the process of removing it from MDN.
+
+Exercise caution when using this macro, to ensure that the transcluded content makes sense in the context of the page it is embedded into.
 
 [`page`](https://github.com/mdn/yari/tree/master/kumascript/macros/page.ejs) lets you embed some or all of a specific page into a document. It accepts five parameters:
 
-1.  The URI of the page to transclude. For example, "/en-US/docs/MDN/About".
-2.  The name of the section within the page to transclude. This can be specified either as the title string or as the ID of a block to copy over. If not specified, the entire article is transcluded. {{optional_inline}}
-3.  The revision number of the page version to transclude. This feature is not currently implemented, but would allow including text from specific versions of an article. {{unimplemented_inline}}
-4.  A Boolean value indicating whether or not to show the heading of the top-level section being transcluded. This is useful if you wish to specify your own heading. The default value is false, meaning the heading is not included by default. {{optional_inline}}
-5.  The heading level to use as the top heading level. This adjusts the outermost first-discovered level of the transcluded content to the specified number, and all other headings correspondingly. This lets you include content that has its own headings but adjust them to match the heading level at which you're including them. If you don't specify this value, the headings are not adjusted. {{unimplemented_inline}}
+1. The URI of the page to transclude. For example, "/en-US/docs/MDN/About".
+2. The name of the section within the page to transclude. This can be specified either as the title string or as the ID of a block to copy over. If not specified, the entire article is transcluded. {{optional_inline}}
+3. The revision number of the page version to transclude. This feature is not currently implemented, but would allow including text from specific versions of an article. {{unimplemented_inline}}
+4. A Boolean value indicating whether or not to show the heading of the top-level section being transcluded. This is useful if you wish to specify your own heading. The default value is false, meaning the heading is not included by default. {{optional_inline}}
+5. The heading level to use as the top heading level. This adjusts the outermost first-discovered level of the transcluded content to the specified number, and all other headings correspondingly. This lets you include content that has its own headings but adjust them to match the heading level at which you're including them. If you don't specify this value, the headings are not adjusted. {{unimplemented_inline}}
 
 #### Example without heading
 

--- a/files/en-us/mdn/structures/page_types/index.md
+++ b/files/en-us/mdn/structures/page_types/index.md
@@ -10,7 +10,8 @@ tags:
 ---
 {{MDNSidebar}}
 
-There are a number of types of pages that are used repeatedly on MDN. This article describes these page types, their purpose, and gives examples of each and templates to use when creating a new page.
+There are a number of types of pages that are used repeatedly on MDN.
+This article describes these page types, their purpose, and gives examples of each and templates to use when creating a new page.
 
 There are three broad categories of page types on MDN, though some page types fall into more than one category.
 
@@ -24,15 +25,21 @@ To create new pages on MDN, you need to use GitHub — have a look at our [conte
 
 ## How to use the templates
 
-When creating a new page you can ensure that you've used the right page structure/contents by referring to one of our page templates — see the sections below. You can find the exact source code of each template (if you want to copy it) by following the "Source on **GitHub**" link at the bottom of each one. These page templates don't make much sense as published pages, but if you view their source code you'll see that they contain a lot of helpful comments, placeholders, and hints detailing how to fill in the missing information and create your page.
+When creating a new page you can ensure that you've used the right page structure/contents by referring to one of our page templates — see the sections below.
+You can find the exact source code of each template (if you want to copy it) by following the "Source on **GitHub**" link at the bottom of each one.
+These page templates don't make much sense as published pages, but if you view their source code you'll see that they contain a lot of helpful comments, placeholders, and hints detailing how to fill in the missing information and create your page.
 
-At the top of each template you'll find a section entitled _Remove before publishing_ — this contains information on how to fill in the page title, slug, sidebar menu, and tags (e.g. information that doesn't actually appear in the body of the article). You need to delete this section after you've followed the instructions in it, before the page can be considered finished.
+At the top of each template you'll find a section entitled _Remove before publishing_ — this contains information on how to fill in the page title, slug, sidebar menu, and tags (e.g. information that doesn't actually appear in the body of the article).
+You need to delete this section after you've followed the instructions in it, before the page can be considered finished.
 
 ## Old-style page layouts
 
-Sometimes you will come across old-style reference pages that look markedly different from the templates presented here. For example, old-style interface pages had all the interfaces' member details on a single page, and individual method/property/constructor/event listener pages didn't exist.
+Sometimes you will come across old-style reference pages that look markedly different from the templates presented here.
+For example, old-style interface pages had all the interfaces' member details on a single page, and individual method/property/constructor/event listener pages didn't exist.
 
-If you come across an old-style set of pages, we'd love for you to update them to the new style! However, we do appreciate that this could be a large amount of work. If the information to update is not too large, and you have some free time, by all means try updating it to the new style.
+If you come across an old-style set of pages, we'd love for you to update them to the new style!
+However, we do appreciate that this could be a large amount of work.
+If the information to update is not too large, and you have some free time, by all means try updating it to the new style.
 
 If the work is more significant, then you should consider a few factors when prioritising the work:
 
@@ -44,9 +51,14 @@ If you want to get a team together to work on an update, or you just want to rep
 
 ## API landing page
 
-An **{{Glossary("API")}} landing page** provides an overview of what a particular API does, as well as links to the documentation for each of the interfaces, globals, functions, etc. offered by the API. It does not link directly to specific methods or properties within the API's classes, except in the context of the overview text. It is primarily a _navigation_ page, but also functions as an at-a-glance _reference_ page for the API.
+An **{{Glossary("API")}} landing page** provides an overview of what a particular API does, as well as links to the documentation for each of the interfaces, globals, functions, etc. offered by the API.
+It does not link directly to specific methods or properties within the API's classes, except in the context of the overview text.
+It is primarily a _navigation_ page, but also functions as an at-a-glance _reference_ page for the API.
 
-There are some instances where multiple APIs exist that are distinct, and are defined in their own specifications, but they closely related and therefore would make sense to cover with a single API landing page. For example, the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/) cover general sensor concerns, but more specific concerns are covered in other APIs such as [Ambient Light Sensor](https://www.w3.org/TR/ambient-light/), [Motion Sensor](https://www.w3.org/TR/motion-sensors/), etc. In such cases, many of the high level concepts are the same, so it makes no sense to repeat those over multiple landing pages. In such a case, it would make more sense in terms of repetition and findability to cover them all under a single "Web sensors" landing page.
+There are some instances where multiple APIs exist that are distinct, and are defined in their own specifications, but they closely related and therefore would make sense to cover with a single API landing page.
+For example, the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/) cover general sensor concerns, but more specific concerns are covered in other APIs such as [Ambient Light Sensor](https://www.w3.org/TR/ambient-light/), [Motion Sensor](https://www.w3.org/TR/motion-sensors/), etc.
+In such cases, many of the high level concepts are the same, so it makes no sense to repeat those over multiple landing pages.
+In such a case, it would make more sense in terms of repetition and findability to cover them all under a single "Web sensors" landing page.
 
 ### Example
 
@@ -60,7 +72,9 @@ There are some instances where multiple APIs exist that are distinct, and are de
 
 > **Note:** Also known as an _Interface landing page_.
 
-An **API reference page** lists all the methods, properties, events, and so forth that are members of a particular interface or class. It provides an overview of what the class or interface does or is used for, and gives links to the documentation for each of these members. It is more granular than an API landing page, which typically links to multiple API reference pages.
+An **API reference page** lists all the methods, properties, events, and so forth that are members of a particular interface or class.
+It provides an overview of what the class or interface does or is used for, and gives links to the documentation for each of these members.
+It is more granular than an API landing page, which typically links to multiple API reference pages.
 
 ### Example
 
@@ -72,7 +86,8 @@ An **API reference page** lists all the methods, properties, events, and so fort
 
 ## API reference subpage
 
-An **API reference subpage** is a child of an API reference page. It documents a single interface member in detail.
+An **API reference subpage** is a child of an API reference page.
+It documents a single interface member in detail.
 
 ### Examples
 
@@ -131,7 +146,8 @@ A **CSS reference page** lists all the available syntax for a CSS feature such a
 
 ## HTTP header reference page
 
-An **HTTP header reference page** lists all the available directives that an HTTP header can contain, and explains the header's purpose and usage. It also provides examples, browser compatibility information, and other important expl.
+An **HTTP header reference page** lists all the available directives that an HTTP header can contain, and explains the header's purpose and usage.
+It also provides examples, browser compatibility information, and other important expl.
 
 ### Example
 
@@ -143,7 +159,9 @@ An **HTTP header reference page** lists all the available directives that an HTT
 
 ## Conceptual page
 
-A **conceptual page** is a _guide_ page that explains or teaches something. Generally, if a page contains primarily prose, and doesn't fall into another page type, it's probably a conceptual page. An extended discussion of a topic might be spread across multiple conceptual pages, and linked using [Next](https://github.com/mdn/kumascript/blob/master/macros/Next.ejs) and [Previous](https://github.com/mdn/kumascript/blob/master/macros/Previous.ejs) macros.
+A **conceptual page** is a _guide_ page that explains or teaches something.
+Generally, if a page contains primarily prose, and doesn't fall into another page type, it's probably a conceptual page.
+An extended discussion of a topic might be spread across multiple conceptual pages, and linked using [Next](https://github.com/mdn/kumascript/blob/master/macros/Next.ejs) and [Previous](https://github.com/mdn/kumascript/blob/master/macros/Previous.ejs) macros.
 
 ### Examples
 
@@ -153,7 +171,10 @@ A **conceptual page** is a _guide_ page that explains or teaches something. Gene
 
 ## Glossary page
 
-A **glossary page** contains a brief explanation of a term, topic, or concept. The first paragraph should be a simple, self-contained description of the term, no more than a couple sentences. This can be followed by links to further information in the **Learn more** section. If the page grows to more than a screenful or so, it's too long and should be converted to a conceptual page. See [How to write and reference an entry in the glossary](/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary) for more details.
+A **glossary page** contains a brief explanation of a term, topic, or concept.
+The first paragraph should be a simple, self-contained description of the term, no more than a couple sentences.
+This can be followed by links to further information in the **Learn more** section.
+If the page grows to more than a screenful or so, it's too long and should be converted to a conceptual page. See [How to write and reference an entry in the glossary](/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary) for more details.
 
 ### Examples
 
@@ -167,9 +188,11 @@ A **glossary page** contains a brief explanation of a term, topic, or concept. T
 
 ## Landing page
 
-A **landing page** serves as a menu, of sorts, for its subpages, and is therefore primarily a _navigation_ page. A landing page layout is typically used for the root page of a tree of pages about a particular topic. It opens with a brief summary of the topic, then presents a structured list of links to its subpages, and optionally, additional material that be useful to the reader.
+A **landing page** serves as a menu, of sorts, for its subpages, and is therefore primarily a _navigation_ page.
+A landing page layout is typically used for the root page of a tree of pages about a particular topic.
+It opens with a brief summary of the topic, then presents a structured list of links to its subpages, and optionally, additional material that be useful to the reader.
 
-The list of subpages can be generated automatically using the templates {{TemplateLink("SubpagesWithSummaries")}}, {{TemplateLink("SubpageMenuByCategories")}}, and {{TemplateLink("LandingPageListSubpages")}}. However, in more complex cases, the list may need to be created (and maintained!) by hand.
+The list of subpages can be generated automatically using the templates [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs), [`SubpageMenuByCategories`](https://github.com/mdn/yari/tree/main/kumascript/macros/SubpageMenuByCategories.ejs), and [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs). However, in more complex cases, the list may need to be created (and maintained!) by hand.
 
 ### Examples
 

--- a/files/en-us/mdn/structures/quicklinks/index.md
+++ b/files/en-us/mdn/structures/quicklinks/index.md
@@ -8,11 +8,16 @@ tags:
 ---
 {{MDNSidebar}}
 
-MDN supports adding quicklinks to pages; these are boxes containing a potentially hierarchical list of links to other pages on MDN or to pages off-site. This article describes how to create quicklinks boxes.
+MDN supports adding quicklinks to pages; these are boxes containing a potentially hierarchical list of links to other pages on MDN or to pages off-site.
+This article describes how to create quicklinks boxes.
 
 ## Quicklinks syntax
 
-The quicklinks for a page are provided by creating a {{HTMLElement("section")}} block with the ID "Quick_links". Then you place the contents that go into the quicklinks box within the section. These should be formatted as an {{HTMLElement("ol")}} ordered list (optionally nested). You can do this by using the numbered list button in the editor toolbar. For example, your quicklinks HTML might look like this:
+The quicklinks for a page are provided by creating a {{HTMLElement("section")}} block with the ID "Quick_links".
+Then you place the contents that go into the quicklinks box within the section.
+These should be formatted as an {{HTMLElement("ol")}} ordered list (optionally nested).
+You can do this by using the numbered list button in the editor toolbar.
+For example, your quicklinks HTML might look like this:
 
 ```html
 <section id="Quick_links">
@@ -40,7 +45,8 @@ The important things to note:
 
 ## Using macros to create quicklinks
 
-It's worth noting that you can (and often **should**) use macros to generate quicklinks. Any time you need to use the same set of quicklinks on more than one page, you should turn them into a macro.
+It's worth noting that you can (and often **should**) use macros to generate quicklinks.
+Any time you need to use the same set of quicklinks on more than one page, you should turn them into a macro.
 
 Your macro can be as simple or as complex as necessary; it needs to output HTML similar to what's shown in {{anch("Quicklinks syntax")}} above.
 
@@ -48,11 +54,11 @@ Your macro can be as simple or as complex as necessary; it needs to output HTML 
 
 Here's a list of our standard macros for generating quicklinks.
 
-- {{TemplateLink("CSSRef")}}
+- [`CSSRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/CSSRef.ejs)
   - : Builds the standard quicklinks for CSS Reference pages.
-- {{TemplateLink("HTMLRef")}}
+- [`HTMLRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/HTMLRef.ejs)
   - : Builds the standard quicklinks for HTML Reference pages.
-- {{TemplateLink("MakeSimpleQuicklinks")}}
-  - : Given a list of pages on MDN, this macro constructs a quicklinks box using the pages' titles as the link text and their summaries as tooltips. This doesn't create hierarchical lists.
-- {{TemplateLink("QuickLinksWithSubpages")}}
-  - : Creates a set of quicklinks using the current page's (or the specified page's) children as the destinations. This creates hierarchical lists up to two levels deep. The pages' titles are used as the link text and their summaries as tooltips.
+- [`QuickLinksWithSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/QuickLinksWithSubpages.ejs)
+  - : Creates a set of quicklinks using the current page's (or the specified page's) children as the destinations.
+    This creates hierarchical lists up to two levels deep.
+    The pages' titles are used as the link text and their summaries as tooltips.


### PR DESCRIPTION
This is part of #9914

It removes all the remaining uses of the `TemplateLink` macro. While I was there I did quite a few layout fixes - splitting on sentences where it makes sense, fixing up some unconverted HTML. Should not be anything controversial - i.e. you could merge this safely. 

