### PR TITLE
improve readability

### DIFF
--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -246,6 +246,8 @@ h1 {
 
 {{CSSSyntax}}
 
+> **Note:** ` `:is()` does not match for pseudo elements
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
I spent a while trying to figure out why my before and after selectors wouldn't work. according to the syntax it should work, but in both the spec and near the top of the page it says it doesn't

so my proposal is to add a note near the syntax for clarification