### PR TITLE
add rgb/hsl examples using alpha slash notation

### DIFF
--- a/files/en-us/web/css/color_value/hsl()/index.md
+++ b/files/en-us/web/css/color_value/hsl()/index.md
@@ -23,7 +23,8 @@ The **`hsl()`** functional notation expresses a given color according to its hue
 ```css
 hsl(100, 100%, 50%) /* #5f0 */
 hsl(235, 100%, 50%, .5) /* #0015ff with 50% opacity */
-hsl(235 100% 50%); /* CSS Colors 4 space-separated values */
+hsl(235 100% 50%) /* CSS Colors 4 space-separated values */
+hsl(235 100% 50% / .5); /* #0015ff with 50% opacity, using CSS Colors 4 space-separated values */
 ```
 
 ### Values

--- a/files/en-us/web/css/color_value/hsla()/index.md
+++ b/files/en-us/web/css/color_value/hsla()/index.md
@@ -21,7 +21,7 @@ The **`hsla()`** functional notation expresses a given color according to its hu
 ```css
 hsla(100, 100%, 50%, 1) /* #5f0 */
 hsla(235, 100%, 50%, .5) /* #0015ff with 50% opacity */
-hsla(235 100% 50% 1); /* CSS Colors 4 space-separated values */
+hsla(235 100% 50% / 1); /* CSS Colors 4 space-separated values */
 ```
 
 ### Values

--- a/files/en-us/web/css/color_value/rgb()/index.md
+++ b/files/en-us/web/css/color_value/rgb()/index.md
@@ -23,7 +23,8 @@ The **`rgb()`** functional notation expresses a color according to its red, gree
 ```css
 rgb(255,255,255) /* white */
 rgb(255,255,255,.5) /* white with 50% opacity */
-rgb(255 255 255); /* CSS Colors 4 space-separated values */
+rgb(255 255 255) /* CSS Colors 4 space-separated values */
+rgb(255 255 255 / .5); /* white with 50% opacity, using CSS Colors 4 space-separated values */
 ```
 
 ### Values


### PR DESCRIPTION
#### Summary
I added examples of `rgb` and `hsl` colors that demonstrate the optional alpha component.

Also, I added a missing slash to an invalid `hsla` color.

#### Motivation
The functional notation for space-separated values in `rgb`/`hsl` shows that an optional value can be added after a ` / ` to specify the alpha channel. It would be helpful to provide a syntax example that shows this alpha component in use, to write a color that was previously written with comma-separated values.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
