### PR TITLE
fix: typo in BigInt comparison example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -119,7 +119,7 @@ A Number value and a BigInt value may be compared as usual:
 2n > 1
 // ↪ true
 
-2 > 2
+2n > 2
 // ↪ false
 
 2n > 2


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes a potential typo in the comparison example of `BigInt` with `Number`.

#### Motivation
It looked wrong to me so I wanted to fix it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
