### PR TITLE
menus.OnClickedData.srcUrl returns raw src value

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -50,7 +50,7 @@ Values of this type are objects. They contain the following properties:
 - `selectionText` {{optional_inline}}
   - : `string`. If some text was selected in the page, this contains the selected text.
 - `srcUrl` {{optional_inline}}
-  - : `string`. The `<img src>` value for the clicked element's image or, where the element has no image, the background image, otherwise not returned.
+  - : `string`. If present, the `src` value for the media in the clicked element.
 - `targetElementId`{{optional_inline}}
   - : `integer`. An identifier of the element, if any, over which the context menu was created. Use {{WebExtAPIRef("menus.getTargetElement()")}} in the content script to locate the element. Note that this is not the [id](/en-US/docs/Web/HTML/Global_attributes/id) attribute of the page element.
 - `viewType` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -50,7 +50,7 @@ Values of this type are objects. They contain the following properties:
 - `selectionText` {{optional_inline}}
   - : `string`. If some text was selected in the page, this contains the selected text.
 - `srcUrl` {{optional_inline}}
-  - : `string`. Will be present for elements with a "src" URL.
+  - : `string`. The `<img src>` value for the clicked element's image or, where the element has no image, the background image, otherwise not returned.
 - `targetElementId`{{optional_inline}}
   - : `integer`. An identifier of the element, if any, over which the context menu was created. Use {{WebExtAPIRef("menus.getTargetElement()")}} in the content script to locate the element. Note that this is not the [id](/en-US/docs/Web/HTML/Global_attributes/id) attribute of the page element.
 - `viewType` {{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -42,7 +42,7 @@ No notable changes
 ## Changes for add-on developers
 
 - Support for `partitionKey`, the first-party URL of a cookie when it's in storage that is partitioned by top-level site, is added to {{WebExtAPIRef('cookies.get')}}, {{WebExtAPIRef('cookies.getAll')}}, {{WebExtAPIRef('cookies.set')}}, {{WebExtAPIRef('cookies.remove')}}, and {{WebExtAPIRef('cookies.cookie')}}. ({{bug(1669716)}})
-- When a context menu is activated, {{WebExtAPIRef('menus.OnClickData','menus.OnClickData.srcUrl')}} returns the raw value of the `src`  attribute of the clicked element.
+- When a context menu is activated, {{WebExtAPIRef('menus.OnClickData','menus.OnClickData.srcUrl')}} returns the raw value of the `src`  attribute of the clicked element, instead of the current URL (after redirects). ({{bug(1659155)}})
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -42,6 +42,7 @@ No notable changes
 ## Changes for add-on developers
 
 - Support for `partitionKey`, the first-party URL of a cookie when it's in storage that is partitioned by top-level site, is added to {{WebExtAPIRef('cookies.get')}}, {{WebExtAPIRef('cookies.getAll')}}, {{WebExtAPIRef('cookies.set')}}, {{WebExtAPIRef('cookies.remove')}}, and {{WebExtAPIRef('cookies.cookie')}}. ({{bug(1669716)}})
+- The value returned by {{WebExtAPIRef('menus.OnClickData','menus.OnClickData.srcUrl')}} is the `<img src>` value for the clicked element's image or, where the element has no image, the background image.
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -42,7 +42,7 @@ No notable changes
 ## Changes for add-on developers
 
 - Support for `partitionKey`, the first-party URL of a cookie when it's in storage that is partitioned by top-level site, is added to {{WebExtAPIRef('cookies.get')}}, {{WebExtAPIRef('cookies.getAll')}}, {{WebExtAPIRef('cookies.set')}}, {{WebExtAPIRef('cookies.remove')}}, and {{WebExtAPIRef('cookies.cookie')}}. ({{bug(1669716)}})
-- The value returned by {{WebExtAPIRef('menus.OnClickData','menus.OnClickData.srcUrl')}} is the `<img src>` value for the clicked element's image or, where the element has no image, the background image.
+- When a context menu is activated, {{WebExtAPIRef('menus.OnClickData','menus.OnClickData.srcUrl')}} returns the raw value of the `src`  attribute of the clicked element.
 
 ## Older versions
 


### PR DESCRIPTION
#### Summary

Addresses the changes made in the return value of `menus.OnClickedData.srcUrl` including:

*updated release notes
* clarification  of `menus.OnClickedData.srcUrl`

Supporting note in compatibility data provided in [menus.OnClickedData.srcUrl returned post-redirect URL #13259](https://github.com/mdn/browser-compat-data/pull/13259).

#### Supporting details

Addresses changes made in  [Bug 1659155](https://bugzilla.mozilla.org/show_bug.cgi?id=1659155). 

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error