### PR TITLE
Replace old event macros in FileReader docs

### DIFF
--- a/files/en-us/web/api/filereader/index.md
+++ b/files/en-us/web/api/filereader/index.md
@@ -46,17 +46,17 @@ See [Using files from web applications](/en-US/docs/Web/API/File/Using_files_fro
 ### Event handlers
 
 - {{domxref("FileReader.onabort")}}
-  - : A handler for the {{event("abort")}} event. This event is triggered each time the reading operation is aborted.
+  - : A handler for the {{domxref("FileReader.abort_event")}} event. This event is triggered each time the reading operation is aborted.
 - {{domxref("FileReader.onerror")}}
-  - : A handler for the {{event("error")}} event. This event is triggered each time the reading operation encounter an error.
+  - : A handler for the {{domxref("FileReader.error_event")}} event. This event is triggered each time the reading operation encounter an error.
 - {{domxref("FileReader.onload")}}
-  - : A handler for the {{event("load")}} event. This event is triggered each time the reading operation is successfully completed.
+  - : A handler for the {{domxref("FileReader.load_event")}} event. This event is triggered each time the reading operation is successfully completed.
 - {{domxref("FileReader.onloadstart")}}
-  - : A handler for the {{event("loadstart")}} event. This event is triggered each time the reading is starting.
+  - : A handler for the {{domxref("FileReader.loadstart_event")}} event. This event is triggered each time the reading is starting.
 - {{domxref("FileReader.onloadend")}}
-  - : A handler for the {{event("loadend")}} event. This event is triggered each time the reading operation is completed (either in success or failure).
+  - : A handler for the {{domxref("FileReader.loadend_event")}} event. This event is triggered each time the reading operation is completed (either in success or failure).
 - {{domxref("FileReader.onprogress")}}
-  - : A handler for the {{event("progress")}} event. This event is triggered while reading a {{domxref("Blob")}} content.
+  - : A handler for the {{domxref("FileReader.progress")}} event. This event is triggered while reading a {{domxref("Blob")}} content.
 
 > **Note:** As `FileReader` inherits from {{domxref("EventTarget")}}, all those events can also be listened for by using the {{domxref("EventTarget.addEventListener()","addEventListener")}} method.
 

--- a/files/en-us/web/api/filereader/onload/index.md
+++ b/files/en-us/web/api/filereader/onload/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileReader.onload
 ---
 {{APIRef}}
 
-The **`FileReader.onload`** property contains an event handler executed when the {{event('load')}} event is fired, when content read with [readAsArrayBuffer](/en-US/docs/Web/API/FileReader/readAsArrayBuffer), [readAsBinaryString](/en-US/docs/Web/API/FileReader/readAsBinaryString), [readAsDataURL](/en-US/docs/Web/API/FileReader/readAsDataURL) or [readAsText](/en-US/docs/Web/API/FileReader/readAsText) is available.
+The **`FileReader.onload`** property contains an event handler executed when the {{domxref('FileReader.load_event')}} event is fired, when content read with [readAsArrayBuffer](/en-US/docs/Web/API/FileReader/readAsArrayBuffer), [readAsBinaryString](/en-US/docs/Web/API/FileReader/readAsBinaryString), [readAsDataURL](/en-US/docs/Web/API/FileReader/readAsDataURL) or [readAsText](/en-US/docs/Web/API/FileReader/readAsText) is available.
 
 ## Example
 

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -14,7 +14,7 @@ browser-compat: api.FileReader.readAsBinaryString
 The `readAsBinaryString` method is used to start reading the contents of the
 specified {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is
 finished, the {{domxref("FileReader.readyState","readyState")}} becomes
-`DONE`, and the {{event("loadend")}} is triggered. At that time, the
+`DONE`, and the {{domxref("FileReader.loadend_event")}} is triggered. At that time, the
 {{domxref("FileReader.result","result")}} attribute contains the raw binary data from
 the file.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

While reading the docs, I noticed there were some old event macros in the `FileReader` docs -- e.g. [`FileReader.onload`](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/onload) linking to the Window `load` event instead of `FileReader.load_event`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Since it is mentioned on the commonly used macros page that the `event` macro is not particularly useful anymore, I replaced them with `domxref`s. They now link to the acurate events.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
