### PR TITLE
Improve BroadcastChannel.postMessage syntax section

### DIFF
--- a/files/en-us/web/api/broadcastchannel/postmessage/index.md
+++ b/files/en-us/web/api/broadcastchannel/postmessage/index.md
@@ -24,8 +24,16 @@ channel.
 ## Syntax
 
 ```js
-var str = channel.postMessage(object);
+channel.postMessage(message);
 ```
+
+### Parameters
+
+- `message`
+  - : Data to be sent to the other window. The data is serialized using
+    {{domxref("Web_Workers_API/Structured_clone_algorithm", "the structured clone
+    algorithm")}}. This means you can pass a broad variety of data objects safely to the
+    destination window without having to serialize them yourself.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Improve BroadcastChannel.postMessage syntax section and describe the `message` parameter.

#### Motivation
The BroadcastChannel.postMessage() syntax section was suggesting that the function returned a string.

#### Supporting details
https://html.spec.whatwg.org/multipage/web-messaging.html#broadcastchannel

#### Related issues
#10571

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
