### PR TITLE
Add load event-listener on window as per description

### DIFF
--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -151,12 +151,14 @@ The following code is run within a handler for the {{domxref("Window", "window")
 the URL selected by the browser from the `srcset`.
 
 ```js
-let box = document.querySelector(".box");
-let image = box.querySelector("img");
+window.addEventListener("load", () => {
+  let box = document.querySelector(".box");
+  let image = box.querySelector("img");
 
-let newElem = document.createElement("p");
-newElem.innerHTML = `Image: <code>${image.currentSrc}</code>`;
-box.appendChild(newElem);
+  let newElem = document.createElement("p");
+  newElem.innerHTML = `Image: <code>${image.currentSrc}</code>`;
+  box.appendChild(newElem);
+});
 ```
 
 ### Result


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added `load` eventlistener on `window` for the `JS` code in live sample.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
open-source
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The example doesn't seem to be retrieving the `currentSrc` in chromium browsers and there isn't a `load` event listener set-up on window as per the [description](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset#javascript)

I'm guessing it was there before and somehow got erased while conversion to markdown??
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Closes #10811 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
