### PR TITLE
Update Resize Observer doc

### DIFF
--- a/files/en-us/web/api/resize_observer_api/index.md
+++ b/files/en-us/web/api/resize_observer_api/index.md
@@ -51,8 +51,8 @@ The code will usually follow this kind of pattern (taken from resize-observer-bo
 const resizeObserver = new ResizeObserver(entries => {
   for (let entry of entries) {
     if(entry.contentBoxSize) {
-      entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +
-                                                      (entry.contentBoxSize.blockSize/10)) + 'px';
+      entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize[0].inlineSize/10) +
+                                                      (entry.contentBoxSize[0].blockSize/10)) + 'px';
     } else {
       entry.target.style.borderRadius = Math.min(100, (entry.contentRect.width/10) +
                                                       (entry.contentRect.height/10)) + 'px';


### PR DESCRIPTION
Given that `contentBoxSize` is an array, one needs to access the 0th element and therefore that warrants the adding of the array index suffix to `contentboxSize`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
