### PR TITLE
Removes TODO, adds Syntax, fixes  #538 partially

### DIFF
--- a/files/en-us/web/api/element/scrollintoviewifneeded/index.md
+++ b/files/en-us/web/api/element/scrollintoviewifneeded/index.md
@@ -15,12 +15,14 @@ browser-compat: api.Element.scrollIntoViewIfNeeded
 The **`Element.scrollIntoViewIfNeeded()`** method scrolls the current element into the visible area of the browser window if it's not already within the visible area of the browser window. If the element is already within the visible area of the browser window, then no scrolling takes place. This method is a proprietary variation of the standard [`Element.scrollIntoView()`](/en-US/docs/Web/API/Element/scrollIntoView) method.
 
 ## Syntax
-
-TODO
+```js
+element.scrollIntoViewIfNeeded();
+element.scrollIntoViewIfNeeded(centerIfNeeded); // Boolean parameter
+```
 
 ### Parameters
 
-- _`opt_center`_
+- `centerIfNeeded` {{optional_inline}}
 
   - : Is an optional boolean value with a default of `true`:
 


### PR DESCRIPTION
#### Summary
The doc has a TODO, discovered via #538

#### Motivation
Low hanging :mango:

#### Supporting details
Polyfills, including [this one](https://stackoverflow.com/questions/11461724/scrollintoviewifneeded-for-ie7). Also changed the parameter to use a more appropriate name from the polyfills -  `centerIfNeeded`.

#### Related issues
Partially fixes #538 

#### Metadata
- [x] Fixes a typo, bug, or other error