### PR TITLE
Remove EXLskills

### DIFF
--- a/files/en-us/learn/javascript/index.md
+++ b/files/en-us/learn/javascript/index.md
@@ -64,7 +64,5 @@ This topic contains the following modules, in a suggested order for working thro
   - : The main entry point for core JavaScript documentation on MDN — this is where you'll find extensive reference docs on all aspects of the JavaScript language, and some advanced tutorials aimed at experienced JavaScripters.
 - [Learn JavaScript](https://learnjavascript.online/)
   - : An excellent resource for aspiring web developers — Learn JavaScript in an interactive environment, with short lessons and interactive tests, guided by automated assessment. The first 40 lessons are free, and the complete course is available for a small one-time payment.
-- [JavaScript Fundamentals on EXLskills](https://exlskills.com/learn-en/courses/javascript-fundamentals-basics_javascript)
-  - : Learn JavaScript for free with the EXLskills open-source course that introduces all you need to get started building applications in JS.
 - [Coding math](https://www.youtube.com/user/codingmath)
   - : An excellent series of video tutorials to teach the math you need to understand to be an effective programmer, by [Keith Peters](https://twitter.com/bit101).


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removed mention of EXLskills

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The site is suspicious (selling coins, default login with mobile number) and broken (buttons don't work, buggy error messages).
You can't even complete courses, so I guess the "certificate" is impossible to get.
Their GitHub wasn't updated in over 1.5 years, as well.
Plus they make it hard to find any information on who is actually behind this.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Link to EXLskills's GitHub:
https://github.com/exlskills/course-javascript-basics

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
