### PR TITLE
Update getContext webgl attribute doc

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -92,13 +92,15 @@ var ctx = canvas.getContext(contextType, contextAttributes);
 
     - **`alpha`**: Boolean that indicates if the canvas
       contains an alpha buffer.
+    - **`depth`**: Boolean that indicates that the drawing
+      buffer is requested to have a depth buffer of at least 16 bits.
+    - **`stencil`**: Boolean that indicates that the drawing
+      buffer is requested to have a stencil buffer of at least 8 bits.
     - **`desynchronized`**: Boolean that hints the user agent
       to reduce the latency by desynchronizing the canvas paint cycle from the event
       loop
     - **`antialias`**: Boolean that indicates whether or not
-      to perform anti-aliasing.
-    - **`depth`**: Boolean that indicates that the drawing
-      buffer has a depth buffer of at least 16 bits.
+      to perform anti-aliasing if possible.
     - **`failIfMajorPerformanceCaveat`**: Boolean that
       indicates if a context will be created if the system performance is low or if no
       hardware GPU is available.
@@ -119,8 +121,6 @@ var ctx = canvas.getContext(contextType, contextAttributes);
     - **`preserveDrawingBuffer`**: If the value is true the
       buffers will not be cleared and will preserve their values until cleared or
       overwritten by the author.
-    - **`stencil`**: Boolean that indicates that the drawing
-      buffer has a stencil buffer of at least 8 bits.
     - **`xrCompatible`**: Boolean that hints to the user agent
       to use a compatible graphics adapter for an
       [immersive XR device](/en-US/docs/Web/API/WebXR_Device_API). Setting this

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -87,11 +87,11 @@ offscreen.getContext(contextType, contextAttributes);
     - **`alpha`**: Boolean that indicates if the canvas
       contains an alpha buffer.
     - **`depth`**: Boolean that indicates that the drawing
-      buffer has a depth buffer of at least 16 bits.
+      buffer is requested to have a depth buffer of at least 16 bits.
     - **`stencil`**: Boolean that indicates that the drawing
-      buffer has a stencil buffer of at least 8 bits.
+      buffer is requested to have a stencil buffer of at least 8 bits.
     - **`antialias`**: Boolean that indicates whether or not
-      to perform anti-aliasing.
+      to perform anti-aliasing if possible.
     - **`premultipliedAlpha`**: Boolean that indicates that
       the page compositor will assume the drawing buffer contains colors with
       pre-multiplied alpha.


### PR DESCRIPTION
#### Summary
Clarify that setting the `antialias`, `depth` and `stencil` attributes are requests, not requirements, context creation may succeed either way. 

#### Motivation
Every now and then people ask about this

#### Supporting details
https://www.khronos.org/registry/webgl/specs/latest/1.0/#actual-context-parameters

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
