### PR TITLE
FF95 Relnote: SpeechSynthesisEvent.elapsedTime in seconds

### DIFF
--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -48,6 +48,8 @@ Firefox 95 is the current [Beta version of Firefox](https://www.mozilla.org/en-U
 
 #### Media, WebRTC, and Web Audio
 
+- {{domxref("SpeechSynthesisEvent.elapsedTime")}} now returns the elapsed time in seconds rather than milliseconds, matching an update to the specification (see {{bug(1732498)}}).
+
 #### Removals
 
 ### WebAssembly


### PR DESCRIPTION
This is FF95 release note for https://bugzilla.mozilla.org/show_bug.cgi?id=1732498

Other docs work tracked in #10221