### PR TITLE
Fix a comment in Unicode property escapes docs

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
@@ -107,7 +107,7 @@ If a character is used in a limited set of scripts, the `Script` property will o
 // it can also be written in the Thaana script
 
 "٢".match(/\p{Script=Thaana}/u);
-// null as Thaana is not the predominant script        super()
+// null as Thaana is not the predominant script
 
 "٢".match(/\p{Script_Extensions=Thaana}/u);
 // ["٢", index: 0, input: "٢", groups: undefined]


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix a comment in Unicode property escapes docs.

#### Motivation
Part of the comment is redundant.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
