### PR TITLE
Remove non-existent links in Document.activeElement docs

### DIFF
--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -18,8 +18,7 @@ of the {{domxref("Document")}} interface returns the {{domxref("Element")}} with
 
 Often `activeElement` will return a {{domxref("HTMLInputElement")}} or
 {{domxref("HTMLTextAreaElement")}} object if it has the text selection at the time. If
-so, you can get more detail by using the object's {{domxref("Document.selectionStart",
-  "selectionStart")}} and {{domxref("Document.selectionEnd", "selectionEnd")}} properties.
+so, you can get more detail by using the object's `selectionStart` and `selectionEnd` properties.
 Other times the focused element might be a {{HTMLElement("select")}} element (menu) or
 an {{HTMLElement("input")}} element, of `type` `"button"`,
 `"checkbox"`, or `"radio"`.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace non-existent `selectionStart` and `selectionEnd` links with code sections in Document.activeElement docs.

#### Motivation
The links don't work, and related docs also mark the properties as code: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
