### PR TITLE
Ff96 canShare release note AND experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1359,6 +1359,7 @@ The addition of a constructor to the {{domxref("CSSStyleSheet")}} interface as w
 ### WebShare API
 
 The [Web Share API](/en-US/docs/Web/API/Web_Share_API) allows sharing of files, URLs and other data from a site.
+This feature is enabled on Android in all builds, but behind a preference on Desktop (unless specified below).
 
 <table>
   <thead>
@@ -1387,7 +1388,7 @@ The [Web Share API](/en-US/docs/Web/API/Web_Share_API) allows sharing of files, 
     <tr>
       <th>Release</th>
       <td>71</td>
-      <td>No</td>
+      <td>No (Desktop). Yes (Android).</td>
     </tr>
     <tr>
       <th>Preference name</th>

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -37,6 +37,10 @@ This article provides information about the changes in Firefox 96 that will affe
 
 ### APIs
 
+- {{domxref("navigator.canShare()")}} is now supported on Android, allowing code to check whether {{domxref("navigator.share()")}} will succeed for particular targets.
+  The feature is behind a preference on desktop operating systems.
+  ({{bug(1666203)}}).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
`navigator.canShare()` support was added in FF96. As with the rest of the Web Share API the feature is enabled on Android but behind a preference on desktop. This adds an android specific release note for the feature and update to the experimental releases page.

