### PR TITLE
Fix the return types of `getFile` and `createWritable`

### DIFF
--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -26,11 +26,7 @@ the temporary file when the writable filestream is closed.
 ## Syntax
 
 ```js
-var promise = FileSystemFileHandle.createWritable();
-
-promise.then((fileSystemWritableFileStream) => {
-  // ...
-})
+const fileStreamPromise = FileSystemFileHandle.createWritable();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -41,7 +41,7 @@ const fileStreamPromise = FileSystemFileHandle.createWritable();
 
 ### Return value
 
-A {{jsxref('Promise')}} which resolves with a {{domxref('FileSystemWritableFileStream')}}.
+A {{jsxref('Promise')}} which resolves to a {{domxref('FileSystemWritableFileStream')}} object.
 
 ### Exceptions
 

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -16,6 +16,7 @@ browser-compat: api.FileSystemFileHandle.createWritable
 The **`createWritable()`** method of the
 {{domxref("FileSystemFileHandle")}} interface creates
 a {{domxref('FileSystemWritableFileStream')}} that can be used to write to a file.
+The method returns a {{jsxref('Promise')}} which resolves to this created stream.
 
 Any changes made through the stream won’t be reflected in the file represented by the
 file handle until the stream has been closed. This is typically implemented by writing
@@ -25,7 +26,11 @@ the temporary file when the writable filestream is closed.
 ## Syntax
 
 ```js
-var FileSystemWritableFileStream = FileSystemFileHandle.createWritable();
+var promise = FileSystemFileHandle.createWritable();
+
+promise.then((fileSystemWritableFileStream) => {
+  // ...
+})
 ```
 
 ### Parameters
@@ -40,7 +45,7 @@ var FileSystemWritableFileStream = FileSystemFileHandle.createWritable();
 
 ### Return value
 
-A Promise which resolves with a {{domxref('FileSystemWritableFileStream')}}.
+A {{jsxref('Promise')}} which resolves with a {{domxref('FileSystemWritableFileStream')}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.md
@@ -14,16 +14,20 @@ browser-compat: api.FileSystemFileHandle.getFile
 {{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 
 The **`getFile()`** method of the
-{{domxref("FileSystemFileHandle")}} interface returns a {{domxref('File','file
-  object')}} representing the state on disk of the entry represented by the handle.
+{{domxref("FileSystemFileHandle")}} interface returns a {{jsxref('Promise')}} which resolves to
+  {{domxref('File')}} object representing the state on disk of the entry represented by the handle.
 
 If the file on disk changes or is removed after this method is called, the returned
-{{domxref('File','file object')}} will likely be no longer readable.
+{{domxref('File')}} object will likely be no longer readable.
 
 ## Syntax
 
 ```js
-var File = FileSystemFileHandle.getFile();
+var promise = FileSystemFileHandle.getFile();
+
+promise.then((file) => {
+  // ...
+})
 ```
 
 ### Parameters
@@ -32,7 +36,7 @@ None.
 
 ### Return value
 
-A {{domxref('File','File object')}}.
+A {{jsxref('Promise')}} which resolves to a {{domxref('File')}} object.
 
 ### Exceptions
 

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.md
@@ -14,7 +14,7 @@ browser-compat: api.FileSystemFileHandle.getFile
 {{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 
 The **`getFile()`** method of the
-{{domxref("FileSystemFileHandle")}} interface returns a {{jsxref('Promise')}} which resolves to
+{{domxref("FileSystemFileHandle")}} interface returns a {{jsxref('Promise')}} which resolves to a
   {{domxref('File')}} object representing the state on disk of the entry represented by the handle.
 
 If the file on disk changes or is removed after this method is called, the returned

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.md
@@ -23,11 +23,7 @@ If the file on disk changes or is removed after this method is called, the retur
 ## Syntax
 
 ```js
-var promise = FileSystemFileHandle.getFile();
-
-promise.then((file) => {
-  // ...
-})
+const filePromise = FileSystemFileHandle.getFile();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemfilehandle/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/index.md
@@ -25,9 +25,11 @@ _Inherits properties from its parent, {{DOMxRef("FileSystemHandle")}}._
 _Inherits methods from its parent, {{DOMxRef("FileSystemHandle")}}._
 
 - {{domxref('FileSystemFileHandle.getFile', 'getFile()')}}
-  - : Returns a {{domxref('File','file object')}} representing the state on disk of the entry represented by the handle.
+  - : Returns a {{jsxref('Promise')}} which resolves to a {{domxref('File')}} object
+      representing the state on disk of the entry represented by the handle.
 - {{domxref('FileSystemFileHandle.createWritable', 'createWritable()')}}
-  - : Creates a {{domxref('FileSystemWritableFileStream')}} that can be used to write to a file.
+  - : Returns a {{jsxref('Promise')}} which resolves to a newly created {{domxref('FileSystemWritableFileStream')}}
+      that can be used to write to a file.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemfilehandle/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/index.md
@@ -29,7 +29,7 @@ _Inherits methods from its parent, {{DOMxRef("FileSystemHandle")}}._
       representing the state on disk of the entry represented by the handle.
 - {{domxref('FileSystemFileHandle.createWritable', 'createWritable()')}}
   - : Returns a {{jsxref('Promise')}} which resolves to a newly created {{domxref('FileSystemWritableFileStream')}}
-      that can be used to write to a file.
+      object that can be used to write to a file.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changed the return types of `FileSystemFileHandle.getFile` and `FileSystemFileHandle.createWritable` to `Promise`.

#### Motivation
`FileSystemFileHandle.getFile` and `FileSystemFileHandle.createWritable` are asynchronous and thus returns promise with their results of type `File` and `FileSystemWritableFileStream` respectively.

#### Supporting details
`FileSystemFileHandle.getFile` and `FileSystemFileHandle.createWritable` returns promises as evident from this spec- https://wicg.github.io/file-system-access/#api-filesystemfilehandle. So, I corrected the types. While correcting the returns types, I also changed the usage of both functions to demonstrate that they return the promises. The actual examples were correct awaiting the calls of the functions.

I also changed "`file object`" reference to "`File` object" reference . I checked some other pages like [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) which used sentences like- 
> promise resolves to the `Response` object

#### Related issues
Fixes #10111

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error