### PR TITLE
Remove non-attribute property

### DIFF
--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -46,7 +46,6 @@ browser-compat: html.elements.input.input-file
       <td>
         {{htmlattrxref("accept", "input/file")}},
         {{htmlattrxref("capture", "input/file")}},
-        {{htmlattrxref("files", "input/file")}},
         {{htmlattrxref("multiple", "input/file")}}
       </td>
     </tr>

--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -108,10 +108,6 @@ The [`capture`](/en-US/docs/Web/HTML/Attributes/capture) attribute value is a st
 
 > **Note:** `capture` was previously a Boolean attribute which, if present, requested that the device's media capture device(s) such as camera or microphone be used instead of requesting a file input.
 
-### files
-
-A {{domxref("FileList")}} object that lists every selected file. This list has no more than one member unless the {{htmlattrxref("multiple", "input/file")}} attribute is specified.
-
 ### multiple
 
 When the [`multiple`](/en-US/docs/Web/HTML/Attributes/multiple) Boolean attribute is specified, the file input allows the user to select more than one file.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes `files` from supported attributes for `<input type=file>`. [spec](https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file))

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
