### PR TITLE
Removes incorrect information about arbitrary order in `for...in` statement

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -258,7 +258,7 @@ Both `for...in` and `for...of` statements iterate over something.
 The main difference between them is in what they iterate over.
 
 The {{jsxref("Statements/for...in", "for...in")}} statement iterates over the [enumerable
-properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object, in an arbitrary order.
+properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object.
 
 The `for...of` statement iterates over values that the [iterable
 object](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#iterables) defines to be iterated over.

--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -312,7 +312,7 @@ for (const i in iterable) {
 ```
 
 This loop logs only [enumerable
-properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of the `iterable` object, in arbitrary order. It doesn't log
+properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of the `iterable` object. It doesn't log
 array **elements** `3`, `5`, `7` or
 `hello` because those are **not** enumerable properties, in fact
 they are not properties at all, they are **values**. It logs array


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

In the live standard, the [order is defined](https://262.ecma-international.org/12.0/#sec-enumerate-object-properties). It boils down to the call of the [`OrdinaryOwnPropertyKeys`](https://262.ecma-international.org/12.0/#sec-ordinaryownpropertykeys) internal method where the order is: 
1. array indexes in the ascending order 
2. string keys in the chronological ascending order
3. symbols (skipped in for...in )

I don't think we need to describe the order in this article because the main point is to show that `for...of` and `for...in` iterate over different things. The order is secondary information.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
