### PR TITLE
fix: correct the latex syntax of Math.LOG10E, close #10165

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.LOG10E
 
 The **`Math.LOG10E`** property represents the base 10 logarithm of e, approximately 0.434:
 
-<math display="block"><semantics><mrow><mstyle mathvariant="monospace"><mi>Math.LOG10E</mi></mstyle><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>10</mn></msub><mo stretchy="false">(</mo><mi>e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>0.434</mn></mrow><annotation encoding="TeX">\mathtt{\mi{Math.LOG10E}} = \log_10(e) \approx 0.434</annotation></semantics></math>
+<math display="block"><semantics><mrow><mstyle mathvariant="monospace"><mi>Math.LOG10E</mi></mstyle><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>10</mn></msub><mo stretchy="false">(</mo><mi>e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>0.434</mn></mrow><annotation encoding="TeX">\mathtt{\mi{Math.LOG10E}} = \log_{10}(e) \approx 0.434</annotation></semantics></math>
 
 {{EmbedInteractiveExample("pages/js/math-log10e.html", "shorter")}}{{js_property_attributes(0, 0, 0)}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

correct the latex syntax of Math.LOG10E

#### Motivation

In latex formula, `\mathtt{\mi{Math.LOG10E}} = \log_10(e) \approx 0.434`, The syntax of \log_10(e) is incorrect. It will render like <img src="https://latex.codecogs.com/svg.image?&space;\log_10(e)" title=" \log_10(e)" />.

#### Supporting details

<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E>

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
