### PR TITLE
update number of opaque black pixels to 2,500

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -87,7 +87,7 @@ portion of the canvas.
 
 The object retrieved by `getImageData()` has a width of 200 and a height of
 100, for a total of 20,000 pixels. Of those pixels, most are either transparent or taken
-from off the canvas; only 5,000 of them are opaque black (the color of the drawn
+from off the canvas; only 2,500 of them are opaque black (the color of the drawn
 rectangle).
 
 ```js


### PR DESCRIPTION
Fixes #10390

```diff
- only 5,000 of them are opaque black (the color of the drawn
+ only 2,500 of them are opaque black (the color of the drawn
```