### PR TITLE
onerror: Document that `error` field can be null

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onerror/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.md
@@ -37,7 +37,7 @@ Function parameters:
 - `source`: URL of the script where the error was raised (string)
 - `lineno`: Line number where error was raised (number)
 - `colno`: Column number for the line where the error occurred (number)
-- `error`: [Error Object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) (object)
+- `error`: [Error Object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) (object). May be `null` if no corresponding Error Object is available.
 
 When the function returns `true`, this prevents the firing of the default event handler.
 


### PR DESCRIPTION
#### Summary

Fix https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#window.addeventlistenererror, documenting that the `error` field can be `null`.

Evidence:

* Linked from https://stackoverflow.com/questions/7099127/get-the-actual-javascript-error-object-with-window-onerror, the spec:
  * https://github.com/whatwg/html/commit/fe7e3504a350727b71d9888aeb77c938beec6ec3

#### Motivation

My app's page went blank because I assumed that `error` cannot be null, as TypeScript also thought that correspondingly.


#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
