### PR TITLE
change examples for Remainder operator to use 13 instead of 12

### DIFF
--- a/files/en-us/web/javascript/reference/operators/remainder/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder/index.md
@@ -33,7 +33,7 @@ x % y
 ### Remainder with positive dividend
 
 ```js
- 12 % 5  //  2
+ 13 % 5  //  3
  1 % -2 //  1
  1 % 2  //  1
  2 % 3  //  2
@@ -43,7 +43,7 @@ x % y
 ### Remainder with negative dividend
 
 ```js
--12 % 5 // -2
+-13 % 5 // -3
 -1 % 2  // -1
 -4 % 2  // -0
 ```


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Change examples for the remainder operator to use 13 % 5 instead of 12 %5.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
using 12%5 to explain how the remainder operator works to some of my coding students was confusing for them since the result of integer division `12 / 5` is *also* 2. I explained that `12 / 5` is 2 with a remainder of 2, so `12 % 2 === 2`. Many of them mistakenly thought that that `%` was just an integer division.

I think using 13 in the example would reduce the confusion since the result of integer division  `13 / 2` (2) is different from the remainder (3).

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
IMO this should also be changed in the interactive box at the top of the page, but I couldn't figure out how to edit that. If you can help me locate the appropriate file I'm happy to make the change there as well and add it to this PR or create a separate one, whatever's easier.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
