### PR TITLE
Fixes #10410 - Adds `that`

### DIFF
--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -83,7 +83,7 @@ let math = {
 math.factit(3) //3;2;1;
 ```
 
-The variable that the function expression is assigned to will have a `name` property.
+The variable that the function expression is assigned to, will have a `name` property.
 The name doesn't change if it's assigned to a different variable.
 If function name is omitted, it will be the variable name (implicit name).
 If function name is present, it will be the function name (explicit name).

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -83,7 +83,7 @@ let math = {
 math.factit(3) //3;2;1;
 ```
 
-The variable the function expression is assigned to will have a `name` property.
+The variable that the function expression is assigned to will have a `name` property.
 The name doesn't change if it's assigned to a different variable.
 If function name is omitted, it will be the variable name (implicit name).
 If function name is present, it will be the function name (explicit name).

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -83,7 +83,7 @@ let math = {
 math.factit(3) //3;2;1;
 ```
 
-The variable to which the function expression is assigned will have a name property.
+The variable to which the function expression is assigned will have a `name` property.
 The name doesn't change if it's assigned to a different variable.
 If function name is omitted, it will be the variable name (implicit name).
 If function name is present, it will be the function name (explicit name).

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -83,7 +83,7 @@ let math = {
 math.factit(3) //3;2;1;
 ```
 
-The variable that the function expression is assigned to, will have a `name` property.
+The variable to which the function expression is assigned will have a name property.
 The name doesn't change if it's assigned to a different variable.
 If function name is omitted, it will be the variable name (implicit name).
 If function name is present, it will be the function name (explicit name).


### PR DESCRIPTION
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changed:-

> The variable the function expression is assigned to will have a name property

to:-

> The variable that the function expression is assigned to will have a name property

That still leaves the **to will** together and grammar rules prohibit adding a comma in between. Or maybe they don't.

#### Motivation
Fixes #10410

#### Supporting details
None

#### Related issues
Fixes #10410

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
