### PR TITLE
Remove Node.hasChildNodes() Polyfill and Fix incorrect link path

### DIFF
--- a/files/en-us/web/api/node/haschildnodes/index.md
+++ b/files/en-us/web/api/node/haschildnodes/index.md
@@ -36,13 +36,6 @@ if (foo.hasChildNodes()) {
 }
 ```
 
-There are various ways to determine whether the node has a child node:
-
-- `node.hasChildNodes()`
-- `node.firstChild != null` (or just `node.firstChild`)
-- `node.childNodes && node.childNodes.length` (or
-  `node.childNodes.length > 0`)
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/node/haschildnodes/index.md
+++ b/files/en-us/web/api/node/haschildnodes/index.md
@@ -36,18 +36,6 @@ if (foo.hasChildNodes()) {
 }
 ```
 
-## Polyfill
-
-Here is one possible polyfill:
-
-```js
-;(function(prototype) {
-  prototype.hasChildNodes = prototype.hasChildNodes || function() {
-    return !!this.firstChild;
-  }
-})(Node.prototype);
-```
-
 There are various ways to determine whether the node has a child node:
 
 - `node.hasChildNodes()`

--- a/files/en-us/web/api/node/haschildnodes/index.md
+++ b/files/en-us/web/api/node/haschildnodes/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Node.hasChildNodes
 {{APIRef("DOM")}}
 
 The **`Node.hasChildNodes()`** method returns a
-boolean value indicating whether the given {{domxref("Node")}} has [child nodes](/en-US/docs/Web/API/Node.childNodes) or not.
+boolean value indicating whether the given {{domxref("Node")}} has [child nodes](/en-US/docs/Web/API/Node/childNodes) or not.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Most of the browsers have support for `Node.hasChildNodes()`, so there's no need for a polyfill.


<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Closes #10104 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
