### PR TITLE
Capitalize ARPANET correctly

### DIFF
--- a/files/en-us/glossary/arpanet/index.md
+++ b/files/en-us/glossary/arpanet/index.md
@@ -1,12 +1,12 @@
 ---
-title: Arpanet
+title: ARPANET
 slug: Glossary/Arpanet
 tags:
   - Glossary
   - Infrastructure
 ---
-The **ARPAnet** (advanced research projects agency network) was an early computer network, constructed in 1969 as a robust medium to transmit sensitive military data and to connect leading research groups throughout the United States. ARPAnet first ran NCP (network control protocol) and subsequently the first version of the Internet protocol or {{glossary("TCP")}}/{{glossary("IPv6","IP")}} suite, making ARPAnet a prominent part of the nascent {{glossary("Internet")}}. ARPAnet was closed in early 1990.
+The **ARPANET** (Advanced Research Projects Agency NETwork) was an early computer network, constructed in 1969 as a robust medium to transmit sensitive military data and to connect leading research groups throughout the United States. ARPANET first ran NCP (Network Control Protocol) and subsequently the first version of the Internet protocol or {{glossary("TCP")}}/{{glossary("IPv4","IP")}} suite, making ARPANET a prominent part of the nascent {{glossary("Internet")}}. ARPANET was closed in early 1990.
 
 ## See also
 
-- {{Interwiki("wikipedia", "Arpanet")}} on Wikipedia
+- {{Interwiki("wikipedia", "ARPANET")}} on Wikipedia


### PR DESCRIPTION
and other minor changes to that glossary entry. By "correctly" I mean the same way it's capitalized on Wikipedia.