### PR TITLE
Corrects terminology and desc. Thanks @rauschma

### DIFF
--- a/files/en-us/glossary/bigint/index.md
+++ b/files/en-us/glossary/bigint/index.md
@@ -13,5 +13,5 @@ In {{Glossary("JavaScript")}}, **BigInt** is a numeric data type that can repre
 ## See also
 
 - {{Interwiki("wikipedia", "Data type#Numeric_types", "Numeric types")}} on Wikipedia
-- The JavaScript data structure: [`BigInt`](/en-US/docs/Web/JavaScript/Data_structures#bigint_type)
+- The JavaScript type: [`BigInt`](/en-US/docs/Web/JavaScript/Data_structures#bigint_type)
 - The JavaScript global object {{jsxref("BigInt")}}

--- a/files/en-us/glossary/number/index.md
+++ b/files/en-us/glossary/number/index.md
@@ -11,7 +11,7 @@ In {{Glossary("JavaScript")}}, **Number** is a numeric data type in the [double-
 ## See also
 
 - {{Interwiki("wikipedia", "Data type#Numeric_types", "Numeric types")}} on Wikipedia
-- The JavaScript data structure: {{jsxref("Number")}}
+- The JavaScript type: [`Number`](/en-US/docs/Web/JavaScript/Data_structures#number_type)
 - The JavaScript global object {{jsxref("Number")}}
 - [Glossary:](/en-US/docs/Glossary)
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.BigInt
 ---
 {{JSRef}}
 
-**`BigInt`** is a built-in object whose constructor returns a `bigint` {{Glossary("Primitive", "primitive")}} — also called a **BigInt value**, or sometimes just a **BigInt** — to represent whole numbers larger than 2^53 - 1 ([`Number.MAX_SAFE_INTEGER`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)), which is the largest number JavaScript can represent with a `number` {{Glossary("Primitive", "primitive")}} (or _Number value_). BigInt values can be used for arbitrarily large integers.
+**`BigInt`** is a [primitive wrapper object](/en-US/docs/Glossary/Primitive#primitive_wrapper_objects_in_javascript) used to represent and manipulate {{Glossary("Primitive", "primitive")}} `bigint` values which are [too large](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) to be represented by the `number` {{Glossary("Primitive", "primitive")}}.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.BigInt
 ---
 {{JSRef}}
 
-**`BigInt`** is a [primitive wrapper object](/en-US/docs/Glossary/Primitive#primitive_wrapper_objects_in_javascript) used to represent and manipulate {{Glossary("Primitive", "primitive")}} `bigint` values which are [too large](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) to be represented by the `number` {{Glossary("Primitive", "primitive")}}.
+**`BigInt`** is a [primitive wrapper object](/en-US/docs/Glossary/Primitive#primitive_wrapper_objects_in_javascript) used to represent and manipulate {{Glossary("Primitive", "primitive")}} `bigint` values — which are [too large](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) to be represented by the `number` {{Glossary("Primitive", "primitive")}}.
 
 ## Description
 


### PR DESCRIPTION
#### Summary
1. **Data Structure** was used to refer to **type** for Bigint and Number.
2. The BigInt defn needed improvements
3. Doesn't address this :- 
    > Is there a better location for this content – a page that focuses on bigints as primitive values?

#### Motivation
Low hanging :mango:

#### Related issues
Fixes #1623

#### Metadata
- [x] Fixes a typo, bug, or other error