### PR TITLE
DOMMatrixReadOnly: Add a description for the array constructor variant

### DIFF
--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
@@ -25,6 +25,10 @@ DOMMatrixReadOnly(init);
   - : Either a string containing a sequence of numbers or an array of numbers
     specifying the matrix you want to create.
 
+    In case an array of numbers is passed, the behavior depends on the length of the array:
+    * for a 6-element array of components in the form `[a, b, c, d, e, f]`, a 2D read-only matrix is created, initialized with the provided components.
+    * for a 16-element array of components (in the column-major order) in the form `[m11, m12, m13, …, m42, m43, m44]`, a 3D read-only matrix is created, initialized with the provided components.
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
...mostly copying it from the DOMMatrix constructor.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
A follow-up to https://github.com/mdn/content/pull/10401

#### Motivation
`DOMMatrix` and `DOMatrixReadOnly` constructors work basically the same.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[6.3. Creating DOMMatrixReadOnly and DOMMatrix objects](https://drafts.fxtf.org/geometry/#dommatrix-create)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
