### PR TITLE
Fix a broken MathML element

### DIFF
--- a/files/en-us/web/api/audioparam/settargetattime/index.md
+++ b/files/en-us/web/api/audioparam/settargetattime/index.md
@@ -91,11 +91,12 @@ the time progresses.
 | `5 * timeConstant`     | 99.3%                             |
 | `n * timeConstant`     | <math><semantics><mrow><mn>1</mn> |
 
+<math><semantics><mrow><mn>1</mn>
 <mo>-</mo>
 <msup><mi>e</mi>
 <mrow><mo>-</mo>
 <mi>n</mi>
-</mrow></msup></mrow><annotation encoding="TeX">1 - e^{-n}</annotation></semantics></math> |
+</mrow></msup></mrow><annotation encoding="TeX">1 - e^{-n}</annotation></semantics></math>
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I fixed a broken MathML element in [AudioParam.setTargetAtTime document](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/setTargetAtTime).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Currently the MathML element is rendered like the below:
![image](https://user-images.githubusercontent.com/83723320/141508164-a04b6fc8-c4ca-42c5-8f2a-be4a656ba5bf.png)
Also, it seems the formula is not completed. In addition, there is a `|` at the end.

So I fixed it and now it is rendered like this:
![image](https://user-images.githubusercontent.com/83723320/141508536-4be101e1-c37e-4a30-a0a3-1a40b2724eb5.png)
In order to complete the formula, I added `1` to it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I heard that MathML elements are not rendered at some browsers (https://github.com/mdn/content/issues/7008). So I think it is better to see the result with browsers that support MathML rendering. Thank you.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
