### PR TITLE
Note and Warning fixes across docs

### DIFF
--- a/files/en-us/games/techniques/2d_collision_detection/index.md
+++ b/files/en-us/games/techniques/2d_collision_detection/index.md
@@ -121,7 +121,7 @@ circle2.bind("EnterFrame", function () {
 
 {{ EmbedLiveSample('Circle_Collision', '700', '300', '', 'Games/Techniques/2D_collision_detection') }}
 
-**Note:** [Here is another example without Canvas or external libraries.](https://jsfiddle.net/jlr7245/teb4znk0/20/)
+> **Note:** [Here is another example without Canvas or external libraries.](https://jsfiddle.net/jlr7245/teb4znk0/20/)
 
 ## Separating Axis Theorem
 

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -73,7 +73,7 @@ function b64EncodeUnicode(str) {
 
 ### Solution #2 – rewriting `atob()` and `btoa()` using `TypedArray`s and UTF-8
 
-**Note:** The following code is also useful to get an [ArrayBuffer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) from a Base64 string and/or viceversa ([see below](#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer)).
+> **Note:** The following code is also useful to get an [ArrayBuffer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) from a Base64 string and/or viceversa ([see below](#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer)).
 
 ```js
 "use strict";
@@ -284,4 +284,4 @@ var myBuffer = base64DecToArr("QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29ya
 alert(myBuffer.byteLength);
 ```
 
-**Note:** The function `base64DecToArr(sBase64[, nBlocksSize])` returns an [`uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the `nBlocksSize` argument, which is the number of bytes of which the `uint8Array.buffer.bytesLength` property must result a multiple (`1` or omitted for ASCII, [binary strings](/en-US/docs/Web/API/DOMString/Binary) or UTF-8-encoded strings, `2` for UTF-16 strings, `4` for UTF-32 strings).
+> **Note:** The function `base64DecToArr(sBase64[, nBlocksSize])` returns an [`uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the `nBlocksSize` argument, which is the number of bytes of which the `uint8Array.buffer.bytesLength` property must result a multiple (`1` or omitted for ASCII, [binary strings](/en-US/docs/Web/API/DOMString/Binary) or UTF-8-encoded strings, `2` for UTF-16 strings, `4` for UTF-32 strings).

--- a/files/en-us/mdn/about/index.md
+++ b/files/en-us/mdn/about/index.md
@@ -36,7 +36,7 @@ MDN's content is entirely available under various open source licenses. This sec
 
 #### Documentation and articles
 
-**Note:** MDN content has been prepared with the contributions of authors from both inside and outside Mozilla. Unless otherwise indicated, the content is available under the terms of the [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA), v2.5 or any later version.
+> **Note:** MDN content has been prepared with the contributions of authors from both inside and outside Mozilla. Unless otherwise indicated, the content is available under the terms of the [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA), v2.5 or any later version.
 
 When reusing MDN content, you need to ensure two things:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -121,8 +121,8 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
-**Note:**
-Instead of using `sendResponse()`, returning a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) is the recommended approach for Firefox add-ons. Examples using a Promise are available in the [examples section](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) of the {{WebExtAPIRef('runtime.onMessage')}} listener.
+> **Note:** Instead of using `sendResponse()`, returning a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) is the recommended approach for Firefox add-ons. 
+> Examples using a Promise are available in the [examples section](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) of the {{WebExtAPIRef('runtime.onMessage')}} listener.
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -110,7 +110,7 @@ Events have three functions:
 
     - `host`
       - : `string`. The server's [hostname](https://en.wikipedia.org/wiki/Hostname#Internet_hostnames).
-        **Warning**: Unlike Chrome, Firefox will return the requested host instead of the proxy requesting the authentication, even if `isProxy` is `true`.
+        > **Warning:** Unlike Chrome, Firefox will return the requested host instead of the proxy requesting the authentication, even if `isProxy` is `true`.
     - `port`
       - : `integer`. The server's port number.
 
@@ -121,7 +121,8 @@ Events have three functions:
 - `incognito`
   - : `boolean`. Whether the request is from a private browsing window.
 - `isProxy`
-  - : `boolean`. `true` for Proxy-Authenticate, `false` for WWW-Authenticate. **Note**: `webRequest.onAuthRequired` is only called for HTTP and HTTPS/SSL proxy servers requiring authentication, and not for SOCKS proxy servers requiring authentication.
+  - : `boolean`. `true` for `Proxy-Authenticate`, `false` for `WWW-Authenticate`.
+    > **Note:** `webRequest.onAuthRequired` is only called for HTTP and HTTPS/SSL proxy servers requiring authentication, and not for SOCKS proxy servers requiring authentication.
 - `method`
   - : `string`. Standard HTTP method (For example, `"GET"` or `"POST"`).
 - `parentFrameId`

--- a/files/en-us/mozilla/firefox/releases/1.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/index.md
@@ -30,7 +30,7 @@ Several tools and browser extensions are available to help developers support Fi
 - View page source, with syntax highlighting and find features.
 - [Browser extensions](https://addons.mozilla.org/extensions/showlist.php?application=firefox&category=Developer%20Tools) including the [FireBug](http://www.joehewitt.com/software/firebug/), [Web Developer toolbar](</en-US/docs/Web_Developer_Extension_(external)>), [Live HTTP Headers](</en-US/docs/Live_HTTP_Headers_(external)>), [HTML Validator](</en-US/docs/HTML_Validator_(external)>) and many more.
 
-**Note:** Some extensions do not currently support Firefox 1.5, and will be automatically disabled.
+> **Note:** Some extensions do not currently support Firefox 1.5, and will be automatically disabled.
 
 ## Overview
 

--- a/files/en-us/mozilla/firefox/releases/21/index.md
+++ b/files/en-us/mozilla/firefox/releases/21/index.md
@@ -52,7 +52,8 @@ Firefox 21 was released on May 14, 2013. This article lists key changes that are
 
 - We continue to update our CSP implementation to match the CSP 1.0 spec, which reached Candidate Recommendation:
 
-  - Support for the spec-compliant `Content-Security-Policy` HTTP header (in addition to the experimental `X-Content-Security-Policy`) has been added ({{bug("783049")}}). **Note**: the patch for this new header landed in Firefox 21, it is disabled on builds ({{bug("842657")}}).
+  - Support for the spec-compliant `Content-Security-Policy` HTTP header (in addition to the experimental `X-Content-Security-Policy`) has been added ({{bug("783049")}}).
+    > **Note:** the patch for this new header landed in Firefox 21, it is disabled on builds ({{bug("842657")}}).
 
 ### Worker
 

--- a/files/en-us/plugins/guide/plug-in_basics/index.md
+++ b/files/en-us/plugins/guide/plug-in_basics/index.md
@@ -116,7 +116,8 @@ exec /usr/lib64/firefox/firefox
 - `/usr/lib/mozilla/plugins` (the 64-bit Firefox checks `/usr/lib64/mozilla/plugins` as well).
 - `/usr/lib64/firefox/plugins` (for 64-bit Firefox)
 
-**Note:** Firefox Nightly checks a subset of these locations. Also some Linux distributions provide a system browser configured differently.
+> **Note:** Firefox Nightly checks a subset of these locations.
+> Also some Linux distributions provide a system browser configured differently.
 
 > _Advanced:_ You can determine which directories a Gecko program checks with the Linux `strace` command, for example:
 >

--- a/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
@@ -25,7 +25,8 @@ When using `aria-braillelabel`, ensure that:
 - The `aria-braillelabel` values are localized to align with the document language. 
 - Communicate to the user that this attribute is available, especially if the content contains Unicode Braille Patterns, so the user knows to set the settings to apply user specific braille translations
 
->  **Note:** Assistive Technologies with braille support can convert the accessible names to Braille. Therefore, only use `aria-braillelabel` when the accessible name is not the user experience you want. 
+> **Note:** Assistive Technologies with braille support can convert the accessible names to Braille.
+> Therefore, only use `aria-braillelabel` when the accessible name is not the user experience you want. 
 
 Using only the accessible name, e.g., from content or via `aria-label` is almost always the better user experience, so don't use aria-braillelabel to replicate aria-label. Only use `aria-braillelabel` if the accessible name cannot provide an adequate braille representation. 
 

--- a/files/en-us/web/accessibility/aria/roles/cell_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/cell_role/index.md
@@ -38,7 +38,7 @@ Each element with `role="cell"` MUST be nested in a container element with [`rol
 
 A cell can contain a number of property attributes clarifying the cell's position within the tabular data structure, including [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex), [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan), [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex), and [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan).
 
-> **Note** Using the native HTML table element ({{HTMLElement('table')}} element, along with the table row element ({{HTMLElement('tr')}},  and table cell element ({{HTMLElement('td')}}, whenever possible, is strongly encouraged.
+> **Note:** Using the native HTML table element ({{HTMLElement('table')}} element, along with the table row element ({{HTMLElement('tr')}},  and table cell element ({{HTMLElement('td')}}, whenever possible, is strongly encouraged.
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
@@ -114,7 +114,8 @@ When the dialog is correctly labeled and focus is moved to an element (often an 
 
 ### Notes 
 
-**Note:** While it is possible to prevent keyboard users from moving focus to elements outside of the dialog, screen reader users may still be able to navigate to that content using their screen reader's virtual cursor. It is important for developers to ensure that content outside of the modal dialog is inaccessible to all users while the modal dialog is active.
+> **Note:** While it is possible to prevent keyboard users from moving focus to elements outside of the dialog, screen reader users may still be able to navigate to that content using their screen reader's virtual cursor.
+> It is important for developers to ensure that content outside of the modal dialog is inaccessible to all users while the modal dialog is active.
 
 ## Specifications
 
@@ -122,7 +123,6 @@ When the dialog is correctly labeled and focus is moved to an element (often an 
 | ------------------------------------------------ | ------------------------ |
 | {{SpecName("ARIA","#dialog","dialog")}} | {{Spec2('ARIA')}} |
 | {{SpecName("ARIA Authoring Practices 1.2","#dialog_modal","Dialog")}} | {{Spec2('ARIA Authoring Practices 1.2')}} |
-
 
 
 

--- a/files/en-us/web/accessibility/aria/roles/form_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/form_role/index.md
@@ -20,7 +20,8 @@ The `form` role can be used to identify a group of elements on a page that provi
 
 This is a form that collects and saves a user's contact information.
 
-> **Warning**: Use an HTML {{htmlelement("form")}} element to contain your form controls, rather than the ARIA `form` role, unless you have a very good reason. The HTML `<form>` element is sufficient to tell assistive technologies that there is a form.
+> **Warning:** Use an HTML {{htmlelement("form")}} element to contain your form controls, rather than the ARIA `form` role, unless you have a very good reason.
+> The HTML `<form>` element is sufficient to tell assistive technologies that there is a form.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/term_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/term_role/index.md
@@ -20,7 +20,7 @@ The `term` role is used to explicitly identify a word or phrase for which a defi
 
 Don't use the  `role="term"` on interactive elements like links because it can interfere with assistive technology users ability to interact with the element. Also, the term itself is the accessible name, so do not use [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby).
 
-> **Warning**: The accessible name should be the term itself, so DO NOT use `aria-label` or `aria-labelledby`.
+> **Warning:** The accessible name should be the term itself, so DO NOT use `aria-label` or `aria-labelledby`.
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -16,7 +16,7 @@ The **`AudioData`** interface of the {{domxref('WebCodecs API')}} represents an 
 
 An audio track consists of a stream of audio samples, each sample representing a captured moment of sound. An `AudioData` object is a representation of such a sample. Working alongside the interfaces of the [Insertable Streams API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API), you can break a stream into individual `AudioData` objects with {{domxref("MediaStreamTrackProcessor")}}, or construct an audio track from a stream of frames with {{domxref("MediaStreamTrackGenerator")}}.
 
-> **Note**: Find out more about audio on the web in [Digital audio concepts](/en-US/docs/Web/Media/Formats/Audio_concepts).
+> **Note:** Find out more about audio on the web in [Digital audio concepts](/en-US/docs/Web/Media/Formats/Audio_concepts).
 
 ### The media resource
 

--- a/files/en-us/web/api/audionode/index.md
+++ b/files/en-us/web/api/audionode/index.md
@@ -22,7 +22,7 @@ Examples include:
 
 {{InheritanceDiagram}}
 
-**Note**: An `AudioNode` can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.
+> **Note:** An `AudioNode` can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.
 
 ## Description
 

--- a/files/en-us/web/api/audioworkletprocessor/process/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.md
@@ -135,10 +135,8 @@ The 3 most common types of audio node are:
     _tail-time_ equal to its {{domxref("DelayNode.delayTime", "delayTime")}}
     property.
 
-**Note**: An absence of the `return` statement
-means that the method returns `undefined`, and as this is a falsy value, it
-is like returning `false`. Omitting an explicit `return` statement
-may cause hard-to-detect problems for your nodes.
+> **Note:** An absence of the `return` statement means that the method returns `undefined`, and as this is a falsy value, it is like returning `false`.
+> Omitting an explicit `return` statement may cause hard-to-detect problems for your nodes.
 
 ### Exceptions
 

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -304,7 +304,8 @@ Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/mas
 
 The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is useful when saving images. It returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)). The returned image is in a resolution of 96 dpi.
 
-**Note:** Be aware that if the canvas contains any pixels that were obtained from another {{Glossary("origin")}} without using CORS, the canvas is **tainted** and its contents can no longer be read and saved. See {{SectionOnPage("/en-US/docs/Web/HTML/CORS_enabled_image", "Security and tainted canvases")}}
+> **Note:** Be aware that if the canvas contains any pixels that were obtained from another {{Glossary("origin")}} without using CORS, the canvas is **tainted** and its contents can no longer be read and saved.
+> See {{SectionOnPage("/en-US/docs/Web/HTML/CORS_enabled_image", "Security and tainted canvases")}}
 
 - {{domxref("HTMLCanvasElement.toDataURL", "canvas.toDataURL('image/png')")}}
   - : Default setting. Creates a PNG image.

--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -37,12 +37,11 @@ messages. To create a new nested block, call `console.group()`. The
 `console.groupCollapsed()` method is similar, but the new block is
 collapsed and requires clicking a disclosure button to read it.
 
-**Note:** From Gecko 9 until Gecko 51, the `groupCollapsed()`
-method was the same as `group()`. Collapsed groups are fully supported
-starting in Gecko 52. See {{bug("1088360")}}.
+> **Note:** From Gecko 9 until Gecko 51, the `groupCollapsed()` method was the same as `group()`.
+> Collapsed groups are fully supported starting in Gecko 52. See {{bug("1088360")}}.
 
-To exit the current group, call `console.groupEnd()`. For example, given
-this code:
+To exit the current group, call `console.groupEnd()`.
+For example, given this code:
 
 ```js
 console.log("This is the outer level");

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -235,7 +235,8 @@ Will log the time needed by the user to dismiss the alert box, log the time to t
 
 Notice that the timer's name is displayed both when the timer is started and when it's stopped.
 
-**Note:** It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header. If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.
+> **Note:** It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header.
+> If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.
 
 ### Stack traces
 

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -30,17 +30,12 @@ elements = document.getElementsByTagNameNS(namespace, name)
   value `*`, which matches all elements (see {{domxref("Element.localName",
     "element.localName")}}).
 
-**Note:** While the W3C specification says
-`elements` is a `NodeList`, this method returns a
-{{DOMxRef("HTMLCollection")}} both in Gecko and Internet Explorer. Opera returns a
-`NodeList`, but with a `namedItem` method implemented, which makes
-it similar to a `HTMLCollection`. As of January 2012, only in WebKit browsers
-is the returned value a pure `NodeList`. See [bug 14869](https://bugzilla.mozilla.org/show_bug.cgi?id=14869) for details.
+> **Note:** While the W3C specification says `elements` is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} both in Gecko and Internet Explorer.
+> Opera returns a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. As of January 2012, only in WebKit browsers is the returned value a pure `NodeList`.
+> See [bug 14869](https://bugzilla.mozilla.org/show_bug.cgi?id=14869) for details.
 
-**Note:** Currently parameters in this method are
-case-sensitive, but they were case-insensitive in Firefox 3.5 and before. See the [developer release note for Firefox
-3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6#dom) and a note in Browser compatibility section in
-{{domxref("Element.getElementsByTagNameNS")}} for details.
+> **Note:** Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.
+> See the [developer release note for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6#dom) and a note in Browser compatibility section in {{domxref("Element.getElementsByTagNameNS")}} for details.
 
 ## Example
 

--- a/files/en-us/web/api/file/type/index.md
+++ b/files/en-us/web/api/file/type/index.md
@@ -42,7 +42,10 @@ function showType(fileInput) {
 }
 ```
 
-**Note:** Based on the current implementation, browsers won't actually read the bytestream of a file to determine its media type. It is assumed based on the file extension; a PNG image file renamed to .txt would give "_text/plain_" and not "_image/png_". Moreover, `file.type` is generally reliable only for common file types like images, HTML documents, audio and video. Uncommon file extensions would return an empty string. Client configuration (for instance, the Windows Registry) may result in unexpected values even for common types. **Developers are advised not to rely on this property as a sole validation scheme.**
+> **Note:** Based on the current implementation, browsers won't actually read the bytestream of a file to determine its media type.
+> It is assumed based on the file extension; a PNG image file renamed to .txt would give "_text/plain_" and not "_image/png_". Moreover, `file.type` is generally reliable only for common file types like images, HTML documents, audio and video.
+> Uncommon file extensions would return an empty string.
+> Client configuration (for instance, the Windows Registry) may result in unexpected values even for common types. **Developers are advised not to rely on this property as a sole validation scheme.**
 
 ## Specifications
 

--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -129,7 +129,7 @@ Each [drag event type](/en-US/docs/Web/API/DragEvent#event_types) has an associa
   </tbody>
 </table>
 
-**Note:** Neither `dragstart` nor `dragend` events are fired when dragging a file into the browser from the OS.
+> **Note:** Neither `dragstart` nor `dragend` events are fired when dragging a file into the browser from the OS.
 
 ## Interfaces
 
@@ -147,7 +147,7 @@ The {{domxref("DataTransferItemList")}} object is a list of {{domxref("DataTrans
 
 A key difference between the {{domxref("DataTransfer")}} and {{domxref("DataTransferItem")}} interfaces is that the former uses the synchronous {{domxref("DataTransfer.getData","getData()")}} method to access a drag item's data, but the latter instead uses the asynchronous {{domxref("DataTransferItem.getAsString","getAsString()")}} method.
 
-**Note:** {{domxref("DragEvent")}} and {{domxref("DataTransfer")}} are broadly supported on desktop browsers. However, the {{domxref("DataTransferItem")}} and {{domxref("DataTransferItemList")}} interfaces have limited browser support. See {{anch("Interoperability")}} for more information about drag-and-drop interoperability.
+> **Note:** {{domxref("DragEvent")}} and {{domxref("DataTransfer")}} are broadly supported on desktop browsers. However, the {{domxref("DataTransferItem")}} and {{domxref("DataTransferItemList")}} interfaces have limited browser support. See {{anch("Interoperability")}} for more information about drag-and-drop interoperability.
 
 ### Gecko-specific interfaces
 

--- a/files/en-us/web/api/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/index.md
@@ -269,7 +269,9 @@ Before Gecko 5.0 {{geckoRelease('5.0')}}, keyboard handling was less consistent 
 - Linux
   - : The event behavior depends on the specific platform. It will either behave like Windows or Mac depending on what the native event model does.
 
-**Note:** Manually firing an event does _not_ generate the default action associated with that event. For example, manually firing a key event does not cause that letter to appear in a focused text input. In the case of UI events, this is important for security reasons, as it prevents scripts from simulating user actions that interact with the browser itself.
+> **Note:** Manually firing an event does _not_ generate the default action associated with that event.
+> For example, manually firing a key event does not cause that letter to appear in a focused text input.
+> In the case of UI events, this is important for security reasons, as it prevents scripts from simulating user actions that interact with the browser itself.
 
 ## Example
 

--- a/files/en-us/web/api/keyboardevent/keycode/index.md
+++ b/files/en-us/web/api/keyboardevent/keycode/index.md
@@ -2257,7 +2257,7 @@ Starting in Firefox 60 {{geckoRelease("60.0")}}, Gecko sets `keyCode` values of 
   </tfoot>
 </table>
 
-**Note:** Recent Mac doesn't have a <kbd>NumLock</kbd> key, and therefore state. That's why the unlocked state is not available.
+> **Note:** Recent Mac doesn't have a <kbd>NumLock</kbd> key, and therefore state. That's why the unlocked state is not available.
 
 ## Constants for keyCode value
 

--- a/files/en-us/web/api/mouseevent/screenx/index.md
+++ b/files/en-us/web/api/mouseevent/screenx/index.md
@@ -15,7 +15,7 @@ browser-compat: api.MouseEvent.screenX
 
 The **`screenX`** read-only property of the {{domxref("MouseEvent")}} interface provides the horizontal coordinate (offset) of the mouse pointer in global (screen) coordinates.
 
-**Note:** In a multiscreen environment, screens aligned horizontally will be treated as a single device, and so the range of the `screenX` value will increase to the combined width of the screens.
+> **Note:** In a multiscreen environment, screens aligned horizontally will be treated as a single device, and so the range of the `screenX` value will increase to the combined width of the screens.
 
 ## Syntax
 

--- a/files/en-us/web/api/navigator/getbattery/index.md
+++ b/files/en-us/web/api/navigator/getbattery/index.md
@@ -19,14 +19,12 @@ system's battery. It returns a battery promise, which is resolved in a
 monitor the battery status. This implements the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API); see that
 documentation for additional details, a guide to using the API, and sample code.
 
-> **Note:** In some browsers access to this feature is controlled by
-> {{HTTPHeader("Feature-Policy")}} directive
-> {{HTTPHeader("Feature-Policy/battery","battery")}}.
+> **Note:** In some browsers access to this feature is controlled by the {{HTTPHeader("Feature-Policy")}} directive {{HTTPHeader("Feature-Policy/battery","battery")}}.
 
 ## Syntax
 
 ```js
-var batteryPromise = navigator.getBattery();
+navigator.getBattery()
 ```
 
 ### Return value
@@ -37,21 +35,20 @@ information about the battery's state.
 
 ## Exceptions
 
-This method doesn't throw true exceptions; instead, it rejects the returned promise,
-passing into it a {{domxref("DOMException")}} whose `name` is one of the
-following:
+This method doesn't throw true exceptions; instead, it rejects the returned promise, passing into it a {{domxref("DOMException")}} whose `name` is one of the following:
 
 - `SecurityError`
-  - : The User Agent does not expose battery information to insecure contexts and this
-    method was called from insecure context.
-    **Note:** Old versions of some User Agents might allow use of this
-    feature in insecure contexts.
+
+  - : The User Agent does not expose battery information to insecure contexts and this method was called from insecure context.
+
+    > **Note:** Old versions of some User Agents might allow use of this feature in insecure contexts.
+
 - `NotAllowedError`
-  - : **Note:** No User Agent currently throws this exception, but the
-    specification describes the following behaviors:
-    This document is not allowed to use this feature. For example, it might not be
-    explicitly allowed or restricted via {{HTTPHeader("Feature-Policy")}}
-    {{HTTPHeader("Feature-Policy/battery", "battery")}} feature.
+
+  - : No User Agent currently throws this exception, but the specification describes the following behaviors:
+    > This document is not allowed to use this feature.
+    > For example, it might not be explicitly allowed or restricted via {{HTTPHeader("Feature-Policy")}} {{HTTPHeader("Feature-Policy/battery", "battery")}} feature.
+
 
 ## Example
 

--- a/files/en-us/web/api/ndefrecord/index.md
+++ b/files/en-us/web/api/ndefrecord/index.md
@@ -24,7 +24,7 @@ The **`NDEFRecord`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_
   - : Returns the {{Glossary("MIME type")}} of the record. This value will be `null` if `recordType` is not equal to `"mime"`.
 - {{DOMxRef("NDEFRecord.id")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns the record identifier, which is an absolute or relative URL used to identify the record.
-    **Note:** The uniqueness of the identifier is enforced only by the generator of the record.
+    > **Note:** The uniqueness of the identifier is enforced only by the generator of the record.
 - {{DOMxRef("NDEFRecord.data")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns a {{jsxref("DataView")}} containing the raw bytes of the record's payload.
 - {{DOMxRef("NDEFRecord.encoding")}} {{Experimental_Inline}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -145,7 +145,7 @@ You can see the [source code on GitHub](https://github.com/mdn/sw-test/), and [v
 
 ## Enter service workers
 
-**NOTE** : We're using the [es6](http://es6-features.org/) **arrow functions** syntax in the Service Worker Implementation
+> **Note:** We're using the [es6](http://es6-features.org/) **arrow functions** syntax in the Service Worker Implementation.
 
 Now let’s get on to service workers!
 

--- a/files/en-us/web/api/svgtextcontentelement/index.md
+++ b/files/en-us/web/api/svgtextcontentelement/index.md
@@ -65,13 +65,13 @@ _This interface also inherits methods from its parent, {{domxref("SVGGraphicsEle
 
   - : Returns a {{domxref("DOMPoint")}} representing the position of a typographic character after text layout has been performed.
 
-    **Note:** In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
+    > **Note:** In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
 
 - {{domxref("SVGTextContentElement.getEndPositionOfChar()")}}
 
   - : Returns a {{domxref("DOMPoint")}} representing the trailing position of a typographic character after text layout has been performed.
 
-    **Note:** In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
+    > **Note:** In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
 
 - {{domxref("SVGTextContentElement.getExtentOfChar()")}}
   - : Returns a {{domxref("DOMRect")}} representing the computed tight bounding box of the glyph cell that corresponds to a given typographic character.

--- a/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
@@ -191,7 +191,9 @@ Let's add another modification node to practice what we've just learnt.
 
 There's a {{domxref("StereoPannerNode")}} node, which changes the balance of the sound between the left and right speakers, if the user has stereo capabilities.
 
-**Note:** The `StereoPannerNode` is for simple cases in which you just want stereo panning from left to right. There is also a {{domxref("PannerNode")}}, which allows for a great deal of control over 3D space, or sound _spatialisation_, for creating more complex effects. This is used in games and 3D apps to create birds flying overhead, or sound coming from behind the user for instance.
+> **Note:** The `StereoPannerNode` is for simple cases in which you just want stereo panning from left to right.
+> There is also a {{domxref("PannerNode")}}, which allows for a great deal of control over 3D space, or sound _spatialisation_, for creating more complex effects.
+> This is used in games and 3D apps to create birds flying overhead, or sound coming from behind the user for instance.
 
 To visualise it, we will be making our audio graph look like this:
 

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -118,11 +118,14 @@ if(!localStorage.getItem('bgcolor')) {
 
 The {{domxref("Storage.getItem()")}} method is used to get a data item from storage; in this case, we are testing to see whether the `bgcolor` item exists; if not, we run `populateStorage()` to add the existing customization values to the storage. If there are already values there, we run `setStyles()` to update the page styling with the stored values.
 
-**Note:** You could also use {{domxref("Storage.length")}} to test whether the storage object is empty or not.
+> **Note:** You could also use {{domxref("Storage.length")}} to test whether the storage object is empty or not.
 
 ### Getting values from storage
 
-**Note:** As noted above, values can be retrieved from storage using {{domxref("Storage.getItem()")}}. This takes the key of the data item as an argument, and returns the data value. For example:
+As noted above, values can be retrieved from storage using {{domxref("Storage.getItem()")}}.
+This takes the key of the data item as an argument, and returns the data value.
+
+For example:
 
 ```js
 function setStyles() {
@@ -140,7 +143,9 @@ function setStyles() {
 }
 ```
 
-Here, the first three lines grab the values from local storage. Next, we set the values displayed in the form elements to those values, so that they keep in sync when you reload the page. Finally, we update the styles/decorative image on the page, so your customization options come up again on reload.
+Here, the first three lines grab the values from local storage.
+Next, we set the values displayed in the form elements to those values, so that they keep in sync when you reload the page.
+Finally, we update the styles/decorative image on the page, so your customization options come up again on reload.
 
 ### Setting values in storage
 

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
@@ -16,11 +16,12 @@ Compressed textures reduce the amount of memory needed to store a texture on the
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** PVRTC is typically only available on mobile devices with PowerVR chipsets. It is used in all generations of the iPhone, iPod Touch and iPad and supported on certain Android devices that use a PowerVR GPU.
+> **Note:** PVRTC is typically only available on mobile devices with PowerVR chipsets.
+> It is used in all generations of the iPhone, iPod Touch and iPad and supported on certain Android devices that use a PowerVR GPU.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
->
-> **Note**: On iOS devices, this extension is named `WEBKIT_WEBGL_compressed_texture_pvrtc`.
+
+> **Note:** On iOS devices, this extension is named `WEBKIT_WEBGL_compressed_texture_pvrtc`.
 
 ## Constants
 

--- a/files/en-us/web/css/@media/forced-colors/index.md
+++ b/files/en-us/web/css/@media/forced-colors/index.md
@@ -53,7 +53,8 @@ Additionally the following properties have special behavior in forced colors mod
 
 The system colors that are forced for the above properties depend on the context of the element. For example the {{cssxref("color")}} property on button element will be forced to `ButtonText`. On normal text it will be forced to `CanvasText`. See the [list of system colors](/en-US/docs/Web/CSS/color_value#system_colors) for additional details of when each might be appropriate in various UI contexts.
 
-**Note:** user agents choose system colors based on native element semantics, _not_ on added ARIA roles. As an example, adding `role="button"` to a div will **not** cause an element's color to be forced to `ButtonText`
+> **Note:** user agents choose system colors based on native element semantics, _not_ on added ARIA roles.
+> As an example, adding `role="button"` to a `div` will **not** cause an element's color to be forced to `ButtonText`
 
 In addition to these adjustments, browsers will help ensure text legibility by drawing “backplates” behind text. This is particularly important for preserving contrast when text is placed on top of images.
 

--- a/files/en-us/web/css/_colon_where/index.md
+++ b/files/en-us/web/css/_colon_where/index.md
@@ -131,7 +131,7 @@ This won't work for the red links, because the selectors inside `:is()` count to
 
 However, selectors inside `:where()` have specificity 0, so the orange footer link will be overridden by our simple selector.
 
-**Note**: You can also find this example on GitHub; see [is-where](https://mdn.github.io/css-examples/is-where/).
+> **Note:** You can also find this example on GitHub; see [is-where](https://mdn.github.io/css-examples/is-where/).
 
 {{EmbedLiveSample('Examples', '100%', 600)}}
 

--- a/files/en-us/web/css/calc()/index.md
+++ b/files/en-us/web/css/calc()/index.md
@@ -78,7 +78,8 @@ When **`calc()`** is used where an {{cssxref("&lt;integer&gt;")}} is expected, t
 
 This will give `.modal` a final `z-index` value of 2.
 
-**Note:** The Chrome browser currently won't accept some values returned by **`calc()`** when an integer is expected. This includes any division, even if it results in an integer. ie. `z-index: calc(4 / 2);` will not be accepted.
+> **Note:** The Chrome browser currently won't accept some values returned by **`calc()`** when an integer is expected.
+> This includes any division, even if it results in an integer. ie. `z-index: calc(4 / 2);` will not be accepted.
 
 ## Examples
 

--- a/files/en-us/web/css/cross-fade()/index.md
+++ b/files/en-us/web/css/cross-fade()/index.md
@@ -18,7 +18,7 @@ It can be used for many simple image manipulations, such as tinting an image wit
 
 ## Syntax
 
-> **Warning**: The specification and current implementations have different syntaxes.
+> **Warning:** The specification and current implementations have different syntaxes.
 > The specification syntax is explained first.
 
 ### Specification syntax

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
@@ -170,4 +170,5 @@ div.lev3 {
 - [Stacking context example 1](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1): 2-level HTML hierarchy, `z-index` on the last level
 - [Stacking context example 2](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2): 2-level HTML hierarchy, `z-index` on all levels
 
-**Note**: the reason the sample image looks wrong - with the second level 2 overlapping the level 3 menus - is because level 2 has opacity, which creates a new stacking context. Basically, this whole sample page is incorrect and misleading.
+> **Note:** the reason the sample image looks wrong - with the second level 2 overlapping the level 3 menus - is because level 2 has opacity, which creates a new stacking context.
+> Basically, this whole sample page is incorrect and misleading.

--- a/files/en-us/web/css/env()/index.md
+++ b/files/en-us/web/css/env()/index.md
@@ -44,7 +44,7 @@ env(safe-area-inset-left, 1.4rem);
 - `safe-area-inset-top`, `safe-area-inset-right`, `safe-area-inset-bottom`, `safe-area-inset-left`
   - : The `safe-area-inset-*` variables are four environment variables that define a rectangle by its top, right, bottom, and left insets from the edge of the viewport, which is safe to put content into without risking it being cut off by the shape of a non‑rectangular display. For rectangular viewports, like your average laptop monitor, their value is equal to zero. For non-rectangular displays — like a round watch face — the four values set by the user agent form a rectangle such that all content inside the rectangle is visible.
 
-**Note**: Unlike other CSS properties, user agent-defined property names are case-sensitive.
+> **Note:** Unlike other CSS properties, user agent-defined property names are case-sensitive.
 
 ### Formal syntax
 
@@ -164,7 +164,7 @@ padding: env(x, 50px, 20px); /* ignored because '50px, 20px' is not a valid padd
 
 The syntax of the fallback, like that of custom properties, allows commas. But, if the property value doesn't support commas, the value is not valid.
 
-**Note**: User agent properties are not reset by the [all](/en-US/docs/Web/CSS/all) property.
+> **Note:** User agent properties are not reset by the [all](/en-US/docs/Web/CSS/all) property.
 
 ## Specifications
 

--- a/files/en-us/web/css/grid-row-start/index.md
+++ b/files/en-us/web/css/grid-row-start/index.md
@@ -56,7 +56,7 @@ This property is specified as a single `<grid-line>` value. A `<grid-line>` valu
 
   - : If there is a named line with the name '\<custom-ident>-start', it contributes the first such line to the grid item’s placement.
 
-    **Note:** Named grid areas automatically generate implicit named lines of this form, so specifying `grid-row-start: foo;` will choose the start edge of that named grid area (unless another line named `foo-start` was explicitly specified before it).
+    > **Note:** Named grid areas automatically generate implicit named lines of this form, so specifying `grid-row-start: foo;` will choose the start edge of that named grid area (unless another line named `foo-start` was explicitly specified before it).
 
     Otherwise, this is treated as if the integer `1` had been specified along with the `<custom-ident>`.
 

--- a/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -153,13 +153,13 @@ For RTMP transfer you can use the [Nginx RTMP Module](https://github.com/arut/ng
 
 [SHOUTcast](https://en.wikipedia.org/wiki/SHOUTcast) is a cross-platform proprietary technology for streaming media. Developed by Nullsoft, it allows digital audio content in MP3 or AAC format to be broadcast. For web use, SHOUTcast streams are transmitted over HTTP.
 
-**Note:** [SHOUTcast URLs may require a semi-colon to be appended to them](https://stackoverflow.com/questions/2743279/how-could-i-play-a-shoutcast-icecast-stream-using-html5).
+> **Note:** [SHOUTcast URLs may require a semi-colon to be appended to them](https://stackoverflow.com/questions/2743279/how-could-i-play-a-shoutcast-icecast-stream-using-html5).
 
 ### Icecast
 
 The [Icecast](https://www.icecast.org/) server is an open source technology for streaming media. Maintained by the [Xiph.org Foundation](https://www.xiph.org/), it streams Ogg Vorbis/Theora as well as MP3 and AAC format via the SHOUTcast protocol.
 
-**Note:** SHOUTcast and Icecast are among the most established and popular technologies, but there are many [more streaming media systems available](https://en.wikipedia.org/wiki/List_of_streaming_media_systems#Servers).
+> **Note:** SHOUTcast and Icecast are among the most established and popular technologies, but there are many [more streaming media systems available](https://en.wikipedia.org/wiki/List_of_streaming_media_systems#Servers).
 
 ### Streaming Services
 

--- a/files/en-us/web/html/attributes/rel/index.md
+++ b/files/en-us/web/html/attributes/rel/index.md
@@ -95,7 +95,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
   - : Relevant to {{htmlelement('form')}}, {{htmlelement('link')}}, {{htmlelement('a')}}, and {{htmlelement('area')}}, the `help` keyword indicates that the linked to content provides context-sensitive help, providing information for the parent of the element defining the hyperlink, and its children. When used within `<link>`, the help is for the whole document. When included with {{htmlelement('a')}} and {{htmlelement('area')}} and supported, the default {{cssxref('cursor')}} will be `help` instead of `pointer`.
 - {{htmlattrdef("icon")}}
 
-  - : **Note:** Valid with {{htmlelement('link')}}, the linked resource represents the icon, a resource for representing the page in the user interface, for the current document.
+  - : Valid with {{htmlelement('link')}}, the linked resource represents the icon, a resource for representing the page in the user interface, for the current document.
 
     The most common use for the `icon` value is the favicon:
 
@@ -107,19 +107,20 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 
     > **Note:** Prior to Firefox 83 the [crossorigin](/en-US/docs/Web/HTML/Attributes/crossorigin) attribute was not supported for `rel="icon"` there is also [an open issue for Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1121645).
 
-    **Note:** Apple's iOS does not use this link type, nor the [`sizes`](sizes) attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder. Instead it uses the non-standard [`apple-touch-icon`](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4) and [`apple-touch-startup-image`](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6) respectively.
+    > **Note:** Apple's iOS does not use this link type, nor the [`sizes`](sizes) attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder.
+    > Instead it uses the non-standard [`apple-touch-icon`](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4) and [`apple-touch-startup-image`](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6) respectively.
 
     > **Note:** The `shortcut` link type is often seen before `icon`, but this link type is non-conforming, ignored and **web authors must not use it anymore**.
 
 - {{htmlattrdef("license")}}
 
-  - : **Note:** Valid on the {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}}, {{HTMLElement("link")}} elements, the `license` value indicates that the hyperlink leads to a document describing the licensing information; that the main content of the current document is covered by the copyright license described by the referenced document. If not inside the {{HTMLElement("head")}} element, the standard doesn't distinguish between a hyperlink applying to a specific part of the document or to the document as a whole. Only the data on the page can indicate this.
+  - : Valid on the {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}}, {{HTMLElement("link")}} elements, the `license` value indicates that the hyperlink leads to a document describing the licensing information; that the main content of the current document is covered by the copyright license described by the referenced document. If not inside the {{HTMLElement("head")}} element, the standard doesn't distinguish between a hyperlink applying to a specific part of the document or to the document as a whole. Only the data on the page can indicate this.
 
     ```html
     <link rel="license" href="#license">
     ```
 
-    **Note:** Although recognized, the synonym `copyright` is incorrect and must be avoided.
+    > **Note:** Although recognized, the synonym `copyright` is incorrect and must be avoided.
 
 - {{htmlattrdef("manifest")}}
   - : [Web app manifest](/en-US/docs/Web/Manifest). Requires the use of the CORS protocol for cross-origin fetching.

--- a/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
+++ b/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
@@ -33,15 +33,15 @@ occurs.
 
 For example, if the response includes:
 
-    Access-Control-Allow-Methods: GET,HEAD,POST
+```
+Access-Control-Allow-Methods: GET,HEAD,POST
+```
 
 Trying to use a {{HTTPMethod("PUT")}} request will fail with this error.
 
 Make sure your code only uses the permitted HTTP methods when accessing the service.
 
-**Note:** If the server includes any unrecognized or undefined method
-names in its `Access-Control-Allow-methods` header, a different error occurs:
-[`Reason: invalid token ‘xyz' in CORS header ‘Access-Control-Allow-Methods’`](/en-US/docs/Web/HTTP/CORS/Errors/CORSInvalidAllowMethod).
+> **Note:** If the server includes any unrecognized or undefined method names in its `Access-Control-Allow-methods` header, a different error occurs: [`Reason: invalid token ‘xyz' in CORS header ‘Access-Control-Allow-Methods’`](/en-US/docs/Web/HTTP/CORS/Errors/CORSInvalidAllowMethod).
 
 ## See also
 

--- a/files/en-us/web/http/public_key_pinning/index.md
+++ b/files/en-us/web/http/public_key_pinning/index.md
@@ -112,7 +112,7 @@ The following line with your relevant key information (pin-sha256="..." fields) 
 setenv.add-response-header  = ( "Public-Key-Pins" => "pin-sha256=\"base64+primary==\"; pin-sha256=\"base64+backup==\"; max-age=5184000; includeSubDomains")
 ```
 
-**Note:** This requires the `mod_setenv` server.module loaded which can be included by the following if not already loaded.
+> **Note:** This requires the `mod_setenv` server.module loaded which can be included by the following if not already loaded.
 
 ```
 server.modules += ( "mod_setenv" )

--- a/files/en-us/web/http/status/451/index.md
+++ b/files/en-us/web/http/status/451/index.md
@@ -22,7 +22,7 @@ The HyperText Transfer Protocol (HTTP) **`451 Unavailable For Legal Reasons`** c
 
 This example response is taken from the IETF RFC (see below) and contains a reference to {{interwiki("wikipedia", "Monty_Python's_Life_of_Brian", "Monty Python's Life of Brian")}}.
 
-**Note:** the {{HTTPHeader("Link")}} header might also contain a `rel="blocked-by"` relation identifying the entity and implementing blockage, not any other entity mandating it.
+> **Note:** the {{HTTPHeader("Link")}} header might also contain a `rel="blocked-by"` relation identifying the entity and implementing blockage, not any other entity mandating it.
 
 Any attempt to identify the entity ultimately responsible for the resource being unavailable belongs in the response body, not in the `rel="blocked-by"` link. This includes the name of the person or organization that made a legal demand resulting in the content's removal.
 

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -144,7 +144,7 @@ Do that
 Do this, no matter what happened before
 ```
 
-**Note:** The text "Do this" is not displayed because the "Something failed" error caused a rejection.
+> **Note:** The text "Do this" is not displayed because the "Something failed" error caused a rejection.
 
 ## Error propagation
 

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -74,7 +74,7 @@ If a `thisArg` parameter is provided to `filter`, it will be used as the callbac
 
 The range of elements processed by `filter()` is set before the first invocation of `callbackFn`. Elements which are assigned to indexes already visited, or to indexes outside the range, will not be visited by `callbackFn`. If existing elements of the array are deleted in the same way they will not be visited.
 
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -103,7 +103,7 @@ by `find` are set _before_ the first invocation of
   visits that element's index.
 - Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.
 
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -104,7 +104,7 @@ changed by `callbackFn`, its value passed to the
 `callbackFn` will be the value at the time `findIndex()`
 visits the element's index.Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.
 
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -86,7 +86,7 @@ visited are not visited. If elements that are already visited are removed (e.g. 
 will be skipped. ([See
 this example, below](#modifying_the_array_during_iteration).)
 
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 `forEach()` executes the `callbackFn` function once for
 each array element; unlike {{jsxref("Array.prototype.map()", "map()")}} or

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -107,7 +107,7 @@ value will be the value at the time `callbackFn` visits them.
 Elements that are deleted after the call to `map` begins and before being
 visited are not visited.
 
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 Due to the algorithm defined in the specification, if the array which `map`
 was called upon is sparse, resulting array will also be sparse keeping same indices

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -88,7 +88,7 @@ changed by `callbackFn`, its value passed to the visiting
 `callbackFn` will be the value at the time that `some()`
 visits that element's index. Elements that are deleted are not visited.
 
-**Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
 
 > **Note:** Calling this method on an empty array returns
 > `false` for any condition!

--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -23,7 +23,7 @@ JavaScript **`Date`** objects represent a single moment in time in a platform-in
 
 A JavaScript date is fundamentally specified as the number of milliseconds that have elapsed since midnight on January 1, 1970, UTC. This date and time are not the same as the **UNIX epoch** (the number of seconds that have elapsed since midnight on January 1, 1970, UTC), which is the predominant base value for computer-recorded date and time values.
 
-**Note:** It's important to keep in mind that while the time value at the heart of a Date object is UTC, the basic methods to fetch the date and time or its components all work in the local (i.e. host system) time zone and offset.
+> **Note:** It's important to keep in mind that while the time value at the heart of a Date object is UTC, the basic methods to fetch the date and time or its components all work in the local (i.e. host system) time zone and offset.
 
 It should be noted that the maximum `Date` is not of the same value as the maximum safe integer (`Number.MAX_SAFE_INTEGER` is 9,007,199,254,740,991). Instead, it is defined in ECMA-262 that a maximum of ±100,000,000 (one hundred million) days relative to January 1, 1970 UTC (that is, April 20, 271821 BCE \~ September 13, 275760 CE) can be represented by the standard `Date` object (equivalent to ±8,640,000,000,000,000 milliseconds).
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
@@ -10,11 +10,9 @@ browser-compat: javascript.builtins.Math.ceil
 ---
 {{JSRef}}
 
-The **`Math.ceil()`** function always rounds a number up to the
-next largest integer.
+The **`Math.ceil()`** function always rounds a number up to the next largest integer.
 
-**Note:** `Math.ceil({{jsxref("null")}})` returns integer 0 and
-does not give a {{jsxref("NaN")}} error.
+> **Note:** `Math.ceil({{jsxref("null")}})` returns integer 0 and does not give a {{jsxref("NaN")}} error.
 
 {{EmbedInteractiveExample("pages/js/math-ceil.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instantiate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instantiate/index.md
@@ -101,9 +101,7 @@ A `Promise` that resolves to an {{jsxref("WebAssembly.Instance")}} object.
 
 ## Examples
 
-**Note**: You'll probably want to use
-{{jsxref("WebAssembly.instantiateStreaming()")}} in most cases, as it is more efficient
-than `instantiate()`.
+> **Note:** You'll probably want to use {{jsxref("WebAssembly.instantiateStreaming()")}} in most cases, as it is more efficient than `instantiate()`.
 
 ### First overload example
 

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -113,7 +113,10 @@ In addition to the following attributes, the `<math>` element accepts any attrib
 </html>
 ```
 
-**Notes**: XHTML documents with MathML must be served as `application/xhtml+xml`. You can achieve that easily by adding the `.xhtml` extension to your local files. For Apache servers you can [configure your `.htaccess` file](https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype) to map extensions to the correct Mime type. Since you notate your MathML in an XML document, also be sure you write a well-formed XML document.
+> **Note:** XHTML documents with MathML must be served as `application/xhtml+xml`.
+> You can achieve that easily by adding the `.xhtml` extension to your local files.
+> For Apache servers you can [configure your `.htaccess` file](https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype) to map extensions to the correct Mime type.
+> Since you notate your MathML in an XML document, also be sure you write a well-formed XML document.
 
 ## Specifications
 

--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.md
@@ -41,7 +41,7 @@ Enough theory — let's see some source code!
 
 We'll start by looking at the code that registers a new Service Worker, in the app.js file:
 
-**NOTE** : We're using the [es6](http://es6-features.org/) **arrow functions** syntax in the Service Worker Implementation
+> **Note:** We're using the [es6](http://es6-features.org/) **arrow functions** syntax in the Service Worker Implementation
 
 ```js
 if('serviceWorker' in navigator) {


### PR DESCRIPTION
This fixes a whole bunch of incorrectly formatted Notes and Warnings - things like putting the `:` outside of the bold text, or omitting the preceding `>`.

FYI @wbamberg 