### PR TITLE
Element methods section – Fix return type of Element.getAttribute(), .getAttributeNS()

### DIFF
--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -213,7 +213,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.getAnimations()")}} {{Experimental_Inline}}
   - : Returns an array of Animation objects currently active on the element.
 - {{DOMxRef("Element.getAttribute()")}}
-  - : Retrieves the value of the named attribute from the current node and returns it as an {{jsxref("Object")}}.
+  - : Retrieves the value of the named attribute from the current node and returns it as a string.
 - {{DOMxRef("Element.getAttributeNames()")}}
   - : Returns an array of attribute names from the current element.
 - {{DOMxRef("Element.getAttributeNode()")}}
@@ -221,7 +221,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.getAttributeNodeNS()")}}
   - : Retrieves the node representation of the attribute with the specified name and namespace, from the current node and returns it as an {{DOMxRef("Attr")}}.
 - {{DOMxRef("Element.getAttributeNS()")}}
-  - : Retrieves the value of the attribute with the specified name and namespace, from the current node and returns it as an {{jsxref("Object")}}.
+  - : Retrieves the value of the attribute with the specified namespace and name from the current node and returns it as a string.
 - {{DOMxRef("Element.getBoundingClientRect()")}}
   - : Returns the size of an element and its position relative to the viewport.
 - {{domxref("Element.getBoxQuads()")}} {{experimental_inline}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Content currently states the `.getAttribute()` and `.getAttributeNS()` return `Object` but they return a primitive `string`

#### Motivation
MDN is a great source of truth – fixing a small typo :)

#### Supporting details
- [`.getAttributeNS()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNS#return_value)
- [`.getAttribute()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute#syntax)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
