### PR TITLE
docs(Using Web Workers): fix typo in code (queryArguments --> queryMethodArguments)

### DIFF
--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -357,7 +357,7 @@ this.sendQuery = function() {
     }
     worker.postMessage({
         'queryMethod': arguments[0],
-        'queryArguments': Array.prototype.slice.call(arguments, 1)
+        'queryMethodArguments': Array.prototype.slice.call(arguments, 1)
     });
 }
 ```


### PR DESCRIPTION
#### Summary
Fix a typo in a code example on the "Using Web Workers" page.
An object property was named `queryArguments` in one place, but the rest of the code expected it to be `queryMethodArguments`.

#### Motivation
To avoid confusion for future readers.

#### Supporting details
https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#passing_data_examples

#### Related issues
N/A

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
