### PR TITLE
DOMMatrixReadOnly: Remove mention of "integers"

### DIFF
--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
@@ -22,7 +22,7 @@ DOMMatrixReadOnly(init);
 ### Parameters
 
 - `init` {{optional_inline}}
-  - : Either a string containing a sequence of numbers or an array of integers
+  - : Either a string containing a sequence of numbers or an array of numbers
     specifying the matrix you want to create.
 
 ## Specifications


### PR DESCRIPTION
...and replace it with "numbers", like in DOMMatrix documentation.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-dommatrixreadonly (no indication that these should actually be integers instead of arbitrary double-precision numbers)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
