### PR TITLE
Content: Fixed a value in an example

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -142,7 +142,7 @@ With the `flex-grow` property set to a positive integer, flex items can grow alo
 
 If we gave all of our items in the example above a `flex-grow` value of 1 then the available space in the flex container would be equally shared between our items and they would stretch to fill the container on the main axis.
 
-The flex-grow property can be used to distribute space in proportion. If we give our first item a `flex-grow` value of 2, and the other items a value of 1 each, 2 parts will be given to the first item (100px out of 200px in the case of the example above), 1 part each the other two (50px each out of the 200px total).
+The flex-grow property can be used to distribute space in proportion. If we give our first item a `flex-grow` value of 2, and the other items a value of 1 each, 2 parts will be given to the first item (250px out of 500px in the case of the example above), 1 part each the other two (125px each out of the 500px total).
 
 ### The flex-shrink property
 


### PR DESCRIPTION
Example given in line 145: container size is 200px instead of 500px (as in the example above)

#### Related issues
Fixes #10486

#### Metadata
This PR:
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
