### PR TITLE
Remove rest of pr-lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
 
-  - package-ecosystem: npm
-    directory: "/pr-lint"
-    schedule:
-      interval: monthly
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -6,7 +6,6 @@ on:
       - '.github/workflows/**'
       - '.github/CODEOWNERS'
       - '.github/dependabot.yml'
-      - 'pr-lint/**'
       - 'scripts/**'
       - package.json
       - yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
-/pr-lint/node_modules/
 /build
 .env
 yarn-debug.log*


### PR DESCRIPTION
The pr-lint feature was removed in https://github.com/mdn/content/pull/9952. It seems that dependabot is still running for this folder (https://github.com/mdn/content/pull/9417) and so this PR removes the remaining occurrences of "pr-lint". 