### PR TITLE
Client hints glossary - update with user hints

### DIFF
--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -44,7 +44,6 @@ You may prefer to omit specifying {{HTTPHeader("Vary")}} or use some other strat
 This applies in particular to network client hints like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}.
 For more information see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses).
 
-
 ## Hint life-time
 
 A server specifies the client hint headers that it is interested in getting in the `Accept-CH` response header.
@@ -53,8 +52,8 @@ A user agent should append the requested client hints, that it wants to share wi
 The same set of hints should be included with requests to the same site until the end of the session.
 In other words, the request for a specific set of hints does not expire until the browser is shut down.
 
-A server can replace the set of client hints it is interested in recieving by resending the `Accept-CH` response header with a new set of hints.
-If the server sent `Accept-CH` this would effectively indicate that it did not wish to recieve any hints (other than some of the low entropy [user agent client hints](#user-agent_client_hints) it gets by default).
+A server can replace the set of client hints it is interested in recieving by resending the `Accept-CH` response header with a new list.
+If the server sent `Accept-CH` this would effectively indicate that it did not wish to recieve any hints (other than the [low entropy hits](#low_entroy_hints) it gets by default).
 
 ## Low entropy hints
 

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -50,7 +50,7 @@ For more information see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP
 ## Hint life-time
 
 A server specifies the client hint headers that it is interested in getting in the `Accept-CH` response header.
-The user agent should append the requested client hint headers, or at least the subset that it wants to share with that server, to all subsequent requests in the current browsing session.
+The user agent appends the requested client hint headers, or at least the subset that it wants to share with that server, to all subsequent requests in the current browsing session.
 
 In other words, the request for a specific set of hints does not expire until the browser is shut down.
 
@@ -86,12 +86,12 @@ Client hints are available to web page Javascript via the [User Agent Client Hin
 
 ### Device client hints
 
-Device client hints allow a server to vary responses based on the device characteristics including available memory and screen properties.
+Device client hints allow a server to vary responses based on device characteristics including available memory and screen properties.
 Headers include: {{HTTPHeader("Device-Memory")}}, {{HTTPHeader("DPR")}}, {{HTTPHeader("Width")}}, {{HTTPHeader("Viewport-Width")}}.
 
 ### Network client hints
 
-Network client hints allow a server to vary responses based on the users' choice, network bandwidth, and latency.
+Network client hints allow a server to vary responses based on the user's choice, network bandwidth, and latency.
 Headers include: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Downlink")}}, {{HTTPHeader("ECT")}}, {{HTTPHeader("RTT")}}.
 
 ## See also

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -8,8 +8,8 @@ tags:
   - Reference
   - Web Performance
 ---
-**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client in order to get information about the device, network, user and user-agent specific preferences.
-The server can then determine which resources to send, based on the information that the client chooses to provide.
+**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client to get information about the device, network, user and user-agent specific preferences.
+The server can determine which resources to send, based on the information that the client chooses to provide.
 
 The set of "hint" headers are listed in the topic [HTTP Headers](/en-US/docs/Web/HTTP/Headers#client_hints) and [summarized below](#hint_types).
 
@@ -36,14 +36,14 @@ There is a small set of [low entropy client hint headers](#low_entropy_hints) th
 
 ## Caching and Client Hints
 
-Client hints that determine which resources are sent in responses should "generally" also be included in the affected response's {{HTTPHeader("Vary")}} header.
+Client hints that determine which resources are sent in responses should generally also be included in the affected response's {{HTTPHeader("Vary")}} header.
 This ensures that a different resource is cached for every different value of the hint header.
 
 ```http
 Vary: Accept, Width, ECT
 ```
 
-You may prefer to omit specifying {{HTTPHeader("Vary")}} or use some other strategy for client hint headers where the value changes a lot, as this effectively makes the resource uncachable (a new cache entry is created for every different value).
+You may prefer to omit specifying {{HTTPHeader("Vary")}} or use some other strategy for client hint headers where the value changes a lot, as this effectively makes the resource uncachable. (A new cache entry is created for every unique value.)
 This applies in particular to network client hints like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}.
 For more information see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses).
 
@@ -61,8 +61,8 @@ For example, to stop requesting any hints it would send `Accept-CH` with an empt
 
 Client hints are broadly divided into high and low entropy hints.
 
-The low entropy hints are: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}  .
-These are the hints that don't give away much information that might be used to "fingerprint" (identify) a particular end user.
+The low entropy hints are: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}.
+These are the hints that don't give away much information that might be used to "fingerprint" (identify) a particular user.
 They may be sent by default on every client request, irrespective of the server `Accept-CH` response header, depending on the permission policy.
 
 All the other client hints are high entropy hints.

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -74,15 +74,15 @@ The decision might be based on user preferences, a permission request, or the pe
 
 ### User-agent client hints
 
-User agent (UA) client hint headers allow a server to vary responses based on the user agent (browser) and their device.
-Headers include: {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Arch")}}, {{HTTPHeader("Sec-CH-UA-Bitness")}}, {{HTTPHeader("Sec-CH-UA-Full-Version")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Model")}}, and {{HTTPHeader("Sec-CH-UA-Platform")}}.
-<!-- {{HTTPHeader("Sec-CH-UA-Platform-Version")}} -->
+User agent (UA) client hint headers allow a server to vary responses based on the user agent (browser), operating system, and device.
+Headers include: {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Arch")}}, {{HTTPHeader("Sec-CH-UA-Bitness")}}, {{HTTPHeader("Sec-CH-UA-Full-Version-List")}}, {{HTTPHeader("Sec-CH-UA-Full-Version")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Model")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}, and {{HTTPHeader("Sec-CH-UA-Platform-Version")}}.
 
 Client hints are available to web page Javascript via the [User Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API).
 
 > **Note:** Servers currently get most of the same information by parsing the {{HTTPHeader("User-Agent")}} header.
 > For historical reasons this header contains a lot of largely irrelevant information, and information that might be used to identify a _particular user_.
