### PR TITLE
Update Application Cache docs

### DIFF
--- a/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.md
@@ -10,11 +10,9 @@ tags:
   - applicationCache
 browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
-{{Deprecated_Header}}{{APIRef("Web Workers API")}}
+{{Deprecated_Header}}{{securecontext_header}}{{APIRef("Web Workers API")}}
 
-> **Warning:** Application Cache is deprecated as of Firefox 44, and is no longer available in insecure contexts from Firefox 60 onwards ({{bug(1354175)}}, currently Nightly/Beta only). Don't use it to make offline websites — consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
-
-The **`applicationCache`** read-only property of the {{domxref("SharedWorkerGlobalScope")}} interface returns the {{domxref("ApplicationCache")}} object for the worker (see [Using the application cache](/en-US/docs/Web/HTML/Using_the_application_cache)).
+The **`applicationCache`** read-only property of the {{domxref("SharedWorkerGlobalScope")}} interface returns the {{domxref("ApplicationCache")}} object for the worker.
 
 ## Syntax
 

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -20,7 +20,7 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("SharedWorkerGlobalScope.name")}} {{readOnlyinline}}
   - : The name that the {{domxref("SharedWorker")}} was (optionally) given when it was created using the {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} constructor. This is mainly useful for debugging purposes.
 - {{domxref("SharedWorkerGlobalScope.applicationCache")}} {{readOnlyinline}} {{deprecated_inline}}
-  - : This property returns the {{domxref("ApplicationCache")}} object for the worker (see [Using the application cache](/en-US/docs/Web/HTML/Using_the_application_cache)).
+  - : This property returns the {{domxref("ApplicationCache")}} object for the worker.
 
 ### Properties inherited from WorkerGlobalScope
 

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -15,6 +15,8 @@ browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
 {{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}
 
+> **Warning**: Application cache is being removed from web platform. Consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
+
 Returns a reference to the application cache object for the window.
 
 ## Syntax

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -13,11 +13,7 @@ tags:
   - Window
 browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
-{{Deprecated_Header}}{{Non-standard_Header}}
-
-> **Warning:** Application Cache is deprecated as of Firefox 44, and is no longer available in
-> insecure contexts from Firefox 60 onwards ({{bug(1354175)}}, currently Nightly/Beta
-> only). Don't use it to offline websites — consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
+{{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}
 
 Returns a reference to the application cache object for the window.
 
@@ -34,8 +30,3 @@ cache = window.applicationCache
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [Using Application
-  Cache](/en-US/docs/Web/HTML/Using_the_application_cache)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Update Application Cache documentation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
 - removed links to "Using Application Cache" article because this article does not exists.
 - added `{{securecontext_header}}` because AppCache was removed from insecure contexts during the gradual deprecation
 - removed lengthy warnings (which contain only partial browser version information) because I will move that data to BCD

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
 - [Firefox 60: Appcache removed from insecure contexts](https://bugzilla.mozilla.org/show_bug.cgi?id=1354175)
 - [Chrome 94: app cache removed](https://chromestatus.com/feature/6192449487634432)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
TBD

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
