### PR TITLE
Add documentation for PermissionStatus.name

### DIFF
--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -17,6 +17,8 @@ The **`PermissionStatus`** interface of the [Permissions API](Permissions_API) p
 
 ## Properties
 
+- {{domxref("PermissionStatus.name")}} {{readonlyinline}}
+  - : Returns the name of a requested permission, identical to the `name` passed to {{domxref("Permissions.query")}}.
 - {{domxref("PermissionStatus.state")}} {{readonlyinline}}
   - : Returns the state of a requested permission; one of `'granted'`, `'denied'`, or `'prompt'`.
 - `PermissionStatus.status`{{readonlyinline}} {{deprecated_inline}}

--- a/files/en-us/web/api/permissionstatus/name/index.md
+++ b/files/en-us/web/api/permissionstatus/name/index.md
@@ -1,0 +1,50 @@
+---
+title: PermissionStatus.name
+slug: Web/API/PermissionStatus/name
+tags:
+  - API
+  - Event Handler
+  - Experimental
+  - PermissionStatus
+  - Permissions
+  - Permissions API
+  - Property
+  - Reference
+  - status
+browser-compat: api.PermissionStatus.name
+---
+{{APIRef("Permissions API")}}{{SeeCompatTable}}
+
+The **`name`** read-only property of the
+{{domxref("PermissionStatus")}} interface returns the name of a requested permission.
+It is identical to the `name` argument passed to {{domxref("Permissions.query", "navigator.permissions.query()")}}.
+
+## Syntax
+
+```js
+var name = PermissionStatus.name;
+```
+
+## Example
+
+```js
+function stateChangeListener() {
+  console.log(this.name, 'permission status changed to', this.state);
+}
+function queryAndTrackPermission(permissionName) {
+  navigator.permissions.query({name: permissionName}).then(function(permissionStatus) {
+    console.log(permissionName, 'permission state is', permissionStatus.state);
+    permissionStatus.onchange = stateChangeListener;
+  });
+};
+queryAndTrackPermission('geolocation');
+queryAndTrackPermission('midi');
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/permissionstatus/name/index.md
+++ b/files/en-us/web/api/permissionstatus/name/index.md
@@ -15,15 +15,11 @@ browser-compat: api.PermissionStatus.name
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 
-The **`name`** read-only property of the
-{{domxref("PermissionStatus")}} interface returns the name of a requested permission.
-It is identical to the `name` argument passed to {{domxref("Permissions.query", "navigator.permissions.query()")}}.
+The **`name`** read-only property of the {{domxref("PermissionStatus")}} interface returns the name of a requested permission.
 
-## Syntax
+## Value
 
-```js
-var name = PermissionStatus.name;
-```
+This is identical to the `name` argument passed to {{domxref("Permissions.query", "navigator.permissions.query()")}}.
 
 ## Example
 

--- a/files/en-us/web/api/permissionstatus/name/index.md
+++ b/files/en-us/web/api/permissionstatus/name/index.md
@@ -19,7 +19,7 @@ The **`name`** read-only property of the {{domxref("PermissionStatus")}} interfa
 
 ## Value
 
-This is identical to the `name` argument passed to {{domxref("Permissions.query", "navigator.permissions.query()")}}.
+A read-only value that is identical to the `name` argument passed to {{domxref("Permissions.query", "navigator.permissions.query()")}}.
 
 ## Example
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add documentation for `PermissionStatus.name`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Keep MDN up-to-date.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
This feature is already supported in Firefox and tracked by BCD ([entry](https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus#browser_compatibility)), will be supported by Chrome 97 ([ChromeStatus entry](https://chromestatus.com/feature/5651653697994752)). [Spec link](https://w3c.github.io/permissions/#dom-permissionstatus-name).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
BCD was updated with this info in https://github.com/mdn/browser-compat-data/pull/13466

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
