### PR TITLE
Redefine first party cookies to include scheme and mention subdomains.

### DIFF
--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -210,7 +210,7 @@ Ways to mitigate attacks involving cookies:
 A cookie is associated with a particular domain and scheme (such as `http` or `https`), and may also be associated with subdomains if the {{HTTPHeader("Set-Cookie")}} `Domain` attribute is set.
 If the cookie domain and scheme match the current page, the cookie is considered to be from the same site as the page, and is referred to as a _first-party cookie_.
 
-If the domain and scheme are different the cookie is not considered to be from the same site, and is referred to as a _third-party cookie_.
+If the domain and scheme are different, the cookie is not considered to be from the same site, and is referred to as a _third-party cookie_.
 While the server hosting a web page sets first-party cookies, the page may contain images or other components stored on servers in other domains (for example, ad banners) that may set third-party cookies.
 These are mainly used for advertising and tracking across the web.
 For example, the [types of cookies used by Google](https://policies.google.com/technologies/types).

--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -207,8 +207,10 @@ Ways to mitigate attacks involving cookies:
 
 ### Third-party cookies
 
-A cookie is associated with a domain. If this domain is the same as the domain of the page you're on, the cookie is called a _first-party cookie_.
-If the domain is different, it's a _third-party cookie_.
+A cookie is associated with a particular domain and scheme (such as `http` or `https`), and may also be associated with subdomains if the {{HTTPHeader("Set-Cookie")}} `Domain` attribute is set.
+If the cookie domain and scheme match the current page, the cookie is considered to be from the same site as the page, and is referred to as a _first-party cookie_.
+
+If the domain and scheme are different the cookie is not considered to be from the same site, and is referred to as a _third-party cookie_.
 While the server hosting a web page sets first-party cookies, the page may contain images or other components stored on servers in other domains (for example, ad banners) that may set third-party cookies.
 These are mainly used for advertising and tracking across the web.
 For example, the [types of cookies used by Google](https://policies.google.com/technologies/types).


### PR DESCRIPTION
This updates the definition of first party cookies in  [Using HTTP Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) to clarify that it is not just the domain that defines a first party cookies (this continues the discussion in https://github.com/mdn/content/pull/10938#discussion_r762649039 with @Elchi3)

According to the [Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) docs for the `Domain` attribute, by default cookies are sent for the current domain, not including subdomains. However if you specify the `Domain` attribute then they are sent for the specified domain and including subdomains. Further, the spec indicates that the origin must be something that would match the domain attribute, if it was specified.

So a first party site is one where the domain and scheme are the same, but the subdomain may be relevant in some cases. 


