### PR TITLE
Cut H2 dupe of H1, make TOC more useful

### DIFF
--- a/files/en-us/web/svg/tutorial/basic_shapes/index.md
+++ b/files/en-us/web/svg/tutorial/basic_shapes/index.md
@@ -10,8 +10,6 @@ tags:
 
 There are several basic shapes used for most SVG drawing. The purpose of these shapes is fairly obvious from their names. Some of the parameters that determine their position and size are given, but an element reference would probably contain more accurate and complete descriptions along with other properties that won't be covered in here. However, since they're used in most SVG documents, it's necessary to give them some sort of introduction.
 
-## Basic shapes
-
 To insert a shape, you create an element in the document. Different elements correspond to different shapes and take different parameters to describe the size and position of those shapes. Some are slightly redundant in that they can be created by other shapes, but they're all there for your convenience and to keep your SVG documents as short and as readable as possible. All the basic shapes are shown in the following image.
 
 ![](shapes.png)
@@ -41,7 +39,7 @@ The code to generate that image looks something like this:
 
 > **Note:** The `stroke`, `stroke-width`, and `fill` attributes are explained later in the tutorial.
 
-### Rectangle
+## Rectangle
 
 The {{SVGElement("rect")}} element draws a rectangle on the screen. There are 6 basic attributes that control the position and shape of the rectangles on screen. The one on the right has its `rx` and `ry` parameters set, giving it rounded corners. If they're not set, they default to `0`.
 
@@ -63,7 +61,7 @@ The {{SVGElement("rect")}} element draws a rectangle on the screen. There are 6 
 *   `ry`
     *   : The y radius of the corners of the rectangle
 
-### Circle
+## Circle
 
 The {{SVGElement("circle")}} element draws a circle on the screen. It takes 3 basic parameters to determine the shape and size of the element.
 
@@ -78,7 +76,7 @@ The {{SVGElement("circle")}} element draws a circle on the screen. It takes 3 ba
 *   `cy`
     *   : The y position of the center of the circle.
 
-### Ellipse
+## Ellipse
 
 An {{SVGElement("ellipse")}} is a more general form of the {{SVGElement("circle")}} element, where you can scale the x and y radius (commonly referred to as the *semimajor* and *semiminor* axes in maths) of the circle separately.
 
@@ -95,7 +93,7 @@ An {{SVGElement("ellipse")}} is a more general form of the {{SVGElement("circle"
 *   `cy`
     *   : The y position of the center of the ellipse.
 
-### Line
+## Line
 
 The {{SVGElement("line")}} element takes the positions of two points as parameters and draws a straight line between them.
 
@@ -112,7 +110,7 @@ The {{SVGElement("line")}} element takes the positions of two points as paramete
 *   `y2`
     *   : The y position of point 2.
 
-### Polyline
+## Polyline
 
 A {{SVGElement("polyline")}} is a group of connected straight lines. Since the list of points can get quite long, all the points are included in one attribute:
 
@@ -123,7 +121,7 @@ A {{SVGElement("polyline")}} is a group of connected straight lines. Since the l
 *   `points`
     *   : A list of points. Each number must be separated by a space, comma, EOL, or a line feed character. Each point must contain two numbers: an x coordinate and a y coordinate. So, the list `(0,0)`, `(1,1)`, and `(2,2)` would be written as `0, 0 1, 1 2, 2`.
 
-### Polygon
+## Polygon
 
 A {{SVGElement("polygon")}} is similar to a {{SVGElement("polyline")}}, in that it is composed of straight line segments connecting a list of points. For polygons though, the path automatically connects the last point with the first, creating a closed shape.
 
@@ -136,7 +134,7 @@ A {{SVGElement("polygon")}} is similar to a {{SVGElement("polyline")}}, in that 
 *   `points`
     *   : A list of points, each number separated by a space, comma, EOL, or a line feed character. Each point must contain two numbers: an x coordinate and a y coordinate. So, the list `(0,0)`, `(1,1)`, and `(2,2)` would be written as `0, 0 1, 1 2, 2`. The drawing then closes the path, so a final straight line would be drawn from `(2,2)` to `(0,0)`.
 
-### Path
+## Path
 
 A {{SVGElement("path")}} is the most general shape that can be used in SVG. Using a `path` element, you can draw rectangles (with or without rounded corners), circles, ellipses, polylines, and polygons. Basically any of the other types of shapes, bezier curves, quadratic curves, and many more.
 


### PR DESCRIPTION
#### Summary

The H2 wasn't helping anything here since it matched the H1, and then all the shapes themselves were H3s, thus excluded from the sidebar table of contents.  This upgrades them to H2s for inclusion there.

#### Motivation

Because the TOC looked like this:

![image](https://user-images.githubusercontent.com/26723818/141767255-6d91c61a-3c35-4a28-9653-9ad9d24d1bad.png)

From that, I couldn't get a quick list of shapes at a glance.

#### Supporting details

n/a

#### Related issues

n/a

#### Metadata

This PR…

- [x] Fixes a typo, bug, or other error