### PR TITLE
Updates to JS Learning Area String basics page

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -48,8 +48,8 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 1.  To start with, enter the following lines:
 
     ```js
-    let string = 'The revolution will not be televised.';
-    string;
+    const string = 'The revolution will not be televised.';
+    console.log(string);
     ```
 
     Just like we did with numbers, we are declaring a variable, initializing it with a string value, and then returning the value. The only difference here is that when writing a string, you need to surround the value with quotes.
@@ -57,9 +57,9 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 2.  If you don't do this, or miss one of the quotes, you'll get an error. Try entering the following lines:
 
     ```js example-bad
-    let badString1 = This is a test;
-    let badString2 = 'This is a test;
-    let badString3 = This is a test';
+    const badString1 = This is a test;
+    const badString2 = 'This is a test;
+    const badString3 = This is a test';
     ```
 
     These lines don't work because any text without quotes around it is assumed to be a variable name, property name, a reserved word, or similar. If the browser can't find it, then an error is raised (e.g. "missing; before statement"). If the browser can see where a string starts, but can't find the end of the string, as indicated by the 2nd quote, it complains with an error (with "unterminated string literal"). If your program is raising such errors, then go back and check all your strings to make sure you have no missing quote marks.
@@ -67,8 +67,8 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 3.  The following will work if you previously defined the variable `string` — try it now:
 
     ```js
-    let badString = string;
-    badString;
+    const badString = string;
+    console.log(badString);
     ```
 
     `badString` is now set to have the same value as `string`.
@@ -78,31 +78,31 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 1.  In JavaScript, you can choose single quotes or double quotes to wrap your strings in. Both of the following will work okay:
 
     ```js
-    let sgl = 'Single quotes.';
-    let dbl = "Double quotes";
-    sgl;
-    dbl;
+    const sgl = 'Single quotes.';
+    const dbl = "Double quotes";
+    console.log(sgl);
+    console.log(dbl);
     ```
 
 2.  There is very little difference between the two, and which you use is down to personal preference. You should choose one and stick to it, however; differently quoted code can be confusing, especially if you use two different quotes on the same string! The following will return an error:
 
     ```js example-bad
-    let badQuotes = 'What on earth?";
+    const badQuotes = 'What on earth?";
     ```
 
 3.  The browser will think the string has not been closed because the other type of quote you are not using to contain your strings can appear in the string. For example, both of these are okay:
 
     ```js
-    let sglDbl = 'Would you eat a "fish supper"?';
-    let dblSgl = "I'm feeling blue.";
-    sglDbl;
-    dblSgl;
+    const sglDbl = 'Would you eat a "fish supper"?';
+    const dblSgl = "I'm feeling blue.";
+    console.log(sglDbl);
+    console.log(dblSgl);
     ```
 
 4.  However, you can't include the same quote mark inside the string if it's being used to contain them. The following will error, as it confuses the browser as to where the string ends:
 
     ```js example-bad
-    let bigmouth = 'I've got no right to take my place...';
+    const bigmouth = 'I've got no right to take my place...';
     ```
 
     This leads us very nicely into our next subject.
@@ -112,44 +112,42 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 To fix our previous problem code line, we need to escape the problem quote mark. Escaping characters means that we do something to them to make sure they are recognized as text, not part of the code. In JavaScript, we do this by putting a backslash just before the character. Try this:
 
 ```js
-let bigmouth = 'I\'ve got no right to take my place...';
-bigmouth;
+const bigmouth = 'I\'ve got no right to take my place...';
+console.log(bigmouth);
 ```
 
 This works fine. You can escape other characters in the same way, e.g. `\"`,  and there are some special codes besides. See [Escape sequences](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) for more details.
 
 ## Concatenating strings
 
-1.  Concatenate is a fancy programming word that means "join together". Joining together strings in JavaScript uses the plus (+) operator, the same one we use to add numbers together, but in this context it does something different. Let's try an example in our console.
+Concatenate just means "join together". To join together strings in JavaScript you can use a different type of string, called a *template literal*.
 
