### PR TITLE
Add a couple of missing event page redirects

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8662,7 +8662,7 @@
 /en-US/docs/Web/API/Touch/touchcancel_event	/en-US/docs/Web/API/Element/touchcancel_event
 /en-US/docs/Web/API/Touch/touchend_event	/en-US/docs/Web/API/Document/touchend_event
 /en-US/docs/Web/API/Touch/touchmove_event	/en-US/docs/Web/API/Document/touchmove_event
-/en-US/docs/Web/API/Touch/touchstart_event	/en-US/docs/Web/API/Element/touchstart_event
+/en-US/docs/Web/API/Touch/touchstart_event	/en-US/docs/Web/API/Document/touchstart_event
 /en-US/docs/Web/API/TouchEvent.changedTouches	/en-US/docs/Web/API/TouchEvent/changedTouches
 /en-US/docs/Web/API/TouchEvent.targetTouches	/en-US/docs/Web/API/TouchEvent/targetTouches
 /en-US/docs/Web/API/TouchEvent.touches	/en-US/docs/Web/API/TouchEvent/touches
@@ -10344,6 +10344,7 @@
 /en-US/docs/Web/Events/focus	/en-US/docs/Web/API/Element/focus_event
 /en-US/docs/Web/Events/focusin	/en-US/docs/Web/API/Element/focusin_event
 /en-US/docs/Web/Events/focusout	/en-US/docs/Web/API/Element/focusout_event
+/en-US/docs/Web/Events/formdata	/en-US/docs/Web/API/HTMLFormElement/formdata_event
 /en-US/docs/Web/Events/fullscreenchange	/en-US/docs/Web/API/Document/fullscreenchange_event
 /en-US/docs/Web/Events/fullscreenerror	/en-US/docs/Web/API/Document/fullscreenerror_event
 /en-US/docs/Web/Events/gamepadconnected	/en-US/docs/Web/API/Window/gamepadconnected_event
@@ -10469,6 +10470,7 @@
 /en-US/docs/Web/Events/touchcancel	/en-US/docs/Web/API/Element/touchcancel_event
 /en-US/docs/Web/Events/touchend	/en-US/docs/Web/API/Document/touchend_event
 /en-US/docs/Web/Events/touchmove	/en-US/docs/Web/API/Document/touchmove_event
+/en-US/docs/Web/Events/touchstart	/en-US/docs/Web/API/Document/touchstart_event
 /en-US/docs/Web/Events/track	/en-US/docs/Web/API/RTCPeerConnection/track_event
 /en-US/docs/Web/Events/transitioncancel	/en-US/docs/Web/API/HTMLElement/transitioncancel_event
 /en-US/docs/Web/Events/transitionend	/en-US/docs/Web/API/HTMLElement/transitionend_event


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Add the missing redirects for `/Web/Events/touchstart` and `/Web/Events/formdata`. The `dataavailable` event doesn't currently have a dedicated page, so I've skipped that.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #10376.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
