### PR TITLE
Fix typo in EventSource.onmessage example

### DIFF
--- a/files/en-us/web/api/eventsource/onmessage/index.md
+++ b/files/en-us/web/api/eventsource/onmessage/index.md
@@ -29,7 +29,7 @@ eventSource.onmessage = function
 ## Examples
 
 ```js
-evtSource.onmessage = function(e) {
+eventSource.onmessage = function(e) {
   var newElement = document.createElement("li");
 
   newElement.textContent = "message: " + e.data;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix typo from `evtSource` to `eventSource`

#### Motivation
I don't like this type of short name personally.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
