### PR TITLE
Fix the latex syntax of Math.log(), close #10222

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
@@ -39,7 +39,7 @@ of a number, that is
 </msup><mo>=</mo>
 <mi>x</mi>
 </mrow><annotation encoding="TeX">\forall x > 0, \mathtt{\operatorname{Math.log10}(x)} =
-\log_10(x) = \text{the unique} \; y \; \text{such that} \; 10^y = x</annotation></semantics></math>
+\log_{10}(x) = \text{the unique} \; y \; \text{such that} \; 10^y = x</annotation></semantics></math>
 
 {{EmbedInteractiveExample("pages/js/math-log10.html")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

correct the latex syntax of Math.log10()

#### Motivation

In latex formula, `\forall x > 0, \mathtt{\operatorname{Math.log10}(x)} = \log_10(x) = \text{the unique} ; y ; \text{such that} ; 10^y = x`, The syntax of \log_10(x) is incorrect. It will render like <img src="https://latex.codecogs.com/svg.image?&space;\log_10(x)" title=" \log_10(x)" />.

#### Supporting details

<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10>
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
