### PR TITLE
corrected output value in comment of example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/and/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/and/index.md
@@ -78,7 +78,7 @@ const sab = new SharedArrayBuffer(1024);
 const ta = new Uint8Array(sab);
 ta[0] = 5;
 
-Atomics.and(ta, 0, 1); // returns 0, the old value
+Atomics.and(ta, 0, 1); // returns 5, the old value
 Atomics.load(ta, 0);  // 1
 ```
 


### PR DESCRIPTION
#### Summary
The output value in the comment behind the **Atomics.and()** operation in the examples section was not correct.

#### Motivation
The commented output value contradicts the described output of the method.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
