### PR TITLE
update return value for performance.measure()

### DIFF
--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -61,7 +61,7 @@ performance.measure(name, undefined, endMark);
 
 ### Return value
 
-- entry
+- undefined
   - : The {{domxref("PerformanceMeasure")}} entry that was created.
 
 ## Example


### PR DESCRIPTION
#### Summary
This PR updates the return value for `performance.measure()`. Currently, at https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure it states that the return value is `entry`. It appears as though `entry` was the draft return value and that `undefined` is the official return value.

#### Related issues
Fixes #10009

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error