### PR TITLE
import specifiers use url rather than path

### DIFF
--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -48,7 +48,7 @@ var promise = import("module-name");
 - `defaultExport`
   - : Name that will refer to the default export from the module.
 - `module-name`
-  - : The module to import from. This is often a relative or absolute path name to the
+  - : The module to import from. This is often a relative or absolute url to the
     `.js` file containing the module. Certain bundlers may permit or require
     the use of the extension; check your environment. Only single quoted and double
     quoted Strings are allowed.


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fixes a nit in import specifier documentation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Import specifiers are most likely to use URLs instead of paths, which add some restrictions such as you have to escape `#` and `?` in your path, and you cannot use `\` as path separator.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://nodejs.org/api/esm.html#urls

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
