### PR TITLE
SpeechSynthesisEvent is not experimental

### DIFF
--- a/files/en-us/web/api/speechsynthesisevent/charindex/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/charindex/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisEvent.charIndex
 slug: Web/API/SpeechSynthesisEvent/charIndex
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisEvent
@@ -13,20 +12,11 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisEvent.charIndex
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
-The **`charIndex`** read-only property of the
-{{domxref("SpeechSynthesisUtterance")}} interface returns the index position of the
-character in the {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken
-when the event was triggered.
+The **`charIndex`** read-only property of the {{domxref("SpeechSynthesisUtterance")}} interface returns the index position of the character in the {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered.
 
-## Syntax
-
-```js
-event.charIndex;
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/speechsynthesisevent/charindex/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/charindex/index.md
@@ -14,7 +14,7 @@ browser-compat: api.SpeechSynthesisEvent.charIndex
 ---
 {{APIRef("Web Speech API")}}
 
-The **`charIndex`** read-only property of the {{domxref("SpeechSynthesisUtterance")}} interface returns the index position of the character in the {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered.
+The **`charIndex`** read-only property of the {{domxref("SpeechSynthesisUtterance")}} interface returns the index position of the character in {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered.
 
 ## Value
 

--- a/files/en-us/web/api/speechsynthesisevent/elapsedtime/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/elapsedtime/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisEvent.elapsedTime
 slug: Web/API/SpeechSynthesisEvent/elapsedTime
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisEvent
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisEvent.elapsedTime
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`elapsedTime`** read-only property of the {{domxref("SpeechSynthesisEvent")}} returns the elapsed time in seconds, after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken, at which the [event](/en-US/docs/Web/API/SpeechSynthesisUtterance#events) was triggered.
 

--- a/files/en-us/web/api/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisEvent
 slug: Web/API/SpeechSynthesisEvent
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechSynthesisEvent
@@ -12,7 +11,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisEvent
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechSynthesisEvent`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) contains information about the current state of {{domxref("SpeechSynthesisUtterance")}} objects that have been processed in the speech service.
 

--- a/files/en-us/web/api/speechsynthesisevent/name/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/name/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisEvent.name
 slug: Web/API/SpeechSynthesisEvent/name
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisEvent
@@ -13,22 +12,12 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisEvent.name
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
-The **`name`** read-only property of the
-{{domxref("SpeechSynthesisUtterance")}} interface returns the name associated with
-certain types of events occurring as the {{domxref("SpeechSynthesisUtterance.text")}}
-is being spoken: the name of the [SSML](https://www.w3.org/TR/speech-synthesis/#S3.3.2) marker reached in
-the case of a {{event("mark")}} event, or the type of boundary reached in the case of
-a {{event("boundary")}} event.
+The **`name`** read-only property of the {{domxref("SpeechSynthesisUtterance")}} interface returns the name associated with certain types of events occurring as the {{domxref("SpeechSynthesisUtterance.text")}} is being spoken:
+the name of the [SSML](https://www.w3.org/TR/speech-synthesis/#S3.3.2) marker reached in the case of a {{event("mark")}} event, or the type of boundary reached in the case of a {{event("boundary")}} event.
 
-## Syntax
-
-```js
-event.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/speechsynthesisevent/utterance/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/utterance/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisEvent.utterance
 slug: Web/API/SpeechSynthesisEvent/utterance
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisEvent
@@ -13,19 +12,11 @@ tags:
   - utterance
 browser-compat: api.SpeechSynthesisEvent.utterance
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
-The **`utterance`** read-only property of the
-{{domxref("SpeechSynthesisUtterance")}} interface returns the
-{{domxref("SpeechSynthesisUtterance")}} instance that the event was triggered on.
+The **`utterance`** read-only property of the {{domxref("SpeechSynthesisUtterance")}} interface returns the {{domxref("SpeechSynthesisUtterance")}} instance that the event was triggered on.
 
-## Syntax
-
-```js
-event.utterance;
-```
-
-### Value
+## Value
 
 A {{domxref("SpeechSynthesisUtterance")}} object.
 


### PR DESCRIPTION
This removes the experimental markup from this API. While in the docs I have also changed the syntax sections to "value"

The status was confirmed in this BCD PR: https://github.com/mdn/browser-compat-data/pull/13236
This follows on from https://github.com/mdn/content/issues/10221
