### PR TITLE
Fix incorrect comment syntax

### DIFF
--- a/files/en-us/web/html/element/p/index.md
+++ b/files/en-us/web/html/element/p/index.md
@@ -186,7 +186,7 @@ If extra space is desired, use {{glossary("CSS")}} properties like {{cssxref("ma
 
 ```css
 p {
-  margin-bottom: 2em; // increase white space after a paragraph
+  margin-bottom: 2em; /* increase white space after a paragraph */
 }
 ```
 


### PR DESCRIPTION
The correct syntax for CSS comments is `/* ... */`

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
