### PR TITLE
Added overrideContentColorScheme to browserSettings

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -47,6 +47,8 @@ To use this API you need to have the "browserSettings" [permission](/en-US/docs/
   - : Determines whether search results are opened in the current tab or a new tab.
 - {{WebExtAPIRef("browserSettings.openUrlbarResultsInNewTabs")}}
   - : Determines whether address bar autocomplete suggestions are opened in the current tab or a new tab.
+- {{WebExtAPIRef("browserSettings.overrideContentColorScheme")}}
+  - : Controls whether to override the browser theme (light or dark) when setting pages' preferred color scheme. 
 - {{WebExtAPIRef("browserSettings.overrideDocumentColors")}}
   - : Controls whether the user-chosen colors override the page's colors.
 - {{WebExtAPIRef("browserSettings.useDocumentFonts")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
@@ -16,13 +16,14 @@ browser-compat: webextensions.api.browserSettings.overrideContentColorScheme
 
 A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object whose underlying value is a string.
 
-Firefox enables users to choose a theme for the browser UI. These themes apply either a light or dark theme to webpages. Using the  `layout.css.prefers-color-scheme.content-override` preference, users can override the theme and choose to render webpages in a light or dark theme. This browser setting exposes that preference.
+Firefox enables users to choose a theme for the browser UI. These themes apply either a light or dark theme to webpages. Using the  `layout.css.prefers-color-scheme.content-override` preference, users can override the theme and choose to render webpages in a light or dark theme or follow the device's theme. This browser setting exposes that preference.
 
 This object takes these values:
 
 - "light": Applies a light theme to webpages.
 - "dark": Applies a  dark theme to webpages.
-- "system": Applies a light or dark theme to webpages based on the browser's theme.
+- "system": Applies a light or dark theme to webpages based on the device's theme.
+- "browser": Applies a light or dark theme to webpages based on the browser's theme.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
@@ -1,0 +1,44 @@
+---
+title: browserSettings.overrideContentColorScheme
+slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideContentColorScheme
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Property
+  - Reference
+  - WebExtensions
+  - browserSettings
+  - overrideContentColorScheme
+browser-compat: webextensions.api.browserSettings.overrideContentColorScheme
+---
+{{AddonSidebar()}}
+
+A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object whose underlying value is a string.
+
+Firefox enables users to choose a theme for the browser UI. These themes apply either a light or dark theme to webpages. Using the  `layout.css.prefers-color-scheme.content-override` preference, users can override the theme and choose to render webpages in a light or dark theme. This browser setting exposes that preference.
+
+This object takes these values:
+
+- "light": Applies a light theme to webpages.
+- "dark": Applies a  dark theme to webpages.
+- "system": Applies a light or dark theme to webpages based on the browser's theme.
+
+## Browser compatibility
+
+{{Compat}}
+
+## Examples
+
+This example overrides the setting to use the dark theme for webpages:
+
+```js
+function logResult(result) {
+  console.log(`Setting was modified: ${result}`);
+}
+
+browser.browserSettings.overrideContentColorScheme.set({value: "dark"}).
+  then(logResult);
+```
+
+{{WebExtExamples}}

--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 95 that will affe
 
 ## Changes for add-on developers
 
+- Added `overrideContentColorScheme` in {{WebExtAPIRef("browserSettings")}} to provide the ability to control the preference `layout.css.prefers-color-scheme.content-override` and set pages' preferred color scheme (light or dark) independently of the browser theme ({{bug(1733461)}}).
+
 #### Removals
 
 ### Other


### PR DESCRIPTION
#### Summary

Adds details for the addition of `overrideContentColorScheme` to `browserSettings` including:

- developer release notes
- addition to the `browserSettings` page
- new `overrideContentColorScheme` page

See also [PR 13179](https://github.com/mdn/browser-compat-data/pull/13179) for changes to browser compatibility data.

#### Motivation
To address the documentation needs of [Bug 1733461](https://bugzilla.mozilla.org/show_bug.cgi?id=1733461) 

#### Related issues
Fixes [#10146](https://github.com/mdn/content/issues/10146)

#### Metadata

This PR…
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
