### PR TITLE
Destructuring assignment - Fix layout of code in note

### DIFF
--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -334,7 +334,13 @@ drawChart({
 });
 ```
 
-> **Note:** In the function signature for **`drawChart`** above, the destructured left-hand side is assigned to an empty object literal on the right-hand side: `{size = 'big', coords = {x: 0, y: 0}, radius = 25} = {}`. You could have also written the function without the right-hand side assignment. However, if you leave out the right-hand side assignment, the function will look for at least one argument to be supplied when invoked, whereas in its current form, you can call **`drawChart()`** without supplying any parameters. The current design is useful if you want to be able to call the function without supplying any parameters, the other can be useful when you want to ensure an object is passed to the function.
+> **Note:** In the function signature for **`drawChart`** above, the destructured left-hand side is assigned to an empty object literal on the right-hand side:
+> ```js
+> {size = 'big', coords = {x: 0, y: 0}, radius = 25} = {}
+> ```
+> You could have also written the function without the right-hand side assignment.
+> However, if you leave out the right-hand side assignment, the function will look for at least one argument to be supplied when invoked, whereas in its current form, you can call **`drawChart()`** without supplying any parameters.
+> The current design is useful if you want to be able to call the function without supplying any parameters, the other can be useful when you want to ensure an object is passed to the function.
 
 #### Nested object and array destructuring
 

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -340,7 +340,7 @@ drawChart({
 > ```
 > You could have also written the function without the right-hand side assignment.
 > However, if you leave out the right-hand side assignment, the function will look for at least one argument to be supplied when invoked, whereas in its current form, you can call **`drawChart()`** without supplying any parameters.
-> The current design is useful if you want to be able to call the function without supplying any parameters, the other can be useful when you want to ensure an object is passed to the function.
+> The current design is useful if you want to be able to call the function without supplying any parameters. The other can be useful when you want to ensure an object is passed to the function.
 
 #### Nested object and array destructuring
 


### PR DESCRIPTION
Fixes #10971

The inline code in the note was overflowing on narrow screens. I've just made it a code block, which scrolls.

