### PR TITLE
[DOM Reference] Update CharacterData interface, and descendants, and their children

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7055,9 +7055,7 @@
 /en-US/docs/Web/API/CanvasRenderingContext2D/mozImageSmoothingEnabled	/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled
 /en-US/docs/Web/API/CanvasRenderingContext2D/mozTextStyle	/en-US/docs/Web/API/CanvasRenderingContext2D/font
 /en-US/docs/Web/API/Canvas_API/Drawing_graphics_with_canvas	/en-US/docs/Web/API/Canvas_API/Tutorial
-/en-US/docs/Web/API/CharacterData.previousElementSibling	/en-US/docs/Web/API/Element/previousElementSibling
-/en-US/docs/Web/API/CharacterData/nextElementSibling	/en-US/docs/Web/API/Element/nextElementSibling
-/en-US/docs/Web/API/CharacterData/previousElementSibling	/en-US/docs/Web/API/Element/previousElementSibling
+/en-US/docs/Web/API/CharacterData.previousElementSibling	/en-US/docs/Web/API/CharacterData/previousElementSibling
 /en-US/docs/Web/API/ChildNode.nextElementSibling	/en-US/docs/Web/API/Element/nextElementSibling
 /en-US/docs/Web/API/ChildNode.remove	/en-US/docs/Web/API/Element/remove
 /en-US/docs/Web/API/ChildNode/after	/en-US/docs/Web/API/Element/after

--- a/files/en-us/web/api/cdatasection/index.md
+++ b/files/en-us/web/api/cdatasection/index.md
@@ -2,9 +2,6 @@
 title: CDATASection
 slug: Web/API/CDATASection
 tags:
-  - API
-  - CDATASection
-  - DOM
   - Interface
   - Reference
 browser-compat: api.CDATASection
@@ -12,9 +9,9 @@ browser-compat: api.CDATASection
 {{APIRef("DOM")}}
 
 The **`CDATASection`** interface represents a CDATA section
-that can be used within XML to include extended portions of unescaped text. The symbols
-`<` and `&` don’t need escaping as they normally do when
-inside a CDATA section.
+that can be used within XML to include extended portions of unescaped text.
+When inside a CDATA section, the symbols `<` and `&` don't need escaping
+as they normally do.
 
 In XML, a CDATA section looks like:
 
@@ -24,18 +21,14 @@ In XML, a CDATA section looks like:
 
 For example:
 
-```xml
+```html
 <foo>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</foo>
 ```
 
 The only sequence which is not allowed within a CDATA section is the closing sequence
-of a CDATA section itself, `]]>`:
+of a CDATA section itself, `]]>`.
 
-```xml
-<![CDATA[ ]]> will cause an error ]]>
-```
-
-Note that CDATA sections should not be used within HTML; they only work in XML.
+> **Note:* CDATA sections should not be used within HTML they are considered as comments and not displayed.
 
 {{InheritanceDiagram(600, 120)}}
 
@@ -56,3 +49,7 @@ _This interface has no specific methods and implements those of its parent
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Document.createCDATASection()")}}

--- a/files/en-us/web/api/characterdata/after/index.md
+++ b/files/en-us/web/api/characterdata/after/index.md
@@ -2,19 +2,17 @@
 title: CharacterData.after()
 slug: Web/API/CharacterData/after
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
 browser-compat: api.CharacterData.after
 ---
 {{APIRef("DOM")}}
 
-The **`CharacterData.after()`** method inserts a set of
-{{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the
-`CharacterData`'s parent, just after the `CharacterData`.
-{{domxref("DOMString")}} objects are inserted as equivalent {{domxref("Text")}} nodes.
+The **`after()`** method of the {{domxref("CharacterData")}} interface
+inserts a set of {{domxref("Node")}} objects or strings in the children list of the
+object's parent, just after the object itself.
+
+Strings are inserted as {{domxref("Text")}} nodes; the string is being passed as argument to the {{domxref("Text/Text", "Text()")}} constructor.
 
 ## Syntax
 
@@ -25,16 +23,19 @@ after(... nodes)
 ### Parameters
 
 - `nodes`
-  - : A set of {{domxref("Node")}} or {{domxref("DOMString")}} objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Exceptions
 
 - `HierarchyRequestError` {{DOMxRef("DOMException")}}
-  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
+  - : Thrown when the new nodes cannot be inserted at the specified point in the hierarchy,
+    that is if one of the following conditions is met:
+    - If the insertion of one of the added node would lead to a cycle, that is if one of them is an ancestor of this {{domxref("CharacterData")}} node.
+    - If one of the added node is not a {{domxref("DocumentFragment")}}, a {{domxref("DocumentType")}}, an {{domxref("Element")}}, or a {{domxref("CharacterData")}}.
+    - If this {{domxref("CharacterData")}} node is actually a {{domxref("Text")}} node, and its parent is a {{domxref("Document")}}.
+    - If the parent of this {{domxref("CharacterData")}} node is a {{domxref("Document")}} and one of the nodes to insert is a {{domxref("DocumentFragment")}} with more than one {{domxref("Element")}} child, or that has a {{domxref("Text")}} child.
 
 ## Examples
-
-### Inserting text in new nodes
 
 The `after()` method allows you to insert new nodes after a `CharacterData` node.
 
@@ -49,21 +50,8 @@ h1TextNode.data;
 // "CharacterData.after()"
 ```
 
-### Appending text to the current node
-
-If you rather want to append text to the current node,
-the [`appendData()`](/en-US/docs/Web/API/CharacterData/appendData) method lets you append to the current node's data:
-
-```js
-const h1TextNode = document.getElementsByTagName('h1')[0].firstChild;
-h1TextNode.appendData(" #h1");
-
-h1TextNode.parentElement.childNodes;
-// NodeList [#text "CharacterData.after() #h1"]
-
-h1TextNode.data;
-// "CharacterData.after() #h1"
-```
+> **Note:** If you rather want to append text to the current node,
+> the [`appendData()`](/en-US/docs/Web/API/CharacterData/appendData) method lets you append to the current node's data.
 
 ## Specifications
 
@@ -80,4 +68,3 @@ h1TextNode.data;
 - {{domxref("Element.append()")}}
 - {{domxref("Node.appendChild()")}}
 - {{domxref("Element.insertAdjacentElement()")}}
-- {{domxref("NodeList")}}

--- a/files/en-us/web/api/characterdata/appenddata/index.md
+++ b/files/en-us/web/api/characterdata/appenddata/index.md
@@ -2,33 +2,44 @@
 title: CharacterData.appendData()
 slug: Web/API/CharacterData/appendData
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
-  - CharacterData
 browser-compat: api.CharacterData.appendData
 ---
 {{APIRef("DOM")}}
 
-The `appendData()` method of the {{domxref("CharacterData")}}
-interface adds the provided data to the end of the Node's current data.
+The **`appendData()`** method of the {{domxref("CharacterData")}} interface
+adds the provided data to the end of the node's current data.
 
 ## Syntax
 
 ```js
-  characterData.appendData(data)
+appendData(data);
 ```
 
 ### Parameters
 
 - `data`
