### PR TITLE
Remove stability warning about BYOB readers

### DIFF
--- a/files/en-us/web/api/streams_api/index.html
+++ b/files/en-us/web/api/streams_api/index.html
@@ -1,0 +1,147 @@
+---
+title: Streams API
+slug: Web/API/Streams_API
+tags:
+  - API
+  - Experimental
+  - JavaScript
+  - Landing
+  - Reference
+  - Streams
+---
+<div>{{DefaultAPISidebar("Streams")}}</div>
+
+<p>The Streams API allows JavaScript to programmatically access streams of data received over the network and process them as desired by the developer.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Concepts_and_usage">Concepts and usage</h2>
+
+<p>Streaming involves breaking a resource that you want to receive over a network down into small chunks, then processing it bit by bit. This is something browsers do anyway when receiving assets to be shown on webpages — videos buffer and more is gradually available to play, and sometimes you'll see images display gradually as more is loaded.</p>
+
+<p>But this has never been available to JavaScript before. Previously, if we wanted to process a resource of some kind (be it a video, or a text file, etc.), we'd have to download the entire file, wait for it to be deserialized into a suitable format, then process the whole lot after it is fully received.</p>
+
+<p>With Streams being available to JavaScript, this all changes — you can now start processing raw data with JavaScript bit by bit as soon as it is available on the client-side, without needing to generate a buffer, string, or blob.</p>
+
+<p><img alt="" src="concept.png"></p>
+
+<p>There are more advantages too — you can detect when streams start or end, chain streams together, handle errors and cancel streams as required, and react to the speed the stream is being read at.</p>
+
+<p>The basic usage of Streams hinges around making responses available as streams. For example, the response body returned by a successful <a href="/en-US/docs/Web/API/fetch">fetch request</a> can be exposed as a {{domxref("ReadableStream")}}, and you can then read it using a reader created with {{domxref("ReadableStream.getReader()")}}, cancel it with {{domxref("ReadableStream.cancel()")}}, etc.</p>
+
+<p>More complicated uses involve creating your own stream using the {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}} constructor, for example to process data inside a <a href="/en-US/docs/Web/API/Service_Worker_API">service worker</a>.</p>
+
+<p>You can also write data to streams using {{domxref("WritableStream")}}.</p>
+
+<div class="note">
+<p><strong>Note:</strong> You can find a lot more details about the theory and practice of streams in our articles — <a href="/en-US/docs/Web/API/Streams_API/Concepts">Streams API concepts</a>, <a href="/en-US/docs/Web/API/Streams_API/Using_readable_streams">Using readable streams</a>, and <a href="/en-US/docs/Web/API/Streams_API/Using_writable_streams">Using writable streams</a>.</p>
+</div>
+
+<h2 id="Stream_interfaces">Stream interfaces</h2>
+
+<h3 id="Readable_streams">Readable streams</h3>
+
+<dl>
+ <dt>{{domxref("ReadableStream")}}</dt>
+ <dd>Represents a readable stream of data. It can be used to handle response streams of the <a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a>, or developer-defined streams (e.g. a custom {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}} constructor).</dd>
+ <dt>{{domxref("ReadableStreamDefaultReader")}}</dt>
+ <dd>Represents a default reader that can be used to read stream data supplied from a network (e.g. a fetch request).</dd>
+ <dt>{{domxref("ReadableStreamDefaultController")}}</dt>
+ <dd>Represents a controller allowing control of a {{domxref("ReadableStream")}}'s state and internal queue. Default controllers are for streams that are not byte streams.</dd>
+</dl>
+
+<h3 id="Writable_streams">Writable streams</h3>
+
+<dl>
+ <dt>{{domxref("WritableStream")}}</dt>
+ <dd>Provides a standard abstraction for writing streaming data to a destination, known as a sink. This object comes with built-in backpressure and queuing.</dd>
+ <dt>{{domxref("WritableStreamDefaultWriter")}}</dt>
+ <dd>Represents a default writable stream writer that can be used to write chunks of data to a writable stream.</dd>
+ <dt>{{domxref("WritableStreamDefaultController")}}</dt>
+ <dd>Represents a controller allowing control of a {{domxref("WritableStream")}}'s state. When constructing a <code>WritableStream</code>, the underlying sink is given a corresponding <code>WritableStreamDefaultController</code> instance to manipulate.</dd>
+</dl>
+
+<h3 id="Transform_Streams">Transform Streams</h3>
+
+<dl>
+  <dt>{{domxref("TransformStream")}}</dt>
+  <dd>Represents a set of transformable data.</dd>
+  <dt>{{domxref("TransformStreamDefaultController")}}</dt>
+  <dd>Provides methods to manipulate the {{domxref("ReadableStream")}} and {{domxref("WritableStream")}} associated with a transform stream.</dd>
+</dl>
+
+<h3 id="Related_stream_APIs_and_operations">Related stream APIs and operations</h3>
+
+<dl>
+ <dt>{{domxref("ByteLengthQueuingStrategy")}}</dt>
+ <dd>Provides a built-in byte length queuing strategy that can be used when constructing streams.</dd>
+ <dt>{{domxref("CountQueuingStrategy")}}</dt>
+ <dd>Provides a built-in chunk counting queuing strategy that can be used when constructing streams.</dd>
+</dl>
+
+<h3 id="Extensions_to_other_APIs">Extensions to other APIs</h3>
+
+<dl>
+ <dt>{{domxref("Request")}}</dt>
+ <dd>When a new <code>Request</code> object is constructed, you can pass it a {{domxref("ReadableStream")}} in the <code>body</code> property of its <code>RequestInit</code> dictionary.  This <code>Request</code> could then be passed to a {{domxref("fetch()")}} to commence fetching the stream.</dd>
+ <dt>{{domxref("Response.body")}}</dt>
+ <dd>The response body returned by a successful <a href="/en-US/docs/Web/API/fetch">fetch request</a> is exposed by default as a {{domxref("ReadableStream")}}, and can have a reader attached to it, etc.</dd>
+</dl>
+
+<h3 id="ByteStream-related_interfaces">ByteStream-related interfaces</h3>
+
+<dl>
+ <dt>{{domxref("ReadableStreamBYOBReader")}}</dt>
+ <dd>Represents a BYOB ("bring your own buffer") reader that can be used to read stream data supplied by the developer (e.g. a custom {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}} constructor).</dd>
+ <dt>{{domxref("ReadableByteStreamController")}}</dt>
+ <dd>Represents a controller allowing control of a {{domxref("ReadableStream")}}'s state and internal queue. Byte stream controllers are for byte streams.</dd>
+ <dt>{{domxref("ReadableStreamBYOBRequest")}}</dt>
+ <dd>Represents a pull into request in a {{domxref("ReadableByteStreamController")}}.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>We have created a directory of examples to go along with the Streams API documentation — see <a href="https://github.com/mdn/dom-examples/tree/master/streams">mdn/dom-examples/streams</a>. The examples are as follows:</p>
+
+<ul>
+ <li><a href="https://mdn.github.io/dom-examples/streams/simple-pump/">Simple stream pump</a>: This example shows how to consume a ReadableStream and pass its data to another.</li>
+ <li><a href="https://mdn.github.io/dom-examples/streams/grayscale-png/">Grayscale a PNG</a>: This example shows how a ReadableStream of a PNG can be turned into grayscale.</li>
+ <li><a href="https://mdn.github.io/dom-examples/streams/simple-random-stream/">Simple random stream</a>: This example shows how to use a custom stream to generate random strings, enqueue them as chunks, and then read them back out again.</li>
+ <li><a href="https://mdn.github.io/dom-examples/streams/simple-tee-example/">Simple tee example</a>: This example extends the Simple random stream example, showing how a stream can be teed and both resulting streams can be read independently.</li>
+ <li><a href="https://mdn.github.io/dom-examples/streams/simple-writer/">Simple writer</a>: This example shows how to write to a writable stream, then decode the stream and write the contents to the UI.</li>
+ <li><a href="https://mdn.github.io/dom-examples/streams/png-transform-stream/">Unpack chunks of a PNG</a>: This example shows how <a href="/en-US/docs/Web/API/ReadableStream/pipeThrough"><code>pipeThrough()</code></a> can be used to transform a ReadableStream into a stream of other data types by transforming a data of a PNG file into a stream of PNG chunks.</li>
+</ul>
+
+<p>Examples from other developers:</p>
+
+<ul>
+ <li><a href="https://fetch-progress.anthum.com/">Progress Indicators with Streams, Service Workers, &amp; Fetch</a>.</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table>
+  <tr>
+   <th>Specification</th>
+  </tr>
+  <tr>
+   <td><a href="https://streams.spec.whatwg.org/">Streams Living Standard</a></td>
+  </tr>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+<h3 id="ReadableStream">ReadableStream</h3>
+
+<p>{{Compat("api.ReadableStream")}}</p>
+
+<h3 id="WritableStream">WritableStream</h3>
+
+<p>{{Compat("api.WritableStream")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/Streams_API/Concepts">Streams API concepts</a></li>
+ <li><a href="/en-US/docs/Web/API/Streams_API/Using_readable_streams">Using readable streams</a></li>
+ <li><a href="/en-US/docs/Web/API/Streams_API/Using_writable_streams">Using writable streams</a></li>
+</ul>


### PR DESCRIPTION
These are now implemented in Chrome, Deno, Node, and Cloudflare Workers.
