### PR TITLE
Don't use a warning telling people to use addEventListener

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -14,7 +14,7 @@ sets up a function that will be called whenever the specified event is delivered
 Common targets are {{domxref("Element")}}, or its children, {{domxref("Document")}}, and {{domxref("Window")}},
 but the target may be any object that supports events (such as {{domxref("XMLHttpRequest")}}).
 
-> **Warning:** The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
+> **Note:** The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
 > - It allows adding more than one handler for an event. This is particularly
 >   useful for libraries, JavaScript modules, or any other kind of
 >   code that needs to work well with other libraries or extensions.


### PR DESCRIPTION
The [`addEventListener` page](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) has a warning telling people that this is the preferred way to listen for events. It seems weird to use a warning for this, when a warning is usually telling you *not* to do something.

I've changed it to a note. Personally I would just make this prose, and I will make that change here if you like. But people seem to like using notes, so I have done the simple thing here.
