### PR TITLE
Update to comment in use case example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -169,7 +169,7 @@ parseInt('0xF', 16)
 parseInt('F', 16)
 parseInt('17', 8)
 parseInt(021, 8)
-parseInt('015', 10)    // but `parseInt(015, 8)` will return 13
+parseInt('015', 10)    // but `parseInt('015', 8)` will return 13
 parseInt(15.99, 10)
 parseInt('15,123', 10)
 parseInt('FXX123', 16)


### PR DESCRIPTION
#### Summary
parseInt('015', 8) returns 13 while parseInt(015, 8) actually returns 11.

#### Motivation
I love learning about coding, parseInt is valuable Javascript method. For people new to the concept, the documentation as is could be confusing for a novice. 

#### Supporting details
The use case example comment should just be refactored to include the quotes. 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
