### PR TITLE
Fix broken link in index.md

### DIFF
--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.md
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.md
@@ -37,7 +37,7 @@ The File and Directory Entries API is an important API for the following reasons
 - It lets users of your web app directly edit a binary file that's in their local file directory.
 - It provides a storage API that is already familiar to your users, who are used to working with file systems.
 
-For examples of features you can create with this app, see the [Sample use cases](#sample "#samples") section.
+For examples of features you can create with this app, see the [Sample use cases](#sample-use-cases) section.
 
 ### The File and Directory Entries API and other storage APIs
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix link to "Sample uses cases" section (I believe the correct syntax is `#sample-use-cases` though I can't test the link when previewing in the GitHub markdown editor).

#### Motivation
Trying to click on the [original link](https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#usefulness_of_the_api) doesn't do anything which is confusing when you want to view the sample uses cases.

#### Supporting details
![image](https://user-images.githubusercontent.com/20465797/141510485-d7aef640-9a1b-485b-b04a-1a607c5eea21.png)

#### Related issues
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
