### PR TITLE
Content: Corrections in stacking context hierarchy

### DIFF
--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
@@ -25,10 +25,10 @@ To better understand the situation, this is the stacking context hierarchy:
 
 - root stacking context
 
-  - DIV #2 (z-index 2)
   - DIV #3 (z-index 1)
-
     - DIV #4 (z-index 10)
+  
+  - DIV #2 (z-index 2)
 
 > **Note:** It is worth remembering that in general the HTML hierarchy is different from the stacking context hierarchy. In the stacking context hierarchy, elements that do not create a stacking context are collapsed on their parent.
 


### PR DESCRIPTION
#### Summary
The order of stacking context hierarchy was changed to ascending order of z-index.

Before Changes:
- root stacking context
    - DIV 2 (z-index 2)
    - DIV 3 (z-index 1)
        - DIV 4 (z-index 10)

After Changes:
- root stacking context
    - DIV 3 (z-index 1)
        - DIV 4 (z-index 10)
    - DIV 2 (z-index 2)

#### Supporting details
Related Link: [The_stacking_context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)

#### Related issues
Fixes #10543

#### Metadata
This PR:
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
