### PR TITLE
Remove spammy link

### DIFF
--- a/files/en-us/glossary/gzip_compression/index.md
+++ b/files/en-us/glossary/gzip_compression/index.md
@@ -10,5 +10,5 @@ gzip is a file format used for file compression and decompression. It is based o
 
 ## See also
 
-- [How to enable compression and gzip for page speed.](http://www.gzip.org/)
+- [The gzip home page](http://www.gzip.org/)
 - [gzip on Wikipedia](https://en.wikipedia.org/wiki/Gzip)

--- a/files/en-us/glossary/gzip_compression/index.md
+++ b/files/en-us/glossary/gzip_compression/index.md
@@ -1,14 +1,14 @@
 ---
-title: Gzip compression
+title: gzip compression
 slug: Glossary/GZip_compression
 tags:
   - Glossary
   - compression
   - gzip
 ---
-Gzip is a file format used for file compression and decompression. It is based on the Deflate algorithm that allows files to be made smaller in size which allows for faster network transfers. Gzip is commonly supported by web servers and modern browsers, meaning that servers can automatically compress files with Gzip before sending them, and browsers can uncompress files upon receiving them.
+gzip is a file format used for file compression and decompression. It is based on the Deflate algorithm that allows files to be made smaller in size which allows for faster network transfers. gzip is commonly supported by web servers and modern browsers, meaning that servers can automatically compress files with gzip before sending them, and browsers can uncompress files upon receiving them.
 
 ## See also
 
-- [How to enable compression and gzip for page speed.](https://varvy.com/pagespeed/enable-compression.html)
-- [Gzip on Wikipedia](https://en.wikipedia.org/wiki/Gzip)
+- [How to enable compression and gzip for page speed.](http://www.gzip.org/)
+- [gzip on Wikipedia](https://en.wikipedia.org/wiki/Gzip)


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/10283.

Deletes a spammy link, replacing it with a link to the actual gzip homepage. Also fixed capitalization (it's gzip not Gzip).