### PR TITLE
Fix non-existent macro

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-dropeffect/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-dropeffect/index.md
@@ -10,7 +10,7 @@ tags:
   - drag and drop
   - deprecated
 ---
-{{deprecated}}
+{{deprecated_header}}
 
 The global `aria-dropeffect` attribute indicates what functions may be performed when a dragged object is released on the drop target.
 


### PR DESCRIPTION
`{{deprecated}}` doesn't exist. It is `{{deprecated_header}}`.