### PR TITLE
Add WebAuthn demo sites to their own section

### DIFF
--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -110,6 +110,16 @@ After this, the registration steps are:
 
 ## Examples
 
+### Demo sites
+
+- [Mozilla Demo](https://webauthn.bin.coffee/) website and its [source code](https://github.com/jcjones/webauthn.bin.coffee).
+- [Google Demo](https://webauthndemo.appspot.com/) website and its [source code](https://github.com/google/webauthndemo).
+- [https://webauthn.io/ Demo](https://github.com/duo-labs/webauthn.io) website and its [source code](https://github.com/duo-labs/webauthn.io).
+- [github.com/webauthn-open-source](https://github.com/webauthn-open-source) and its [client source code](https://github.com/webauthn-open-source/webauthn-simple-app) and [server source code](https://github.com/webauthn-open-source/fido2-lib)
+- [OWASP Single Sign-On](https://owasp.org/www-project-sso/)
+
+### Usage example
+
 > **Warning:** For security reasons, web authentication calls ({{domxref('CredentialsContainer.create','create()')}} and {{domxref('CredentialsContainer.get','get()')}}) are cancelled if the browser window loses focus while the call is pending.
 
 ```js
@@ -178,12 +188,6 @@ navigator.credentials.create(createCredentialDefaultArgs)
         console.log("ERROR", err);
     });
 ```
-
-- [Mozilla Demo](https://webauthn.bin.coffee/) website and its [source code](https://github.com/jcjones/webauthn.bin.coffee).
-- [Google Demo](https://webauthndemo.appspot.com/) website and its [source code](https://github.com/google/webauthndemo).
-- [https://webauthn.io/ Demo](https://github.com/duo-labs/webauthn.io) website and its [source code](https://github.com/duo-labs/webauthn.io).
-- [github.com/webauthn-open-source](https://github.com/webauthn-open-source) and its [client source code](https://github.com/webauthn-open-source/webauthn-simple-app) and [server source code](https://github.com/webauthn-open-source/fido2-lib)
-- [OWASP Single Sign-On](https://owasp.org/www-project-sso/)
 
 ## Specifications
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/pull/10721, which just puts the demo links in their own section, rather than under the example.