### PR TITLE
Issue with "Client-side storage"

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -304,7 +304,7 @@ Now let's look at what we have to do in the first place, to actually set up a da
 
     To handle this in IndexedDB, you create a request object (which can be called anything you like — we called it `request` so it is obvious what it is for). You then use event handlers to run code when the request completes, fails, etc., which you'll see in use below.
 
-    > **Note:** The version number is important. If you want to upgrade your database (for example, by changing the table structure), you have to run your code again with an increased version number, different schema specified inside the `onupgradeneeded` handler (see below), etc. We won't cover upgrading databases in this simple tutorial.
+    > **Note:** The version number is important. If you want to upgrade your database (for example, by changing the table structure), you have to run your code again with an increased version number, different schema specified inside the `onupgradeneeded` handler (see below), etc. We won't cover upgrading databases in this simple tutorial. However, try using higher version numbers if your browser throws the following error: `Uncaught DOMException: IDBDatabase.transaction: ‘notes_os’ is not a known object store name`.
 
 4.  Now add the following event handlers just below your previous addition — again inside the `window.onload` handler:
 


### PR DESCRIPTION
Using version '1' to open the 'indexedDB' [1] kept throwing the error of not knowing the object store name [2]. However, it worked just fine in chromium. Maybe it was because I have already tried executing the `js` code as I was going with the tutorial, and did not use the complete `js` file from the beginning. Anyways, I came up with this solution: just upgrade the database version.

Footnotes:
----------
[1] let request = window.indexedDB.open('notes_db', 1);
[2] Uncaught DOMException: IDBDatabase.transaction: ‘notes_os’ is not a known object store name

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Update a note to increment the database version which might help fix the following error: `Uncaught DOMException: IDBDatabase.transaction: ‘notes_os’ is not a known object store name`
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'd expect following MDN tutorials to be easy, and address problems and errors that may rise. I even found out that [others](https://discourse.mozilla.org/t/help-wanted-on-client-side-storage-indexeddb/66241) have been facing this problem, but they didn't post a valid answer.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://discourse.mozilla.org/t/help-wanted-on-client-side-storage-indexeddb/66241
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
