### PR TITLE
"Document: drag event":  example text selection for Firefox users

### DIFF
--- a/files/en-us/web/api/document/drag_event/index.md
+++ b/files/en-us/web/api/document/drag_event/index.md
@@ -65,7 +65,8 @@ See this code in a [JSFiddle demo](https://jsfiddle.net/zfnj5rv4/) or interact w
 
 ```css
 body {
-  user-select: none; /*Prevent the text from getting selectable for Firefox users*/
+  /* Prevent the user selecting text in the example */
+  user-select: none;
 }
 
 #draggable {

--- a/files/en-us/web/api/document/drag_event/index.md
+++ b/files/en-us/web/api/document/drag_event/index.md
@@ -64,6 +64,10 @@ See this code in a [JSFiddle demo](https://jsfiddle.net/zfnj5rv4/) or interact w
 ### CSS
 
 ```css
+body {
+  user-select: none; /*Prevent the text from getting selectable for Firefox users*/
+}
+
 #draggable {
   width: 200px;
   height: 20px;
@@ -85,9 +89,6 @@ See this code in a [JSFiddle demo](https://jsfiddle.net/zfnj5rv4/) or interact w
 ```js
 var dragged;
 
-//Prevent the text from getting selectable for Firefox users
-  document.body.style.MozUserSelect="none"
-  
 /* events fired on the draggable target */
 document.addEventListener("drag", function(event) {
 

--- a/files/en-us/web/api/document/drag_event/index.md
+++ b/files/en-us/web/api/document/drag_event/index.md
@@ -85,6 +85,9 @@ See this code in a [JSFiddle demo](https://jsfiddle.net/zfnj5rv4/) or interact w
 ```js
 var dragged;
 
+//Prevent the text from getting selectable for Firefox users
+  document.body.style.MozUserSelect="none"
+  
 /* events fired on the draggable target */
 document.addEventListener("drag", function(event) {
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
"Document: drag event":  example  section Text was getting selected and getting dragged with the <div> for Firefox users
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Added a specific check for `MozUsers` to prevent the Text Selection while performing drag event.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes [2941](https://github.com/mdn/content/issues/2941)
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
