### PR TITLE
Clarify Parameters section

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -31,7 +31,7 @@ lastIndexOf(searchValue, fromIndex)
 - `searchValue`
   - : A string representing the value to search for. If
     `searchValue` is an empty string, then
-    `fromIndex` is returned.
+    `fromIndex` is returned, or the string length if `fromIndex` is not defined.
 - `fromIndex` {{optional_inline}}
   - : The index of the last character in the string to be considered as the beginning of a
     match. The default value is `+Infinity`. If

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -31,7 +31,7 @@ lastIndexOf(searchValue, fromIndex)
 - `searchValue`
   - : A string representing the value to search for. If
     `searchValue` is an empty string, then
-    `fromIndex` is returned, or the string length if `fromIndex` is not defined.
+    `fromIndex` is returned. If `fromIndex` is not defined, the string length is returned. 
 - `fromIndex` {{optional_inline}}
   - : The index of the last character in the string to be considered as the beginning of a
     match. The default value is `+Infinity`. If


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Explain what is returned if an empty string is passed as searchValue in the case that fromIndex is not specified.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This scenario wasn't mentioned.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The spec mentions "If position [called fromIndex on MDN] is undefined, the length of the String value is assumed, so as to search all of the String." This behavior was also explained in a comment of [this Stack Overflow question](https://stackoverflow.com/questions/70048602/result-for-passing-empty-string-to-indexof-and-lastindexof-for-string-contai?noredirect=1#comment123826987_70048602).

This PR…

- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
