### PR TITLE
Fix some typos in Web/CSS/length-percentage

### DIFF
--- a/files/en-us/web/css/length-percentage/index.md
+++ b/files/en-us/web/css/length-percentage/index.md
@@ -60,7 +60,7 @@ p {
 
 ### Use in calc()
 
-Where a `<length-percentage>` is specified as an allowable type, this means that the percentage resolves to a length and therefore can be used in a {{cssxref("calc", "calc()")}} expression. Therefore, all of the following values are acceptable for {{cssxref("width")}}:
+Where a `<length-percentage>` is specified as an allowable type, this means that the percentage resolves to a length and therefore can be used in a {{cssxref("calc()")}} expression. Therefore, all of the following values are acceptable for {{cssxref("width")}}:
 
 ```css example-good
 width: 200px;
@@ -75,8 +75,6 @@ width: calc(100% - 200px);
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
 
 ## See also
 


### PR DESCRIPTION
#### Summary
- fix a macro call
- remove duplicated "See also" heading

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
