### PR TITLE
Add information about drag feedback image

### DIFF
--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -44,6 +44,13 @@ void dataTransfer.setDragImage(img | element, xOffset, yOffset);
     to an image generated from the given element (the exact mechanism for doing so is not
     currently specified).
 
+    It is important to note that if the {{domxref("Element")}} is an existing {{domxref("HTMLElement")}}
+    it needs to be visible in the viewport in order to be shown as the drag feedback image.
+    Therefore, it is better to use {{domxref("Document_Object_Model")}} to create an additional
+    element specifically for this purpose. That way it can be off-screen and still be used
+    as a drag feedback image.
+    
+
 - _xOffset_
   - : A `long` indicating the horizontal offset within the image.
 - _yOffset_

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -44,12 +44,7 @@ void dataTransfer.setDragImage(img | element, xOffset, yOffset);
     to an image generated from the given element (the exact mechanism for doing so is not
     currently specified).
 
-    It is important to note that if the {{domxref("Element")}} is an existing {{domxref("HTMLElement")}}
-    it needs to be visible in the viewport in order to be shown as the drag feedback image.
-    Therefore, it is better to use {{domxref("Document_Object_Model")}} to create an additional
-    element specifically for this purpose. That way it can be off-screen and still be used
-    as a drag feedback image.
-    
+    Note: If the {{domxref("Element")}} is an existing {{domxref("HTMLElement")}} it needs to be visible in the viewport in order to be shown as a drag feedback image. Alternatively, you can create a new DOM element that might be off-screen specifically for this purpose.
 
 - _xOffset_
   - : A `long` indicating the horizontal offset within the image.


### PR DESCRIPTION
#### Summary
This is a contribution to the documentation for situations when an HTML element other than an image is used for a drag feedback image. It is important to note that an existing HTML element will not be usable if it is hidden outside the viewport via "display: none", absolute position or "visibility: hidden".

#### Motivation
The viewport issue is one I came across in my development, but there was no explanation about it in this documentation, so I had to spend a lot of time researching. I wish to help other developers by informing them about this in order to save them some time and effort.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
