### PR TITLE
Add Deprecation Notice to String.prototype.substr

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
@@ -11,7 +11,7 @@ tags:
   - Polyfill
 browser-compat: javascript.builtins.String.substr
 ---
-{{JSRef}}
+{{JSRef}} {{deprecated_header}}
 
 The **`substr()`** method returns a portion
 of the string, starting at the specified index and extending for a given number of


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add a deprecation notice to the `String.prototype.substr` method

#### Motivation
So that people will be aware that this feature is non-standard, and deprecated, and is therefore not recommend for production environments, or at any up-to-date system.

#### Supporting details
[Stack Overflow: Why String.prototype.substr is deprecated](https://stackoverflow.com/questions/52640271/why-string-prototype-substr-seems-to-be-deprecated)

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error