### PR TITLE
Fixed a typo on line 247

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -244,7 +244,7 @@ let myArray = ['I', 'love', 'chocolate', 'frogs'];
 let madeAString = myArray.join(' ');
 // returns 'I love chocolate frogs'
 let madeAString = myArray.join();
-// returns 'I,love,chocolate,frogs'
+// returns 'Ilovechocolatefrogs'
 ```
 
 If no parameter is included to specify a joining/delimiting character, a comma is used by default.


### PR DESCRIPTION
Fixed a typo in line 247, which  made it look like calling a the join function with no parameter on an array returned the joined elements of such array separated by comas instead of it being joined with nothing in between words.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed a typo in line 247, which  made it look like calling a the join function with no parameter on an array returned the joined elements of such array separated by comas instead of it being joined with nothing in between words.

#### Motivation
I tried the snippet on JSFiddle and it returned "Ilovechocolatefrogs" instead of "I,love,chocolate,frogs".

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
