### PR TITLE
HTTP Origin header — improve overview

### DIFF
--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -11,7 +11,7 @@ browser-compat: http.headers.Origin
 ---
 {{HTTPSidebar}}
 
-The **`Origin`** HyperText Transfer Protocol (HTTP) request header indicates the {{glossary("origin")}} (scheme, hostname, and port) that _caused_ the request.
+The **`Origin`** request header indicates the {{glossary("origin")}} (scheme, hostname, and port) that _caused_ the request.
 For example, if a user agent needs to request resources included in a page, or fetched by scripts that it executes, then the origin of the page may be included in the request.
 
 <table class="properties">

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -11,14 +11,8 @@ browser-compat: http.headers.Origin
 ---
 {{HTTPSidebar}}
 
-The **`Origin`** HyperText Transfer Protocol (HTTP) request header indicates the origin of the request. This header does not include any path information. It is similar to the {{HTTPHeader("Referer")}} header, but unlike that header, the Origin header does not disclose the whole path.
-
-> **Note:** Basically, browsers add the {{httpheader("Origin")}} request header to:
->
-> - all {{Glossary("CORS", "cross origin")}} requests.
-> - [same-origin](/en-US/docs/Web/Security/Same-origin_policy) requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).
->
-> There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode](/en-US/docs/Web/API/Request/mode#value), the `Origin` header will not be added.
+The **`Origin`** HyperText Transfer Protocol (HTTP) request header indicates the {{glossary("origin")}} (scheme, hostname, and port) that _caused_ the request.
+For example, if a user agent needs to request resources included in a page, or fetched by scripts that it executes, then the origin of the page may be included in the request.
 
 <table class="properties">
   <tbody>
@@ -37,22 +31,52 @@ The **`Origin`** HyperText Transfer Protocol (HTTP) request header indicates the
 
 ```
 Origin: null
-Origin: <scheme> "://" <hostname> [ ":" <port> ]
+Origin: <scheme>://<hostname>
+Origin: <scheme>://<hostname>:<port>
 ```
 
 ## Directives
 
-- \<scheme>
-  - : The protocol that is used. Usually, it is the HTTP protocol or its secured version, HTTPS.
-- \<hostname>
-  - : The domain name of the server (for virtual hosting) or the IP.
-- \<port> {{optional_inline}}
-  - : TCP port number on which the server is listening. If no port is given, the default port for the service requested (e.g., "80" for an HTTP URL) is implied.
+- `null`
+  - : The origin is "privacy sensitive", or is an _opaque origin_ as defined by the HTML specification (specific cases are listed in the [description](#description) section).
+
+- `<scheme>`
+  - : The protocol that is used.
+    Usually, it is the HTTP protocol or its secured version, HTTPS.
+- `<hostname>`
+  - : The domain name or the IP address of the origin server.
+- `<port>` {{optional_inline}}
+  - : Port number on which the server is listening.
+    If no port is given, the default port for the requested service is implied (e.g., "80" for an HTTP URL) .
+
+## Description
+
+The `Origin` is similar to the {{HTTPHeader("Referer")}} header, but does not disclose the whole path, and may contain `null`.
+It is used to provide the "security context" for the origin request, except in cases where the origin information would be sensitive or unnecessary.
+
+Broadly speaking, user agents add the {{httpheader("Origin")}} request header to:
+- {{Glossary("CORS", "cross origin")}} requests.
+- [same-origin](/en-US/docs/Web/Security/Same-origin_policy) requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).
+
+There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode](/en-US/docs/Web/API/Request/mode#value), the `Origin` header will not be added.
+
+The `Origin` header may return `null` in a number of cases, including (non-exhaustively):
+- Origin's whose scheme is not one of `http`, `https`, `ftp`, `ws`, `wss`, or `gopher` (including `blob`, `file` and `data`).
+- Cross origin images and media data, including that in `<img>`, `<video>` and `<audio>` elements.
+- Documents created programmatically using `createDocument()`, generated from a `data:` url, or that do not have a creator browsing context. 
+- Redirects across origins.
+- iframes with a sandbox attribute that doesn’t contain the value `allow-same-origin`.
+- Responses that are network errors.
+
+> **Note:** There is a more detailed listing of case that may return `null` on Stack Overflow here: [When do browsers send the Origin header? When do browsers set the origin to null?](https://stackoverflow.com/a/42242802/).
 
 ## Examples
 
-```
+```http
 Origin: https://developer.mozilla.org
+```
+```http
+Origin: http://developer.mozilla.org:80
 ```
 
 ## Specifications
@@ -68,4 +92,4 @@ Origin: https://developer.mozilla.org
 - {{HTTPHeader("Host")}}
 - {{HTTPHeader("Referer")}}
 - [Same-origin policy](/en-US/docs/Web/Security/Same-origin_policy)
-- Stack Overflow: [When do browsers send the Origin header? When do browsers set the origin to null?](https://stackoverflow.com/a/42242802/)
+- [When do browsers send the Origin header? When do browsers set the origin to null?](https://stackoverflow.com/a/42242802/) (Stack Overflow)

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -61,8 +61,8 @@ Broadly speaking, user agents add the {{httpheader("Origin")}} request header to
 There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode](/en-US/docs/Web/API/Request/mode#value), the `Origin` header will not be added.
 
 The `Origin` header value may be `null` in a number of cases, including (non-exhaustively):
-- Origin's whose scheme is not one of `http`, `https`, `ftp`, `ws`, `wss`, or `gopher` (including `blob`, `file` and `data`).
-- Cross origin images and media data, including that in `<img>`, `<video>` and `<audio>` elements.
+- Origins whose scheme is not one of `http`, `https`, `ftp`, `ws`, `wss`, or `gopher` (including `blob`, `file` and `data`).
+- Cross-origin images and media data, including that in `<img>`, `<video>` and `<audio>` elements.
 - Documents created programmatically using `createDocument()`, generated from a `data:` url, or that do not have a creator browsing context. 
 - Redirects across origins.
 - iframes with a sandbox attribute that doesn’t contain the value `allow-same-origin`.

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -51,7 +51,7 @@ Origin: <scheme>://<hostname>:<port>
 
 ## Description
 
-The `Origin` header is similar to the {{HTTPHeader("Referer")}} header, but does not disclose the whole path, and may be `null`.
+The `Origin` header is similar to the {{HTTPHeader("Referer")}} header, but does not disclose the path, and may be `null`.
 It is used to provide the "security context" for the origin request, except in cases where the origin information would be sensitive or unnecessary.
 
 Broadly speaking, user agents add the {{httpheader("Origin")}} request header to:

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -51,7 +51,7 @@ Origin: <scheme>://<hostname>:<port>
 
 ## Description
 
-The `Origin` is similar to the {{HTTPHeader("Referer")}} header, but does not disclose the whole path, and may contain `null`.
+The `Origin` header is similar to the {{HTTPHeader("Referer")}} header, but does not disclose the whole path, and may be `null`.
 It is used to provide the "security context" for the origin request, except in cases where the origin information would be sensitive or unnecessary.
 
 Broadly speaking, user agents add the {{httpheader("Origin")}} request header to:

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -60,7 +60,7 @@ Broadly speaking, user agents add the {{httpheader("Origin")}} request header to
 
 There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode](/en-US/docs/Web/API/Request/mode#value), the `Origin` header will not be added.
 
-The `Origin` header may return `null` in a number of cases, including (non-exhaustively):
+The `Origin` header value may be `null` in a number of cases, including (non-exhaustively):
 - Origin's whose scheme is not one of `http`, `https`, `ftp`, `ws`, `wss`, or `gopher` (including `blob`, `file` and `data`).
 - Cross origin images and media data, including that in `<img>`, `<video>` and `<audio>` elements.
 - Documents created programmatically using `createDocument()`, generated from a `data:` url, or that do not have a creator browsing context. 


### PR DESCRIPTION
Fixes #10679.

This improves [Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) header docs by:
- Linking to definition of origin
- Stating that it is the origin of the page that initiated the download/fetch
- Adding a bunch of the case that return `null` into the description (without the detailed explanation) and a link to the Stack overflow topic that has the detail.

@sideshowbarker Last time we went around a discussion on this page (last year maybe) we decided that the stack overflow contained too much detail. I still feel that way, but this is a better balance - we provide an overview of the common cases and link to more information about the logic.