### PR TITLE
SpeechSynthesisUtterance - remove experimental tagging

### DIFF
--- a/files/en-us/web/api/speechsynthesisutterance/boundary_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/boundary_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.boundary_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`boundary`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when the spoken utterance reaches a word or sentence boundary.
 

--- a/files/en-us/web/api/speechsynthesisutterance/end_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/end_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.end_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`end`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechSynthesisUtterance")}} object is fired when the utterance has finished being spoken.
 

--- a/files/en-us/web/api/speechsynthesisutterance/error_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/error_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.error_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`error`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechSynthesisUtterance")}} object is fired when an error occurs that prevents the utterance from being successfully spoken.
 

--- a/files/en-us/web/api/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/index.md
@@ -13,7 +13,8 @@ browser-compat: api.SpeechSynthesisUtterance
 ---
 {{APIRef("Web Speech API")}}
 
-The **`SpeechSynthesisUtterance`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a speech request. It contains the content the speech service should read and information about how to read it (e.g. language, pitch and volume.)
+The **`SpeechSynthesisUtterance`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a speech request.
+It contains the content the speech service should read and information about how to read it (e.g. language, pitch and volume.)
 
 ## Constructor
 
@@ -65,7 +66,8 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 ## Examples
 
-In our basic [Speech synthesiser demo](https://mdn.github.io/web-speech-api/speak-easy-synthesis/) ([source](https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis)), we first grab a reference to the SpeechSynthesis controller using `window.speechSynthesis`. After defining some necessary variables, we retrieve a list of the voices available using {{domxref("SpeechSynthesis.getVoices()")}} and populate a select menu with them so the user can choose what voice they want.
+In our basic [Speech synthesiser demo](https://mdn.github.io/web-speech-api/speak-easy-synthesis/) ([source](https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis)), we first grab a reference to the SpeechSynthesis controller using `window.speechSynthesis`.
+After defining some necessary variables, we retrieve a list of the voices available using {{domxref("SpeechSynthesis.getVoices()")}} and populate a select menu with them so the user can choose what voice they want.
 
 Inside the `inputForm.onsubmit` handler, we stop the form submitting with {{domxref("Event.preventDefault","preventDefault()")}}, use the {{domxref("SpeechSynthesisUtterance.SpeechSynthesisUtterance()", "constructor")}} to create a new utterance instance containing the text from the text {{htmlelement("input")}}, set the utterance's {{domxref("SpeechSynthesisUtterance.voice","voice")}} to the voice selected in the {{htmlelement("select")}} element, and start the utterance speaking via the {{domxref("SpeechSynthesis.speak()")}} method.
 

--- a/files/en-us/web/api/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance
 slug: Web/API/SpeechSynthesisUtterance
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechSynthesisUtterance
@@ -12,7 +11,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechSynthesisUtterance`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a speech request. It contains the content the speech service should read and information about how to read it (e.g. language, pitch and volume.)
 

--- a/files/en-us/web/api/speechsynthesisutterance/lang/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/lang/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance.lang
 slug: Web/API/SpeechSynthesisUtterance/lang
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisUtterance
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.lang
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`lang`** property of the
 {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the language of the

--- a/files/en-us/web/api/speechsynthesisutterance/lang/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/lang/index.md
@@ -14,12 +14,9 @@ browser-compat: api.SpeechSynthesisUtterance.lang
 ---
 {{APIRef("Web Speech API")}}
 
-The **`lang`** property of the
-{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the language of the
-utterance.
+The **`lang`** property of the {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the language of the utterance.
 
-If unset, the app's (i.e. the {{htmlelement("html")}} {{htmlattrxref("lang", "html")}}
-value) lang will be used, or the user-agent default if that is unset too.
+If unset, the app's (i.e. the {{htmlelement("html")}} {{htmlattrxref("lang", "html")}} value) lang will be used, or the user-agent default if that is unset too.
 
 ## Syntax
 

--- a/files/en-us/web/api/speechsynthesisutterance/mark_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/mark_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.mark_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`mark`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechSynthesisUtterance")}} object is fired when the spoken utterance reaches a named SSML "mark" tag.
 

--- a/files/en-us/web/api/speechsynthesisutterance/pause_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/pause_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.pause_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`pause`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechSynthesisUtterance")}} object is fired when the utterance is paused part way through.
 

--- a/files/en-us/web/api/speechsynthesisutterance/pitch/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/pitch/index.md
@@ -14,9 +14,7 @@ browser-compat: api.SpeechSynthesisUtterance.pitch
 ---
 {{APIRef("Web Speech API")}}
 
-The **`pitch`** property of the
-{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the pitch at which the
-utterance will be spoken at.
+The **`pitch`** property of the {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the pitch at which the utterance will be spoken at.
 
 If unset, a default value of 1 will be used.
 
@@ -29,11 +27,9 @@ speechSynthesisUtteranceInstance.pitch = 1.5;
 
 ### Value
 
-A float representing the pitch value. It can range between 0 (lowest) and 2 (highest),
-with 1 being the default pitch for the current platform or voice. Some speech synthesis
-engines or voices may constrain the minimum and maximum rates further. If [SSML](https://www.w3.org/TR/speech-synthesis/) is used, this value will be
-overridden by [prosody tags](https://www.w3.org/TR/speech-synthesis/#S3.2.4)
-in the markup.
+A float representing the pitch value.
+It can range between 0 (lowest) and 2 (highest), with 1 being the default pitch for the current platform or voice. Some speech synthesis engines or voices may constrain the minimum and maximum rates further.
+If [SSML](https://www.w3.org/TR/speech-synthesis/) is used, this value will be overridden by [prosody tags](https://www.w3.org/TR/speech-synthesis/#S3.2.4) in the markup.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/pitch/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/pitch/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance.pitch
 slug: Web/API/SpeechSynthesisUtterance/pitch
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisUtterance
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.pitch
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`pitch`** property of the
 {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the pitch at which the

--- a/files/en-us/web/api/speechsynthesisutterance/rate/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/rate/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance.rate
 slug: Web/API/SpeechSynthesisUtterance/rate
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisUtterance
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.rate
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`rate`** property of the
 {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the speed at which the

--- a/files/en-us/web/api/speechsynthesisutterance/rate/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/rate/index.md
@@ -14,9 +14,7 @@ browser-compat: api.SpeechSynthesisUtterance.rate
 ---
 {{APIRef("Web Speech API")}}
 
-The **`rate`** property of the
-{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the speed at which the
-utterance will be spoken at.
+The **`rate`** property of the {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the speed at which the utterance will be spoken at.
 
 If unset, a default value of 1 will be used.
 
@@ -29,14 +27,12 @@ speechSynthesisUtteranceInstance.rate = 1.5;
 
 ### Value
 
-A float representing the rate value. It can range between 0.1 (lowest) and 10
-(highest), with 1 being the default pitch for the current platform or voice, which
-should correspond to a normal speaking rate. Other values act as a percentage relative
-to this, so for example 2 is twice as fast, 0.5 is half as fast, etc.
+A float representing the rate value.
+It can range between 0.1 (lowest) and 10 (highest), with 1 being the default pitch for the current platform or voice, which should correspond to a normal speaking rate.
+Other values act as a percentage relative to this, so for example 2 is twice as fast, 0.5 is half as fast, etc.
 
-Some speech synthesis engines or voices may constrain the minimum and maximum rates
-further. If [SSML](https://www.w3.org/TR/speech-synthesis/) is used, this
-value will be overridden by [prosody tags](https://www.w3.org/TR/speech-synthesis/#S3.2.4) in the markup.
+Some speech synthesis engines or voices may constrain the minimum and maximum rates further.
+If [SSML](https://www.w3.org/TR/speech-synthesis/) is used, this value will be overridden by [prosody tags](https://www.w3.org/TR/speech-synthesis/#S3.2.4) in the markup.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/resume_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/resume_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.resume_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`resume`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechSynthesisUtterance")}} object is fired when a paused utterance is resumed.
 

--- a/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.md
@@ -13,9 +13,7 @@ browser-compat: api.SpeechSynthesisUtterance.SpeechSynthesisUtterance
 ---
 {{APIRef("Web Speech API")}}
 
-The `SpeechSynthesisUtterance()` constructor of the
-{{domxref("SpeechSynthesisUtterance")}} interface returns a new
-`SpeechSynthesisUtterance` object instance.
+The `SpeechSynthesisUtterance()` constructor of the {{domxref("SpeechSynthesisUtterance")}} interface returns a new `SpeechSynthesisUtterance` object instance.
 
 ## Syntax
 
@@ -25,14 +23,12 @@ var utterThis = new SpeechSynthesisUtterance(text);
 
 ### Parameters
 
-- text
-  - : A {{domxref("DOMString")}} containing the text that will be synthesized when the
-    utterance is spoken..
+- `text`
+  - : A {{domxref("DOMString")}} containing the text that will be synthesized when the utterance is spoken..
 
 ## Examples
 
-The following snippet is excerpted from our [Speech
-synthesizer demo](https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis).
+The following snippet is excerpted from our [Speech synthesizer demo](https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis).
 
 ```js
 var synth = window.speechSynthesis;

--- a/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.md
@@ -11,7 +11,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.SpeechSynthesisUtterance
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The `SpeechSynthesisUtterance()` constructor of the
 {{domxref("SpeechSynthesisUtterance")}} interface returns a new

--- a/files/en-us/web/api/speechsynthesisutterance/start_event/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/start_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesisUtterance.start_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`start`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechSynthesisUtterance")}} object is fired when the utterance has begun to be spoken.
 

--- a/files/en-us/web/api/speechsynthesisutterance/text/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/text/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance.text
 slug: Web/API/SpeechSynthesisUtterance/text
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisUtterance
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.text
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`text`** property of the
 {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the text that will be

--- a/files/en-us/web/api/speechsynthesisutterance/text/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/text/index.md
@@ -15,11 +15,10 @@ browser-compat: api.SpeechSynthesisUtterance.text
 {{APIRef("Web Speech API")}}
 
 The **`text`** property of the
-{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the text that will be
-synthesised when the utterance is spoken.
+{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the text that will be synthesised when the utterance is spoken.
 
-The text may be provided as plain text, or a well-formed [SSML](https://www.w3.org/TR/speech-synthesis/)
-document. The SSML tags will be stripped away by devices that don't support SSML.
+The text may be provided as plain text, or a well-formed [SSML](https://www.w3.org/TR/speech-synthesis/) document.
+The SSML tags will be stripped away by devices that don't support SSML.
 
 ## Syntax
 
@@ -30,8 +29,8 @@ speechSynthesisUtteranceInstance.text = 'Hello I am speaking';
 
 ### Value
 
-A {{domxref("DOMString")}} representing the text to the synthesised. The maximum length
-of the text that can be spoken in each utterance is 32,767 characters.
+A {{domxref("DOMString")}} representing the text to the synthesised.
+The maximum length of the text that can be spoken in each utterance is 32,767 characters.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/voice/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/voice/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance.voice
 slug: Web/API/SpeechSynthesisUtterance/voice
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisUtterance
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.voice
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`voice`** property of the
 {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the voice that will be

--- a/files/en-us/web/api/speechsynthesisutterance/voice/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/voice/index.md
@@ -14,14 +14,10 @@ browser-compat: api.SpeechSynthesisUtterance.voice
 ---
 {{APIRef("Web Speech API")}}
 
-The **`voice`** property of the
-{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the voice that will be
-used to speak the utterance.
+The **`voice`** property of the {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the voice that will be used to speak the utterance.
 
-This should be set to one of the {{domxref("SpeechSynthesisVoice")}} objects returned
-by {{domxref("SpeechSynthesis.getVoices()")}}. If not set by the time the utterance is
-spoken, the voice used will be the most suitable default voice available for the
-utterance's {{domxref("SpeechSynthesisUtterance.lang","lang")}} setting.
+This should be set to one of the {{domxref("SpeechSynthesisVoice")}} objects returned by {{domxref("SpeechSynthesis.getVoices()")}}.
+If not set by the time the utterance is spoken, the voice used will be the most suitable default voice available for the utterance's {{domxref("SpeechSynthesisUtterance.lang","lang")}} setting.
 
 ## Syntax
 

--- a/files/en-us/web/api/speechsynthesisutterance/volume/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/volume/index.md
@@ -14,9 +14,7 @@ browser-compat: api.SpeechSynthesisUtterance.volume
 ---
 {{APIRef("Web Speech API")}}
 
-The **`volume`** property of the
-{{domxref("SpeechSynthesisUtterance")}} interface gets and sets the volume that the
-utterance will be spoken at.
+The **`volume`** property of the {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the volume that the utterance will be spoken at.
 
 If not set, the default value 1 will be used.
 
@@ -31,9 +29,7 @@ speechSynthesisUtteranceInstance.volume = 0.5;
 
 A float that represents the volume value, between 0 (lowest) and 1 (highest.)
 
-If [SSML](https://www.w3.org/TR/speech-synthesis/) is used, this value will
-be overridden by [prosody
-tags](https://www.w3.org/TR/speech-synthesis/#S3.2.4) in the markup.
+If [SSML](https://www.w3.org/TR/speech-synthesis/) is used, this value will be overridden by [prosody tags](https://www.w3.org/TR/speech-synthesis/#S3.2.4) in the markup.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/volume/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/volume/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisUtterance.volume
 slug: Web/API/SpeechSynthesisUtterance/volume
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisUtterance
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisUtterance.volume
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`volume`** property of the
 {{domxref("SpeechSynthesisUtterance")}} interface gets and sets the volume that the

--- a/files/en-us/web/api/web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/index.md
@@ -3,7 +3,6 @@ title: Web Speech API
 slug: Web/API/Web_Speech_API
 tags:
   - API
-  - Experimental
   - Landing
   - Reference
   - Web Speech API
@@ -11,7 +10,7 @@ tags:
   - speech
   - synthesis
 ---
-{{DefaultAPISidebar("Web Speech API")}}{{SeeCompatTable}}
+{{DefaultAPISidebar("Web Speech API")}}
 
 The **Web Speech API** enables you to incorporate voice data into web apps. The Web Speech API has two parts: `SpeechSynthesis` (Text-to-Speech), and `SpeechRecognition` (Asynchronous Speech Recognition.)
 

--- a/files/en-us/web/api/web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/index.md
@@ -12,14 +12,19 @@ tags:
 ---
 {{DefaultAPISidebar("Web Speech API")}}
 
-The **Web Speech API** enables you to incorporate voice data into web apps. The Web Speech API has two parts: `SpeechSynthesis` (Text-to-Speech), and `SpeechRecognition` (Asynchronous Speech Recognition.)
+The **Web Speech API** enables you to incorporate voice data into web apps.
+The Web Speech API has two parts: `SpeechSynthesis` (Text-to-Speech), and `SpeechRecognition` (Asynchronous Speech Recognition.)
 
 ## Web Speech Concepts and Usage
 
-The Web Speech API makes web apps able to handle voice data. There are two components to this API:
+The Web Speech API makes web apps able to handle voice data.
+There are two components to this API:
 
-- Speech recognition is accessed via the {{domxref("SpeechRecognition")}} interface, which provides the ability to recognize voice context from an audio input (normally via the device's default speech recognition service) and respond appropriately. Generally you'll use the interface's constructor to create a new {{domxref("SpeechRecognition")}} object, which has a number of event handlers available for detecting when speech is input through the device's microphone. The {{domxref("SpeechGrammar")}} interface represents a container for a particular set of grammar that your app should recognize. Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (**JSGF**.)
-- Speech synthesis is accessed via the {{domxref("SpeechSynthesis")}} interface, a text-to-speech component that allows programs to read out their text content (normally via the device's default speech synthesiser.) Different voice types are represented by {{domxref("SpeechSynthesisVoice")}} objects, and different parts of text that you want to be spoken are represented by {{domxref("SpeechSynthesisUtterance")}} objects. You can get these spoken by passing them to the {{domxref("SpeechSynthesis.speak()")}} method.
+- Speech recognition is accessed via the {{domxref("SpeechRecognition")}} interface, which provides the ability to recognize voice context from an audio input (normally via the device's default speech recognition service) and respond appropriately.
+  Generally you'll use the interface's constructor to create a new {{domxref("SpeechRecognition")}} object, which has a number of event handlers available for detecting when speech is input through the device's microphone. The {{domxref("SpeechGrammar")}} interface represents a container for a particular set of grammar that your app should recognize.
+  Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (**JSGF**.)
+- Speech synthesis is accessed via the {{domxref("SpeechSynthesis")}} interface, a text-to-speech component that allows programs to read out their text content (normally via the device's default speech synthesiser.) Different voice types are represented by {{domxref("SpeechSynthesisVoice")}} objects, and different parts of text that you want to be spoken are represented by {{domxref("SpeechSynthesisUtterance")}} objects.
+  You can get these spoken by passing them to the {{domxref("SpeechSynthesis.speak()")}} method.
 
 For more details on using these features, see [Using the Web Speech API](/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API).
 
@@ -53,9 +58,11 @@ For more details on using these features, see [Using the Web Speech API](/en-US/
 - {{domxref("SpeechSynthesisEvent")}}
   - : Contains information about the current state of {{domxref("SpeechSynthesisUtterance")}} objects that have been processed in the speech service.
 - {{domxref("SpeechSynthesisUtterance")}}
-  - : Represents a speech request. It contains the content the speech service should read and information about how to read it (e.g. language, pitch and volume.)
+  - : Represents a speech request.
+    It contains the content the speech service should read and information about how to read it (e.g. language, pitch and volume.)
 - {{domxref("SpeechSynthesisVoice")}}
-  - : Represents a voice that the system supports. Every `SpeechSynthesisVoice` has its own relative speech service including information about language, name and URI.
+  - : Represents a voice that the system supports.
+    Every `SpeechSynthesisVoice` has its own relative speech service including information about language, name and URI.
 - {{domxref("Window.speechSynthesis")}}
   - : Specced out as part of a `[NoInterfaceObject]` interface called `SpeechSynthesisGetter`, and Implemented by the `Window` object, the `speechSynthesis` property provides access to the {{domxref("SpeechSynthesis")}} controller, and therefore the entry point to speech synthesis functionality.
 
@@ -67,7 +74,8 @@ The [Web Speech API repo](https://github.com/mdn/web-speech-api/) on GitHub cont
 
 | Specification      |
 | ------------------ |
-| [Web Speech API]() |
+| [Web Speech API](https://wicg.github.io/speech-api/) |
+
 
 ## Browser compatibility
 


### PR DESCRIPTION
Matches changes to BCD in https://github.com/mdn/browser-compat-data/pull/13627

Note, this has two commits. The content changes are in the first commit. The second commit is pretty much just layout.