### PR TITLE
Crypto.randomUUID updates for FF95

### DIFF
--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -9,7 +9,8 @@ tags:
 ---
 {{FirefoxSidebar}}{{draft}}
 
-This article provides information about the changes in Firefox 95 that will affect developers. Firefox 95 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta), and will ship on [December 7, 2021](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 95 that will affect developers.
+Firefox 95 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta), and will ship on [December 7, 2021](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 
 ## Changes for web developers
 
@@ -36,6 +37,8 @@ This article provides information about the changes in Firefox 95 that will affe
 #### Removals
 
 ### APIs
+
+- The {{domxref("Crypto.randomUUID()")}} function is now supported. This returns a cryptographically strong 36 character fixed-length UUID ({{bug(1723674)}}).
 
 #### DOM
 

--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -19,39 +19,32 @@ browser-compat: api.Crypto.getRandomValues
 ---
 {{APIRef("Web Crypto API")}}
 
-The **`Crypto.getRandomValues()`** method lets you get
-cryptographically strong random values. The array given as the parameter is filled with
-random numbers (random in its cryptographic meaning).
+The **`Crypto.getRandomValues()`** method lets you get cryptographically strong random values.
+The array given as the parameter is filled with random numbers (random in its cryptographic meaning).
 
-To guarantee enough performance, implementations are not using a truly random number
-generator, but they are using a pseudo-random number generator _seeded_ with a
-value with enough entropy. The pseudo-random number generator algorithm (PRNG) may vary
-across {{Glossary("user agent", "user agents")}}, but is suitable for cryptographic
-purposes. Implementations are required to use a seed with enough entropy, like a
-system-level entropy source.
+To guarantee enough performance, implementations are not using a truly random number generator, but they are using a pseudo-random number generator _seeded_ with a value with enough entropy.
+The pseudo-random number generator algorithm (PRNG) may vary across {{Glossary("user agent", "user agents")}}, but is suitable for cryptographic purposes.
+Implementations are required to use a seed with enough entropy, like a system-level entropy source.
 
-`getRandomValues()` is the only member of the `Crypto` interface
-which can be used from an insecure context.
+`getRandomValues()` is the only member of the `Crypto` interface which can be used from an insecure context.
 
 ## Syntax
 
 ```js
-typedArray = cryptoObj.getRandomValues(typedArray);
+crypto.getRandomValues(typedArray)
 ```
 
 ### Parameters
 
 - `typedArray`
-  - : An integer-based {{jsxref("TypedArray")}}, that is an {{jsxref("Int8Array")}}, a
-    {{jsxref("Uint8Array")}}, an {{jsxref("Int16Array")}}, a {{jsxref("Uint16Array")}}, an
-    {{jsxref("Int32Array")}}, or a {{jsxref("Uint32Array")}}. All elements in the array
-    are overwritten with random numbers.
+  - : An integer-based {{jsxref("TypedArray")}}, that is an {{jsxref("Int8Array")}}, a {{jsxref("Uint8Array")}}, an {{jsxref("Int16Array")}}, a {{jsxref("Uint16Array")}}, an
+    {{jsxref("Int32Array")}}, or a {{jsxref("Uint32Array")}}.
+    All elements in the array are overwritten with random numbers.
 
 ### Return value
 
-The same array passed as `typedArray` but with its contents
-replaced with the newly generated random numbers. Note that
-`typedArray` is modified in-place, and no copy is made.
+The same array passed as `typedArray` but with its contents replaced with the newly generated random numbers.
+Note that `typedArray` is modified in-place, and no copy is made.
 
 ### Exceptions
 
@@ -62,17 +55,15 @@ This method can throw an exception under error conditions.
 
 ## Usage notes
 
-Don't use `getRandomValues()` to generate encryption keys. Instead, use the
-{{domxref("SubtleCrypto.generateKey", "generateKey()")}} method. There are a few reasons
-for this; for example, `getRandomValues()` is not guaranteed to be running in
-a secure context.
+Don't use `getRandomValues()` to generate encryption keys.
+Instead, use the {{domxref("SubtleCrypto.generateKey", "generateKey()")}} method.
+There are a few reasons for this; for example, `getRandomValues()` is not guaranteed to be running in a secure context.
 
 There is no minimum degree of entropy mandated by the Web Cryptography specification.
-User agents are instead urged to provide the best entropy they can when generating
-random numbers, using a well-defined, efficient pseudorandom number generator built into
-the user agent itself, but seeded with values taken from an external source of
-pseudorandom numbers, such as a platform-specific random number function, the Unix
-`/dev/urandom` device, or other source of random or pseudorandom data.
+User agents are instead urged to provide the best entropy they can when generating random numbers,
+using a well-defined, efficient pseudorandom number generator built into the user agent itself,
+but seeded with values taken from an external source of pseudorandom numbers, such as a platform-specific random number function,
+the Unix `/dev/urandom` device, or other source of random or pseudorandom data.
 
 ## Examples
 
@@ -80,7 +71,7 @@ pseudorandom numbers, such as a platform-specific random number function, the Un
 /* Assuming that window.crypto.getRandomValues is available */
 
 var array = new Uint32Array(10);
-window.crypto.getRandomValues(array);
+self.crypto.getRandomValues(array);
 
 console.log("Your lucky numbers:");
 for (var i = 0; i < array.length; i++) {

--- a/files/en-us/web/api/crypto/index.md
+++ b/files/en-us/web/api/crypto/index.md
@@ -16,7 +16,8 @@ browser-compat: api.Crypto
 ---
 {{APIRef("Web Crypto API")}}
 
-The **`Crypto`** interface represents basic cryptography features available in the current context. It allows access to a cryptographically strong random number generator and to cryptographic primitives.
+The **`Crypto`** interface represents basic cryptography features available in the current context.
+It allows access to a cryptographically strong random number generator and to cryptographic primitives.
 
 {{AvailableInWorkers}}
 
@@ -35,10 +36,13 @@ _This interface implements methods defined on {{domxref("Crypto/getRandomValues"
 
 - {{domxref("Crypto.getRandomValues()")}}
   - : Fills the passed {{ jsxref("TypedArray") }} with cryptographically sound random values.
+- {{domxref("Crypto.randomUUID()")}}
+  - : Returns a randomly generated, 36 character long v4 UUID.
 
 ## Usage notes
 
-You should avoid using the Web Crypto API on insecure contexts, even though the `Crypto` interface is present on insecure contexts, as is the {{domxref("crypto_property", "crypto")}} property. In addition, the `Crypto` method {{domxref("Crypto.getRandomValues", "getRandomValues()")}} is available on insecure contexts, but the {{domxref("Crypto.subtle", "subtle")}} property is not.
+You should avoid using the Web Crypto API on insecure contexts, even though the `Crypto` interface is present on insecure contexts, as is the {{domxref("crypto_property", "crypto")}} property.
+In addition, the `Crypto` method {{domxref("Crypto.getRandomValues", "getRandomValues()")}} is available on insecure contexts, but the {{domxref("Crypto.subtle", "subtle")}} property is not.
 
 In general, you probably should just treat `Crypto` as available only on secure contexts.
 

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -14,22 +14,21 @@ browser-compat: api.Crypto.randomUUID
 ---
 {{APIRef("Web Crypto API")}}{{SecureContext_header}}
 
-The **`randomUUID()`** method of the {{domxref("Crypto")}}
-interface lets you generate a v4 UUID using a cryptographically secure random
-number generator, like is used for
-{{domxref("Crypto.getRandomValues", "getRandomValues()")}}.
+The **`randomUUID()`** method of the {{domxref("Crypto")}} interface is used to generate a v4 UUID using a cryptographically secure random number generator.
 
 ## Syntax
 
 ```js
-crypto.randomUUID();
+crypto.randomUUID()
 ```
 
 ### Return value
 
-A randomly generated, 36 character long v4 UUID.
+A {{domxref("DOMString")}} containing a randomly generated, 36 character long v4 UUID.
 
 ## Examples
+
+The method is accessed through the global {{domxref("crypto_property", "crypto")}} property.
 
 ```js
 /* Assuming that self.crypto.randomUUID() is available */


### PR DESCRIPTION
[Crypto.randomUUID()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) is supported from FF95 
- Bug fix: https://bugzilla.mozilla.org/show_bug.cgi?id=1723674
- Doc tracking: #10143

This was mostly documented already. All this PR does is improve linking and layout and a couple of syntax boxes around the area.