### PR TITLE
Replace references to "void"

### DIFF
--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -29,7 +29,7 @@ await audioCtx.close();
 
 ### Returns
 
-A {{jsxref("Promise")}} that resolves with void.
+A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/audiocontext/suspend/index.md
+++ b/files/en-us/web/api/audiocontext/suspend/index.md
@@ -26,7 +26,7 @@ audioCtx.suspend().then(function() { ... });
 
 ### Returns
 
-A {{jsxref("Promise")}} that resolves with void. The promise is rejected if the context has already been closed.
+A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}. The promise is rejected if the context has already been closed.
 
 ## Example
 

--- a/files/en-us/web/api/audiolistener/setorientation/index.md
+++ b/files/en-us/web/api/audiolistener/setorientation/index.md
@@ -31,7 +31,7 @@ myListener.setOrientation(0,0,-1,0,1,0);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/audiolistener/setposition/index.md
+++ b/files/en-us/web/api/audiolistener/setposition/index.md
@@ -29,7 +29,7 @@ myListener.setPosition(1,1,1);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/audioparam/cancelscheduledvalues/index.md
+++ b/files/en-us/web/api/audioparam/cancelscheduledvalues/index.md
@@ -30,7 +30,7 @@ var AudioParam = AudioParam.cancelScheduledValues(startTime)
 ### Returns
 
 A reference to this `AudioParam` object. In some older implementations this
