### PR TITLE
Remove duplicate title

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/format/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/format/index.md
@@ -1,5 +1,5 @@
 ---
-title: Version Format
+title: Manifest Version Format
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/version/format
 tags:
   - Add-ons
@@ -7,8 +7,6 @@ tags:
   - WebExtensions
 ---
 {{AddonSidebar}}
-
-# Manifest Version Format
 
 A **version string** consists of one or more _version parts_, separated with dots.
 


### PR DESCRIPTION
- [x] Fixes a typo, bug, or other error

Fixes #10274
Intended page : [Version Format](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version/format)
Remove duplicate title (heading)
```diff
- Manifest Version Format
```
Change the title to 
```diff
- title: Version Format
+ title: Manifest Version Format
```