### PR TITLE
Remove link to missing demo in :hover page

### DIFF
--- a/files/en-us/web/css/_colon_hover/index.md
+++ b/files/en-us/web/css/_colon_hover/index.md
@@ -56,12 +56,6 @@ a:hover {
 
 {{EmbedLiveSample("Basic_example")}}
 
-### Image gallery
-
-You can use the `:hover` pseudo-class to build an image gallery with full-size images that show only when the mouse moves over a thumbnail. See [this demo](/@api/deki/files/6247/=css-gallery.zip "css-gallery.zip") for a possible cue.
-
-> **Note:** For an analogous effect, but based on the [`:checked`](/en-US/docs/Web/CSS/:checked) pseudo-class (applied to hidden radioboxes), see [this demo](/@api/deki/files/6268/=css-checked-gallery.zip "css-checked-gallery.zip"), taken from the [:checked](/en-US/docs/Web/CSS/:checked) reference page.
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
@wbamberg.  Not sure if this is how I was supposed to do it, but here is the follow up on issue 10959.  I deleted the h3 "image gallery", the paragraph after it, and the note referring to the ``` :checked``` .  See https://github.com/mdn/content/pull/10959.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
