### PR TITLE
API links to aria-* attributes

### DIFF
--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaAtomic
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.
+The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaAtomic
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the `aria-atomic` attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.
+The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaautocomplete/index.md
+++ b/files/en-us/web/api/element/ariaautocomplete/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaAutoComplete
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaautocomplete/index.md
+++ b/files/en-us/web/api/element/ariaautocomplete/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaAutoComplete
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface reflects the value of the `aria-autocomplete` attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaBusy
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaBusy
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the value of the `aria-busy` attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaChecked
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaChecked
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects the value of the `aria-checked` attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
+The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects the value of the `aria-colcount` attribute, which defines the number of columns in a table, grid, or treegrid.
+The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolindex/index.md
+++ b/files/en-us/web/api/element/ariacolindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolindex/index.md
+++ b/files/en-us/web/api/element/ariacolindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects the value of the `aria-colindex` attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndexText`** property of the {{domxref("Element")}} interface reflects the value of the `aria-colindextext` attribute, which defines a human readable text alternative of aria-colindex.
+The **`ariaColIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+The **`ariaColIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolspan/index.md
+++ b/files/en-us/web/api/element/ariacolspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects the value of the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacolspan/index.md
+++ b/files/en-us/web/api/element/ariacolspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaColSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacurrent/index.md
+++ b/files/en-us/web/api/element/ariacurrent/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaCurrent
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects the value of the `aria-current` attribute, which indicates the element that represents the current item within a container or set of related elements.
+The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariacurrent/index.md
+++ b/files/en-us/web/api/element/ariacurrent/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaCurrent
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
+The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariadescription/index.md
+++ b/files/en-us/web/api/element/ariadescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
+The **`ariaDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariadescription/index.md
+++ b/files/en-us/web/api/element/ariadescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDescription`** property of the {{domxref("Element")}} interface reflects the value of the `aria-description` attribute, which defines a string value that describes or annotates the current element.
+The **`ariaDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaDisabled
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 
 > **Note:** Where possible, use the {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element —  because those elements have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaDisabled
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects the value of the `aria-disabled` attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 
 > **Note:** Where possible, use the {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element —  because those elements have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariaexpanded/index.md
+++ b/files/en-us/web/api/element/ariaexpanded/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaExpanded
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects the value of the `aria-expanded` attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaexpanded/index.md
+++ b/files/en-us/web/api/element/ariaexpanded/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaExpanded
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaHasPopup
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects the value of the `aria-haspopup` attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaHasPopup
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariahidden/index.md
+++ b/files/en-us/web/api/element/ariahidden/index.md
@@ -33,7 +33,7 @@ A {{domxref("DOMString")}} with one of the following values:
 
 ## Examples
 
-In this example the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-hidden) attribute on the element with an ID of `hidden` is set to "true". Using `ariaHidden` we update the value to "false".
+In this example the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute on the element with an ID of `hidden` is set to "true". Using `ariaHidden` we update the value to "false".
 
 ```html
 <div id="hidden" aria-hidden="true">Some things are better left unsaid.</div>

--- a/files/en-us/web/api/element/ariahidden/index.md
+++ b/files/en-us/web/api/element/ariahidden/index.md
@@ -33,7 +33,7 @@ A {{domxref("DOMString")}} with one of the following values:
 
 ## Examples
 
-In this example the `aria-hidden` attribute on the element with an ID of `hidden` is set to "true". Using `ariaHidden` we update the value to "false".
+In this example the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-hidden) attribute on the element with an ID of `hidden` is set to "true". Using `ariaHidden` we update the value to "false".
 
 ```html
 <div id="hidden" aria-hidden="true">Some things are better left unsaid.</div>

--- a/files/en-us/web/api/element/arialabel/index.md
+++ b/files/en-us/web/api/element/arialabel/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}}.
 
 ## Examples
 
