### PR TITLE
Caption must be first child when used in table

### DIFF
--- a/files/en-us/web/html/element/caption/index.md
+++ b/files/en-us/web/html/element/caption/index.md
@@ -96,7 +96,7 @@ The following attributes are deprecated and should not be used. They are documen
 
 ## Usage notes
 
-The `<caption>` element should be the first child of its parent {{htmlelement("table")}} element.
+The `<caption>` element must be the first child of its parent {{htmlelement("table")}} element.
 
 When the `<table>` element that contains the `<caption>` is the only descendant of a {{HTMLElement("figure")}} element, you should use the {{HTMLElement("figcaption")}} element instead of `<caption>`.
 

--- a/files/en-us/web/html/element/caption/index.md
+++ b/files/en-us/web/html/element/caption/index.md
@@ -96,7 +96,7 @@ The following attributes are deprecated and should not be used. They are documen
 
 ## Usage notes
 
-The `<caption>` element must be the first child of its parent {{htmlelement("table")}} element.
+If used, the `<caption>` element must be the first child of its parent {{htmlelement("table")}} element.
 
 When the `<table>` element that contains the `<caption>` is the only descendant of a {{HTMLElement("figure")}} element, you should use the {{HTMLElement("figcaption")}} element instead of `<caption>`.
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Replacing should with must to better align with the spec which requires caption to be the table’s first child, if used: https://html.spec.whatwg.org/multipage/tables.html#the-caption-element

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

More precise wording

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
