### PR TITLE
Fix typo in WASM text format document.

### DIFF
--- a/files/en-us/webassembly/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/understanding_the_text_format/index.md
@@ -595,7 +595,7 @@ At the time of writing (June 2020) this is at an early stage, and the only multi
     i32.const 1
     i32.const 2
   )
-  (func (export "add_to_numbers") (result i32)
+  (func (export "add_two_numbers") (result i32)
     call $get_two_numbers
     i32.add
   )


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`add_to_numbers` should be `add_two_numbers`

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
