### PR TITLE
Fixed a typo: 'cannnot'

### DIFF
--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
@@ -205,7 +205,7 @@ This example displays a page with the data we sent. You can see this in action i
 
 ![](php-result.png)
 
-> **Note:** This example won't work when you load it into a browser locally — browsers cannnot interpret PHP code, so when the form is submitted the browser will just offer to download the PHP file for you. To get it to work, you need to run the example through a PHP server of some kind. Good options for local PHP testing are [MAMP](https://www.mamp.info/en/downloads/) (Mac and Windows) and [AMPPS](https://ampps.com/download) (Mac, Windows, Linux).
+> **Note:** This example won't work when you load it into a browser locally — browsers cannot interpret PHP code, so when the form is submitted the browser will just offer to download the PHP file for you. To get it to work, you need to run the example through a PHP server of some kind. Good options for local PHP testing are [MAMP](https://www.mamp.info/en/downloads/) (Mac and Windows) and [AMPPS](https://ampps.com/download) (Mac, Windows, Linux).
 >
 > Note also that if you are using MAMP but don't have MAMP Pro installed (or if the MAMP Pro demo time trial has expired), you might have trouble getting it working. To get it working again, we have found that you can load up the MAMP app, then choose the menu options _MAMP_ > _Preferences_ > _PHP_, and set "Standard Version:" to "7.2.x" (x will differ depending on what version you have installed).
 


### PR DESCRIPTION
Fixed a typo: 'cannnot'

#### Related issues
Fixes #10530

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

