### PR TITLE
DOMMatrixReadOnly is no more experimental

### DIFF
--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
@@ -2,16 +2,11 @@
 title: DOMMatrixReadOnly()
 slug: Web/API/DOMMatrixReadOnly/DOMMatrixReadOnly
 tags:
-  - API
   - Constructor
-  - Experimental
-  - Geometry
-  - Geometry Interfaces
   - Reference
-  - matrix
 browser-compat: api.DOMMatrixReadOnly.DOMMatrixReadOnly
 ---
-{{APIRef("Geometry Interfaces")}}{{Non-standard_header}}
+{{APIRef("Geometry Interfaces")}}
 
 The **`DOMMatrixReadOnly`** constructor creates a new
 {{domxref("DOMMatrixReadOnly")}} object which represents 4x4 matrices, suitable for 2D
@@ -20,12 +15,13 @@ and 3D operations.
 ## Syntax
 
 ```js
-var domMatrixReadOnly = new DOMMatrixReadOnly([init])
+DOMMatrixReadOnly();
+DOMMatrixReadOnly(init);
 ```
 
 ### Parameters
 
-- init {{optional_inline}}
+- `init` {{optional_inline}}
   - : Either a string containing a sequence of numbers or an array of integers
     specifying the matrix you want to create.
 

--- a/files/en-us/web/api/dommatrixreadonly/flipx/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/flipx/index.md
@@ -2,17 +2,8 @@
 title: DOMMatrixReadOnly.flipX()
 slug: Web/API/DOMMatrixReadOnly/flipX
 tags:
-  - API
-  - DOMMatrix
-  - DOMMatrixReadOnly
-  - Experimental
-  - FlipX
-  - Geometry
-  - Geometry Interfaces
-  - Interface
   - Method
   - Reference
