### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -94,8 +94,11 @@ function dragover_handler(ev) {
 function dragend_handler(ev) {
   console.log("dragEnd");
   var dataList = ev.dataTransfer.items;
-  for (var i = 0; i < dataList.length; i++) {
-    dataList.remove(i);
+  // Clear all the files.  Iterate in reverse order to safely remove.
+  for (var i = dataList.length - 1; i >= 0; i--) {
+    if (dataList[i].kind === "file") {
+      dataList.remove(i);
+    }
   }
   // Clear any remaining drag data
   dataList.clear();


### PR DESCRIPTION
Changed the example for DataTransferItemList.remove()
* Iterating in reverse order which is required to safely remove items from the list.
* Changing the example to only remove specific items (file items).

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed the example code of DataTransferItemList.remove().

#### Motivation
The example was kind of wrong to be calling remove while doing a forward iteration.

#### Supporting details

#### Related issues

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ X] Fixes a typo, bug, or other error
