### PR TITLE
Fix inconsistency between layer name and description in html

### DIFF
--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -145,7 +145,7 @@ In the following example, two layers are created with no rules applied, then CSS
 
 ```html
 <div class="item">I am displayed in <code>color: rebeccapurple</code>
-because the <code>type</code> layer comes after the <code>base</code> layer.
+because the <code>special</code> layer comes after the <code>base</code> layer.
 My green border, font-size, and padding come from the <code>base</code> layer.</div>
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The layer name in the css is `special`, but the html description referred to a `type` layer. This is likely because the preceding example has a layer named `type`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Decrease confusion when looking at the description and comparing to the css used.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
