### PR TITLE
Matches example with original. Thanks @CEOehis

### DIFF
--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -47,7 +47,7 @@ We already met this in the previous article.
 
 > **Warning:** It's strictly forbidden to nest a form inside another form. Nesting can cause forms to behave in an unpredictable manner, so it is a bad idea.
 
-It's always possible to use a form control outside of a {{HTMLElement("form")}} element. If you do so, by default that control has nothing to do with any form unless you associate it with a form using the [`form`](/en-US/docs/Web/HTML/Attributes/form) attribute. This was introduced to let you explicitly bind a control with a form even if it is not nested inside it.
+It's always possible to use a form control outside of a {{HTMLElement("form")}} element. If you do so, by default that control has nothing to do with any form unless you associate it with a form using its [`form`](/en-US/docs/Web/HTML/Element/input#attr-form) attribute. This was introduced to let you explicitly bind a control with a form even if it is not nested inside it.
 
 Let's move forward and cover the structural elements you'll find nested in a form.
 

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -140,20 +140,20 @@ Let's consider this example:
 <p>Required fields are followed by <abbr title="required">*</abbr>.</p>
 
 <!-- So this: -->
-<div>
+<!--div>
   <label for="username">Name:</label>
   <input id="username" type="text" name="username">
   <label for="username"><abbr title="required" aria-label="required">*</abbr></label>
-</div>
+</div-->
 
 <!-- would be better done like this: -->
-<div>
+<!--div>
   <label for="username">
     <span>Name:</span>
     <input id="username" type="text" name="username">
     <abbr title="required" aria-label="required">*</abbr>
   </label>
-</div>
+</div-->
 
 <!-- But this is probably best: -->
 <div>


### PR DESCRIPTION
#### Summary
1. The [original example](https://github.com/mdn/learning-area/blob/main/html/forms/html-form-structure/required-labels.html) has just one with the `username` id. The others are commented. The following warning below the example also confirms this is how it should have been:-

>  don't test the example with 2 or 3 of the versions uncommented

2. The link [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-form) is not exactly right. But in the absence of a common page that serves them all, this is hopefully better.

#### Motivation
Low hanging :mango:

#### Supporting details
See the original example [here](https://github.com/mdn/learning-area/blob/main/html/forms/html-form-structure/required-labels.html)

#### Related issues
Fixes #9598

#### Metadata
- [x] Fixes a typo, bug, or other error