### PR TITLE
Revise the "Logical AND (&&)" page

### DIFF
--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -14,8 +14,6 @@ browser-compat: javascript.operators.logical_and
 The logical AND (`&&`) operator (logical conjunction) for a set of {{jsxref("Boolean")}} operands will be `true` if and only if all the operands are `true`. Otherwise it will be `false`.
 
 More generally, the operator returns the value of the first {{Glossary("falsy")}} operand encountered when evaluating from left to right, or the value of the last operand if they are all {{Glossary("truthy")}}.
-It is typically used with {{jsxref("Boolean")}} (logical) values, in which case it returns a Boolean value.
-However, when the `&&` operator is used with non-Boolean values, it preserves the value of one of the specified operands and returns it as the original non-Boolean value.
 
 {{EmbedInteractiveExample("pages/js/expressions-logical-and.html", "shorter")}}
 
@@ -40,12 +38,12 @@ Examples of expressions that can be converted to false are:
 - empty string (`""` or `''` or ` `` `);
 - `undefined`.
 
-The AND operator preserves non-Boolean values and returns them as is:
+The AND operator preserves non-Boolean values and returns them as they are:
 
 ```js
-result = 0 && 1;   // result is assigned 0
-result = 2 && 0;   // result is assigned 0
-result = 1 && 4;   // result is assigned 4
+result = '' && 'foo';  // result is assigned '' (empty string)
+result = 2 && 0;       // result is assigned 0
+result = 'foo' && 4;       // result is assigned 4
 ```
 
 Even though the `&&` operator can be used with non-Boolean operands, it is still considered a boolean operator since its return value can always be 
@@ -81,9 +79,9 @@ console.log( A() && B() );
 The AND operator has a higher precedence than the OR operator, meaning the `&&` operator is executed before the `||` operator (see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
 
 ```js
-false || true && true             // evaluates `true && true` first, then the || finds and returns true
-true && (false || false)          // evaluates `(false || false)` first, then the && finds and returns false
-(2 == 3) || ((4 < 0) && (1 == 1))  // evaluates `((4 < 0) && (1 == 1))` first, becomes (2 == 3) || false, then returns false
+false || true && true              // returns true
+true && (false || false)           // returns false
+(2 == 3) || (4 < 0) && (1 == 1)  // returns false
 ```
 
 ## Examples

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -12,11 +12,10 @@ browser-compat: javascript.operators.logical_and
 {{jsSidebar("Operators")}}
 
 The logical AND (`&&`) operator (logical conjunction) for a set of
-operands is true if and only if all of its operands are true. It is typically used with
-{{jsxref("Boolean")}} (logical) values. When it is, it returns a Boolean value. However,
-the `&&` operator actually returns the value of one of the specified
-operands, so if this operator is used with non-Boolean values, it will return a
-non-Boolean value.
+operands is true if, and only if, all of its operands are true. It is typically used with
+{{jsxref("Boolean")}} (logical) values, in which case it returns a Boolean value. However,
+when the `&&` operator is used with non-Boolean values, it preserves the value of one of the 
+specified operands and returns it as the original non-Boolean value.
 
 {{EmbedInteractiveExample("pages/js/expressions-logical-and.html", "shorter")}}
 
@@ -28,8 +27,9 @@ expr1 && expr2
 
 ## Description
 
-If `expr1` can be converted to `true`, returns
-`expr2`; else, returns `expr1`.
+Logical AND (`&&`) evaluates operands from left to right, converts each to a 
+Boolean, then returns the first falsy value found; if all values are truthy, 
+the last value is returned.
 
 If a value can be converted to `true`, the value is so-called
 {{Glossary("truthy")}}. If a value can be converted to `false`, the value is
@@ -43,46 +43,55 @@ Examples of expressions that can be converted to false are:
 - empty string (`""` or `''` or ` `` `);
 - `undefined`.
 
+Some examples of the AND operator used with non-Boolean values:
+```js
+false || true && true             // evaluates `true && true` first, then the || finds and returns true
+true && (false || false)          // evaluates `(false || false)` first, then the && finds and returns false
+(2 == 3) || (4 < 0) && (1 == 1))  // evaluates `(4 < 0) && (1 == 1))` first, becomes (2 == 3) || false, then returns false
+```
+
 Even though the `&&` operator can be used with operands that are not
 Boolean values, it can still be considered a boolean operator since its return value can
 always be converted to a [boolean primitive](/en-US/docs/Web/JavaScript/Data_structures#Boolean_type).
 To explicitly convert its return value (or any expression in general) to the
-corresponding boolean value, use a double [NOT
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT) or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}}
-constructor.
+corresponding boolean value, use a double [`NOT operator`](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT) or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}} constructor.
 
 ### Short-circuit evaluation
 
