### PR TITLE
Fixed link to "presentation role"

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/none_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/none_role/index.md
@@ -12,9 +12,9 @@ tags:
   - presentation role
 ---
 
-The `none` role is a synonym for the [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role) role; they both remove the element with the role and its descendants from the accessibility tree.
+The `none` role is a synonym for the [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) role; they both remove the element with the role and its descendants from the accessibility tree.
 
-See the [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role) role for more information.
+See the [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) role for more information.
 
 
 <section id="Quick_links">


### PR DESCRIPTION
On "ARIA: none role" page

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

On the on "ARIA: none role" page, the links in the text "The none role is a synonym for the presentation role" and "See the presentation role for more information," were pointing at the "ARIA: list role" page when it is clear that they should point to the "Aria: presentation role" page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
