### PR TITLE
Update See Also with focusin/focusout

### DIFF
--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -137,3 +137,5 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
 
 - {{domxref("HTMLElement.blur")}} to remove the focus from an element.
 - {{domxref("document.activeElement")}} to know which is the currently focused element.
+- {{domxref("Element.focusin")}} Fired when an element is about to gain focus.
+- {{domxref("Element.focusout")}} Fired when an element is about to lose focus.

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -137,5 +137,5 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
 
 - {{domxref("HTMLElement.blur")}} to remove the focus from an element.
 - {{domxref("document.activeElement")}} to know which is the currently focused element.
-- {{domxref("Element/focusin_event", "focusin")}} Fired when an element is about to gain focus.
-- {{domxref("Element/focusout_event", "focusout")}} Fired when an element is about to lose focus.
+- {{domxref("Element/focusin_event", "focusin")}} event: fired when an element is about to gain focus.
+- {{domxref("Element/focusout_event", "focusout")}} event: fired when an element is about to lose focus.

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -137,5 +137,5 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
 
 - {{domxref("HTMLElement.blur")}} to remove the focus from an element.
 - {{domxref("document.activeElement")}} to know which is the currently focused element.
-- {{domxref("Element.focusin")}} Fired when an element is about to gain focus.
-- {{domxref("Element.focusout")}} Fired when an element is about to lose focus.
+- {{domxref("Element/focusin_event", "focusin")}} Fired when an element is about to gain focus.
+- {{domxref("Element/focusout_event", "focusout")}} Fired when an element is about to lose focus.


### PR DESCRIPTION
Fixes #10008

Update See Also with focusin/focusout
```diff
+ - {{domxref("Element/focusin_event", "focusin")}} Fired when an element is about to gain focus.
+ - {{domxref("Element/focusout_event", "focusout")}} Fired when an element is about to lose focus.
```