### PR TITLE
Fix markdown link in Origin Header Page

### DIFF
--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -18,7 +18,7 @@ The **`Origin`** HyperText Transfer Protocol (HTTP) request header indicates the
 > - all {{Glossary("CORS", "cross origin")}} requests.
 > - [same-origin](/en-US/docs/Web/Security/Same-origin_policy) requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).
 >
-> There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode], (/en-US/docs/Web/API/Request/mode#value) the `Origin` header will not be added.
+> There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode](/en-US/docs/Web/API/Request/mode#value), the `Origin` header will not be added.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix the markdown link to `no-cors mode` in the Origin HTTP header page

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To fix the broken link

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
