### PR TITLE
Remove a duplicated header

### DIFF
--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -81,11 +81,6 @@ function draw() {
 draw();
 ```
 
-## Parameters
-
-- array
-  - : The {{jsxref("Uint8Array")}} that the frequency domain data will be copied to.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -81,11 +81,6 @@ function draw() {
 draw();
 ```
 
-## Parameters
-
-- array
-  - : The {{jsxref("Float32Array")}} that the time domain data will be copied to.
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I removed a duplicated header from the following documents.
- [AnalyserNode.getByteFrequencyData()](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getByteFrequencyData)
- [AnalyserNode.getFloatTimeDomainData](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getFloatTimeDomainData)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The parameter section already exists in the Syntax section, so I deleted the duplicated one located at the below of the document (above Specifications section).

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
none

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
none

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
