### PR TITLE
Fix description for `navigator.hid.getDevices()`

### DIFF
--- a/files/en-us/web/api/hid/getdevices/index.md
+++ b/files/en-us/web/api/hid/getdevices/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HID.getDevices
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
-The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of the connected HID devices.
+The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of the connected HID devices, that the user has previously been granted access to in response to a {{domxref("HID.requestDevice","requestDevice()")}} call
 
 ## Syntax
 

--- a/files/en-us/web/api/hid/getdevices/index.md
+++ b/files/en-us/web/api/hid/getdevices/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HID.getDevices
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
-The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of the connected HID devices, that the user has previously been granted access to in response to a {{domxref("HID.requestDevice","requestDevice()")}} call.
+The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of the connected HID devices that the user has previously been granted access to in response to a {{domxref("HID.requestDevice","requestDevice()")}} call.
 
 ## Syntax
 

--- a/files/en-us/web/api/hid/getdevices/index.md
+++ b/files/en-us/web/api/hid/getdevices/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HID.getDevices
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
-The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of the connected HID devices, that the user has previously been granted access to in response to a {{domxref("HID.requestDevice","requestDevice()")}} call
+The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of the connected HID devices, that the user has previously been granted access to in response to a {{domxref("HID.requestDevice","requestDevice()")}} call.
 
 ## Syntax
 

--- a/files/en-us/web/api/webhid_api/index.md
+++ b/files/en-us/web/api/webhid_api/index.md
@@ -41,7 +41,7 @@ const device = await navigator.hid.requestDevice({filters: []})
 // Select one and click on `Connect` button. Then the device will be an array with the selected device in it.
 ```
 
-We can retrieve all the connected devices and log the device names to the console.
+We can retrieve all the devices the website has been granted access to previously and log the device names to the console.
 
 ```js
 let devices = await navigator.hid.getDevices();


### PR DESCRIPTION
It said `navigator.hid.getDevices()` returns all connected devices (which would be a privacy issue).

But luckily `navigator.hid.getDevices()` only returns a list of devices the website has been granted access to previously.

#### Supporting details
https://web.dev/hid/#open
