### PR TITLE
Fix up title bug in hyperlink page

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
+++ b/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
@@ -18,7 +18,8 @@ tags:
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML")}}
 
-Hyperlinks are really important — they are what makes the Web _a web_. This article shows the syntax required to make a link, and discusses link best practices.
+Hyperlinks are really important — they are what makes the Web _a web_.
+This article shows the syntax required to make a link, and discusses link best practices.
 
 <table>
   <tbody>
@@ -47,9 +48,13 @@ Hyperlinks are really important — they are what makes the Web _a web_. This ar
 
 ## What is a hyperlink?
 
-Hyperlinks are one of the most exciting innovations the Web has to offer. They've been a feature of the Web since the beginning, and are what makes the Web _a web._ Hyperlinks allow us to link documents to other documents or resources, link to specific parts of documents, or make apps available at a web address. Almost any web content can be converted to a link so that when clicked or otherwise activated the web browser goes to another web address ({{glossary("URL")}}).
+Hyperlinks are one of the most exciting innovations the Web has to offer.
+They've been a feature of the Web since the beginning, and are what makes the Web _a web._
+Hyperlinks allow us to link documents to other documents or resources, link to specific parts of documents, or make apps available at a web address.
+Almost any web content can be converted to a link so that when clicked or otherwise activated the web browser goes to another web address ({{glossary("URL")}}).
 
-> **Note:** A URL can point to HTML files, text files, images, text documents, video and audio files, or anything else that lives on the Web. If the web browser doesn't know how to display or handle the file, it will ask you if you want to open the file (in which case the duty of opening or handling the file is passed to a suitable native app on the device) or download the file (in which case you can try to deal with it later on).
+> **Note:** A URL can point to HTML files, text files, images, text documents, video and audio files, or anything else that lives on the Web.
+> If the web browser doesn't know how to display or handle the file, it will ask you if you want to open the file (in which case the duty of opening or handling the file is passed to a suitable native app on the device) or download the file (in which case you can try to deal with it later on).
 
 For example, the BBC homepage contains many links that point not only to multiple news stories, but also different areas of the site (navigation functionality), login/registration pages (user tools), and more.
 
@@ -71,7 +76,8 @@ I'm creating a link to [the Mozilla homepage](https://www.mozilla.org/en-US/).
 
 ### Adding supporting information with the title attribute
 
-Another attribute you may want to add to your links is `title`. The title contains additional information about the link, such as which kind of information the page contains, or things to be aware of on the web site.
+Another attribute you may want to add to your links is `title`.
+The title contains additional information about the link, such as which kind of information the page contains, or things to be aware of on the web site.
 
 ```html
 <p>I'm creating a link to
@@ -81,11 +87,12 @@ Another attribute you may want to add to your links is `title`. The title contai
 </p>
 ```
 
-This gives us the following result and hovering over the link displays the title as a tooltip.
+This gives us the following result and hovering over the link displays the title as a tooltip:
 
-I'm creating a link to [the Mozilla homepage](https://www.mozilla.org/en-US/).
+I'm creating a link to <a href="https://www.mozilla.org/en-US/" title="The best place to find more information about Mozilla's mission and how to contribute">the Mozilla homepage</a>.
 
-> **Note:** A link title is only revealed on mouse hover, which means that people relying on keyboard controls or touchscreens to navigate web pages will have difficulty accessing title information. If a title's information is truly important to the usability of the page, then you should present it in a manner that will be accessible to all users, for example by putting it in the regular text.
+> **Note:** A link title is only revealed on mouse hover, which means that people relying on keyboard controls or touchscreens to navigate web pages will have difficulty accessing title information.
+> If a title's information is truly important to the usability of the page, then you should present it in a manner that will be accessible to all users, for example by putting it in the regular text.
 
 ### Active learning: creating your own example link
 