-  - : The data to append to the given `CharacterData` object.
+  - : The data to append to the current node.
 
 ### Return value
 
-{{jsxref("undefined")}}.
+None.
+
+## Example
+
+```html
+<span>Result: </span>A text
+```
+
+```js
+let span = document.getElementsByTagName("span")[0];
+let textnode = span.nextSibling;
+
+textnode.appendData(" - appended text.");
+```
+
+{{EmbedLiveSample("Example", "100%", 50)}}
 
 ## Specifications
 
@@ -37,3 +48,8 @@ interface adds the provided data to the end of the Node's current data.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.deleteData()")}}, {{domxref("CharacterData.insertData()")}}, {{domxref("CharacterData.replaceData()")}}
+- {{domxref("CharacterData.data")}}

--- a/files/en-us/web/api/characterdata/before/index.md
+++ b/files/en-us/web/api/characterdata/before/index.md
@@ -2,19 +2,17 @@
 title: CharacterData.before()
 slug: Web/API/CharacterData/before
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
 browser-compat: api.CharacterData.before
 ---
 {{APIRef("DOM")}}
 
-The **`CharacterData.before()`** method inserts a set of
-{{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the
-`CharacterData`'s parent, just before the `CharacterData`.
-{{domxref("DOMString")}} objects are inserted as equivalent {{domxref("Text")}} nodes.
+The **`before()`** method of the {{domxref("CharacterData")}} interface
+inserts a set of {{domxref("Node")}} objects and strings
+in the children list of the `CharacterData`'s parent, just before the `CharacterData` node.
+
+Strings are inserted as {{domxref("Text")}} nodes; the string is being passed as argument to the {{domxref("Text/Text", "Text()")}} constructor.
 
 ## Syntax
 
@@ -25,16 +23,18 @@ before(... nodes)
 ### Parameters
 
 - `nodes`
-  - : A set of {{domxref("Node")}} or {{domxref("DOMString")}} objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Exceptions
 
 - `HierarchyRequestError` {{DOMxRef("DOMException")}}
-  - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
+  - : Thrown when the new nodes cannot be inserted at the specified point in the hierarchy, that is if one of the following conditions is met:
+    - If the insertion of one of the added node would lead to a cycle, that is if one of them is an ancestor of this {{domxref("CharacterData")}} node.
+    - If one of the added node is not a {{domxref("DocumentFragment")}}, a {{domxref("DocumentType")}}, an {{domxref("Element")}}, or a {{domxref("CharacterData")}}.
+    - If this {{domxref("CharacterData")}} node is actually a {{domxref("Text")}} node, and its parent is a {{domxref("Document")}}.
+    - If the parent of this {{domxref("CharacterData")}} node is a {{domxref("Document")}} and one of the nodes to insert is a {{domxref("DocumentFragment")}} with more than one {{domxref("Element")}} child, or that has a {{domxref("Text")}} child.
 
 ## Examples
-
-### Inserting text in new nodes
 
 The `before()` method allows you to insert new nodes before a
 `CharacterData` node leaving the current node's data unchanged.
@@ -65,4 +65,3 @@ h1TextNode.data;
 - {{domxref("Element.append()")}}
 - {{domxref("Node.appendChild()")}}
 - {{domxref("Element.insertAdjacentElement()")}}
-- {{domxref("NodeList")}}

--- a/files/en-us/web/api/characterdata/data/index.md
+++ b/files/en-us/web/api/characterdata/data/index.md
@@ -2,19 +2,53 @@
 title: CharacterData.data
 slug: Web/API/CharacterData/data
 tags:
-  - API
-  - DOM
-  - Method
-  - Node
+  - Property
   - Reference
-  - CharacterData
 browser-compat: api.CharacterData.data
 ---
 {{APIRef("DOM")}}
 
-The `data` property of the {{domxref("CharacterData")}}
-interface returns or sets the value of the current `CharacterData`
-Node's data.
+The **`data`** property of the {{domxref("CharacterData")}} interface represent the value of the current object's data.
+
+## Value
+
+A string with the character information contained in the {{domxref("CharacterData")}} node.
+
+## Example
+
+> **Note:** {{domxref("CharacterData")}} is an abstract interface.
+> The examples below use two concrete interfaces implementing it, {{domxref("Text")}} and {{domxref("Comment")}}.
+
+### Reading a comment using data
+
+```html
+<!-- This is an html comment !-->
+<output id="Result"></output>
+```
+
+```js
+let comment = document.body.childNodes[1];
+let output = document.getElementById("Result");
+
+output.value = comment.data;
+```
+
+{{EmbedLiveSample("Reading_a_comment_using_data", "100%", 50)}}
+
+### Setting the content of a text node using data
+
+```html
+<span>Result: </span>Not set.
+````
+
+```js
+let span = document.getElementsByTagName("span")[0];
+let textnode = span.nextSibling;
+
+textnode.data = "This text has been set using textnode.data."
+```
+
+{{EmbedLiveSample("Setting_the_content_of_a_text_node_using_data", "100%", 50)}}
 
 ## Specifications
 
@@ -23,3 +57,7 @@ Node's data.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.length")}} returning the length of the data contained in the {{domxref("CharacterData")}} node.

--- a/files/en-us/web/api/characterdata/deletedata/index.md
+++ b/files/en-us/web/api/characterdata/deletedata/index.md
@@ -2,36 +2,47 @@
 title: CharacterData.deleteData()
 slug: Web/API/CharacterData/deleteData
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
-  - CharacterData
 browser-compat: api.CharacterData.deleteData
 ---
 {{APIRef("DOM")}}
 
-The `deleteData()` method of the {{domxref("CharacterData")}}
-interface removes all data from this `CharacterData` Node, leaving
-it empty.
+The **`deleteData()`** method of the {{domxref("CharacterData")}} interface
+removes all or part of the data from this `CharacterData` node.
 
 ## Syntax
 
 ```js
-  characterData.deleteData(offset, count)
+characterData.deleteData(offset, count)
 ```
 
 ### Parameters
 
 - `offset`
-  - : is an integer representing the number of bytes from the start of the data to remove from.
+  - : The number of bytes from the start of the data to remove from.
+    `0` is the first character of the string.
 - `count`
-  - : is an integer representing the number of bytes to remove.
+  - : Tthe number of bytes to remove.
 
 ### Return value
 
-{{jsxref("undefined")}}.
+None.
+
+## Example
+
+```html
+<span>Result: </span>A long string.
+```
+
+```js
+let span = document.getElementsByTagName("span")[0];
+let textnode = span.nextSibling;
+
+textnode.deleteData(1, 5);
+```
+
+{{EmbedLiveSample("Example", "100%", 50)}}
 
 ## Specifications
 
@@ -40,3 +51,8 @@ it empty.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.appendData()")}}, {{domxref("CharacterData.insertData()")}}, {{domxref("CharacterData.replaceData()")}}
+- {{domxref("CharacterData.data")}}

--- a/files/en-us/web/api/characterdata/index.md
+++ b/files/en-us/web/api/characterdata/index.md
@@ -2,55 +2,53 @@
 title: CharacterData
 slug: Web/API/CharacterData
 tags:
-  - API
-  - DOM
   - Interface
-  - Node
+  - Reference
 browser-compat: api.CharacterData
 ---
 {{APIRef("DOM")}}
 
-The **`CharacterData`** abstract interface represents a {{domxref("Node")}} object that contains characters. This is an abstract interface, meaning there aren't any objects of type `CharacterData`: it is implemented by other interfaces like {{domxref("Text")}}, {{domxref("Comment")}}, or {{domxref("ProcessingInstruction")}}, which aren't abstract.
+The **`CharacterData`** abstract interface represents a {{domxref("Node")}} object that contains characters. This is an abstract interface, meaning there aren't any objects of type `CharacterData`: it is implemented by other interfaces like {{domxref("Text")}}, {{domxref("Comment")}}, {{domxref("CDATASection")}}, or {{domxref("ProcessingInstruction")}}, which aren't abstract.
 
 {{InheritanceDiagram}}
 
 ## Properties
 
-_`CharacterData` inherits properties from its parent, {{domxref("Node")}}._
+_This interface also inherits properties from its parents, {{domxref("Node")}} and {{domxref("EventTarget")}}._
 
 - {{domxref("CharacterData.data")}}
-  - : Is a {{domxref("DOMString")}} representing the textual data contained in this object.
+  - : Is a string representing the textual data contained in this object.
 - {{domxref("CharacterData.length")}} {{readonlyInline}}
-  - : Returns an `unsigned long` representing the size of the string contained in `CharacterData.data`.
-- {{domxref("Element.nextElementSibling")}} {{readonlyInline}}
-  - : Returns the {{domxref("Element")}} immediately following the specified one in its parent's children list, or `null` if the specified element is the last one in the list.
-- {{domxref("Element.previousElementSibling")}} {{readonlyInline}}
-  - : Returns the {{domxref("Element")}} immediately prior to the specified one in its parent's children list, or `null` if the specified element is the first one in the list.
+  - : Returns a number representing the size of the string contained in the object.
+- {{domxref("CharacterData.nextElementSibling")}} {{readonlyInline}}
+  - : Returns the first {{domxref("Element")}} that _follows_ this node, and is a sibling.
+- {{domxref("CharacterData.previousElementSibling")}} {{readonlyInline}}
+  - : Returns the first {{domxref("Element")}} that _precedes_ this node, and is a sibling.
 
 ## Methods
 
-_`CharacterData` inherits methods from its parent, {{domxref("Node")}}._
+_This interface also inherits methods from its parents, {{domxref("Node")}} and {{domxref("EventTarget")}}._
 
 - {{domxref("CharacterData.after()")}}
-  - : Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the
+  - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the
     `CharacterData`'s parent, just after the `CharacterData` object.
 - {{domxref("CharacterData.appendData()")}}
-  - : Appends the given {{domxref("DOMString")}} to the `CharacterData.data` string; when this method returns, `data` contains the concatenated {{domxref("DOMString")}}.
+  - : Appends the given string to the `CharacterData.data` string; when this method returns, `data` contains the concatenated {{domxref("DOMString")}}.
 - {{domxref("CharacterData.before()")}}
-  - : Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the
+  - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the
     `CharacterData`'s parent, just before the `CharacterData` object.
 - {{domxref("CharacterData.deleteData()")}}
-  - : Removes the specified amount of characters, starting at the specified offset, from the `CharacterData.data` string; when this method returns, `data` contains the shortened {{domxref("DOMString")}}.
+  - : Removes the specified amount of characters, starting at the specified offset, from the `CharacterData.data` string; when this method returns, `data` contains the shortened string.
 - {{domxref("CharacterData.insertData()")}}
   - : Inserts the specified characters, at the specified offset, in the `CharacterData.data` string; when this method returns, `data` contains the modified {{domxref("DOMString")}}.
 - {{domxref("CharacterData.remove()")}}
   - : Removes the object from its parent children list.
 - {{domxref("CharacterData.replaceData()")}}
-  - : Replaces the specified amount of characters, starting at the specified offset, with the specified {{domxref("DOMString")}}; when this method returns, `data` contains the modified {{domxref("DOMString")}}.
+  - : Replaces the specified amount of characters, starting at the specified offset, with the specified {{domxref("DOMString")}}; when this method returns, `data` contains the modified string.
 - {{DOMxRef("CharacterData.replaceWith()")}}
-  - : Replaces the characters in the children list of its parent with a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects.
+  - : Replaces the characters in the children list of its parent with a set of {{domxref("Node")}} objects or strings.
 - {{domxref("CharacterData.substringData()")}}
-  - : Returns a {{domxref("DOMString")}} containing the part of `CharacterData.data` of the specified length and starting at the specified offset.
+  - : Returns a {{jsxref("String")}} containing the part of `CharacterData.data` of the specified length and starting at the specified offset.
 
 ## Specifications
 
@@ -62,4 +60,5 @@ _`CharacterData` inherits methods from its parent, {{domxref("Node")}}._
 
 ## See also
 
-- [The DOM interfaces index](/en-US/docs/Web/API/Document_Object_Model).
+- [The DOM overview page](/en-US/docs/Web/API/Document_Object_Model).
+- The concrete interfaces implemented it: {{domxref("Text")}}, {{domxref("CDATASection")}}, {{domxref("ProcessingInstruction")}}, and {{domxref("Comment")}}.

--- a/files/en-us/web/api/characterdata/insertdata/index.md
+++ b/files/en-us/web/api/characterdata/insertdata/index.md
@@ -2,37 +2,49 @@
 title: CharacterData.insertData()
 slug: Web/API/CharacterData/insertData
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
-  - CharacterData
 browser-compat: api.CharacterData.insertData
 ---
 {{APIRef("DOM")}}
 
-The `insertData()` method of the {{domxref("CharacterData")}}
-interface inserts the provided data into this `CharacterData`
-Node's current data, at the provided offset from the start of the existing
-data. The provided data is spliced into the existing data.
+The **`insertData()`** method of the {{domxref("CharacterData")}} interface
+inserts the provided data into this `CharacterData` node's current data,
+at the provided offset from the start of the existing data.
+The provided data is spliced into the existing data.
 
 ## Syntax
 
 ```js
-  characterData.insertData(offset, data)
+characterData.insertData(offset, data)
 ```
 
 ### Parameters
 
 - `offset`
   - : The offset number of characters to insert the provided data at.
+    `0` is the first character of the string.
 - `data`
-  - : The data to insert to the given `CharacterData` object.
+  - : The data to insert.
 
 ### Return value
 
-{{jsxref("undefined")}}.
+None.
+
+## Example
+
+```html
+<span>Result: </span>A string.
+```
+
+```js
+let span = document.getElementsByTagName("span")[0];
+let textnode = span.nextSibling;
+
+textnode.insertData(2, "long ");
+```
+
+{{EmbedLiveSample("Example", "100%", 50)}}
 
 ## Specifications
 
@@ -41,3 +53,8 @@ data. The provided data is spliced into the existing data.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.appendData()")}}, {{domxref("CharacterData.deleteData()")}}, {{domxref("CharacterData.replaceData()")}}
+- {{domxref("CharacterData.data")}}

--- a/files/en-us/web/api/characterdata/length/index.md
+++ b/files/en-us/web/api/characterdata/length/index.md
@@ -2,18 +2,37 @@
 title: CharacterData.length
 slug: Web/API/CharacterData/length
 tags:
-  - API
-  - DOM
-  - Method
-  - Node
+  - Property
   - Reference
-  - CharacterData
+  - Read-only
 browser-compat: api.CharacterData.length
 ---
 {{APIRef("DOM")}}
 
-The **`CharacterData.length`** property returns the
-number of characters in the contained data, as a positive integer.
+The read-only **`CharacterData.length`** property
+returns the number of characters in the contained data, as a positive integer.
+
+## Value
+
+A positive integer with the length of the {{domxref("CharacterData.data")}} string.
+
+## Example
+
+> **Note:** {{domxref("CharacterData")}} is an abstract interface.
+> The examples below use {{domxref("Text")}}, a concrete interface implementing it.
+
+```html
+Length of the string in the <code>Text</code> node: <output></output>
+```
+
+```js
+let output = document.getElementsByTagName("output")[0];
+let textnode = new Text("This text has been set using textnode.data.");
+
+output.value = textnode.length;
+```
+
+{{EmbedLiveSample("Example", "100%", 50)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/characterdata/nextelementsibling/index.md
+++ b/files/en-us/web/api/characterdata/nextelementsibling/index.md
@@ -1,0 +1,56 @@
+---
+title: CharacterData.nextElementSibling
+slug: Web/API/CharacterData/nextElementSibling
+tags:
+  - Property
+  - Reference
+  - Read-only
+browser-compat: api.CharacterData.nextElementSibling
+---
+{{APIRef("DOM")}}
+
+The read-only **`nextElementSibling`** property of the {{domxref("CharacterData")}} interface
+returns the first {{domxref("Element")}} node following the specified one in its parent's
+children list, or `null` if the specified element is the last one in the list.
+
+## Value
+
+A {{domxref("Element")}} object, or `null` if no sibling has been found.
+
+## Example
+
+```html
+TEXT
+<div id="div-01">Here is div-01</div>
+TEXT2
+<div id="div-02">Here is div-02</div>
+<pre>Here is the result area</pre>
+```
+
+```js
+// Initially, set node to the Text node with `TEXT`
+let node = document.getElementById('div-01').previousSibling;
+
+let result = 'Next element siblings of TEXT:\n';
+
+while (node) {
+  result += node.nodeName + '\n';
+  node = node.nextElementSibling; // The first node is a CharacterData, the others Element objects
+}
+
+document.getElementsByTagName('pre')[0].textContent = result;
+```
+
+{{EmbedLiveSample("Example", "100%", "230")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.previousElementSibling")}}

--- a/files/en-us/web/api/characterdata/previouselementsibling/index.md
+++ b/files/en-us/web/api/characterdata/previouselementsibling/index.md
@@ -1,0 +1,58 @@
+---
+title: CharacterData.previousElementSibling
+slug: Web/API/CharacterData/previousElementSibling
+tags:
+  - Property
+  - Read-only
+  - Reference
+browser-compat: api.Element.previousElementSibling
+---
+{{APIRef("DOM")}}
+
+The read-only **`previousElementSibling`** of the {{domxref("CharacterData")}} interface
+returns the first {{domxref("Element")}} before the current node in its parent's children list,
+or `null` if there is none.
+
+## Value
+
+A {{domxref("Element")}} object, or `null` if no sibling has been found.
+
+## Example
+
+```html
+<div id="div-01">Here is div-01</div>
+TEXT
+<div id="div-02">Here is div-02</div>
+SOME TEXT
+<div id="div-03">Here is div-03</div>
+<pre>Result</pre>
+```
+
+```js
+// Initially set node to the Text node with `SOME TEXT`
+let node = document.getElementById('div-02').nextSibling;
+
+let result = 'Previous element siblings of SOME TEXT:\n';
+
+while (node) {
+  result += node.nodeName + '\n';
+  node = node.previousElementSibling;
+}
+
+document.getElementsByTagName('pre')[0].textContent = result;
+
+```
+
+{{EmbedLiveSample("Example", "100%", "200")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.nextElementSibling")}}

--- a/files/en-us/web/api/characterdata/remove/index.md
+++ b/files/en-us/web/api/characterdata/remove/index.md
@@ -2,38 +2,40 @@
 title: CharacterData.remove()
 slug: Web/API/CharacterData/remove
 tags:
-  - API
-  - CharacterData
-  - DOM
   - Method
+  - Reference
 browser-compat: api.CharacterData.remove
 ---
 {{APIRef("DOM")}}
 
-The **`CharacterData.remove()`** method removes text.
+The **`remove()`** method of the {{domxref("CharacterData")}} removes the text contained in the node.
 
 ## Syntax
 
 ```js
-remove()
+remove();
 ```
 
-## Examples
+### Parameters
+
+None.
+
+## Example
 
 ### Using `remove()`
 
 ```html
-<p id="myText">Some text</p>
+<span>Result: </span>A long string.
 ```
 
 ```js
-let text = document.getElementById('myText').firstChild;
-text.remove(); // Removes the text
+let span = document.getElementsByTagName("span")[0];
+let textnode = span.nextSibling;
+
+textnode.remove(); // Removes the text
 ```
 
-```html
-<p id="myText"></p>
-```
+{{EmbedLiveSample("Example", "100%", 50)}}
 
 ## Specifications
 
@@ -46,3 +48,4 @@ text.remove(); // Removes the text
 ## See also
 
 - {{domxref("Element.remove()")}}
+- {{domxref("CharacterData.deleteData()")}}

--- a/files/en-us/web/api/characterdata/replacedata/index.md
+++ b/files/en-us/web/api/characterdata/replacedata/index.md
@@ -2,38 +2,52 @@
 title: CharacterData.replaceData()
 slug: Web/API/CharacterData/replaceData
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
-  - CharacterData
 browser-compat: api.CharacterData.replaceData
 ---
 {{APIRef("DOM")}}
 
-The `replaceData()` of the {{domxref("CharacterData")}} interface
-is similar to `insertData()`, but `replaceData()` allows
-overwriting of a certain number of bytes.
+The **`replaceData()`** of the {{domxref("CharacterData")}} interface
+replace a part of the data inside the node with the string given in paramater.
+
+This method is similar to `insertData()`, but `replaceData()` allows
+overwriting a certain number of bytes.
 
 ## Syntax
 
 ```js
-  characterData.replaceData(offset, count, data)
+characterData.replaceData(offset, count, data)
 ```
 
 ### Parameters
 
 - `offset`
   - : The number of characters from the start of the data to insert at.
+    `0` is the first character of the string.
 - `count`
   - : The number of characters to replace with the provided data.
 - `data`
-  - : The data to insert into the given `CharacterData` object.
+  - : The data to insert.
 
 ### Return value
 
-{{jsxref("undefined")}}.
+None.
+
+## Example
+
+```html
+<span>Result: </span>A long string.
+```
+
+```js
+let span = document.getElementsByTagName("span")[0];
+let textnode = span.nextSibling;
+
+textnode.replaceData(2, 4, "replaced");
+```
+
+{{EmbedLiveSample("Example", "100%", 50)}}
 
 ## Specifications
 
@@ -42,3 +56,8 @@ overwriting of a certain number of bytes.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CharacterData.appendData()")}}, {{domxref("CharacterData.deleteData()")}}, {{domxref("CharacterData.insertData()")}}
+- {{domxref("CharacterData.data")}}

--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -11,29 +11,31 @@ browser-compat: api.CharacterData.replaceWith
 ---
 {{APIRef("DOM")}}
 
-The **`CharacterData.replaceWith()`** method replaces characters
-in the children list of its parent with a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects.
-{{domxref("DOMString")}} objects are inserted as equivalent {{domxref("Text")}} nodes.
+The **`replaceWith()`** method of the {{domxref("CharacterData")}} interface
+replaces this node in the children list of its parent
+with a set of {{domxref("Node")}} objects or string.
+
+Strings are inserted as {{domxref("Text")}} nodes; the string is being passed as argument to the {{domxref("Text/Text", "Text()")}} constructor.
 
 ## Syntax
 
 ```js
-replaceWith(...nodes)
+replaceWith(... nodes)
 ```
 
 ### Parameters
 
-- `nodes`
-  - : A set of {{domxref("Node")}} or {{domxref("DOMString")}} objects to replace.
+- `nodes` {{optional_inline}}
+  - : A comma-separated list of {{domxref("Node")}} objects or strings that will replace the current node.
+
+> **Note:** If there no argument is passed, this method acts just remove the node from the DOM tree.
 
 ### Exceptions
 
 - `HierarchyRequestError` {{DOMxRef("DOMException")}}
   - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
-## Examples
-
-### Using `replaceWith()`
+## Example
 
 ```html
 <p id="myText">Some text</p>
@@ -41,12 +43,13 @@ replaceWith(...nodes)
 
 ```js
 let text = document.getElementById('myText').firstChild;
-text.replaceWith("Other text");
+let em = document.createElement("em");
+em.textContent = "Italic text";
+
+text.replaceWith(); // Replace `Some text` by `Italic text`
 ```
 
-```html
-<p id="myText">Other text</p>
-```
+{{EmbedLiveSample("Example", "100%", 30)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/characterdata/substringdata/index.md
+++ b/files/en-us/web/api/characterdata/substringdata/index.md
@@ -2,19 +2,16 @@
 title: CharacterData.substringData()
 slug: Web/API/CharacterData/substringData
 tags:
-  - API
-  - DOM
   - Method
-  - Node
   - Reference
-  - CharacterData
 browser-compat: api.CharacterData.substringData
 ---
 {{APIRef("DOM")}}
 
-The `substringData()` method of the {{domxref("CharacterData")}}
-interface returns a portion of the existing data, starting at the specified
-index and extending for a given number of characters afterwards.
+The **`substringData()`** method of the {{domxref("CharacterData")}} interface
+returns a portion of the existing data,
+starting at the specified index
+and extending for a given number of characters afterwards.
 
 ## Syntax
 
@@ -26,12 +23,18 @@ index and extending for a given number of characters afterwards.
 
 - `offset`
   - : The index of the first character to include in the returned substring.
+    `0` is the first character of the string.
 - `count`
   - : The number of characters to return.
 
 ### Return value
 
-{{jsxref("DOMString")}}.
+A new {{jsxref("String")}} object with the substring.
+
+## Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if `offset` + `count` is larger than the length of the contained data.
 
 ## Specifications
 

--- a/files/en-us/web/api/comment/comment/index.md
+++ b/files/en-us/web/api/comment/comment/index.md
@@ -2,29 +2,35 @@
 title: Comment()
 slug: Web/API/Comment/Comment
 tags:
-  - API
-  - Comment
   - Constructor
-  - DOM
+  - Reference
 browser-compat: api.Comment.Comment
 ---
-{{ApiRef("DOM")}}{{SeeCompatTable}}
+{{ApiRef("DOM")}}
 
 The **`Comment()`** constructor returns a newly created
-{{domxref("Comment")}} object with the optional {{domxref("DOMString")}} given in
+{{domxref("Comment")}} object with the optional string given in
 parameter as its textual content.
 
 ## Syntax
 
 ```js
-comment1 = new Comment(); // Create an empty comment
-comment2 = new Comment("This is a comment");
+new Comment();
+new Comment(aString);
 ```
+
+### Parameters
+
+- `aString` {{optional_inline}}
+
+### Return value
+
+A new {{domxref("Comment")}} containing `aString`, or the empty string if no parameter was given.
 
 ## Example
 
 ```js
-var comment = new Comment("Test");
+let comment = new Comment("Test");
 ```
 
 ## Specifications
@@ -35,9 +41,7 @@ var comment = new Comment("Test");
 
 {{Compat}}
 
-> **Note:** For browsers where this constructor is not supported,
-> {{domxref("Document.createComment()")}} may be suitable.
-
 ## See also
 
 - [The DOM interfaces index](/en-US/docs/Web/API/Document_Object_Model)
+- {{domxref("Document.createComment()")}} is an outdated alternative to this constructor.

--- a/files/en-us/web/api/comment/index.md
+++ b/files/en-us/web/api/comment/index.md
@@ -2,8 +2,7 @@
 title: Comment
 slug: Web/API/Comment
 tags:
-  - API
-  - DOM
+  - Interface
   - Reference
 browser-compat: api.Comment
 ---
@@ -11,7 +10,7 @@ browser-compat: api.Comment
 
 The **`Comment`** interface represents textual notations within markup; although it is generally not visually shown, such comments are available to be read in the source view.
 
-Comments are represented in HTML and XML as content between '`<!--`' and '`-->`'. In XML, the character sequence '`--`' cannot be used within a comment.
+Comments are represented in HTML and XML as content between '`<!--`' and '`-->`'. In XML, like inside SVG or MathML markup, the character sequence '`--`' cannot be used within a comment.
 
 {{InheritanceDiagram}}
 
@@ -21,8 +20,8 @@ _This interface has no specific property, but inherits those of its parent, {{do
 
 ## Constructor
 
-- {{ domxref("Comment.Comment()", "Comment()") }} {{experimental_inline}}
-  - : Returns a `Comment` object with the parameter as its textual content.
+- {{ domxref("Comment.Comment()", "Comment()") }}
+  - : Returns a new `Comment` object with the parameter as its textual content. If not present, its default value is the empty string, `''`.
 
 ## Methods
 
@@ -38,4 +37,4 @@ _This interface has no specific method, but inherits those of its parent, {{domx
 
 ## See also
 
-- [The DOM interfaces index](/en-US/docs/Web/API/Document_Object_Model)
+- [The DOM API](/en-US/docs/Web/API/Document_Object_Model)

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -2,26 +2,40 @@
 title: ProcessingInstruction
 slug: Web/API/ProcessingInstruction
 tags:
-  - API
-  - DOM
+  - Interface
+  - Reference
 browser-compat: api.ProcessingInstruction
 ---
 {{APIRef("DOM")}}
 
 The **`ProcessingInstruction`** interface represents a [processing instruction](https://www.w3.org/TR/xml/#sec-pi); that is, a {{domxref("Node")}} which embeds an instruction targeting a specific application but that can be ignored by any other applications which don't recognize the instruction.
 
-A processing instruction is different from the [XML declaration](/en-US/docs/Web/XML/XML_introduction#xml_declaration).
+> **Warning:** `ProcessingInstruction` nodes are only supported in XML documents, not in HTML documents. In these, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree.
 
-> **Note:** User-defined processing instructions cannot begin with "`xml`", as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, [`<?xml-stylesheet ?>`](/en-US/docs/XML/xml-stylesheet)).
+A processing instruction may be different than the [XML declaration](/en-US/docs/Web/XML/XML_introduction#xml_declaration).
 
-The `ProcessingInstruction` interface inherits methods and properties from {{domxref("Node")}}.
+> **Note:** User-defined processing instructions cannot begin with "`xml`", as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, `<?xml-stylesheet ?>`.
+
+For example:
+
+```html
+<?xml version="1.0"?>
+```
+
+is a processing instruction whose `target`is `xml`.
 
 {{InheritanceDiagram(700,70)}}
 
 ## Properties
 
-- `target` ({{domxref("DOMString")}}) {{readonlyInline}}
+_This interface also inherits properties from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
+
+- {{domxref("ProcessingInstruction.target")}} {{readonlyInline}}
   - : A name identifying the application to which the instruction is targeted.
+
+## Methods
+
+_This interface doesn't have any specific property, but inherits properties from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
 ## Specifications
 
@@ -33,4 +47,5 @@ The `ProcessingInstruction` interface inherits methods and properties from {{dom
 
 ## See also
 
-- [document.createProcessingInstruction](/en-US/docs/Web/API/Document/createProcessingInstruction)
+- [document.createProcessingInstruction()](/en-US/docs/Web/API/Document/createProcessingInstruction)
+- The [DOM API](/en-US/docs/Web/API/Document_Object_Model)

--- a/files/en-us/web/api/processinginstruction/sheet/index.md
+++ b/files/en-us/web/api/processinginstruction/sheet/index.md
@@ -1,0 +1,42 @@
+---
+title: ProcessingInstruction.sheet
+slug: Web/API/ProcessingInstruction/sheet
+tags:
+  - Property
+  - Reference
+  - Read-only
+browser-compat: api.ProcessingInstruction.sheet
+---
+{{ApiRef("DOM")}}
+
+The read-only **`sheet`** property of the {{domxref("ProcessingInstruction")}} interface
+represent the name of the stylesheet associated to the `ProcessingInstruction`.
+
+The `xml-stylesheet` processing instruction is used to associate a stylesheet in an xml file.
+
+## Value
+
+A {{jsxref("String")}} containing the name of the associated stylesheet, or `null` if there are none.
+
+## Example
+
+```html
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/css" href="rule.css"?>
+...
+```
+
+The `sheet` property of the processing instruction will return `rule.css`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The [DOM API](/en-US/docs/Web/API/Document_Object_Model)
+

--- a/files/en-us/web/api/processinginstruction/target/index.md
+++ b/files/en-us/web/api/processinginstruction/target/index.md
@@ -1,0 +1,78 @@
+---
+title: ProcessingInstruction.target
+slug: Web/API/ProcessingInstruction/target
+tags:
+  - Property
+  - Reference
+  - Read-only
+browser-compat: api.ProcessingInstruction.target
+---
+{{ApiRef("DOM")}}
+
+The read-only **`target`** property of the {{domxref("ProcessingInstruction")}} interface
+represent the application to which the `ProcessingInstruction` is targeted.
+
+For example:
+
+```html
+<?xml version="1.0"?>
+```
+
+is a processing instruction whose `target`is `xml`.
+
+## Value
+
+A {{jsxref("String")}} containing the name of the application.
+
+## Example
+
+### In an XML document
+
+```html hidden
+<output>
+```
+
+```js
+let parser = new DOMParser();
+const doc = parser.parseFromString('<?xml version="1.0"?><test/>', "application/xml");
+const pi = doc.createProcessingInstruction('xml-stylesheet', 'href="mycss.css" type="text/css"');
+doc.insertBefore(pi, doc.firstChild);
+
+const output = document.getElementsByTagName("output")[0];
+output.textContent = "This processing instruction's target is: " + doc.firstChild.target;
+```
+
+{{EmbedLiveSample("In an XML document", "100%", 50)}}
+
+
+### In an HTML document
+
+The processing instruction line will be considered, and represented, as a {{domxref("Comment")}} object.
+
+```html
+<?xml version="1.0"?>
+<pre></pre>
+```
+
+```js
+let node = document.getElementsByTagName("pre")[0].previousSibling.previousSibling;
+
+let result = "Node with the processing instructiion: " + node.nodeName + ": " + node.nodeValue + "\n";
+
+document.getElementsByTagName("pre")[0].textContent = result;
+```
+
+{{EmbedLiveSample("In an HTML document", "100%", 50)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The [DOM API](/en-US/docs/Web/API/Document_Object_Model)
+

--- a/files/en-us/web/api/text/assignedslot/index.md
+++ b/files/en-us/web/api/text/assignedslot/index.md
@@ -2,29 +2,20 @@
 title: Text.assignedSlot
 slug: Web/API/Text/assignedSlot
 tags:
-  - API
   - Property
   - Reference
-  - Text
-  - assignedSlot
-  - shadow dom
+  - Read-only
 browser-compat: api.Text.assignedSlot
 ---
-{{APIRef("Shadow DOM")}}
+{{APIRef("DOM")}}
 
-The **`assignedSlot`** property of the
-{{domxref("Text")}} interface returns the {{domxref("HTMLSlotElement")}} object
-associated with the element.
+The read-only **`assignedSlot`** property of the {{domxref("Text")}} interface
+returns the {{domxref("HTMLSlotElement")}} object associated with the element.
 
-## Syntax
+## Value
 
-```js
-var htmlSlotElement = text.assignedSlot
-```
-
-### Value
-
-A {{domxref("HTMLSlotElement")}} object.
+An {{domxref("HTMLSlotElement")}},
+or `null` if no {{HTMLElement("slot")}} element is associated with the text node.
 
 ## Specifications
 

--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -2,8 +2,6 @@
 title: Text
 slug: Web/API/Text
 tags:
-  - API
-  - DOM
   - Interface
   - Reference
 browser-compat: api.Text
@@ -32,12 +30,12 @@ Each of those text nodes is an object that has the properties and methods docume
 
 ## Constructor
 
-- {{domxref("Text.Text", "Text()")}} {{experimental_inline}}
-  - : Returns a `Text` node with the parameter as its textual content.
+- {{domxref("Text.Text", "Text()")}}
+  - : Returns a new `Text` node with the parameter as its textual content.
 
 ## Properties
 
-_Inherits properties from its parent, {{domxref("CharacterData")}}._
+_Inherits properties from its parents, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
 - {{domxref("Text.assignedSlot")}} {{readonlyInline}}
   - : Returns a {{domxref("HTMLSlotElement")}} representing the {{htmlelement("slot")}} the node is inserted in.
@@ -46,10 +44,8 @@ _Inherits properties from its parent, {{domxref("CharacterData")}}._
 
 ## Methods
 
-_Inherits methods from its parent, {{domxref("CharacterData")}}._
+_Inherits methods from its parent, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
-- {{domxref("Text.getBoxQuads()")}} {{experimental_inline}}
-  - : Returns a list of {{domxref("DOMQuad")}} objects representing the CSS fragments of the node.
 - {{domxref("Text.replaceWholeText")}} {{deprecated_inline}}
   - : Replaces the text of the current node and all logically adjacent nodes with the specified text.
 - {{domxref("Text.splitText")}}
@@ -65,4 +61,4 @@ _Inherits methods from its parent, {{domxref("CharacterData")}}._
 
 ## See also
 
-- [The DOM interfaces index](/en-US/docs/Web/API/Document_Object_Model).
+- [The DOM API](/en-US/docs/Web/API/Document_Object_Model).

--- a/files/en-us/web/api/text/replacewholetext/index.md
+++ b/files/en-us/web/api/text/replacewholetext/index.md
@@ -2,43 +2,53 @@
 title: Text.replaceWholeText()
 slug: Web/API/Text/replaceWholeText
 tags:
-  - API
-  - DOM
   - Method
   - Deprecated
-  - Text
+  - Reference
 browser-compat: api.Text.replaceWholeText
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 
-The **`Text.replaceWholeText()`** method replaces the text of
-the node and all of its logically adjacent text nodes with the specified text. The
-replaced nodes are removed, including the current node, unless it was the recipient of
+The **`replaceWholeText()`** method of the {{domxref("Text")}} interface
+replaces the text of the node and _all of its logically adjacent text nodes_ with the specified text.
+The replaced nodes are removed, including the current node, unless it was the recipient of
 the replacement text.
 
-A {{domxref("DOMException")}} with the value `NO_MODIFICATION_ERR` is thrown
-if one of the text nodes being replaced is read only.
-
-This method returns the text node which received the replacement text, or
-`null` if the replacement text is an empty string. The returned node is the
-current node unless the current node is read only, in which case the returned node is a
-newly created text node of the same type which has been inserted at the location of the
-replacement.
-
 > **Note:** In order to achieve a similar effect in modern browsers,
-> consider using {{domxref("Node.textContent")}} or {{domxref("Element.innerHTML")}}.
+> consider using {{domxref("Node.textContent")}}, {{domxref("Element.innerHTML")}},
+> {{domxref("HTMLELement.innerText")}}, or {{domxref("CharacterData.replaceData()")}}.
 
 ## Syntax
 
 ```js
-replacementNode = textnode.replaceWholeText(content)
+replaceWholeText(content)
 ```
+
+### Parameters
+
+- `content`
+  - : The text to replace the nodes with.
+    > **Note:** The `content` parameter is not optional but can be set to the empty string (`""`).
+
+### Return value
+
+A {{domxref("Text")}} node with the replaced string, or `null` if the replaces string was `""`.
+
+> **Note:** The returned node is the current node unless the current node is read-only,
+> in which case the returned node is a newly created text node of the same type
+> which has been inserted at the location of the replacement.
+
+### Exceptions
+
+- `NoModificationError` {{domxref("DOMException")}}
+  - : Thrown if all text nodes being replaced are read-only.
 
 ## Specifications
 
 This method was originally present in the DOM specification. It has been removed and this feature is no longer on track to become a standard.
 
-Instead, consider using algorithms based on {{domxref("Node.textContent")}} or {{domxref("Element.innerHTML")}}.
+Instead, consider using algorithms based on {{domxref("Node.textContent")}}, {{domxref("Element.innerHTML")}},
+{{domxref("HTMLELement.innerText")}}, or {{domxref("CharacterData.replaceData()")}}.
 
 ## Browser compatibility
 
@@ -47,3 +57,5 @@ Instead, consider using algorithms based on {{domxref("Node.textContent")}} or {
 ## See also
 
 - The {{domxref("Text")}} interface it belongs to.
+- {{domxref("Node.textContent")}}, {{domxref("Element.innerHTML")}},
+  {{domxref("HTMLELement.innerText")}}, {{domxref("CharacterData.replaceData()")}}

--- a/files/en-us/web/api/text/splittext/index.md
+++ b/files/en-us/web/api/text/splittext/index.md
@@ -2,24 +2,23 @@
 title: Text.splitText()
 slug: Web/API/Text/splitText
 tags:
-  - API
-  - DOM
   - Method
-  - Text
-  - splitText
+  - Reference
 browser-compat: api.Text.splitText
 ---
 {{APIRef("DOM")}}
 
-The **`Text.splitText()`** method breaks the
-{{domxref("Text")}} node into two nodes at the specified offset, keeping both nodes in
-the tree as siblings.
+The **`splitText()`** method of the {{domxref("Text")}} interface
+breaks the {{domxref("Text")}} node into two nodes at the specified offset,
+keeping both nodes in the tree as siblings.
 
-After the split, the current node contains all the content up to the specified offset
-point, and a newly created node of the same type contains the remaining text. The newly
-created node is returned to the caller. If the original node had a parent, the new node
-is inserted as the next sibling of the original node. If the offset is equal to the
-length of the original node, the newly created node has no data.
+After the split, the current node contains all the content
+up to the specified offset point,
+and a newly created node of the same type contains the remaining text.
+The newly created node is returned to the caller.
+If the original node had a parent, the new node is inserted as the next sibling of the original node.
+If the offset is equal to the length of the original node,
+the newly created node has no data.
 
 Separated text nodes can be concatenated using the {{domxref("Node.normalize()")}}
 method.
@@ -37,28 +36,25 @@ newNode = textNode.splitText(offset)
 
 ### Return value
 
-Returns a newly created {{domxref("Text")}} node that contains the text after the
+Returns the newly created {{domxref("Text")}} node that contains the text after the
 specified offset point.
 
-### Exceptions thrown
+### Exceptions
 
-A {{domxref("DOMException")}} with a value of `INDEX_SIZE_ERR` is thrown if
-the specified offset is negative or is greater than the number of 16-bit units in the
-node's text; a {{domxref("DOMException")}} with a value of
-`NO_MODIFICATION_ALLOWED_ERR` is thrown if the node is read-only.
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if the specified offset is negative or is greater
+    than the number of 16-bit units in the node's text.
+- `NoModificationAllowedError` {{domxref("DOMException")}}
+  - : Thrown if the node is read-only.
 
 ## Example
 
 In this example, the text of a {{HTMLElement("p")}} is split into two text nodes, and a
 {{HTMLElement("u")}} is inserted between them.
 
-### HTML
-
 ```html
 <p>foobar</p>
 ```
-
-### JavaScript
 
 ```js
 const p = document.querySelector('p');
@@ -79,8 +75,6 @@ p.insertBefore(u, bar);
 
 // The result is: <p>foo<u> new content </u>bar</p>
 ```
-
-### Result
 
 {{EmbedLiveSample("Example", 700, 70)}}
 

--- a/files/en-us/web/api/text/text/index.md
+++ b/files/en-us/web/api/text/text/index.md
@@ -2,26 +2,29 @@
 title: Text()
 slug: Web/API/Text/Text
 tags:
-  - API
   - Constructor
-  - DOM
-  - Experimental
   - Reference
-  - Text
 browser-compat: api.Text.Text
 ---
-{{ Apiref("DOM")}}{{SeeCompatTable}}
+{{ APIRef("DOM")}}
 
-The **`Text()`** constructor returns a newly created
-{{domxref("Text")}} object with the optional {{domxref("DOMString")}} given in parameter
-as its textual content.
+The **`Text()`** constructor returns a new {{domxref("Text")}} object
+with the optional string given in parameter as its textual content.
 
 ## Syntax
 
 ```js
-text1 = new Text(); // Create an empty text node
-text2 = new Text("This is a text node");
+new Text();
+new Text(aString);
 ```
+
+### Parameters
+
+- `aString` {{optional_inline}}
+
+### Return value
+
+A new {{domxref("Text")}} object containing `aString`, or the empty string if no parameter was given.
 
 ## Example
 
@@ -39,4 +42,4 @@ let text = new Text("Test");
 
 ## See also
 
-- [The DOM interfaces index.](/en-US/docs/Web/API/Document_Object_Model)
+- The [DOM API](/en-US/docs/Web/API/Document_Object_Model)

--- a/files/en-us/web/api/text/wholetext/index.md
+++ b/files/en-us/web/api/text/wholetext/index.md
@@ -2,59 +2,67 @@
 title: Text.wholeText
 slug: Web/API/Text/wholeText
 tags:
-  - API
-  - DOM
   - Property
-  - Text
+  - Reference
+  - Read-only
 browser-compat: api.Text.wholeText
 ---
 {{ apiref("DOM") }}
 
-The **`Text.wholeText`** read-only property returns the full text of all {{domxref("Text")}} nodes logically adjacent to the node. The text is concatenated in document order. This allows specifying any text node and obtaining all adjacent text as a single string.
+The read-only **`wholeText`** property of the {{domxref("Text")}} interface
+returns the full text of all {{domxref("Text")}} nodes logically adjacent to the node.
+The text is concatenated in document order.
+This allows specifying any text node and obtaining all adjacent text as a single string.
 
-## Syntax
+> **Note:** This is similar to call {{domxref("Node.normalize()")}} followed by reading the text value,
+> but without modifying the tree.
 
-```js
-str = textnode.wholeText;
-```
+## Value
 
-## Notes and example
+A {{jsxref("String")}} with the concanated text.
 
-Suppose you have the following simple paragraph within your webpage (with some whitespace added to aid formatting throughout the code samples here), whose DOM node is stored in the variable `para`:
+## Example
 
-```html
-<p>Thru-hiking is great!  <strong>No insipid election coverage!</strong>
-  However, <a href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a
-  ballot</a> is tricky.</p>
-```
-
-You decide you don’t like the middle sentence, so you remove it:
-
-```js
-para.removeChild(para.childNodes[1]);
-```
-
-Later, you decide to rephrase things to, “Thru-hiking is great, but casting a ballot is tricky.” _while preserving the hyperlink_. So you try this:
-
-```js
-para.firstChild.data = "Thru-hiking is great, but ";
-```
-
-All set, right? _Wrong!_ What happened was you removed the `strong` element, but the removed sentence’s element separated two text nodes. One for the first sentence, and one for the first word of the last. Instead, you now effectively have this:
+Suppose you have the following simple paragraph within your webpage:
 
 ```html
-<p>Thru-hiking is great, but However, <a
-  href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a
-  ballot</a> is tricky.</p>
+<p>Through-hiking is great!  <strong>No insipid election coverage!</strong> However, <a href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a ballot</a> is tricky.</p>
 ```
 
-You’d really prefer to treat all those adjacent text nodes as a single one. That’s where `wholeText` comes in: if you have multiple adjacent text nodes, you can access the contents of all of them using `wholeText`. Let’s pretend you never made that last mistake. In that case, we have:
+You decide you don't like the middle sentence, so you remove it:
 
 ```js
-assert(para.firstChild.wholeText == "Thru-hiking is great!    However, ");
+const para = document.getElementsByTagname("p")[0]; // Reads the paragraph
+para.removeChild(para.childNodes[1]); // Delete the strong element
 ```
 
-`wholeText` is just a property of text nodes that returns the string of data making up all the adjacent (i.e. not separated by an element boundary) text nodes combined.
+Later, you want to rephrase things to, "Through-hiking is great, but casting a ballot is tricky." _while preserving the hyperlink_.
+
+But, when you removed the `<strong>` element, the two text nodes on each part of the removed element, weren't merged into a single one: you have two consecutive `Text` nodes, one with `'Through-hiking is great!  '`, immediately followed by `' However, '`.
+
+So, if you do this:
+
+```js example-bad
+para.firstChild.data = "Through-hiking is great, but ";
+```
+
+you'll end replacing  the first `Text` node only and you'll get:
+
+```html
+<p>Through-hiking is great, but However, <a href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a  ballot</a> is tricky.</p>
+```
+
+To treat all those adjacent text nodes as a single one, you use `wholeText`.
+
+```js example-good
+para.firstChild.wholeText == "Through-hiking is great, but ";
+```
+
+and you end with:
+
+```html
+<p>Through-hiking is great, but <a href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a  ballot</a> is tricky.</p>
+```
 
 ## Specifications
 


### PR DESCRIPTION
Part of #9740

- Update `CharacterData` and children
- Note that `previousElementSibling` and `nextElementSibling`were missing and redirects to their `Element` equivalent. I added them and fixed the redirects.
- Update `Comment` and children.
- Update `Text`and children.
- Update `CDATASection`.
- Update `ProcessingInstruction` and children.
- Added the missing `ProcessingInstruction.sheet` and `ProcessingInstruction.target` pages.
- Replaced all `var`.
- Replaced all `DOMString`.
- Removed extraneous experimental banners
- Removed extraneous tags
- Fixed the structure of the pages to match the current convention
- Added/fixed a lot of examples.