-> UA client hints provide a more efficient and privacy preserving way of getting the desired information: they are eventually expected to replace this older approach.
+> UA client hints provide a more efficient and privacy preserving way of getting the desired information.
+> They are eventually expected to replace this older approach.
 
 ### Device client hints
 

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -61,9 +61,9 @@ For example, to stop requesting any hints it would send `Accept-CH` with an empt
 
 Client hints are broadly divided into high and low entropy hints.
 
-The low entropy hints are: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}.
-These are the hints that don't give away much information that might be used to "fingerprint" (identify) a particular user.
+The low entropy hints are those that don't give away much information that might be used to "fingerprint" (identify) a particular user.
 They may be sent by default on every client request, irrespective of the server `Accept-CH` response header, depending on the permission policy.
+These hints include: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}.
 
 All the other client hints are high entropy hints.
 These have the potential to give away more information that can be used for user fingerprinting, and therefore are gated in such a way that the user agent can make a decision as to whether to provide them.

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -8,47 +8,92 @@ tags:
   - Reference
   - Web Performance
 ---
-**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client in order to get information about the device, network, user and agent specific preferences. The server can then determine which resources to send based on the client information.
+**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client in order to get information about the device, network, user and user-agent specific preferences.
+The server can then determine which resources to send, based on the information that the client chooses to provide.
 
 The set of "hint" headers are listed in the topic [HTTP Headers](/en-US/docs/Web/HTTP/Headers#client_hints) and [summarized below](#hint_types).
 
 ## Overview
 
 A server must announce that it supports client hints, using the {{HTTPHeader("Accept-CH")}} header to specify the hints that it is interested in receiving.
-When a client that supports client hints receives the `Accept-CH` header it can append client hint headers that match the advertised field-values to subsequent requests.
+When a client that supports client hints receives the `Accept-CH` header it can choose to append some or all of the listed client hint headers in its subsequent requests.
 
-For example, following `Accept-CH` in a response below, the client could append {{HTTPHeader("Width")}} and {{HTTPHeader("Downlink")}} headers to all subsequent requests.
+For example, following `Accept-CH` in a response below, the client could append {{HTTPHeader("Width")}}, {{HTTPHeader("Downlink")}} and {{HTTPHeader("Sec-CH-UA")}} headers to all subsequent requests.
 
-```plain
-Accept-CH: Width, Downlink
+```http
+Accept-CH: Width, Downlink, Sec-CH-UA
 ```
+
+This approach is efficient in that the server only requests the information that it is able to usefully handle.
+It is also relatively "privacy-preserving", in that it is up to the client to decide what information it can safely share.
 
 > **Note:** Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) attribute.
 >
->     <meta http-equiv="Accept-CH" content="Width, Viewport-Width, Downlink">
+>     <meta http-equiv="Accept-CH" content="Width, Downlink, Sec-CH-UA">
 
 ## Caching and Client Hints
 
-Client hints that determine which resources are sent in responses should "generally" also be included in the affected response's {{HTTPHeader("Vary")}} header. This ensures that a different resource is cached for every different value of the hint header.
+Client hints that determine which resources are sent in responses should "generally" also be included in the affected response's {{HTTPHeader("Vary")}} header.
+This ensures that a different resource is cached for every different value of the hint header.
 
-```plain
+```http
 Vary: Accept, Width, ECT
 ```
 
-You may prefer to omit specifying {{HTTPHeader("Vary")}} or use some other strategy for client hint headers where the value changes a lot, as this effectively makes the resource uncachable (a new cache entry is created for every different value). This applies in particular to network client hints like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}. For more information see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses).
+You may prefer to omit specifying {{HTTPHeader("Vary")}} or use some other strategy for client hint headers where the value changes a lot, as this effectively makes the resource uncachable (a new cache entry is created for every different value).
+This applies in particular to network client hints like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}.
+For more information see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses).
+
+
+## Hint life-time
+
+A server specifies the client hint headers that it is interested in getting in the `Accept-CH` response header.
+A user agent should append the requested client hints, that it wants to share with that server, to all subsequent requests.
+
+The same set of hints should be included with requests to the same site until the end of the session.
+In other words, the request for a specific set of hints does not expire until the browser is shut down.
+
+A server can replace the set of client hints it is interested in recieving by resending the `Accept-CH` response header with a new set of hints.
+If the server sent `Accept-CH` this would effectively indicate that it did not wish to recieve any hints (other than some of the low entropy [user agent client hints](#user-agent_client_hints) it gets by default).
+
+## Low entropy hints
+
+Client hints are broadly divided into high and low entropy hints.
+The low entropy hints are those that don't give away much information that might be used, for example, to identify a particular end user.
+These mayb be sent by default on every request, irrespective of the `Accept-CH` response header, depending on the permission policy.
+
+High entropy hints have the potential to give away more information and therefore are gated in such a way that the user agent can make a decision as to whether to provide them.
+The decision might be based on user preferences, a permission request, or the permission policy.
+
 
 ## Hint types
 
+### User-agent client hints
+
+User agent (UA) client hint headers allow a server to vary responses based on the user agent (browser) and their device.
+Headers include: {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Arch")}}, {{HTTPHeader("Sec-CH-UA-Bitness")}}, {{HTTPHeader("Sec-CH-UA-Full-Version")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Model")}}, and {{HTTPHeader("Sec-CH-UA-Platform")}}.
+<!-- {{HTTPHeader("Sec-CH-UA-Platform-Version")}} -->
+
+Client hints are available to web page Javascript via the [User Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API).
+
+> **Note:** Servers currently get most of the same information by parsing the {{HTTPHeader("User-Agent")}} header.
+> For historical reasons this header contains a lot of largely irrelevant information, and information that might be used to identify a _particular user_.
+> UA client hints provide a more efficient and privacy preserving way of getting the desired information: they are eventually expected to replace this older approach.
+
 ### Device client hints
 
