### PR TITLE
fix: clarify usage of dialog value for the method attribute

### DIFF
--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<form>: The Form element"
+title: '<form>: The Form element'
 slug: Web/HTML/Element/form
 tags:
   - Element
@@ -174,18 +174,16 @@ The following attributes control behavior during form submission.
 ```html
 <!-- Form which will send a GET request to the current URL -->
 <form>
-  <label
-    >Name:
-    <input name="submitted-name" autocomplete="name" />
+  <label>Name:
+    <input name="submitted-name" autocomplete="name">
   </label>
   <button>Save</button>
 </form>
 
 <!-- Form which will send a POST request to the current URL -->
 <form method="post">
-  <label
-    >Name:
-    <input name="submitted-name" autocomplete="name" />
+  <label>Name:
+    <input name="submitted-name" autocomplete="name">
   </label>
   <button>Save</button>
 </form>
@@ -194,7 +192,7 @@ The following attributes control behavior during form submission.
 <form method="post">
   <fieldset>
     <legend>Title</legend>
-    <label><input type="radio" name="radio" /> Select me</label>
+    <label><input type="radio" name="radio"> Select me</label>
   </fieldset>
 </form>
 ```

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -148,7 +148,7 @@ The following attributes control behavior during form submission.
 
     - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
     - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side-effects](/en-US/docs/Glossary/Idempotent).
-    - `dialog`: When the form is inside a {{HTMLElement("dialog")}}, closes the dialog on submission. This is a means to close the `dialog` element without the need for JavaScript. Note that no form data is submitted so, specifying an `action` attribute will have no effect.
+    - `dialog`: When the form is inside a {{HTMLElement("dialog")}}, closes the dialog and throws a submit event on submission without submitting data or clearing the form.
 
     This value is overridden by {{htmlattrxref("formmethod", "button")}} attributes on {{HTMLElement("button")}}, [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit), or [`<input type="image"> `](/en-US/docs/Web/HTML/Element/input/image)elements.
 

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -131,7 +131,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 The following attributes control behavior during form submission.
 
 - {{htmlattrdef("action")}}
-  - : The URL that processes the form submission. This value can be overridden by a {{htmlattrxref("formaction", "button")}} attribute on a {{HTMLElement("button")}}, [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit), or [`<input type="image">`](/en-US/docs/Web/HTML/Element/input/image) element.
+  - : The URL that processes the form submission. This value can be overridden by a {{htmlattrxref("formaction", "button")}} attribute on a {{HTMLElement("button")}}, [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit), or [`<input type="image">`](/en-US/docs/Web/HTML/Element/input/image) element. This attribute is ignored when `method="dialog"` is set.
 - {{htmlattrdef("enctype")}}
 
   - : If the value of the `method` attribute is `post`, `enctype` is the [MIME type](https://en.wikipedia.org/wiki/Mime_type) of the form submission. Possible values:

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<form>: The Form element'
+title: "<form>: The Form element"
 slug: Web/HTML/Element/form
 tags:
   - Element
@@ -148,7 +148,7 @@ The following attributes control behavior during form submission.
 
     - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
     - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side-effects](/en-US/docs/Glossary/Idempotent).
-    - `dialog`: When the form is inside a {{HTMLElement("dialog")}}, closes the dialog on submission.
+    - `dialog`: When the form is inside a {{HTMLElement("dialog")}}, closes the dialog on submission. This is a means to close the `dialog` element without the need for JavaScript. Note that no form data is submitted so, specifying an `action` attribute will have no effect.
 
     This value is overridden by {{htmlattrxref("formmethod", "button")}} attributes on {{HTMLElement("button")}}, [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit), or [`<input type="image"> `](/en-US/docs/Web/HTML/Element/input/image)elements.
 
@@ -174,16 +174,18 @@ The following attributes control behavior during form submission.
 ```html
 <!-- Form which will send a GET request to the current URL -->
 <form>
-  <label>Name:
-    <input name="submitted-name" autocomplete="name">
+  <label
+    >Name:
+    <input name="submitted-name" autocomplete="name" />
   </label>
   <button>Save</button>
 </form>
 
 <!-- Form which will send a POST request to the current URL -->
 <form method="post">
-  <label>Name:
-    <input name="submitted-name" autocomplete="name">
+  <label
+    >Name:
+    <input name="submitted-name" autocomplete="name" />
   </label>
   <button>Save</button>
 </form>
@@ -192,7 +194,7 @@ The following attributes control behavior during form submission.
 <form method="post">
   <fieldset>
     <legend>Title</legend>
-    <label><input type="radio" name="radio"> Select me</label>
+    <label><input type="radio" name="radio" /> Select me</label>
   </fieldset>
 </form>
 ```


### PR DESCRIPTION
#### Summary

Clarify that using the dialog value on `method` is purely a means to close the `dialog` element, and will not submit any form data.

#### Motivation

See issue #10568

#### Related issues

fix #10568

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
