### PR TITLE
Remove false exception about comments.

### DIFF
--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -16,8 +16,6 @@ browser-compat: html.manifest
 
 The web app manifest provides information about a web application in a {{Glossary("JSON")}} text file, necessary for the web app to be downloaded and be presented to the user similarly to a native app (e.g., be installed on the homescreen of a device, providing users with quicker access and a richer experience). PWA manifests include its name, author, icon(s), version, description, and list of all the necessary resources (among other things).
 
-A manifest is a {{Glossary("JSON")}}-formatted file, with one exception: it is allowed to contain "`//`"-style comments.
-
 ## Members
 
 Web manifests can contain the following keys. Click on each one to link through to more information about it:


### PR DESCRIPTION
As discovered in https://twitter.com/quicksave2k/status/1453275366899036175, the exception applies only to Chromium and is not spec'ed compliant.
I've filed a Chromium bug at https://bugs.chromium.org/p/chromium/issues/detail?id=1263590

In the mean time, we should update the MDN documentation so that developers who don't test their manifest in Firefox and Safari are not caught by this issue.