### PR TITLE
Fix content model for the “a” element

### DIFF
--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -155,7 +155,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
         <a
           href="/en-US/docs/Web/HTML/Global_attributes/tabindex"
           >tabindex</a
-        > attribute
+        > attribute.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -144,18 +144,18 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
         <a
           href="/en-US/docs/Web/Guide/HTML/Content_categories#transparent_content_model"
           >Transparent</a
-        >, containing either
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content"
-          >flow content</a
-        >
-        (excluding
+        >, except that no descendant may be
         <a
           href="/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content"
           >interactive content</a
-        >) or
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >.
+        > or an
+        <a href="/en-US/docs/Web/HTML/Element/a"
+          >a</a
+        > element, and no descendant may have a specified
+        <a
+          href="/en-US/docs/Web/HTML/Global_attributes/tabindex"
+          >tabindex</a
+        > attribute
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Corrected permitted content, which deviated from the HTML standard.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changed permitted content to conform to the HTML standard.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Current text says all phrasing content is permitted as a descendant of an <a> element. That conflicts with the standard.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
