### PR TITLE
implement: Add an example showing ths is() does not match pseudo-elements

### DIFF
--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -242,7 +242,7 @@ h1 {
 }
 ```
 
-### `:is()` does not select pseudo-elements
+### :is() does not select pseudo-elements
 
 ```css example-bad
 some-element:is(::before, ::after) {

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -242,6 +242,23 @@ h1 {
 }
 ```
 
+### `:is()` does not select pseudo-elements
+
+```css example-bad
+some-element:is(::before, ::after) {
+  display: block;
+}
+```
+
+instead do:
+
+```css
+some-element::before,
+some-element::after {
+  display: block;
+}
+```
+
 ## Syntax
 
 {{CSSSyntax}}

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -243,6 +243,7 @@ h1 {
 ```
 
 ### :is() does not select pseudo-elements
+The `:is()` pseudo-class does not match pseudo-elements. So rather than this:
 
 ```css example-bad
 some-element:is(::before, ::after) {


### PR DESCRIPTION
implements https://github.com/mdn/content/issues/10382

@wbamberg I tried to keep it as concise as possible, less is more after all. let me know what you think.