### PR TITLE
Document conditions for popup-opening by window.open, and BarProp values

### DIFF
--- a/files/en-us/web/api/barprop/visible/index.md
+++ b/files/en-us/web/api/barprop/visible/index.md
@@ -21,11 +21,16 @@ let visible = BarProp.visible;
 
 ### Value
 
-A {{jsxref("Boolean")}}, which is true if the bar represented by the used interface element is visible.
+A {{jsxref("Boolean")}}, which is true if the top-level window is opened by
+{{domxref("window.open")}} with {{domxref("window.open", "requesting a popup window", "#popup_feature", 1)}}.
+
+> **Note:** Historically this represented whether the used interface element is visible
+> or not. For privacy reasons, this no more represent the actual visibility of each
+> interface element.
 
 ## Examples
 
-The following example prints `true` to the console if the location bar is visible, `false` if it is not.
+The following example prints `true` to the console if the window is not a popup.
 
 ```js
 console.log(window.locationbar.visible);

--- a/files/en-us/web/api/barprop/visible/index.md
+++ b/files/en-us/web/api/barprop/visible/index.md
@@ -22,10 +22,10 @@ let visible = BarProp.visible;
 ### Value
 
 A {{jsxref("Boolean")}}, which is true if the top-level window is opened by
-{{domxref("window.open")}} with {{domxref("window.open", "requesting a popup window", "popup_feature", 1)}}.
+{{domxref("window.open")}} with the {{domxref("window.open", "requesting a popup window", "popup_feature", 1)}}.
 
-> **Note:** Historically this represented whether the used interface element is visible
-> or not. For privacy reasons, this no more represent the actual visibility of each
+> **Note:** Historically this represented whether the interface element used is visible
+> or not. But for privacy reasons, this no longer represents the actual visibility of each
 > interface element.
 
 ## Examples

--- a/files/en-us/web/api/barprop/visible/index.md
+++ b/files/en-us/web/api/barprop/visible/index.md
@@ -22,7 +22,7 @@ let visible = BarProp.visible;
 ### Value
 
 A {{jsxref("Boolean")}}, which is true if the top-level window is opened by
-{{domxref("window.open")}} with {{domxref("window.open", "requesting a popup window", "#popup_feature", 1)}}.
+{{domxref("window.open")}} with {{domxref("window.open", "requesting a popup window", "popup_feature", 1)}}.
 
 > **Note:** Historically this represented whether the used interface element is visible
 > or not. For privacy reasons, this no more represent the actual visibility of each

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -150,7 +150,7 @@ by specifying feature names either using _name=value_ pairs, or for boolean feat
 If any feature names are given, and the `popup` feature name is not given, it requests that the browser
 use a minimal pop-up window for the secondary window.
 
-> **Note:** In some browsers, users can override this behavior. Also this also has no effect in
+> **Note:** In some browsers, users can override this behavior. Also, it has no effect in
 > mobile browsers, which lack the concept of windows.
 
 [Note on position and

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -50,7 +50,7 @@ var window = window.open(url, windowName, [windowFeatures]);
 
 - `windowFeatures` {{optional_inline}}
   - : A {{domxref("DOMString")}} containing a comma-separated list of window features
-    given with their corresponding values in the form "name=value", or "name" for boolean feature. These
+    given with their corresponding values in the form "name=value", or "name" for boolean features. These
     features include options such as the window's default size and position, whether or
     not to open a minimal-popup window, and so forth. See {{anch("Window features")}}
     below for documentation of each of the features that can be specified.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -151,7 +151,7 @@ Otherwise:
 ### Position and size features
 
 You can use the _windowFeatures_ parameter to control the position and size of the new secondary window,
-by specifying feature names either using _name=value_ pairs, or for boolean features, using just a _name_.
+by specifying feature names using _name=value_ pairs.
 If any feature names are given, and the `popup` feature name is not given, it requests that the browser
 use a minimal pop-up window for the secondary window.
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -209,7 +209,7 @@ of the most recently rendered window.
 
 > **Warning:** These features are kept only for backward compatibility.
 > In modern browsers (Firefox 76 or newer, Google Chrome, Safari, Chromium Edge), the
-> following features are just a condition for whether to open popup or not. See [popup condition](#popup_condition) section.
+> following features are just a condition for whether to open popup or not. See the [popup condition](#popup_condition) section.
 
 The following features control the visibility of each UI parts, these features can also
 be set to `yes` or `1`, or just be present to be on. Set them to `no` or `0`, or in most

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -134,7 +134,12 @@ To enable the feature, specify `popup` either with no value at all, or else set 
 
 Example: `popup=yes`, `popup=1`, and `popup` have identical results.
 
-To disable the feature, ether don’t specify it all all (omit it), or else set it to `no` or `0`.
+Otherwise:
+
+* To not request a popup, omit the _windowFeatures_ parameter.
+* Otherwise:
+   * Specifying any features other than `noopener` or `noreferer` has the effect of also requesting a popup.
+   * Otherwise, no popup is requested.
 
 - `popup`
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -150,7 +150,7 @@ Otherwise:
 
 ### Position and size features
 
-The _windowFeatures_ parameter can specify the position and size of the new secondary window,
+You can use the _windowFeatures_ parameter to control the position and size of the new secondary window,
 by specifying feature names either using _name=value_ pairs, or for boolean features, using just a _name_.
 If any feature names are given, and the `popup` feature name is not given, it requests that the browser
 use a minimal pop-up window for the secondary window.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -209,7 +209,7 @@ of the most recently rendered window.
 
 > **Warning:** These features are kept only for backward compatibility.
 > In modern browsers (Firefox 76 or newer, Google Chrome, Safari, Chromium Edge), the
-> following features are just a condition for whether to open popup or not. See the [popup condition](#popup_condition) section.
+> following features are just a condition for whether to open a popup or not. See the [popup condition](#popup_condition) section.
 
 The following features control the visibility of each UI parts, these features can also
 be set to `yes` or `1`, or just be present to be on. Set them to `no` or `0`, or in most

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -52,7 +52,7 @@ var window = window.open(url, windowName, [windowFeatures]);
   - : A {{domxref("DOMString")}} containing a comma-separated list of window features
     given with their corresponding values in the form _name=value_ — or for boolean features, just _name_. These
     features include options such as the window's default size and position, whether or
-    not to open a minimal-popup window, and so forth. See {{anch("Window features")}}
+    not to open a minimal popup window, and so forth. See {{anch("Window features")}}
     below for documentation of each of the features that can be specified.
 
 ### Return value

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -122,24 +122,25 @@ main window.
 
 ### Popup feature
 
-`windowFeatures` can be used to explicitly request the browser to use a popup window,
-that has minimal UI parts, for the new secondary window.
+`windowFeatures` can be used to explicitly request that the browser use a popup window
+with minimal UI parts for the new secondary window.
 
-Whether or not to use a popup window affects {{domxref("BarProp.visible")}} value.
+Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} value.
 
-> **Note:** In some browsers, users can configure not to use a popup window.  Also, some
+> **Note:** In some browsers, users can configure the browser to not to use a popup window.  Also, some
 > browsers, such as mobile browsers, don't have the concept of windows.
 
-The feature can be set to `yes` or `1`, or just be present to be on. Set them to
-`no` or `0`, or in most cases just omit them, to be off.
+To enable the feature, specify `popup` either with no value at all, or else set it to `yes` or `1`.
 
 Example: `popup=yes`, `popup=1`, and `popup` have identical results.
 
+To disable the feature, ether don’t specify it all all (omit it), or else set it to `no` or `0`.
+
 - `popup`
 
-  - : If this feature is present and on, it requests the browser to use a minimal pop-up
+  - : If this feature is present and enabled, it requests that the browser use a minimal pop-up
       window for the new secondary window.
-      If this feature is present and off, it requests the browser not to use minimal
+      If this feature is not present, or is present and disabled, it requests that the browser not use a minimal
       pop-up window for the secondary window.
 
 ### Position and size features

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -130,23 +130,23 @@ Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} 
 > **Note:** In some browsers, users can configure the browser to not to use a popup window. Also, some
 > browsers, such as mobile browsers, don't have the concept of windows.
 
-To enable the feature, specify `popup` either with no value at all, or else set it to `yes` or `1`.
-
-Example: `popup=yes`, `popup=1`, and `popup` have identical results.
-
-Otherwise:
-
-* To not request a popup, omit the _windowFeatures_ parameter.
-* Otherwise:
-   * Specifying any features other than `noopener` or `noreferer` has the effect of also requesting a popup.
-   * Otherwise, no popup is requested.
-
 - `popup`
 
   - : If this feature is present and enabled, it requests that the browser use a minimal pop-up
       window for the new secondary window.
       If this feature is not present, or is present and disabled, it requests that the browser not use a minimal
       pop-up window for the secondary window.
+
+To enable the feature, specify `popup` either with no value at all, or else set it to `yes` or `1`.
+
+Example: `popup=yes`, `popup=1`, and `popup` all have identical results.
+
+Otherwise:
+
+* To not request a popup, omit the _windowFeatures_ parameter.
+* Otherwise:
+   * Specifying any features in the _windowFeatures_ parameter other than `noopener` or `noreferer` has the effect of also requesting a popup.
+   * Otherwise, no popup is requested.
 
 ### Position and size features
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -122,7 +122,7 @@ main window.
 
 ### Popup feature
 
-The _windowFeatures_ features parameter can be used to explicitly request that the browser use a popup window
+The _windowFeatures_ parameter can be used to explicitly request that the browser use a popup window
 with minimal UI parts for the new secondary window.
 
 Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} value.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -127,7 +127,7 @@ with minimal UI parts for the new secondary window.
 
 Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} value.
 
-> **Note:** In some browsers, users can configure the browser to not to use a popup window.  Also, some
+> **Note:** In some browsers, users can configure the browser to not to use a popup window. Also, some
 > browsers, such as mobile browsers, don't have the concept of windows.
 
 To enable the feature, specify `popup` either with no value at all, or else set it to `yes` or `1`.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -211,9 +211,9 @@ of the most recently rendered window.
 > In modern browsers (Firefox 76 or newer, Google Chrome, Safari, Chromium Edge), the
 > following features are just a condition for whether to open a popup or not. See the [popup condition](#popup_condition) section.
 
-The following features control the visibility of each UI parts, these features can also
-be set to `yes` or `1`, or just be present to be on. Set them to `no` or `0`, or in most
-cases just omit them, to be off.
+The following features control the visibility of each UI part.
+To enable them, either specify them with no value at all, or else set them to `yes` or `1`.
+To disable them, either omit them, or else set them to `no` or `0`.
 
 - `menubar`
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -681,7 +681,7 @@ UI-related items of `windowFeatures` are used as a condition to
 whether opening a popup or a new tab, or a new window, and UI parts visibility of each
 of them is fixed.
 
-The detailed condition is described in ["To check if a popup window is requested"](https://html.spec.whatwg.org/#popup-window-is-requested) section in the spec.
+The condition is described in detail in the ["To check if a popup window is requested"](https://html.spec.whatwg.org/multipage/window-object.html#popup-window-is-requested) section in the spec.
 
 ### Note on scrollbars
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -50,11 +50,10 @@ var window = window.open(url, windowName, [windowFeatures]);
 
 - `windowFeatures` {{optional_inline}}
   - : A {{domxref("DOMString")}} containing a comma-separated list of window features
-    given with their corresponding values in the form "name=value". These features include
-    options such as the window's default size and position, whether or not to include
-    toolbar, and so forth. There must be no whitespace in the string. See
-    {{anch("Window features")}} below for documentation of each of the features that can
-    be specified.
+    given with their corresponding values in the form "name=value", or "name" for boolean feature. These
+    features include options such as the window's default size and position, whether or
+    not to open a minimal-popup window, and so forth. See {{anch("Window features")}}
+    below for documentation of each of the features that can be specified.
 
 ### Return value
 
@@ -82,7 +81,7 @@ creation and the loading of the referenced resource are done asynchronously.
 
 ```js
 var windowObjectReference;
