### PR TITLE
fix typo

### DIFF
--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -91,7 +91,7 @@ the value of a parameter:
 - If the current time equals or exceeds the time specified by a previous call to
   {{domxref("AudioParam.setValueAtTime", "setValueAtTime()")}}, the `value`
   is changed to the value passed into `setValueAtTime()`.
-- If any gradiated or ramped value changing methods have been called and the current
+- If any graduated or ramped value changing methods have been called and the current
   time is within the time range over which the gradiated change should occur, the value
   is updated based on the appropriate algorithm. These ramped or gradiated
   value-changing methods include {{domxref("AudioParam.linearRampToValueAtTime",

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -93,7 +93,7 @@ the value of a parameter:
   is changed to the value passed into `setValueAtTime()`.
 - If any graduated or ramped value changing methods have been called and the current
   time is within the time range over which the graduated change should occur, the value
-  is updated based on the appropriate algorithm. These ramped or gradiated
+  is updated based on the appropriate algorithm. These ramped or graduated
   value-changing methods include {{domxref("AudioParam.linearRampToValueAtTime",
     "linearRampToValueAtTime()")}}, {{domxref("AudioParam.setTargetAtTime",
     "setTargetAtTime()")}}, and {{domxref("AudioParam.setValueCurveAtTime",

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -92,7 +92,7 @@ the value of a parameter:
   {{domxref("AudioParam.setValueAtTime", "setValueAtTime()")}}, the `value`
   is changed to the value passed into `setValueAtTime()`.
 - If any graduated or ramped value changing methods have been called and the current
-  time is within the time range over which the gradiated change should occur, the value
+  time is within the time range over which the graduated change should occur, the value
   is updated based on the appropriate algorithm. These ramped or gradiated
   value-changing methods include {{domxref("AudioParam.linearRampToValueAtTime",
     "linearRampToValueAtTime()")}}, {{domxref("AudioParam.setTargetAtTime",

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -92,7 +92,7 @@ the value of a parameter:
   {{domxref("AudioParam.setValueAtTime", "setValueAtTime()")}}, the `value`
   is changed to the value passed into `setValueAtTime()`.
 - If any gradiated or ramped value changing methods have been called and the current
-  time is within the time range over which the graduated change should occur, the value
+  time is within the time range over which the gradiated change should occur, the value
   is updated based on the appropriate algorithm. These ramped or gradiated
   value-changing methods include {{domxref("AudioParam.linearRampToValueAtTime",
     "linearRampToValueAtTime()")}}, {{domxref("AudioParam.setTargetAtTime",
@@ -110,7 +110,7 @@ This example instantly changes the volume of a {{domxref("GainNode")}} to 40%.
 const audioCtx = new AudioContext();
 const gainNode = audioCtx.createGain();
 gainNode.gain.value = 0.4;
-//which is identical to:
+// which is identical to:
 gainNode.gain.setValueAtTime(0.4, audioCtx.currentTime);
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
just little modification on [AudioParam.value document](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/value)
- graduated → gradiated
- add a space `//which is...` → `// which is...`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

> If any **gradiated** or ramped value changing methods have been called and the current time is within the time range over which the **graduated** change should occur, the value is updated based on the appropriate algorithm.

- According to the context of the sentence, it seems `gradiated` is correct.
- I think it is better to have a space in a comment.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
none

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
none

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
