### PR TITLE
Fix a bad link in the page Styling lists

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_lists/index.md
+++ b/files/en-us/learn/css/styling_text/styling_lists/index.md
@@ -285,7 +285,7 @@ Gives you this output:
 
 ### value
 
-The {{htmlattrxref("value","ol")}} attribute allows you to set your list items to specific numerical values. The following example:
+The {{htmlattrxref("value","li")}} attribute allows you to set your list items to specific numerical values. The following example:
 
 ```html
 <ol>


### PR DESCRIPTION
Fix a link in the page 'Styling lists' that erroneously points to 'the attribute value of ol' instead of 'the attribute value of li'.

#### Summary
In the page _Styling lists_, a link points to the attribute _value_ of the _ol_ element.
It should point to the attribute _value_ of the _**li**_ element.

#### Motivation
N/A

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

