### PR TITLE
Typo for "height", not "heigth"

### DIFF
--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -95,7 +95,7 @@ function openRequestedPopup() {
   windowObjectReference = window.open(
     "http://www.domainname.ext/path/ImageFile.png",
     "DescriptiveWindowName",
-    "left=100,top=100,width=320,heigth=320"
+    "left=100,top=100,width=320,height=320"
   );
 }
 ```


### PR DESCRIPTION
#### Summary
Just a fixing a typo, where the example currently doesn't work.

#### Motivation
Helps anyone trying to copy the example.

#### Supporting details
See rest of page :-)

#### Related issues
N/A

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error