### PR TITLE
2x is missing in srcset

### DIFF
--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -118,7 +118,7 @@ displays while the 400-pixel version should be used for 2x displays.
 <div class="box">
   <img src="/en-us/web/html/element/img/clock-demo-200px.png"
        alt="Clock"
-       srcset="/en-us/web/html/element/img/clock-demo-200px.png 1x, /en-us/web/html/element/img/clock-demo-400px.png">
+       srcset="/en-us/web/html/element/img/clock-demo-200px.png 1x, /en-us/web/html/element/img/clock-demo-400px.png 2x">
 </div>
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Ad "2x" at the end of the srcset-value
#### Motivation
"2x" is missing in the srcset value at the end, otherwise it won't work. Also the live example on 
https://yari-demos.prod.mdn.mozit.cloud/en-US/docs/Web/API/HTMLImageElement/srcset/_sample_.Example.html
doesn't work because of the missing "2x" in the code. 
I tried in XCode Simulator with IPhone and Firefox Inspector in Responsiv Design Mode (DRP:2). As soon as I add the "2x" it works as expected.


#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

