### PR TITLE
Updated Parsing link from speculative parsing to parsing

### DIFF
--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -106,7 +106,7 @@ As the server sends data in TCP packets, the user's client confirms delivery by 
 
 ## Parsing
 
-Once the browser receives the first chunk of data, it can begin parsing the information received. {{glossary('speculative parsing', 'Parsing')}} is the step the browser takes to turn the data it receives over the network into the {{glossary('DOM')}} and {{glossary('CSSOM')}}, which is used by the renderer to paint a page to the screen.
+Once the browser receives the first chunk of data, it can begin parsing the information received. {{glossary('parse', 'Parsing')}} is the step the browser takes to turn the data it receives over the network into the {{glossary('DOM')}} and {{glossary('CSSOM')}}, which is used by the renderer to paint a page to the screen.
 
 The DOM is the internal representation of the markup for the browser. The DOM is also exposed, and can be manipulated through various APIs in JavaScript.
 


### PR DESCRIPTION
In the "Parsing" section, "parsing" link should get to "parse" of MDN glossary rather than "speculative-parsing"

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
It makes sense to get to "Parse" page rather than "Speculative Parsing" page from a link that says "Parsing". Quite self explanatory.

#### Motivation
Readers will get clear understanding of parsing rather than speculative parsing from this change.

#### Supporting details
Just a link change, supporting details shouldn't make sense here.

#### Related issues
Not applicable

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