@@ -97,7 +104,8 @@ Create an HTML document using your local code editor and our [getting started te
 
 ### Block level links
 
-As mentioned before, almost any content can be made into a link, even [block-level elements](/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#block_versus_inline_elements). If you have an image you want to make into a link, use the {{htmlelement("a")}} element and reference the image file with the {{htmlelement("img")}} element.
+As mentioned before, almost any content can be made into a link, even [block-level elements](/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#block_versus_inline_elements).
+If you have an image you want to make into a link, use the {{htmlelement("a")}} element and reference the image file with the {{htmlelement("img")}} element.
 
 ```html
 <a href="https://www.mozilla.org/en-US/">
@@ -128,13 +136,15 @@ There are also two directories inside our root — `pdfs` and `projects`. These 
   Find details on our <a href="contacts.html">contacts page</a>.</p>
   ```
 
-- **Moving down into subdirectories**: If you wanted to include a hyperlink inside `index.html` (the top level `index.html`) pointing to `projects/index.html`, you would need to go down into the `projects` directory before indicating the file you want to link to. This is done by specifying the directory's name, then a forward slash, then the name of the file. The URL you would use is `projects/index.html`:
+- **Moving down into subdirectories**: If you wanted to include a hyperlink inside `index.html` (the top level `index.html`) pointing to `projects/index.html`, you would need to go down into the `projects` directory before indicating the file you want to link to.
+  This is done by specifying the directory's name, then a forward slash, then the name of the file. The URL you would use is `projects/index.html`:
 
   ```html
   <p>Visit my <a href="projects/index.html">project homepage</a>.</p>
   ```
 
-- **Moving back up into parent directories**: If you wanted to include a hyperlink inside `projects/index.html` pointing to `pdfs/project-brief.pdf`, you'd have to go up a directory level, then back down into the `pdf` directory. To go up a directory, use two dots — `..` — so the URL you would use is `../pdfs/project-brief.pdf`:
+- **Moving back up into parent directories**: If you wanted to include a hyperlink inside `projects/index.html` pointing to `pdfs/project-brief.pdf`, you'd have to go up a directory level, then back down into the `pdf` directory.
+  To go up a directory, use two dots — `..` — so the URL you would use is `../pdfs/project-brief.pdf`:
 
   ```html
   <p>A link to my <a href="../pdfs/project-brief.pdf">project brief</a>.</p>
@@ -144,7 +154,9 @@ There are also two directories inside our root — `pdfs` and `projects`. These 
 
 ### Document fragments
 
-It's possible to link to a specific part of an HTML document, known as a **document fragment**, rather than just to the top of the document. To do this you first have to assign an {{htmlattrxref("id")}} attribute to the element you want to link to. It normally makes sense to link to a specific heading, so this would look something like the following:
+It's possible to link to a specific part of an HTML document, known as a **document fragment**, rather than just to the top of the document.
+To do this you first have to assign an {{htmlattrxref("id")}} attribute to the element you want to link to.
+It normally makes sense to link to a specific heading, so this would look something like the following:
 
 ```html
 <h2 id="Mailing_address">Mailing address</h2>
@@ -166,11 +178,13 @@ You can even use the document fragment reference on its own to link to _another 
 
 Two terms you'll come across on the Web are **absolute URL** and **relative URL:**
 
-**absolute URL**: Points to a location defined by its absolute location on the web, including {{glossary("protocol")}} and {{glossary("domain name")}}. For example, if an `index.html` page is uploaded to a directory called `projects` that sits inside the **root** of a web server, and the web site's domain is `https://www.example.com`, the page would be available at `https://www.example.com/projects/index.html` (or even just `https://www.example.com/projects/`, as most web servers just look for a landing page such as `index.html` to load if it isn't specified in the URL.)
+**absolute URL**: Points to a location defined by its absolute location on the web, including {{glossary("protocol")}} and {{glossary("domain name")}}.
+For example, if an `index.html` page is uploaded to a directory called `projects` that sits inside the **root** of a web server, and the web site's domain is `https://www.example.com`, the page would be available at `https://www.example.com/projects/index.html` (or even just `https://www.example.com/projects/`, as most web servers just look for a landing page such as `index.html` to load if it isn't specified in the URL.)
 
 An absolute URL will always point to the same location, no matter where it's used.
 
-**relative URL**: Points to a location that is _relative_ to the file you are linking from, more like what we looked at in the previous section. For example, if we wanted to link from our example file at `https://www.example.com/projects/index.html` to a PDF file in the same directory, the URL would just be the filename — `project-brief.pdf` — no extra information needed. If the PDF was available in a subdirectory inside `projects` called `pdfs`, the relative link would be `pdfs/project-brief.pdf` (the equivalent absolute URL would be `https://www.example.com/projects/pdfs/project-brief.pdf`.)
+**relative URL**: Points to a location that is _relative_ to the file you are linking from, more like what we looked at in the previous section.
+For example, if we wanted to link from our example file at `https://www.example.com/projects/index.html` to a PDF file in the same directory, the URL would just be the filename — `project-brief.pdf` — no extra information needed. If the PDF was available in a subdirectory inside `projects` called `pdfs`, the relative link would be `pdfs/project-brief.pdf` (the equivalent absolute URL would be `https://www.example.com/projects/pdfs/project-brief.pdf`.)
 
 A relative URL will point to different places depending on the actual location of the file you refer from — for example if we moved our `index.html` file out of the `projects` directory and into the **root** of the web site (the top level, not in any directories), the `pdfs/project-brief.pdf` relative URL link inside it would now point to a file located at `https://www.example.com/pdfs/project-brief.pdf`, not a file located at `https://www.example.com/projects/pdfs/project-brief.pdf`.
 
@@ -190,17 +204,17 @@ It's easy to throw links up on your page. That's not enough. We need to make our
 
 Let's look at a specific example:
 
-**\*Good** link text:\* [Download Firefox](https://firefox.com)
+**Good** link text: [Download Firefox](https://firefox.com)
 
-```html
+```html example-good
 <p><a href="https://firefox.com/">
   Download Firefox
 </a></p>
 ```
 
-**\*Bad** link text:\* [Click here](https://firefox.com/) to download Firefox
+**Bad** link text: [Click here](https://firefox.com/) to download Firefox
 
-```html
+```html example-bad
 <p><a href="https://firefox.com/">
   Click here
 </a>
@@ -210,9 +224,11 @@ to download Firefox</p>
 Other tips:
 
 - Don't repeat the URL as part of the link text — URLs look ugly, and sound even uglier when a screen reader reads them out letter by letter.
-- Don't say "link" or "links to" in the link text — it's just noise. Screen readers tell people there's a link. Visual users will also know there's a link, because links are generally styled in a different color and underlined (this convention generally shouldn't be broken, as users are used to it).
+- Don't say "link" or "links to" in the link text — it's just noise. Screen readers tell people there's a link.
+  Visual users will also know there's a link, because links are generally styled in a different color and underlined (this convention generally shouldn't be broken, as users are used to it).
 - Keep your link text as short as possible — this is helpful because screen readers need to interpret the entire link text.
-- Minimize instances where multiple copies of the same text are linked to different places. This can cause problems for screen reader users, if there's a list of links out of context that are labeled "click here", "click here", "click here".
+- Minimize instances where multiple copies of the same text are linked to different places.
+  This can cause problems for screen reader users, if there's a list of links out of context that are labeled "click here", "click here", "click here".
 
 ### Linking to non-HTML resources — leave clear signposts
 
@@ -263,10 +279,12 @@ You'll need to make local copies of the following four pages, all in the same di
 
 You should:
 
-1.  Add an unordered list in the indicated place on one page that includes the names of the pages to link to. A navigation menu is usually just a list of links, so this is semantically OK.
-2.  Change each page name into a link to that page.
-3.  Copy the navigation menu across to each page.
-4.  On each page, remove just the link to that same page — it's confusing and unnecessary for a page to include a link to itself. And, the lack of a link acts a good visual reminder of which page you are currently on.
+1. Add an unordered list in the indicated place on one page that includes the names of the pages to link to.
+   A navigation menu is usually just a list of links, so this is semantically OK.
+2. Change each page name into a link to that page.
+3. Copy the navigation menu across to each page.
+4. On each page, remove just the link to that same page — it's confusing and unnecessary for a page to include a link to itself.
+   And, the lack of a link acts a good visual reminder of which page you are currently on.
 
 The finished example should look similar to the following page:
 
@@ -276,7 +294,8 @@ The finished example should look similar to the following page:
 
 ## E-mail links
 
-It's possible to create links or buttons that, when clicked, open a new outgoing email message rather than linking to a resource or page. This is done using the {{HTMLElement("a")}} element and the `mailto:` URL scheme.
+It's possible to create links or buttons that, when clicked, open a new outgoing email message rather than linking to a resource or page.
+This is done using the {{HTMLElement("a")}} element and the `mailto:` URL scheme.
 
 In its most basic and commonly used form, a `mailto:` link indicates the email address of the intended recipient. For example:
 
@@ -286,11 +305,14 @@ In its most basic and commonly used form, a `mailto:` link indicates the email a
 
 This results in a link that looks like this: [Send email to nowhere](mailto:nowhere@mozilla.org).
 
-In fact, the email address is optional. If you omit it and your {{htmlattrxref("href", "a")}} is "mailto:", a new outgoing email window will be opened by the user's email client with no destination address. This is often useful as "Share" links that users can click to send an email to an address of their choosing.
+In fact, the email address is optional. If you omit it and your {{htmlattrxref("href", "a")}} is "mailto:", a new outgoing email window will be opened by the user's email client with no destination address.
+This is often useful as "Share" links that users can click to send an email to an address of their choosing.
 
 ### Specifying details
 
-In addition to the email address, you can provide other information. In fact, any standard mail header fields can be added to the `mailto` URL you provide. The most commonly used of these are "subject", "cc", and "body" (which is not a true header field, but allows you to specify a short content message for the new email). Each field and its value is specified as a query term.
+In addition to the email address, you can provide other information. In fact, any standard mail header fields can be added to the `mailto` URL you provide.
+The most commonly used of these are "subject", "cc", and "body" (which is not a true header field, but allows you to specify a short content message for the new email).
+Each field and its value is specified as a query term.
 
 Here's an example that includes a cc, bcc, subject and body:
 
@@ -300,7 +322,10 @@ Here's an example that includes a cc, bcc, subject and body:
 </a>
 ```
 
-> **Note:** The values of each field must be URL-encoded, that is with non-printing characters (invisible characters like tabs, carriage returns, and page breaks) and spaces [percent-escaped](https://en.wikipedia.org/wiki/Percent-encoding). Also, note the use of the question mark (`?`) to separate the main URL from the field values, and ampersands (&) to separate each field in the `mailto:` URL. This is standard URL query notation. Read [The GET method](/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_get_method) to understand what URL query notation is more commonly used for.
+> **Note:** The values of each field must be URL-encoded, that is with non-printing characters (invisible characters like tabs, carriage returns, and page breaks) and spaces [percent-escaped](https://en.wikipedia.org/wiki/Percent-encoding).
+> Also, note the use of the question mark (`?`) to separate the main URL from the field values, and ampersands (&) to separate each field in the `mailto:` URL.
+> This is standard URL query notation.
+> Read [The GET method](/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_get_method) to understand what URL query notation is more commonly used for.
 
 Here are a few other sample `mailto` URLs:
 


### PR DESCRIPTION
Fixes #10357

The markdown translation converted an example html link with a specific title into a markdown link, which takes its title from the heading text. This changes the link back to HTML. Also some basic layout fixes.