### PR TITLE
Avoid confusing mention of header in "Responsive images"

### DIFF
--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -63,7 +63,7 @@ This works well on a wide screen device, such as a laptop or desktop (you can [s
 - The header image has been set so that its center always stays in the center of the header, no matter what width the heading is set at. If the site is being viewed on a narrower screen, the important detail in the center of the image (the people) can still be seen, and the excess is lost off either side. It is 200px high.
 - The content images have been set so that if the body element becomes smaller than the image, the images start to shrink so that they always stay inside the body, rather than overflowing it.
 
-However, issues arise when you start to view the site on a narrow screen device. The header below looks OK, but it's starting to take up a lot of the screen height for a mobile device. And at this size, it is difficult to see the people within the first content image.
+However, issues arise when you start to view the site on a narrow screen device. The first content image below looks OK, but it's starting to take up a lot of the screen height for a mobile device. And at this size, it is difficult to see the people within the image.
 
 ![Our example site as viewed on a narrow screen; the first image has shrunk to the point where it is hard to make out the detail on it.](non-responsive-narrow.png)
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The text here brings up the header when it's talking about the content image. This fixes it to avoid the confusion mentioned in https://github.com/mdn/content/issues/9858.

#### Related issues
https://github.com/mdn/content/issues/9858.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