-var windowFeatures = "menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes";
+var windowFeatures = "popup";
 
 function openRequestedPopup() {
   windowObjectReference = window.open("http://www.cnn.com/", "CNN_WindowName", windowFeatures);
@@ -96,7 +95,7 @@ function openRequestedPopup() {
   windowObjectReference = window.open(
     "http://www.domainname.ext/path/ImageFile.png",
     "DescriptiveWindowName",
-    "resizable,scrollbars,status"
+    "left=100,top=100,width=320,heigth=320"
   );
 }
 ```
@@ -121,15 +120,36 @@ parameter is not provided (or if the `windowFeatures` parameter is
 an empty string), then the new secondary window will render the default toolbars of the
 main window.
 
-> **Note:** In some browsers, users can override the
-> `windowFeatures` settings and enable (or prevent the disabling
-> of) features. Further, control of some window features is available only on some browsers
-> and platforms (See [popup condition](#popup_condition) section)
+### Popup feature
+
+`windowFeatures` can be used to explicitly request the browser to use a popup window,
+that has minimal UI parts, for the new secondary window.
+
+Whether or not to use a popup window affects {{domxref("BarProp.visible")}} value.
+
+> **Note:** In some browsers, users can configure not to use a popup window.  Also, some
+> browsers, such as mobile browsers, don't have the concept of windows.
+
+The feature can be set to `yes` or `1`, or just be present to be on. Set them to
+`no` or `0`, or in most cases just omit them, to be off.
+
+Example: `popup=yes`, `popup=1`, and `popup` have identical results.
+
+- `popup`
+
+  - : If this feature is present and on, it requests the browser to use a minimal pop-up
+      window for the new secondary window.
+      If this feature is present and off, it requests the browser not to use minimal
+      pop-up window for the secondary window.
 
 ### Position and size features
 
-`windowFeatures` parameter can specify the position and size of
-the new window.
+`windowFeatures` parameter can specify the position and size of the new secondary window.
+If any of them are given, and the `popup` feature is not given, it requests the browser
+to use a minimal pop-up window for the secondary window.
+
+> **Note:** In some browsers, users can override the behavior. Also this has no effect on
+> the mobile browsers without the concept of windows.
 
 [Note on position and
 dimension error correction](#note_on_position_and_dimension_error_correction)
@@ -178,31 +198,15 @@ If the `windowFeatures` parameter is non-empty and no size
 features are defined, then the new window dimensions will be the same as the dimensions
 of the most recently rendered window.
 
-### Browser-dependent size features
-
-> **Warning:** Do not use them.
-
-- `outerWidth` {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)
-  - : Specifies the width of the whole browser window in pixels. This
-    `outerWidth` value includes the window vertical scrollbar (if present) and
-    left and right window resizing borders.
-- `outerHeight` {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)
-  - : Specifies the height of the whole browser window in pixels. This
-    `outerHeight` value includes any/all present toolbar, window horizontal
-    scrollbar (if present) and top and bottom window resizing borders. Minimal required
-    value is 100.
-
 ### Toolbar and UI parts features
 
-> **Warning:** In modern browsers (Firefox 76 or newer, Google Chrome, Safari, Chromium Edge), the
+> **Warning:** These features are kept only for backward compatibility.
+> In modern browsers (Firefox 76 or newer, Google Chrome, Safari, Chromium Edge), the
 > following features are just a condition for whether to open popup or not. See [popup condition](#popup_condition) section.
 
-The following features control the visibility of each UI parts, All features can be set
-to `yes` or `1`, or just be present to be on. Set them to
-`no` or `0`, or in most cases just omit them, to be off.
-
-Example: `status=yes`, `status=1`, and `status` have
-identical results.
+The following features control the visibility of each UI parts, these features can also
+be set to `yes` or `1`, or just be present to be on. Set them to `no` or `0`, or in most
+cases just omit them, to be off.
 
 - `menubar`
 
@@ -305,7 +309,7 @@ function openFFPromotionPopup() {
 
   {
     windowObjectReference = window.open("http://www.spreadfirefox.com/",
-   "PromoteFirefoxWindowName", "resizable,scrollbars,status");
+   "PromoteFirefoxWindowName", "popup");
     /* then create it. The new window will be created and
        will be brought on top of any other window. */
   }
@@ -357,8 +361,7 @@ var windowObjectReference = null; // global variable
 
 function openRequestedPopup(url, windowName) {
   if(windowObjectReference == null || windowObjectReference.closed) {
-    windowObjectReference = window.open(url, windowName,
-           "resizable,scrollbars,status");
+    windowObjectReference = window.open(url, windowName, "popup");
   } else {
     windowObjectReference.focus();
   };
@@ -387,10 +390,10 @@ var PreviousUrl; /* global variable that will store the
 function openRequestedSinglePopup(url) {
   if(windowObjectReference == null || windowObjectReference.closed) {
     windowObjectReference = window.open(url, "SingleSecondaryWindowName",
-         "resizable,scrollbars,status");
+         "popup");
   } else if(PreviousUrl != url) {
     windowObjectReference = window.open(url, "SingleSecondaryWindowName",
-      "resizable=yes,scrollbars=yes,status=yes");
+      "popup");
     /* if the resource to load is different,
        then we load it in the already opened secondary window and then
        we bring such window back on top/in front of its parent window. */
@@ -671,7 +674,7 @@ UI-related items of `windowFeatures` are used as a condition to
 whether opening a popup or a new tab, or a new window, and UI parts visibility of each
 of them is fixed.
 
-The condition is implementation-dependent and not guaranteed to be stable.
+The detailed condition is described in ["To check if a popup window is requested"](https://html.spec.whatwg.org/#popup-window-is-requested) section in the spec.
 
 ### Note on scrollbars
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -50,7 +50,7 @@ var window = window.open(url, windowName, [windowFeatures]);
 
 - `windowFeatures` {{optional_inline}}
   - : A {{domxref("DOMString")}} containing a comma-separated list of window features
-    given with their corresponding values in the form "name=value", or "name" for boolean features. These
+    given with their corresponding values in the form _name=value_ — or for boolean features, just _name_. These
     features include options such as the window's default size and position, whether or
     not to open a minimal-popup window, and so forth. See {{anch("Window features")}}
     below for documentation of each of the features that can be specified.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -145,12 +145,13 @@ To disable the feature, ether don’t specify it all all (omit it), or else set 
 
 ### Position and size features
 
-`windowFeatures` parameter can specify the position and size of the new secondary window.
-If any of them are given, and the `popup` feature is not given, it requests the browser
-to use a minimal pop-up window for the secondary window.
+The _windowFeatures_ parameter can specify the position and size of the new secondary window,
+by specifying feature names either using _name=value_ pairs, or for boolean features, using just a _name_.
+If any feature names are given, and the `popup` feature name is not given, it requests that the browser
+use a minimal pop-up window for the secondary window.
 
-> **Note:** In some browsers, users can override the behavior. Also this has no effect on
-> the mobile browsers without the concept of windows.
+> **Note:** In some browsers, users can override this behavior. Also this also has no effect in
+> mobile browsers, which lack the concept of windows.
 
 [Note on position and
 dimension error correction](#note_on_position_and_dimension_error_correction)

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -122,7 +122,7 @@ main window.
 
 ### Popup feature
 
-The _windowFeatures_ parameter can be used to explicitly request that the browser use a popup window
+You can specify the _windowFeatures_ parameter to explicitly request that the browser use a popup window
 with minimal UI parts for the new secondary window.
 
 Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} value.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -134,7 +134,7 @@ Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} 
 
   - : If this feature is present and enabled, it requests that the browser use a minimal pop-up
       window for the new secondary window.
-      If this feature is not present, or is present and disabled, it requests that the browser not use a minimal
+      If this feature is present and disabled, it requests that the browser not use a minimal
       pop-up window for the secondary window.
 
 To enable the feature, specify `popup` either with no value at all, or else set it to `yes` or `1`.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -122,7 +122,7 @@ main window.
 
 ### Popup feature
 
-`windowFeatures` can be used to explicitly request that the browser use a popup window
+The _windowFeatures_ features parameter can be used to explicitly request that the browser use a popup window
 with minimal UI parts for the new secondary window.
 
 Whether or not to use a popup window affects the {{domxref("BarProp.visible")}} value.

--- a/files/en-us/web/api/window/open/obsolete_features/index.md
+++ b/files/en-us/web/api/window/open/obsolete_features/index.md
@@ -13,3 +13,13 @@ This page lists the obsolete `windowFeatures` parameter of [window.open](/en-US/
 - `personalbar` {{deprecated_inline}}
   - : If this feature is on, then the new secondary window renders the Personal Toolbar in Netscape 6.x, Netscape 7.x and Mozilla browser. It renders the Bookmarks Toolbar in Firefox. In addition to the Personal Toolbar, Mozilla browser will render the Site Navigation Bar if such toolbar is visible, present in the parent window.
     Mozilla and Firefox users can force new windows to always render the Personal Toolbar/Bookmarks toolbar by setting `dom.disable_window_open_feature.personalbar` to _true_ in [about:config](http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config) or in their [user.js file](http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js).
+- `outerWidth` {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)
+  - : Specifies the width of the whole browser window in pixels. This
+    `outerWidth` value includes the window vertical scrollbar (if present) and
+    left and right window resizing borders.
+- `outerHeight` {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)
+  - : Specifies the height of the whole browser window in pixels. This
+    `outerHeight` value includes any/all present toolbar, window horizontal
+    scrollbar (if present) and top and bottom window resizing borders. Minimal required
+    value is 100.
+

--- a/files/en-us/web/api/window/open/obsolete_features/index.md
+++ b/files/en-us/web/api/window/open/obsolete_features/index.md
@@ -13,13 +13,13 @@ This page lists the obsolete `windowFeatures` parameter of [window.open](/en-US/
 - `personalbar` {{deprecated_inline}}
   - : If this feature is on, then the new secondary window renders the Personal Toolbar in Netscape 6.x, Netscape 7.x and Mozilla browser. It renders the Bookmarks Toolbar in Firefox. In addition to the Personal Toolbar, Mozilla browser will render the Site Navigation Bar if such toolbar is visible, present in the parent window.
     Mozilla and Firefox users can force new windows to always render the Personal Toolbar/Bookmarks toolbar by setting `dom.disable_window_open_feature.personalbar` to _true_ in [about:config](http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config) or in their [user.js file](http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js).
-- `outerWidth` {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)
-  - : Specifies the width of the whole browser window in pixels. This
+- `outerWidth` {{deprecated_inline}} (only in Firefox; obsolete from Firefox 80)
+  - : Specifies the width of the whole browser window, in pixels. This
     `outerWidth` value includes the window vertical scrollbar (if present) and
     left and right window resizing borders.
-- `outerHeight` {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)
-  - : Specifies the height of the whole browser window in pixels. This
-    `outerHeight` value includes any/all present toolbar, window horizontal
-    scrollbar (if present) and top and bottom window resizing borders. Minimal required
+- `outerHeight` {{deprecated_inline}} (only in Firefox; obsolete from Firefox 80)
+  - : Specifies the height of the whole browser window, in pixels. This
+    `outerHeight` value includes any and all present toolbars, the window horizontal
+    scrollbar (if present), and top and bottom window-resizing borders. The minimal required
     value is 100.
 


### PR DESCRIPTION
for https://github.com/whatwg/html/pull/6530

 * Added popup feature
 * Added description about requesting popup
 * Changed examples not to use the backward-compat-only UI parts features
 * Updated BarProp.visible to reflect popup request
 * Moved outerWidth/outerHeight to obsolete features page

#### Summary

Update `windowFeatures` parameter behavior for `window.open`, and also `BarProp.visible` behavior, to follow the spec change in https://github.com/whatwg/html/pull/6530.

#### Motivation

Reflect the latest spec.

#### Supporting details

Firefox: fixed in 96 (currently Nightly) https://bugzilla.mozilla.org/show_bug.cgi?id=1701001
Chrome: in progress https://bugs.chromium.org/p/chromium/issues/detail?id=1192701
Safari: bug is filed https://bugs.webkit.org/show_bug.cgi?id=223751

#### Related issues

 * https://github.com/mdn/browser-compat-data/pull/13322

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
