### PR TITLE
Fix {{Specifications}} macro name

### DIFF
--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -55,7 +55,7 @@ const lastnameSpan = container.children.lastname;
 
 ## Specification
 
-{{Specification}}
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
Added the final `s` to `{{Specifications}}` so that it works.