### PR TITLE
Remove link to SelectorsHub

### DIFF
--- a/files/en-us/web/xpath/index.md
+++ b/files/en-us/web/xpath/index.md
@@ -38,8 +38,6 @@ XPath uses a path notation (as in URLs) for navigating through the hierarchical 
 
 ## Tools
 
-- [SelectorsHub](https://addons.mozilla.org/en-US/firefox/addon/selectorshub/)
-  - : XPath panel that integrates tightly into FireBug, providing an editor and inspector (FireFox Add-On).
 - [XMLQuire (formerly known as SketchPath)](http://qutoric.com/xmlquire/)
   - : A Graphical XPath Builder/Debugger(.NET).
 - [XPath tester](https://extendsclass.com/xpath-tester.html)


### PR DESCRIPTION
Removing the link to SelectorsHub that was added in https://github.com/mdn/content/pull/10084 . The link is being used in promotional material to claim a degree of endorsement from MDN that we don't want to, and can't, make.
