### PR TITLE
Add two examples of URL() constructor

### DIFF
--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -71,6 +71,8 @@ let d = new URL('/en-US/docs', b);                     // =
         new URL('http://www.example.com', );           // => 'http://www.example.com/'
         new URL('http://www.example.com', b);          // => 'http://www.example.com/'
 
+        new URL("", "https://example.com/?query=1")    // => 'https://example.com/?query=1' (Edge before 79 removes query arguments)
+        new URL("/a", "https://example.com/?query=1")    // => 'https://example.com/a' (see relative URLs)
         new URL("//foo.com", "https://example.com")    // => 'https://foo.com' (see relative URLs)
 ```
 

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -72,7 +72,7 @@ let d = new URL('/en-US/docs', b);                     // =
         new URL('http://www.example.com', b);          // => 'http://www.example.com/'
 
         new URL("", "https://example.com/?query=1")    // => 'https://example.com/?query=1' (Edge before 79 removes query arguments)
-        new URL("/a", "https://example.com/?query=1")    // => 'https://example.com/a' (see relative URLs)
+        new URL("/a", "https://example.com/?query=1")  // => 'https://example.com/a' (see relative URLs)
         new URL("//foo.com", "https://example.com")    // => 'https://foo.com' (see relative URLs)
 ```
 


### PR DESCRIPTION
#### Summary

Add two examples of URL Constructor according to https://github.com/mdn/browser-compat-data/pull/13820.

#### Motivation

To tell readers an edge case when passing empty string value to the first argument.

#### Supporting details

```js
// Chrome, Firefox, Node, New Edge
new URL('', 'http://www.test.com?sid=1').searchParams.get('sid'); // => "1"
// Old Edge
new URL('', 'http://www.test.com?sid=1').searchParams.get('sid'); // => null
```

#### Metadata

- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
