### PR TITLE
improve(doc): Generalization of Set names in syntax

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/delete/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/delete/index.md
@@ -26,12 +26,12 @@ delete(value)
 ### Parameters
 
 - `value`
-  - : The value to remove from `mySet`.
+  - : The value to remove from `Set`.
 
 ### Return value
 
 Returns `true` if `value` was already in
-`mySet`; otherwise `false`.
+`Set`; otherwise `false`.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
Generalization of Set names in syntax Object Set: from `mySet` to `Set`
