### PR TITLE
Add glossary entry for UUID

### DIFF
--- a/files/en-us/glossary/uuid/index.md
+++ b/files/en-us/glossary/uuid/index.md
@@ -5,16 +5,16 @@ tags:
   - Glossary
   - Infrastructure
 ---
-A **Universally Unique Identifier** (**UUID**) or **Globally Unique Identifier** (**GUID**) is a label used to uniquely identify a resource among all other resources of that type.
+A **Universally Unique Identifier** (**UUID**) is a label used to uniquely identify a resource among all other resources of that type.
 
-Computer systems typically generate UUIDs locally using very large random numbers, often seeded with date and/or timestamps.
-In theory these IDs may not be globally unique, but with large enough identifiers the probability of duplicates is vanishingly small.
-If systems really need absolutely unique IDs then these may be allocated by a central authority.
+Computer systems generate UUIDs locally using very large random numbers seeded with timestamp information.
+In theory the IDs may not be globally unique, but the probability of duplicates is vanishingly small.
+If systems really need absolutely unique IDs then these might be allocated by a central authority.
 
-Many different UUID schemes have been defined, using different key lengths and mechanisms to reduce duplicate identifiers.
-For example, the [`Crypto.randomUUID()`](/en-US/docs/Web/API/Crypto/randomUUID) interface returns a 36 byte "version 4 UUID" as defined in [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122#section-4.4).
-
+The "version 4" UUID is a 128-bit value that is canonically represented as a 36-character string in the format `123e4567-e89b-12d3-a456-426614174000` (5 hex strings separated by hyphens).
+Its formal definition can be found in: [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122#section-4.4).
 
 ## See also
 
 - {{Interwiki("wikipedia", "UUID")}} on Wikipedia
+- [`Crypto.randomUUID()`](/en-US/docs/Web/API/Crypto/randomUUID)

--- a/files/en-us/glossary/uuid/index.md
+++ b/files/en-us/glossary/uuid/index.md
@@ -7,12 +7,14 @@ tags:
 ---
 A **Universally Unique Identifier** (**UUID**) is a label used to uniquely identify a resource among all other resources of that type.
 
-Computer systems generate UUIDs locally using very large random numbers seeded with timestamp information.
+Computer systems generate UUIDs locally using very large random numbers, possibly seeded with timestamp or other information.
 In theory the IDs may not be globally unique, but the probability of duplicates is vanishingly small.
 If systems really need absolutely unique IDs then these might be allocated by a central authority.
 
-The "version 4" UUID is a 128-bit value that is canonically represented as a 36-character string in the format `123e4567-e89b-12d3-a456-426614174000` (5 hex strings separated by hyphens).
-Its formal definition can be found in: [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122#section-4.4).
+UUIDs are 128-bit values that are canonically represented as a 36-character string in the format `123e4567-e89b-12d3-a456-426614174000` (5 hex strings separated by hyphens).
+There are a number of versions that differ slightly in the way they are calculated; for example, the inclusion of temporal information.
+
+The formal definition can be found in: [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122).
 
 ## See also
 

--- a/files/en-us/glossary/uuid/index.md
+++ b/files/en-us/glossary/uuid/index.md
@@ -7,7 +7,7 @@ tags:
 ---
 A **Universally Unique Identifier** (**UUID**) is a label used to uniquely identify a resource among all other resources of that type.
 
-Computer systems generate UUIDs locally using very large random numbers, possibly seeded with timestamp or other information.
+Computer systems generate UUIDs locally using very large random numbers.
 In theory the IDs may not be globally unique, but the probability of duplicates is vanishingly small.
 If systems really need absolutely unique IDs then these might be allocated by a central authority.
 

--- a/files/en-us/glossary/uuid/index.md
+++ b/files/en-us/glossary/uuid/index.md
@@ -1,0 +1,20 @@
+---
+title: UUID
+slug: Glossary/UUID
+tags:
+  - Glossary
+  - Infrastructure
+---
+A **Universally Unique Identifier** (**UUID**) or **Globally Unique Identifier** (**GUID**) is a label that can be used to uniquely identify a particular resource among all other resources of that type.
+
+Computer systems typically generate UUIDs locally using very large random numbers, often seeded with date and/or timestamps.
+In theory these ids may not be globally unique, but with large enough identifiers the probability of duplicate ids is vanishingly small.
+If systems really need absolutely unique IDs then these may be allocated by a central authority.
+
+Many different UUID/GUID schemes have been defined, using different key lengths and mechanisms to reduce duplicate identifiers.
+For example, the [`Crypto.randomUUID()`](/en-US/docs/Web/API/Crypto/randomUUID) interface returns a 36 byte "version 4 UUID" as defined in [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122#section-4.4).
+
+
+## See also
+
+- {{Interwiki("wikipedia", "UUID")}} on Wikipedia

--- a/files/en-us/glossary/uuid/index.md
+++ b/files/en-us/glossary/uuid/index.md
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - Infrastructure
 ---
-A **Universally Unique Identifier** (**UUID**) or **Globally Unique Identifier** (**GUID**) is a label that can be used to uniquely identify a particular resource among all other resources of that type.
+A **Universally Unique Identifier** (**UUID**) or **Globally Unique Identifier** (**GUID**) is a label used to uniquely identify a resource among all other resources of that type.
 
 Computer systems typically generate UUIDs locally using very large random numbers, often seeded with date and/or timestamps.
 In theory these IDs may not be globally unique, but with large enough identifiers the probability of duplicates is vanishingly small.

--- a/files/en-us/glossary/uuid/index.md
+++ b/files/en-us/glossary/uuid/index.md
@@ -8,10 +8,10 @@ tags:
 A **Universally Unique Identifier** (**UUID**) or **Globally Unique Identifier** (**GUID**) is a label that can be used to uniquely identify a particular resource among all other resources of that type.
 
 Computer systems typically generate UUIDs locally using very large random numbers, often seeded with date and/or timestamps.
-In theory these ids may not be globally unique, but with large enough identifiers the probability of duplicate ids is vanishingly small.
+In theory these IDs may not be globally unique, but with large enough identifiers the probability of duplicates is vanishingly small.
 If systems really need absolutely unique IDs then these may be allocated by a central authority.
 
-Many different UUID/GUID schemes have been defined, using different key lengths and mechanisms to reduce duplicate identifiers.
+Many different UUID schemes have been defined, using different key lengths and mechanisms to reduce duplicate identifiers.
 For example, the [`Crypto.randomUUID()`](/en-US/docs/Web/API/Crypto/randomUUID) interface returns a 36 byte "version 4 UUID" as defined in [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122#section-4.4).
 
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -31,7 +31,7 @@ Values of this type are objects. They contain the following properties:
 
   - : `string`. The ID of the extension that sent the message, if the message was sent by an extension. If the sender set an ID explicitly using the [applications](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `id` will have this value. Otherwise it will have the ID that was generated for the sender.
 
-    Note that in Firefox, before version 54, this value was the extension's internal ID (that is, the [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) that appears in the extension's URL).
+    Note that in Firefox, before version 54, this value was the extension's internal ID (that is, the {{Glossary("UUID")}} that appears in the extension's URL).
 
 - `url`{{optional_inline}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -31,8 +31,6 @@ Values of this type are objects. They contain the following properties:
 
   - : `string`. The ID of the extension that sent the message, if the message was sent by an extension. If the sender set an ID explicitly using the [applications](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `id` will have this value. Otherwise it will have the ID that was generated for the sender.
 
-    Note that in Firefox, before version 54, this value was the extension's internal ID (that is, the {{Glossary("UUID")}} that appears in the extension's URL).
-
 - `url`{{optional_inline}}
 
   - : `string`. The URL of the page or frame hosting the script that sent the message.

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -183,7 +183,7 @@ When calling `tabs.remove()`:
 
 #### web_accessible_resources
 
-- **In Firefox:** Resources are assigned a random UUID that changes for every instance of Firefox: `moz-extension://«random-UUID»/«path»`. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.
+- **In Firefox:** Resources are assigned a random {{Glossary("UUID")}} that changes for every instance of Firefox: `moz-extension://«random-UUID»/«path»`. This randomness can prevent you from doing a few things, such as add your specific extension's URL to another domain's CSP policy.
 - **In Chrome:** When a resource is listed in `web_accessible_resources`, it is accessible as `chrome-extension://«your-extension-id»/«path»`. The extension ID is fixed for a given extension.
 
 #### Manifest "key" property

--- a/files/en-us/mozilla/firefox/releases/69/index.md
+++ b/files/en-us/mozilla/firefox/releases/69/index.md
@@ -19,7 +19,7 @@ This article provides information about the changes in Firefox 69 that will af
 
 - [Event Listener Breakpoints](/en-US/docs/Tools/Debugger/Set_event_listener_breakpoints) let you diagnose which code a page executes in response to browser events. You can pick specific types, such as `click` or `keydown`, or whole categories of events, like all mouse input events. ({{bug(1526082)}}).
 - Scripts shown in the debugger's  [source list pane](/en-US/docs/Tools/Debugger/UI_Tour#source_list_pane) can now be saved via the _Download file_ context menu option ({{bug(888161)}}).
-- In the debugger's source list pane, loaded extensions are listed with their name, rather than just their UUID ({{bug(1486416)}}), making it much easier to find the extension code you want to debug.
+- In the debugger's source list pane, loaded extensions are listed with their name, rather than just their {{Glossary("UUID")}} ({{bug(1486416)}}), making it much easier to find the extension code you want to debug.
 - The debugger now loads significantly faster via lazy-loading scripts ({{bug(1527488)}}).
 
 #### Console

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
@@ -14,10 +14,8 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.uuid
 ---
 {{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}
 
-The **`BluetoothRemoteGATTDescriptor.uuid`** read-only property
-returns the UUID of the characteristic descriptor, for
-example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient Characteristic
-Configuration descriptor.
+The **`BluetoothRemoteGATTDescriptor.uuid`** read-only property returns the {{Glossary("UUID")}} of the characteristic descriptor.
+For example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient Characteristic Configuration descriptor.
 
 ## Syntax
 

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Crypto.randomUUID
 ---
 {{APIRef("Web Crypto API")}}{{SecureContext_header}}
 
-The **`randomUUID()`** method of the {{domxref("Crypto")}} interface is used to generate a v4 UUID using a cryptographically secure random number generator.
+The **`randomUUID()`** method of the {{domxref("Crypto")}} interface is used to generate a v4 {{Glossary("UUID")}} using a cryptographically secure random number generator.
 
 ## Syntax
 

--- a/files/en-us/web/api/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/index.md
@@ -30,7 +30,7 @@ _This interface inherits properties from its parent, {{domxref("EventTarget")}}.
 - {{domxref("MediaStream.active")}} {{readonlyinline}}
   - : A Boolean value that returns `true` if the `MediaStream` is active, or `false` otherwise.
 - {{domxref("MediaStream.id")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} containing 36 characters denoting a universally unique identifier (UUID) for the object.
+  - : A {{domxref("DOMString")}} containing 36 characters denoting a universally unique identifier ({{Glossary("UUID")}}) for the object.
 
 ### Event handlers
 

--- a/files/en-us/web/webdriver/errors/staleelementreference/index.md
+++ b/files/en-us/web/webdriver/errors/staleelementreference/index.md
@@ -9,7 +9,8 @@ tags:
 ---
 The **stale element reference** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs because the referenced [web element](/en-US/docs/Web/WebDriver/WebElement) is no longer attached to the [DOM](/en-US/docs/Glossary/DOM).
 
-Every DOM element is represented in WebDriver by a unique identifying reference, known as a _[web element](/en-US/docs/Web/WebDriver/WebElement)_. The web element reference is a UUID used to execute commands targeting specific elements, such as [getting an element’s tag name](/en-US/docs/Web/WebDriver/Commands/GetElementTagName) and [retrieving a property](/en-US/docs/Web/WebDriver/Commands/GetElementProperty) off an element.
+Every DOM element is represented in WebDriver by a unique identifying reference, known as a _[web element](/en-US/docs/Web/WebDriver/WebElement)_.
+The web element reference is a {{Glossary("UUID")}} used to execute commands targeting specific elements, such as [getting an element’s tag name](/en-US/docs/Web/WebDriver/Commands/GetElementTagName) and [retrieving a property](/en-US/docs/Web/WebDriver/Commands/GetElementProperty) off an element.
 
 When an element is no longer attached to the DOM, i.e. it has been removed from the document or the document has changed, it is said to be _stale_. Staleness occurs for example when you have a web element reference and the document it was retrieved from navigates.
 


### PR DESCRIPTION
Commonly we link to wikipedia, which is a relatively poor entry. I've created an entry and linked to it from some places - in particular Crypto.randomUUID() following discussion here: https://github.com/mdn/content/pull/10198#discussion_r740149450

Note I didn't link from the millions of BluetoothUUID instances. There are so many, and perhaps it has a special meaning we should capture in the glossary too.