### PR TITLE
Clipboard can only be used in a secure context

### DIFF
--- a/files/en-us/web/api/clipboard/index.md
+++ b/files/en-us/web/api/clipboard/index.md
@@ -15,7 +15,7 @@ tags:
   - paste
 browser-compat: api.Clipboard
 ---
-{{APIRef("Clipboard API")}}
+{{APIRef("Clipboard API")}} {{SecureContext_Header}}
 
 The **`Clipboard`** interface implements the [Clipboard API](/en-US/docs/Web/API/Clipboard_API), providing—if the user grants permission—both read and write access to the contents of the system clipboard. The Clipboard API can be used to implement cut, copy, and paste features within a web application.
 


### PR DESCRIPTION
Fixes #10741

Clipboard can only be used in a secure context. This adds the appropriate header to the API page as per [the guidance on the secure context header](https://developer.mozilla.org/en-US/docs/MDN/Structures/Macros/Commonly-used_macros#page_or_section_header_indicators).