### PR TITLE
[DOM Reference] Update DOMTokenList and its children

### DIFF
--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -2,34 +2,31 @@
 title: DOMTokenList.add()
 slug: Web/API/DOMTokenList/add
 tags:
-  - API
-  - Add
-  - DOM
-  - DOMTokenList
   - Method
   - Reference
 browser-compat: api.DOMTokenList.add
 ---
 {{APIRef("DOM")}}
 
-The **`add()`** method of the {{domxref("DOMTokenList")}}
-interface adds the given _token_ to the list.
+The **`add()`** method of the {{domxref("DOMTokenList")}} interface adds the given _tokens_ to the list.
 
 ## Syntax
 
 ```js
-tokenList.add(token1[, token2[, ...tokenN]]);
+add(token);
+add(token, token);
+add(token, token, token);
+...
 ```
 
 ### Parameters
 
-- `tokenN`
-  - : A {{domxref("DOMString")}} representing the token (or tokens) to add to the
-    `tokenList`.
+- `token`
+  - : A string representing a token (or tokens) to add to the `DOMTokenList`.
 
 ### Return value
 
-`undefined`
+None.
 
 ## Examples
 
@@ -47,8 +44,8 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
+const span = document.querySelector("span");
+const classes = span.classList;
 classes.add("d");
 span.textContent = classes;
 ```

--- a/files/en-us/web/api/domtokenlist/contains/index.md
+++ b/files/en-us/web/api/domtokenlist/contains/index.md
@@ -2,31 +2,27 @@
 title: DOMTokenList.contains()
 slug: Web/API/DOMTokenList/contains
 tags:
-  - API
-  - Contains
-  - DOM
-  - DOMTokenList
   - Method
   - Reference
 browser-compat: api.DOMTokenList.contains
 ---
 {{APIRef("DOM")}}
 
-The **`contains()`** method of the {{domxref("DOMTokenList")}}
-interface returns a boolean value — `true` if the underlying list
-contains the given `token`, otherwise `false`.
+The **`contains()`** method of the {{domxref("DOMTokenList")}} interface
+returns a boolean value — `true` if the underlying list contains the given token,
+otherwise `false`.
 
 ## Syntax
 
 ```js
-tokenList.contains(token);
+contains(token);
 ```
 
 ### Parameters
 
 - `token`
-  - : A {{domxref("DOMString")}} representing the token you want to check for the
-    existence of in the list.
+  - : A string representing the token
+    you want to check for the existence of in the list.
 
 ### Return value
 
@@ -50,13 +46,12 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
-let result = classes.contains("c");
-if (result) {
+const span = document.querySelector("span");
+const classes = span.classList;
+if (classes.contains("c")) {
   span.textContent = "The classList contains 'c'";
 } else {
-   span.textContent = "The classList does not contain 'c'";
+  span.textContent = "The classList does not contain 'c'";
 }
 ```
 

--- a/files/en-us/web/api/domtokenlist/entries/index.md
+++ b/files/en-us/web/api/domtokenlist/entries/index.md
@@ -2,25 +2,21 @@
 title: DOMTokenList.entries()
 slug: Web/API/DOMTokenList/entries
 tags:
-  - DOM
-  - DOMTokenList
-  - Iterable
   - Method
   - Reference
-  - Web
 browser-compat: api.DOMTokenList.entries
 ---
 {{APIRef("DOM")}}
 
-The **`DOMTokenList.entries()`**
-method returns an {{jsxref("Iteration_protocols",'iterator')}} allowing you to go
-through all key/value pairs contained in this object. The values are
-{{domxref("DOMString")}} objects, each representing a single token.
+The **`entries()`** method of the {{domxref("DOMTokenList")}} interface
+returns an {{jsxref("Iteration_protocols",'iterator')}} allowing you
+to go through all key/value pairs contained in this object. The values are
+{{jsxref("String")}} objects, each representing a single token.
 
 ## Syntax
 
 ```js
-tokenList.entries();
+entries();
 ```
 
 ### Return value
@@ -45,12 +41,12 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
-let iterator = classes.entries();
+const span = document.querySelector("span");
+const classes = span.classList;
+const iterator = classes.entries();
 
 for (let value of iterator) {
-  span.textContent += value + ' ++ ';
+  span.textContent += '(' + value + ') ';
 }
 ```
 
@@ -68,5 +64,4 @@ The output looks like this:
 
 ## See also
 
-- {{domxref("DOMSettableTokenList")}} (object that extends DOMTokenList with settable
-  _.value_ property)
+- {{domxref("DOMTokenList.foreach()")}}, {{domxref("DOMTokenList.keys")}} and {{domxref("DOMTokenList.values")}}.

--- a/files/en-us/web/api/domtokenlist/entries/index.md
+++ b/files/en-us/web/api/domtokenlist/entries/index.md
@@ -46,7 +46,7 @@ const classes = span.classList;
 const iterator = classes.entries();
 
 for (let value of iterator) {
-  span.textContent += '(' + value + ') ';
+  span.textContent += `(${value})`;
 }
 ```
 

--- a/files/en-us/web/api/domtokenlist/foreach/index.md
+++ b/files/en-us/web/api/domtokenlist/foreach/index.md
@@ -33,7 +33,7 @@ forEach(callback, thisArg);
       - : The array that `forEach()` is being applied to.
 
 - `thisArg` {{Optional_inline}}
-  - : The  value to use as {{jsxref("Operators/this", "this")}} when executing `callback`.
+  - : The value to use as {{jsxref("Operators/this", "this")}} when executing `callback`.
 
 ### Return value
 

--- a/files/en-us/web/api/domtokenlist/foreach/index.md
+++ b/files/en-us/web/api/domtokenlist/foreach/index.md
@@ -2,71 +2,67 @@
 title: DOMTokenList.forEach()
 slug: Web/API/DOMTokenList/forEach
 tags:
-  - DOM
-  - DOMTokenList
-  - Iterable
   - Method
   - Reference
-  - Web
-  - forEach
 browser-compat: api.DOMTokenList.forEach
 ---
 {{APIRef("DOM")}}
 
-The **`forEach()`** method of the {{domxref("DOMTokenList")}}
-interface calls the callback given in parameter once for each value pair in the list, in
+The **`forEach()`** method of the {{domxref("DOMTokenList")}} interface
+calls the callback given in parameter once for each value pair in the list, in
 insertion order.
 
 ## Syntax
 
 ```js
-tokenList.forEach(callback [, thisArg]);
+forEach(callback);
+forEach(callback, thisArg);
 ```
 
 ### Parameters
 
 - `callback`
 
-  - : Function to execute for each element, eventually taking three arguments:
+  - : The function to execute for each element, eventually taking three arguments:
 
     - `currentValue`
       - : The current element being processed in the array.
     - `currentIndex`
       - : The index of the current element being processed in the array.
     - `listObj`
-      - : The array that `forEach()` is being applied to.
+      - : The array that `forEach()` is being applied to.
 
 - `thisArg` {{Optional_inline}}
-  - : Value to use as {{jsxref("Operators/this", "this")}} when executing `callback`.
+  - : The  value to use as {{jsxref("Operators/this", "this")}} when executing `callback`.
 
 ### Return value
 
-{{jsxref('undefined')}}.
+None.
 
 ## Example
 
 In the following example we retrieve the list of classes set on a
-{{htmlelement("span")}} element as a `DOMTokenList` using
+{{htmlelement("pre")}} element as a `DOMTokenList` using
 {{domxref("Element.classList")}}. We when retrieve an iterator containing the values
-using `forEach()`, writing each one to the `<span>`'s
+using `forEach()`, writing each one to the `<pre>`'s
 {{domxref("Node.textContent")}} inside the `forEach()` inner function.
 
 ### HTML
 
 ```html
-<span class="a b c"></span>
+<pre class="a b c"></pre>
 ```
 
 ### JavaScript
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
-let iterator = classes.values();
+const pre = document.querySelector("pre");
+const classes = pre.classList;
+const iterator = classes.values();
 
 classes.forEach(
   function(value, key, listObj) {
-    span.textContent += `${value} ${key}/${this}  ++  `;
+    pre.textContent += `(${value} ${key})/${this}\n`;
   },
   "arg"
 );
