### PR TITLE
Add a note about `htmlFor` that trips you when you want to set `for` on a `label`

### DIFF
--- a/files/en-us/web/api/htmllabelelement/index.md
+++ b/files/en-us/web/api/htmllabelelement/index.md
@@ -26,6 +26,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLLabelElement.htmlFor")}}
   - : Is a string containing the ID of the labeled control. This reflects the {{htmlattrxref("for", "label")}} attribute.
 
+> **Note:** To programmatically set the `for` attribute, use [`htmlFor`](/en-US/docs/Web/API/HTMLLabelElement/htmlFor).
+
 ## Methods
 
 _No specific methods; inherits methods from its parent, {{domxref("HTMLElement")}}._

--- a/files/en-us/web/html/element/label/index.md
+++ b/files/en-us/web/html/element/label/index.md
@@ -48,6 +48,8 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
   - : The value of the `for` attribute must be a single {{htmlattrxref("id")}} for a [labelable](/en-US/docs/Web/Guide/HTML/Content_categories#form_labelable) form-related element in the same document as the `<label>` element. So, any given `label` element can be associated with only one form control.
 
+    > **Note:** To programmatically set the `for` attribute, use [`htmlFor`](/en-US/docs/Web/API/HTMLLabelElement/htmlFor).
+  
     The first element in the document with an `id` attribute matching the value of the `for` attribute is the _labeled control_ for this `label` element — if the element with that `id` is actually a [labelable element](https://html.spec.whatwg.org/multipage/forms.html#category-label). If it is _not_ a labelable element, then the `for` attribute has no effect. If there are other elements that also match the `id` value, later in the document, they are not considered.
 
     Multiple `label` elements can be given the same value for their `for` attribute; doing so causes the associated form control (the form control that `for` value references) to have multiple labels.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Add a note about `htmlFor` that trips you when you want to set `for` on a `label`

#### Motivation

Reduce developer confusion.

#### Supporting details



#### Related issues



#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
