### PR TITLE
Adds note about `const` and `let`

### DIFF
--- a/files/en-us/glossary/global_object/index.md
+++ b/files/en-us/glossary/global_object/index.md
@@ -14,7 +14,7 @@ In JavaScript, there's always a global object defined. In a web browser, when sc
 - Code running in a {{domxref("Worker")}} has a {{domxref("WorkerGlobalScope")}} object as its global object.
 - Scripts running under {{Glossary("Node.js")}} have an object called [`global`](https://nodejs.org/api/globals.html#globals_global) as their global object.
 
-> **Note**: Unlike {{jsxref("Statements/var", "var")}}, the statements {{jsxref("Statements/let", "let")}} and {{jsxref("Statements/const", "const")}} do not create properties of the window object.
+> **Note**: Unlike {{jsxref("Statements/var", "var")}}, the statements {{jsxref("Statements/let", "let")}} and {{jsxref("Statements/const", "const")}} do not create properties of the global object.
 
 ## `window` object in the Browser
 

--- a/files/en-us/glossary/global_object/index.md
+++ b/files/en-us/glossary/global_object/index.md
@@ -14,6 +14,8 @@ In JavaScript, there's always a global object defined. In a web browser, when sc
 - Code running in a {{domxref("Worker")}} has a {{domxref("WorkerGlobalScope")}} object as its global object.
 - Scripts running under {{Glossary("Node.js")}} have an object called [`global`](https://nodejs.org/api/globals.html#globals_global) as their global object.
 
+> **Note**: Unlike {{jsxref("Statements/var", "var")}}, the statements {{jsxref("Statements/let", "let")}} and {{jsxref("Statements/const", "const")}} do not create properties of the window object.
+
 ## `window` object in the Browser
 
 The `window` object is the Global Object in the Browser. Any Global Variables or Functions can be accessed as _properties_ of the `window` object.


### PR DESCRIPTION
#### Summary
Adds a note about `const` and `let` that they don't affect the `window` object

#### Motivation
I agree with https://github.com/mdn/content/issues/9684#issuecomment-939573191. Creating a PR to draw attn towards closure. And this is a low hanging :mango:

#### Supporting details
> Just like const the let does not create properties of the window object when declared globally (in the top-most scope). 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let

#### Related issues
Fixes #9684

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
