### PR TITLE
Event page: Add syntax section, remove table

### DIFF
--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -15,25 +15,21 @@ browser-compat: api.XRLightProbe.reflectionchange_event
 ---
 {{APIRef("WebXR Device API")}}
 
-The WebXR **`reflectionchange`** event is passed to an {{domxref("XRLightProbe")}} each time the estimated reflection cube map changes. This happens in response to use movements through different lighting conditions or to direct changes to lighting itself.
+The WebXR **`reflectionchange`** event fires each time the estimated reflection cube map changes. This happens in response to use movements through different lighting conditions or to direct changes to lighting itself. This event is not cancelable.
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th>Cancelable</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Interface</th>
-      <td>{{domxref("Event")}}</td>
-    </tr>
-    <tr>
-      <th>Event handler property</th>
-      <td><code>onreflectionchange</code></td>
-    </tr>
-  </tbody>
-</table>
+## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('reflectionchange', () => { });
+
+onreflectionchange = event => { });
+```
+
+## Event type
+
+{{domxref("Event")}}.
 
 ## Examples
 
@@ -56,8 +52,6 @@ lightProbe.addEventListener('reflectionchange', () => {
 The `reflectionchange` event is also available using the `onreflectionchange` event handler property.
 
 ```js
-const glBinding = new XRWebGLBinding(xrSession, gl);
-
 lightProbe.onreflectionchange = event => {
   glCubeMap = glBinding.getReflectionCubeMap(lightProbe);
 });


### PR DESCRIPTION
#### Summary

This PR demonstrates how an event page would look like if we add a syntax section, and remove the tabular information box.

#### Motivation

Better readability and usefulness of event pages.
Consistency with other reference page types.

I'm not yet sure if this is the best way to represent the information. 
"Event type" seems quite analog to say "Return value" of method pages, so I believe making this its own heading is useful.

The syntax box is a first attempt, open to feedback to make it more useful.

"Cancelable" seems to be something that can be mentioned in the summary and doesn't necessarily need to stand on its own.


Thoughts?