### PR TITLE
Response object not experimental

### DIFF
--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -12,27 +12,17 @@ browser-compat: api.Response.body
 ---
 {{APIRef("Fetch")}}
 
-The **`body`** read-only property of the {{domxref("Response")}}
-interface is a {{domxref("ReadableStream")}} of the body contents.
+The **`body`** read-only property of the {{domxref("Response")}} interface is a {{domxref("ReadableStream")}} of the body contents.
 
-## Syntax
-
-```js
-response.body;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 
 ## Example
 
-In our [simple stream
-pump](https://mdn.github.io/dom-examples/streams/simple-pump/) example we fetch an image, expose the response's stream using
-`response.body`, create a reader using
-{{domxref("ReadableStream.getReader()", "ReadableStream.getReader()")}}, then enqueue
-that stream's chunks into a second, custom readable stream — effectively creating an
-identical copy of the image.
+In our [simple stream pump](https://mdn.github.io/dom-examples/streams/simple-pump/) example we fetch an image,
+expose the response's stream using `response.body`, create a reader using {{domxref("ReadableStream.getReader()", "ReadableStream.getReader()")}},
+then enqueue that stream's chunks into a second, custom readable stream — effectively creating an identical copy of the image.
 
 ```js
 const image = document.getElementById('target');

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -12,34 +12,21 @@ browser-compat: api.Response.bodyUsed
 ---
 {{APIRef("Fetch")}}
 
-The **`bodyUsed`** read-only property of the
-{{domxref("Response")}} interface is a boolean value that indicates whether the
-body has been read yet.
+The **`bodyUsed`** read-only property of the {{domxref("Response")}} interface is a boolean value that indicates whether the body has been read yet.
 
-## Syntax
-
-```js
-response.bodyUsed;
-```
-
-### Value
+## Value
 
 A boolean value.
 
 ## Example
 
