### PR TITLE
HTTP Client hints: Fix developers.google link to web.dev

### DIFF
--- a/files/en-us/web/http/headers/content-dpr/index.md
+++ b/files/en-us/web/http/headers/content-dpr/index.md
@@ -68,7 +68,7 @@ See the [`DPR`](/en-US/docs/Web/HTTP/Headers/DPR#examples) header example.
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Device client hints
 
   - {{HTTPHeader("Device-Memory")}}

--- a/files/en-us/web/http/headers/device-memory/index.md
+++ b/files/en-us/web/http/headers/device-memory/index.md
@@ -74,7 +74,7 @@ Device-Memory: 1
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - [Device Memory API](/en-US/docs/Web/API/Device_Memory_API)
 - {{DOMxRef("Navigator.deviceMemory")}}
 - Device client hints

--- a/files/en-us/web/http/headers/downlink/index.md
+++ b/files/en-us/web/http/headers/downlink/index.md
@@ -72,7 +72,7 @@ Downlink: 1.7
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Network client hints
 
   - {{HTTPHeader("RTT")}}

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -82,7 +82,7 @@ Content-DPR: 2.0
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Device client hints
 
   - {{HTTPHeader("Content-DPR")}}

--- a/files/en-us/web/http/headers/ect/index.md
+++ b/files/en-us/web/http/headers/ect/index.md
@@ -72,7 +72,7 @@ ECT: 2g
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Network client hints
 
   - {{HTTPHeader("Downlink")}}

--- a/files/en-us/web/http/headers/rtt/index.md
+++ b/files/en-us/web/http/headers/rtt/index.md
@@ -72,7 +72,7 @@ RTT: 125
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Network client hints
 
   - {{HTTPHeader("Downlink")}}

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -120,7 +120,7 @@ Content-Type: image/jpeg
 - [Delivering Fast and Light Applications with Save-Data - Google Developers](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/save-data/)
 - {{HTTPHeader("Vary")}} header which indicate that the content served varies by `Save-Data` (see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses))
 - CSS @media feature [`prefers-reduced-data`](/en-US/docs/Web/CSS/@media/prefers-reduced-data) {{experimental_inline}}
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Network client hints
 
   - {{HTTPHeader("Downlink")}}

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -74,7 +74,7 @@ Viewport-Width: 320
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Device client hints
 
   - {{HTTPHeader("Content-DPR")}}

--- a/files/en-us/web/http/headers/width/index.md
+++ b/files/en-us/web/http/headers/width/index.md
@@ -76,7 +76,7 @@ Width: 1920
 
 ## See also
 
-- [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - Device client hints
 
   - {{HTTPHeader("Content-DPR")}}


### PR DESCRIPTION
Fixes up moved link in HTTP client hints from [Adapting to Users with Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints) (developer.google.com) TO [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)