### PR TITLE
array.reduce() improvements

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -124,10 +124,17 @@ const getMax = (a, b) => Math.max(a, b);
 ### How reduce() works without an initial value
 
 The code below shows what happens if we call `reduce()` with an array and no initial value.
-The example uses an {{jsxref("Functions/Arrow_functions", "Arrow Function","",1)}} but there is nothing to stop you using a full function.
 
 ```js
-[5, 6, 7, 8, 9].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue )
+const array = [15, 16, 17, 18, 19];
+
+function reducer(previous, current, index, array) {
+  const returns = previous + current;
+  console.log(`previous: ${previous}, current: ${current}, index: ${index}, returns: ${returns}`);
+  return returns;
+}
+
+array.reduce(reducer);
 ```
 
 The callback would be invoked four times, with the arguments and return values in each call being as follows:
@@ -194,7 +201,7 @@ The value returned by `reduce()` would be that of the last callback invocation (
 
 ### How reduce() works with an initial value
 
-If you were to provide an *initialValue* of `10` as the second argument to `reduce()`, the code would look like this:
+Here we reduce the same array using the same algorithm, but with an *initialValue* of `10` passed the second argument to `reduce()`:
 
 ```js
 [5, 6, 7, 8, 9].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue, 10 )

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -22,13 +22,11 @@ The first time that the callback is run there is no "return value of the previou
 If supplied, an initial value may be used in its place.
 Otherwise array element 0 is used as the initial value and iteration starts from the next element (index 1 instead of index 0).
 
-Perhaps the easiest-to-understand case for `reduce()` is to return the sum of all the elements in an array.
-
-The reducer walks through the array element-by-element, at each step adding the current array value to the result from the previous step (this result is the running sum of all the previous steps) — until there are no more elements to add.
-
-This is shown in the following interactive example:
+Perhaps the easiest-to-understand case for `reduce()` is to return the sum of all the elements in an array:
 
 {{EmbedInteractiveExample("pages/js/array-reduce.html")}}
+
+The reducer walks through the array element-by-element, at each step adding the current array value to the result from the previous step (this result is the running sum of all the previous steps) — until there are no more elements to add.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -15,7 +15,12 @@ browser-compat: javascript.builtins.Array.reduce
 ---
 {{JSRef}}
 
-The **`reduce()`** method executes a user-supplied “reducer” callback function on each element of the array, passing in the return value from the calculation on the preceding element. The final result of running the reducer across all elements of the array is a single value.
+The **`reduce()`** method executes a user-supplied “reducer” callback function on each element of the array, in order, passing in the return value from the calculation on the preceding element.
+The final result of running the reducer across all elements of the array is a single value.
+
+The first time that the callback is run there is no "return value of the previous calculation".
+If supplied, an initial value may be used in its place.
+Otherwise array element 0 is used as the intitial value and iteration starts from the next element (index 1 instead of index 0).
 
 Perhaps the easiest-to-understand case for `reduce()` is to return the sum of all the elements in an array.
 
@@ -49,13 +54,18 @@ reduce(function(previousValue, currentValue, currentIndex, array) { ... }, initi
 
 - `callbackFn`
   - : A “reducer” function that takes four arguments:
-    - *previousValue* (the value resulting from the previous call to `callbackfn`)
-    - *currentValue* (the value of the current element)
-    - *currentIndex* {{optional_inline}}
-    - *array* (the array to traverse) {{optional_inline}}
+    - `previousValue`: the value resulting from the previous call to `callbackfn`.
+      On first call, `initialValue` if specified, otherwise the value of `array[0]`. 
+    - `currentValue`: the value of the current element.
+      On first call, the value of `array[0]` if an `initialValue` was specified, otherwise the value of `array[1]`. 
+    - `currentIndex`: the index position of `currentValue` in the array.
+      On first call, `0` if `initialValue` was specified, otherwise `1`. 
+    - `array`: the array to traverse.
 
 - `initialValue` {{optional_inline}}
-  - : A value to which *previousValue* is initialized the first time the callback is called. If `initialValue` is specified, that also causes *currentValue* to be initialized to the first value in the array. If `initialValue` is *not* specified, *previousValue* is initialized to the first value in the array, and *currentValue* is initialized to the second value in the array.
+  - : A value to which *previousValue* is initialized the first time the callback is called.
+    If `initialValue` is specified, that also causes `currentValue` to be initialized to the first value in the array.
+    If `initialValue` is *not* specified, `previousValue` is initialized to the first value in the array, and `currentValue` is initialized to the second value in the array.
 
 ### Return value
 
@@ -63,7 +73,9 @@ The value that results from running the “reducer” callback function to compl
 
 ### Exceptions
 
-Throws a {{jsxref("TypeError")}} if the array contains no elements and `initialValue` is not provided.
+- {{jsxref("TypeError")}}
+
+  - : The array contains no elements and `initialValue` is not provided.
 
 ## Description
 
@@ -86,17 +98,11 @@ The ECMAScript spec describes the behavior of `reduce()` as follows:
 >
 > The range of elements processed by `reduce` is set before the first call to *callbackfn*. Elements that are appended to the array after the call to `reduce` begins will not be visited by *callbackfn*. If existing elements of the array are changed, their value as passed to *callbackfn* will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.
 
-If the array only has one element (regardless of position) and no
-*initialValue* is provided, or if
-*initialValue* is provided but the array is empty, the solo value
-will be returned _without_ calling _`callbackFn`._
+If the array only has one element (regardless of position) and no *initialValue* is provided, or if *initialValue* is provided but the array is empty, the solo value will be returned _without_ calling _`callbackFn`._
 
-If *initialValue* is provided and the array is not empty, then the
-reduce method will always invoke the callback function starting at index 0.
+If *initialValue* is provided and the array is not empty, then the reduce method will always invoke the callback function starting at index 0.
 
-If *initialValue* is not provided then the reduce method will act
-differently for arrays with length larger than 1, equal to 1 and 0, as shown in the
-following example:
+If *initialValue* is not provided then the reduce method will act differently for arrays with length larger than 1, equal to 1 and 0, as shown in the following example:
 
 ```js
 const getMax = (a, b) => Math.max(a, b);
@@ -115,18 +121,16 @@ const getMax = (a, b) => Math.max(a, b);
 [      ].reduce(getMax);     // TypeError
 ```
 
-### How reduce() works
+### How reduce() works without an initial value
 
-Suppose the following use of `reduce()` occurred:
+The code below shows what happens if we call `reduce()` with an array and no initial value.
+The example uses an {{jsxref("Functions/Arrow_functions", "Arrow Function","",1)}} but there is nothing to stop you using a full function.
 
 ```js
-[0, 1, 2, 3, 4].reduce(function(previousValue, currentValue, currentIndex, array) {
-  return previousValue + currentValue
-})
+[5, 6, 7, 8, 9].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue )
 ```
 
-The callback would be invoked four times, with the arguments and return values in each
-call being as follows:
+The callback would be invoked four times, with the arguments and return values in each call being as follows:
 
 <table class="standard-table">
   <thead>
@@ -152,58 +156,51 @@ call being as follows:
   <tbody>
     <tr>
       <th scope="row">first call</th>
-      <td><code>0</code></td>
+      <td><code>5</code></td>
+      <td><code>6</code></td>
       <td><code>1</code></td>
-      <td><code>1</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>1</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>11</code></td>
     </tr>
     <tr>
       <th scope="row">second call</th>
-      <td><code>1</code></td>
+      <td><code>11</code></td>
+      <td><code>7</code></td>
       <td><code>2</code></td>
-      <td><code>2</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>3</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>18</code></td>
     </tr>
     <tr>
       <th scope="row">third call</th>
+      <td><code>18</code></td>
+      <td><code>8</code></td>
       <td><code>3</code></td>
-      <td><code>3</code></td>
-      <td><code>3</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>6</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>26</code></td>
     </tr>
     <tr>
       <th scope="row">fourth call</th>
-      <td><code>6</code></td>
+      <td><code>26</code></td>
+      <td><code>9</code></td>
       <td><code>4</code></td>
-      <td><code>4</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>10</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>25</code></td>
     </tr>
   </tbody>
 </table>
 
-The value returned by `reduce()` would be that of the last callback
-invocation (`10`).
+The value returned by `reduce()` would be that of the last callback invocation (`35`).
 
-You can also provide an {{jsxref("Functions/Arrow_functions", "Arrow Function","",1)}}
-instead of a full function. The code below will produce the same output as the code in
-the block above:
 
-```js
-[0, 1, 2, 3, 4].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue )
-```
+### How reduce() works with an initial value
 
-If you were to provide an *initialValue* as the second argument
-to `reduce()`, the result would look like this:
+If you were to provide an *initialValue* of `10` as the second argument to `reduce()`, the code would look like this:
 
 ```js
