### PR TITLE
Fix a link to the `invalid` event

### DIFF
--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLSelectElement.checkValidity
 
 The **`HTMLSelectElement.checkValidity()`** method checks
 whether the element has any constraints and whether it satisfies them. If the element
-fails its constraints, the browser fires a cancelable {{event("invalid")}} event at the
+fails its constraints, the browser fires a cancelable {{domxref("HTMLSelectElement/invalid_event", "invalid")}} event at the
 element, and then returns `false`.
 
 ## Syntax
@@ -33,4 +33,4 @@ var result = selectElt.checkValidity();
 
 ## See also
 
-- [Form validation](/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation)
+- [Form validation](/en-US/docs/Web/Guide/HTML/Constraint_validation)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Replace a {{event}} macro with a link to HTMLSelectElement/invalid_event.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The {{event}} macro in this page produces a link to an event of HTMLInputElement. However this interface (HTMLSelectElement) isn't a derived interface of HTMLInputElement, so it is incorrect.


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
