### PR TITLE
Clarify behaviour of margin-block values

### DIFF
--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -41,13 +41,13 @@ This property is a shorthand for the following CSS properties:
 - [`margin-block-start`](/en-US/docs/Web/CSS/margin-block-start)
 - [`margin-block-end`](/en-US/docs/Web/CSS/margin-block-end)
 
-If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
-
 ## Syntax
 
 ### Values
 
 The `margin-block` property takes the same values as the {{CSSxRef("margin-left")}} property.
+
+If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
 
 ## Formal definition
 

--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -18,9 +18,9 @@ The **`margin-block`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/do
 ```css
 /* <length> values */
 margin-block: 10px 20px;  /* An absolute length */
-margin-block: 1em 2em;   /* relative to the text size */
-margin-block: 5% 2%;    /* relative to the nearest block container's width */
-margin-block: 10px; /* sets both start and end values */
+margin-block: 1em 2em;    /* relative to the text size */
+margin-block: 5% 2%;      /* relative to the nearest block container's width */
+margin-block: 10px;       /* sets both start and end values */
 
 /* Keyword values */
 margin-block: auto;
@@ -38,8 +38,10 @@ This property corresponds to the {{CSSxRef("margin-top")}} and {{CSSxRef("margin
 
 This property is a shorthand for the following CSS properties:
 
-- [`margin-block-end`](/en-US/docs/Web/CSS/margin-block-end)
 - [`margin-block-start`](/en-US/docs/Web/CSS/margin-block-start)
+- [`margin-block-end`](/en-US/docs/Web/CSS/margin-block-end)
+
+If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
 
 ## Syntax
 

--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -43,12 +43,14 @@ This property is a shorthand for the following CSS properties:
 
 ## Syntax
 
-### Values
-
-The `margin-block` property may be specified using one or two values. Each value is a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or the keyword `auto`. Negative values draw the element closer to its neighbors than it would be by default.
+The `margin-block` property may be specified using one or two values.
 
 - When **one** value is specified, it applies the same margin to **both start and end**.
 - When **two** values are specified, the first margin applies to the **start**, the second to the **end**.
+
+### Values
+
+The `margin-block` property takes the same values as the {{CSSxRef("margin", "", "#values")}} property.
 
 ## Formal definition
 

--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -38,16 +38,17 @@ This property corresponds to the {{CSSxRef("margin-top")}} and {{CSSxRef("margin
 
 This property is a shorthand for the following CSS properties:
 
-- [`margin-block-start`](/en-US/docs/Web/CSS/margin-block-start)
-- [`margin-block-end`](/en-US/docs/Web/CSS/margin-block-end)
+- {{cssxref("margin-block-start")}}
+- {{cssxref("margin-block-end")}}
 
 ## Syntax
 
 ### Values
 
-The `margin-block` property takes the same values as the {{CSSxRef("margin-left")}} property.
+The `margin-block` property may be specified using one or two values. Each value is a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or the keyword `auto`. Negative values draw the element closer to its neighbors than it would be by default.
 
-If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
+- When **one** value is specified, it applies the same margin to **both start and end**.
+- When **two** values are specified, the first margin applies to the **start**, the second to the **end**.
 
 ## Formal definition
 

--- a/files/en-us/web/css/margin-inline/index.md
+++ b/files/en-us/web/css/margin-inline/index.md
@@ -38,16 +38,17 @@ This property corresponds to the {{CSSxRef("margin-top")}} and {{CSSxRef("margin
 
 This property is a shorthand for the following CSS properties:
 
-- [`margin-inline-start`](/en-US/docs/Web/CSS/margin-inline-start)
-- [`margin-inline-end`](/en-US/docs/Web/CSS/margin-inline-end)
+- {{cssxref("margin-inline-start")}}
+- {{cssxref("margin-inline-end")}}
 
 ## Syntax
 
 ### Values
 
-The `margin-inline` property takes the same values as the {{CSSxRef("margin-left")}} property.
+The `margin-inline` property may be specified using one or two values. Each value is a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or the keyword `auto`. Negative values draw the element closer to its neighbors than it would be by default.
 
-If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
+- When **one** value is specified, it applies the same margin to **both start and end**.
+- When **two** values are specified, the first margin applies to the **start**, the second to the **end**.
 
 ## Formal definition
 

--- a/files/en-us/web/css/margin-inline/index.md
+++ b/files/en-us/web/css/margin-inline/index.md
@@ -43,12 +43,14 @@ This property is a shorthand for the following CSS properties:
 
 ## Syntax
 
-### Values
-
-The `margin-inline` property may be specified using one or two values. Each value is a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or the keyword `auto`. Negative values draw the element closer to its neighbors than it would be by default.
+The `margin-inline` property may be specified using one or two values.
 
 - When **one** value is specified, it applies the same margin to **both start and end**.
 - When **two** values are specified, the first margin applies to the **start**, the second to the **end**.
+
+### Values
+
+The `margin-inline` property takes the same values as the {{CSSxRef("margin", "", "#values")}} property.
 
 ## Formal definition
 

--- a/files/en-us/web/css/margin-inline/index.md
+++ b/files/en-us/web/css/margin-inline/index.md
@@ -41,13 +41,13 @@ This property is a shorthand for the following CSS properties:
 - [`margin-inline-start`](/en-US/docs/Web/CSS/margin-inline-start)
 - [`margin-inline-end`](/en-US/docs/Web/CSS/margin-inline-end)
 
-If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
-
 ## Syntax
 
 ### Values
 
 The `margin-inline` property takes the same values as the {{CSSxRef("margin-left")}} property.
+
+If 2 values are specified, the first value sets the start, the second value sets the end. If 1 value is specified, it sets both properties with the same value.
 
 ## Formal definition
 


### PR DESCRIPTION
Explicitly state the behaviour of 2- vs 1-value use, and the order of the values. Matches wording on https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
