### PR TITLE
fix a word

### DIFF
--- a/files/en-us/web/api/audioparam/index.md
+++ b/files/en-us/web/api/audioparam/index.md
@@ -35,7 +35,7 @@ A _k-rate_ `AudioParam` uses the same initial audio parameter value for the whol
 ## Properties
 
 - {{domxref("AudioParam.defaultValue")}} {{readonlyInline}}
-  - : Represents the initial volume of the attribute as defined by the specific {{domxref("AudioNode")}} creating the `AudioParam`.
+  - : Represents the initial value of the attribute as defined by the specific {{domxref("AudioNode")}} creating the `AudioParam`.
 - {{domxref("AudioParam.maxValue")}} {{readonlyInline}}
   - : Represents the maximum possible value for the parameter's nominal (effective) range.
 - {{domxref("AudioParam.minValue")}} {{readonlyinline}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I changed a word which seems not appropriate.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
[AudioParam document](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam#properties) says `defaultValue` represents the initial **volume**, while [defaultValue document](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/defaultValue) says it represents the initial **value**, which are different descriptions and it seems the latter is correct.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
none
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
none
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