-[0, 1, 2, 3, 4].reduce((previousValue, currentValue, currentIndex, array) => {
-    return previousValue + currentValue
-}, 10)
+[5, 6, 7, 8, 9].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue, 10 )
 ```
+
+The callback would be invoked five times, with the arguments and return values in each call being as follows:
 
 <table class="standard-table">
   <thead>
@@ -230,47 +227,47 @@ to `reduce()`, the result would look like this:
     <tr>
       <th scope="row">first call</th>
       <td><code>10</code></td>
+      <td><code>5</code></td>
       <td><code>0</code></td>
-      <td><code>0</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>10</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>15</code></td>
     </tr>
     <tr>
       <th scope="row">second call</th>
-      <td><code>10</code></td>
+      <td><code>15</code></td>
+      <td><code>6</code></td>
       <td><code>1</code></td>
-      <td><code>1</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>11</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>21</code></td>
     </tr>
     <tr>
       <th scope="row">third call</th>
-      <td><code>11</code></td>
+      <td><code>21</code></td>
+      <td><code>7</code></td>
       <td><code>2</code></td>
-      <td><code>2</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>13</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>28</code></td>
     </tr>
     <tr>
       <th scope="row">fourth call</th>
-      <td><code>13</code></td>
+      <td><code>28</code></td>
+      <td><code>8</code></td>
       <td><code>3</code></td>
-      <td><code>3</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>16</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>36</code></td>
     </tr>
     <tr>
       <th scope="row">fifth call</th>
-      <td><code>16</code></td>
+      <td><code>36</code></td>
+      <td><code>9</code></td>
       <td><code>4</code></td>
-      <td><code>4</code></td>
-      <td><code>[0, 1, 2, 3, 4]</code></td>
-      <td><code>20</code></td>
+      <td><code>[5, 6, 7, 8, 9]</code></td>
+      <td><code>45</code></td>
     </tr>
   </tbody>
 </table>
 
-The value returned by `reduce()` in this case would be `20`.
+The value returned by `reduce()` in this case would be `45`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -194,7 +194,7 @@ The callback would be invoked four times, with the arguments and return values i
   </tbody>
 </table>
 
-The value returned by `reduce()` would be that of the last callback invocation (`35`).
+The value returned by `reduce()` would be that of the last callback invocation (`85`).
 
 
 ### How reduce() works with an initial value

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -161,35 +161,35 @@ The callback would be invoked four times, with the arguments and return values i
   <tbody>
     <tr>
       <th scope="row">first call</th>
-      <td><code>5</code></td>
-      <td><code>6</code></td>
+      <td><code>15</code></td>
+      <td><code>16</code></td>
       <td><code>1</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>11</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>31</code></td>
     </tr>
     <tr>
       <th scope="row">second call</th>
-      <td><code>11</code></td>
-      <td><code>7</code></td>
+      <td><code>31</code></td>
+      <td><code>17</code></td>
       <td><code>2</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>18</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>48</code></td>
     </tr>
     <tr>
       <th scope="row">third call</th>
+      <td><code>48</code></td>
       <td><code>18</code></td>
-      <td><code>8</code></td>
       <td><code>3</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>26</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>66</code></td>
     </tr>
     <tr>
       <th scope="row">fourth call</th>
-      <td><code>26</code></td>
-      <td><code>9</code></td>
+      <td><code>66</code></td>
+      <td><code>19</code></td>
       <td><code>4</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>35</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>85</code></td>
     </tr>
   </tbody>
 </table>
@@ -202,7 +202,7 @@ The value returned by `reduce()` would be that of the last callback invocation (
 Here we reduce the same array using the same algorithm, but with an *initialValue* of `10` passed the second argument to `reduce()`:
 
 ```js
