### PR TITLE
Make clear: typed arrays can only be copy-constructed from same type

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
@@ -39,7 +39,7 @@ new BigInt64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of either of the {{glossary("bigint")}} typed array types (such as {{JSxRef("BigUInt64Array")}}), the
+    object of either of the {{glossary("bigint")}} typed-array types (such as {{JSxRef("BigUInt64Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
@@ -39,7 +39,7 @@ new BigInt64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
+    object of either of the {{glossary("bigint")}} typed array types (such as {{JSxRef("BigUInt64Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
@@ -39,7 +39,7 @@ new BigUint64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
+    object of either of the {{glossary("bigint")}} typed array types (such as {{JSxRef("BigInt64Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
@@ -39,7 +39,7 @@ new BigUint64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of either of the {{glossary("bigint")}} typed array types (such as {{JSxRef("BigInt64Array")}}), the
+    object of either of the {{glossary("bigint")}} typed-array types (such as {{JSxRef("BigInt64Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -40,7 +40,7 @@ new Float32Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    object of any of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -40,7 +40,7 @@ new Float32Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
+    object of any of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -40,7 +40,7 @@ new Float32Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    object of any of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -40,7 +40,7 @@ new Float64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    object of any of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -40,7 +40,7 @@ new Float64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    object of any of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -40,7 +40,7 @@ new Float64Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
+    object of any of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -39,7 +39,7 @@ new Int16Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -39,7 +39,7 @@ new Int16Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -39,7 +39,7 @@ new Int16Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -36,7 +36,7 @@ new Int32Array(buffer [, byteOffset [, length]]);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -36,7 +36,7 @@ new Int32Array(buffer [, byteOffset [, length]]);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -36,7 +36,7 @@ new Int32Array(buffer [, byteOffset [, length]]);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
@@ -37,7 +37,7 @@ new Int8Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
@@ -37,7 +37,7 @@ new Int8Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
@@ -37,7 +37,7 @@ new Int8Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -84,7 +84,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an
-    object of any of the typed array types (such as `Int32Array`), the
+    object of any of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -84,15 +84,15 @@ Where _TypedArray_ is a constructor for one of the concrete types.
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument the `typedArray` gets copied
-    into a new typed array. For (**non {{glossary("bigint")}}**) `TypedArray`,
-    the `typedArray` parameter can be an object of only the (**non**
-    {{glossary("bigint")}}) typed array types (such as {{JSxRef("Int32Array")}}).
-    Similarly, for **{{glossary("bigint")}}** `TypedArray`, the `typedArray`
-    parameter can be an object of only the {{glossary("bigint")}} typed array types
-    (such as {{JSxRef("BigInt64Array")}}). Each value in `typedArray` is converted
-    to the corresponding type of the constructor before being copied into the new
-    array.  The length of the new typed array will be same as the length of the
-    `typedArray` argument.
+    into a new typed array. For **non-{{glossary("bigint")}}** `TypedArray`,
+    the `typedArray` parameter can be an object of only the
+    **non**-{{glossary("bigint")}} typed array types (such as
+    {{JSxRef("Int32Array")}}).  Similarly, for **{{glossary("bigint")}}**
+    `TypedArray`, the `typedArray` parameter can be an object of only the
+    {{glossary("bigint")}} typed array types (such as {{JSxRef("BigInt64Array")}}).
+    Each value in `typedArray` is converted to the corresponding type of the
+    constructor before being copied into the new array.  The length of the new
+    typed array will be same as the length of the `typedArray` argument.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -83,12 +83,16 @@ Where _TypedArray_ is a constructor for one of the concrete types.
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
+  - : When called with a `typedArray` argument the `typedArray` gets copied
+    into a new typed array. For (**non {{glossary("bigint")}}**) `TypedArray`,
+    the `typedArray` parameter can be an object of only the (**non**
+    {{glossary("bigint")}}) typed array types (such as {{JSxRef("Int32Array")}}).
+    Similarly, for **{{glossary("bigint")}}** `TypedArray`, the `typedArray`
+    parameter can be an object of only the {{glossary("bigint")}} typed array types
+    (such as {{JSxRef("BigInt64Array")}}). Each value in `typedArray` is converted
+    to the corresponding type of the constructor before being copied into the new
+    array.  The length of the new typed array will be same as the length of the
+    `typedArray` argument.
 - `object`
   - : When called with an `object` argument, a new typed array is
     created as if by the `TypedArray.from()` method.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -83,11 +83,11 @@ Where _TypedArray_ is a constructor for one of the concrete types.
     is created in memory, of size `length` _multiplied by
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
-  - : When called with a `typedArray` argument the `typedArray` gets copied
-    into a new typed array. For **non-{{glossary("bigint")}}** `TypedArray`,
+  - : When called with a `typedArray` argument, the `typedArray` gets copied
+    into a new typed array. For a **non-{{glossary("bigint")}}** `TypedArray`,
     the `typedArray` parameter can be an object of only the
     **non**-{{glossary("bigint")}} typed array types (such as
-    {{JSxRef("Int32Array")}}).  Similarly, for **{{glossary("bigint")}}**
+    {{JSxRef("Int32Array")}}).  Similarly, for a **{{glossary("bigint")}}**
     `TypedArray`, the `typedArray` parameter can be an object of only the
     {{glossary("bigint")}} typed array types (such as {{JSxRef("BigInt64Array")}}).
     Each value in `typedArray` is converted to the corresponding type of the

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -35,7 +35,7 @@ new Uint16Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -35,7 +35,7 @@ new Uint16Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -35,7 +35,7 @@ new Uint16Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -39,7 +39,7 @@ new Uint32Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -39,7 +39,7 @@ new Uint32Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -39,7 +39,7 @@ new Uint32Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -37,7 +37,7 @@ new Uint8Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -37,7 +37,7 @@ new Uint8Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -37,7 +37,7 @@ new Uint8Array(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as `Int32Array`), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as `Int32Array`), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -39,7 +39,7 @@ new Uint8ClampedArray(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the typed array types (such as `Int32Array`), the
+    of the (**non** {{glossary("bigint")}}) typed array types (such as {{JSxRef("Int32Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -39,7 +39,7 @@ new Uint8ClampedArray(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed array types (such as {{JSxRef("Int32Array")}}), the
+    of the **non**-{{glossary("bigint")}} typed-array types (such as {{JSxRef("Int32Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -39,7 +39,7 @@ new Uint8ClampedArray(buffer, byteOffset, length);
     `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
   - : When called with a `typedArray` argument, which can be an object of any
-    of the (**non** {{glossary("bigint")}}) typed array types (such as {{JSxRef("Int32Array")}}), the
+    of the **non**-{{glossary("bigint")}} typed array types (such as {{JSxRef("Int32Array")}}), the
     `typedArray` gets copied into a new typed array. Each value in
     `typedArray` is converted to the corresponding type of the
     constructor before being copied into the new array. The length of the new typed array


### PR DESCRIPTION
#### Summary
The [TypedArray's](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) behave differently when used as constructor args. Added exception.

#### Motivation
Low hanging :mango: esp with partial fix from @sideshowbarker 

#### Supporting details
See Also https://github.com/mdn/content/pull/7597

#### Related issues
Fixes #7592. Fixex #7597.

#### Metadata
- [x] Fixes a typo, bug, or other error