-Device client hints allow a server to choose what information is sent based on the device characteristics including available memory and screen properties. Headers include: {{HTTPHeader("Device-Memory")}}, {{HTTPHeader("DPR")}}, {{HTTPHeader("Width")}}, {{HTTPHeader("Viewport-Width")}}.
+Device client hints allow a server to vary responses based on the device characteristics including available memory and screen properties.
+Headers include: {{HTTPHeader("Device-Memory")}}, {{HTTPHeader("DPR")}}, {{HTTPHeader("Width")}}, {{HTTPHeader("Viewport-Width")}}.
 
 ### Network client hints
 
-Network client hints allow a server to choose what information is sent based on the user choice and network bandwidth and latency. Headers include: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Downlink")}}, {{HTTPHeader("ECT")}}, {{HTTPHeader("RTT")}}.
+Network client hints allow a server to vary responses based on the users' choice, network bandwidth, and latency.
+Headers include: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Downlink")}}, {{HTTPHeader("ECT")}}, {{HTTPHeader("RTT")}}.
 
 ## See also
 
 - [Client Hints headers](/en-US/docs/Web/HTTP/Headers#client_hints)
 - [`Vary` HTTP Header](/en-US/docs/Web/HTTP/Headers/Vary)
 - [Client Hints Infrastructure](https://wicg.github.io/client-hints-infrastructure/)
+- [User Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -65,9 +65,9 @@ The low entropy hints are those that don't give away much information that might
 They may be sent by default on every client request, irrespective of the server `Accept-CH` response header, depending on the permission policy.
 These hints include: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}.
 
-All the other client hints are high entropy hints.
-These have the potential to give away more information that can be used for user fingerprinting, and therefore are gated in such a way that the user agent can make a decision as to whether to provide them.
+The high entropy hints are those that have the potential to give away more information that can be used for user fingerprinting, and therefore are gated in such a way that the user agent can make a decision as to whether to provide them.
 The decision might be based on user preferences, a permission request, or the permission policy.
+All client hints that are not low entropy hints are considered high entropy hints.
 
 
 ## Hint types

--- a/files/en-us/glossary/client_hints/index.md
+++ b/files/en-us/glossary/client_hints/index.md
@@ -27,9 +27,12 @@ Accept-CH: Width, Downlink, Sec-CH-UA
 This approach is efficient in that the server only requests the information that it is able to usefully handle.
 It is also relatively "privacy-preserving", in that it is up to the client to decide what information it can safely share.
 
+There is a small set of [low entropy client hint headers](#low_entropy_hints) that may be sent by a client event if not requested.
+
 > **Note:** Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) attribute.
->
->     <meta http-equiv="Accept-CH" content="Width, Downlink, Sec-CH-UA">
+> ```html
+> <meta http-equiv="Accept-CH" content="Width, Downlink, Sec-CH-UA">
+> ```
 
 ## Caching and Client Hints
 
@@ -47,21 +50,23 @@ For more information see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP
 ## Hint life-time
 
 A server specifies the client hint headers that it is interested in getting in the `Accept-CH` response header.
-A user agent should append the requested client hints, that it wants to share with that server, to all subsequent requests.
+The user agent should append the requested client hint headers, or at least the subset that it wants to share with that server, to all subsequent requests in the current browsing session.
 
-The same set of hints should be included with requests to the same site until the end of the session.
 In other words, the request for a specific set of hints does not expire until the browser is shut down.
 
 A server can replace the set of client hints it is interested in recieving by resending the `Accept-CH` response header with a new list.
-If the server sent `Accept-CH` this would effectively indicate that it did not wish to recieve any hints (other than the [low entropy hits](#low_entroy_hints) it gets by default).
+For example, to stop requesting any hints it would send `Accept-CH` with an empty list.
 
 ## Low entropy hints
 
 Client hints are broadly divided into high and low entropy hints.
-The low entropy hints are those that don't give away much information that might be used, for example, to identify a particular end user.
-These mayb be sent by default on every request, irrespective of the `Accept-CH` response header, depending on the permission policy.
 
-High entropy hints have the potential to give away more information and therefore are gated in such a way that the user agent can make a decision as to whether to provide them.
+The low entropy hints are: {{HTTPHeader("Save-Data")}}, {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}  .
+These are the hints that don't give away much information that might be used to "fingerprint" (identify) a particular end user.
+They may be sent by default on every client request, irrespective of the server `Accept-CH` response header, depending on the permission policy.
+
+All the other client hints are high entropy hints.
+These have the potential to give away more information that can be used for user fingerprinting, and therefore are gated in such a way that the user agent can make a decision as to whether to provide them.
 The decision might be based on user preferences, a permission request, or the permission policy.
 
 

--- a/files/en-us/web/api/user-agent_client_hints_api/index.md
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.md
@@ -16,7 +16,7 @@ The User-Agent Client Hints API extends [Client Hints](/en-US/docs/Glossary/Clie
 
 Parsing the User-Agent string has historically been the way to get information about the user's browser or device. A typical user agent string looks like the following example, identifying Chrome 92 on Windows:
 
-```html
+```
 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36
 ```
 
@@ -26,12 +26,14 @@ In order to decide what to return, the information accessed via this API is spli
 
 ### Use cases for User-Agent Client Hints
 
-The [User-Agent Client Hints Explainer]() explains some potential use cases for the API. These include:
+Potential use cases include:
 
 - Providing custom-tailored polyfills to users on identifying that their browser lacked some web platform feature.
 - Working around browser bugs.
 - Recording browser analytics.
-- Adapting content based on user-agent information. This includes serving different content to mobile devices, in particular devices identified as low-powered. It might also include adapting the design to tailor the interfaces to the user's OS, or providing links to OS-specific ones.
+- Adapting content based on user-agent information.
+  This includes serving different content to mobile devices, in particular devices identified as low-powered.
+  It might also include adapting the design to tailor the interfaces to the user's OS, or providing links to OS-specific ones.
 - Providing a notification when a user logs in from a different browser or device, as a security feature.
 - Providing the correct binary executable, on a site offering a download.
 - Collecting information about the browser and device to identify application errors.

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -35,17 +35,20 @@ should include in subsequent requests.
 </table>
 
 > **Note:** Client hints are accessible only on secure origins (via TLS).
-> `Accept-CH` (and `Accept-CH-Lifetime`) headers should be persisted for all secure requests
-> to ensure client hints are sent reliably.
+> `Accept-CH` (and `Accept-CH-Lifetime`) headers should be persisted for all secure requests to ensure client hints are sent reliably.
 
 ## Syntax
 
-    Accept-CH: <list of client hints>
+```http
+Accept-CH: <comma separated list of client hint headers>
+```
 
 ## Examples
 
-    Accept-CH: Viewport-Width, Width
-    Vary: Viewport-Width, Width
+```http
+Accept-CH: Viewport-Width, Width
+Vary: Viewport-Width, Width
+```
 
 > **Note:** Remember to [vary the response](/en-US/docs/Glossary/Client_hints#varying_client_hints)
 > based on the accepted client hints.

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -79,10 +79,34 @@ Servers proactively requests the client hint headers they are interested in from
 
 The different categories of client hints are listed below.
 
+### User agent client hints
+
+The UA client hints are request headers that provide information about the user agent and the platform/architecture on which it is running:
+
+- {{HTTPHeader("Sec-CH-UA")}} {{experimental_inline}}
+  - : User agent's branding and version.
+- {{HTTPHeader("Sec-CH-UA-Arch")}} {{experimental_inline}}
+  - : User agent's underlying platform architecture.
+- {{HTTPHeader("Sec-CH-UA-Bitness")}} {{experimental_inline}}
+  - : User agent's underlying CPU architecture bitness (for example "64" bit).
+- {{HTTPHeader("Sec-CH-UA-Full-Version")}} {{deprecated_inline}}
+  - : User agent's full semantic version string.
+- {{HTTPHeader("Sec-CH-UA-Full-Version-List")}} {{experimental_inline}}<!-- chrome intent to ship Nov 2021 -->
+  - : Full version for each brand in the user agent's brand list.
+- {{HTTPHeader("Sec-CH-UA-Mobile")}} {{experimental_inline}}
+  - : User agent is running on a mobile device or, more generally, prefers a "mobile" user experience.
+- {{HTTPHeader("Sec-CH-UA-Model")}} {{experimental_inline}}
+  - : User agent's device model.
+- {{HTTPHeader("Sec-CH-UA-Platform")}} {{experimental_inline}}
+  - : User agent's underlying operation system/platform.
+- {{HTTPHeader("Sec-CH-UA-Platform-Version")}} {{experimental_inline}}
+  - : User agent's underlying operation system version.
+ 
+
 ### Device client hints
 
 - {{HTTPHeader("Content-DPR")}} {{deprecated_inline}}{{experimental_inline}}
-  - : Response header used to confirm the image device to pixel ratio in requests where the {{HTTPHeader("DPR")}} client hint was used to select an image resource.
+  - : _Response header_ used to confirm the image device to pixel ratio in requests where the {{HTTPHeader("DPR")}} client hint was used to select an image resource.
 - {{HTTPHeader("Device-Memory")}} {{deprecated_inline}}{{experimental_inline}}
   - : Approximate amount of available client RAM memory. This is part of the [Device Memory API](/en-US/docs/Web/API/Device_Memory_API).
 - {{HTTPHeader("DPR")}} {{deprecated_inline}}{{experimental_inline}}
@@ -90,7 +114,7 @@ The different categories of client hints are listed below.
 - {{HTTPHeader("Viewport-Width")}} {{deprecated_inline}}{{experimental_inline}}
   - : A number that indicates the layout viewport width in CSS pixels. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).
 - {{HTTPHeader("Width")}} {{deprecated_inline}}{{experimental_inline}}
-  - : The `Width` request header field is a number that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image).
+  - : A number that indicates the desired resource width in physical pixels (i.e. intrinsic size of an image).
 
 ### Network client hints
 

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -1,0 +1,108 @@
+---
+title: Sec-CH-UA
+slug: Web/HTTP/Headers/Sec-CH-UA
+tags:
+  - Sec-CH-UA
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Headers#user_agent_client_hints) request header provides the user-agent's branding and significant version information.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+The **`Sec-CH-UA`** header provides the brand and significant version for each brand associated with the browser, in a comma-separated list.
+
+A brand is a commercial name for the user agent like: Chromium, Opera, Google Chrome, Microsoft Edge, Firefox, and Safari.
+A user agent might have several associated _brands_.
+For example, Opera, Chrome and Edge are all based on Chromium, and will provide both brands in the **`Sec-CH-UA`** header.
+
+The _significant version_ is the "marketing" version identifier that is used to distinguish between major releases of the brand.
+For example a Chromium build with _full version number_ "96.0.4664.45" might have significant version number of "96".
+
+The header therefore allows the server to customise its response based on both shared brands and on particular customisations in their respective versions.
+
+`Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+Unless blocked by a user agent permission policy, it is sent by default, without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}.
+
+The header may include "fake" brands in any position and with any name in the header.
+This is a feature designed to prevent servers from rejecting unknown user agents outright, forcing user agents to lie about their brand identity.
+
+
+> **Note:** {{HTTPHeader("Sec-CH-UA-Full-Version-List")}} is the same as **`Sec-CH-UA`**, but includes the full version number rather than the signficant version number for each brand.
+
+
+## Syntax
+
+A comma separated list of brands in the user agent brand list, and their associated significant version number.
+The syntax for single entry has the following format:
+
+```http
+Sec-CH-UA: "<brand>";v="<significant version>", ...
+```
+
+## Directives
+
+- `<brand>`
+  - : A brand associated with the user agent, like "Chromium", "Google Chrome".
+    This should also include "intentionally incorrect" brands like `"Not A;Brand"` to prevent servers blocking unknown browsers.
+- `<significant version>`
+  - : The "marketing" version number associated with distinguishable web-exposed features.
+    For example a Chromium build with full version number "96.0.4664.45" might have significant version number of "96".
+
+
+## Examples
+
+`Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+Unless explicitly blocked by a user agent policy, if support it will be sent in all requests, without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}.
+
+Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below. 
+Note that they all share the "Chromium" brand, but have an additional brand indicating their origin.
+They also have an intentionally incorrect brand string `" Not A;Brand"`, which may appear in any position and have different text.
+
+```http
+Sec-CH-UA: "(Not(A:Brand";v="8", "Chromium";v="98"
+```
+```http
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
+```
+```http
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Microsoft Edge";v="96"
+```
+```http
+Sec-CH-UA: "Opera";v="81", " Not;A Brand";v="99", "Chromium";v="95"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -35,17 +35,17 @@ The **`Sec-CH-UA`** header provides the brand and significant version for each b
 
 A brand is a commercial name for the user agent like: Chromium, Opera, Google Chrome, Microsoft Edge, Firefox, and Safari.
 A user agent might have several associated brands.
-For example, Opera, Chrome and Edge are all based on Chromium, and will provide both brands in the **`Sec-CH-UA`** header.
+For example, Opera, Chrome, and Edge are all based on Chromium, and will provide both brands in the **`Sec-CH-UA`** header.
 
 The _significant version_ is the "marketing" version identifier that is used to distinguish between major releases of the brand.
-For example a Chromium build with _full version number_ "96.0.4664.45" might have significant version number of "96".
+For example a Chromium build with _full version number_ "96.0.4664.45" has a significant version number of "96".
 
 The header therefore allows the server to customise its response based on both shared brands and on particular customisations in their respective versions.
 
 `Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
-Unless blocked by a user agent permission policy, it is sent by default, without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}.
+Unless blocked by a user agent permission policy, it is sent by default, without the server opting in by sending {{HTTPHeader("Accept-CH")}}.
 
-The header may include "fake" brands in any position and with any name in the header.
+The header may include "fake" brands in any position and with any name.
 This is a feature designed to prevent servers from rejecting unknown user agents outright, forcing user agents to lie about their brand identity.
 
 > **Note:** {{HTTPHeader("Sec-CH-UA-Full-Version-List")}} is the same as **`Sec-CH-UA`**, but includes the full version number rather than the signficant version number for each brand.

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -31,7 +31,7 @@ The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Headers#user_a
   </tbody>
 </table>
 
-The **`Sec-CH-UA`** header provides the brand and significant version for each brand associated with the browser, in a comma-separated list.
+The **`Sec-CH-UA`** header provides the brand and significant version for each brand associated with the browser in a comma-separated list.
 
 A brand is a commercial name for the user agent like: Chromium, Opera, Google Chrome, Microsoft Edge, Firefox, and Safari.
 A user agent might have several associated brands.
@@ -48,14 +48,12 @@ Unless blocked by a user agent permission policy, it is sent by default, without
 The header may include "fake" brands in any position and with any name in the header.
 This is a feature designed to prevent servers from rejecting unknown user agents outright, forcing user agents to lie about their brand identity.
 
-
 > **Note:** {{HTTPHeader("Sec-CH-UA-Full-Version-List")}} is the same as **`Sec-CH-UA`**, but includes the full version number rather than the signficant version number for each brand.
-
 
 ## Syntax
 
 A comma separated list of brands in the user agent brand list, and their associated significant version number.
-The syntax for single entry has the following format:
+The syntax for a single entry has the following format:
 
 ```http
 Sec-CH-UA: "<brand>";v="<significant version>", ...
@@ -72,7 +70,7 @@ Sec-CH-UA: "<brand>";v="<significant version>", ...
 ## Examples
 
 `Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
-Unless explicitly blocked by a user agent policy, if support it will be sent in all requests, without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}.
+Unless explicitly blocked by a user agent policy, and if supported it will be sent in all requests, without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}.
 
 Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below. 
 Note that they all share the "Chromium" brand, but have an additional brand indicating their origin.

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -34,7 +34,7 @@ The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Headers#user_a
 The **`Sec-CH-UA`** header provides the brand and significant version for each brand associated with the browser, in a comma-separated list.
 
 A brand is a commercial name for the user agent like: Chromium, Opera, Google Chrome, Microsoft Edge, Firefox, and Safari.
-A user agent might have several associated _brands_.
+A user agent might have several associated brands.
 For example, Opera, Chrome and Edge are all based on Chromium, and will provide both brands in the **`Sec-CH-UA`** header.
 
 The _significant version_ is the "marketing" version identifier that is used to distinguish between major releases of the brand.
@@ -64,11 +64,9 @@ Sec-CH-UA: "<brand>";v="<significant version>", ...
 ## Directives
 
 - `<brand>`
-  - : A brand associated with the user agent, like "Chromium", "Google Chrome".
-    This should also include "intentionally incorrect" brands like `"Not A;Brand"` to prevent servers blocking unknown browsers.
+  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `"Not A;Brand"`.
 - `<significant version>`
   - : The "marketing" version number associated with distinguishable web-exposed features.
-    For example a Chromium build with full version number "96.0.4664.45" might have significant version number of "96".
 
 
 ## Examples
@@ -78,7 +76,7 @@ Unless explicitly blocked by a user agent policy, if support it will be sent in 
 
 Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below. 
 Note that they all share the "Chromium" brand, but have an additional brand indicating their origin.
-They also have an intentionally incorrect brand string `" Not A;Brand"`, which may appear in any position and have different text.
+They also have an intentionally incorrect brand string, which may appear in any position and have different text.
 
 ```http
 Sec-CH-UA: "(Not(A:Brand";v="8", "Chromium";v="98"


### PR DESCRIPTION
This PR follows on from adding most of the UA hints to BCD in https://github.com/mdn/browser-compat-data/pull/11235

- updates the client hints glossary page with user agent client hints (this is the overview page for all client hints on MDN). It also cross links to https://web.dev/user-agent-client-hints/ and also added sections on low latency hints, hint lifetime. 
- Adds the user agent client hints to [HTTP/Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers)
- Adds `Sec-CH-UA` page
- Other pages to follow, but that should not block this merging.
