### PR TITLE
image element - add pre-spec

### DIFF
--- a/files/en-us/web/html/element/image/index.md
+++ b/files/en-us/web/html/element/image/index.md
@@ -12,24 +12,19 @@ tags:
   - Reference
 browser-compat: html.elements.image
 ---
+{{HTMLRef}}{{deprecated_header}}
 
-{{deprecated_header}}{{non-standard_header}}
+The **`<image>`** [HTML](/en-US/docs/Web/HTML) element is an ancient and poorly supported precursor to the {{HTMLElement("img")}} element.
+**It should not be used**.
 
-The **`<image>`** [HTML](/en-US/docs/Web/HTML) element is an obsolete remnant of an ancient version of HTML lost in the mists of time; use the standard {{HTMLElement("img")}} element instead. Seriously, the specification even literally uses the words "Don't ask" when describing this element.
-
-> **Warning:** Do not use this element! In order to display images, use the standard {{HTMLElement("img")}} element.
-
-While some browsers will attempt to automatically convert this into an {{HTMLElement("img")}} element, they won't always do so, and won't always succeed when they try, due to various ways in which the options can be interpreted. So just don't use it if you like your users.
+Some browsers will attempt to automatically convert this into an {{HTMLElement("img")}} element, and may succeed if the {{htmlattrxref("src", "img")}} attribute is specified as well.
 
 ## Specifications
 
-This might have once been part of a specification, but nobody seems to remember. It certainly isn't anymore. Just avoid it like the plague.
+This does not appear to have been part of any formal specification.
+It was mentioned in [HTML+ Discussion Document - Dave Raggett, November 8, 1993](https://www.w3.org/MarkUp/HTMLPlus/htmlplus_21.html) (Section 5.9 - Images), but was not part of the first revision of [ HyperText Markup Language Specification - 2.0](https://datatracker.ietf.org/doc/html/draft-ietf-html-spec-00) in 1994.
 
 ## Browser compatibility
-
-In general, browsers will attempt to map this to `<img>`, but only if the {{htmlattrxref("src", "img")}} attribute is specified as well.  Creating an `<image>` element without a `src` attribute results in an {{domxref("HTMLElement")}} object with the local element name `"image"`. However, if the element is created with a `src` attribute, the result is instead an {{domxref("HTMLImageElement")}} and its local element name is changed to `"img"`.
-
-However, that doesn't mean this is a good idea to use. It's not.
 
 {{Compat}}
 
@@ -37,5 +32,3 @@ However, that doesn't mean this is a good idea to use. It's not.
 
 - {{HTMLElement("img")}}: The correct way to display an image in a document
 - {{HTMLElement("picture")}}: A more powerful correct way to display an image in a document
-
-{{HTMLRef}}


### PR DESCRIPTION
Fixes #10350

This simplifies the page and adds the information about a pre-spec comment on the tag. 

Why did I bother? Well, the archaeology is interesting :-). 

We could just delete the BCD and page, but not inclined to do that unless Firefox removes support.