### PR TITLE
WebDriver conformance changes for Firefox 95

### DIFF
--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -60,6 +60,11 @@ Firefox 95 is the current [Beta version of Firefox](https://www.mozilla.org/en-U
 
 ### WebDriver conformance (Marionette)
 
+<ul>
+  <li>The <code>port</code> used by Marionette is now written to the <code>MarionetteActivePort</code> file in the profile directory. This can be used to easily retrieve the <code>port</code>, which before was only possible by parsing the <code>prefs.js</code> file of the profile. ({{bug(1735162)}}).</li>
+  <li><code>WebDriver:NewSession</code> now waits for the initial tab to have completed loading to prevent unexpected unloads of the window proxy. ({{bug(1736323)}}).</li>
+</ul>
+
 #### Removals
 
 ## Changes for add-on developers


### PR DESCRIPTION
The following PR contains all the user facing changes to Marionette for the Firefox 95 release. Here a [list of all the changes](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&v1=fixed&component=Marionette&v2=verified&product=Testing&f1=cf_status_firefox95&list_id=15923056)

Included in the release notes:

- [Bug 1735162](https://bugzilla.mozilla.org/show_bug.cgi?id=1735162) - Write Marionette connection details to "MarionetteActivePort" file in the profile directory
  - This is a new feature which should be visible to users.
- [Bug 1736323](https://bugzilla.mozilla.org/show_bug.cgi?id=1736323) - Marionette has to wait for the very first tab during startup being finished loading
  - This is an internal bug fix to accomodate a platform change. But since it impacts the logic to create new sessions, I feel like mentioning it could be helpful if users face issues with new sessions and check the release notes.

Quick review of the other bugs:

- [Bug 1735346](https://bugzilla.mozilla.org/show_bug.cgi?id=1735346) - Intermittent [Tier 2] testing/marionette/harness/marionette_harness/tests/unit/test_navigation.py TestPageLoadStrategy.test_none | marionette_driver.errors.NoSuchElementException: Unable to locate element: slow
  - Test-only.
- [Bug 1736061](https://bugzilla.mozilla.org/show_bug.cgi?id=1736061) - Ensure second page is loaded in test_switch_window_content.py test_switch_to_unloaded_tab before continuing
  - Test-only.
- [Bug 1736147](https://bugzilla.mozilla.org/show_bug.cgi?id=1736147) - High frequency testing/marionette/harness/marionette_harness/tests/unit/test_marionette.py TestMarionette.test_single_active_session | AssertionError: 1 != None
  - Test-only, and no patch attached.
- [Bug 1739008](https://bugzilla.mozilla.org/show_bug.cgi?id=1739008) - Intermittent Mn/en-US | marionette_driver.errors.SessionNotCreatedException: TimeoutError: TimedPromise timed out after 300000 ms
  - Even though this impacted the new session logic, this is really just a followup to Bug 1736323 and there's no need to mention it twice.