### PR TITLE
JS Learn: add task to Functions-Test your skills

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
@@ -72,6 +72,18 @@ Try updating the live code below to recreate the finished example:
 >
 > [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/functions/functions3-download.html) to work in your own editor or in an online editor.
 
+## Functions 4
+
+In this task, we have an array of names, and we're using {{jsxref("Array.filter()")}} to get an array of only names shorter than 5 characters. The filter is currently being passed a named function `isShort()` which checks the length of the name, returning `true` if the name is less than 5 characters long and `false` otherwise.
+
+We'd like you to change this into an arrow function. See how compact you can make it.
+
+{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/functions/functions4.html", '100%', 400)}}
+
+> **Callout:**
+>
+> [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/functions/functions4-download.html) to work in your own editor or in an online editor.
+
 ## Assessment or further help
 
 You can practice these examples in the Interactive Editors above.

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
@@ -74,7 +74,7 @@ Try updating the live code below to recreate the finished example:
 
 ## Functions 4
 
-In this task, we have an array of names, and we're using {{jsxref("Array.filter()")}} to get an array of only names shorter than 5 characters. The filter is currently being passed a named function `isShort()` which checks the length of the name, returning `true` if the name is less than 5 characters long and `false` otherwise.
+In this task, we have an array of names, and we're using {{jsxref("Array.filter()")}} to get an array of only names shorter than 5 characters. The filter is currently being passed a named function `isShort()` which checks the length of the name, returning `true` if the name is less than 5 characters long, and `false` otherwise.
 
 We'd like you to change this into an arrow function. See how compact you can make it.
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/10337.

https://github.com/mdn/content/pull/10799 updates the [JS Learning Area's "Functions" page](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Functions), mostly to talk about arrow functions.

There's a ["Test Your Skills" page for functions](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Test_your_skills:_Functions) and I wanted to add a new task to this page to cover arrow functions.

https://github.com/mdn/learning-area/pull/425 added the new task to the learn area, and this PR makes the corresponding update to the MDN page.

