### PR TITLE
Fix case of BCD query in reportError

### DIFF
--- a/files/en-us/web/api/reporterror/index.md
+++ b/files/en-us/web/api/reporterror/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - Global
   - Errors
-browser-compat: api.reporterror
+browser-compat: api.reportError
 ---
 {{APIRef}} {{AvailableInWorkers}}
 


### PR DESCRIPTION
The `browser-compat` property is case-sensitive, so `api.reporterror` was not finding the BCD for `api.reportError`, so spec tables and BCD weren't appearing.