### PR TITLE
Add accessibility info to <progress> doc

### DIFF
--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -119,7 +119,7 @@ In most cases you should provide an accessible label when using `<progress>`. Wh
     
 ### Describing a particular region
 
-If the `<progress>` element is describing the loading progress of a particular region of a page, you **SHOULD** use [`aria-describedby`](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby) to point to the status, and set the [`aria-busy`](https://www.w3.org/TR/wai-aria-1.1/#aria-busy) attribute to true on the region until it is finished loading.
+If the `<progress>` element is describing the loading progress of a section of a page, use [`aria-describedby`](en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) to point to the status, and set [`aria-busy="true"`](en-US/docs/Web/Accessibility/ARIA/Attributes/aria_busy ) on the section that is being updated, removing the `aria-busy` attribute when it has finished loading.
 
 #### Example
 

--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -97,6 +97,41 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 On Windows 7, the resulting progress looks like this:
 
 ![progress-firefox.JPG](progress-firefox.jpg)
+  
+## Accessibility Concerns
+  
+### Labelling
+  
+In most cases you should provide an accessible label when using `<progress>`. While you can use the standard ARIA labelling attributes [`aria-labelledby`](https://www.w3.org/TR/wai-aria/#aria-labelledby) or [`aria-label`](https://www.w3.org/TR/wai-aria/#aria-label) as you would for any element with `role="progressbar"`, when using `<progress>` you can alternatively use the {{htmlelement("label")}} element.
+  
+> **Note:** Text placed between the element's tags is not an accessible label, it is only recommended as a fallback for old browsers that do not support this element.
+
+#### Example
+  
+```html
+  <label>Uploading Document: <progress value="70" max="100">70 %</progress></label>
+  
+  <!-- OR -->
+  
+  <label for="progress-bar">Uploading Document</label>
+  <progress id="progress-bar" value="70" max="100">
+```
+    
+### Describing a particular region
+
+If the `<progress>` element is describing the loading progress of a particular region of a page, you **SHOULD** use [`aria-describedby`](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby) to point to the status, and set the [`aria-busy`](https://www.w3.org/TR/wai-aria-1.1/#aria-busy) attribute to true on the region until it is finished loading.
+
+#### Example
+
+```html
+  <div aria-busy="true" aria-describedby="progress-bar">
+    <!-- content is for this region is loading -->
+  </div>
+  
+  <!-- ... -->
+
+  <progress id="progress-bar" aria-label="Content loading..."></progress>
+```
 
 ## Specifications
 

--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -102,7 +102,7 @@ On Windows 7, the resulting progress looks like this:
   
 ### Labelling
   
-In most cases you should provide an accessible label when using `<progress>`. While you can use the standard ARIA labelling attributes [`aria-labelledby`](https://www.w3.org/TR/wai-aria/#aria-labelledby) or [`aria-label`](https://www.w3.org/TR/wai-aria/#aria-label) as you would for any element with `role="progressbar"`, when using `<progress>` you can alternatively use the {{htmlelement("label")}} element.
+In most cases you should provide an accessible label when using `<progress>`. While you can use the standard ARIA labelling attributes [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) as you would for any element with `role="progressbar"`, when using `<progress>` you can alternatively use the {{htmlelement("label")}} element.
   
 > **Note:** Text placed between the element's tags is not an accessible label, it is only recommended as a fallback for old browsers that do not support this element.
 
@@ -119,7 +119,7 @@ In most cases you should provide an accessible label when using `<progress>`. Wh
     
 ### Describing a particular region
 
-If the `<progress>` element is describing the loading progress of a section of a page, use [`aria-describedby`](en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) to point to the status, and set [`aria-busy="true"`](en-US/docs/Web/Accessibility/ARIA/Attributes/aria_busy ) on the section that is being updated, removing the `aria-busy` attribute when it has finished loading.
+If the `<progress>` element is describing the loading progress of a section of a page, use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) to point to the status, and set [`aria-busy="true"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria_busy ) on the section that is being updated, removing the `aria-busy` attribute when it has finished loading.
 
 #### Example
 


### PR DESCRIPTION
#### Summary
Adds content outlining common accessibility concerns when using the HTML `<progress>` element as described in various specs.

#### Motivation
To increase awareness of how to use the `<progress>` element in an accessible way.

#### Supporting details
https://www.w3.org/TR/wai-aria-practices-1.2/#naming_role_guidance (scroll down to `progressbar` role)
https://www.w3.org/TR/wai-aria-1.2/#progressbar
https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element

#### Related issues
None that I could find

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
