### PR TITLE
Remove mentions of removed moz* features of HTMLMediaElement

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -111,18 +111,8 @@ These properties are obsolete and should not be used, even if a browser still su
   - : A {{domxref("DOMString")}} that reflects the {{ htmlattrxref("mediagroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common {{domxref('MediaController')}}.
 - {{domxref("HTMLMediaElement.mozAudioCaptured")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}
   - : Returns a {{jsxref('Boolean')}}. Related to audio stream capture.
-- {{domxref("HTMLMediaElement.mozChannels")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}
-  - : Returns a `double` representing the number of channels in the audio resource (e.g., `2` for stereo).
 - {{domxref("HTMLMediaElement.mozFragmentEnd")}} {{non-standard_inline}} {{deprecated_inline}}
   - : Is a `double` that provides access to the fragment end time if the media element has a fragment URI for `currentSrc`, otherwise it is equal to the media duration.
-- {{domxref("HTMLMediaElement.mozFrameBufferLength")}} {{non-standard_inline}} {{deprecated_inline}}
-
-  - : Is a `unsigned long` that indicates the number of samples that will be returned in the framebuffer of each `MozAudioAvailable` event. This number is a total for all channels, and by default is set to be the number of channels \* 1024 (e.g., 2 channels \* 1024 samples = 2048 total).
-
-    The `mozFrameBufferLength` property can be set to a new value for lower latency, larger amounts of data, etc. The size given _must_ be a number between 512 and 16384. Using any other size results in an exception being thrown. The best time to set a new length is after the [loadedmetadata](/en-US/docs/Web/API/HTMLMediaElement/loadedmetadata_event) event fires, when the audio info is known, but before the audio has started or `MozAudioAvailable` events have begun firing.
-
-- {{domxref("HTMLMediaElement.mozSampleRate")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}
-  - : Returns a `double` representing the number of samples per second that will be played. For example, 44100 samples per second is the sample rate used by CD audio.
 
 ## Methods
 
@@ -159,8 +149,6 @@ _These methods are obsolete and should not be used, even if a browser still supp
   - : \[enter description]
 - {{domxref("HTMLMediaElement.mozGetMetadata()")}} {{non-standard_inline}} {{deprecated_inline}}
   - : Returns {{jsxref('Object')}}, which contains properties that represent metadata from the playing media resource as `{key: value}` pairs. A separate copy of the data is returned each time the method is called. This method must be called after the [loadedmetadata](/en-US/docs/Web/API/HTMLMediaElement/loadedmetadata_event) event fires.
-- {{domxref("HTMLMediaElement.mozLoadFrom()")}} {{non-standard_inline}} {{deprecated_inline}}
-  - : This method, available only in Mozilla's implementation, loads data from another media element. This works similarly to `load()` except that instead of running the normal resource selection algorithm, the source is set to the `other` element's `currentSrc`. This is optimized so this element gets access to all of the `other` element's cached and buffered data; in fact, the two elements share downloaded data, so data downloaded by either element is available to both.
 
 ## Events
 

--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -44,14 +44,6 @@ The `loadedmetadata` event is fired when the metadata has been loaded.
   </tbody>
 </table>
 
-## Additional Properties
-
-| Property                                        | Type | Description                                      |
-| ----------------------------------------------- | ---- | ------------------------------------------------ |
-| `mozChannels` {{readonlyInline}}          | int  | The number of channels.                          |
-| `mozSampleRate` {{readonlyInline}}        | int  | The sample rate per second.                      |
-| `mozFrameBufferLength` {{readonlyInline}} | int  | The number of samples collected in all channels. |
-
 ## Examples
 
 These examples add an event listener for the HTMLMediaElement's `loadedmetadata` event, then post a message when that event handler has reacted to the event firing.


### PR DESCRIPTION
BCD PR: https://github.com/mdn/browser-compat-data/pull/13794
