### PR TITLE
headless mode link not found 404 likely from template {FirefoxSidebar}

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -7,7 +7,7 @@ tags:
   - Mozilla
   - Release
 ---
-{{FirefoxSidebar}}{{draft}}
+{{FirefoxSidebar}}{{draft}} <-- Update Template to point to the correct link for headless mode
 
 This article provides information about the changes in Firefox 96 that will affect developers. Firefox 96 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly), and will ship on [January 11, 2022](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 


### PR DESCRIPTION
The template {{FirefoxSidebar}}{{draft}} probably contains the sidebar and "Related Topics". Below "Related Topics"  is a link  "Firefox internals" / "Headless mode". This points to https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode but this page is no longer available.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Please update information if headless mode is still available or no longer available

#### Motivation
Browsing the docs is confusing. Was headless mode removed from firefox?

#### Supporting details
Once in 2017 was a headless mode: https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/#usage

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error  <-- points to a bug (dead link 404)


<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
