### PR TITLE
Fix examples so they (should) work with empty id argument

### DIFF
--- a/files/en-us/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/distant_example/index.md
+++ b/files/en-us/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/distant_example/index.md
@@ -56,6 +56,6 @@ document.addEventListener('click', function (e) {
 });
 ```
 
-## Live result
+### Result
 
-{{EmbedLiveSample('The_example', 120, 120)}}
+{{EmbedLiveSample('', 120, 120)}}

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/example/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/example/index.md
@@ -11,11 +11,11 @@ tags:
 ---
 {{CanvasSidebar}}
 
-This sample program demonstrates a number of [compositing operations](/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation). The output looks like this:
-
-{{EmbedLiveSample("Compositing_example", "100%", 7250)}}
+This sample program demonstrates a number of [compositing operations](/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation).
 
 ## Compositing example
+
+{{EmbedLiveSample("Compositing_example", "100%", 7250)}}
 
 This code sets up the global values used by the rest of the program.
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
@@ -32,11 +32,11 @@ The `z-index` property can be specified with an integer value (positive, zero, o
 > - When no `z-index` property is specified, elements are rendered on the default rendering layer 0 (zero).
 > - If several elements share the same `z-index` value (i.e., they are placed on the same layer), stacking rules explained in the section [Stacking without the z-index property](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index) apply.
 
+## Example
+
 In the following example, the layers' stacking order is rearranged using `z-index`. The `z-index` of element #5 has no effect since it is not a positioned element.
 
-{{EmbedLiveSample("Source_code_for_the_example", 600, 400)}}
-
-## Source code for the example
+{{EmbedLiveSample("Example", 600, 400)}}
 
 ### HTML
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
@@ -20,7 +20,9 @@ For floated blocks, the stacking order is a bit different. Floating blocks are p
 
 See [types of positioning](/en-US/docs/Web/CSS/position#types_of_positioning) for an explanation of positioned and non-positioned elements.
 
-Actually, as you can see in the example below, the background and border of the non-positioned block (DIV #4) is completely unaffected by floating blocks, but the content is affected. This happens according to standard float behavior. This behavior can be shown with an added rule to the above list:
+## Example
+
+As you can see in the example below, the background and border of the non-positioned block (DIV #4) is completely unaffected by floating blocks, but the content is affected. This happens according to standard float behavior. This behavior can be shown with an added rule to the above list:
 
 1.  The background and borders of the root element
 2.  Descendant non-positioned blocks, in order of appearance in the HTML
@@ -28,11 +30,9 @@ Actually, as you can see in the example below, the background and border of the 
 4.  _Descendant non-positioned inline elements_
 5.  Descendant positioned elements, in order of appearance in the HTML
 
-{{EmbedLiveSample("Source_code_for_the_example", 600, 250)}}
-
 > **Note:** If an `opacity` value is applied to the non-positioned block (DIV #4), then something strange happens: the background and border of that block pops up above the floating blocks and the positioned blocks. This is due to a peculiar part of the specification: applying a `opacity` value creates a new stacking context (see [What No One Told You About Z-Index](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/)).
 
-## Source code for the example
+{{EmbedLiveSample("Example", 600, 250)}}
 
 ### HTML
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
@@ -21,11 +21,11 @@ See [types of positioning](/en-US/docs/Web/CSS/position#types_of_positioning) fo
 
 Keep in mind, when the {{cssxref("order")}} property alters rendering from the "order of appearance in the HTML" within {{cssxref("flex")}} containers, it similarly affects the order for stacking context.
 
+## Example
+
 In the example below, elements #1 through #4 are positioned elements. Element #5 is static, and so is drawn below the other four elements, even though it comes later in the HTML markup.
 
-{{EmbedLiveSample("Source_code_for_the_example", 600, 400)}}
-
-## Source code for the example
+{{EmbedLiveSample("Example", 600, 400)}}
 
 ### HTML
 

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -19,7 +19,11 @@ A related attribute, {{htmlattrxref("itemtype")}}, is used to specify the valid 
 
 Every HTML element may have an `itemscope` attribute specified. An `itemscope` element that does not have an associated `itemtype` must have an associated `itemref`.
 
+When you specify the `itemscope` attribute for an element, a new item is created. The item consists of a group of name-value pairs. For elements with an `itemscope` attribute and an `itemtype` attribute, you may also specify an {{htmlattrxref("id")}} attribute. You can use the `id` attribute to set a global identifier for the new item. A global identifier allows the item to relate to other items found on pages across the Web.
+
 > **Note:** Find more about `itemtype` attributes at <http://schema.org/Thing>
+
+## Examples
 
 ### Simple example
 
@@ -75,13 +79,11 @@ The following table shows the structured data from the preceding example.
   </tbody>
 </table>
 
-### itemscope id attributes
-
-When you specify the `itemscope` attribute for an element, a new item is created. The item consists of a group of name-value pairs. For elements with an `itemscope` attribute and an `itemtype` attribute, you may also specify an {{htmlattrxref("id")}} attribute. You can use the `id` attribute to set a global identifier for the new item. A global identifier allows the item to relate to other items found on pages across the Web.
-
-### Example
+### Recipe example
 
 There are four `itemscope` attributes in the following example. Each `itemscope` attribute sets the scope of its corresponding `itemtype` attribute. The `itemtype`s, `Recipe`, `AggregateRating`, and `NutritionInformation` in the following example are part of the [schema.org](www.schema.org) structured data for a recipe, as specified by the first `itemtype`, http\://schema.org/Recipe.
+
+#### HTML
 
 ```html
 <div itemscope itemtype="http://schema.org/Recipe">