-In this example the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-label) attribute on the element with an ID of `close-button` is set to "Close". Using `ariaLabel` we update the value to "Close dialog".
+In this example the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute on the element with an ID of `close-button` is set to "Close". Using `ariaLabel` we update the value to "Close dialog".
 
 ```html
 <button aria-label="Close" id="close-button">X</button>

--- a/files/en-us/web/api/element/arialabel/index.md
+++ b/files/en-us/web/api/element/arialabel/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}}.
 
 ## Examples
 
-In this example the `aria-label` attribute on the element with an ID of `close-button` is set to "Close". Using `ariaLabel` we update the value to "Close dialog".
+In this example the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-label) attribute on the element with an ID of `close-button` is set to "Close". Using `ariaLabel` we update the value to "Close dialog".
 
 ```html
 <button aria-label="Close" id="close-button">X</button>

--- a/files/en-us/web/api/element/arialive/index.md
+++ b/files/en-us/web/api/element/arialive/index.md
@@ -32,7 +32,7 @@ A {{domxref("DOMString")}} with one of the following values:
 
 ## Examples
 
-In this example the `aria-live` attribute on the element with an ID of `planetInfo` is set to "polite". We then update the value to "assertive".
+In this example the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-live) attribute on the element with an ID of `planetInfo` is set to "polite". We then update the value to "assertive".
 
 ```html
 <div role="region" id="planetInfo" aria-live="polite">

--- a/files/en-us/web/api/element/arialive/index.md
+++ b/files/en-us/web/api/element/arialive/index.md
@@ -32,7 +32,7 @@ A {{domxref("DOMString")}} with one of the following values:
 
 ## Examples
 
-In this example the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-live) attribute on the element with an ID of `planetInfo` is set to "polite". We then update the value to "assertive".
+In this example the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute on the element with an ID of `planetInfo` is set to "polite". We then update the value to "assertive".
 
 ```html
 <div role="region" id="planetInfo" aria-live="polite">

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaMultiline
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiline`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+The **`ariaMultiline`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaMultiline
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiline`** property of the {{domxref("Element")}} interface reflects the value of the `aria-multiline` attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+The **`ariaMultiline`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaMultiSelectable
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface reflects the value of the `aria-multiselectable` attribute, which indicates that the user may select more than one item from the current selectable descendants.
+The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 
 > **Note:** Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaMultiSelectable
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
+The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 
 > **Note:** Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariaorientation/index.md
+++ b/files/en-us/web/api/element/ariaorientation/index.md
@@ -33,7 +33,7 @@ A {{domxref("DOMString")}} with one of the following values:
 
 ## Examples
 
-In this example the `aria-orientation` attribute on the element with an ID of `handle_zoomSlider` is set to "`vertical`". Using `ariaOrientation` we update the value to "`horizontal`".
+In this example the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-orientation) attribute on the element with an ID of `handle_zoomSlider` is set to "`vertical`". Using `ariaOrientation` we update the value to "`horizontal`".
 
 ```html
 <div id="handle_zoomSlider"

--- a/files/en-us/web/api/element/ariaorientation/index.md
+++ b/files/en-us/web/api/element/ariaorientation/index.md
@@ -33,7 +33,7 @@ A {{domxref("DOMString")}} with one of the following values:
 
 ## Examples
 
-In this example the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-orientation) attribute on the element with an ID of `handle_zoomSlider` is set to "`vertical`". Using `ariaOrientation` we update the value to "`horizontal`".
+In this example the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute on the element with an ID of `handle_zoomSlider` is set to "`vertical`". Using `ariaOrientation` we update the value to "`horizontal`".
 
 ```html
 <div id="handle_zoomSlider"

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPosInSet
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects the value of the `aria-posinset` attribute, which defines an element's number or position in the current set of listitems or treeitems.
+The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPosInSet
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
+The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPressed
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
+The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaPressed
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects the value of the `aria-pressed` attribute, which indicates the current "pressed" state of toggle buttons.
+The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaReadOnly
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
+The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaReadOnly
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects the value of the `aria-readonly` attribute, which indicates that the element is not editable, but is otherwise operable.
+The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 

