### PR TITLE
Change iframe example code

### DIFF
--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -211,10 +211,10 @@ There are some serious {{anch("Security concerns")}} to consider with `<iframe>`
   <style> iframe { border: none } </style>
 </head>
 <body>
-  <iframe src="https://developer.mozilla.org/en-US/docs/Glossary"
+  <iframe src="https://en.wikipedia.org/wiki/Mozilla"
           width="100%" height="500" allowfullscreen sandbox>
     <p>
-      <a href="/en-US/docs/Glossary">
+      <a href="/wiki/Mozilla">
          Fallback link for browsers that don't support iframes
       </a>
     </p>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
mozilla.org has 'X-Frame-Options' set to 'deny', causing the iframe to fail loading. Changed to Wikipedia/Mozilla to fix example.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Fixes an error in tutorial example code

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
