### PR TITLE
Fix links to guides in "CSS Backgrounds and Borders"

### DIFF
--- a/files/en-us/web/css/background-color/index.md
+++ b/files/en-us/web/css/background-color/index.md
@@ -129,7 +129,7 @@ Color contrast ratio is determined by comparing the luminance of the text and b
 
 ## See also
 
-- [Multiple backgrounds](/en-US/docs/Web/CSS/CSS_Background_and_Borders/Using_CSS_multiple_backgrounds)
+- [Multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
 - The {{cssxref("&lt;color&gt;")}} data type
 - Other color-related properties: {{cssxref("color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}}, and {{cssxref("column-rule-color")}}
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/HTML/Applying_color)

--- a/files/en-us/web/css/background-size/index.md
+++ b/files/en-us/web/css/background-size/index.md
@@ -105,7 +105,7 @@ Based on the intrinsic dimensions and proportions, the rendered size of the back
 
 ### Working with gradients
 
-If you use a `<gradient>` as the background and specify a `background-size` to go with it, it's best not to specify a size that uses a single `auto` component, or is specified using only a width value (for example, `background-size: 50%`). Rendering of `<gradient>`s in such cases changed in Firefox 8, and at present is generally inconsistent across browsers, which do not all implement rendering in full accordance with [the CSS3 `background-size` specification](https://www.w3.org/TR/css3-background/#the-background-size) and with [the CSS3 Image Values gradient specification](http://dev.w3.org/csswg/css3-images/#gradients).
+If you use a `<gradient>` as the background and specify a `background-size` to go with it, it's best not to specify a size that uses a single `auto` component, or is specified using only a width value (for example, `background-size: 50%`). Rendering of `<gradient>`s in such cases changed in Firefox 8, and at present is generally inconsistent across browsers, which do not all implement rendering in full accordance with [the CSS3 `background-size` specification](https://www.w3.org/TR/css3-background/#the-background-size) and with [the CSS3 Image Values gradient specification](https://dev.w3.org/csswg/css3-images/#gradients).
 
 ```css
 .gradient-example {
@@ -165,7 +165,7 @@ Let's consider a large image, a 2982x2808 Firefox logo image. We want to tile fo
 
 {{EmbedLiveSample("Tiling_a_large_image", 340, 340)}}
 
-See [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Scaling_background_images) for more examples.
+See [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images) for more examples.
 
 ## Specifications
 
@@ -177,6 +177,6 @@ See [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/
 
 ## See also
 
-- [Scaling background images](/en-US/docs/Web/CSS/Scaling_background_images)
+- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
 - [Scaling of SVG backgrounds](/en-US/docs/Web/CSS/Scaling_of_SVG_backgrounds)
 - {{cssxref("object-fit")}}

--- a/files/en-us/web/css/background-size/index.md
+++ b/files/en-us/web/css/background-size/index.md
@@ -11,7 +11,8 @@ browser-compat: css.properties.background-size
 ---
 {{CSSRef}}
 
-The **`background-size`** [CSS](/en-US/docs/Web/CSS) property sets the size of the element's background image. The image can be left to its natural size, stretched, or constrained to fit the available space.
+The **`background-size`** [CSS](/en-US/docs/Web/CSS) property sets the size of the element's background image.
+The image can be left to its natural size, stretched, or constrained to fit the available space.
 
 {{EmbedInteractiveExample("pages/css/background-size.html")}}
 
@@ -54,29 +55,38 @@ The `background-size` property is specified in one of the following ways:
 
 - Using the keyword values `contain` or `cover`.
 - Using a width value only, in which case the height defaults to `auto`.
-- Using both a width and a height value, in which case the first sets the width and the second sets the height. Each value can be a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or `auto`.
+- Using both a width and a height value, in which case the first sets the width and the second sets the height.
+  Each value can be a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or `auto`.
 
 To specify the size of multiple background images, separate the value for each one with a comma.
 
 ### Values
 
 - `contain`
-  - : Scales the image as large as possible within its container without cropping or stretching the image. If the container is larger than the image, this will result in image tiling, unless the {{cssxref("background-repeat")}} property is set to `no-repeat`.
+  - : Scales the image as large as possible within its container without cropping or stretching the image.
+    If the container is larger than the image, this will result in image tiling, unless the {{cssxref("background-repeat")}} property is set to `no-repeat`.
 - `cover`
-  - : Scales the image as large as possible to fill the container, stretching the image if necessary. If the proportions of the image differ from the element, it is cropped either vertically or horizontally so that no empty space remains.
+  - : Scales the image as large as possible to fill the container, stretching the image if necessary.
+    If the proportions of the image differ from the element, it is cropped either vertically or horizontally so that no empty space remains.
 - `auto`
   - : Scales the background image in the corresponding direction such that its intrinsic proportions are maintained.
 - {{cssxref("&lt;length&gt;")}}
   - : Stretches the image in the corresponding dimension to the specified length. Negative values are not allowed.
 - {{cssxref("&lt;percentage&gt;")}}
-  - : Stretches the image in the corresponding dimension to the specified percentage of the _background positioning area_. The background positioning area is determined by the value of {{cssxref("background-origin")}} (by default, the padding box). However, if the background's {{cssxref("background-attachment")}} value is `fixed`, the positioning area is instead the entire {{glossary("viewport")}}. Negative values are not allowed.
+  - : Stretches the image in the corresponding dimension to the specified percentage of the _background positioning area_.
+    The background positioning area is determined by the value of {{cssxref("background-origin")}} (by default, the padding box).
+    However, if the background's {{cssxref("background-attachment")}} value is `fixed`, the positioning area is instead the entire {{glossary("viewport")}}.
+    Negative values are not allowed.
 
 ### Intrinsic dimensions and proportions
 
-The computation of values depends on the image's intrinsic dimensions (width and height) and intrinsic proportions (width-to-height ratio). These attributes are as follows:
+The computation of values depends on the image's intrinsic dimensions (width and height) and intrinsic proportions (width-to-height ratio).
+These attributes are as follows:
 
 - A bitmap image (such as JPG) always has intrinsic dimensions and proportions.
-- A vector image (such as SVG) does not necessarily have intrinsic dimensions. If it has both horizontal and vertical intrinsic dimensions, it also has intrinsic proportions. If it has no dimensions or only one dimension, it may or may not have proportions.
+- A vector image (such as SVG) does not necessarily have intrinsic dimensions.
+  If it has both horizontal and vertical intrinsic dimensions, it also has intrinsic proportions.
+  If it has no dimensions or only one dimension, it may or may not have proportions.
 - CSS {{cssxref("&lt;gradient&gt;")}}s have no intrinsic dimensions or intrinsic proportions.
 - Background images created with the {{cssxref("element()")}} function use the intrinsic dimensions and proportions of the generating element.
 
@@ -85,27 +95,34 @@ The computation of values depends on the image's intrinsic dimensions (width and
 Based on the intrinsic dimensions and proportions, the rendered size of the background image is computed as follows:
 
 - **If both components of `background-size` are specified and are not `auto`:** The background image is rendered at the specified size.
-- **If the `background-size` is `contain` or `cover`:** While preserving its intrinsic proportions, the image is rendered at the largest size contained within, or covering, the background positioning area. If the image has no intrinsic proportions, then it's rendered at the size of the background positioning area.
+- **If the `background-size` is `contain` or `cover`:** While preserving its intrinsic proportions, the image is rendered at the largest size contained within, or covering, the background positioning area.
+  If the image has no intrinsic proportions, then it's rendered at the size of the background positioning area.
 - **If the `background-size` is `auto` or `auto auto`:**
 
   - If the image has both horizontal and vertical intrinsic dimensions, it's rendered at that size.
   - If the image has no intrinsic dimensions and has no intrinsic proportions, it's rendered at the size of the background positioning area.
   - If the image has no intrinsic dimensions but has intrinsic proportions, it's rendered as if `contain` had been specified instead.
-  - If the image has only one intrinsic dimension and has intrinsic proportions, it's rendered at the size corresponding to that one dimension. The other dimension is computed using the specified dimension and the intrinsic proportions.
+  - If the image has only one intrinsic dimension and has intrinsic proportions, it's rendered at the size corresponding to that one dimension.
+    The other dimension is computed using the specified dimension and the intrinsic proportions.
   - If the image has only one intrinsic dimension but has no intrinsic proportions, it's rendered using the specified dimension and the other dimension of the background positioning area.
 
   > **Note:** SVG images have a [`preserveAspectRatio`](/en-US/docs/Web/SVG/Attribute/preserveAspectRatio) attribute that defaults to the equivalent of `contain`; an explicit `background-size` causes `preserveAspectRatio` to be ignored.
 
 - **If the `background-size` has one `auto` component and one non-`auto` component:**
 
-  - If the image has intrinsic proportions, it's stretched to the specified dimension. The unspecified dimension is computed using the specified dimension and the intrinsic proportions.
-  - If the image has no intrinsic proportions, it's stretched to the specified dimension. The unspecified dimension is computed using the image's corresponding intrinsic dimension, if there is one. If there is no such intrinsic dimension, it becomes the corresponding dimension of the background positioning area.
+  - If the image has intrinsic proportions, it's stretched to the specified dimension.
+    The unspecified dimension is computed using the specified dimension and the intrinsic proportions.
+  - If the image has no intrinsic proportions, it's stretched to the specified dimension.
+    The unspecified dimension is computed using the image's corresponding intrinsic dimension, if there is one.
+    If there is no such intrinsic dimension, it becomes the corresponding dimension of the background positioning area.
 
-> **Note:** Background sizing for vector images that lack intrinsic dimensions or proportions is not yet fully implemented in all browsers. Be careful about relying on the behavior described above, and test in multiple browsers to be sure the results are acceptable.
+> **Note:** Background sizing for vector images that lack intrinsic dimensions or proportions is not yet fully implemented in all browsers.
+> Be careful about relying on the behavior described above, and test in multiple browsers to be sure the results are acceptable.
 
 ### Working with gradients
 
-If you use a `<gradient>` as the background and specify a `background-size` to go with it, it's best not to specify a size that uses a single `auto` component, or is specified using only a width value (for example, `background-size: 50%`). Rendering of `<gradient>`s in such cases changed in Firefox 8, and at present is generally inconsistent across browsers, which do not all implement rendering in full accordance with [the CSS3 `background-size` specification](https://www.w3.org/TR/css3-background/#the-background-size) and with [the CSS3 Image Values gradient specification](https://dev.w3.org/csswg/css3-images/#gradients).
+If you use a `<gradient>` as the background and specify a `background-size` to go with it, it's best not to specify a size that uses a single `auto` component, or is specified using only a width value (for example, `background-size: 50%`).
+Rendering of `<gradient>`s in such cases changed in Firefox 8, and at present is generally inconsistent across browsers, which do not all implement rendering in full accordance with [the CSS3 `background-size` specification](https://www.w3.org/TR/css3-background/#the-background-size) and with [the CSS3 Image Values gradient specification](https://dev.w3.org/csswg/css3-images/#gradients).
 
 ```css
 .gradient-example {
@@ -139,7 +156,8 @@ Note that it's particularly not recommended to use a pixel dimension and an `aut
 
 ### Tiling a large image
 
-Let's consider a large image, a 2982x2808 Firefox logo image. We want to tile four copies of this image into a 300x300-pixel element. To do this, we can use a fixed `background-size` value of 150 pixels.
+Let's consider a large image, a 2982x2808 Firefox logo image. We want to tile four copies of this image into a 300x300-pixel element.
+To do this, we can use a fixed `background-size` value of 150 pixels.
 
 #### HTML
 
@@ -165,7 +183,7 @@ Let's consider a large image, a 2982x2808 Firefox logo image. We want to tile fo
 
 {{EmbedLiveSample("Tiling_a_large_image", 340, 340)}}
 
-See [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images) for more examples.
+See [Resizing background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images) for more examples.
 
 ## Specifications
 
@@ -177,6 +195,6 @@ See [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/
 
 ## See also
 
-- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
+- [Resizing background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
 - [Scaling of SVG backgrounds](/en-US/docs/Web/CSS/Scaling_of_SVG_backgrounds)
 - {{cssxref("object-fit")}}

--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -10,7 +10,9 @@ tags:
 ---
 {{CSSRef}}
 
-Styles in the **CSS Backgrounds and Borders** module allow filling backgrounds with color or an image (clipped or resized), or modifying them in other ways. These styles can also decorate borders with lines or images, and make them square or rounded. (Additionally, element boxes can be decorated with a shadow.)
+Styles in the **CSS Backgrounds and Borders** module allow filling backgrounds with color or an image (clipped or resized), or modifying them in other ways.
+These styles can also decorate borders with lines or images, and make them square or rounded.
+(Additionally, element boxes can be decorated with a shadow.)
 
 ## Reference
 
@@ -65,7 +67,7 @@ Styles in the **CSS Backgrounds and Borders** module allow filling backgrounds w
 
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
   - : Explains how to set one or more backgrounds on an element.
-- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
+- [Resizing background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
   - : Describes how to change the size and repeating behavior of background images.
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/HTML/Applying_color)
   - : An overview of how CSS color can be used in HTML, including for borders.

--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -65,7 +65,7 @@ Styles in the **CSS Backgrounds and Borders** module allow filling backgrounds w
 
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
   - : Explains how to set one or more backgrounds on an element.
-- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Scaling_background_images)
+- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
   - : Describes how to change the size and repeating behavior of background images.
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/HTML/Applying_color)
   - : An overview of how CSS color can be used in HTML, including for borders.

--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -15,9 +15,9 @@ This page lists them all, with a short description. They are grouped by complexi
 
 - [Getting started](/en-US/docs/Web/CSS/Getting_Started)
   - : This guide is aimed at complete beginners: You haven't written one single line of CSS? — this is for you. It explains the fundamental concepts of the language and guides you in writing basic stylesheets.
-- [Using multiple backgrounds](/en-US/docs/Web/CSS/Using_CSS_multiple_backgrounds)
+- [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
   - : Backgrounds are fundamental for nice styling: CSS allows you to set several of them on each box. This tutorial explains how they interact and how to achieve nice effects.
-- [Scaling background images](/en-US/docs/Web/CSS/Scaling_background_images)
+- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
   - : CSS allows you to resize images used as an element's background. This tutorial describes how to achieve this in a simple way.
 - [Media queries](/en-US/docs/Web/CSS/Media_queries)
   - : The size of the screens, or the kind of devices like touchscreens or printed sheets vary greatly nowadays. Media queries are the fundamental building blocks in achieving Web sites that render everywhere in their best quality.

--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -7,26 +7,35 @@ tags:
   - Junk
   - Tutorial
 ---
-Learning CSS may be a daunting task. In order to help you, we have written numerous **tutorials about CSS**. Some are aimed at complete beginners, while others present complex features to be used by more experienced users.
+Learning CSS may be a daunting task.
+In order to help you, we have written numerous **tutorials about CSS**.
+Some are aimed at complete beginners, while others present complex features to be used by more experienced users.
 
-This page lists them all, with a short description. They are grouped by complexity so that you can choose the most appropriate for your level.
+This page lists them all, with a short description.
+They are grouped by complexity so that you can choose the most appropriate for your level.
 
 ## Beginner-level CSS tutorials
 
 - [Getting started](/en-US/docs/Web/CSS/Getting_Started)
-  - : This guide is aimed at complete beginners: You haven't written one single line of CSS? — this is for you. It explains the fundamental concepts of the language and guides you in writing basic stylesheets.
+  - : This guide is aimed at complete beginners: You haven't written one single line of CSS? — this is for you.
+    It explains the fundamental concepts of the language and guides you in writing basic stylesheets.
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
   - : Backgrounds are fundamental for nice styling: CSS allows you to set several of them on each box. This tutorial explains how they interact and how to achieve nice effects.
-- [Scaling background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
-  - : CSS allows you to resize images used as an element's background. This tutorial describes how to achieve this in a simple way.
+- [Resizing background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
+  - : CSS allows you to resize images used as an element's background.
+    This tutorial describes how to achieve this in a simple way.
 - [Media queries](/en-US/docs/Web/CSS/Media_queries)
-  - : The size of the screens, or the kind of devices like touchscreens or printed sheets vary greatly nowadays. Media queries are the fundamental building blocks in achieving Web sites that render everywhere in their best quality.
+  - : The size of the screens, or the kind of devices like touchscreens or printed sheets vary greatly nowadays.
+    Media queries are the fundamental building blocks in achieving Web sites that render everywhere in their best quality.
 - [Understanding z-index](/en-US/docs/Web/CSS/Understanding_z-index)
-  - : Controlling superposition of boxes is a basic feature that is very quickly needed by Web developers. Though not that difficult, it requires a basic knowledge of CSS.
+  - : Controlling superposition of boxes is a basic feature that is very quickly needed by Web developers.
+    Though not that difficult, it requires a basic knowledge of CSS.
 
 ## Intermediate-level CSS tutorials
 
-After the release of CSS 2 (Level 1), new features have been added to CSS. Some of them are _fancy_ and are pretty self contained. They are easy to use for anybody with a fair knowledge of basic concepts.
+After the release of CSS 2 (Level 1), new features have been added to CSS.
+Some of them are _fancy_ and are pretty self contained.
+They are easy to use for anybody with a fair knowledge of basic concepts.
 
 - [CSS Counters](/en-US/docs/Web/CSS/Counters)
   - : Counting items and pages is an easy task in CSS. Learn to use {{cssxref("counter-reset")}}, {{cssxref("counter-increment")}}, {{cssxref("counters", "counters()")}}, and {{cssxref("counter", "counter()")}}.
@@ -37,13 +46,18 @@ After the release of CSS 2 (Level 1), new features have been added to CSS. Some 
 - [CSS Transforms](/en-US/docs/Web/CSS/Tutorials/Using_CSS_transforms)
   - : Transforms allow you to change the position of elements by modifying their coordinate space: it allows for translating, rotating, and deforming them in the 2D or 3D spaces.
 - [CSS Gradients](/en-US/docs/Web/CSS/Using_CSS_gradients)
-  - : Gradients are images that transition smoothly from one color to another. There are several types of gradients allowed in CSS: linear or radial, repeating or not. This tutorial describes how to use them.
+  - : Gradients are images that transition smoothly from one color to another.
+    There are several types of gradients allowed in CSS: linear or radial, repeating or not.
+    This tutorial describes how to use them.
 
 ## Advanced-level CSS tutorials
 
-CSS also got new features allowing you to create complex layouts. Though the simplest way to achieve such layout, they are more complex to use for people without too much experience.
+CSS also got new features allowing you to create complex layouts.
+Though the simplest way to achieve such layout, they are more complex to use for people without too much experience.
 
 - [CSS multi-column layouts](/en-US/docs/Web/CSS/Using_CSS_multi-column_layouts)
-  - : CSS3 introduces a new layout allowing you to easily define multiple columns in an element. Though multi-column text is not that common on devices like screens, this is particularly useful on printed pages, or for indexes.
+  - : CSS3 introduces a new layout allowing you to easily define multiple columns in an element.
+    Though multi-column text is not that common on devices like screens, this is particularly useful on printed pages, or for indexes.
 - [CSS flexible boxes layouts](/en-US/docs/Web/CSS/Using_CSS_flexible_boxes)
-  - : This new layout allow you to give boxes flexibility, allowing them to be resized smoothly. It is a powerful way to describe complex interfaces.
+  - : This new layout allow you to give boxes flexibility, allowing them to be resized smoothly.
+    It is a powerful way to describe complex interfaces.


### PR DESCRIPTION
#### Summary
Fix links to guides in "CSS Backgrounds and Borders"

#### Motivation
Slugs of some documents in "CSS Backgrounds and Borders" have been changed, but there are some links which hasn't been updated yet.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
