### PR TITLE
Adding back a reverted change because markdown conversion

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/sidebars/index.md
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/sidebars/index.md
@@ -112,7 +112,7 @@ These are all technically optional, but it is strongly encouraged that instead o
 
 7. `"dictionaries"` — an array of strings listing all of the dictionaries which are part of the API.
    Generally, only dictionaries used by more than one property or method should be listed here, unless they are of special significance or are likely to require being referenced from multiple pages.
-   "RTCPeerConnection" results in a link to [https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection).
+   "CryptoKeyPair" results in a link to [https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair](/en-US/docs/Web/API/CryptoKeyPair).
    > **Note:** MDN is moving away from separately documenting dictionaries.
    > Where possible, these are now described as objects in the places where they are used.
 8. `"types"` — an array of typedefs and enumerated types defined by the API.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

As promised adding back a change @queengooborg made when removing the RTCConfiguration dictionary: Updating the mdn docs page which mentioned it as an example.

For context: https://github.com/mdn/content/pull/9759

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