-    ```js
-    let one = 'Hello, ';
-    let two = 'how are you?';
-    let joined = one + two;
-    joined;
-    ```
+A template literal looks just like a normal string, but instead of using single or double quote marks  (`'` or `"`), you use backtick characters (`` ` ``):
 
-    The result of this is a variable called `joined`, which contains the value "Hello, how are you?".
+```js
+const greeting = `Hello`;
+```
 
-2.  In the last instance, we joined only two strings, but you can join as many as you like, as long as you include a `+` between each pair. Try this:
+This can work just like a normal string, except you can include variables in it, wrapped inside `${ }` characters, and the variable's value will be inserted into the result:
 
-    ```js
-    let multiple = one + one + one + one + two;
-    multiple;
-    ```
+```js
+const name = 'Chris';
+const greeting = `Hello, ${name}`;
+console.log(greeting); // "Hello, Chris"
+```
 
-3.  You can also use a mix of variables and actual strings. Try this:
+You can use the same technique to join together two variables:
 
-    ```js
-    let response = one + 'I am fine — ' + two;
-    response;
-    ```
-
-> **Note:** When you enter an actual string in your code, enclosed in single or double quotes, it is called a **string literal**.
+```js
+const one = 'Hello, ';
+const two = 'how are you?';
+const joined = `${one}${two}`;
+console.log(joined); // "Hello, how are you?"
+```
 
 ### Concatenation in context
 
-Let's have a look at concatenation being used in action — here's an example from earlier in the course:
+Let's have a look at concatenation being used in action:
 
 ```html
 <button>Press me</button>
@@ -158,113 +156,98 @@ Let's have a look at concatenation being used in action — here's an example fr
 ```js
 const button = document.querySelector('button');
 
-button.onclick = function() {
-  let name = prompt('What is your name?');
-  alert('Hello ' + name + ', nice to see you!');
+function greet() {
+  const name = prompt('What is your name?');
+  alert(`Hello ${name}, nice to see you!`);
 }
+
+button.addEventListener('click', greet);
 ```
 
-{{ EmbedLiveSample('Concatenation_in_context', '100%', 50, "", "", "hide-codepen-jsfiddle") }}
+{{ EmbedLiveSample('Concatenation_in_context', '100%', 50) }}
 
-Here we're using a {{domxref("window.prompt()", "window.prompt()")}} function in line 4, which asks the user to answer a question via a popup dialog box then stores the text they enter inside a given variable — in this case `name`. We then use a {{domxref("window.alert()", "window.alert()")}} function in line 5 to display another popup containing a string we've assembled from two string literals and the `name` variable, via concatenation.
+Here we're using the {{domxref("window.prompt()", "window.prompt()")}} function, which asks the user to answer a question via a popup dialog box then stores the text they enter inside a given variable — in this case `name`. We then use the {{domxref("window.alert()", "window.alert()")}} function to display another popup containing a string which inserts the name into a generic greeting message.
 
-### Numbers vs. strings
+### Concatenation using "+"
 
-1.  So what happens when we try to add (or concatenate) a string and a number? Let's try it in our console:
-
-    ```js
-    'Front ' + 242;
-    ```
-
-    You might expect this to return an error,  but it works just fine. Trying to represent a string as a number doesn't really make sense, but representing a number as a string does, so the browser rather cleverly converts the number to a string and concatenates the two strings.
-
-2.  You can even do this with two numbers — you can force a number to become a string by wrapping it in quote marks. Try the following (we are using the `typeof` operator to check whether the variable is a number or a string):
-
-    ```js
-    let myDate = '19' + '67';
-    typeof myDate;
-    ```
-
-3.  If you have a numeric variable that you want to convert to a string but not change otherwise, or a string variable that you want to convert to a number but not change otherwise, you can use the following two constructs:
-
-    - The {{jsxref("Number")}} object converts anything passed to it into a number, if it can. Try the following:
-
-      ```js
-      let myString = '123';
-      let myNum = Number(myString);
-      typeof myNum;
-      ```
-
-    - Conversely, every number has a method called [`toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) that converts it to the equivalent string. Try this:
-
-      ```js
-      let myNum2 = 123;
-      let myString2 = myNum2.toString();
-      typeof myString2;
-      ```
-
-    These constructs can be really useful in some situations. For example, if a user enters a number into a form's text field, it's a string. However, if you want to add this number to something, you'll need it to be a number, so you could pass it through `Number()` to handle this. We did exactly this in our [Number Guessing Game, in line 54](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/first-splash/number-guessing-game.html#L54).
-
-## Template literals
-
-Another type of string syntax that you may come across is **template literals** (sometimes referred to as template strings). This is a newer syntax that provides more flexible, easier to read strings.
-
-> **Note:** Try entering the below examples into your browser's JavaScript console, to see what results you get.
-
-To turn a standard string literal into a template literal, you have to replace the quote marks (`' '`, or `" "`) with backtick characters (`` ` ` ``). So, taking a simple example:
+You can also concatenate strings using the `+` operator:
 
 ```js
-let song = 'Fight the Youth';
+const greeting = "Hello";
+const name = "Chris";
+console.log(greeting + ", " + name); // "Hello, Chris"
 ```
 
-Would be turned into a template literal like so:
+However, template literals usually give you more readable code:
 
 ```js
-song = `Fight the Youth`;
+const greeting = "Hello";
+const name = "Chris";
+console.log(`${greeting}, ${name}`); // "Hello, Chris"
 ```
 
-If we want to concatenate strings, or include expression results inside them, traditional strings can be fiddly to write:
+## Numbers vs. strings
+
+So what happens when we try to combine a string and a number? Let's try it in our console:
 
 ```js
-let score = 9;
-let highestScore = 10;
-let output = 'I like the song "' + song + '". I gave it a score of ' + (score/highestScore * 100) + '%.';
+const name = "Front ";
+const number = 242;
+console.log(`${name}${number}`); // "Front 242"
 ```
 
-Template literals simplify this enormously:
+You might expect this to return an error,  but it works just fine. Trying to represent a string as a number doesn't really make sense, but representing a number as a string does, so the browser converts the number to a string and concatenates the two strings.
+
+If you have a numeric variable that you want to convert to a string but not change otherwise, or a string variable that you want to convert to a number but not change otherwise, you can use the following two constructs:
+
+- The {{jsxref("Number")}} object converts anything passed to it into a number, if it can. Try the following:
+
+  ```js
+  const myString = '123';
+  const myNum = Number(myString);
+  console.log(typeof myNum);
+  ```
+
+- Conversely, every number has a method called [`toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) that converts it to the equivalent string. Try this:
+
+  ```js
+  const myNum2 = 123;
+  const myString2 = myNum2.toString();
+  console.log(typeof myString2);
+  ```
+
+These constructs can be really useful in some situations. For example, if a user enters a number into a form's text field, it's a string. However, if you want to add this number to something, you'll need it to be a number, so you could pass it through `Number()` to handle this. We did exactly this in our [Number Guessing Game, in line 54](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/first-splash/number-guessing-game.html#L54).
+
+## Including expressions in strings
+
+You can include JavaScript expressions in template literals, as well as simple variables, and the results will be included in the result:
 
 ```js
-output = `I like the song "${ song }". I gave it a score of ${ score/highestScore * 100 }%.`;
+const song = 'Fight the Youth';
+const score = 9;
+const highestScore = 10;
+const output = `I like the song ${song}. I gave it a score of ${score/highestScore * 100}%.`;
+console.log(output);  // "I like the song Fight the Youth. I gave it a score of 90%."
 ```
 
-There is no more need to open and close multiple string pieces — the whole lot can just be wrapped in a single pair of backticks. When you want to include a variable or expression inside the string, you include it inside a `${ }` construct, which is called a _placeholder_.
+## Multiline strings
 
-You can include complex expressions inside template literals, for example:
+Template literals respect the line breaks in the source code, so you can write strings that span multiple lines like this:
 
 ```js
-let examScore = 45;
-let examHighestScore = 70;
-examReport = `You scored ${ examScore }/${ examHighestScore } (${ Math.round(examScore/examHighestScore*100) }%). ${ examScore >= 49 ? 'Well done, you passed!' : 'Bad luck, you didn\'t pass this time.' }`;
+const output = `I like the song.
+I gave it a score of 90%.`;
+console.log(output);  // I like the song.
+                      // I gave it a score of 90%.
 ```
 
-- The first two placeholders here are pretty simple, only including a simple value in the string.
-- The third one calculates a percentage result and rounds it to the nearest integer.
-- The fourth one includes a ternary operator to check whether the score is above a certain mark and print a pass or fail message depending on the result.
-
-Another point to note is that if you want to split a traditional string over multiple lines, you need to include a newline character, `\n`:
+To have the equivalent output using a normal string you'd have to include line break characters (`\n`) in the string:
 
 ```js
-output = 'I like the song "' + song + '".\nI gave it a score of ' + (score/highestScore * 100) + '%.';
+const output = 'I like the song.\nI gave it a score of 90%.';
+console.log(output);  // I like the song".
+                      // I gave it a score of 90%.
 ```
-
-Template literals respect the line breaks in the source code, so newline characters are no longer needed. This would achieve the same result:
-
-```js
-output = `I like the song "${ song }".
-I gave it a score of ${ score/highestScore * 100 }%.`;
-```
-
-We would recommend that you get used to using template literals as soon as possible. They are well-supported in modern browsers, and the only place you'll find a lack of support is Internet Explorer. Many of our examples still use standard string literals, but we will include more template literals going forward.
 
 See our [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals) reference page for more examples and details of advanced features.
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/10337.

This PR updates https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings .

The main thing here is to describe template literals as the primary way to combine strings, rather than secondarily as some new thing. But I also updated examples to use `const`, and changed things like this:

```js
const string = 'hello';
hello;
```

to things like this:

```js
const string = 'hello';
console.log(hello);
```

...which I think is more explicit and works better when there's more than one line to log, as in https://github.com/mdn/content/blob/a2046b7c137786cd510358982d831fd760686299/files/en-us/learn/javascript/first_steps/strings/index.md?plain=1#L81-L84 for example.
