### PR TITLE
Remove Experimental Features note about about canShare() support

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1359,7 +1359,6 @@ The addition of a constructor to the {{domxref("CSSStyleSheet")}} interface as w
 ### WebShare API
 
 The [Web Share API](/en-US/docs/Web/API/Web_Share_API) allows sharing of files, URLs and other data from a site.
-Note that Firefox implements {{domxref("Navigator.share()")}} but not {{domxref("Navigator.canShare()")}} ({{bug(1666203)}}).
 
 <table>
   <thead>


### PR DESCRIPTION
FF96 adds support for canShare behind a preference. This removes the note about that method not being supported in Experimental features doc. It wasn't really necessary anyway, and now it is wrong.