### PR TITLE
Fix issue 10106: the type attribute of the style element is deprecated

### DIFF
--- a/files/en-us/web/html/element/style/index.md
+++ b/files/en-us/web/html/element/style/index.md
@@ -28,8 +28,6 @@ In the same manner as `<link>` elements, `<style>` elements can include `media` 
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("type")}}
-  - : This attribute defines the styling language as a MIME type (charset should not be specified). This attribute is optional and defaults to `text/css` if it is not specified; values other than the empty string or `text/css` are not used. **Note:** There is very little reason to include this attribute in modern web documents.
 - {{htmlattrdef("media")}}
   - : This attribute defines which media the style should be applied to. Its value is a [media query](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries), which defaults to `all` if the attribute is missing.
 - {{htmlattrdef("nonce")}}
@@ -40,10 +38,12 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 ### Deprecated attributes
 
 - {{htmlattrdef("scoped")}} {{non-standard_inline}} {{deprecated_inline}}
-
   - : This attribute specifies that the styles only apply to the elements of its parent(s) and children.
 
     > **Note:** This attribute may be re-introduced in the future per <https://github.com/w3c/csswg-drafts/issues/3547>. If you want to use the attribute now, you can use a [polyfill](https://github.com/samthor/scoped).
+
+- {{htmlattrdef("type")}} {{deprecated_inline}}
+  - : This attribute should not be provided: if it is, the only permitted values are the empty string or a case-insensitive match for `text/css`.
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/10106.

It looks like the "type" attribute of the [`<style>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style) element is deprecated: it was marked as such in BCD in https://github.com/mdn/browser-compat-data/pull/7268, which referred to https://html.spec.whatwg.org/multipage/obsolete.html.