### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/css/time-percentage/index.md
+++ b/files/en-us/web/css/time-percentage/index.md
@@ -34,7 +34,7 @@ Where a `<time-percentage>` is specified as an allowable type, this means that t
 ### Invalid percentages
 
 ```plain example-bad
-50 %        Space not allowed between the space and the percentage sign
+50 %        Space not allowed between the number and the percentage sign
 ```
 
 ### Valid times


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix typo in CSS/time-percentage

#### Motivation
Space not allowed between the number and the percentage sign, not the space.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
