### PR TITLE
Mark "for each...in" as deprecated

### DIFF
--- a/files/en-us/web/javascript/reference/errors/for-each-in_loops_are_deprecated/index.md
+++ b/files/en-us/web/javascript/reference/errors/for-each-in_loops_are_deprecated/index.md
@@ -25,7 +25,7 @@ Warning
 ## What went wrong?
 
 JavaScript 1.6's {{jsxref("Statements/for_each...in", "for each (variable in obj)")}}
-statement is deprecated, and will be removed in the near future.
+statement is deprecated, and has been removed.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -176,7 +176,6 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 
 - {{jsxref("Statements/do...while", "do...while")}}
 - {{jsxref("Statements/for", "for")}}
-- {{jsxref("Statements/for_each...in", "for each...in [Deprecated]")}}
 - {{jsxref("Statements/for...in", "for...in")}}
 - {{jsxref("Statements/for...of", "for...of")}}
 - {{jsxref("Statements/for-await...of", "for await...of")}}

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -176,7 +176,7 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 
 - {{jsxref("Statements/do...while", "do...while")}}
 - {{jsxref("Statements/for", "for")}}
-- {{jsxref("Statements/for_each...in", "for each...in")}}
+- {{jsxref("Statements/for_each...in", "for each...in [Deprecated]")}}
 - {{jsxref("Statements/for...in", "for...in")}}
 - {{jsxref("Statements/for...of", "for...of")}}
 - {{jsxref("Statements/for-await...of", "for await...of")}}

--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -178,9 +178,6 @@ investigating whether to remove the nonstandard behavior as well.
 
 - {{jsxref("Statements/for...of", "for...of")}} – a similar statement that iterates
   over the property _values_
-- {{jsxref("Statements/for_each...in", "for each...in")}} – a similar but deprecated
-  statement that iterates over the values of an object's properties, rather than the
-  property names themselves
 - {{jsxref("Statements/for", "for")}}
 - [Iterators and
   Generator functions](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) (usable with `for...of` syntax)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The JavaScript Reference page still lists a now deprecated statement ("`for each...in`").  Rather than removing it from the list, it may be better to just add a note that it's deprecated.

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference#iterations

This page shows that the method is deprecated:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
