### PR TITLE
Update encodeURIComponent() parameter information

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -27,7 +27,7 @@ encodeURIComponent(uriComponent);
 ### Parameters
 
 - `uriComponent`
-  - : It can be string, number, boolean, null, undefined, or any object. Before encoding, the `uriComponent` gets converted to string. 
+  - : A string, number, boolean, null, undefined, or any object. Before encoding, the `uriComponent` gets converted to string. 
 ### Return value
 
 A new string representing the provided _uriComponent_ encoded as a URI component.

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -30,7 +30,7 @@ encodeURIComponent(uriComponent);
   - : It can be `string`, `number`, `boolean`, `null`, `undefined` or any other object. Before encoding, the `uriComponent` gets converted to `string` using `toString` method. 
 ### Return value
 
-A new string representing the provided string encoded as a URI component.
+A new string representing the provided `uriComponent` encoded as a URI component.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -21,14 +21,13 @@ characters).
 ## Syntax
 
 ```js
-encodeURIComponent(str);
+encodeURIComponent(uriComponent);
 ```
 
 ### Parameters
 
-- `str`
-  - : String. A component of a URI.
-
+- `uriComponent`
+  - : It can be `string`, `number`, `boolean`, `null`, `undefined` or any other object. Before encoding, the `uriComponent` gets converted to `string` using `toString` method. 
 ### Return value
 
 A new string representing the provided string encoded as a URI component.

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -30,7 +30,7 @@ encodeURIComponent(uriComponent);
   - : It can be string, number, boolean, null, undefined, or any object. Before encoding, the `uriComponent` gets converted to string. 
 ### Return value
 
-A new string representing the provided `uriComponent` encoded as a URI component.
+A new string representing the provided _uriComponent_ encoded as a URI component.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -27,7 +27,7 @@ encodeURIComponent(uriComponent);
 ### Parameters
 
 - `uriComponent`
-  - : It can be `string`, `number`, `boolean`, `null`, `undefined` or any other object. Before encoding, the `uriComponent` gets converted to `string` using `toString` method. 
+  - : It can be string, number, boolean, null, undefined, or any object. Before encoding, the `uriComponent` gets converted to string. 
 ### Return value
 
 A new string representing the provided `uriComponent` encoded as a URI component.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Parameter changed to `uriComponent` which can be a `string`, `number`, `boolean`, `null`, `undefined` or any other object.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Before encoding `uriComponent` is typecasted to string, using toString method. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
```
const obj1 = false
const obj2 = null

console.log(`${encodeURIComponent(obj1)}`) //false
console.log(typeof `${encodeURIComponent(obj1)}`) //string
console.log(`${encodeURIComponent(obj2)}`) //null
console.log(typeof `${encodeURIComponent(obj2)}`) //string

const book = {
    name:"The Alchemist",
    author:"Paulo Coelho",
    toString: function(){
        return this.name + " by " + this.author
    }
}

console.log(`${encodeURIComponent(book)}`) //The%20Alchemist%20by%20Paulo%20Coelho //first toString method is called, then encoding
```

Ref - https://tc39.es/ecma262/multipage/global-object.html#sec-encodeuricomponent-uricomponent
Similar issue was raised in TypeScript - https://github.com/microsoft/typescript/issues/18159

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #10093
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
