### PR TITLE
Fix typo and links in CSS Backgrounds and Borders

### DIFF
--- a/files/en-us/web/css/background-color/index.md
+++ b/files/en-us/web/css/background-color/index.md
@@ -56,7 +56,7 @@ background-color: revert;
 background-color: unset;
 ```
 
-The `background-color` property is specified as a single `><color>` value.
+The `background-color` property is specified as a single `<color>` value.
 
 ### Values
 
@@ -70,7 +70,7 @@ It is important to ensure that the contrast ratio between the background color a
 Color contrast ratio is determined by comparing the luminance of the text and background color values. In order to meet current [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/intro/wcag), a ratio of 4.5:1 is required for text content and 3:1 for larger text such as headings. Large text is defined as 18.66px and [bold](/en-US/docs/Web/CSS/font-weight) or larger, or 24px or larger.
 
 - [WebAIM: Color Contrast Checker](https://webaim.org/resources/contrastchecker/)
-- [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.4_Make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
+- [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
 - [Understanding Success Criterion 1.4.3  | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 ## Formal definition
@@ -129,7 +129,7 @@ Color contrast ratio is determined by comparing the luminance of the text and b
 
 ## See also
 
-- [Multiple backgrounds](/en-US/docs/Web/CSS/CSS_Background_and_Borders/Using_CSS_multiple_backgrounds)
+- [Multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
 - The {{cssxref("&lt;color&gt;")}} data type
 - Other color-related properties: {{cssxref("color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}}, and {{cssxref("column-rule-color")}}
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/HTML/Applying_color)

--- a/files/en-us/web/css/background-image/index.md
+++ b/files/en-us/web/css/background-image/index.md
@@ -128,11 +128,13 @@ div {
 
   - {{cssxref("cross-fade()")}}
   - {{cssxref("element()")}}
-  - {{cssxref("image()", "image()")}}
-  - {{cssxref("image-set()")}}
-  - {{cssxref("linear-gradient()")}}
-  - {{cssxref("radial-gradient()")}}
-  - {{cssxref("repeating-linear-gradient()")}}
-  - {{cssxref("repeating-radial-gradient()")}}
-  - {{cssxref("paint()")}}
+  - {{cssxref("image/image()", "image()")}}
+  - {{cssxref("image/image-set()", "image-set()")}}
+  - {{cssxref("gradient/linear-gradient()", "linear-gradient()")}}
+  - {{cssxref("gradient/radial-gradient()", "radial-gradient()")}}
+  - {{cssxref("gradient/conic-gradient()", "conic-gradient()")}}
+  - {{cssxref("gradient/repeating-linear-gradient()", "repeating-linear-gradient()")}}
+  - {{cssxref("gradient/repeating-radial-gradient()", "repeating-radial-gradient()")}}
+  - {{cssxref("gradient/repeating-conic-gradient()", "repeating-conic-gradient()")}}
+  - {{cssxref("image/paint()", "paint()")}}
   - {{cssxref("url()", "url()")}}

--- a/files/en-us/web/css/border-left-style/index.md
+++ b/files/en-us/web/css/border-left-style/index.md
@@ -101,7 +101,7 @@ tr, td {
 .b10 {border-left-style: outset;}
 ```
 
-Result
+#### Result
 
 {{ EmbedLiveSample('Examples', 300, 200) }}
 

--- a/files/en-us/web/css/border-right-style/index.md
+++ b/files/en-us/web/css/border-right-style/index.md
@@ -116,4 +116,4 @@ tr, td {
 ## See also
 
 - The other style-related border properties: {{Cssxref("border-bottom-style")}}, {{Cssxref("border-left-style")}}, {{Cssxref("border-top-style")}}, and {{Cssxref("border-style")}}.
-- The other bottom-border-related properties: {{Cssxref("border-right")}}, {{Cssxref("border-right-color")}}, and {{Cssxref("border-right-width")}}.
+- The other right-border-related properties: {{Cssxref("border-right")}}, {{Cssxref("border-right-color")}}, and {{Cssxref("border-right-width")}}.


### PR DESCRIPTION
#### Summary
Fix typo and links in CSS Backgrounds and Borders

#### Motivation
There are some links to be updated.
And there are some typos.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
