### PR TITLE
Fix a typo in "Test your skills: Form structure"

### DIFF
--- a/files/en-us/learn/forms/test_your_skills_colon__form_structure/index.md
+++ b/files/en-us/learn/forms/test_your_skills_colon__form_structure/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 {{learnsidebar}}
 
-This aim of this skill test is to assess whether you've understood our [How to structure a web form](/en-US/docs/Learn/Forms/How_to_structure_a_web_form) article.
+The aim of this skill test is to assess whether you've understood our [How to structure a web form](/en-US/docs/Learn/Forms/How_to_structure_a_web_form) article.
 
 > **Note:** You can try out the solution in the interactive editor below, however it may be helpful to download the code and use an online tool such as [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/) to work on the tasks.
 >


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix Typo.  
"This aim of.." was used instead of "The aim of..".

#### Motivation
N/A

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
