### PR TITLE
Fix typo under "Indexing object properties"

### DIFF
--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -298,7 +298,7 @@ You can refer to a property of an object either by its property name or by its o
 
 This restriction applies when you create an object and its properties with a constructor function (as we did previously with the `Car` object type) and when you define individual properties explicitly (for example, `myCar.color = "red"`). If you initially define an object property with an index, such as `myCar[5] = "25 mpg"`, you subsequently refer to the property only as `myCar[5]`.
 
-The exception to this rule is array-like object reflected from HTML, such as the `forms` array-like object. You can always refer to objects in these array-like objects by either their ordinal number (based on where they appear in the document) or their name (if defined). For example, if the second `<FORM>` tag in a document has a `NAME` attribute of "myForm", you can refer to the form as `document.forms[1]` or `document.forms["myForm"]` or `document.forms.myForm`.
+The exception to this rule is array-like objects reflected from HTML, such as the `forms` array-like object. You can always refer to objects in these array-like objects by either their ordinal number (based on where they appear in the document) or their name (if defined). For example, if the second `<FORM>` tag in a document has a `NAME` attribute of "myForm", you can refer to the form as `document.forms[1]` or `document.forms["myForm"]` or `document.forms.myForm`.
 
 ## Defining properties for an object type
 


### PR DESCRIPTION
Under header  "Indexing object properties" the word "object" should be plural in this sentence: "The exception to this rule is array-like object reflected from HTML, such as the `forms` array-like object."