### PR TITLE
Fix warning markup in with statement page

### DIFF
--- a/files/en-us/web/javascript/reference/statements/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/with/index.md
@@ -8,7 +8,7 @@ tags:
   - Statement
 browser-compat: javascript.statements.with
 ---
-> **Warning:**Use of the `with` statement is not recommended, as it may
+> **Warning:** Use of the `with` statement is not recommended, as it may
 > be the source of confusing bugs and compatibility issues. See the "Ambiguity Contra"
 > paragraph in the "Description" section below for details.
 


### PR DESCRIPTION
This PR fixes the markup for a warning in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with .