-The logical AND expression is evaluated left to right, it is tested for possible
-"short-circuit" evaluation using the following rule:
+The logical AND expression is a short-circuit operator. As each operand is 
+converted to a boolean, if the result of one conversion is found to be `false`, 
+the AND operator stops and returns the original value of that falsy operand; it 
+does **not** evaluate any of the remaining operands:
 
 `(some falsy expression) && expr` is short-circuit
 evaluated to the falsy expression;
 
-Short circuit means that the `expr` part above is **not
-evaluated**, hence any side effects of doing so do not take effect (e.g., if
-`expr` is a function call, the calling never takes place). This
-happens because the value of the operator is already determined after the evaluation of
-the first operand. See example:
+Due to short-circuiting, the `expr` part above is **never evaluated**, 
+meaning any side effects of doing so won't occur (e.g., if `expr` is a 
+function call, the calling never takes place). This happens because the
+first operand evaluated is converted to `false`, which turns the final value 
+of the AND operator into `(some falsy expression)` if it's non-Boolean, or 
+`false` if it's a Boolean. See the example below:
 
 ```js
-function A(){ console.log('called A'); return false; }
-function B(){ console.log('called B'); return true; }
+function A() { console.log('called A'); return false; }
+function B() { console.log('called B'); return true; }
 
 console.log( A() && B() );
-// logs "called A" due to the function call,
-// then logs false (which is the resulting value of the operator)
+// logs "called A" to the console due to the call for function A,
+// && evaluates to false (function A returns false), then false is logged to the console;
+// the AND operator short-circuits here and ignores function B
 ```
 
 ### Operator precedence
 
