### PR TITLE
Remove "non-standard" from `preservesPitch` in HTMLMediaElement

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -75,7 +75,7 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
   - : Returns a {{domxref('TimeRanges')}} object that contains the ranges of the media source that the browser has played, if any.
 - {{domxref("HTMLMediaElement.preload")}}
   - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("preload", "video")}} HTML attribute, indicating what data should be preloaded, if any. Possible values are: `none`, `metadata`, `auto`.
-- {{domxref("HTMLMediaElement.preservesPitch")}} {{non-standard_inline}}
+- {{domxref("HTMLMediaElement.preservesPitch")}}
   - : Is a {{jsxref('Boolean')}} that determines if the pitch of the sound will be preserved. If set to `false`, the pitch will adjust to the speed of the audio. This is implemented with prefixes in Firefox (`mozPreservesPitch`) and WebKit (`webkitPreservesPitch`).
 - {{domxref("HTMLMediaElement.readyState")}} {{readonlyinline}}
   - : Returns a `unsigned short` (enumeration) indicating the readiness state of the media.


### PR DESCRIPTION
`media.preservesPitch` is now part of the HTML standard

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removing the "non-standard" label from the `preservesPitch` property.
<img width="702" alt="image" src="https://user-images.githubusercontent.com/25948390/144658130-cf986b2d-beb7-4732-a01f-ee2c052ad0cd.png">

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I would like to correct some misleading information on the overview page

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://html.spec.whatwg.org/multipage/media.html#dom-media-preservespitch
https://github.com/whatwg/html/issues/262

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
