### PR TITLE
Removes redundant type attributes

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -92,7 +92,7 @@ Here is a minimalistic template, which we'll be using as a starting point for la
   <head>
     <meta charset="utf-8"/>
     <title>Canvas tutorial</title>
-    <script type="text/javascript">
+    <script>
       function draw() {
         var canvas = document.getElementById('tutorial');
         if (canvas.getContext) {
@@ -100,7 +100,7 @@ Here is a minimalistic template, which we'll be using as a starting point for la
         }
       }
     </script>
-    <style type="text/css">
+    <style>
       canvas { border: 1px solid black; }
     </style>
   </head>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes `type` attributes that are no longer recommended to be specified. Thanks @bjkeefe  for reporting. 

#### Motivation
Low hanging :mango:

#### Supporting details
> There is very little reason to include this attribute in modern web documents.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#attr-type

> The HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type

#### Related issues
Fixes #10331

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
