### PR TITLE
FF80 Relnote - remove KHR_parallel_shader_compile note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/80/index.md
+++ b/files/en-us/mozilla/firefox/releases/80/index.md
@@ -42,10 +42,6 @@ _No changes_
 
 - Web Animations API compositing operations are now enabled — see [`KeyframeEffect.composite`](/en-US/docs/Web/API/KeyframeEffect/composite) and [`KeyframeEffect.iterationComposite`](/en-US/docs/Web/API/KeyframeEffect/iterationComposite) ({{bug(1652676)}}).
 
-#### WebGL
-
-- The {{domxref("KHR_parallel_shader_compile")}} [WebGL extension](/en-US/docs/Web/API/WebGL_API/Using_Extensions) is now supported ({{bug(1536674)}}).
-
 #### Removals
 
 - The `outerHeight` and `outerWidth` features of [`Window.open()`](/en-US/docs/Web/API/Window/open) are no longer exposed to web content ({{bug(1623826)}}).


### PR DESCRIPTION
This removes the FF80 release note about support for [KHR_parallel_shader_compile](https://developer.mozilla.org/en-US/docs/Web/API/KHR_parallel_shader_compile) - as per https://bugzilla.mozilla.org/show_bug.cgi?id=1736076 

Other work for this can be tracked using https://github.com/mdn/content/issues/10147