### PR TITLE
Fix the order of arguments to getPose()

### DIFF
--- a/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
+++ b/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
@@ -60,7 +60,7 @@ There is only one way to create an {{domxref("XRPose")}}, and that's using the�
 For example, if you wish to draw a hand controller's representation using the controller's {{domxref("XRInputSource.gripSpace", "gripSpace")}}, you can get the pose needed like this:
 
 ```js
-let controlPose = frame.getPose(worldRefSpace, inputSource.gripSpace);
+let controlPose = frame.getPose(inputSource.gripSpace, worldRefSpace);
 ```
 
 This converts the position and orientation of the input's grip space to use the world's coordinate system, then generates the corresponding `XRPose`, storing it in `controlPose`. You can then apply `controlPose`'s {{domxref("XRPose.transform", "transform")}} to the vertices in the object model representing the controller to calculate the WebGL coordinates to use when rendering the controller's representation to the framebuffer.


### PR DESCRIPTION
#### Summary
Fix the order of arguments to `getPose()`: the reference (base) space should be the second argument.

#### Supporting details
According to https://immersive-web.github.io/webxr/#dom-xrframe-getpose, the reference space (`baseSpace`) is the _second_ parameter to `XRFrame.getPose()`.

```webidl
[SecureContext, Exposed=Window] interface XRFrame {
  [SameObject] readonly attribute XRSession session;
  readonly attribute DOMHighResTimeStamp predictedDisplayTime;

  XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
  XRPose? getPose(XRSpace space, XRSpace baseSpace);
};
```

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error