### PR TITLE
Update for the bubbling and capturing example

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -652,10 +652,11 @@ function phase(evt) {
     log(evtPhasestr[evt.eventPhase] + this.firstChild.nodeValue.trim());
 }
 function gphase(evt) {
-    log(evtPhasestr[evt.eventPhase] + evt.currentTarget)
+    log(evtPhasestr[evt.eventPhase] + evt.currentTarget.toString().slice(8,-1));
 }
 
-function clearOutput() {
+function clearOutput(evt) {
+    evt.stopPropagation();
     logElement.innerHTML = "";
 }
 


### PR DESCRIPTION
Minor changes to the "event phases" example code in the "Bubbling and capturing explained" section. The aim was to clear persistent messages relating to the bubbling phases of the window and the HTML document objects when the "clear output" button was clicked.

I added "evt" as an argument to the clearOutput() function and "evt.stopPropagation()" to the function's body.
This prevents window and HTML document events from bubbling up after the "clear output" button is clicked; the log text will then be fully cleared when the button is clicked.

I have also added some string formatting - chaining ".toString().slice(8,-1)" onto "evt.currentTarget" to tidy the output of the gphase() function - this removes "[ object" and "]" from the output text; so "BUBBLING PHASE: [object Window]" becomes "BUBBLING PHASE: Window".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Used evt.stopPropagation to prevent persistent messages appearing in the "event phases" example in the "Bubbling and capturing explained" section.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Because IMO the "clear output" button in the example does not quite work correctly: it should remove all text, but currently two "BUBBLING PHASE" lines reappear after the text is cleared by the button's event handler.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I investigated this in a live example - see https://johnrjervis.github.io/bubbling-and-capture/

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #10773  - I submitted this as an issue earlier today. Thanks to @wbamberg for explaining how the live examples work and encouraging me to submit a PR.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
