### PR TITLE
Removed prefixing in appearance: none; example.

### DIFF
--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -283,8 +283,6 @@ The following values are implemented only for one or both of the prefixed proper
 
 ```css
 input {
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   display: inline-block;
   vertical-align: middle;


### PR DESCRIPTION
unprefixed for `none` is now universally supported.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

Edited example