@@ -74,23 +70,7 @@ classes.forEach(
 
 ### Result
 
-{{ EmbedLiveSample('Example', '100%', 60) }}
-
-## Polyfill
-
-This {{Glossary("Polyfill","polyfill")}} adds compatibility to all Browsers supporting
-[ES5](https://caniuse.com/#search=es5):
-
-```js
-if (window.DOMTokenList && !DOMTokenList.prototype.forEach) {
-  DOMTokenList.prototype.forEach = function (callback, thisArg) {
-    thisArg = thisArg || window;
-    for (var i = 0; i < this.length; i++) {
-      callback.call(thisArg, this[i], i, this);
-    }
-  };
-}
-```
+{{ EmbedLiveSample('Example', '100%', 100) }}
 
 ## Specifications
 
@@ -102,5 +82,4 @@ if (window.DOMTokenList && !DOMTokenList.prototype.forEach) {
 
 ## See also
 
-- {{domxref("DOMSettableTokenList")}} (object that extends DOMTokenList with settable
-  _.value_ property)
+- {{domxref("DOMTokenList.entries()")}}, {{domxref("DOMTokenList.keys")}} and {{domxref("DOMTokenList.values")}}.

--- a/files/en-us/web/api/domtokenlist/index.md
+++ b/files/en-us/web/api/domtokenlist/index.md
@@ -17,7 +17,7 @@ A `DOMTokkenList` is indexed beginning with `0` as with JavaScript {{jsxref("Arr
 - {{domxref("DOMTokenList.length")}} {{ReadOnlyInline}}
   - : Is an `integer` representing the number of objects stored in the object.
 - {{domxref("DOMTokenList.value")}}
-  - : A stringifier property that returns the value of the list as a {{jsxref("String")}}.
+  - : A stringifier property that returns the value of the list as a string.
 
 ## Methods
 

--- a/files/en-us/web/api/domtokenlist/index.md
+++ b/files/en-us/web/api/domtokenlist/index.md
@@ -2,44 +2,43 @@
 title: DOMTokenList
 slug: Web/API/DOMTokenList
 tags:
-  - API
-  - DOM
-  - DOMTokenList
   - Interface
   - Reference
 browser-compat: api.DOMTokenList
 ---
 {{APIRef("DOM")}}
 
-The **`DOMTokenList`** interface represents a set of space-separated tokens. Such a set is returned by {{domxref("Element.classList")}}, {{domxref("HTMLLinkElement.relList")}}, {{domxref("HTMLAnchorElement.relList")}}, {{domxref("HTMLAreaElement.relList")}}, {{domxref("HTMLIframeElement.sandbox")}}, or {{domxref("HTMLOutputElement.htmlFor")}}. It is indexed beginning with `0` as with JavaScript {{jsxref("Array")}} objects. `DOMTokenList` is always case-sensitive.
+The **`DOMTokenList`** interface represents a set of space-separated tokens. Such a set is returned by {{domxref("Element.classList")}} or {{domxref("HTMLLinkElement.relList")}}, and many others.
+
+A `DOMTokkenList` is indexed beginning with `0` as with JavaScript {{jsxref("Array")}} objects. `DOMTokenList` is always case-sensitive.
 
 ## Properties
 
 - {{domxref("DOMTokenList.length")}} {{ReadOnlyInline}}
   - : Is an `integer` representing the number of objects stored in the object.
 - {{domxref("DOMTokenList.value")}}
-  - : A stringifier property that returns the value of the list as a {{domxref("DOMString")}}.
+  - : A stringifier property that returns the value of the list as a {{jsxref("String")}}.
 
 ## Methods
 
-- {{domxref("DOMTokenList.item()", "DOMTokenList.item(<var>index</var>)")}}
-  - : Returns the item in the list by its `index`, or `undefined` if `index` is greater than or equal to the list's `length`.
-- {{domxref("DOMTokenList.contains()", "DOMTokenList.contains(<var>token</var>)")}}
-  - : Returns `true` if the list contains the given `token`, otherwise `false`.
-- {{domxref("DOMTokenList.add()", "DOMTokenList.add(<var>token1</var>[, <var>token2</var>[, ...<var>tokenN</var>]])")}}
-  - : Adds the specified `token`(s) to the list.
-- {{domxref("DOMTokenList.remove()", "DOMTokenList.remove(<var>token1</var>[, <var>token2</var>[, ...<var>tokenN</var>]])")}}
-  - : Removes the specified `token`(s) from the list.
-- {{domxref("DOMTokenList.replace()", "DOMTokenList.replace(<var>oldToken</var>, <var>newToken</var>)")}}
-  - : Replaces `token` with `newToken`.
-- {{domxref("DOMTokenList.supports()", "DOMTokenList.supports(<var>token</var>)")}}
-  - : Returns `true` if a given `token` is in the associated attribute's supported tokens.
-- {{domxref("DOMTokenList.toggle()", "DOMTokenList.toggle(<var>token</var> [, <var>force</var>])")}}
-  - : Removes `token` from the list if it exists, or adds `token` to the list if it doesn't. Returns a boolean indicating whether `token` is in the list after the operation.
+- {{domxref("DOMTokenList.item()")}}
+  - : Returns the item in the list by its index, or `undefined` if the index is greater than or equal to the list's `length`.
+- {{domxref("DOMTokenList.contains()")}}
+  - : Returns `true` if the list contains the given token, otherwise `false`.
+- {{domxref("DOMTokenList.add()")}}
+  - : Adds the specified tokens to the list.
+- {{domxref("DOMTokenList.remove()")}}
+  - : Removes the specified tokens from the list.
+- {{domxref("DOMTokenList.replace()")}}
+  - : Replaces the token with another one.
+- {{domxref("DOMTokenList.supports()")}}
+  - : Returns `true` if the given token is in the associated attribute's supported tokens.
+- {{domxref("DOMTokenList.toggle()")}}
+  - : Removes the token from the list if it exists, or adds it to the list if it doesn't. Returns a boolean indicating whether the token is in the list after the operation.
 - {{domxref("DOMTokenList.entries()")}}
   - : Returns an {{jsxref("Iteration_protocols", "iterator", "", 1)}}, allowing you to go through all key/value pairs contained in this object.
-- {{domxref("DOMTokenList.forEach()", "DOMTokenList.forEach(<var>callback</var> [, <var>thisArg</var>])")}}
-  - : Executes a provided `callback` function once per `DOMTokenList` element.
+- {{domxref("DOMTokenList.forEach()")}}
+  - : Executes a provided callback function once for each `DOMTokenList` element.
 - {{domxref("DOMTokenList.keys()")}}
   - : Returns an {{jsxref("Iteration_protocols", "iterator", "", 1)}}, allowing you to go through all keys of the key/value pairs contained in this object.
 - {{domxref("DOMTokenList.values()")}}

--- a/files/en-us/web/api/domtokenlist/item/index.md
+++ b/files/en-us/web/api/domtokenlist/item/index.md
@@ -23,7 +23,7 @@ tokenList.item(index)
 ### Parameters
 
 - `index`
-  - : A {{jsxref("Number")}} representing the index of the item you want to return. If it isn't an integer, only the integer part is considered.
+  - : A number representing the index of the item you want to return. If it isn't an integer, only the integer part is considered.
 
 ### Return value
 

--- a/files/en-us/web/api/domtokenlist/item/index.md
+++ b/files/en-us/web/api/domtokenlist/item/index.md
@@ -27,7 +27,7 @@ tokenList.item(index)
 
 ### Return value
 
-A {{jsxref("String")}} representing the returned item,
+A string representing the returned item,
 or `null` if the number is greater than or equal to the `length` of the list.
 
 ### Exceptions

--- a/files/en-us/web/api/domtokenlist/item/index.md
+++ b/files/en-us/web/api/domtokenlist/item/index.md
@@ -2,18 +2,17 @@
 title: DOMTokenList.item()
 slug: Web/API/DOMTokenList/item
 tags:
-  - API
-  - DOM
-  - DOMTokenList
   - Method
   - Reference
-  - item
 browser-compat: api.DOMTokenList.item
 ---
 {{APIRef("DOM")}}
 
-The **`item()`** method of the {{domxref("DOMTokenList")}}
-interface returns an item in the list by its index.
+The **`item()`** method of the {{domxref("DOMTokenList")}} interface returns an item in the list,
+determined by its position in the list, its index.
+
+> **Note:** This method is equivalent as the operator `[]`.
+> So `aList.item(i)` is the same as `aList[i]`, like the [operator[]](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#accessing_array_elements) of an {{jsxref("Array")}}.
 
 ## Syntax
 
@@ -24,13 +23,17 @@ tokenList.item(index)
 ### Parameters
 
 - `index`
-  - : A 32-bit unsigned integer ({{jsxref("Number")}}) representing the index of the item you want to return.
+  - : A {{jsxref("Number")}} representing the index of the item you want to return. If it isn't an integer, only the integer part is considered.
 
 ### Return value
 
-A {{domxref("DOMString")}} representing the returned item. It returns
-`null` if the number is greater than or equal to the `length` of
-the list.
+A {{jsxref("String")}} representing the returned item,
+or `null` if the number is greater than or equal to the `length` of the list.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the `index` cannot be converted to an integer.
 
 ## Examples
 
@@ -49,9 +52,9 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
-let item = classes.item(classes.length-1);
+const span = document.querySelector("span");
+const classes = span.classList;
+const item = classes.item(classes.length-1);
 span.textContent = item;
 ```
 

--- a/files/en-us/web/api/domtokenlist/keys/index.md
+++ b/files/en-us/web/api/domtokenlist/keys/index.md
@@ -2,25 +2,20 @@
 title: DOMTokenList.keys()
 slug: Web/API/DOMTokenList/keys
 tags:
-  - DOM
-  - DOMTokenList
-  - Iterable
   - Method
   - Reference
-  - Web
-  - keys
 browser-compat: api.DOMTokenList.keys
 ---
 {{APIRef("DOM")}}
 
-The **`keys()`** method of the {{domxref("DOMTokenList")}}
-interface returns an {{jsxref("Iteration_protocols",'iterator',"",1)}} allowing to go through
-all keys contained in this object. The keys are of type `unsigned integer`.
+The **`keys()`** method of the {{domxref("DOMTokenList")}} interface
+returns an {{jsxref("Iteration_protocols",'iterator',"",1)}} allowing to go through all keys contained in this object.
+The keys are unsigned integers.
 
 ## Syntax
 
 ```js
-tokenList.keys();
+keys();
 ```
 
 ### Parameters
@@ -35,8 +30,8 @@ Returns an {{jsxref("Iteration_protocols","iterator","",1)}}.
 
 In the following example we retrieve the list of classes set on a
 {{htmlelement("span")}} element as a `DOMTokenList` using
-{{domxref("Element.classList")}}. We then retrieve an iterator containing the keys using
-`keys()`, then iterate through those keys using a [for ... of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop,
+{{domxref("Element.classList")}}. We then retrieve an iterator containing the keys using `keys()`,
+then iterate through those keys using a [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop,
 writing each one to the `<span>`'s {{domxref("Node.textContent")}}.
 
 First, the HTML:
@@ -48,12 +43,12 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-var span = document.querySelector("span");
-var classes = span.classList;
-var iterator = classes.keys();
+const span = document.querySelector("span");
+const classes = span.classList;
+const iterator = classes.keys();
 
-for(var value of iterator) {
-  span.textContent += value + ' ++ ';
+for(let value of iterator) {
+  span.textContent += `(${value}) `;
 }
 ```
 
@@ -68,3 +63,7 @@ The output looks like this:
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("DOMTokenList.entries()")}}, {{domxref("DOMTokenList.forEach()xs")}} and {{domxref("DOMTokenList.values")}}.

--- a/files/en-us/web/api/domtokenlist/keys/index.md
+++ b/files/en-us/web/api/domtokenlist/keys/index.md
@@ -66,4 +66,4 @@ The output looks like this:
 
 ## See also
 
-- {{domxref("DOMTokenList.entries()")}}, {{domxref("DOMTokenList.forEach()xs")}} and {{domxref("DOMTokenList.values")}}.
+- {{domxref("DOMTokenList.entries()")}}, {{domxref("DOMTokenList.forEach()")}} and {{domxref("DOMTokenList.values")}}.

--- a/files/en-us/web/api/domtokenlist/length/index.md
+++ b/files/en-us/web/api/domtokenlist/length/index.md
@@ -2,29 +2,19 @@
 title: DOMTokenList.length
 slug: Web/API/DOMTokenList/length
 tags:
-  - API
-  - DOM
-  - DOMTokenList
   - Property
   - Reference
-  - length
+  - Read-only
 browser-compat: api.DOMTokenList.length
 ---
 {{APIRef("DOM")}}
 
-The **`length`** read-only property of the
-{{domxref("DOMTokenList")}} interface is an `integer` representing the number
+The read-only **`length`** property of the {{domxref("DOMTokenList")}} interface is an `integer` representing the number
 of objects stored in the object.
 
-## Syntax
+## Value
 
-```js
-tokenList.length;
-```
-
-### Value
-
-An `integer`.
+An positive integer, or `0` if the list is empty..
 
 ## Examples
 
@@ -42,9 +32,9 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
-let length = classes.length;
+const span = document.querySelector("span");
+const classes = span.classList;
+const length = classes.length;
 
 span.textContent = `classList length = ${length}`;
 ```

--- a/files/en-us/web/api/domtokenlist/remove/index.md
+++ b/files/en-us/web/api/domtokenlist/remove/index.md
@@ -12,24 +12,27 @@ browser-compat: api.DOMTokenList.remove
 ---
 {{APIRef("DOM")}}
 
-The **`remove()`** method of the {{domxref("DOMTokenList")}}
-interface removes the specified _tokens_ from the list.
+The **`remove()`** method of the {{domxref("DOMTokenList")}} interface
+removes the specified _tokens_ from the list.
 
 ## Syntax
 
 ```js
-tokenList.remove(token1[, token2[, ...tokenN]]);
+remove(token);
+remove(token, token);
+remove(token, token, token);
+...
 ```
 
 ### Parameters
 
-- `tokenN`
-  - : A {{domxref("DOMString")}} representing the token you want to remove from the list.
+- `token`
+  - : A string representing the token you want to remove from the list.
     If the string is not in the list, no error is thrown, and nothing happens.
 
 ### Return value
 
-`undefined`
+None.
 
 ## Examples
 
@@ -48,8 +51,8 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.getElementById("ab");
-let classes = span.classList;
+const span = document.getElementById("ab");
+const classes = span.classList;
 classes.remove("c");
 span.textContent = classes;
 ```
@@ -58,8 +61,8 @@ To remove multiple classes at once, you can supply multiple tokens. The order yo
 supply the tokens doesn't have to match the order they appear in the list:
 
 ```js
-let span2 = document.getElementById("a")
-let classes2 = span2.classList;
+const span2 = document.getElementById("a")
+const classes2 = span2.classList;
 
 classes2.remove("c", "b");
 span2.textContent = classes2;

--- a/files/en-us/web/api/domtokenlist/replace/index.md
+++ b/files/en-us/web/api/domtokenlist/replace/index.md
@@ -11,31 +11,28 @@ browser-compat: api.DOMTokenList.replace
 ---
 {{APIRef("DOM")}}
 
-The **`replace()`** method of the {{domxref("DOMTokenList")}}
-interface replaces an existing token with a new token. If the first token doesn't
-exist, `replace()` returns `false` immediately, without adding the
-new token to the token list.
+The **`replace()`** method of the {{domxref("DOMTokenList")}} interface
+replaces an existing token with a new token.
+If the first token doesn't exist, `replace()` returns `false` immediately,
+without adding the new token to the token list.
 
 ## Syntax
 
 ```js
-tokenList.replace(oldToken, newToken);
+replace(oldToken, newToken);
 ```
 
 ### Parameters
 
 - `oldToken`
-  - : A {{domxref("DOMString")}} representing the token you want to replace.
+  - : A string representing the token you want to replace.
 - `newToken`
-  - : A {{domxref("DOMString")}} representing the token you want to replace
-    `oldToken` with.
+  - : A string representing the token you want to replace `oldToken` with.
 
 ### Return value
 
 A boolean value, which is `true` if `oldToken` was
 successfully replaced, or `false` if not.
-
-> **Note:** In older browsers, `replace()` returns void.
 
 ## Examples
 
@@ -53,11 +50,10 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
+const span = document.querySelector("span");
+const classes = span.classList;
 
-let result = classes.replace("c", "z");
-console.log(result);
+const result = classes.replace("c", "z");
 
 if (result) {
   span.textContent = classes;
@@ -69,24 +65,6 @@ if (result) {
 The output looks like this:
 
 {{ EmbedLiveSample('Examples', '100%', 60) }}
-
-## Polyfill
-
-The following polyfill will add the replace method to the `DOMTokenList`
-class.  The following code will only work with **IE10-11**. To use with
-earlier versions of IE, refer to the polyfill at
-{{domxref("element.classList#Polyfill")}}
-
-```js
-DOMTokenList.prototype.replace = function (a, b) {
-    if (this.contains(a)) {
-        this.add(b);
-        this.remove(a);
-        return true;
-    }
-    return false;
-}
-```
 
 ## Specifications
 

--- a/files/en-us/web/api/domtokenlist/supports/index.md
+++ b/files/en-us/web/api/domtokenlist/supports/index.md
@@ -2,29 +2,26 @@
 title: DOMTokenList.supports()
 slug: Web/API/DOMTokenList/supports
 tags:
-  - API
-  - DOM
   - Method
   - Reference
 browser-compat: api.DOMTokenList.supports
 ---
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("DOM")}}
 
-The **`supports()`** method of the
-{{domxref("DOMTokenList")}} interface returns `true` if a
-given `token` is in the associated attribute's supported tokens.
+The **`supports()`** method of the {{domxref("DOMTokenList")}} interface
+returns `true` if a given `token` is in the associated attribute's supported tokens.
 This method is intended to support feature detection.
 
 ## Syntax
 
 ```js
-let trueOrFalse = element.supports(token)
+supports(token);
 ```
 
 ### Parameters
 
 - `token`
-  - : A {{domxref("DOMString")}} containing the token to query for.
+  - : A string containing the token to query for.
 
 ### Returns
 
@@ -33,7 +30,7 @@ A boolean value indicating whether the token was found.
 ## Example
 
 ```js
-let iframe = document.getElementById('display');
+const iframe = document.getElementById('display');
 
 if (iframe.sandbox.supports('an-upcoming-feature')) {
   // support code for mystery future feature

--- a/files/en-us/web/api/domtokenlist/toggle/index.md
+++ b/files/en-us/web/api/domtokenlist/toggle/index.md
@@ -31,7 +31,7 @@ toggle(token, force);
 ### Return value
 
 A boolean value, `true` or `false`, indicating whether `token` is in the
-list after the call, or not.
+list after the call or not.
 
 ## Examples
 

--- a/files/en-us/web/api/domtokenlist/toggle/index.md
+++ b/files/en-us/web/api/domtokenlist/toggle/index.md
@@ -2,41 +2,36 @@
 title: DOMTokenList.toggle()
 slug: Web/API/DOMTokenList/toggle
 tags:
-  - API
-  - DOM
-  - DOMTokenList
   - Method
   - Reference
-  - toggle
 browser-compat: api.DOMTokenList.toggle
 ---
 {{APIRef("DOM")}}
 
-The **`toggle()`** method of the {{domxref("DOMTokenList")}}
-interface removes a given `token` from the list and returns
-`false`. If `token` doesn't exist it's added and the function returns
-`true`.
+The **`toggle()`** method of the {{domxref("DOMTokenList")}} interface
+removes an existing token from the list and returns `false`.
+If the token doesn't exist it's added and the function returns `true`.
 
 ## Syntax
 
 ```js
-tokenList.toggle(token [, force]);
+toggle(token);
+toggle(token, force);
 ```
 
 ### Parameters
 
 - `token`
-  - : A {{domxref("DOMString")}} representing the token you want to toggle.
+  - : A string representing the token you want to toggle.
 - `force` {{optional_inline}}
-  - : If included, turns the toggle into a one way-only operation. If set to
-    `false`, then `token` will
-    _only_ be removed, but not added. If set to `true`, then
-    `token` will _only_ be added, but not removed.
+  - : If included, turns the toggle into a one way-only operation.
+     If set to `false`, then `token` will _only_ be removed, but not added.
+     If set to `true`, then `token` will _only_ be added, but not removed.
 
 ### Return value
 
-`true` or `false`, indicating whether `token` is in the
-list after the call.
+A boolean value, `true` or `false`, indicating whether `token` is in the
+list after the call, or not.
 
 ## Examples
 
@@ -54,11 +49,11 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
+const span = document.querySelector("span");
+const classes = span.classList;
 
 span.addEventListener('click', function() {
-  let result = classes.toggle("c");
+  const result = classes.toggle("c");
 
   if (result) {
     span.textContent = `'c' added; classList is now "${classes}".`;
@@ -68,7 +63,7 @@ span.addEventListener('click', function() {
 })
 ```
 
-The output looks like this:
+The output looks like this and it will change each time you click on the text:
 
 {{ EmbedLiveSample('Examples', '100%', 60) }}
 

--- a/files/en-us/web/api/domtokenlist/value/index.md
+++ b/files/en-us/web/api/domtokenlist/value/index.md
@@ -9,12 +9,12 @@ browser-compat: api.DOMTokenList.value
 {{APIRef("DOM")}}
 
 The **`value`** property of the {{domxref("DOMTokenList")}}
-interface is a stringifier that returns the value of the list serialized in  a
-{{jsxref("String")}}, or clears and sets the list to the given value.
+interface is a stringifier that returns the value of the list serialized as a
+string, or clears and sets the list to the given value.
 
-##  Value
+## Value
 
-A {{jsxref("String")}} representing the serialized content of the list.
+A string representing the serialized content of the list.
 Each item is separated by a space.
 
 ## Examples

--- a/files/en-us/web/api/domtokenlist/value/index.md
+++ b/files/en-us/web/api/domtokenlist/value/index.md
@@ -2,29 +2,20 @@
 title: DOMTokenList.value
 slug: Web/API/DOMTokenList/value
 tags:
-  - API
-  - DOM
-  - DOMTokenList
   - Property
   - Reference
-  - value
 browser-compat: api.DOMTokenList.value
 ---
 {{APIRef("DOM")}}
 
-The **`value`** property of the {{domxref("DOMTokenList")}}
-interface is a stringifier that returns the value of the list as a
-{{domxref("DOMString")}}, or clears and sets the list to the given value.
+The **`value`** property of the {{domxref("DOMTokenList")}}
+interface is a stringifier that returns the value of the list serialized in  a
+{{jsxref("String")}}, or clears and sets the list to the given value.
 
-## Syntax
+##  Value
 
-```js
-tokenList.value;
-```
-
-### Value
-
-A {{domxref("DOMString")}}
+A {{jsxref("String")}} representing the serialized content of the list.
+Each item is separated by a space.
 
 ## Examples
 
@@ -42,8 +33,8 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-let span = document.querySelector("span");
-let classes = span.classList;
+const span = document.querySelector("span");
+const classes = span.classList;
 span.textContent = classes.value;
 ```
 

--- a/files/en-us/web/api/domtokenlist/values/index.md
+++ b/files/en-us/web/api/domtokenlist/values/index.md
@@ -2,21 +2,16 @@
 title: DOMTokenList.values()
 slug: Web/API/DOMTokenList/values
 tags:
-  - DOM
-  - DOMTokenList
-  - Iterable
   - Method
   - Reference
-  - Web
-  - values
 browser-compat: api.DOMTokenList.values
 ---
 {{APIRef("DOM")}}
 
-The **`values()`** method of the {{domxref("DOMTokenList")}}
-interface returns an {{jsxref("Iteration_protocols",'iterator')}} allowing developers to
-go through all values contained in the `DOMTokenList`. The individual values
-are {{domxref("DOMString")}} objects.
+The **`values()`** method of the {{domxref("DOMTokenList")}} interface
+returns an {{jsxref("Iteration_protocols",'iterator')}}
+allowing to go through all values contained in the `DOMTokenList`.
+The individual values are {{jsxref("String")}} objects.
 
 ## Syntax
 
@@ -37,7 +32,7 @@ Returns an {{jsxref("Iteration_protocols","iterator")}}.
 In the following example we retrieve the list of classes set on a
 {{htmlelement("span")}} element as a `DOMTokenList` using
 {{domxref("Element.classList")}}. We when retrieve an iterator containing the values
-using `values()`, then iterate through those values using a [for ... of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop,
+using `values()`, then iterate through those values using a [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop,
 writing each one to the `<span>`'s {{domxref("Node.textContent")}}.
 
 First, the HTML:
@@ -49,12 +44,12 @@ First, the HTML:
 Now the JavaScript:
 
 ```js
-var span = document.querySelector("span");
-var classes = span.classList;
-var iterator = classes.values();
+const span = document.querySelector("span");
+const classes = span.classList;
+const iterator = classes.values();
 
-for(var value of iterator) {
-  span.textContent += value + ' ++ ';
+for(let value of iterator) {
+  span.textContent += `(${value}) `;
 }
 ```
 

--- a/files/en-us/web/api/domtokenlist/values/index.md
+++ b/files/en-us/web/api/domtokenlist/values/index.md
@@ -10,7 +10,7 @@ browser-compat: api.DOMTokenList.values
 
 The **`values()`** method of the {{domxref("DOMTokenList")}} interface
 returns an {{jsxref("Iteration_protocols",'iterator')}}
-allowing to go through all values contained in the `DOMTokenList`.
+allowing the caller to go through all values contained in the `DOMTokenList`.
 The individual values are {{jsxref("String")}} objects.
 
 ## Syntax

--- a/files/en-us/web/api/domtokenlist/values/index.md
+++ b/files/en-us/web/api/domtokenlist/values/index.md
@@ -11,7 +11,7 @@ browser-compat: api.DOMTokenList.values
 The **`values()`** method of the {{domxref("DOMTokenList")}} interface
 returns an {{jsxref("Iteration_protocols",'iterator')}}
 allowing the caller to go through all values contained in the `DOMTokenList`.
-The individual values are {{jsxref("String")}} objects.
+The individual values are strings.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -21,47 +21,47 @@ The **`HTMLElement`** interface represents any [HTML](/en-US/docs/Web/HTML) elem
 _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements those from {{DOMxRef("DocumentAndElementEventHandlers")}}, {{DOMxRef("GlobalEventHandlers")}}, and {{DOMxRef("TouchEventHandlers")}}._
 
 - {{DOMxRef("HTMLElement.accessKey")}}
-  - : Is a {{DOMxRef("DOMString")}} representing the access key assigned to the element.
+  - : A {{DOMxRef("DOMString")}} representing the access key assigned to the element.
 - {{DOMxRef("HTMLElement.accessKeyLabel")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DOMString")}} containing the element's assigned access key.
 - {{DOMxRef("HTMLElement.attributeStyleMap")}} {{ReadOnlyInline}}
-  - : Is a {{DOMxRef("StylePropertyMap")}} representing the declarations of the element's {{htmlattrxref("style")}} attribute.
+  - : A {{DOMxRef("StylePropertyMap")}} representing the declarations of the element's {{htmlattrxref("style")}} attribute.
 - {{DOMxRef("HTMLElement.contentEditable")}}
-  - : Is a {{DOMxRef("DOMString")}}, where a value of `true` means the element is editable and a value of `false` means it isn't.
+  - : A {{DOMxRef("DOMString")}}, where a value of `true` means the element is editable and a value of `false` means it isn't.
 - {{DOMxRef("HTMLElement.isContentEditable")}} {{ReadOnlyInline}}
   - : Returns a boolean value indicating whether or not the content of the element can be edited.
 - {{DOMxRef("HTMLElement.contextMenu")}} {{Deprecated_Inline}}
-  - : Is a {{DOMxRef("HTMLMenuElement")}} representing the contextual menu associated with the element. It may be `null`.
+  - : A {{DOMxRef("HTMLMenuElement")}} representing the contextual menu associated with the element. It may be `null`.
 - {{DOMxRef("HTMLElement.dataset")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DOMStringMap")}} with which script can read and write the element's [custom data attributes](/en-US/docs/Learn/HTML/Howto/Use_data_attributes) (`data-*`) .
 - {{DOMxRef("HTMLElement.dir")}}
-  - : Is a {{DOMxRef("DOMString")}}, reflecting the `dir` global attribute, representing the directionality of the element. Possible values are `"ltr"`, `"rtl"`, and `"auto"`.
+  - : A {{DOMxRef("DOMString")}}, reflecting the `dir` global attribute, representing the directionality of the element. Possible values are `"ltr"`, `"rtl"`, and `"auto"`.
 - {{DOMxRef("HTMLElement.draggable")}}
-  - : Is a {{JSxRef("Boolean")}} indicating if the element can be dragged.
+  - : A boolean value indicating if the element can be dragged.
 - {{DOMxRef("HTMLElement.enterkeyhint")}}
-  - : Is a {{DOMxRef("DOMString")}} defining what action label (or icon) to present for the enter key on virtual keyboards.
+  - : A {{DOMxRef("DOMString")}} defining what action label (or icon) to present for the enter key on virtual keyboards.
 - {{DOMxRef("HTMLElement.hidden")}}
-  - : Is a {{JSxRef("Boolean")}} indicating if the element is hidden or not.
+  - : A boolean value indicating if the element is hidden or not.
 - {{DOMxRef("HTMLElement.inert")}}
-  - : Is a {{JSxRef("Boolean")}} indicating whether the user agent must act as though the given node is absent for the purposes of user interaction events, in-page text searches ("find in page"), and text selection.
+  - : A boolean value indicating whether the user agent must act as though the given node is absent for the purposes of user interaction events, in-page text searches ("find in page"), and text selection.
 - {{DOMxRef("HTMLElement.innerText")}}
   - : Represents the "rendered" text content of a node and its descendants. As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied it to the clipboard.
 - {{DOMxRef("HTMLElement.itemScope")}} {{Experimental_Inline}}
-  - : Is a {{JSxRef("Boolean")}} representing the item scope.
+  - : A boolean value representing the item scope.
 - {{DOMxRef("HTMLElement.itemType")}} {{Experimental_Inline}}{{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMSettableTokenList")}}…
+  - : Returns a {{DOMxRef("DOMTokenList")}}…
 - {{DOMxRef("HTMLElement.itemId")}} {{Experimental_Inline}}
-  - : Is a {{DOMxRef("DOMString")}} representing the item ID.
+  - : A {{DOMxRef("DOMString")}} representing the item ID.
 - {{DOMxRef("HTMLElement.itemRef")}} {{Experimental_Inline}}{{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMSettableTokenList")}}…
+  - : Returns a {{DOMxRef("DOMTokenList")}}…
 - {{DOMxRef("HTMLElement.itemProp")}} {{Experimental_Inline}}{{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMSettableTokenList")}}…
+  - : Returns a {{DOMxRef("DOMTokenList")}}…
 - {{DOMxRef("HTMLElement.itemValue")}} {{Experimental_Inline}}
   - : Returns a {{JSxRef("Object")}} representing the item value.
 - {{DOMxRef("HTMLElement.lang")}}
-  - : Is a {{DOMxRef("DOMString")}} representing the language of an element's attributes, text, and element contents.
+  - : A {{DOMxRef("DOMString")}} representing the language of an element's attributes, text, and element contents.
 - {{DOMxRef("HTMLElement.noModule")}}
-  - : Is a {{JSxRef("Boolean")}} indicating whether an import script can be executed in user agents that support module scripts.
+  - : A boolean value indicating whether an import script can be executed in user agents that support module scripts.
 - {{DOMxRef("HTMLElement.nonce")}}
   - : Returns the cryptographic number used once that is used by Content Security Policy to determine whether a given fetch will be allowed to proceed.
 - {{DOMxRef("HTMLElement.offsetHeight")}} {{Experimental_Inline}}{{ReadOnlyInline}}
@@ -77,15 +77,15 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements tho
 - {{DOMxRef("HTMLElement.properties")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns a {{DOMxRef("HTMLPropertiesCollection")}}…
 - {{DOMxRef("HTMLElement.spellcheck")}}
-  - : Is a {{JSxRef("Boolean")}} that controls [spell-checking](/en-US/docs/Web/HTML/Global_attributes/spellcheck). It is present on all HTML elements, though it doesn't have an effect on all of them.
+  - : A boolean value that controls [spell-checking](/en-US/docs/Web/HTML/Global_attributes/spellcheck). It is present on all HTML elements, though it doesn't have an effect on all of them.
 - {{DOMxRef("HTMLElement.style")}}
-  - : Is a {{DOMxRef("CSSStyleDeclaration")}} representing the declarations of the element's {{htmlattrxref("style")}} attribute.
+  - : A {{DOMxRef("CSSStyleDeclaration")}} representing the declarations of the element's {{htmlattrxref("style")}} attribute.
 - {{DOMxRef("HTMLElement.tabIndex")}}
-  - : Is a `long` representing the position of the element in the tabbing order.
+  - : A `long` representing the position of the element in the tabbing order.
 - {{DOMxRef("HTMLElement.title")}}
-  - : Is a {{DOMxRef("DOMString")}} containing the text that appears in a popup box when mouse is over the element.
+  - : A {{DOMxRef("DOMString")}} containing the text that appears in a popup box when mouse is over the element.
 - {{DOMxRef("HTMLElement.translate")}} {{Experimental_Inline}}
-  - : Is a {{JSxRef("Boolean")}} representing the translation.
+  - : A boolean value representing the translation.
 
 ### Event handlers
 

--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -21,13 +21,13 @@ The **`HTMLElement`** interface represents any [HTML](/en-US/docs/Web/HTML) elem
 _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements those from {{DOMxRef("DocumentAndElementEventHandlers")}}, {{DOMxRef("GlobalEventHandlers")}}, and {{DOMxRef("TouchEventHandlers")}}._
 
 - {{DOMxRef("HTMLElement.accessKey")}}
-  - : A {{DOMxRef("DOMString")}} representing the access key assigned to the element.
+  - : A string representing the access key assigned to the element.
 - {{DOMxRef("HTMLElement.accessKeyLabel")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} containing the element's assigned access key.
+  - : Returns a string containing the element's assigned access key.
 - {{DOMxRef("HTMLElement.attributeStyleMap")}} {{ReadOnlyInline}}
   - : A {{DOMxRef("StylePropertyMap")}} representing the declarations of the element's {{htmlattrxref("style")}} attribute.
 - {{DOMxRef("HTMLElement.contentEditable")}}
-  - : A {{DOMxRef("DOMString")}}, where a value of `true` means the element is editable and a value of `false` means it isn't.
+  - : A string, where a value of `true` means the element is editable and a value of `false` means it isn't.
 - {{DOMxRef("HTMLElement.isContentEditable")}} {{ReadOnlyInline}}
   - : Returns a boolean value indicating whether or not the content of the element can be edited.
 - {{DOMxRef("HTMLElement.contextMenu")}} {{Deprecated_Inline}}
@@ -35,11 +35,11 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements tho
 - {{DOMxRef("HTMLElement.dataset")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DOMStringMap")}} with which script can read and write the element's [custom data attributes](/en-US/docs/Learn/HTML/Howto/Use_data_attributes) (`data-*`) .
 - {{DOMxRef("HTMLElement.dir")}}
-  - : A {{DOMxRef("DOMString")}}, reflecting the `dir` global attribute, representing the directionality of the element. Possible values are `"ltr"`, `"rtl"`, and `"auto"`.
+  - : A string, reflecting the `dir` global attribute, representing the directionality of the element. Possible values are `"ltr"`, `"rtl"`, and `"auto"`.
 - {{DOMxRef("HTMLElement.draggable")}}
   - : A boolean value indicating if the element can be dragged.
 - {{DOMxRef("HTMLElement.enterkeyhint")}}
-  - : A {{DOMxRef("DOMString")}} defining what action label (or icon) to present for the enter key on virtual keyboards.
+  - : A string defining what action label (or icon) to present for the enter key on virtual keyboards.
 - {{DOMxRef("HTMLElement.hidden")}}
   - : A boolean value indicating if the element is hidden or not.
 - {{DOMxRef("HTMLElement.inert")}}
@@ -51,7 +51,7 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements tho
 - {{DOMxRef("HTMLElement.itemType")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DOMTokenList")}}…
 - {{DOMxRef("HTMLElement.itemId")}} {{Experimental_Inline}}
-  - : A {{DOMxRef("DOMString")}} representing the item ID.
+  - : A string representing the item ID.
 - {{DOMxRef("HTMLElement.itemRef")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DOMTokenList")}}…
 - {{DOMxRef("HTMLElement.itemProp")}} {{Experimental_Inline}}{{ReadOnlyInline}}
@@ -59,7 +59,7 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements tho
 - {{DOMxRef("HTMLElement.itemValue")}} {{Experimental_Inline}}
   - : Returns a {{JSxRef("Object")}} representing the item value.
 - {{DOMxRef("HTMLElement.lang")}}
-  - : A {{DOMxRef("DOMString")}} representing the language of an element's attributes, text, and element contents.
+  - : A string representing the language of an element's attributes, text, and element contents.
 - {{DOMxRef("HTMLElement.noModule")}}
   - : A boolean value indicating whether an import script can be executed in user agents that support module scripts.
 - {{DOMxRef("HTMLElement.nonce")}}
@@ -83,7 +83,7 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements tho
 - {{DOMxRef("HTMLElement.tabIndex")}}
   - : A `long` representing the position of the element in the tabbing order.
 - {{DOMxRef("HTMLElement.title")}}
-  - : A {{DOMxRef("DOMString")}} containing the text that appears in a popup box when mouse is over the element.
+  - : A string containing the text that appears in a popup box when mouse is over the element.
 - {{DOMxRef("HTMLElement.translate")}} {{Experimental_Inline}}
   - : A boolean value representing the translation.
 

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLIFrameElement`** interface provides special properties and methods (b
 _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 
 - {{domxref("HTMLIFrameElement.align")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} that specifies the alignment of the frame with respect to the surrounding context.
+  - : A string that specifies the alignment of the frame with respect to the surrounding context.
 - {{domxref("HTMLIFrameElement.allow")}} {{experimental_inline}}
   - : A list of origins the frame is allowed to display content from. This attribute also accepts the values `self` and `src` which represent the origin in the iframe's src attribute. The default value is `src`.
 - {{domxref("HTMLIFrameElement.allowfullscreen")}} {{experimental_inline}}
@@ -33,31 +33,31 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 - {{domxref("HTMLIFrameElement.csp")}}
   - : Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.
 - {{domxref("HTMLIFrameElement.frameBorder")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} that indicates whether to create borders between frames.
+  - : A string that indicates whether to create borders between frames.
 - {{domxref("HTMLIFrameElement.height")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("height", "iframe")}} HTML attribute, indicating the height of the frame.
+  - : A string that reflects the {{htmlattrxref("height", "iframe")}} HTML attribute, indicating the height of the frame.
 - {{domxref("HTMLIFrameElement.longDesc")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} that contains the URI of a long description of the frame.
+  - : A string that contains the URI of a long description of the frame.
 - {{domxref("HTMLIFrameElement.marginHeight")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} being the height of the frame margin.
+  - : A string being the height of the frame margin.
 - {{domxref("HTMLIFrameElement.marginWidth")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} being the width of the frame margin.
+  - : A string being the width of the frame margin.
 - {{domxref("HTMLIFrameElement.name")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("name", "iframe")}} HTML attribute, containing a name by which to refer to the frame.
+  - : A string that reflects the {{htmlattrxref("name", "iframe")}} HTML attribute, containing a name by which to refer to the frame.
 - {{domxref("HTMLIFrameElement.featurePolicy")}} {{readonlyinline}}{{experimental_inline}}
   - : Returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.
 - {{domxref("HTMLIFrameElement.referrerPolicy")}} {{experimental_inline}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "iframe")}} HTML attribute indicating which referrer to use when fetching the linked resource.
+  - : A string that reflects the {{htmlattrxref("referrerPolicy", "iframe")}} HTML attribute indicating which referrer to use when fetching the linked resource.
 - {{domxref("HTMLIFrameElement.sandbox")}}
   - : A {{domxref("DOMTokenList")}} that reflects the {{htmlattrxref("sandbox", "iframe")}} HTML attribute, indicating extra restrictions on the behavior of the nested content.
 - {{domxref("HTMLIFrameElement.scrolling")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} that indicates whether the browser should provide scrollbars for the frame.
+  - : A string that indicates whether the browser should provide scrollbars for the frame.
 - {{domxref("HTMLIFrameElement.src")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("src", "iframe")}} HTML attribute, containing the address of the content to be embedded. Note that programmatically removing an `<iframe>`'s src attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
+  - : A string that reflects the {{htmlattrxref("src", "iframe")}} HTML attribute, containing the address of the content to be embedded. Note that programmatically removing an `<iframe>`'s src attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
 - {{domxref("HTMLIFrameElement.srcdoc")}}
-  - : A {{domxref("DOMString")}} that represents the content to display in the frame.
+  - : A string that represents the content to display in the frame.
 - {{domxref("HTMLIFrameElement.width")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("width", "iframe")}} HTML attribute, indicating the width of the frame.
+  - : A string that reflects the {{htmlattrxref("width", "iframe")}} HTML attribute, indicating the width of the frame.
 
 ## Methods
 

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -19,13 +19,13 @@ The **`HTMLIFrameElement`** interface provides special properties and methods (b
 _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 
 - {{domxref("HTMLIFrameElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that specifies the alignment of the frame with respect to the surrounding context.
+  - : A {{domxref("DOMString")}} that specifies the alignment of the frame with respect to the surrounding context.
 - {{domxref("HTMLIFrameElement.allow")}} {{experimental_inline}}
-  - : Is a list of origins the frame is allowed to display content from. This attribute also accepts the values `self` and `src` which represent the origin in the iframe's src attribute. The default value is `src`.
+  - : A list of origins the frame is allowed to display content from. This attribute also accepts the values `self` and `src` which represent the origin in the iframe's src attribute. The default value is `src`.
 - {{domxref("HTMLIFrameElement.allowfullscreen")}} {{experimental_inline}}
-  - : Is a boolean value indicating whether the inline frame is willing to be placed into full screen mode. See [Using full-screen mode](/en-US/docs/Web/API/Fullscreen_API) for details.
+  - : A boolean value indicating whether the inline frame is willing to be placed into full screen mode. See [Using full-screen mode](/en-US/docs/Web/API/Fullscreen_API) for details.
 - {{domxref("HTMLIFrameElement.allowPaymentRequest")}}
-  - : Is a boolean value indicating whether the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) may be invoked inside a cross-origin iframe.
+  - : A boolean value indicating whether the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) may be invoked inside a cross-origin iframe.
 - {{domxref("HTMLIFrameElement.contentDocument")}} {{readonlyInline}}
   - : Returns a {{domxref("Document")}}, the active document in the inline frame's nested browsing context.
 - {{domxref("HTMLIFrameElement.contentWindow")}} {{readonlyInline}}
@@ -33,31 +33,31 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 - {{domxref("HTMLIFrameElement.csp")}}
   - : Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.
 - {{domxref("HTMLIFrameElement.frameBorder")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that indicates whether to create borders between frames.
+  - : A {{domxref("DOMString")}} that indicates whether to create borders between frames.
 - {{domxref("HTMLIFrameElement.height")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("height", "iframe")}} HTML attribute, indicating the height of the frame.
+  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("height", "iframe")}} HTML attribute, indicating the height of the frame.
 - {{domxref("HTMLIFrameElement.longDesc")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that contains the URI of a long description of the frame.
+  - : A {{domxref("DOMString")}} that contains the URI of a long description of the frame.
 - {{domxref("HTMLIFrameElement.marginHeight")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} being the height of the frame margin.
+  - : A {{domxref("DOMString")}} being the height of the frame margin.
 - {{domxref("HTMLIFrameElement.marginWidth")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} being the width of the frame margin.
+  - : A {{domxref("DOMString")}} being the width of the frame margin.
 - {{domxref("HTMLIFrameElement.name")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("name", "iframe")}} HTML attribute, containing a name by which to refer to the frame.
+  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("name", "iframe")}} HTML attribute, containing a name by which to refer to the frame.
 - {{domxref("HTMLIFrameElement.featurePolicy")}} {{readonlyinline}}{{experimental_inline}}
   - : Returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.
 - {{domxref("HTMLIFrameElement.referrerPolicy")}} {{experimental_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "iframe")}} HTML attribute indicating which referrer to use when fetching the linked resource.
+  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "iframe")}} HTML attribute indicating which referrer to use when fetching the linked resource.
 - {{domxref("HTMLIFrameElement.sandbox")}}
-  - : Is a {{domxref("DOMSettableTokenList")}} that reflects the {{htmlattrxref("sandbox", "iframe")}} HTML attribute, indicating extra restrictions on the behavior of the nested content.
+  - : A {{domxref("DOMTokenList")}} that reflects the {{htmlattrxref("sandbox", "iframe")}} HTML attribute, indicating extra restrictions on the behavior of the nested content.
 - {{domxref("HTMLIFrameElement.scrolling")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that indicates whether the browser should provide scrollbars for the frame.
+  - : A {{domxref("DOMString")}} that indicates whether the browser should provide scrollbars for the frame.
 - {{domxref("HTMLIFrameElement.src")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("src", "iframe")}} HTML attribute, containing the address of the content to be embedded. Note that programmatically removing an `<iframe>`'s src attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
+  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("src", "iframe")}} HTML attribute, containing the address of the content to be embedded. Note that programmatically removing an `<iframe>`'s src attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
 - {{domxref("HTMLIFrameElement.srcdoc")}}
-  - : Is a {{domxref("DOMString")}} that represents the content to display in the frame.
+  - : A {{domxref("DOMString")}} that represents the content to display in the frame.
 - {{domxref("HTMLIFrameElement.width")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("width", "iframe")}} HTML attribute, indicating the width of the frame.
+  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("width", "iframe")}} HTML attribute, indicating the width of the frame.
 
 ## Methods
 

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -20,29 +20,29 @@ The **`HTMLLinkElement`** interface represents reference information for externa
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLLinkElement.as")}}
-  - : Is a {{domxref("DOMString")}} representing the type of content being loaded by the HTML link.
+  - : A {{domxref("DOMString")}} representing the type of content being loaded by the HTML link.
 - {{domxref("HTMLLinkElement.crossOrigin")}} {{experimental_inline}}
-  - : Is a {{domxref("DOMString")}} that corresponds to the CORS setting for this link element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
+  - : A {{domxref("DOMString")}} that corresponds to the CORS setting for this link element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
 - {{domxref("HTMLLinkElement.disabled")}}
-  - : Is a `Boolean` which represents whether the link is disabled; currently only used with style sheet links.
+  - : A `Boolean` which represents whether the link is disabled; currently only used with style sheet links.
 - {{domxref("HTMLLinkElement.href")}}
-  - : Is a {{domxref("DOMString")}} representing the URI for the target resource.
+  - : A {{domxref("DOMString")}} representing the URI for the target resource.
 - {{domxref("HTMLLinkElement.hreflang")}}
-  - : Is a {{domxref("DOMString")}} representing the language code for the linked resource.
+  - : A {{domxref("DOMString")}} representing the language code for the linked resource.
 - {{domxref("HTMLLinkElement.media")}}
-  - : Is a {{domxref("DOMString")}} representing a list of one or more media formats to which the resource applies.
+  - : A {{domxref("DOMString")}} representing a list of one or more media formats to which the resource applies.
 - {{domxref("HTMLLinkElement.referrerPolicy")}} {{experimental_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerpolicy", "link")}} HTML attribute indicating which referrer to use.
+  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerpolicy", "link")}} HTML attribute indicating which referrer to use.
 - {{domxref("HTMLLinkElement.rel")}}
-  - : Is a {{domxref("DOMString")}} representing the forward relationship of the linked resource from the document to the resource.
+  - : A {{domxref("DOMString")}} representing the forward relationship of the linked resource from the document to the resource.
 - {{domxref("HTMLLinkElement.relList")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMTokenList")}} that reflects the {{htmlattrxref("rel", "link")}} HTML attribute, as a list of tokens.
+  - : A {{domxref("DOMTokenList")}} that reflects the {{htmlattrxref("rel", "link")}} HTML attribute, as a list of tokens.
 - {{domxref("HTMLLinkElement.sizes")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMSettableTokenList")}} that reflects the {{htmlattrxref("sizes", "link")}} HTML attribute, as a list of tokens.
+  - : A {{domxref("DOMTokenList")}} that reflects the {{htmlattrxref("sizes", "link")}} HTML attribute, as a list of tokens.
 - {{domxref("HTMLLinkElement.sheet")}} {{readonlyInline}}
   - : Returns the {{domxref("StyleSheet")}} object associated with the given element, or `null` if there is none.
 - {{domxref("HTMLLinkElement.type")}}
-  - : Is a {{domxref("DOMString")}} representing the MIME type of the linked resource.
+  - : A {{domxref("DOMString")}} representing the MIME type of the linked resource.
 
 ### Obsolete properties
 
@@ -55,7 +55,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
     > **Note:** Currently the W3C HTML 5.2 spec states that `rev` is no longer obsolete, whereas the WHATWG living standard still has it labeled obsolete. Until this discrepancy is resolved, you should still assume it is obsolete.
 
 - {{domxref("HTMLLinkElement.target")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the name of the target frame to which the resource applies.
+  - : Is a {{domxref("DOMString")}} representing the name of the target frame to which the resource applies.
 
 ## Methods
 

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -20,21 +20,21 @@ The **`HTMLLinkElement`** interface represents reference information for externa
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLLinkElement.as")}}
-  - : A {{domxref("DOMString")}} representing the type of content being loaded by the HTML link.
+  - : A string representing the type of content being loaded by the HTML link.
 - {{domxref("HTMLLinkElement.crossOrigin")}} {{experimental_inline}}
-  - : A {{domxref("DOMString")}} that corresponds to the CORS setting for this link element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
+  - : A string that corresponds to the CORS setting for this link element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
 - {{domxref("HTMLLinkElement.disabled")}}
-  - : A `Boolean` which represents whether the link is disabled; currently only used with style sheet links.
+  - : A boolean value which represents whether the link is disabled; currently only used with style sheet links.
 - {{domxref("HTMLLinkElement.href")}}
-  - : A {{domxref("DOMString")}} representing the URI for the target resource.
+  - : A string representing the URI for the target resource.
 - {{domxref("HTMLLinkElement.hreflang")}}
-  - : A {{domxref("DOMString")}} representing the language code for the linked resource.
+  - : A string representing the language code for the linked resource.
 - {{domxref("HTMLLinkElement.media")}}
-  - : A {{domxref("DOMString")}} representing a list of one or more media formats to which the resource applies.
+  - : A string representing a list of one or more media formats to which the resource applies.
 - {{domxref("HTMLLinkElement.referrerPolicy")}} {{experimental_inline}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerpolicy", "link")}} HTML attribute indicating which referrer to use.
+  - : A string that reflects the {{htmlattrxref("referrerpolicy", "link")}} HTML attribute indicating which referrer to use.
 - {{domxref("HTMLLinkElement.rel")}}
-  - : A {{domxref("DOMString")}} representing the forward relationship of the linked resource from the document to the resource.
+  - : A string representing the forward relationship of the linked resource from the document to the resource.
 - {{domxref("HTMLLinkElement.relList")}} {{readonlyInline}}
   - : A {{domxref("DOMTokenList")}} that reflects the {{htmlattrxref("rel", "link")}} HTML attribute, as a list of tokens.
 - {{domxref("HTMLLinkElement.sizes")}} {{readonlyInline}}
@@ -42,20 +42,20 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLLinkElement.sheet")}} {{readonlyInline}}
   - : Returns the {{domxref("StyleSheet")}} object associated with the given element, or `null` if there is none.
 - {{domxref("HTMLLinkElement.type")}}
-  - : A {{domxref("DOMString")}} representing the MIME type of the linked resource.
+  - : A string representing the MIME type of the linked resource.
 
 ### Obsolete properties
 
 - {{domxref("HTMLLinkElement.charset")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the character encoding for the target resource.
+  - : Is a string representing the character encoding for the target resource.
 - {{domxref("HTMLLinkElement.rev")}} {{deprecated_inline}}
 
-  - : Is a {{domxref("DOMString")}} representing the reverse relationship of the linked resource from the resource to the document.
+  - : Is a string representing the reverse relationship of the linked resource from the resource to the document.
 
     > **Note:** Currently the W3C HTML 5.2 spec states that `rev` is no longer obsolete, whereas the WHATWG living standard still has it labeled obsolete. Until this discrepancy is resolved, you should still assume it is obsolete.
 
 - {{domxref("HTMLLinkElement.target")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the name of the target frame to which the resource applies.
+  - : Is a string representing the name of the target frame to which the resource applies.
 
 ## Methods
 

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -23,7 +23,7 @@ The **`HTMLTableCellElement`** interface provides special properties and methods
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTableCellElement.abbr")}}
-  - : A {{domxref("DOMString")}} which can be used on `<th>` elements (not on {{HTMLElement("td")}}), specifying an alternative label for the header cell. This alternate label can be used in other contexts, such as when describing the headers that apply to a data cell. This is used to offer a shorter term for use by screen readers in particular, and is a valuable accessibility tool. Usually the value of `abbr` is an abbreviation or acronym, but can be any text that's appropriate contextually.
+  - : A string which can be used on `<th>` elements (not on {{HTMLElement("td")}}), specifying an alternative label for the header cell. This alternate label can be used in other contexts, such as when describing the headers that apply to a data cell. This is used to offer a shorter term for use by screen readers in particular, and is a valuable accessibility tool. Usually the value of `abbr` is an abbreviation or acronym, but can be any text that's appropriate contextually.
 - {{domxref("HTMLTableCellElement.cellIndex")}} {{readonlyInline}}
   - : A long integer representing the cell's position in the {{domxref("HTMLTableRowElement.cells", "cells")}} collection of the {{HTMLElement("tr")}} the cell is contained within. If the cell doesn't belong to a `<tr>`, it returns `-1`.
 - {{domxref("HTMLTableCellElement.colSpan")}}
@@ -34,7 +34,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : An unsigned long integer indicating the number of rows this cell must span; this lets a cell occupy space across multiple rows of the table. It reflects the {{htmlattrxref("rowspan", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.scope")}}
 
-  - : A {{domxref("DOMString")}} indicating the scope of a {{HTMLElement("th")}} cell. Header cells can be configured, using the `scope` property, the apply to a specified row or column, or to the not-yet-scoped cells within the current row group (that is, the same ancestor {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, or {{HTMLElement("tfoot")}} element). If no value is specified for `scope`, the header is not associated directly with cells in this way. Permitted values for `scope` are:
+  - : A string indicating the scope of a {{HTMLElement("th")}} cell. Header cells can be configured, using the `scope` property, the apply to a specified row or column, or to the not-yet-scoped cells within the current row group (that is, the same ancestor {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, or {{HTMLElement("tfoot")}} element). If no value is specified for `scope`, the header is not associated directly with cells in this way. Permitted values for `scope` are:
 
     - `col`
       - : The header cell applies to the following cells in the same column (or columns, if `colspan` is used as well), until either the end of the column or another `<th>` in the column establishes a new scope.
@@ -56,23 +56,23 @@ _No specific method; inherits methods from its parent, {{domxref("HTMLElement")}
 > **Warning:** These properties have been {{Glossary("deprecated")}} and should no longer be used. They are documented primarily to help understand older code bases.
 
 - {{domxref("HTMLTableCellElement.align")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing an enumerated value reflecting the {{htmlattrxref("align", "td")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
+  - : A string containing an enumerated value reflecting the {{htmlattrxref("align", "td")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
 - {{domxref("HTMLTableCellElement.axis")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing a name grouping cells in virtual. It reflects the obsolete {{htmlattrxref("axis", "td")}} attribute.
+  - : A string containing a name grouping cells in virtual. It reflects the obsolete {{htmlattrxref("axis", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.bgColor")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing the background color of the cells. It reflects the obsolete {{htmlattrxref("bgColor", "td")}} attribute.
+  - : A string containing the background color of the cells. It reflects the obsolete {{htmlattrxref("bgColor", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.ch")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing one single chararcter. This character is the one to align all the cell of a column on. It reflects the {{htmlattrxref("char", "td")}} and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
+  - : A string containing one single chararcter. This character is the one to align all the cell of a column on. It reflects the {{htmlattrxref("char", "td")}} and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
 - {{domxref("HTMLTableCellElement.chOff")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing a integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableCellElement.ch`. This property was optional and was not very well supported.
+  - : A string containing a integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableCellElement.ch`. This property was optional and was not very well supported.
 - {{domxref("HTMLTableCellElement.height")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing a length of pixel of the hinted height of the cell. It reflects the obsolete {{htmlattrxref("height", "td")}} attribute.
+  - : A string containing a length of pixel of the hinted height of the cell. It reflects the obsolete {{htmlattrxref("height", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.noWrap")}} {{deprecated_inline}}
   - : A boolean value reflecting the {{htmlattrxref("nowrap", "td")}} attribute and indicating if cell content can be broken in several lines.
 - {{domxref("HTMLTableCellElement.vAlign")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "td")}} attribute and can have one of the following values: `"top"`, `"middle"`, `"bottom"`, or `"baseline"`. Use the CSS {{cssxref("vertical-align")}} property instead.
+  - : A string representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "td")}} attribute and can have one of the following values: `"top"`, `"middle"`, `"bottom"`, or `"baseline"`. Use the CSS {{cssxref("vertical-align")}} property instead.
 - {{domxref("HTMLTableCellElement.width")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} specifying the number of pixels wide the cell should be drawn, if possible. This property reflects the also obsolete {{htmlattrxref("width", "td")}} attribute. Use the CSS {{cssxref("width")}} property instead.
+  - : A string specifying the number of pixels wide the cell should be drawn, if possible. This property reflects the also obsolete {{htmlattrxref("width", "td")}} attribute. Use the CSS {{cssxref("width")}} property instead.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -29,7 +29,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLTableCellElement.colSpan")}}
   - : An unsigned long integer indicating the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the {{htmlattrxref("colspan", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.headers")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMSettableTokenList")}} describing a list of `id` of {{HTMLElement("th")}} elements that represents headers associated with the cell. It reflects the {{htmlattrxref("headers", "td")}} attribute.
+  - : A {{domxref("DOMTokenList")}} describing a list of `id` of {{HTMLElement("th")}} elements that represents headers associated with the cell. It reflects the {{htmlattrxref("headers", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.rowSpan")}}
   - : An unsigned long integer indicating the number of rows this cell must span; this lets a cell occupy space across multiple rows of the table. It reflects the {{htmlattrxref("rowspan", "td")}} attribute.
 - {{domxref("HTMLTableCellElement.scope")}}


### PR DESCRIPTION
Part of #9740.

- Update interface and properties/methods to the modern structure
- Removed all mention of `DOMString`
- Removed all use of `var`
- Changed all mentions of `DOMSettableTokenList` that doesn't exist anymore (except one, saying that it doesn't exist anymore :-) )
- Checked/Updated examples.
- Removed all flaws.

There are a few `spec_url` missing in bcd, I'll open a PR to fix them.