### PR TITLE
Custom elements not supported note removed

### DIFF
--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -14,8 +14,6 @@ tags:
 
 One of the key features of the Web Components standard is the ability to create custom elements that encapsulate your functionality on an HTML page, rather than having to make do with a long, nested batch of elements that together provide a custom page feature. This article introduces the use of the Custom Elements API.
 
-> **Note:** Custom elements are supported by default in Firefox, Chrome, and Edge (76). Opera and Safari so far support only autonomous custom elements.
-
 ## High-level view
 
 The controller of custom elements on a web document is the {{domxref("CustomElementRegistry")}} object — this object allows you to register a custom element on the page, return information on what custom elements are registered, etc.


### PR DESCRIPTION
Removed note about custom elements not being supported. https://caniuse.com/custom-elementsv1 

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