-In our [fetch
-request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (run [fetch request live](https://mdn.github.io/fetch-examples/fetch-request/)), we
-create a new request using the {{domxref("Request.Request","Request()")}} constructor,
-then use it to fetch a JPG. When the fetch is successful, we read a {{domxref("Blob")}}
-out of the response using `blob()`, put it into an object URL using
-{{domxref("URL.createObjectURL")}}, and then set that URL as the source of an
-{{htmlelement("img")}} element to display the image.
+In our [fetch request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (run [fetch request live](https://mdn.github.io/fetch-examples/fetch-request/)),
+we create a new request using the {{domxref("Request.Request","Request()")}} constructor,
+then use it to fetch a JPG. When the fetch is successful, we read a {{domxref("Blob")}} out of the response using `blob()`,
+put it into an object URL using {{domxref("URL.createObjectURL")}}, and then set that URL as the source of an {{htmlelement("img")}} element to display the image.
 
-Notice that we log `response.bodyUsed` to the console once
-before the `response.blob()` call and once after. This returns
-`false` before and `true` afterwards, as at that point the body
-has been read.
+Notice that we log `response.bodyUsed` to the console once before the `response.blob()` call and once after.
+This returns `false` before and `true` afterwards, as at that point the body has been read.
 
 ### HTML Content
 

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -3,7 +3,6 @@ title: Response.clone()
 slug: Web/API/Response/clone
 tags:
   - API
-  - Experimental
   - Fetch
   - Method
   - Reference
@@ -13,14 +12,10 @@ browser-compat: api.Response.clone
 ---
 {{APIRef("Fetch")}}
 
-The **`clone()`** method of the {{domxref("Response")}}
-interface creates a clone of a response object, identical in every way, but stored in a
-different variable.
+The **`clone()`** method of the {{domxref("Response")}} interface creates a clone of a response object, identical in every way, but stored in a different variable.
 
-`clone()` throws a {{jsxref("TypeError")}} if the response
-body has already been used. In fact, the main reason `clone()`
-exists is to allow multiple uses of body objects (when they are one-use
-only.)
+`clone()` throws a {{jsxref("TypeError")}} if the response body has already been used.
+In fact, the main reason `clone()` exists is to allow multiple uses of body objects (when they are one-use only.)
 
 ## Syntax
 
@@ -38,15 +33,10 @@ A {{domxref("Response")}} object.
 
 ## Example
 
-In our [Fetch
-Response clone example](https://github.com/mdn/fetch-examples/tree/master/fetch-response-clone) (see [Fetch Response clone
-live](https://mdn.github.io/fetch-examples/fetch-response-clone/)) we create a new {{domxref("Request")}} object using the
-{{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then
-fetch this request using {{domxref("fetch()")}}. When the fetch
-resolves successfully, we clone it, extract a blob from both responses using two
-{{domxref("Response.blob")}} calls, create object URLs out of the blobs using
-{{domxref("URL.createObjectURL")}}, and display them in two separate
-{{htmlelement("img")}} elements.
+In our [Fetch Response clone example](https://github.com/mdn/fetch-examples/tree/master/fetch-response-clone) (see [Fetch Response clone live](https://mdn.github.io/fetch-examples/fetch-response-clone/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}.
+When the fetch resolves successfully, we clone it, extract a blob from both responses using two {{domxref("Response.blob")}} calls, create object URLs out of the blobs using
+{{domxref("URL.createObjectURL")}}, and display them in two separate {{htmlelement("img")}} elements.
 
 ```js
 var image1 = document.querySelector('.img1');

--- a/files/en-us/web/api/response/error/index.md
+++ b/files/en-us/web/api/response/error/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Response/error
 tags:
   - API
   - Error
-  - Experimental
   - Fetch
   - Method
   - Reference
@@ -13,16 +12,12 @@ browser-compat: api.Response.error
 ---
 {{APIRef("Fetch")}}
 
-The **`error()`** method of the {{domxref("Response")}}
-interface returns a new `Response` object associated with a network error.
+The **`error()`** method of the {{domxref("Response")}} interface returns a new `Response` object associated with a network error.
 
-> **Note:** This is mainly relevant to [ServiceWorkers](/en-US/docs/Web/API/Service_Worker_API); the error method is
-> used to return an error if you so wish it. An error response has its
-> {{domxref("Response.type","type")}} set to `error`.
+> **Note:** This is mainly relevant to [ServiceWorkers](/en-US/docs/Web/API/Service_Worker_API); the error method is used to return an error if you so wish it.
+> An error response has its {{domxref("Response.type","type")}} set to `error`.
 
-> **Note:** An "error" `Response` never really gets exposed to
-> script: such a response to a {{domxref("fetch()")}} would reject
-> the promise.
+> **Note:** An "error" `Response` never really gets exposed to script: such a response to a {{domxref("fetch()")}} would reject the promise.
 
 ## Syntax
 

--- a/files/en-us/web/api/response/headers/index.md
+++ b/files/en-us/web/api/response/headers/index.md
@@ -3,7 +3,6 @@ title: Response.headers
 slug: Web/API/Response/headers
 tags:
   - API
-  - Experimental
   - Fetch
   - Headers
   - Property
@@ -17,28 +16,18 @@ The **`headers`** read-only property of the
 {{domxref("Response")}} interface contains the {{domxref("Headers")}} object associated
 with the response.
 
-## Syntax
-
-```js
-var myHeaders = response.headers;
-```
-
-### Value
+## Value
 
 A {{domxref("Headers")}} object.
 
 ## Example
 
-In our [Fetch
-Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
-we create a new {{domxref("Request")}} object using the
-{{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then
-fetch this request using {{domxref("fetch()")}}, extract a blob from
-the response using {{domxref("Response.blob")}}, create an object URL out of it using
-{{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}},
+create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
-Note that at the top of the `fetch()` block we log the response
-`headers` value to the console.
+Note that at the top of the `fetch()` block we log the response `headers` value to the console.
 
 ```js
 var myImage = document.querySelector('img');

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -3,7 +3,6 @@ title: Response
 slug: Web/API/Response
 tags:
   - API
-  - Experimental
   - Fetch
   - Fetch API
   - Interface
@@ -68,7 +67,8 @@ You can create a new `Response` object using the {{domxref("Response.Response()"
 
 ### Fetching an image
 
-In our [basic fetch example](https://github.com/mdn/fetch-examples/tree/master/basic-fetch) ([run example live](https://mdn.github.io/fetch-examples/basic-fetch/)) we use a simple `fetch()` call to grab an image and display it in an {{htmlelement("img")}} element. The `fetch()` call returns a promise, which resolves to the `Response` object associated with the resource fetch operation.
+In our [basic fetch example](https://github.com/mdn/fetch-examples/tree/master/basic-fetch) ([run example live](https://mdn.github.io/fetch-examples/basic-fetch/)) we use a simple `fetch()` call to grab an image and display it in an {{htmlelement("img")}} element.
+The `fetch()` call returns a promise, which resolves to the `Response` object associated with the resource fetch operation.
 
 You'll notice that since we are requesting an image, we need to run {{domxref("Response.blob")}} to give the response its correct MIME type.
 

--- a/files/en-us/web/api/response/ok/index.md
+++ b/files/en-us/web/api/response/ok/index.md
@@ -3,7 +3,6 @@ title: Response.ok
 slug: Web/API/Response/ok
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference
@@ -13,32 +12,19 @@ browser-compat: api.Response.ok
 ---
 {{APIRef("Fetch")}}
 
-The **`ok`** read-only property of the {{domxref("Response")}}
-interface contains a Boolean stating whether the response was successful (status in the
-range 200-299) or not.
+The **`ok`** read-only property of the {{domxref("Response")}} interface contains a Boolean stating whether the response was successful (status in the range 200-299) or not.
 
-## Syntax
-
-```js
-var myOK = response.ok;
-```
-
-### Value
+## Value
 
 A boolean value.
 
 ## Example
 
-In our [Fetch
-Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
-we create a new {{domxref("Request")}} object using the
-{{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then
-fetch this request using {{domxref("fetch()")}}, extract a blob from
-the response using {{domxref("Response.blob")}}, create an object URL out of it using
-{{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
-> **Note:** at the top of the `fetch()` block we log the
-> response `ok` value to the console.
+> **Note:** at the top of the `fetch()` block we log the response `ok` value to the console.
 
 ```js
 var myImage = document.querySelector('img');

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -3,7 +3,6 @@ title: Response.redirect()
 slug: Web/API/Response/redirect
 tags:
   - API
-  - Experimental
   - Fetch
   - Method
   - Redirect
@@ -13,12 +12,11 @@ browser-compat: api.Response.redirect
 ---
 {{APIRef("Fetch")}}
 
-The **`redirect()`** method of the {{domxref("Response")}}
-interface returns a `Response` resulting in a redirect to the specified URL.
+The **`redirect()`** method of the {{domxref("Response")}} interface returns a `Response` resulting in a redirect to the specified URL.
 
-> **Note:** This is mainly relevant to the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API). A controlling
-> service worker could intercept a page's request and redirect it as desired. This will
-> actually lead to a real redirect if a service worker sends it upstream.
+> **Note:** This is mainly relevant to the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API).
+> A controlling service worker could intercept a page's request and redirect it as desired.
+> This will actually lead to a real redirect if a service worker sends it upstream.
 
 ## Syntax
 
@@ -39,10 +37,10 @@ A {{domxref("Response")}} object.
 
 ### Exceptions
 
-| Exception    | Explanation                                    |
-| ------------ | ---------------------------------------------- |
-| `RangeError` | The specified status is not a redirect status. |
-| `TypeError`  | The specified URL is invalid.                  |
+- `RangeError`
+  - : The specified status is not a redirect status.
+- `TypeError`
+  - : The specified URL is invalid.
 
 ## Example
 

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -37,7 +37,7 @@ A {{domxref("Response")}} object.
 
 ### Exceptions
 
-- {{jsxref("RangeError"}}
+- {{jsxref("RangeError")}}
   - : The specified status is not a redirect status.
 - {{jsxref("TypeError")}}
   - : The specified URL is invalid.

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -37,9 +37,9 @@ A {{domxref("Response")}} object.
 
 ### Exceptions
 
-- `RangeError`
+- {{jsxref("RangeError"}}
   - : The specified status is not a redirect status.
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : The specified URL is invalid.
 
 ## Example

--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -3,7 +3,6 @@ title: Response.redirected
 slug: Web/API/Response/redirected
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Read-only
@@ -14,35 +13,23 @@ browser-compat: api.Response.redirected
 ---
 {{APIRef("Fetch")}}
 
-The read-only **`redirected`** property of the
-{{domxref("Response")}} interface indicates whether or not the response is the result of
-a request you made which was redirected.
+The read-only **`redirected`** property of the {{domxref("Response")}} interface indicates whether or not the response is the result of a request you made which was redirected.
 
-> **Note:** Relying on redirected to filter out redirects makes it easy for a forged redirect to
-> prevent your content from working as expected. Instead, you should actually instead do
-> the filtering when you call {{domxref("fetch()")}}. See the
-> example {{anch("Disallowing redirects")}}, which shows this being done.
+> **Note:** Relying on redirected to filter out redirects makes it easy for a forged redirect to prevent your content from working as expected.
+> Instead, you should actually instead do the filtering when you call {{domxref("fetch()")}}.
+> See the example {{anch("Disallowing redirects")}}, which shows this being done.
 
-## Syntax
+## Value
 
-```js
-var isRedirected = Response.redirected;
-```
-
-### Value
-
-A boolean value which is `true` if the response indicates that your
-request was redirected.
+A boolean value which is `true` if the response indicates that your request was redirected.
 
 ## Examples
 
 ### Detecting redirects
 
-Checking to see if the response comes from a redirected request is as simple as
-checking this flag on the {{domxref("Response")}} object. In the code below, a textual
-message is inserted into an element when a redirect occurred during the fetch operation.
-Note, however, that this isn't as safe as outright rejecting redirects if they're
-unexpected, as described under {{anch("Disallowing redirects")}} below.
+Checking to see if the response comes from a redirected request is as simple as checking this flag on the {{domxref("Response")}} object.
+In the code below, a textual message is inserted into an element when a redirect occurred during the fetch operation.
+Note, however, that this isn't as safe as outright rejecting redirects if they're unexpected, as described under {{anch("Disallowing redirects")}} below.
 
 ```js
 fetch("awesome-picture.jpg").then(function(response) {
@@ -61,10 +48,7 @@ fetch("awesome-picture.jpg").then(function(response) {
 
 ### Disallowing redirects
 
-Because using redirected to manually filter out redirects can allow forgery of
-redirects, you should instead set the redirect mode to `"error"` in the
-`init` parameter when calling {{domxref("fetch()")}},
-like this:
+Because using redirected to manually filter out redirects can allow forgery of redirects, you should instead set the redirect mode to `"error"` in the `init` parameter when calling {{domxref("fetch()")}}, like this:
 
 ```js
 fetch("awesome-picture.jpg", { redirect: "error" }).then(function(response) {

--- a/files/en-us/web/api/response/response/index.md
+++ b/files/en-us/web/api/response/response/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Response/Response
 tags:
   - API
   - Constructor
-  - Experimental
   - Fetch
   - Reference
   - Response
@@ -12,18 +11,17 @@ browser-compat: api.Response.Response
 ---
 {{APIRef("Fetch")}}
 
-The **`Response()`** constructor creates a new
-{{domxref("Response")}} object.
+The **`Response()`** constructor creates a new {{domxref("Response")}} object.
 
 ## Syntax
 
 ```js
-var myResponse = new Response(body, init);
+new Response(body, init)
 ```
 
 ### Parameters
 
-- _body_ {{optional_inline}}
+- `body` {{optional_inline}}
 
   - : An object defining a body for the response. This can be `null` (which is
     the default value), or one of:
@@ -35,7 +33,7 @@ var myResponse = new Response(body, init);
     - {{domxref("URLSearchParams")}}
     - {{domxref("USVString")}}
 
-- _init_ {{optional_inline}}
+- `init` {{optional_inline}}
 
   - : An options object containing any custom settings that you want to apply to the
     response, or an empty object (which is the default value). The possible options are:
@@ -49,11 +47,8 @@ var myResponse = new Response(body, init);
 
 ## Examples
 
-In our [Fetch
-Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
-we create a new `Response` object using the constructor, passing it a new
-{{domxref("Blob")}} as a body, and an init object containing a custom
-`status` and `statusText`:
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+we create a new `Response` object using the constructor, passing it a new {{domxref("Blob")}} as a body, and an init object containing a custom `status` and `statusText`:
 
 ```js
 var myBlob = new Blob();

--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -3,7 +3,6 @@ title: Response.status
 slug: Web/API/Response/status
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference
@@ -13,32 +12,22 @@ browser-compat: api.Response.status
 ---
 {{APIRef("Fetch")}}
 
-The **`status`** read-only property of the
-{{domxref("Response")}} interface contains the status code of the response (e.g.,
-`200` for a success).
+The **`status`** read-only property of the {{domxref("Response")}} interface contains the [HTTP status codes](/en-US/docs/Web/HTTP/Status) of the response.
 
-## Syntax
+For example, `200` for success, `404` if the resource could not be found.
 
-```js
-var myStatus = response.status;
-```
+## Value
 
-### Value
-
-A number (to be precise, an unsigned short).
+A unsigned short number.
+This is one of the [HTTP response status codes](/en-US/docs/Web/HTTP/Status).
 
 ## Example
 
-In our [Fetch
-Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
-we create a new {{domxref("Request")}} object using the
-{{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then
-fetch this request using {{domxref("fetch()")}}, extract a blob from
-the response using {{domxref("Response.blob")}}, create an object URL out of it using
-{{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
-Note that at the top of the `fetch()` block we log the response
-`status` value to the console.
+Note that at the top of the `fetch()` block we log the response `status` value to the console.
 
 ```js
 var myImage = document.querySelector('img');

--- a/files/en-us/web/api/response/statustext/index.md
+++ b/files/en-us/web/api/response/statustext/index.md
@@ -3,7 +3,6 @@ title: Response.statusText
 slug: Web/API/Response/statusText
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference
@@ -13,35 +12,24 @@ browser-compat: api.Response.statusText
 ---
 {{APIRef("Fetch")}}
 
-The **`statusText`** read-only property of the
-{{domxref("Response")}} interface contains the status message corresponding to the
-status code (e.g., `OK` for `200`).
+The **`statusText`** read-only property of the {{domxref("Response")}} interface contains the status message corresponding to the HTTP status code in {{domxref("Response.status")}}.
 
-## Syntax
+For example, this would be `OK` for a status code `200`, `Continue` for `100`, `Not Found` for `404`.
 
-```js
-var myStatusText = response.statusText;
-```
+## Value
 
-### Value
+A {{jsxref("String")}} containing the HTTP status message associated with the response.
+The default value is "".
 
-A {{jsxref("String")}}.
-
-The default value is "". Note that HTTP/2 [does not
-support](https://fetch.spec.whatwg.org/#concept-response-status-message) status messages.
+See [HTTP response status codes](/en-US/docs/Web/HTTP/Status) for a list of codes and their associated status messages.
+Note that HTTP/2 [does not support](https://fetch.spec.whatwg.org/#concept-response-status-message) status messages.
 
 ## Example
 
-In our [Fetch
-Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response
-live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the
-{{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then
-fetch this request using {{domxref("fetch()")}}, extract a blob
-from the response using {{domxref("Response.blob")}}, create an object URL out of it using
-{{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
-Note that at the top of the `fetch()` block we log the response
-`statusText` value to the console.
+Note that at the top of the `fetch()` block we log the response `statusText` value to the console.
 
 ```js
 var myImage = document.querySelector('img');

--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -12,10 +12,9 @@ browser-compat: api.Response.text
 ---
 {{APIRef("Fetch")}}
 
-The **`text()`** method of the {{domxref("Response")}} interface takes
-a {{domxref("Response")}} stream and reads it to completion. It returns a promise that
-resolves with a {{jsxref("String")}}. The response
-is *always* decoded using UTF-8.
+The **`text()`** method of the {{domxref("Response")}} interface takes a {{domxref("Response")}} stream and reads it to completion.
+It returns a promise that resolves with a {{jsxref("String")}}.
+The response is *always* decoded using UTF-8.
 
 ## Syntax
 
@@ -35,20 +34,11 @@ A Promise that resolves with a {{jsxref("String")}}.
 
 ## Example
 
-In our [fetch
-text example](https://github.com/mdn/fetch-examples/tree/master/fetch-text) (run [fetch
-text live](https://mdn.github.io/fetch-examples/fetch-text/)), we have an {{htmlelement("article")}} element and three links (stored
-in the `myLinks` array.) First, we loop through all of these and give each
-one an `onclick` event handler so that the `getData()` function is
-run — with the link's `data-page` identifier passed to it as an argument —
-when one of the links is clicked.
+In our [fetch text example](https://github.com/mdn/fetch-examples/tree/master/fetch-text) (run [fetch text live](https://mdn.github.io/fetch-examples/fetch-text/)), we have an {{htmlelement("article")}} element and three links (stored in the `myLinks` array.)
+First, we loop through all of these and give each one an `onclick` event handler so that the `getData()` function is run — with the link's `data-page` identifier passed to it as an argument — when one of the links is clicked.
 
-When `getData()` is run, we create a new request using the
-{{domxref("Request.Request","Request()")}} constructor, then use it to fetch a specific
-`.txt` file. When the fetch is successful, we read a {{domxref("USVString")}}
-(text) object out of the response using `text()`, then set the
-{{domxref("Element.innerHTML","innerHTML")}} of the {{htmlelement("article")}} element
-equal to the text object.
+When `getData()` is run, we create a new request using the {{domxref("Request.Request","Request()")}} constructor, then use it to fetch a specific `.txt` file.
+When the fetch is successful, we read a {{domxref("USVString")}} (text) object out of the response using `text()`, then set the {{domxref("Element.innerHTML","innerHTML")}} of the {{htmlelement("article")}} element equal to the text object.
 
 ```js
 let myArticle = document.querySelector('article');

--- a/files/en-us/web/api/response/type/index.md
+++ b/files/en-us/web/api/response/type/index.md
@@ -3,7 +3,6 @@ title: Response.type
 slug: Web/API/Response/type
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference
@@ -13,29 +12,30 @@ browser-compat: api.Response.type
 ---
 {{APIRef("Fetch")}}
 
-The **`type`** read-only property of the {{domxref("Response")}} interface contains the type of the response. It can be one of the following:
+The **`type`** read-only property of the {{domxref("Response")}} interface contains the type of the response.
+It can be one of the following:
 
 - `basic`: Normal, same origin response, with all headers exposed except “Set-Cookie” and “Set-Cookie2″.
 - `cors`: Response was received from a valid cross-origin request. [Certain headers and the body](https://fetch.spec.whatwg.org/#concept-filtered-response-cors) may be accessed.
-- `error`: Network error. No useful information describing the error is available. The Response’s status is 0, headers are empty and immutable. This is the type for a Response obtained from `Response.error()`.
-- `opaque`: Response for “no-cors” request to cross-origin resource. [Severely restricted](https://fetch.spec.whatwg.org/#concept-filtered-response-opaque).
-- `opaqueredirect`: The fetch request was made with `redirect: "manual"`. The Response's status is 0, headers are empty, body is null and trailer is empty.
+- `error`: Network error.
+  No useful information describing the error is available.
+  The Response’s status is 0, headers are empty and immutable.
+  This is the type for a Response obtained from `Response.error()`.
+- `opaque`: Response for “no-cors” request to cross-origin resource.
+  [Severely restricted](https://fetch.spec.whatwg.org/#concept-filtered-response-opaque).
+- `opaqueredirect`: The fetch request was made with `redirect: "manual"`.
+  The Response's status is 0, headers are empty, body is null and trailer is empty.
 
 > **Note:** An "error" Response never really gets exposed to script: such a response to a {{domxref("fetch()")}} would reject the promise.
 
-## Syntax
-
-```js
-var myType = response.type;
-```
-
-### Value
+## Value
 
 A `ResponseType` string indicating the type of the response.
 
 ## Example
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
 Note that at the top of the `fetch()` block we log the response `type` to the console.
 

--- a/files/en-us/web/api/response/url/index.md
+++ b/files/en-us/web/api/response/url/index.md
@@ -3,7 +3,6 @@ title: Response.url
 slug: Web/API/Response/url
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference
@@ -13,32 +12,19 @@ browser-compat: api.Response.url
 ---
 {{APIRef("Fetch")}}
 
-The **`url`** read-only property of the {{domxref("Response")}}
-interface contains the URL of the response. The value of the `url` property
-will be the final URL obtained after any redirects.
+The **`url`** read-only property of the {{domxref("Response")}} interface contains the URL of the response.
+The value of the `url` property will be the final URL obtained after any redirects.
 
-## Syntax
-
-```js
-var myURL = response.url;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 
 ## Example
 
-In our [Fetch
-Response example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
-we create a new {{domxref("Request")}} object using the
-{{domxref("Request.Request","Request()")}} constructor, passing it a JPG path. We then
-fetch this request using {{domxref("fetch()")}}, extract a blob from
-the response using {{domxref("Response.blob")}}, create an object URL out of it using
-{{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
+In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
-Note that at the top of the `fetch()` block we log the response
-`URL` to the console.
+Note that at the top of the `fetch()` block we log the response `URL` to the console.
 
 ```js
 var myImage = document.querySelector('img');


### PR DESCRIPTION
Fixes #10384

Specifically it adds a link to HTTP status codes list to the Response.status and Response.statusText.

While I was here I fixed up all the response items that were tagged as "Experimental" and fixed up the Syntax/values sections and layout across the `Response` object.