### PR TITLE
Fix developer.google.com links

### DIFF
--- a/files/en-us/web/accessibility/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/seizure_disorders/index.md
@@ -469,7 +469,7 @@ Support for prefers-reduced-motion in modern browsers is growing.
 @media screen and (prefers-reduced-motion) { }
 ```
 
-To see a great example of how to use the code `prefers-reduced-motion`, visit the MDN document, **[prefers-reduced-motion](/en-US/docs/Web/CSS/@media/prefers-reduced-motion)**, or see the example below from the section on **[New in Chrome 74](https://developers.google.com/web/updates/2019/04/nic74)**.
+To see a great example of how to use the code `prefers-reduced-motion`, visit the MDN document, [prefers-reduced-motion](/en-US/docs/Web/CSS/@media/prefers-reduced-motion), or see the example below from the section on [New in Chrome 74](https://developer.chrome.com/blog/new-in-chrome-74/).
 
 ```css
 button {

--- a/files/en-us/web/api/clients/claim/index.md
+++ b/files/en-us/web/api/clients/claim/index.md
@@ -14,13 +14,8 @@ browser-compat: api.Clients.claim
 ---
 {{APIRef("Service Worker Clients")}}
 
-The **`claim()`** method of the
-{{domxref("Clients")}} interface allows an active service worker to set itself as the
-{{domxref("ServiceWorkerContainer.controller", "controller")}} for all clients within
-its {{domxref("ServiceWorkerRegistration.scope", "scope")}}. This triggers a
-"`controllerchange`" event
-on {{domxref("ServiceWorkerContainer","navigator.serviceWorker")}} in any clients that
-become controlled by this service worker.
+The **`claim()`** method of the {{domxref("Clients")}} interface allows an active service worker to set itself as the {{domxref("ServiceWorkerContainer.controller", "controller")}} for all clients within its {{domxref("ServiceWorkerRegistration.scope", "scope")}}. 
+This triggers a "`controllerchange`" event on {{domxref("ServiceWorkerContainer","navigator.serviceWorker")}} in any clients that become controlled by this service worker.
 
 When a service worker is initially registered, pages won't use it until they next
 load. The `claim()` method causes those pages to be controlled immediately.
@@ -43,9 +38,7 @@ A {{jsxref("Promise")}} that resolves to `undefined`.
 
 ## Example
 
-The following example uses `claim()` inside service worker's
-"`activate`" event listener so that clients loaded in the same scope do not
-need to be reloaded before their fetches will go through this service worker.
+The following example uses `claim()` inside service worker's "`activate`" event listener so that clients loaded in the same scope do not need to be reloaded before their fetches will go through this service worker.
 
 ```js
 self.addEventListener('activate', event => {
@@ -63,12 +56,8 @@ self.addEventListener('activate', event => {
 
 ## See also
 
-- [Using Service
-  Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
-- [The
-  service worker lifecycle](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/lifecycle)
-- [Is ServiceWorker
-  ready?](https://jakearchibald.github.io/isserviceworkerready/)
+- [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
+- [The service worker lifecycle](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/lifecycle)
+- [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)
 - {{jsxref("Promise", "Promises")}}
-- {{domxref("ServiceWorkerGlobalScope.skipWaiting()", "self.skipWaiting()")}} - skip
-  the service worker's waiting phase
+- {{domxref("ServiceWorkerGlobalScope.skipWaiting()", "self.skipWaiting()")}} - skip the service worker's waiting phase

--- a/files/en-us/web/api/document/createelementns/index.md
+++ b/files/en-us/web/api/document/createelementns/index.md
@@ -24,28 +24,20 @@ var element = document.createElementNS(namespaceURI, qualifiedName[, options]);
 ### Parameters
 
 - _namespaceURI_
-  - : A string that specifies the [namespace
-    URI](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/glossary.html#dt-namespaceURI) to associate with the element. The {{DOMxRef("element.namespaceURI",
-    "namespaceURI")}} property of the created element is initialized with the value of
-    _namespaceURI_. See [Valid Namespace
-    URIs](#important_namespace_uris).
+  - : A string that specifies the [namespace URI](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/glossary.html#dt-namespaceURI) to associate with the element.
+    The {{DOMxRef("element.namespaceURI", "namespaceURI")}} property of the created element is initialized with the value of _namespaceURI_.
+    See [Valid Namespace URIs](#important_namespace_uris).
 - _qualifiedName_
-  - : A string that specifies the type of element to be created. The
-    {{DOMxRef("element.nodeName", "nodeName")}} property of the created element is
-    initialized with the value of _qualifiedName_.
+  - : A string that specifies the type of element to be created.
+    The {{DOMxRef("element.nodeName", "nodeName")}} property of the created element is initialized with the value of _qualifiedName_.
 - _options_{{Optional_Inline}}
 
-  - : An optional `ElementCreationOptions` object containing a single property
-    named `is`, whose value is the tag name for a custom element previously
-    defined using `customElements.define()`. For backwards compatibility with
-    previous versions of the [Custom Elements specification](https://www.w3.org/TR/custom-elements/),
-    some browsers will allow you to pass a string here instead of an object, where the
-    string's value is the custom element's tag name. See [Extending
-    native HTML elements](https://developers.google.com/web/fundamentals/primers/customelements/#extendhtml) for more information on how to use this parameter.
+  - : An optional `ElementCreationOptions` object containing a single property named `is`, whose value is the tag name for a custom element previously defined using `customElements.define()`.
+    For backwards compatibility with previous versions of the [Custom Elements specification](https://www.w3.org/TR/custom-elements/),
+    some browsers will allow you to pass a string here instead of an object, where the string's value is the custom element's tag name.
+    See [Extending native HTML elements](https://developers.google.com/web/fundamentals/primers/customelements/#extendhtml) for more information on how to use this parameter.
 
-    The new element will be given an `is` attribute whose value is the custom
-    element's tag name. Custom elements are an experimental feature only available in some
-    browsers.
+    The new element will be given an `is` attribute whose value is the custom element's tag name. Custom elements are an experimental feature only available in some browsers.
 
 ### Return value
 

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -40,8 +40,7 @@ Element.setAttribute(name, value);
 
 Boolean attributes are considered to be `true` if they're present on the
 element at all. You should set `value` to the empty string (`""`)
-or the attribute's name, with no leading or trailing whitespace. See the {{anch("Example",
-  "example")}} below for a practical demonstration.
+or the attribute's name, with no leading or trailing whitespace. See the {{anch("Example", "example")}} below for a practical demonstration.
 
 Since the specified `value` gets converted into a string, specifying
 `null` doesn't necessarily do what you expect. Instead of removing the
@@ -81,19 +80,14 @@ b.setAttribute("disabled", "");
 
 This demonstrates two things:
 
-- The first call to `setAttribute()` above shows changing the
-  `name` attribute's value to "helloButton". You can see this using your
-  browser's page inspector ([Chrome](https://developers.google.com/web/tools/chrome-devtools/inspect-styles),
+- The first call to `setAttribute()` above shows changing the `name` attribute's value to "helloButton".
+  You can see this using your browser's page inspector ([Chrome](https://developer.chrome.com/docs/devtools/css/),
   [Edge](https://docs.microsoft.com/en-us/microsoft-edge/f12-devtools-guide/dom-explorer),
   [Firefox](/en-US/docs/Tools/Page_Inspector), [Safari](https://developer.apple.com/library/content/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Introduction/Introduction.html)).
-- To set the value of a Boolean attribute, such as `disabled`, you can
-  specify any value. An empty string or the name of the attribute are recommended
-  values. All that matters is that if the attribute is present at all, _regardless of
-  its actual value_, its value is considered to be `true`. The absence
-  of the attribute means its value is `false`. By setting the value of the
-  `disabled` attribute to the empty string (`""`), we are setting
-  `disabled` to `true`, which results in the button being
-  disabled.
+- To set the value of a Boolean attribute, such as `disabled`, you can specify any value.
+  An empty string or the name of the attribute are recommended values.
+  All that matters is that if the attribute is present at all, _regardless of its actual value_, its value is considered to be `true`.
+  The absence of the attribute means its value is `false`. By setting the value of the `disabled` attribute to the empty string (`""`), we are setting `disabled` to `true`, which results in the button being disabled.
 
 {{ EmbedLiveSample('Example', '300', '50') }}
 

--- a/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.md
+++ b/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.md
@@ -98,4 +98,4 @@ We track the "last access time" for each origin using temporary storage. Once th
 ## See also
 
 - [Working with quota on mobile browsers](http://www.html5rocks.com/en/tutorials/offline/quota-research/), by [Eiji Kitamura.](http://blog.agektmr.com "Eiji Kitamura") A detailed analysis of client-side storage on mobile browsers.
-- [Quota Management API: Fast Facts](https://developers.google.com/web/updates/2011/11/Quota-Management-API-Fast-Facts), by [Eiji Kitamura.](http://blog.agektmr.com "Eiji Kitamura") A look at the Quota Management API in Chrome/Blink (which should include Opera, too).
+- [Storage for the web](https://web.dev/storage-for-the-web/) (https://web.dev/)

--- a/files/en-us/web/api/long_tasks_api/index.md
+++ b/files/en-us/web/api/long_tasks_api/index.md
@@ -18,7 +18,8 @@ tags:
 
 ## Motivation
 
-The experimental Long Tasks API gives us visibility into tasks that take 50 milliseconds or more. The 50 ms threshold comes from the [RAIL Model](https://developers.google.com/web/fundamentals/performance/rail), in particular the ["Response: process events in under 50 ms"](https://developers.google.com/web/fundamentals/performance/rail#response) section.
+The experimental Long Tasks API gives us visibility into tasks that take 50 milliseconds or more.
+The 50 ms threshold comes from the [RAIL Model](https://web.dev/rail/), in particular the ["Response: process events in under 50 ms"](https://web.dev/rail/#response:-process-events-in-under-50ms) section.
 
 Tasks that block the main thread for 50 ms or more cause, among other issues:
 

--- a/files/en-us/web/api/resize_observer_api/index.md
+++ b/files/en-us/web/api/resize_observer_api/index.md
@@ -65,9 +65,7 @@ resizeObserver.observe(document.querySelector('div'));
 
 ## Specifications
 
-| Specification                                                |
-| ------------------------------------------------------------ |
-| [Resize Observer](https://drafts.csswg.org/resize-observer/) |
+{{Specifications("api.ResizeObserver")}}
 
 ## Browser compatibility
 
@@ -75,4 +73,4 @@ resizeObserver.observe(document.querySelector('div'));
 
 ## See also
 
-- [ResizeObserver: It’s Like document.onresize for Elements](https://developers.google.com/web/updates/2016/10/resizeobserver)
+- [ResizeObserver: It’s Like document.onresize for Elements](https://web.dev/resize-observer/)

--- a/files/en-us/web/progressive_web_apps/add_to_home_screen/index.md
+++ b/files/en-us/web/progressive_web_apps/add_to_home_screen/index.md
@@ -40,7 +40,7 @@ If you have Mobile Chrome available, the experience is slightly different; upon 
 
 ![](chrome-a2hs-banner.png)
 
-> **Note:** You can find out a lot more about Chrome install banners from the article [Web App Install Banners](https://developers.google.com/web/fundamentals/app-install-banners/).
+> **Note:** You can find out a lot more about Chrome install banners from the article [How to provide your own in-app install experience](https://web.dev/customize-install/).
 
 If you choose not to add it to your Home screen at this point, you can do so later using the _Add to Home screen_ icon in the main Chrome menu.
 
@@ -204,13 +204,12 @@ If the user selects _Install_, the app is installed (available as standalone des
 
 If the user selects _Cancel_, the state of the app goes back to how it was before the button was clicked.
 
-> **Note:** The code for this section was mostly taken from [App install banners/Add to Home Screen](https://developers.google.com/web/fundamentals/app-install-banners/) by Pete LePage.
+> **Note:** The code for this section was mostly taken from [How to provide your own in-app install experience](https://web.dev/customize-install/) by Pete LePage.
 
 ## See also
 
 - [Progressive web apps](/en-US/docs/Web/Progressive_web_apps)
 - [Service Worker API](/en-US/docs/Web/API/Service_Worker_API)
 - [Web manifest reference](/en-US/docs/Web/Manifest)
-- [App install banners](https://developers.google.com/web/fundamentals/app-install-banners/)
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Progressive_web_apps/")}}

--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -37,7 +37,8 @@ Safari on iOS is a little different. Some parts of the PWA ecosystem are support
 
 ## The install user experience
 
-We've written a very simple example web site ([see our demo live](https://mdn.github.io/pwa-examples/a2hs/), and also[ see the source code](https://github.com/mdn/pwa-examples/tree/master/a2hs)) that doesn't do much, but was developed with the necessary code to allow it to be installed, as well as a service worker to enable it to be used offline. The example displays a series of fox pictures.If you have a web application compatible device available, use it to navigate to our demo at `https://mdn.github.io/pwa-examples/a2hs/`. You'll see fox pictures, but more importantly, some form of user interface will be available to let you install the site as a web app.
+We've written a very simple example web site ([see our demo live](https://mdn.github.io/pwa-examples/a2hs/), and also [see the source code](https://github.com/mdn/pwa-examples/tree/master/a2hs)) that doesn't do much, but was developed with the necessary code to allow it to be installed, as well as a service worker to enable it to be used offline.
+The example displays a series of fox pictures.If you have a web application compatible device available, use it to navigate to our demo at `https://mdn.github.io/pwa-examples/a2hs/`. You'll see fox pictures, but more importantly, some form of user interface will be available to let you install the site as a web app.
 
 The UI for this varies from browser to browser, but the general idea is the same.  Unfortunately, there isn't a standard for icons and symbols used for operations such as this.
 

--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -65,7 +65,7 @@ If you have Google Chrome for Android available, the experience is slightly dif
 
 ![Screenshot of a Chrome banner requesting permission to install the Foxes sample app](chrome-a2hs-banner.png)
 
-> **Note:** You can find out a lot more about Chrome install banners from the article[ Web App Install Banners](https://developers.google.com/web/fundamentals/app-install-banners/).
+> **Note:** You can find out a lot more about Chrome install banners from the article [How to provide your own in-app install experience](https://web.dev/customize-install/).
 
 If you choose not to add it to your Home screen at this point, you can do so later using the "Add to Home Screen" icon in the main Chrome menu.
 

--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -38,7 +38,7 @@ Safari on iOS is a little different. Some parts of the PWA ecosystem are support
 ## The install user experience
 
 We've written a very simple example web site ([see our demo live](https://mdn.github.io/pwa-examples/a2hs/), and also [see the source code](https://github.com/mdn/pwa-examples/tree/master/a2hs)) that doesn't do much, but was developed with the necessary code to allow it to be installed, as well as a service worker to enable it to be used offline.
-The example displays a series of fox pictures.If you have a web application compatible device available, use it to navigate to our demo at `https://mdn.github.io/pwa-examples/a2hs/`. You'll see fox pictures, but more importantly, some form of user interface will be available to let you install the site as a web app.
+The example displays a series of fox pictures. If you have a web application compatible device available, use it to navigate to our demo at `https://mdn.github.io/pwa-examples/a2hs/`. You'll see fox pictures, but more importantly, some form of user interface will be available to let you install the site as a web app.
 
 The UI for this varies from browser to browser, but the general idea is the same.  Unfortunately, there isn't a standard for icons and symbols used for operations such as this.
 


### PR DESCRIPTION
Fixes up links to developer.google.com that have been migrated elsewhere - part of #7586

There are 2 docs that were just layout changes. Sorry. I have highlighted those in-line.