### PR TITLE
Add example-good style to CSS examples

### DIFF
--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -253,7 +253,7 @@ some-element:is(::before, ::after) {
 
 instead do:
 
-```css
+```css example-good
 some-element::before,
 some-element::after {
   display: block;

--- a/files/en-us/web/css/frequency-percentage/index.md
+++ b/files/en-us/web/css/frequency-percentage/index.md
@@ -29,9 +29,11 @@ Where a `<frequency-percentage>` is specified as an allowable type, this means t
 
 ### Valid percentage values
 
-    90% Positive percentage
-    +90% Positive percentage with leading +
-    -90% Negative percentage — not valid for all properties that use percentages
+``` plain example-good
+90% Positive percentage
++90% Positive percentage with leading +
+-90% Negative percentage — not valid for all properties that use percentages
+```
 
 ### Invalid percentage values
 
@@ -41,11 +43,13 @@ Where a `<frequency-percentage>` is specified as an allowable type, this means t
 
 ### Valid frequency values
 
-    12Hz     Positive integer
-    4.3Hz    Non-integer
-    14KhZ    The unit is case-insensitive, though non-SI capitalization is not recommended.
-    +0Hz     Zero, with a leading + and a unit
-    -0kHz    Zero, with a leading - and a unit
+``` plain example-good
+12Hz     Positive integer
+4.3Hz    Non-integer
+14KhZ    The unit is case-insensitive, though non-SI capitalization is not recommended.
++0Hz     Zero, with a leading + and a unit
+-0kHz    Zero, with a leading - and a unit
+```
 
 ### Invalid frequency values
 

--- a/files/en-us/web/css/frequency/index.md
+++ b/files/en-us/web/css/frequency/index.md
@@ -30,11 +30,13 @@ The `<frequency>` data type consists of a {{cssxref("&lt;number&gt;")}} followed
 
 ### Valid frequency values
 
-    12Hz     Positive integer
-    4.3Hz    Non-integer
-    14KhZ    The unit is case-insensitive, though non-SI capitalization is not recommended.
-    +0Hz     Zero, with a leading + and a unit
-    -0kHz    Zero, with a leading - and a unit
+```css example-good
+12Hz     Positive integer
+4.3Hz    Non-integer
+14KhZ    The unit is case-insensitive, though non-SI capitalization is not recommended.
++0Hz     Zero, with a leading + and a unit
+-0kHz    Zero, with a leading - and a unit
+```
 
 ### Invalid frequency values
 

--- a/files/en-us/web/css/integer/index.md
+++ b/files/en-us/web/css/integer/index.md
@@ -27,12 +27,14 @@ When animated, values of the `<integer>` data type are interpolated using discre
 
 ### Valid integers
 
-    12          Positive integer (without a leading + sign)
-    +123        Positive integer (with a leading + sign)
-    -456        Negative integer
-    0           Zero
-    +0          Zero, with a leading +
-    -0          Zero, with a leading -
+```css example-good
+12          Positive integer (without a leading + sign)
++123        Positive integer (with a leading + sign)
+-456        Negative integer
+0           Zero
++0          Zero, with a leading +
+-0          Zero, with a leading -
+```
 
 ### Invalid integers
 

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -65,15 +65,17 @@ When animated, a point's abscissa and ordinate values are interpolated independe
 
 ### Valid positions
 
-    center
-    left
-    center top
+```css example-good
+center
+left
+center top
 
-    right 8.5%
-    bottom 12vmin right -6px
+right 8.5%
+bottom 12vmin right -6px
 
-    10% 20%
-    8rem 14px
+10% 20%
+8rem 14px
+```
 
 ### Invalid positions
 

--- a/files/en-us/web/css/resolution/index.md
+++ b/files/en-us/web/css/resolution/index.md
@@ -43,9 +43,11 @@ The `<resolution>` data type consists of a strictly positive {{cssxref("&lt;numb
 
 ### Valid resolutions
 
-    96dpi
-    50.82dpcm
-    3dppx
+```plain example-good
+96dpi
+50.82dpcm
+3dppx
+```
 
 ### Invalid resolutions
 

--- a/files/en-us/web/css/time-percentage/index.md
+++ b/files/en-us/web/css/time-percentage/index.md
@@ -27,9 +27,11 @@ Where a `<time-percentage>` is specified as an allowable type, this means that t
 
 ### Valid percentages
 
-    50%
-    +50%        Optional plus sign
-    -50%        Negative percentages are not valid for all properties that accept percentages
+```plain example-good
+50%
++50%        Optional plus sign
+-50%        Negative percentages are not valid for all properties that accept percentages
+```
 
 ### Invalid percentages
 
@@ -39,12 +41,14 @@ Where a `<time-percentage>` is specified as an allowable type, this means that t
 
 ### Valid times
 
-    12s         Positive integer
-    -456ms      Negative integer
-    4.3ms       Non-integer
-    14mS        The unit is case-insensitive, although capital letters are not recommended.
-    +0s         Zero with a leading + and a unit
-    -0ms        Zero with a leading - and a unit
+```plain example-good
+12s         Positive integer
+-456ms      Negative integer
+4.3ms       Non-integer
+14mS        The unit is case-insensitive, although capital letters are not recommended.
++0s         Zero with a leading + and a unit
+-0ms        Zero with a leading - and a unit
+```
 
 ### Invalid times
 

--- a/files/en-us/web/css/time/index.md
+++ b/files/en-us/web/css/time/index.md
@@ -33,12 +33,14 @@ The `<time>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by o
 
 ### Valid times
 
+```plain example-good
     12s         Positive integer
     -456ms      Negative integer
     4.3ms       Non-integer
     14mS        The unit is case-insensitive, although capital letters are not recommended.
     +0s         Zero with a leading + and a unit
     -0ms        Zero with a leading - and a unit
+```
 
 ### Invalid times
 


### PR DESCRIPTION
#### Summary
Add `example-good` style to CSS examples

#### Motivation
There are mixed samples which have a `example-good` style.
Add it to examples as a counterpart of `example-bad`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
