### PR TITLE
API method template: return undefined not void

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -98,7 +98,9 @@ Fill in a syntax box, according to the guidance in our [syntax sections](/en-US/
 
 ### Return value
 
-Include a description of the method's return value, including data type and what it represents. If the method doesn't return anything, just put "Void".
+Include a description of the method's return value, including data type and what it represents.
+
+If the method doesn't return anything, just put "{{jsxref('undefined')}}.".
 
 ### Exceptions
 


### PR DESCRIPTION
Copied from #10574:

> For a web developer audience, the term "void" does not describe a value--it is the name of a rarely-used unary operator which happens to produce the value undefined. This makes its use in the context of function return values somewhat confusing. Replace the term "void" with the term "undefined", and use the project's cross-linking capabilities to relate this to the canonical definition of the "undefined" language value.

Upshot, void is not helpful, but `undefined` is.