### PR TITLE
Automating needs triage for new issues

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -9,11 +9,8 @@ on:
 jobs:
   label-new-issues:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - name: initial labelling
         uses: andymckay/labeler@master
         with:
           add-labels: "needs-triage"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -1,0 +1,19 @@
+name: 'Mark new issues with needs-triage label'
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label-new-issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: initial labelling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "needs-triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -7,7 +7,7 @@ on:
       - opened
 
 jobs:
-  label-new-issues
+  label-new-issues:
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Adding a workflow to add the `needs-triage` label automatically to new issues

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Followed https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
