### PR TITLE
Websocket onmessage syntax block

### DIFF
--- a/files/en-us/web/api/websocket/onmessage/index.md
+++ b/files/en-us/web/api/websocket/onmessage/index.md
@@ -18,7 +18,7 @@ It is called with a {{domxref("MessageEvent")}}.
 ## Syntax
 
 ```js
-aWebSocket.onmessage = function(event) {
+WebSocket.onmessage = function(event) {
   console.debug("WebSocket message received:", event);
 };
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Looks like a minor typo

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Returns ```Uncaught ReferenceError: aWebSocket is not defined``` when run in the console

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
