### PR TITLE
Error constructor - fix up sytnax for non-standard params

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/error/index.md
@@ -17,8 +17,8 @@ The **`Error`** constructor creates an error object.
 new Error()
 new Error(message)
 new Error(message, options)
-new Error(message, options, fileName)
-new Error(message, options, fileName, lineNumber)
+new Error(message, fileName)
+new Error(message, fileName, lineNumber)
 ```
 
 ### Parameters
@@ -33,8 +33,7 @@ new Error(message, options, fileName, lineNumber)
           When catching and re-throwing an error with a more-specific or useful error message, this property should be used to pass the original error.
 - `fileName` {{Optional_Inline}}{{Non-standard_inline}}
   - : The value for the `fileName` property on the created `Error` object.
-    Defaults to the name of the file containing the code that
-    called the `Error()` constructor.
+    Defaults to the name of the file containing the code that called the `Error()` constructor.
 - `lineNumber` {{Optional_Inline}}{{Non-standard_inline}}
   - : The value for the `lineNumber` property on the created `Error` object. 
      Defaults to the line number containing the `Error()` constructor invocation.


### PR DESCRIPTION
Fixes #10159

The non-standard filename/number params are ignored if `options.cause` is specified. This OK @saschanaz ?

BCD fixes are being done in https://github.com/mdn/browser-compat-data/pull/13172
Essentially the lineNumber, filename were listed as properties of the error, but not as parameters of the error constructor.