### PR TITLE
Remove 'checked="false"' from `<input>` tag

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_first_component/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_first_component/index.md
@@ -91,7 +91,7 @@ We can now begin to add actual content to our `ToDoItem`. Vue templates are curr
     ```html
     <template>
       <div>
-        <input type="checkbox" id="todo-item" checked="false" />
+        <input type="checkbox" id="todo-item" />
         <label for="todo-item">My Todo Item</label>
       </div>
     </template>
@@ -203,7 +203,7 @@ Your component’s template section should now look like this:
 ```html
 <template>
   <div>
-    <input type="checkbox" id="todo-item" checked="false" />
+    <input type="checkbox" id="todo-item" />
     <label for="todo-item">\{{label}}</label>
   </div>
 </template>
@@ -289,7 +289,7 @@ So in the case of the checkbox in our `ToDoItem` component, we can use `v-bind` 
 
 You're free to use whichever pattern you would like. It's best to keep it consistent though. Because the shorthand syntax is more commonly used, this tutorial will stick to that pattern.
 
-So let's do this. Update your `<input>` element now to replace `checked="false"` with `:checked="isDone"`.
+So let's do this. Update your `<input>` element now to include `:checked="isDone"`.
 
 Test out your component by passing `:done="true"` to the `ToDoItem` call in `App.vue`. Note that you need to use the `v-bind` syntax, because otherwise `true` is passed as a string. The displayed checkbox should be checked.
 


### PR DESCRIPTION
'checked="false" is incorrect html syntax and the result is counterintuitive. Removing the incorrect text outputs the desired result

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The text: 'checked="false" is incorrect html syntax in a checkbox and the result is counterintuitive (the checkbox displays as checked when the intent is to display an unchecked checkbox). Removing the incorrect text outputs the desired result

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Making this change fixes incorrect syntax and aligns the code with the intent of the instruction on the page

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[MDN checkbox documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/checkbox#attr-checked)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #4823

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
