### PR TITLE
JSON Stringify documentation update (space parameter)

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -40,8 +40,8 @@ JSON.stringify(value, replacer, space)
     object are included in the resulting JSON string.
 - `space` {{optional_inline}}
 
-  - : A {{JSxRef("String")}} or {{JSxRef("Number")}} object that's used to insert white
-    space into the output JSON string for readability purposes.
+  - : A {{JSxRef("String")}} or {{JSxRef("Number")}} object that's used to insert indentation, white space,
+    and line break characters into the output JSON string for readability purposes.
 
     If this is a `Number`, it indicates the number of space characters to
     use as white space for indenting purposes; this number is capped at 10 (if it is greater, the value is just

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -40,8 +40,7 @@ JSON.stringify(value, replacer, space)
     object are included in the resulting JSON string.
 - `space` {{optional_inline}}
 
-  - : A {{JSxRef("String")}} or {{JSxRef("Number")}} object that's used to insert indentation, white space,
-    and line break characters into the output JSON string for readability purposes.
+  - : A {{JSxRef("String")}} or {{JSxRef("Number")}} object that's used to insert white space (including indentation, line break characters, etc.) into the output JSON string for readability purposes.
 
     If this is a `Number`, it indicates the number of space characters to
     use as white space for indenting purposes; this number is capped at 10 (if it is greater, the value is just


### PR DESCRIPTION
JSON Stringify does more than white spacing. it adds indentation and line break to the return-value JSON.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
