### PR TITLE
fixed a spelling error in index.md

### DIFF
--- a/files/en-us/web/guide/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/guide/parsing_and_serializing_xml/index.md
@@ -47,7 +47,7 @@ const errorNode = doc.querySelector("parsererror");
 if (errorNode) {
   console.log("error while parsing");
 } else {
-  console.log(dom.documentElement.nodeName);
+  console.log(doc.documentElement.nodeName);
 }
 ```
 


### PR DESCRIPTION
i noticed that the first code example called for dom instead of doc, which make the code not work out of the box

(sorry if this is useless,it's my first time contributing and i'm not really knowledgeable about the proper etiquette)