--- a/files/en-us/web/api/element/ariarelevant/index.md
+++ b/files/en-us/web/api/element/ariarelevant/index.md
@@ -35,7 +35,7 @@ A {{domxref("DOMString")}} containing one or more of the following values, space
 
 ## Examples
 
-In this example the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-relevant) attribute on the element with an ID of `text` is set to "all". Using `ariaRelevant` we update the value to "text".
+In this example the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute on the element with an ID of `text` is set to "all". Using `ariaRelevant` we update the value to "text".
 
 ```html
 <div id="clock" role="timer" aria-live="polite" aria-atomic="true" aria-relevant="all"></div>

--- a/files/en-us/web/api/element/ariarelevant/index.md
+++ b/files/en-us/web/api/element/ariarelevant/index.md
@@ -35,7 +35,7 @@ A {{domxref("DOMString")}} containing one or more of the following values, space
 
 ## Examples
 
-In this example the `aria-relevant` attribute on the element with an ID of `text` is set to "all". Using `ariaRelevant` we update the value to "text".
+In this example the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-relevant) attribute on the element with an ID of `text` is set to "all". Using `ariaRelevant` we update the value to "text".
 
 ```html
 <div id="clock" role="timer" aria-live="polite" aria-atomic="true" aria-relevant="all"></div>

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRoleDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the `aria-roledescription` attribute, which defines a human-readable, author-localized description for the role of an element.
+The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRoleDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
+The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
+The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects the value of the `aria-rowcount` attribute, which defines the total number of rows in a table, grid, or treegrid.
+The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowindex/index.md
+++ b/files/en-us/web/api/element/ariarowindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects the value of the `aria-rowindex` attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowindex/index.md
+++ b/files/en-us/web/api/element/ariarowindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface reflects the value of the `aria-rowindextext` attribute, which defines a human readable text alternative of aria-rowindex.
+The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowspan/index.md
+++ b/files/en-us/web/api/element/ariarowspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariarowspan/index.md
+++ b/files/en-us/web/api/element/ariarowspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaRowSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects the value of the `aria-rowspan` attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaselected/index.md
+++ b/files/en-us/web/api/element/ariaselected/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSelected
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
+The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariaselected/index.md
+++ b/files/en-us/web/api/element/ariaselected/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSelected
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects the value of the `aria-selected` attribute, which indicates the current "selected" state of elements that have a selected state.
+The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariasetsize/index.md
+++ b/files/en-us/web/api/element/ariasetsize/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSetSize
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
+The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariasetsize/index.md
+++ b/files/en-us/web/api/element/ariasetsize/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSetSize
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects the value of the `aria-setsize` attribute, which defines the number of items in the current set of listitems or treeitems.
+The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariasort/index.md
+++ b/files/en-us/web/api/element/ariasort/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSort
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariasort/index.md
+++ b/files/en-us/web/api/element/ariasort/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Element.ariaSort
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the value of the `aria-sort` attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/ariavaluemax/index.md
+++ b/files/en-us/web/api/element/ariavaluemax/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}} which contains a number.
 
 ## Examples
 
-In this example the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valuemax) attribute on the element with an ID of `slider` is set to "7". Using `ariaValueMax` we update the value to "6".
+In this example the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute on the element with an ID of `slider` is set to "7". Using `ariaValueMax` we update the value to "6".
 
 ```html
 <div role="slider" aria-valuenow="1"

--- a/files/en-us/web/api/element/ariavaluemax/index.md
+++ b/files/en-us/web/api/element/ariavaluemax/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}} which contains a number.
 
 ## Examples
 
-In this example the `aria-valuemax` attribute on the element with an ID of `slider` is set to "7". Using `ariaValueMax` we update the value to "6".
+In this example the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valuemax) attribute on the element with an ID of `slider` is set to "7". Using `ariaValueMax` we update the value to "6".
 
 ```html
 <div role="slider" aria-valuenow="1"

