### PR TITLE
Add touch support for the mouse following animation example

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -383,6 +383,7 @@ addEventListener("mousemove", (e) => {
   cursor.x = e.clientX;
   cursor.y = e.clientY;
 });
+
 addEventListener(
   "touchmove",
   (e) => {
@@ -392,6 +393,7 @@ addEventListener(
   },
   { passive: false }
 );
+
 addEventListener("resize", () => setSize());
 
 function generateParticles(amount) {

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -380,16 +380,16 @@ generateParticles(101);
 setSize();
 anim();
 
-onmousemove = (e) => {
+window.onmousemove = (e) => {
   cursor.x = e.clientX;
   cursor.y = e.clientY;
 };
-ontouchmove = (e) => {
+window.ontouchmove = (e) => {
   e.preventDefault();
   cursor.x = e.touches[0].clientX;
   cursor.y = e.touches[0].clientY;
 };
-onresize = () => {
+window.onresize = () => {
   setSize();
 }
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -352,6 +352,7 @@ function draw() {
 #cw {
   position: fixed;
   z-index: -1;
+  touch-action: none;
 }
 
 body {
@@ -368,7 +369,7 @@ const canvas = document.getElementById("cw");
 const context = canvas.getContext("2d");
 context.globalAlpha = 0.5;
 
-const mouse = {
+const cursor = {
   x: innerWidth / 2,
   y: innerHeight / 2,
 };
@@ -379,12 +380,16 @@ generateParticles(101);
 setSize();
 anim();
 
-window.onmousemove = (e) => {
-  mouse.x = e.clientX;
-  mouse.y = e.clientY;
+onmousemove = (e) => {
+  cursor.x = e.clientX;
+  cursor.y = e.clientY;
 };
-
-window.onresize = () => {
+ontouchmove = (e) => {
+  e.preventDefault();
+  cursor.x = e.touches[0].clientX;
+  cursor.y = e.touches[0].clientY;
+};
+onresize = () => {
   setSize();
 }
 
@@ -429,8 +434,8 @@ function Particle(x, y, particleTrailWidth, strokeColor, rotateSpeed) {
       y: this.y,
     };
     this.theta += this.rotateSpeed;
-    this.x = mouse.x + Math.cos(this.theta) * this.t;
-    this.y = mouse.y + Math.sin(this.theta) * this.t;
+    this.x = cursor.x + Math.cos(this.theta) * this.t;
+    this.y = cursor.y + Math.sin(this.theta) * this.t;
     context.beginPath();
     context.lineWidth = this.particleTrailWidth;
     context.strokeStyle = this.strokeColor;

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -380,18 +380,20 @@ generateParticles(101);
 setSize();
 anim();
 
-window.onmousemove = (e) => {
+addEventListener("mousemove", (e) => {
   cursor.x = e.clientX;
   cursor.y = e.clientY;
-};
-window.ontouchmove = (e) => {
-  e.preventDefault();
-  cursor.x = e.touches[0].clientX;
-  cursor.y = e.touches[0].clientY;
-};
-window.onresize = () => {
-  setSize();
-}
+});
+addEventListener(
+  "touchmove",
+  (e) => {
+    e.preventDefault();
+    cursor.x = e.touches[0].clientX;
+    cursor.y = e.touches[0].clientY;
+  },
+  { passive: false }
+);
+addEventListener("resize", () => setSize());
 
 function generateParticles(amount) {
   for (let i = 0; i < amount; i++) {

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -352,7 +352,6 @@ function draw() {
 #cw {
   position: fixed;
   z-index: -1;
-  touch-action: none;
 }
 
 body {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
Right now, the mouse following animation example doesn't support touchmove -- users cannot drag the orbit thing around. I have added just a few more lines of code to support dragging.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The code now supports both mouse and touch, so I changed the previously named "mouse" variable to "cursor" (probably not the best name, but makes more sense to me).

I used addEventListener for touchmove because I needed the passive flag. And for consistency, I have decided to change window.onmousemove and window.onresize to be addEventListener as well.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