@@ -125,13 +127,11 @@ There are four `itemscope` attributes in the following example. Each `itemscope`
 </div>
 ```
 
-### Results
-
-#### HTML
+#### Result
 
 The following is an example rendering of the preceding code example.
 
-{{EmbedLiveSample('Example', '500', '550', '', 'Web/HTML/Global_attributes/itemscope')}}
+{{EmbedLiveSample('', '500', '550', '', 'Web/HTML/Global_attributes/itemscope')}}
 
 #### Structured data
 


### PR DESCRIPTION
This is motivated by @SphinxKnight 's https://github.com/mdn/yari/issues/4971#issuecomment-978198406, in which he tried removing the id argument to `EmbedLiveSample` and found that 8 pages broke.

This is an attempt to fix those 8 pages. However it looks like the new algorithm has at least one bug in it, which means we can't finish this off. But this PR at least fixes some of the pages, and tries to detail the remaining problems.

@SphinxKnight listed these pages as one that give us an error when the argument is removed:

http://developer.mozilla.org/en-us/docs/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/distant_example
http://developer.mozilla.org/en-us/docs/web/html/global_attributes/itemscope
http://developer.mozilla.org/en-us/docs/web/html/element/input/date
http://developer.mozilla.org/en-us/docs/web/html/element/input/month
http://developer.mozilla.org/en-us/docs/web/css/css_positioning/understanding_z_index/adding_z-index
http://developer.mozilla.org/en-us/docs/web/css/css_positioning/understanding_z_index/stacking_and_float
http://developer.mozilla.org/en-us/docs/web/css/css_positioning/understanding_z_index/stacking_without_z-index
http://developer.mozilla.org/en-us/docs/web/api/canvas_api/tutorial/compositing/example

* [mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/distant_example](http://developer.mozilla.org/en-us/docs/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/distant_example): this is a simple case where the macro call was under its own H2, so was outside the section where the code blocks are. Simple fix is to bump the macro call's H2 to an H3.

* [web/html/global_attributes/itemscope](http://developer.mozilla.org/en-us/docs/web/html/global_attributes/itemscope): this page was in a bit of a mess generally, I straightened out the headings and it works. **But** when I remove the id argument, it looks like the treatment of whitespace in the example has changed, so instead of:

<img width="343" alt="Screen Shot 2021-11-24 at 5 17 32 PM" src="https://user-images.githubusercontent.com/432915/143334820-c05b242e-bd62-491a-b3c7-ba94344d1c11.png">

... we get:

<img width="343" alt="Screen Shot 2021-11-24 at 5 17 43 PM" src="https://user-images.githubusercontent.com/432915/143334839-11d505e2-aaba-4096-a5c7-5411a1792db9.png">

I don't understand why this is happening and it is worrying, because this will pass any tests we write but not look good.

* [web/html/element/input/date](http://developer.mozilla.org/en-us/docs/web/html/element/input/date)
* [web/html/element/input/month](http://developer.mozilla.org/en-us/docs/web/html/element/input/month): these ought to work as is but don't because of a bug. They have a structure like:

```
H2 Examples
(some prose)
{{EmbedLiveSample}}

H3 HTML
(the HTML source)

H3 JavaScript
(the JS source)
```

According to the spec this ought to work, but it doesn't - I guess the algorithm isn't looking for code blocks in subsections inside the section where the macro call is.

* [web/css/css_positioning/understanding_z_index/adding_z-index](http://developer.mozilla.org/en-us/docs/web/css/css_positioning/understanding_z_index/adding_z-index)
* [web/css/css_positioning/understanding_z_index/stacking_and_float](http://developer.mozilla.org/en-us/docs/web/css/css_positioning/understanding_z_index/stacking_and_float)
* [web/css/css_positioning/understanding_z_index/stacking_without_z-index](http://developer.mozilla.org/en-us/docs/web/css/css_positioning/understanding_z_index/stacking_without_z-index)
* [web/api/canvas_api/tutorial/compositing/example](http://developer.mozilla.org/en-us/docs/web/api/canvas_api/tutorial/compositing/example)
I have fixed these four so they ought to work with the new algorithm, but they won't because of the same but that affects the `<input>` pages.