### PR TITLE
Aria tooltip role - Fix typo in aria-label

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
@@ -33,7 +33,7 @@ The tooltip is not considered a popup in terms of the the `aria-haspopup` proper
 
 Though a tooltip may appear and disapper, as it this appearance is automatic and not intentionally controlled by the user, the `aria-expanded` role is not supported. 
 
-The accessible name of a tooltip can come from the contents, or from an `aria-lable` or `aria-labelledby`.
+The accessible name of a tooltip can come from the contents, or from an `aria-label` or `aria-labelledby`.
 
 ### Associated WAI-ARIA roles, states, and properties
 


### PR DESCRIPTION
#### Aria tooltip role - Fix typo in aria-label

#### Motivation
There's a typo in the Description section of the doc where the attribute `aria-label` is incorrectly spelled as `aria-lable`. This patch fixes the typo.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