-The following expressions might seem equivalent, but they are not, because the
-`&&` operator is executed before the `||` operator (see [operator
-precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
+The AND operator has a higher precedence than the OR operator, meaning the `&&` 
+operator is executed before the `||` operator (see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
 
 ```js
-true || false && false      // returns true, because && is executed first
-(true || false) && false    // returns false, because operator precedence cannot apply
+false || true && true             // evaluates `true && true` first, then the || finds and returns true
+true && (false || false)          // evaluates `(false || false)` first, then the && finds and returns false
+(2 == 3) || (4 < 0) && (1 == 1))  // evaluates `(4 < 0) && (1 == 1))` first, becomes (2 == 3) || false, then returns false
 ```
 
 ## Examples
@@ -137,7 +146,7 @@ is always equal to:
 ### Removing nested parentheses
 
 As logical expressions are evaluated left to right, it is always possible to remove
-parentheses from a complex expression following some rules.
+parentheses from a complex expression provided that certain rules are followed.
 
 The following composite operation involving **booleans**:
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -53,15 +53,16 @@ To explicitly convert its return value (or any expression in general) to the cor
 ### Short-circuit evaluation
 
 The logical AND expression is a short-circuit operator.
-As each operand is converted to a boolean, if the result of one conversion is found to be `false`, the AND operator stops and returns the original value of that falsy operand; it does **not** evaluate any of the remaining operands:
+As each operand is converted to a boolean, if the result of one conversion is found to be `false`, the AND operator stops and returns the original value of that falsy operand; it does **not** evaluate any of the remaining operands.
+
+Consider the pseudo code below.
 
 ```
 (some falsy expression) && expr
 ```
 
-Due to short-circuiting, the `expr` part above is **never evaluated**, meaning any side effects of doing so won't occur (e.g., if `expr` is a function call, the calling never takes place). 
-This happens because the first operand evaluated is converted to `false`, which turns the final value of the AND operator into `(some falsy expression)` if it's non-Boolean, or 
-`false` if it's a Boolean.
+The `expr` part is **never evaluated** because the first operand `(some falsy expression)` is evaluated is `falsy`.
+If `expr` is a function, the function is never called.
 See the example below:
 
 ```js

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -11,11 +11,9 @@ browser-compat: javascript.operators.logical_and
 ---
 {{jsSidebar("Operators")}}
 
-The logical AND (`&&`) operator (logical conjunction) for a set of
-operands is true if, and only if, all of its operands are true. It is typically used with
-{{jsxref("Boolean")}} (logical) values, in which case it returns a Boolean value. However,
-when the `&&` operator is used with non-Boolean values, it preserves the value of one of the 
-specified operands and returns it as the original non-Boolean value.
+The logical AND (`&&`) operator (logical conjunction) for a set of operands is true if, and only if, all of its operands are true.
+It is typically used with {{jsxref("Boolean")}} (logical) values, in which case it returns a Boolean value.
+However, when the `&&` operator is used with non-Boolean values, it preserves the value of one of the specified operands and returns it as the original non-Boolean value.
 
 {{EmbedInteractiveExample("pages/js/expressions-logical-and.html", "shorter")}}
 
@@ -27,13 +25,9 @@ expr1 && expr2
 
 ## Description
 
-Logical AND (`&&`) evaluates operands from left to right, converts each to a 
-Boolean, then returns the first falsy value found; if all values are truthy, 
-the last value is returned.
+Logical AND (`&&`) evaluates operands from left to right, converts each to a Boolean, then returns the first falsy value found; if all values are truthy, the last value is returned.
 
-If a value can be converted to `true`, the value is so-called
-{{Glossary("truthy")}}. If a value can be converted to `false`, the value is
-so-called {{Glossary("falsy")}}.
+If a value can be converted to `true`, the value is so-called {{Glossary("truthy")}}. If a value can be converted to `false`, the value is so-called {{Glossary("falsy")}}.
 
 Examples of expressions that can be converted to false are:
 
@@ -45,34 +39,30 @@ Examples of expressions that can be converted to false are:
 - `undefined`.
 
 The AND operator preserves non-Boolean values and returns them as is:
+
 ```js
 result = 0 && 1;   // result is assigned 0
 result = 2 && 0;   // result is assigned 0
 result = 1 && 4;   // result is assigned 4
 ```
 
-Even though the `&&` operator can be used with non-Boolean operands, it is 
-still considered a boolean operator since its return value can always be 
+Even though the `&&` operator can be used with non-Boolean operands, it is still considered a boolean operator since its return value can always be 
 converted to a [boolean primitive](/en-US/docs/Web/JavaScript/Data_structures#Boolean_type).
-To explicitly convert its return value (or any expression in general) to the
-corresponding boolean value, use a double [`NOT operator`](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT) or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}} constructor.
+To explicitly convert its return value (or any expression in general) to the corresponding boolean value, use a double [`NOT operator`](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT) or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}} constructor.
 
 ### Short-circuit evaluation
 
-The logical AND expression is a short-circuit operator. As each operand is 
-converted to a boolean, if the result of one conversion is found to be `false`, 
-the AND operator stops and returns the original value of that falsy operand; it 
-does **not** evaluate any of the remaining operands:
+The logical AND expression is a short-circuit operator.
+As each operand is converted to a boolean, if the result of one conversion is found to be `false`, the AND operator stops and returns the original value of that falsy operand; it does **not** evaluate any of the remaining operands:
 
-`(some falsy expression) && expr` is short-circuit
-evaluated to the falsy expression;
+```
+(some falsy expression) && expr
+```
 
-Due to short-circuiting, the `expr` part above is **never evaluated**, 
-meaning any side effects of doing so won't occur (e.g., if `expr` is a 
-function call, the calling never takes place). This happens because the
-first operand evaluated is converted to `false`, which turns the final value 
-of the AND operator into `(some falsy expression)` if it's non-Boolean, or 
-`false` if it's a Boolean. See the example below:
+Due to short-circuiting, the `expr` part above is **never evaluated**, meaning any side effects of doing so won't occur (e.g., if `expr` is a function call, the calling never takes place). 
+This happens because the first operand evaluated is converted to `false`, which turns the final value of the AND operator into `(some falsy expression)` if it's non-Boolean, or 
+`false` if it's a Boolean.
+See the example below:
 
 ```js
 function A() { console.log('called A'); return false; }
@@ -86,8 +76,7 @@ console.log( A() && B() );
 
 ### Operator precedence
 
-The AND operator has a higher precedence than the OR operator, meaning the `&&` 
-operator is executed before the `||` operator (see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
+The AND operator has a higher precedence than the OR operator, meaning the `&&` operator is executed before the `||` operator (see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
 
 ```js
 false || true && true             // evaluates `true && true` first, then the || finds and returns true
@@ -146,8 +135,7 @@ is always equal to:
 
 ### Removing nested parentheses
 
-As logical expressions are evaluated left to right, it is always possible to remove
-parentheses from a complex expression provided that certain rules are followed.
+As logical expressions are evaluated left to right, it is always possible to remove parentheses from a complex expression provided that certain rules are followed.
 
 The following composite operation involving **booleans**:
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -37,6 +37,7 @@ so-called {{Glossary("falsy")}}.
 
 Examples of expressions that can be converted to false are:
 
+- `false`;
 - `null`;
 - `NaN`;
 - `0`;
@@ -50,9 +51,9 @@ result = 2 && 0;   // result is assigned 0
 result = 1 && 4;   // result is assigned 4
 ```
 
-Even though the `&&` operator can be used with operands that are not
-Boolean values, it can still be considered a boolean operator since its return value can
-always be converted to a [boolean primitive](/en-US/docs/Web/JavaScript/Data_structures#Boolean_type).
+Even though the `&&` operator can be used with non-Boolean operands, it is 
+still considered a boolean operator since its return value can always be 
+converted to a [boolean primitive](/en-US/docs/Web/JavaScript/Data_structures#Boolean_type).
 To explicitly convert its return value (or any expression in general) to the
 corresponding boolean value, use a double [`NOT operator`](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT) or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}} constructor.
 
@@ -91,7 +92,7 @@ operator is executed before the `||` operator (see [operator precedence](/en-US/
 ```js
 false || true && true             // evaluates `true && true` first, then the || finds and returns true
 true && (false || false)          // evaluates `(false || false)` first, then the && finds and returns false
-(2 == 3) || (4 < 0) && (1 == 1))  // evaluates `(4 < 0) && (1 == 1))` first, becomes (2 == 3) || false, then returns false
+(2 == 3) || ((4 < 0) && (1 == 1))  // evaluates `((4 < 0) && (1 == 1))` first, becomes (2 == 3) || false, then returns false
 ```
 
 ## Examples

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -25,7 +25,7 @@ expr1 && expr2
 
 ## Description
 
-Logical AND (`&&`) evaluates operands from left to right, converts each to a Boolean, then returns the first falsy value found; if all values are truthy, the last value is returned.
+Logical AND (`&&`) evaluates operands from left to right, returning immediately with the value of the first {{Glossary("falsy")}} operand it encounters; if all values are {{Glossary("truthy")}}, the value of the last operand is returned.
 
 If a value can be converted to `true`, the value is so-called {{Glossary("truthy")}}. If a value can be converted to `false`, the value is so-called {{Glossary("falsy")}}.
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -43,11 +43,11 @@ Examples of expressions that can be converted to false are:
 - empty string (`""` or `''` or ` `` `);
 - `undefined`.
 
-Some examples of the AND operator used with non-Boolean values:
+The AND operator preserves non-Boolean values and returns them as is:
 ```js
-false || true && true             // evaluates `true && true` first, then the || finds and returns true
-true && (false || false)          // evaluates `(false || false)` first, then the && finds and returns false
-(2 == 3) || (4 < 0) && (1 == 1))  // evaluates `(4 < 0) && (1 == 1))` first, becomes (2 == 3) || false, then returns false
+result = 0 && 1;   // result is assigned 0
+result = 2 && 0;   // result is assigned 0
+result = 1 && 4;   // result is assigned 4
 ```
 
 Even though the `&&` operator can be used with operands that are not

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -11,7 +11,9 @@ browser-compat: javascript.operators.logical_and
 ---
 {{jsSidebar("Operators")}}
 
-The logical AND (`&&`) operator (logical conjunction) for a set of operands is true if, and only if, all of its operands are true.
+The logical AND (`&&`) operator (logical conjunction) for a set of {{jsxref("Boolean")}} operands will be `true` if and only if all the operands are `true`. Otherwise it will be `false`.
+
+More generally, the operator returns the value of the first {{Glossary("falsy")}} operand encountered when evaluating from left to right, or the value of the last operand if they are all {{Glossary("truthy")}}.
 It is typically used with {{jsxref("Boolean")}} (logical) values, in which case it returns a Boolean value.
 However, when the `&&` operator is used with non-Boolean values, it preserves the value of one of the specified operands and returns it as the original non-Boolean value.
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -41,9 +41,9 @@ Examples of expressions that can be converted to false are:
 The AND operator preserves non-Boolean values and returns them as they are:
 
 ```js
-result = '' && 'foo';  // result is assigned '' (empty string)
+result = '' && 'foo';  // result is assigned "" (empty string)
 result = 2 && 0;       // result is assigned 0
-result = 'foo' && 4;       // result is assigned 4
+result = 'foo' && 4;   // result is assigned 4
 ```
 
 Even though the `&&` operator can be used with non-Boolean operands, it is still considered a boolean operator since its return value can always be 
@@ -79,8 +79,8 @@ console.log( A() && B() );
 The AND operator has a higher precedence than the OR operator, meaning the `&&` operator is executed before the `||` operator (see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
 
 ```js
-false || true && true              // returns true
-true && (false || false)           // returns false
+false || true && true            // returns true
+true && (false || false)         // returns false
 (2 == 3) || (4 < 0) && (1 == 1)  // returns false
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Revised the documentation for "Logical AND (&&)" except for these sections: "Examples", "Conversion rules for booleans", and most of "Removing nested parentheses". Added, modified and replaced certain examples, and edited the link of the (double) NOT operator to directly lead to a page with explanations of said operator. 

(Just quickly adding that I’m new to contributions here so my formatting and style may not exactly fit the docs standards, but I looked through lots of pages for examples and did my best.)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Help make this page more beginner-friendly as per an issue, and make sure the && operator is well-explained in the MDN docs.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Read this article to ensure correctness of description: https://javascript.info/logical-operators#and

Read this answer to verify definition of short-circuit evaluation in programming: https://stackoverflow.com/questions/9344305/what-is-short-circuiting-and-how-is-it-used-when-programming-in-java

Created a repl to test some new examples that I created (html file is blank, only uses JS console): https://replit.com/join/jdytjlndrb-cw118

The text of the (double) NOT operator, which is not fully explained in the logical AND page, originally linked to a summary page that does not provide any information on the NOT or double NOT operators (and NOT is placed with the unary operators, not with the logical operators as one might expect at first): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#logical_not

The above link was replaced with the NOT operator documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #4218

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
