### PR TITLE
Simplify URLSearchParams examples

### DIFF
--- a/files/en-us/web/api/urlsearchparams/append/index.md
+++ b/files/en-us/web/api/urlsearchparams/append/index.md
@@ -40,7 +40,7 @@ Void.
 
 ```js
 let url = new URL('https://example.com?foo=1&bar=2');
-let params = new URLSearchParams(url.search.slice(1));
+let params = new URLSearchParams(url.search);
 
 //Add a second foo parameter.
 params.append('foo', 4);

--- a/files/en-us/web/api/urlsearchparams/get/index.md
+++ b/files/en-us/web/api/urlsearchparams/get/index.md
@@ -38,7 +38,7 @@ If the URL of your page is `https://example.com/?name=Jonathan&age=18`
 you could parse out the 'name' and 'age' parameters using:
 
 ```js
-let params = new URLSearchParams(document.location.search.substring(1));
+let params = new URLSearchParams(document.location.search);
 let name = params.get("name"); // is the string "Jonathan"
 let age = parseInt(params.get("age"), 10); // is the number 18
 ```

--- a/files/en-us/web/api/urlsearchparams/getall/index.md
+++ b/files/en-us/web/api/urlsearchparams/getall/index.md
@@ -35,7 +35,7 @@ An array of {{domxref("USVString")}}s.
 
 ```js
 let url = new URL('https://example.com?foo=1&bar=2');
-let params = new URLSearchParams(url.search.slice(1));
+let params = new URLSearchParams(url.search);
 
 //Add a second foo parameter.
 params.append('foo', 4);

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -36,7 +36,7 @@ A boolean value.
 
 ```js
 let url = new URL('https://example.com?foo=1&bar=2');
-let params = new URLSearchParams(url.search.slice(1));
+let params = new URLSearchParams(url.search);
 
 params.has('bar') === true; //true
 ```

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -40,7 +40,7 @@ search parameters have been set.)
 
 ```js
 let url = new URL('https://example.com?foo=1&bar=2');
-let params = new URLSearchParams(url.search.slice(1));
+let params = new URLSearchParams(url.search);
 
 //Add a second foo parameter.
 params.append('foo', 4);


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove the slicing/substringing out the question marks of `url.search` in `URLSearchParams` examples. This was unnecessary because the `URLSearchParams` constructor can deal with the leading question mark.

#### Motivation
Having the question mark explicitly removed in (some of) the examples can be confusing, readers may think it is a required step.

#### Supporting details
The [`URLSearchParams()` constructor documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams) specifically mentions how a leading `?` is ignored.

#### Related issues
n.a.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