-[5, 6, 7, 8, 9].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue, 10 )
+[15, 16, 17, 18, 19].reduce( (previousValue, currentValue, currentIndex, array) => previousValue + currentValue, 10 )
 ```
 
 The callback would be invoked five times, with the arguments and return values in each call being as follows:
@@ -232,42 +232,42 @@ The callback would be invoked five times, with the arguments and return values i
     <tr>
       <th scope="row">first call</th>
       <td><code>10</code></td>
-      <td><code>5</code></td>
-      <td><code>0</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
       <td><code>15</code></td>
+      <td><code>0</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>25</code></td>
     </tr>
     <tr>
       <th scope="row">second call</th>
-      <td><code>15</code></td>
-      <td><code>6</code></td>
+      <td><code>25</code></td>
+      <td><code>16</code></td>
       <td><code>1</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>21</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>41</code></td>
     </tr>
     <tr>
       <th scope="row">third call</th>
-      <td><code>21</code></td>
-      <td><code>7</code></td>
+      <td><code>41</code></td>
+      <td><code>17</code></td>
       <td><code>2</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>28</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>58</code></td>
     </tr>
     <tr>
       <th scope="row">fourth call</th>
-      <td><code>28</code></td>
-      <td><code>8</code></td>
+      <td><code>58</code></td>
+      <td><code>18</code></td>
       <td><code>3</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>36</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>76</code></td>
     </tr>
     <tr>
       <th scope="row">fifth call</th>
-      <td><code>36</code></td>
-      <td><code>9</code></td>
+      <td><code>76</code></td>
+      <td><code>19</code></td>
       <td><code>4</code></td>
-      <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>45</code></td>
+      <td><code>[15, 16, 17, 18, 19]</code></td>
+      <td><code>95</code></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -272,7 +272,7 @@ The callback would be invoked five times, with the arguments and return values i
   </tbody>
 </table>
 
-The value returned by `reduce()` in this case would be `45`.
+The value returned by `reduce()` in this case would be `95`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -20,7 +20,7 @@ The final result of running the reducer across all elements of the array is a si
 
 The first time that the callback is run there is no "return value of the previous calculation".
 If supplied, an initial value may be used in its place.
-Otherwise array element 0 is used as the intitial value and iteration starts from the next element (index 1 instead of index 0).
+Otherwise array element 0 is used as the initial value and iteration starts from the next element (index 1 instead of index 0).
 
 Perhaps the easiest-to-understand case for `reduce()` is to return the sum of all the elements in an array.
 
@@ -54,7 +54,7 @@ reduce(function(previousValue, currentValue, currentIndex, array) { ... }, initi
 
 - `callbackFn`
   - : A “reducer” function that takes four arguments:
-    - `previousValue`: the value resulting from the previous call to `callbackfn`.
+    - `previousValue`: the value resulting from the previous call to `callbackFn`.
       On first call, `initialValue` if specified, otherwise the value of `array[0]`. 
     - `currentValue`: the value of the current element.
       On first call, the value of `array[0]` if an `initialValue` was specified, otherwise the value of `array[1]`. 
@@ -184,7 +184,7 @@ The callback would be invoked four times, with the arguments and return values i
       <td><code>9</code></td>
       <td><code>4</code></td>
       <td><code>[5, 6, 7, 8, 9]</code></td>
-      <td><code>25</code></td>
+      <td><code>35</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Fixes #10524

This is not precisely a "fix" but is a slight improvement to [Array.prototype.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) that fell out of the discussion (i.e. that issue is not actually a bug, but did make us think we could improve this).

What this does:
- In introduction provides overview of what happens in the first iteration.
- Splits the with/without initial value examples into separate headings and just uses arrow functions. Also uses different array values so that the things that relevant points are easier to see in the tables (i.e. the index iteration and the movement of the previousValue.

A really thorough fix might be to replace the spec inclusion in the description with hand written text. I could do that, and I think it would be good, but there are things I consider higher value at this point.