-method returns void.
+method returns {{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
@@ -41,7 +41,7 @@ var AudioParam = AudioParam.exponentialRampToValueAtTime(value, endTime)
 ### Returns
 
 A reference to this `AudioParam` object. In some browsers older
-implementations of this interface return void.
+implementations of this interface return {{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/audioparam/linearramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/linearramptovalueattime/index.md
@@ -38,7 +38,7 @@ var AudioParam = AudioParam.linearRampToValueAtTime(value, endTime)
 ### Returns
 
 A reference to this `AudioParam` object. In some browsers older
-implementations of this interface return void.
+implementations of this interface return {{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/audioparam/settargetattime/index.md
+++ b/files/en-us/web/api/audioparam/settargetattime/index.md
@@ -38,7 +38,7 @@ var paramRef = param.setTargetAtTime(target, startTime, timeConstant);
 ### Returns
 
 A reference to this `AudioParam` object. Some older browser implementations
-of this interface return void.
+of this interface return {{jsxref('undefined')}}.
 
 ## Description
 

--- a/files/en-us/web/api/audioparam/setvalueattime/index.md
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.md
@@ -36,7 +36,7 @@ var AudioParam = AudioParam.setValueAtTime(value, startTime)
 ### Returns
 
 A reference to this `AudioParam` object. In some browsers older
-implementations of this interface return void.
+implementations of this interface return {{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -43,7 +43,7 @@ postMessage(aMessage, transferList)
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -285,7 +285,7 @@ None
 
 ##### Returns
 
-`void`
+{{jsxref('undefined')}}
 
 ##### Exceptions
 

--- a/files/en-us/web/api/formdata/append/index.md
+++ b/files/en-us/web/api/formdata/append/index.md
@@ -41,7 +41,7 @@ formData.append(name, value, filename);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/formdata/delete/index.md
+++ b/files/en-us/web/api/formdata/delete/index.md
@@ -30,7 +30,7 @@ formData.delete(name);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/headers/append/index.md
+++ b/files/en-us/web/api/headers/append/index.md
@@ -41,7 +41,7 @@ myHeaders.append(name, value);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/headers/delete/index.md
+++ b/files/en-us/web/api/headers/delete/index.md
@@ -38,7 +38,7 @@ myHeaders.delete(name);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/headers/set/index.md
+++ b/files/en-us/web/api/headers/set/index.md
@@ -42,7 +42,7 @@ myHeaders.set(name, value);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
@@ -36,7 +36,7 @@ HMDVRDevice.setFieldOfView(leftFOV,rightFOV,zNear,zFar);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/idbdatabasesync/index.md
+++ b/files/en-us/web/api/idbdatabasesync/index.md
@@ -167,7 +167,7 @@ Destroys an object store with the given name, as well as all indexes that refere
 
 ##### Returns
 
-`void`
+{{jsxref('undefined')}}.
 
 ##### Exceptions
 
@@ -188,7 +188,7 @@ Sets the version of the connected database.
 
 ##### Returns
 
-`void`
+{{jsxref('undefined')}}.
 
 - version
   - : The version to store in the database.

--- a/files/en-us/web/api/idbindexsync/index.md
+++ b/files/en-us/web/api/idbindexsync/index.md
@@ -240,7 +240,7 @@ Creates a [cursor](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor) o
 
 ##### Returns
 
-`void`
+{{jsxref('undefined')}}.
 
 ##### Exceptions
 
@@ -267,7 +267,7 @@ Creates a cursor over the records of this index's referenced object store, as ar
 
 ##### Returns
 
-`void`
+{{jsxref('undefined')}}.
 
 ##### Exceptions
 

--- a/files/en-us/web/api/idbobjectstoresync/index.md
+++ b/files/en-us/web/api/idbobjectstoresync/index.md
@@ -350,7 +350,7 @@ Removes from this object store any records that correspond to the given key.
 
 ##### Returns
 
-`void`
+{{jsxref('undefined')}}.
 
 ##### Exceptions
 

--- a/files/en-us/web/api/messageport/close/index.md
+++ b/files/en-us/web/api/messageport/close/index.md
@@ -26,7 +26,7 @@ port.close()
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/messageport/postmessage/index.md
+++ b/files/en-us/web/api/messageport/postmessage/index.md
@@ -26,7 +26,7 @@ port.postMessage(message, transferList);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/messageport/start/index.md
+++ b/files/en-us/web/api/messageport/start/index.md
@@ -27,7 +27,7 @@ port.start()
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/notification/close/index.md
+++ b/files/en-us/web/api/notification/close/index.md
@@ -36,7 +36,7 @@ None.
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.md
@@ -32,7 +32,7 @@ None.
 
 ### Returns
 
-A {{jsxref("Promise")}} resolving to void.
+A {{jsxref("Promise")}} resolving to {{jsxref('undefined')}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
@@ -49,7 +49,7 @@ None.
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.md
@@ -38,7 +38,7 @@ OfflineAudioContext.suspend(suspendTime).then(function() { ... });
 
 ### Returns
 
-A {{jsxref("Promise")}} resolving to void.
+A {{jsxref("Promise")}} resolving to {{jsxref('undefined')}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/pannernode/setorientation/index.md
+++ b/files/en-us/web/api/pannernode/setorientation/index.md
@@ -28,7 +28,7 @@ panner.setOrientation(1,0,0);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/pannernode/setposition/index.md
+++ b/files/en-us/web/api/pannernode/setposition/index.md
@@ -26,7 +26,7 @@ panner.setPosition(0,0,0);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/pannernode/setvelocity/index.md
+++ b/files/en-us/web/api/pannernode/setvelocity/index.md
@@ -35,7 +35,7 @@ panner.setVelocity(0,0,17);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/paymentrequest/abort/index.md
+++ b/files/en-us/web/api/paymentrequest/abort/index.md
@@ -25,7 +25,7 @@ PaymentRequest.abort();
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.md
@@ -30,7 +30,7 @@ None.
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
@@ -28,7 +28,7 @@ speechGrammarListInstance.addFromString(string,weight);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
@@ -31,7 +31,7 @@ speechGrammarListInstance.addFromURI(src,weight);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechrecognition/abort/index.md
+++ b/files/en-us/web/api/speechrecognition/abort/index.md
@@ -27,7 +27,7 @@ mySpeechRecognition.abort();
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechrecognition/stop/index.md
+++ b/files/en-us/web/api/speechrecognition/stop/index.md
@@ -27,7 +27,7 @@ mySpeechRecognition.stop();
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechsynthesis/cancel/index.md
+++ b/files/en-us/web/api/speechsynthesis/cancel/index.md
@@ -28,7 +28,7 @@ speechSynthesisInstance.cancel();
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechsynthesis/pause/index.md
+++ b/files/en-us/web/api/speechsynthesis/pause/index.md
@@ -26,7 +26,7 @@ speechSynthesisInstance.pause();
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechsynthesis/resume/index.md
+++ b/files/en-us/web/api/speechsynthesis/resume/index.md
@@ -27,7 +27,7 @@ speechSynthesisInstance.resume();
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/speechsynthesis/speak/index.md
+++ b/files/en-us/web/api/speechsynthesis/speak/index.md
@@ -27,7 +27,7 @@ speechSynthesisInstance.speak(utterance);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ### Parameters
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -41,7 +41,7 @@ worker.postMessage(message, [transfer]);
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 

--- a/files/en-us/web/api/workerglobalscope/dump/index.md
+++ b/files/en-us/web/api/workerglobalscope/dump/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}} containing the message you want to send.
 
 ### Returns
 
-Void.
+{{jsxref('undefined')}}.
 
 ## Example
 


### PR DESCRIPTION
For a web developer audience, the term "void" does not describe a
value--it is the name of a rarely-used unary operator which happens to
produce the value `undefined`. This makes its use in the context of
function return values somewhat confusing. Replace the term "void" with
the term "undefined", and use the project's cross-linking capabilities
to relate this to the canonical definition of the "undefined" language
value.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Replace "void" with "undefined"

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Express values in terms of the JavaScript language. I've worked with students studying JavaScript who were confused by the term "void".

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
