### PR TITLE
Remove the note about `SVGRect` inheriting from `DOMRectReadOnly`

### DIFF
--- a/files/en-us/web/api/svgrect/index.md
+++ b/files/en-us/web/api/svgrect/index.md
@@ -14,8 +14,6 @@ The **`SVGRect`** represents a rectangle. Rectangles consist of an `x` and `y` 
 
 An **`SVGRect`** object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-{{InheritanceDiagram(600, 140)}}
-
 ## Properties
 
 - {{domxref("SVGRect.x")}}
@@ -29,7 +27,7 @@ An **`SVGRect`** object can be designated as read only, which means that attempt
 
 ## Methods
 
-_This interface also inherits properties from its parent, {{domxref("DOMRectReadOnly")}}._
+None.
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary

The PR removes incorrect note.

#### Motivation

The note was incorrect

#### Supporting details

This document doesn't define any relationship between those types
https://www.w3.org/TR/SVG11/types.html#InterfaceSVGRect

If we check this in a browser (Chrome) then we won't see this inheriting from the `DOMRectReadOnly`:
<img width="757" alt="Screenshot 2021-11-11 at 07 34 37" src="https://user-images.githubusercontent.com/9800850/141249651-ed7c9208-67d5-4fdd-bde9-b448bf52ad1b.png">

#### Related issues
not applicable

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
