### PR TITLE
Fix anchors to checkbox attributes

### DIFF
--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -41,9 +41,9 @@ browser-compat: html.elements.input.input-checkbox
     <tr>
       <td><strong>IDL attributes</strong></td>
       <td>
-        <code>{{anch("checked")}}</code>,
-        <code>{{anch("indeterminate")}}</code> and
-        <code>{{anch("value")}}</code>
+        <code>{{anch("attr-checked")}}</code>,
+        <code>{{anch("attr-indeterminate")}}</code> and
+        <code>{{anch("attr-value")}}</code>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -41,9 +41,9 @@ browser-compat: html.elements.input.input-checkbox
     <tr>
       <td><strong>IDL attributes</strong></td>
       <td>
-        <code>{{anch("attr-checked")}}</code>,
-        <code>{{anch("attr-indeterminate")}}</code> and
-        <code>{{anch("attr-value")}}</code>
+        <code>{{anch("attr-checked", "checked")}}</code>,
+        <code>{{anch("attr-indeterminate", "indeterminate")}}</code> and
+        <code>{{anch("attr-value", "value")}}</code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Updated the anchors so they match the corresponding attributes.

#### Motivation
The links are broken, now they work!

#### Supporting details
In [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/checkbox), these links do not work:
![image](https://user-images.githubusercontent.com/2636763/142269846-40c2d2bf-5b7d-460f-a7d3-84ba3e6864bf.png)

#### Related issues
None, I think.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