--- a/files/en-us/web/api/element/ariavaluenow/index.md
+++ b/files/en-us/web/api/element/ariavaluenow/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}} which contains a number.
 
 ## Examples
 
-In this example the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valuenow) attribute on the element with an ID of `slider` is set to "1". Using `ariaValueNow` we update the value to "2".
+In this example the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute on the element with an ID of `slider` is set to "1". Using `ariaValueNow` we update the value to "2".
 
 ```html
 <div role="slider" aria-valuenow="1"

--- a/files/en-us/web/api/element/ariavaluenow/index.md
+++ b/files/en-us/web/api/element/ariavaluenow/index.md
@@ -26,7 +26,7 @@ A {{domxref("DOMString")}} which contains a number.
 
 ## Examples
 
-In this example the `aria-valuenow` attribute on the element with an ID of `slider` is set to "1". Using `ariaValueNow` we update the value to "2".
+In this example the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valuenow) attribute on the element with an ID of `slider` is set to "1". Using `ariaValueNow` we update the value to "2".
 
 ```html
 <div role="slider" aria-valuenow="1"

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -99,85 +99,85 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 _The `Element` interface includes the following properties, defined on the `ARIAMixin` mixin._
 
 - {{domxref("Element.ariaAtomic")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-atomic` attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
 - {{domxref("Element.ariaAutoComplete")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-autocomplete` attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 - {{domxref("Element.ariaBusy")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-busy` attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 - {{domxref("Element.ariaChecked")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-checked` attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 - {{domxref("Element.ariaColCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colcount` attribute, which defines the number of columns in a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("Element.ariaColIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colindex` attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 - {{domxref("Element.ariaColIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colindextext` attribute, which defines a human readable text alternative of aria-colindex.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("Element.ariaColSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("Element.ariaCurrent")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-current` attribute, which indicates the element that represents the current item within a container or set of related elements.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 - {{domxref("Element.ariaDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-description` attribute, which defines a string value that describes or annotates the current element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 - {{domxref("Element.ariaDisabled")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-disabled` attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 - {{domxref("Element.ariaExpanded")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-expanded` attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 - {{domxref("Element.ariaHasPopup")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-haspopup` attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 - {{domxref("Element.ariaHidden")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-hidden` attribute, which indicates whether the element is exposed to an accessibility API.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 - {{domxref("Element.ariaKeyShortcuts")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-keyshortcuts` attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 - {{domxref("Element.ariaLabel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-label` attribute, which defines a string value that labels the current element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current element.
 - {{domxref("Element.ariaLevel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-level` attribute, which defines the hierarchical level of an element within a structure.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 - {{domxref("Element.ariaLive")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-live` attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 - {{domxref("Element.ariaModal")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-modal` attribute, which indicates whether an element is modal when displayed.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 - {{domxref("Element.ariaMultiline")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-multiline` attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 - {{domxref("Element.ariaMultiSelectable")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-multiselectable` attribute, which indicates that the user may select more than one item from the current selectable descendants.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 - {{domxref("Element.ariaOrientation")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-orientation` attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 - {{domxref("Element.ariaPlaceholder")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-placeholder` attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 - {{domxref("Element.ariaPosInSet")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-posinset` attribute, which defines an element's number or position in the current set of listitems or treeitems.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 - {{domxref("Element.ariaPressed")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-pressed` attribute, which indicates the current "pressed" state of toggle buttons.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 - {{domxref("Element.ariaReadOnly")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-readonly` attribute, which indicates that the element is not editable, but is otherwise operable.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 - {{domxref("Element.ariaRelevant")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-relevant` attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 - {{domxref("Element.ariaRequired")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-required` attribute, which indicates that user input is required on the element before a form may be submitted.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 - {{domxref("Element.ariaRoleDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-roledescription` attribute, which defines a human-readable, author-localized description for the role of an element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 - {{domxref("Element.ariaRowCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowcount` attribute, which defines the total number of rows in a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("Element.ariaRowIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowindex` attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 - {{domxref("Element.ariaRowIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowindextext` attribute, which defines a human readable text alternative of aria-rowindex.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("Element.ariaRowSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowspan` attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("Element.ariaSelected")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-selected` attribute, which indicates the current "selected" state of elements that have a selected state.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 - {{domxref("Element.ariaSetSize")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-setsize` attribute, which defines the number of items in the current set of listitems or treeitems.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 - {{domxref("Element.ariaSort")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-sort` attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 - {{domxref("Element.ariaValueMax")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valueMax` attribute, which defines the maximum allowed value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMax) attribute, which defines the maximum allowed value for a range widget.
 - {{domxref("Element.ariaValueMin")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valueMin` attribute, which defines the minimum allowed value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMin) attribute, which defines the minimum allowed value for a range widget.
 - {{domxref("Element.ariaValueNow")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valueNow` attribute, which defines the current value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueNow) attribute, which defines the current value for a range widget.
 - {{domxref("Element.ariaValueText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valuetext` attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
 ### Event handlers
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaAtomic
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-atomic` attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
+The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaAtomic
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
+The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaAutoComplete
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaAutoComplete
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-autocomplete` attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaBusy
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-busy` attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaBusy
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaChecked
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-checked` attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaChecked
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-colcount` attribute, which defines the number of columns in a table, grid, or treegrid.
+The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
@@ -30,7 +30,7 @@ A {{domxref("DOMString")}}.
 
 ## Examples
 
-In this example the `aria-colcount` attribute is set to "3".
+In this example the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute is set to "3".
 
 ```js
 this.internals_.ariaColCount = "3";

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
+The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
@@ -30,7 +30,7 @@ A {{domxref("DOMString")}}.
 
 ## Examples
 
-In this example the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute is set to "3".
+In this example the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute is set to "3".
 
 ```js
 this.internals_.ariaColCount = "3";

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-colindex` attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-colindextext` attribute, which defines a human readable text alternative of aria-colindex.
+The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaColSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaCurrent
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-current` attribute, which indicates the element that represents the current item within a container or set of related elements.
+The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaCurrent
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
+The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
+The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-description` attribute, which defines a string value that describes or annotates the current element.
+The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaDisabled
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaDisabled
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-disabled` attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaExpanded
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-expanded` attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaExpanded
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaHasPopup
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaHasPopup
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-haspopup` attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaKeyShortcuts
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-keyshortcuts` attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
+The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaKeyShortcuts
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
+The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaLevel
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
+The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaLevel
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-level` attribute, which defines the hierarchical level of an element within a structure.
+The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaModal
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
+The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaModal
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-modal` attribute, which indicates whether an element is modal when displayed.
+The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaMultiline
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiline`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+The **`ariaMultiline`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaMultiline
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiline`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-multiline` attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+The **`ariaMultiline`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaMultiSelectable
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-multiselectable` attribute, which indicates that the user may select more than one item from the current selectable descendants.
+The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaMultiSelectable
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
+The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPlaceholder
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPlaceholder
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-placeholder` attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPosInSet
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
+The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPosInSet
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-posinset` attribute, which defines an element's number or position in the current set of listitems or treeitems.
+The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPressed
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
+The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaPressed
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-pressed` attribute, which indicates the current "pressed" state of toggle buttons.
+The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaReadOnly
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
+The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaReadOnly
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-readonly` attribute, which indicates that the element is not editable, but is otherwise operable.
+The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRequired
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
+The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRequired
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the `aria-required` attribute, which indicates that user input is required on the element before a form may be submitted.
+The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRoleDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the `aria-roledescription` attribute, which defines a human-readable, author-localized description for the role of an element.
+The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRoleDescription
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
+The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-rowcount` attribute, which defines the total number of rows in a table, grid, or treegrid.
+The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowCount
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
+The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowIndex
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-rowindex` attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowIndexText
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-rowindextext` attribute, which defines a human readable text alternative of aria-rowindex.
+The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaRowSpan
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-rowspan` attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSelected
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
+The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSelected
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-selected` attribute, which indicates the current "selected" state of elements that have a selected state.
+The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSetSize
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-setsize` attribute, which defines the number of items in the current set of listitems or treeitems.
+The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSetSize
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
+The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSort
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface reflects the value of the `aria-sort` attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ElementInternals.ariaSort
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -41,85 +41,85 @@ The `ElementInternals` interface includes the following properties, defined on t
 > **Note:** These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 - {{domxref("ElementInternals.ariaAtomic")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-atomic` attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-relevant) attribute.
 - {{domxref("ElementInternals.ariaAutoComplete")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-autocomplete` attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 - {{domxref("ElementInternals.ariaBusy")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-busy` attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 - {{domxref("ElementInternals.ariaChecked")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-checked` attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 - {{domxref("ElementInternals.ariaColCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colcount` attribute, which defines the number of columns in a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colindex` attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colindextext` attribute, which defines a human readable text alternative of aria-colindex.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("ElementInternals.ariaColSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaCurrent")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-current` attribute, which indicates the element that represents the current item within a container or set of related elements.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 - {{domxref("ElementInternals.ariaDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-description` attribute, which defines a string value that describes or annotates the current ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-description) attribute, which defines a string value that describes or annotates the current ElementInternals.
 - {{domxref("ElementInternals.ariaDisabled")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-disabled` attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 - {{domxref("ElementInternals.ariaExpanded")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-expanded` attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 - {{domxref("ElementInternals.ariaHasPopup")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-haspopup` attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an ElementInternals.
 - {{domxref("ElementInternals.ariaHidden")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-hidden` attribute, which indicates whether the element is exposed to an accessibility API.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 - {{domxref("ElementInternals.ariaKeyShortcuts")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-keyshortcuts` attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
 - {{domxref("ElementInternals.ariaLabel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-label` attribute, which defines a string value that labels the current ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-label) attribute, which defines a string value that labels the current ElementInternals.
 - {{domxref("ElementInternals.ariaLevel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-level` attribute, which defines the hierarchical level of an element within a structure.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 - {{domxref("ElementInternals.ariaLive")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-live` attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 - {{domxref("ElementInternals.ariaModal")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-modal` attribute, which indicates whether an element is modal when displayed.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 - {{domxref("ElementInternals.ariaMultiline")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-multiline` attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 - {{domxref("ElementInternals.ariaMultiSelectable")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-multiselectable` attribute, which indicates that the user may select more than one item from the current selectable descendants.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 - {{domxref("ElementInternals.ariaOrientation")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-orientation` attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 - {{domxref("ElementInternals.ariaPlaceholder")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-placeholder` attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 - {{domxref("ElementInternals.ariaPosInSet")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-posinset` attribute, which defines an element's number or position in the current set of listitems or treeitems.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 - {{domxref("ElementInternals.ariaPressed")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-pressed` attribute, which indicates the current "pressed" state of toggle buttons.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 - {{domxref("ElementInternals.ariaReadOnly")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-readonly` attribute, which indicates that the element is not editable, but is otherwise operable.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 - {{domxref("ElementInternals.ariaRelevant")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-relevant` attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 - {{domxref("ElementInternals.ariaRequired")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-required` attribute, which indicates that user input is required on the element before a form may be submitted.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 - {{domxref("ElementInternals.ariaRoleDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-roledescription` attribute, which defines a human-readable, author-localized description for the role of an Element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an Element.
 - {{domxref("ElementInternals.ariaRowCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowcount` attribute, which defines the total number of rows in a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowindex` attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowindextext` attribute, which defines a human readable text alternative of aria-rowindex.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("ElementInternals.ariaRowSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-rowspan` attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaSelected")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-selected` attribute, which indicates the current "selected" state of elements that have a selected state.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 - {{domxref("ElementInternals.ariaSetSize")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-setsize` attribute, which defines the number of items in the current set of listitems or treeitems.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 - {{domxref("ElementInternals.ariaSort")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-sort` attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 - {{domxref("ElementInternals.ariaValueMax")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valueMax` attribute, which defines the maximum allowed value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valueMax) attribute, which defines the maximum allowed value for a range widget.
 - {{domxref("ElementInternals.ariaValueMin")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valueMin` attribute, which defines the minimum allowed value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valueMin) attribute, which defines the minimum allowed value for a range widget.
 - {{domxref("ElementInternals.ariaValueNow")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valueNow` attribute, which defines the current value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valueNow) attribute, which defines the current value for a range widget.
 - {{domxref("ElementInternals.ariaValueText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the `aria-valuetext` attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
 ## Methods
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -41,85 +41,85 @@ The `ElementInternals` interface includes the following properties, defined on t
 > **Note:** These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 - {{domxref("ElementInternals.ariaAtomic")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-relevant) attribute.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
 - {{domxref("ElementInternals.ariaAutoComplete")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 - {{domxref("ElementInternals.ariaBusy")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 - {{domxref("ElementInternals.ariaChecked")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 - {{domxref("ElementInternals.ariaColCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("ElementInternals.ariaColSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaCurrent")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 - {{domxref("ElementInternals.ariaDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-description) attribute, which defines a string value that describes or annotates the current ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current ElementInternals.
 - {{domxref("ElementInternals.ariaDisabled")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 - {{domxref("ElementInternals.ariaExpanded")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 - {{domxref("ElementInternals.ariaHasPopup")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an ElementInternals.
 - {{domxref("ElementInternals.ariaHidden")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 - {{domxref("ElementInternals.ariaKeyShortcuts")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
 - {{domxref("ElementInternals.ariaLabel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-label) attribute, which defines a string value that labels the current ElementInternals.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current ElementInternals.
 - {{domxref("ElementInternals.ariaLevel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 - {{domxref("ElementInternals.ariaLive")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 - {{domxref("ElementInternals.ariaModal")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 - {{domxref("ElementInternals.ariaMultiline")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 - {{domxref("ElementInternals.ariaMultiSelectable")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 - {{domxref("ElementInternals.ariaOrientation")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 - {{domxref("ElementInternals.ariaPlaceholder")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 - {{domxref("ElementInternals.ariaPosInSet")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 - {{domxref("ElementInternals.ariaPressed")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 - {{domxref("ElementInternals.ariaReadOnly")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 - {{domxref("ElementInternals.ariaRelevant")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 - {{domxref("ElementInternals.ariaRequired")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 - {{domxref("ElementInternals.ariaRoleDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an Element.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an Element.
 - {{domxref("ElementInternals.ariaRowCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("ElementInternals.ariaRowSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaSelected")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 - {{domxref("ElementInternals.ariaSetSize")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 - {{domxref("ElementInternals.ariaSort")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 - {{domxref("ElementInternals.ariaValueMax")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valueMax) attribute, which defines the maximum allowed value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMax) attribute, which defines the maximum allowed value for a range widget.
 - {{domxref("ElementInternals.ariaValueMin")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valueMin) attribute, which defines the minimum allowed value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMin) attribute, which defines the minimum allowed value for a range widget.
 - {{domxref("ElementInternals.ariaValueNow")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valueNow) attribute, which defines the current value for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueNow) attribute, which defines the current value for a range widget.
 - {{domxref("ElementInternals.ariaValueText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA//Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
+  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
 ## Methods
 


### PR DESCRIPTION
Link attributes mention in Element and ElementInternals API docs to the newly created or soon to be created ARIA attribute pages
