### PR TITLE
FF95 inputmode supported all platforms

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -63,45 +63,6 @@ The current implementation is a little inelegant but is basically functional. (S
   </tbody>
 </table>
 
-### Global attribute: inputmode
-
-Our implementation of the [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) global attribute has been updated as per the WHATWG spec ({{bug(1509527)}}), but we still need to make other changes too, like making it available on contenteditable content. (See {{bug(1205133)}} for details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>75</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>75</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>75</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>75</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.forms.inputmode</code></td>
-    </tr>
-  </tbody>
-</table>
 
 ### inert attribute
 

--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -18,6 +18,9 @@ Firefox 95 is the current [Beta version of Firefox](https://www.mozilla.org/en-U
 
 ### HTML
 
+- The [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) global attribute is now supported on all platforms, instead of just Android.
+  This provides a hint to browsers about the type of virtual keyboard that would be best suited to editing a particular element ({{bug(1205133)}}).
+
 #### Removals
 
 ### CSS

--- a/files/en-us/web/html/global_attributes/inputmode/index.md
+++ b/files/en-us/web/html/global_attributes/inputmode/index.md
@@ -21,25 +21,41 @@ browser-compat: html.global_attributes.inputmode
 {{HTMLSidebar("Global_attributes")}}
 
 The **`inputmode`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an enumerated attribute that hints at the type of data that might be entered by the user while editing the element or its contents.
+This allows a browser to display an appropriate virtual keyboard.
 
-It can have the following values:
+It is used primarily on {{HTMLElement("input")}} elements, but is usable on any element while in {{HTMLAttrxRef("contenteditable")}} mode.
+
+## Values
+
+The attribute can have any of the following values:
 
 - `none`
-  - : No virtual keyboard. For when the page implements its own keyboard input control.
+  - : No virtual keyboard.
+    For when the page implements its own keyboard input control.
 - `text` (default value)
   - : Standard input keyboard for the user's current locale.
 - `decimal`
-  - : Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically <kbd>.</kbd> or <kbd>,</kbd>). Devices may or may not show a minus key (<kbd>-</kbd>).
+  - : Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically <kbd>.</kbd> or <kbd>,</kbd>).
+    Devices may or may not show a minus key (<kbd>-</kbd>).
 - `numeric`
-  - : Numeric input keyboard, but only requires the digits 0–9. Devices may or may not show a minus key.
+  - : Numeric input keyboard, but only requires the digits 0–9.
+    Devices may or may not show a minus key.
 - `tel`
-  - : A telephone keypad input, including the digits 0–9, the asterisk (<kbd>*</kbd>), and the pound (<kbd>#</kbd>) key. Inputs that *require\* a telephone number should typically use `{{HTMLElement("input/tel", '&lt;input type="tel"&gt;')}}`instead.
+  - : A telephone keypad input, including the digits 0–9, the asterisk (<kbd>*</kbd>), and the pound (<kbd>#</kbd>) key.
+    Inputs that *require\* a telephone number should typically use `{{HTMLElement("input/tel", '&lt;input type="tel"&gt;')}}` instead.
 - `search`
-  - : A virtual keyboard optimized for search input. For instance, the [return/submit key](https://html.spec.whatwg.org/dev/interaction.html#input-modalities:-the-enterkeyhint-attribute) may be labeled “Search”, along with possible other optimizations. Inputs that _require_ a search query should typically use `{{HTMLElement("input/search", '&lt;input type="search"&gt;')}}` instead.
+  - : A virtual keyboard optimized for search input.
+    For instance, the [return/submit key](https://html.spec.whatwg.org/dev/interaction.html#input-modalities:-the-enterkeyhint-attribute) may be labeled “Search”, along with possible other optimizations.
+    Inputs that _require_ a search query should typically use `{{HTMLElement("input/search", '&lt;input type="search"&gt;')}}` instead.
 - `email`
-  - : A virtual keyboard optimized for entering email addresses. Typically includes the <kbd>@</kbd>character as well as other optimizations. Inputs that _require_ email addresses should typically use `{{HTMLElement("input/email", '&lt;input type="email"&gt;')}}` instead.
+  - : A virtual keyboard optimized for entering email addresses.
+    Typically includes the <kbd>@</kbd>character as well as other optimizations.
+    Inputs that _require_ email addresses should typically use `{{HTMLElement("input/email", '&lt;input type="email"&gt;')}}` instead.
 - `url`
-  - : A keypad optimized for entering URLs. This may have the <kbd>/</kbd> key more prominent, for example. Enhanced features could include history access and so on. Inputs that _require_ a URL should typically use `{{HTMLElement("input/url", '&lt;input type="url"&gt;')}}` instead.
+  - : A keypad optimized for entering URLs.
+    This may have the <kbd>/</kbd> key more prominent, for example.
+    Enhanced features could include history access and so on.
+    Inputs that _require_ a URL should typically use `{{HTMLElement("input/url", '&lt;input type="url"&gt;')}}` instead.
 
 ## Specifications
 


### PR DESCRIPTION
FF95 now supports the global attribute [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) on all platforms - see bug https://bugzilla.mozilla.org/show_bug.cgi?id=1205133

This adds release note, removes the experimental features, and does minor tidy of the doc. 

Other docs work for this can be tracked in https://github.com/mdn/content/issues/10144