### PR TITLE
update window.innerWidth to layout viewport

### DIFF
--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -20,7 +20,7 @@ The read-only {{domxref("Window")}} property
 pixels. This includes the width of the vertical scroll bar, if one is present.
 
 More precisely, `innerWidth` returns the width of the window's
-{{Glossary("visual viewport")}}. The interior height of the window—the height of the
+{{Glossary("layout viewport")}}. The interior height of the window—the height of the
 layout viewport—can be obtained from the {{domxref("Window.innerHeight",
   "innerHeight")}} property.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR updates https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth by changing 'innerWidth returns the width of the window's `visual viewport`' to 'innerWidth returns the width of the window's `layout viewport`.'

#### Related issues
Fixes #9757

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
