### PR TITLE
Fix typo: menu path for Remote Debugging

### DIFF
--- a/files/en-us/tools/about_colon_debugging/index.html
+++ b/files/en-us/tools/about_colon_debugging/index.html
@@ -16,7 +16,7 @@ tags:
 
 <ul>
  <li>Type <code>about:debugging</code> in the Firefox URL bar.</li>
- <li>In the <strong>Tools</strong> &gt; <strong>Web Developer</strong> menu, click <strong>Remote Debugging</strong>.</li>
+ <li>In the <strong>Tools</strong> &gt; <strong>Browser Tools</strong> menu, click <strong>Remote Debugging</strong>.</li>
 </ul>
 
 <p>When about:debugging opens, on the left-hand side, you'll see a sidebar with two options and information about your remote debugging setup:</p>


### PR DESCRIPTION
#### Summary
Fix menu path for Remote Debugging. Fixes #10213

#### Motivation
Fixes incorrect menu path in documentation.

#### Supporting details
![Screen Shot 2021-11-01 at 13 28 44](https://user-images.githubusercontent.com/120511/139739520-43c1048c-2b18-476e-9ee0-ed6229db7557.png)

#### Related issues
Fixes #10213

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error