### PR TITLE
FF95 Updates for ElementInternals

### DIFF
--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -39,6 +39,10 @@ This article provides information about the changes in Firefox 95 that will affe
 
 #### DOM
 
+- Support for additional {{domxref("ElementInternals")}} properties and methods that allow a custom element to interact with a form.
+  These include {{domxref("ElementInternals.form","form")}} to get the form associated with the element, {{domxref("ElementInternals.labels","labels")}} to get the list of labels ({{bug(1556373)}}), and the {{domxref("ElementInternals.setFormValue()","setFormValue()")}} method to set the sanitized value and user-entered data, if needed.
+  The related bugs are: {{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556449)}}.
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/elementinternals/form/index.md
+++ b/files/en-us/web/api/elementinternals/form/index.md
@@ -13,19 +13,14 @@ browser-compat: api.ElementInternals.form
 
 The **`form`** read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("HTMLFormElement")}} associated with this element.
 
-## Syntax
-
-```js
-let form = ElementInternals.form;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLFormElement")}}.
 
 ## Examples
 
-The following example shows a custom checkbox component inside a form with an ID of `myForm`. Printing `form.length` to the console, gives us the value of {{domxref("HTMLFormElement.length")}}.
+The following example shows a custom checkbox component inside a form with an ID of `myForm`.
+Printing `form.length` to the console, gives us the value of {{domxref("HTMLFormElement.length")}}.
 
 ```html
 <form id="myForm"><custom-checkbox id="join-checkbox"></custom-checkbox>

--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -13,19 +13,14 @@ browser-compat: api.ElementInternals.labels
 
 The **`labels`** read-only property of the {{domxref("ElementInternals")}} interface returns the labels associated with the element.
 
-## Syntax
-
-```js
-let labels = ElementInternals.labels;
-```
-
-### Value
+## Value
 
 A {{domxref("NodeList")}} containing all of the label elements associated with this element.
 
 ## Examples
 
-The following example shows a custom checkbox component with a {{HTMLElement("label")}} element linked to it. Printing the value of `labels` to the console returns a {{domxref("NodeList")}} with one entry, representing this label.
+The following example shows a custom checkbox component with a {{HTMLElement("label")}} element linked to it.
+Printing the value of `labels` to the console returns a {{domxref("NodeList")}} with one entry, representing this label.
 
 ```html
 <form id="myForm">

--- a/files/en-us/web/api/elementinternals/setformvalue/index.md
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.md
@@ -16,8 +16,8 @@ The **`setFormValue()`** method of the {{domxref("ElementInternals")}} interface
 ## Syntax
 
 ```js
-ElementInternals.setFormValue(value);
-ElementInternals.setFormValue(value, state);
+setFormValue(value)
+setFormValue(value, state)
 ```
 
 ### Parameters
@@ -25,9 +25,13 @@ ElementInternals.setFormValue(value, state);
 - `value`
   - : A {{domxref("File")}}, or a {{domxref("USVString","string")}}, or {{domxref("FormData")}} as the value to be submitted to the server.
 - `state`{{Optional_Inline}}
-  - : A {{domxref("File")}}, or a {{domxref("USVString","string")}}, or {{domxref("FormData")}} representing the input made by the user. This allows the application to re-display the information that the user submitted, in the form that they submitted it, if required.
+  - : A {{domxref("File")}}, or a {{domxref("USVString","string")}}, or {{domxref("FormData")}} representing the input made by the user.
+    This allows the application to re-display the information that the user submitted, in the form that they submitted it, if required.
 
-> **Note:** In general, `state` is used to pass information specified by a user, the `value` is suitable for submission to a server, post sanitization. For example, if a custom element asked a user to submit a date, the user might enter "3/15/2019". This would be the `state`. The server expects a date format of `2019-03-15`, the date in this format would be passed as the `value`.
+> **Note:** In general, `state` is used to pass information specified by a user, the `value` is suitable for submission to a server, post sanitization.
+> For example, if a custom element asked a user to submit a date, the user might enter "3/15/2019".
+> This would be the `state`.
+> The server expects a date format of `2019-03-15`, the date in this format would be passed as the `value`.
 
 ### Return value
 


### PR DESCRIPTION
FF95 adds support for [ElementInternals.form](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/form) ,  [ElementInternals.labels](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/labels) and [ElementInternals.setFormValue()](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setFormValue)

The APIs were all documented, so this just does  minor updates to the docs for current syntax etc. This is minimal work required for release. It might be worth doing more, but need to do some digging.

Other work for this release can be tracked in #10142