-  - matrix
 browser-compat: api.DOMMatrixReadOnly.flipX
 ---
 {{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}
@@ -21,24 +12,26 @@ The `flipX()` method of the {{domxref("DOMMatrixReadOnly")}} interface creates a
 
 ## Syntax
 
-    DOMMatrix.flipX()
+```js
+  DOMMatrixReadOnly.flipX();
+```
 
 ### Return value
 
-Returns a [`DOMMatrix`](/en-US/docs/Web/API/DOMMatrix "The DOMMatrix interface represents 4x4 matrices, suitable for 2D and 3D operations.") containing a new matrix being the result of the original matrix flipped about the x-axis, which is equivalent to multiplying the matrix by `DOMMatrix(-1, 0, 0, 1, 0, 0)`.  The original matrix is not modified.
+Returns a [`DOMMatrix`](/en-US/docs/Web/API/DOMMatrix "The DOMMatrix interface represents 4x4 matrices, suitable for 2D and 3D operations.") containing a new matrix being the result of the original matrix flipped about the x-axis, which is equivalent to multiplying the matrix by `DOMMatrix(-1, 0, 0, 1, 0, 0)`.  The original matrix is not modified.
 
 ## Examples
 
-This SVG contains two paths in the shape of a triangle, both drawn to the same position.  Note that the x co-ordinate of the viewBox attribute is negative, showing us content from both sides of the x-axis.
+This SVG contains two paths in the shape of a triangle, both drawn to the same position.  Note that the x co-ordinate of the viewBox attribute is negative, showing us content from both sides of the x-axis.
 
 ```html
 <svg width="100" height="100" viewBox="-50 0 100 100">
-  <path fill="red" d="M 0 50 L 50 0 L 50 100 Z" />
-  <path id="flipped" fill="blue" d="M 0 50 L 50 0 L 50 100 Z" />
+  <path fill="red" d="M 0 50 L 50 0 L 50 100 Z" />
+  <path id="flipped" fill="blue" d="M 0 50 L 50 0 L 50 100 Z" />
 </svg>
 ```
 
-This JavaScript first creates an identity matrix, then uses the \`flipX()\` method to create a new matrix, which is then applied to the blue triangle, inverting it across the x-axis.  The red triangle is left in place.
+This JavaScript first creates an identity matrix, then uses the \`flipX()\` method to create a new matrix, which is then applied to the blue triangle, inverting it across the x-axis.  The red triangle is left in place.
 
 ```js
 const flipped = document.getElementById('flipped');

--- a/files/en-us/web/api/dommatrixreadonly/flipx/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/flipx/index.md
@@ -6,8 +6,7 @@ tags:
   - Reference
 browser-compat: api.DOMMatrixReadOnly.flipX
 ---
-{{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}
-
+{{APIRef("Geometry Interfaces")}}
 The `flipX()` method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new matrix being the result of the original matrix flipped about the x-axis.
 
 ## Syntax

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -14,7 +14,7 @@ This interface should be available inside [web workers](/en-US/docs/Web/API/Web_
 
 ## Constructor
 
-- {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly())"}}
+- {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly()")}}
   - : Creates a new `DOMMMatrixReadOnly` object.
 
 ## Properties

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -12,6 +12,11 @@ The **`DOMMatrixReadOnly`** interface represents a read-only 4×4 matrix, suitab
 
 This interface should be available inside [web workers](/en-US/docs/Web/API/Web_Workers_API), though some implementations doesn't allow it yet.
 
+## Constructor
+
+- {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly())"}}
+  - : Creates a new `DOMMMatrixReadOnly` object.
+
 ## Properties
 
 _This interface doesn't inherit any properties._

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -2,28 +2,8 @@
 title: DOMMatrixReadOnly
 slug: Web/API/DOMMatrixReadOnly
 tags:
-  - 2D
-  - 3D
-  - API
-  - Computation
-  - DOMMatrixReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Graphics
   - Interface
-  - Math
-  - Modeling
-  - Read-only
   - Reference
-  - Rotate
-  - Scale
-  - Skew
-  - VR
-  - Web
-  - angle
-  - camera
-  - matrix
-  - transform
 browser-compat: api.DOMMatrixReadOnly
 ---
 {{APIRef("Geometry Interfaces")}}
@@ -36,13 +16,13 @@ This interface should be available inside [web workers](/en-US/docs/Web/API/Web_
 
 _This interface doesn't inherit any properties._
 
-- `is2D` {{ReadOnlyInline}}
-  - : A Boolean flag whose value is `true` if the matrix was initialized as a 2D matrix. If `false`, the matrix is 3D.
-- `isIdentity` {{ReadOnlyInline}}
-  - : A Boolean whose value is `true` if the matrix is the {{interwiki("wikipedia", "identity matrix")}}. The identity matrix is one in which every value is `0` *except* those on the main diagonal from top-left to bottom-right corner (in other words, where the offsets in each direction are equal).
-- `m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`
-  - : Double-precision floating-point values representing each component of a 4×4 matrix, where `m11` through `m14` are the first column, `m21` through `m24` are the second column, and so forth.
-- `a`, `b`, `c`, `d`, `e`, `f`
+- `is2D` {{ReadOnlyInline}}
+  - : A Boolean flag whose value is `true` if the matrix was initialized as a 2D matrix. If `false`, the matrix is 3D.
+- `isIdentity` {{ReadOnlyInline}}
+  - : A Boolean whose value is `true` if the matrix is the {{interwiki("wikipedia", "identity matrix")}}. The identity matrix is one in which every value is `0` *except* those on the main diagonal from top-left to bottom-right corner (in other words, where the offsets in each direction are equal).
+- `m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`
+  - : Double-precision floating-point values representing each component of a 4×4 matrix, where `m11` through `m14` are the first column, `m21` through `m24` are the second column, and so forth.
+- `a`, `b`, `c`, `d`, `e`, `f`
 
   - : Double-precision floating-point values representing the components of a 4×4 matrix which are required in order to perform 2D rotations and translations. These are aliases for specific components of a 4×4 matrix, as shown below.
 
@@ -60,23 +40,23 @@ _This interface doesn't inherit any properties._
 _This interface doesn't inherit any methods. None of the following methods alter the original matrix._
 
 - {{domxref("DOMMatrixReadOnly.flipX()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by flipping the source matrix around its X-axis. This is equivalent to multiplying the matrix by  `DOMMatrix(-1, 0, 0, 1, 0, 0)`. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by flipping the source matrix around its X-axis. This is equivalent to multiplying the matrix by  `DOMMatrix(-1, 0, 0, 1, 0, 0)`. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.flipY()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by flipping the source matrix around its Y-axis. This is equivalent to multiplying the matrix by  `DOMMatrix(1, 0, 0, -1, 0, 0)`. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by flipping the source matrix around its Y-axis. This is equivalent to multiplying the matrix by  `DOMMatrix(1, 0, 0, -1, 0, 0)`. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.inverse()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by inverting the source matrix. If the matrix cannot be inverted, the new matrix's components are all set to `NaN` and its `is2D` property is set to `false`. The original matrix is not altered.
+  - : Returns a new {{domxref("DOMMatrix")}} created by inverting the source matrix. If the matrix cannot be inverted, the new matrix's components are all set to `NaN` and its `is2D` property is set to `false`. The original matrix is not altered.
 - {{domxref("DOMMatrixReadOnly.multiply()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by computing the dot product of the source matrix and the specified matrix: `A⋅B`. If no matrix is specified as the multiplier, the matrix is multiplied by a matrix in which every element is `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by computing the dot product of the source matrix and the specified matrix: `A⋅B`. If no matrix is specified as the multiplier, the matrix is multiplied by a matrix in which every element is `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.rotateAxisAngle()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by rotating the source matrix by the given angle around the specified vector. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by rotating the source matrix by the given angle around the specified vector. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.rotate()")}}
   - : Returns a new {{domxref("DOMMatrix")}} created by rotating the source matrix around each of its axes by the specified number of degrees. The original matrix is not altered.
 - {{domxref("DOMMatrixReadOnly.rotateFromVector()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by rotating the source matrix by the angle between the specified vector and `(1, 0)`. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by rotating the source matrix by the angle between the specified vector and `(1, 0)`. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.scale()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by scaling the source matrix by the amount specified for each axis, centered on the given origin. By default, the X and Z axes are scaled by `1` and the Y axis has no default scaling value. The default origin is `(0, 0, 0)`. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by scaling the source matrix by the amount specified for each axis, centered on the given origin. By default, the X and Z axes are scaled by `1` and the Y axis has no default scaling value. The default origin is `(0, 0, 0)`. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.scale3d()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by scaling the source 3D matrix by the given factor along all its axes, centered on the specified origin point. The default origin is `(0, 0, 0)`. The original matrix is not modified.
+  - : Returns a new {{domxref("DOMMatrix")}} created by scaling the source 3D matrix by the given factor along all its axes, centered on the specified origin point. The default origin is `(0, 0, 0)`. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.scaleNonUniform()")}} {{deprecated_inline}}
   - : Returns a new {{domxref("DOMMatrix")}} created by applying the specified scaling on the X, Y, and Z axes, centered at the given origin. By default, the Y and Z axes' scaling factors are both `1`, but the scaling factor for X must be specified. The default origin is `(0, 0, 0)`. The original matrix is not changed.
 - {{domxref("DOMMatrixReadOnly.skewX()")}}
@@ -84,20 +64,20 @@ _This interface doesn't inherit any methods. None of the following methods alter
 - {{domxref("DOMMatrixReadOnly.skewY()")}}
   - : Returns a new {{domxref("DOMMatrix")}} created by applying the specified skew transformation to the source matrix along its Y-axis. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.toFloat32Array()")}}
-  - : Returns a new {{jsxref("Float32Array")}} containing all 16 elements (`m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`) which comprise the matrix. The elements are stored into the array as single-precision floating-point numbers in column-major (colexographical access, or "colex") order. (In other words, down the first column from top to bottom, then the second column, and so forth.)
+  - : Returns a new {{jsxref("Float32Array")}} containing all 16 elements (`m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`) which comprise the matrix. The elements are stored into the array as single-precision floating-point numbers in column-major (colexographical access, or "colex") order. (In other words, down the first column from top to bottom, then the second column, and so forth.)
 - {{domxref("DOMMatrixReadOnly.toFloat64Array()")}}
-  - : Returns a new {{jsxref("Float64Array")}} containing all 16 elements (`m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`) which comprise the matrix. The elements are stored into the array as double-precision floating-point numbers in column-major (colexographical access, or "colex") order. (In other words, down the first column from top to bottom, then the second column, and so forth.)
+  - : Returns a new {{jsxref("Float64Array")}} containing all 16 elements (`m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`) which comprise the matrix. The elements are stored into the array as double-precision floating-point numbers in column-major (colexographical access, or "colex") order. (In other words, down the first column from top to bottom, then the second column, and so forth.)
 - {{domxref("DOMMatrixReadOnly.toJSON()")}}
   - : Returns a JSON representation of the `DOMMatrixReadOnly` object.
 - {{domxref("DOMMatrixReadOnly.toString()")}}
 
   - : Creates and returns a {{domxref("DOMString")}} object which contains a string representation of the matrix in CSS matrix syntax, using the appropriate CSS matrix notation. See the {{cssxref("matrix()")}} CSS function for details on this syntax.
 
-    For a 2D matrix, the elements `a` through `f` are listed, for a total of six values and the form `matrix(a, b, c, d, e, f)`.
+    For a 2D matrix, the elements `a` through `f` are listed, for a total of six values and the form `matrix(a, b, c, d, e, f)`.
 
-    For a 3D matrix, the returned string contains all 16 elements and takes the form `matrix3d(m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44)`. See the CSS {{cssxref("matrix3d()")}} function for details on the 3D notation's syntax.
+    For a 3D matrix, the returned string contains all 16 elements and takes the form `matrix3d(m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44)`. See the CSS {{cssxref("matrix3d()")}} function for details on the 3D notation's syntax.
 
-    Throws an `InvalidStateError` exception if any of the elements in the matrix are non-finite (even if, in the case of a 2D matrix, the non-finite values are in elements not used by the 2D matrix representation).
+    Throws an `InvalidStateError` exception if any of the elements in the matrix are non-finite (even if, in the case of a 2D matrix, the non-finite values are in elements not used by the 2D matrix representation).
 
 - {{domxref("DOMMatrixReadOnly.transformPoint()")}}
   - : Transforms the specified point using the matrix, returning a new {{domxref("DOMPoint")}} object containing the transformed point. Neither the matrix nor the original point are altered.

--- a/files/en-us/web/api/dommatrixreadonly/scale/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/scale/index.md
@@ -6,7 +6,7 @@ tags:
   - Reference
 browser-compat: api.DOMMatrixReadOnly.scale
 ---
-{{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}
+{{APIRef("Geometry Interfaces")}}
 
 The **`scale()`** method of the
 {{domxref("DOMMatrixReadOnly")}} interface creates a new matrix being the result of the

--- a/files/en-us/web/api/dommatrixreadonly/scale/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/scale/index.md
@@ -2,17 +2,8 @@
 title: DOMMatrixReadOnly.scale()
 slug: Web/API/DOMMatrixReadOnly/scale
 tags:
-  - API
-  - DOMMatrix
-  - DOMMatrixReadOnly
-  - Experimental
-  - Geometry
-  - Geometry Interfaces
-  - Interface
   - Method
   - Reference
-  - Scale
-  - matrix
 browser-compat: api.DOMMatrixReadOnly.scale
 ---
 {{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}
@@ -26,27 +17,32 @@ original matrix with a scale transform applied.
 The `scale()` method is specified with either one or six values.
 
 ```js
-DOMMatrix.scale(scaleX[, scaleY][, scaleZ][, originX][, originY][, originZ])
+DOMMatrixReadOnly.scale(scaleX);
+DOMMatrixReadOnly.scale(scaleX, scaleY);
+DOMMatrixReadOnly.scale(scaleX, scaleY, scaleZ);
+DOMMatrixReadOnly.scale(scaleX, scaleY, scaleZ, originX);
+DOMMatrixReadOnly.scale(scaleX, scaleY, scaleZ, originX, originY);
+DOMMatrixReadOnly.scale(scaleX, scaleY, scaleZ, originX, originY, originZ);
 ```
 
 ### Parameters
 
-- scaleX
+- `scaleX`
   - : A multiplier for the scale value on the x-axis.
-- scaleY {{optional_inline}}
-  - : A multiplier for the scale value on the y-axis.  If not supplied, this defaults to
+- `scaleY` {{optional_inline}}
+  - : A multiplier for the scale value on the y-axis. If not supplied, this defaults to
     the value of `scaleX`.
-- scaleZ {{optional_inline}}
-  - : A multiplier for the scale value on the z-axis.  If this value is anything other
+- `scaleZ` {{optional_inline}}
+  - : A multiplier for the scale value on the z-axis. If this value is anything other
     than 1, the resulting matrix will be 3D.
-- originX {{optional_inline}}
-  - : An x-coordinate for the origin of the transformation.  If no origin is supplied,
+- `originX` {{optional_inline}}
+  - : An x-coordinate for the origin of the transformation. If no origin is supplied,
     this defaults to 0.
-- originY {{optional_inline}}
-  - : A y-coordinate for the origin of the transformation.  If no origin is supplied, this
+- `originY` {{optional_inline}}
+  - : A y-coordinate for the origin of the transformation. If no origin is supplied, this
     defaults to 0.
-- originZ {{optional_inline}}
-  - : A z-coordinate for the origin of the transformation.  If no origin is supplied, this
+- `originZ` {{optional_inline}}
+  - : A z-coordinate for the origin of the transformation. If no origin is supplied, this
     defaults to 0. If this value is anything other than 0, the resulting matrix will be
     3D.
 
@@ -57,14 +53,6 @@ containing a new matrix being the result of the matrix x and y dimensions being 
 by the given factor, centered on the origin given. The original matrix is not modified.
 
 If a scale is applied about the z-axis, the resulting matrix will be a 4x4 3D matrix.
-
-> **Note:** At time of writing, Firefox still supports an older version of
-> the specification that accepts either one or three values.
->
->     DOMMatrix.scale(scale[, originX][, originY])
->
-> We'll show an example of how you can deal with the cross-browser support implications
-> of this in the Examples section, below.
 
 ## Examples
 

--- a/files/en-us/web/api/dommatrixreadonly/translate/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/translate/index.md
@@ -6,7 +6,7 @@ tags:
   - Reference
 browser-compat: api.DOMMatrixReadOnly.translate
 ---
-{{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}
+{{APIRef("Geometry Interfaces")}}
 
 The `translate()` method of the {{domxref("DOMMatrixReadOnly")}} interface
 creates a new matrix being the result of the original matrix with a translation applied.

--- a/files/en-us/web/api/dommatrixreadonly/translate/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/translate/index.md
@@ -2,17 +2,8 @@
 title: DOMMatrixReadOnly.translate()
 slug: Web/API/DOMMatrixReadOnly/translate
 tags:
-  - API
-  - DOMMatrix
-  - DOMMatrixReadOnly
-  - Experimental
-  - Geometry
-  - Geometry Interfaces
-  - Interface
   - Method
   - Reference
-  - Translate
-  - matrix
 browser-compat: api.DOMMatrixReadOnly.translate
 ---
 {{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}
@@ -22,21 +13,20 @@ creates a new matrix being the result of the original matrix with a translation 
 
 ## Syntax
 
-The `translate()` method accepts two or three values.
-
 ```js
-DOMMatrix.translate(translateX, translateY[, translateZ])
+DOMMatrix.translate(translateX, translateY);
+DOMMatrix.translate(translateX, translateY, translateZ);
 ```
 
 ### Parameters
 
-- translateX
+- `translateX`
   - : A number representing the abscissa (x-coordinate) of the translating vector.
-- translateY
+- `translateY`
   - : A number representing the ordinate (y-coordinate) of the translating vector.
-- translateZ {{optional_inline}}
-  - : A number representing the z component of the translating vector.  If not supplied,
-    this defaults to 0.  If this is anything other than 0, the resulting matrix will be
+- `translateZ` {{optional_inline}}
+  - : A number representing the z component of the translating vector. If not supplied,
+    this defaults to 0. If this is anything other than 0, the resulting matrix will be
     3D.
 
 ### Return value


### PR DESCRIPTION
Fixes #10352.

- Removed Experimental and Non-standard.
- Fixed the tags
- Fixed the syntax boxes