### PR TITLE
Add listing of missing method.

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/index.md
@@ -72,7 +72,10 @@ _Inherits event handlers from its parent, {{domxref("AudioScheduledSourceNode")}
 
 ## Methods
 
-_Inherits methods from its parent, {{domxref("AudioScheduledSourceNode")}}_.
+_Inherits methods from its parent, {{domxref("AudioScheduledSourceNode")}}, and overrides the following method:_.
+
+- {{domxref("AudioBufferSourceNode.start", "start()")}}
+  - :  Schedules playback of the audio data contained in the buffer, or begins playback immediately. Additionally allows the start offset and play duration to be set.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add listing of overriding start() method on the AudioBufferSourceNode page as it is currently missing.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It is unclear that AudioBufferSourceNode has any methods of its own.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Page in question:
https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode
The overriding start method:
https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
