### PR TITLE
Remove not-so-bad bad example of empty statement

### DIFF
--- a/files/en-us/web/javascript/reference/statements/empty/index.md
+++ b/files/en-us/web/javascript/reference/statements/empty/index.md
@@ -58,26 +58,6 @@ if (condition);       // Caution, this "if" does nothing!
    killTheUniverse()  // So this always gets executed!!!
 ```
 
-In the next example, an {{jsxref("Statements/if...else", "if...else")}} statement
-without curly braces (`{}`) is used.
-
-If `three` is `true`, nothing will happen, `four` does
-not matter, and also the `launchRocket()` function in the `else`
-case will not be executed.
-
-```js example-bad
-if (one)
-  doOne();
-else if (two)
-  doTwo();
-else if (three)
-  ; // nothing here
-else if (four)
-  doFour();
-else
-  launchRocket();
-```
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
I stared at this description, and the stated reason it's bad. I don't see the problem
with this code -- specifically, it would have the same behavior if braces were used
instead of the empty-statement semicolon. (If not, if the empty-statement semicolon
in case three actually meant "end the if/else chain here and start a new statement",
then the subsequent "else if" wouldn't _parse_. So... that can't be it.)

#### Summary
This PR removes a case presented as problematic which I don't think is problematic.
(Aside from not using braces in the first place.)

#### Motivation
The next reader will not have to puzzle over why this code is presented as a bad example.
(I would have substituted a better bad example, but I don't quite get what badness was supposed to be demonstrated.)

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
N/A

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


