### PR TITLE
Remove mention of SpiderMonkey in description of anonymous functions

### DIFF
--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -398,9 +398,8 @@ defined by function expressions, functions defined by function declarations can 
 accessed by their name in the scope they were defined in:
 
 A function defined by '`new Function'` does not have a function name.
-However, in the [SpiderMonkey](/en-US/docs/Mozilla/Projects/SpiderMonkey)
-JavaScript engine, the serialized form of the function shows as if it has the name
-"anonymous". For example, `alert(new Function())` outputs:
+However, the serialized form of the function shows as if it has the name "anonymous."
+For example, `alert(new Function())` outputs:
 
 ```js
 function anonymous() {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Removes mention of a specific JS implementation for a seemingly standard behavior.

#### Motivation
The behavior described seems pretty universal. Chrome, Safari, Firefox, and Node.js are consistent with this. And by changing the text, I don't have to fix the link.

#### Related issues
Fixes https://github.com/mdn/content/issues/9947

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
