### PR TITLE
Remove instant mention

### DIFF
--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -37,7 +37,7 @@ element.scrollTo(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`auto`, default).
 
 ## Examples
 

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -37,7 +37,7 @@ element.scrollTo(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`auto`, default).
+      - : Specifies whether the scrolling should animate smoothly (`smooth`), or happen instantly in a single jump (`auto`, the default value).
 
 ## Examples
 


### PR DESCRIPTION
Fixes #10265
Intended page : [Element.scrollTo()](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo)

According to W3C CSSOM View Module :
Currently under section "[Changes From 17 December 2013](https://drafts.csswg.org/cssom-view/#changes-from-2013-12-17)" there is a note:
>The instant value of scroll-behavior was renamed to auto.

[And](https://drafts.csswg.org/css-overflow-3/#valdef-scroll-behavior-auto),
> 'auto' : 
The scrolling box is scrolled in an instant fashion.

I propose this change :

**behavior** :
```diff
- - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+ - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`auto`, default).
```