### PR TITLE
Syntax - comments around ellipses

### DIFF
--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -129,19 +129,19 @@ For methods with a callback function, the syntax for arrow functions, functions,
 
 ```js
 // Arrow function
-filter((currentValue) => { ... } )
-filter((currentValue, index) => { ... } )
-filter((currentValue, index, array) => { ... } )
+filter((currentValue) => { /* ... */ } )
+filter((currentValue, index) => { /* ... */ } )
+filter((currentValue, index, array) => { /* ... */ } )
 
 // Callback function
 filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function(currentValue) { ... })
-filter(function(currentValue, index) { ... })
-filter(function(currentValue, index, array){ ... })
-filter(function(currentValue, index, array) { ... }, thisArg)
+filter(function(currentValue) { /* ... */ })
+filter(function(currentValue, index) { /* ... */ })
+filter(function(currentValue, index, array){ /* ... */ })
+filter(function(currentValue, index, array) { /* ... */ }, thisArg)
 ```
 
 ##### Syntax for arbitrary number of parameters
@@ -151,7 +151,7 @@ For methods that accept an arbitrary number of parameters, the syntax block is w
 ```js
 unshift(element0)
 unshift(element0, element1)
-unshift(element0, element1, ... , elementN)
+unshift(element0, element1, /* ... ,*/ elementN)
 ```
 
 #### Parameters section

--- a/files/en-us/web/api/abortsignal/onabort/index.md
+++ b/files/en-us/web/api/abortsignal/onabort/index.md
@@ -19,7 +19,7 @@ The **`onabort`** read-only property of the {{domxref("AbortSignal")}} interface
 ## Syntax
 
 ```js
-abortSignal.onabort = function() { ... };
+abortSignal.onabort = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -23,7 +23,7 @@ This function does not automatically release all `AudioContext`-created objects,
 
 ```js
 var audioCtx = new AudioContext();
-audioCtx.close().then(function() { ... });
+audioCtx.close().then(function() { /* ... */ });
 await audioCtx.close();
 ```
 

--- a/files/en-us/web/api/audiocontext/suspend/index.md
+++ b/files/en-us/web/api/audiocontext/suspend/index.md
@@ -21,7 +21,7 @@ This method will cause an `INVALID_STATE_ERR` exception to be thrown if called o
 
 ```js
 var audioCtx = new AudioContext();
-audioCtx.suspend().then(function() { ... });
+audioCtx.suspend().then(function() { /* ... */ });
 ```
 
 ### Returns

--- a/files/en-us/web/api/audioworkletnode/onprocessorerror/index.md
+++ b/files/en-us/web/api/audioworkletnode/onprocessorerror/index.md
@@ -28,7 +28,7 @@ throughout its lifetime.
 ## Syntax
 
 ```js
-audioWorkletNode.onprocessorerror = function() { ... };
+audioWorkletNode.onprocessorerror = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/baseaudiocontext/onstatechange/index.md
+++ b/files/en-us/web/api/baseaudiocontext/onstatechange/index.md
@@ -22,7 +22,7 @@ changes.
 ## Syntax
 
 ```js
-baseAudioContext.onstatechange = function() { ... };
+baseAudioContext.onstatechange = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -21,7 +21,7 @@ UI, this method returns the first device matching the criteria.
 
 ```js
 Bluetooth.requestDevice([options])
-  .then(function(bluetoothDevice) { ... })
+  .then(function(bluetoothDevice) { /* ... */ })
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -21,7 +21,7 @@ first {{domxref("BluetoothRemoteGATTDescriptor")}} for a given descriptor UUID.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.getDescriptor(bluetoothDescriptorUUID).then(function(bluetoothGATTDescriptor) { ... })
+BluetoothRemoteGATTCharacteristic.getDescriptor(bluetoothDescriptorUUID).then(function(bluetoothGATTDescriptor) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
@@ -21,7 +21,7 @@ returns a {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}} of all
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.getDescriptors(bluetoothDescriptorUUID).then(function(bluetoothGATTDescriptors[]) { ... })
+BluetoothRemoteGATTCharacteristic.getDescriptors(bluetoothDescriptorUUID).then(function(bluetoothGATTDescriptors[]) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -22,7 +22,7 @@ it throws an error.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.readValue().then(function(dataView) { ... })
+BluetoothRemoteGATTCharacteristic.readValue().then(function(dataView) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
@@ -21,7 +21,7 @@ there is an active notification on it.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.startNotifications().then(function(BluetoothRemoteGATTCharacteristic) { ... })
+BluetoothRemoteGATTCharacteristic.startNotifications().then(function(BluetoothRemoteGATTCharacteristic) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
@@ -21,7 +21,7 @@ there is no longer an active notification on it.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.stopNotifications().then(function(BluetoothRemoteGATTCharacteristic) { ... })
+BluetoothRemoteGATTCharacteristic.stopNotifications().then(function(BluetoothRemoteGATTCharacteristic) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -21,7 +21,7 @@ The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a {{domxref
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.writeValue(value).then(function() { ... })
+BluetoothRemoteGATTCharacteristic.writeValue(value).then(function() { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -17,7 +17,7 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method s
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse(value).then(function() { ... })
+BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse(value).then(function() { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -17,7 +17,7 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.writeValueWithResponse(value).then(function() { ... })
+BluetoothRemoteGATTCharacteristic.writeValueWithResponse(value).then(function() { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
@@ -24,7 +24,7 @@ it is available and supported. Otherwise it throws an error.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTDescriptor.readValue().then(function(value[]) { ... })
+BluetoothRemoteGATTDescriptor.readValue().then(function(value[]) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
@@ -22,7 +22,7 @@ an {{jsxref("ArrayBuffer")}} and returns a {{jsxref("Promise")}}.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTDescriptor.writeValue(array[]).then(function() { ... })
+BluetoothRemoteGATTDescriptor.writeValue(array[]).then(function() { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
@@ -22,7 +22,7 @@ script execution environment to connect to `this.device`.
 
 ```js
 BluetoothRemoteGATTServer.connect()
-  .then(function(bluetoothRemoteGATTServer) { ... })
+  .then(function(bluetoothRemoteGATTServer) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
@@ -21,7 +21,7 @@ bluetooth device for a specified {{domxref("BluetoothServiceUUID")}}.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTServer.getPrimaryService(bluetoothServiceUUID).then(function(bluetoothGATTService) { ... })
+BluetoothRemoteGATTServer.getPrimaryService(bluetoothServiceUUID).then(function(bluetoothGATTService) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
@@ -21,7 +21,7 @@ bluetooth device for a specified `BluetoothServiceUUID`.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTServer.getPrimaryServices(bluetoothServiceUUID).then(function(bluetoothGATTServices) { ... })
+BluetoothRemoteGATTServer.getPrimaryServices(bluetoothServiceUUID).then(function(bluetoothGATTServices) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
@@ -22,7 +22,7 @@ returns a {{jsxref("Promise")}} to an instance of
 ## Syntax
 
 ```js
-bluetoothGATTServiceInstance.getCharacteristic(characteristic).then(function(BluetoothGATTCharacteristic) { ... } )
+bluetoothGATTServiceInstance.getCharacteristic(characteristic).then(function(BluetoothGATTCharacteristic) { /* ... */ } )
 ```
 
 ### Returns

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
@@ -21,7 +21,7 @@ instances for a given universally unique identifier (UUID).
 ## Syntax
 
 ```js
-bluetoothGATTServiceInstance.getCharacteristics(characteristics).then(function(BluetoothGATTCharacteristic[]) { ... } )
+bluetoothGATTServiceInstance.getCharacteristics(characteristics).then(function(BluetoothGATTCharacteristic[]) { /* ... */ } )
 ```
 
 ### Returns

--- a/files/en-us/web/api/broadcastchannel/onmessageerror/index.md
+++ b/files/en-us/web/api/broadcastchannel/onmessageerror/index.md
@@ -23,7 +23,7 @@ cannot be {{glossary("Deserialization", "deserialized")}}.
 ## Syntax
 
 ```js
-bc.onmessageerror = function() { ... };
+bc.onmessageerror = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cookiestore/onchange/index.md
+++ b/files/en-us/web/api/cookiestore/onchange/index.md
@@ -16,8 +16,8 @@ The **`onchange`** EventHandler of the {{domxref("CookieStore")}} interface fire
 ## Syntax
 
 ```js
-CookieStore.onchange = function() { ... }
-CookieStore.addEventListener('change', function() { ... })
+CookieStore.onchange = function() { /* ... */ }
+CookieStore.addEventListener('change', function() { /* ... */ })
 ```
 
 ## Examples

--- a/files/en-us/web/api/credentialscontainer/store/index.md
+++ b/files/en-us/web/api/credentialscontainer/store/index.md
@@ -23,7 +23,7 @@ The **`store()`** method of the
 ## Syntax
 
 ```js
-CredentialsContainer.store(Credential).then(function(Credential) { ... } )
+CredentialsContainer.store(Credential).then(function(Credential) { /* ... */ } )
 ```
 
 ### Parameters

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.md
@@ -17,7 +17,7 @@ The **`onmessage`** property of the {{domxref("DedicatedWorkerGlobalScope")}} in
 ## Syntax
 
 ```js
-self.onmessage = function() { ... };
+self.onmessage = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessageerror/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessageerror/index.md
@@ -23,7 +23,7 @@ fired on the worker—that is, when it receives a message that cannot be
 ## Syntax
 
 ```js
-onmessageerror = function() { ... };
+onmessageerror = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/filereader/onabort/index.md
+++ b/files/en-us/web/api/filereader/onabort/index.md
@@ -14,7 +14,7 @@ The **`FileReader.onabort`** property contains an event handler executed when th
 ## Syntax
 
 ```js
-reader.onabort = function() { ... };
+reader.onabort = function() { /* ... */ };
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
@@ -19,7 +19,7 @@ The **`pulse()`** method of the {{domxref("GamepadHapticActuator")}} interface m
 ## Syntax
 
 ```js
-gamepadHapticActuatorInstance.pulse(value, duration).then(function(result) { ... });
+gamepadHapticActuatorInstance.pulse(value, duration).then(function(result) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/globaleventhandlers/onerror/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.md
@@ -28,7 +28,7 @@ For historical reasons, different arguments are passed to `window.onerror` and `
 ### window\.onerror
 
 ```js
-window.onerror = function(message, source, lineno, colno, error) { ... };
+window.onerror = function(message, source, lineno, colno, error) { /* ... */ };
 ```
 
 Function parameters:
@@ -44,7 +44,7 @@ When the function returns `true`, this prevents the firing of the default event 
 ### window\.addEventListener('error')
 
 ```js
-window.addEventListener('error', function(event) { ... })
+window.addEventListener('error', function(event) { /* ... */ })
 ```
 
 `event` of type {{domxref("ErrorEvent")}} contains all the information about the event and the error.
@@ -52,7 +52,7 @@ window.addEventListener('error', function(event) { ... })
 ### element.onerror
 
 ```js
-element.onerror = function(event) { ... }
+element.onerror = function(event) { /* ... */ }
 ```
 
 `element.onerror` accepts a function with a single argument of type {{domxref("Event")}}.

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -154,7 +154,7 @@ You can get a `2d` context of the canvas with the following code:
 ```js
 var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
-console.log(ctx); // CanvasRenderingContext2D { ... }
+console.log(ctx); // CanvasRenderingContext2D { /* ... */ }
 ```
 
 Now you have the [2D rendering

--- a/files/en-us/web/api/htmlmediaelement/onencrypted/index.md
+++ b/files/en-us/web/api/htmlmediaelement/onencrypted/index.md
@@ -16,7 +16,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 ## Syntax
 
 ```js
-HTMLMediaElement.onencrypted = function(encrypted) { ... }
+HTMLMediaElement.onencrypted = function(encrypted) { /* ... */ }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlmediaelement/onwaitingforkey/index.md
+++ b/files/en-us/web/api/htmlmediaelement/onwaitingforkey/index.md
@@ -17,7 +17,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 ## Syntax
 
 ```js
-HTMLMediaElement.onwaitingforkey = function(waitingforkey) { ... }
+HTMLMediaElement.onwaitingforkey = function(waitingforkey) { /* ... */ }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
@@ -21,7 +21,7 @@ This only works when the application is authorized to use the specified device.
 ## Syntax
 
 ```js
-HTMLMediaElement.setSinkId(sinkId).then(function() { ... })
+HTMLMediaElement.setSinkId(sinkId).then(function() { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/idbdatabase/onabort/index.md
+++ b/files/en-us/web/api/idbdatabase/onabort/index.md
@@ -23,7 +23,7 @@ connection object.
 ## Syntax
 
 ```js
-IDBDatabase.onabort = function(event) { ... };
+IDBDatabase.onabort = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbdatabase/onclose/index.md
+++ b/files/en-us/web/api/idbdatabase/onclose/index.md
@@ -27,7 +27,7 @@ the connection has been closed.
 ## Syntax
 
 ```js
-IDBDatabase.onclose = function(event) { ... };
+IDBDatabase.onclose = function(event) { /* ... */ };
 ```
 
 ### Value

--- a/files/en-us/web/api/idbdatabase/onerror/index.md
+++ b/files/en-us/web/api/idbdatabase/onerror/index.md
@@ -26,7 +26,7 @@ returns an error and bubbles up to the connection object.
 ## Syntax
 
 ```js
-IDBDatabase.onerror = function(event) { ... }
+IDBDatabase.onerror = function(event) { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/idbdatabase/onversionchange/index.md
+++ b/files/en-us/web/api/idbdatabase/onversionchange/index.md
@@ -28,7 +28,7 @@ related).
 ## Syntax
 
 ```js
-IDBDatabase.onversionchange = function(event) { ... }
+IDBDatabase.onversionchange = function(event) { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/idbopendbrequest/onblocked/index.md
+++ b/files/en-us/web/api/idbopendbrequest/onblocked/index.md
@@ -25,7 +25,7 @@ is, not closed) somewhere, even after the `versionchange` event was sent.
 ## Syntax
 
 ```js
-IDBOpenDBRequest.onblocked = function(event) { ... };
+IDBOpenDBRequest.onblocked = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbopendbrequest/onupgradeneeded/index.md
+++ b/files/en-us/web/api/idbopendbrequest/onupgradeneeded/index.md
@@ -29,7 +29,7 @@ structure, as shown in the example below.
 ## Syntax
 
 ```js
-IDBOpenDBRequest.onupgradeneeded = function(event) { ... };
+IDBOpenDBRequest.onupgradeneeded = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbrequest/onerror/index.md
+++ b/files/en-us/web/api/idbrequest/onerror/index.md
@@ -25,7 +25,7 @@ The event handler takes one parameter, an error [Event](/en-US/docs/Web/API/Elem
 ## Syntax
 
 ```js
-request.onerror = function(event) { ... };
+request.onerror = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbrequest/onsuccess/index.md
+++ b/files/en-us/web/api/idbrequest/onsuccess/index.md
@@ -26,7 +26,7 @@ The event handler takes one parameter, a success [Event](/en-US/docs/Web/API/IDB
 ## Syntax
 
 ```js
-request.onsuccess = function(event) { ... };
+request.onsuccess = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbtransaction/onabort/index.md
+++ b/files/en-us/web/api/idbtransaction/onabort/index.md
@@ -23,7 +23,7 @@ transaction is aborted via the {{domxref("IDBTransaction.abort")}} method.
 ## Syntax
 
 ```js
-transaction.onabort = function(event) { ... };
+transaction.onabort = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbtransaction/oncomplete/index.md
+++ b/files/en-us/web/api/idbtransaction/oncomplete/index.md
@@ -42,7 +42,7 @@ the OS crashes or there is a loss of system power before the data is flushed to 
 ## Syntax
 
 ```js
-transaction.oncomplete = function(event) { ... };
+transaction.oncomplete = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/idbtransaction/onerror/index.md
+++ b/files/en-us/web/api/idbtransaction/onerror/index.md
@@ -26,7 +26,7 @@ returns an error and bubbles up to the transaction object.
 ## Syntax
 
 ```js
-transaction.onerror = function(event) { ... };
+transaction.onerror = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/mediakeys/setservercertificate/index.md
+++ b/files/en-us/web/api/mediakeys/setservercertificate/index.md
@@ -20,7 +20,7 @@ server certificate to be used to encrypt messages to the license server.
 ## Syntax
 
 ```js
-MediaKeys.setServerCertificate(serverCertificate).then(function() { ... });
+MediaKeys.setServerCertificate(serverCertificate).then(function() { /* ... */ });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediakeysession/close/index.md
+++ b/files/en-us/web/api/mediakeysession/close/index.md
@@ -21,7 +21,7 @@ associated with this object and close it. Then, it returns a {{jsxref('Promise')
 ## Syntax
 
 ```js
-mediaKeySession.close().then(function() { ... });
+mediaKeySession.close().then(function() { /* ... */ });
 ```
 
 ### Return value

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -20,7 +20,7 @@ The `MediaKeySession.generateRequest()` method returns a
 ## Syntax
 
 ```js
-mediaKeySession.generateRequest().then(function) { ... });
+mediaKeySession.generateRequest().then(function) { /* ... */ });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediakeysession/load/index.md
+++ b/files/en-us/web/api/mediakeysession/load/index.md
@@ -20,7 +20,7 @@ resolves to a boolean value after loading data for a specified session object.
 ## Syntax
 
 ```js
-mediaKeySession.load(sessionId).then(function(booleanValue) { ... });
+mediaKeySession.load(sessionId).then(function(booleanValue) { /* ... */ });
 ```
 
 ### Parameter

--- a/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.md
+++ b/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.md
@@ -14,7 +14,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 ## Syntax
 
 ```js
-MediaKeySession.onkeystatuseschange = function(keystatuschange) { ... }
+MediaKeySession.onkeystatuseschange = function(keystatuschange) { /* ... */ }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediakeysession/onmessage/index.md
+++ b/files/en-us/web/api/mediakeysession/onmessage/index.md
@@ -17,7 +17,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 ## Syntax
 
 ```js
-MediaKeySession.onmessage = function(MediaKeyMessageEvent) { ... }
+MediaKeySession.onmessage = function(MediaKeyMessageEvent) { /* ... */ }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediakeysession/update/index.md
+++ b/files/en-us/web/api/mediakeysession/update/index.md
@@ -20,7 +20,7 @@ CDM, and then returns a {{jsxref('Promise')}} .
 ## Syntax
 
 ```js
-mediaKeySession.update(response).then(function() { ... });
+mediaKeySession.update(response).then(function() { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mediaquerylist/onchange/index.md
+++ b/files/en-us/web/api/mediaquerylist/onchange/index.md
@@ -24,7 +24,7 @@ purposes.
 ## Syntax
 
 ```js
-MediaQueryList.onchange = function() { ... };
+MediaQueryList.onchange = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/mediarecorder/onpause/index.md
+++ b/files/en-us/web/api/mediarecorder/onpause/index.md
@@ -25,8 +25,8 @@ The `pause` event is thrown as a result of the
 ## Syntax
 
 ```js
-MediaRecorder.onpause = function(event) { ... }
-MediaRecorder.addEventListener('pause', function(event) { ... })
+MediaRecorder.onpause = function(event) { /* ... */ }
+MediaRecorder.addEventListener('pause', function(event) { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/mediarecorder/onresume/index.md
+++ b/files/en-us/web/api/mediarecorder/onresume/index.md
@@ -25,8 +25,8 @@ The `resume` event is thrown as a result of the
 ## Syntax
 
 ```js
-MediaRecorder.onresume = function(event) { ... }
-MediaRecorder.addEventListener('resume', function(event) { ... })
+MediaRecorder.onresume = function(event) { /* ... */ }
+MediaRecorder.addEventListener('resume', function(event) { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/mediarecorder/onstart/index.md
+++ b/files/en-us/web/api/mediarecorder/onstart/index.md
@@ -26,8 +26,8 @@ starts being gathered into a {{domxref("Blob")}}.
 ## Syntax
 
 ```js
-MediaRecorder.onstart = function(event) { ... }
-MediaRecorder.addEventListener('start', function(event) { ... })
+MediaRecorder.onstart = function(event) { /* ... */ }
+MediaRecorder.addEventListener('start', function(event) { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/mediarecorder/onstop/index.md
+++ b/files/en-us/web/api/mediarecorder/onstop/index.md
@@ -28,8 +28,8 @@ point available for you to use in your application.
 ## Syntax
 
 ```js
-MediaRecorder.onstop = function(event) { ... }
-MediaRecorder.addEventListener('stop', function(event) { ... })
+MediaRecorder.onstop = function(event) { /* ... */ }
+MediaRecorder.addEventListener('stop', function(event) { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/mediarecorder/onwarning/index.md
+++ b/files/en-us/web/api/mediarecorder/onwarning/index.md
@@ -23,8 +23,8 @@ halt recording).
 ## Syntax
 
 ```js
-mediaRecorder.onwarning = function(event) { ... }
-mediaRecorder.addEventListener('warning', function(event) { ... })
+mediaRecorder.onwarning = function(event) { /* ... */ }
+mediaRecorder.addEventListener('warning', function(event) { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/messageport/onmessage/index.md
+++ b/files/en-us/web/api/messageport/onmessage/index.md
@@ -22,7 +22,7 @@ is, when the port receives a message.
 ## Syntax
 
 ```js
-channel.onmessage = function() { ... };
+channel.onmessage = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/messageport/onmessageerror/index.md
+++ b/files/en-us/web/api/messageport/onmessageerror/index.md
@@ -24,7 +24,7 @@ port—that is, when it receives a message that cannot be {{glossary("Deserializ
 ## Syntax
 
 ```js
-port.onmessageerror = function() { ... };
+port.onmessageerror = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/networkinformation/onchange/index.md
+++ b/files/en-us/web/api/networkinformation/onchange/index.md
@@ -20,7 +20,7 @@ is received by the {{domxref("NetworkInformation")}} object.
 ## Syntax
 
 ```js
-netInfo.onchange = function() { ... }
+netInfo.onchange = function() { /* ... */ }
 ```
 
 ## Examples

--- a/files/en-us/web/api/notification/onclick/index.md
+++ b/files/en-us/web/api/notification/onclick/index.md
@@ -20,7 +20,7 @@ occur when the user clicks on a displayed {{domxref("Notification")}}.
 ## Syntax
 
 ```js
-Notification.onclick = function(event) { ... };
+Notification.onclick = function(event) { /* ... */ };
 ```
 
 The default behavior is to move the focus to the viewport of the notification's related

--- a/files/en-us/web/api/notification/onclose/index.md
+++ b/files/en-us/web/api/notification/onclose/index.md
@@ -21,7 +21,7 @@ interface specifies an event listener to receive
 ## Syntax
 
 ```js
-Notification.onclose = function() { ... };
+Notification.onclose = function() { /* ... */ };
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/notification/onerror/index.md
+++ b/files/en-us/web/api/notification/onerror/index.md
@@ -21,7 +21,7 @@ These events occur when something goes wrong with a {{domxref("Notification")}}
 ## Syntax
 
 ```js
-Notification.onerror = function() { ... };
+Notification.onerror = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/notification/onshow/index.md
+++ b/files/en-us/web/api/notification/onshow/index.md
@@ -20,7 +20,7 @@ interface specifies an event listener to receive {{domxref("Element/show_event",
 ## Syntax
 
 ```js
-Notification.onshow = function() { ... };
+Notification.onshow = function() { /* ... */ };
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/notification/requestpermission/index.md
+++ b/files/en-us/web/api/notification/requestpermission/index.md
@@ -23,7 +23,7 @@ The **`requestPermission()`** method of the {{domxref("Notification")}} interfac
 The latest spec has updated this method to a promise-based syntax that works like this:
 
 ```js
-Notification.requestPermission().then(function(permission) { ... });
+Notification.requestPermission().then(function(permission) { /* ... */ });
 ```
 
 Previously, the syntax was based on a simple callback; this version is now deprecated:

--- a/files/en-us/web/api/offlineaudiocontext/oncomplete/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/oncomplete/index.md
@@ -18,7 +18,7 @@ The `oncomplete` event handler of the `OfflineAudioContext` interface is called 
 
 ```js
 var offlineAudioCtx = new OfflineAudioContext();
-offlineAudioCtx.oncomplete = function() { ... }
+offlineAudioCtx.oncomplete = function() { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.md
@@ -23,7 +23,7 @@ not currently suspended or the rendering has not started, the promise is rejecte
 ## Syntax
 
 ```js
-OfflineAudioContext.resume().then(function() { ... });
+OfflineAudioContext.resume().then(function() { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.md
@@ -28,7 +28,7 @@ precise suspension.
 ## Syntax
 
 ```js
-OfflineAudioContext.suspend(suspendTime).then(function() { ... });
+OfflineAudioContext.suspend(suspendTime).then(function() { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.md
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.md
@@ -33,8 +33,8 @@ Request API (or even provide instructions for paying by mail or by phone).
 
 ```js
 paymentRequest.canMakePayment()
-    .then( canPay => { ... })
-    .catch( error => { ... })
+    .then( canPay => { /* ... */ })
+    .catch( error => { /* ... */ })
 
 canPay = await paymentRequest.canMakePayment();
 ```

--- a/files/en-us/web/api/paymentrequest/onpaymentmethodchange/index.md
+++ b/files/en-us/web/api/paymentrequest/onpaymentmethodchange/index.md
@@ -29,9 +29,9 @@ This event may not be fired by all payment handlers.
 ## Syntax
 
 ```js
-PaymentRequest.addEventListener('paymentmethodchange', paymentMethodChangeEvent => { ... });
+PaymentRequest.addEventListener('paymentmethodchange', paymentMethodChangeEvent => { /* ... */ });
 
-PaymentRequest.onpaymentmethodchange = function(paymentMethodChangeEvent) { ... };
+PaymentRequest.onpaymentmethodchange = function(paymentMethodChangeEvent) { /* ... */ };
 ```
 
 ### Value

--- a/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.md
+++ b/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.md
@@ -22,9 +22,9 @@ shipping address, including when an address is added by the user for the first t
 ## Syntax
 
 ```js
-PaymentRequest.addEventListener('shippingaddresschange', shippingAddressChangeEvent => { ... });
+PaymentRequest.addEventListener('shippingaddresschange', shippingAddressChangeEvent => { /* ... */ });
 
-PaymentRequest.onshippingaddresschange = function(shippingAddressChangeEvent) { ... };
+PaymentRequest.onshippingaddresschange = function(shippingAddressChangeEvent) { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.md
+++ b/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.md
@@ -21,9 +21,9 @@ option.
 ## Syntax
 
 ```js
-PaymentRequest.addEventListener('shippingoptionchange', shippingOptionChangeEvent => { ... });
+PaymentRequest.addEventListener('shippingoptionchange', shippingOptionChangeEvent => { /* ... */ });
 
-PaymentRequest.onshippingoptionchange = function(shippingOptionChangeEvent) { ... };
+PaymentRequest.onshippingoptionchange = function(shippingOptionChangeEvent) { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -16,7 +16,7 @@ The **`Permissions.query()`** method of the {{domxref("Permissions")}} interface
 ## Syntax
 
 ```js
-navigator.permissions.query(PermissionDescriptor).then(function(permissionStatus) { ... })
+navigator.permissions.query(PermissionDescriptor).then(function(permissionStatus) { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/api/permissionstatus/onchange/index.md
+++ b/files/en-us/web/api/permissionstatus/onchange/index.md
@@ -19,8 +19,8 @@ The **`onchange`** event handler of the {{domxref("PermissionStatus")}} interfac
 ## Syntax
 
 ```js
-PermissionStatus.onchange = function() { ... }
-PermissionStatus.addEventListener('change', function() { ... })
+PermissionStatus.onchange = function() { /* ... */ }
+PermissionStatus.addEventListener('change', function() { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/presentationrequest/start/index.md
+++ b/files/en-us/web/api/presentationrequest/start/index.md
@@ -21,7 +21,7 @@ user to select a display and grant permission to use that display.
 
 ```js
 var promise = presentationRequest.start()
-promise.then(function(PresentationConnection) { ... })
+promise.then(function(PresentationConnection) { /* ... */ })
        .catch(function(error) { ...})
 ```
 

--- a/files/en-us/web/api/pushmanager/getsubscription/index.md
+++ b/files/en-us/web/api/pushmanager/getsubscription/index.md
@@ -19,7 +19,7 @@ It returns a {{jsxref("Promise")}} that resolves to a {{domxref("PushSubscriptio
 ## Syntax
 
 ```js
-PushManager.getSubscription().then(function(pushSubscription) { ... } );
+PushManager.getSubscription().then(function(pushSubscription) { /* ... */ } );
 ```
 
 ### Parameters

--- a/files/en-us/web/api/pushmanager/haspermission/index.md
+++ b/files/en-us/web/api/pushmanager/haspermission/index.md
@@ -18,7 +18,7 @@ The **`PushManager.hasPermission()`** method of the {{domxref("PushManager")}} i
 ## Syntax
 
 ```js
-PushManager.hasPermission().then(function(pushPermissionStatus) { ... } );
+PushManager.hasPermission().then(function(pushPermissionStatus) { /* ... */ } );
 ```
 
 ## Example

--- a/files/en-us/web/api/pushmanager/permissionstate/index.md
+++ b/files/en-us/web/api/pushmanager/permissionstate/index.md
@@ -24,7 +24,7 @@ values are  `'prompt'`, `'denied'`, or `'granted'`.
 ## Syntax
 
 ```js
-PushManager.permissionState(options).then(function(PushMessagingState) { ... });
+PushManager.permissionState(options).then(function(PushMessagingState) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/pushmanager/subscribe/index.md
+++ b/files/en-us/web/api/pushmanager/subscribe/index.md
@@ -23,7 +23,7 @@ the current service worker does not have an existing subscription.
 ## Syntax
 
 ```js
-PushManager.subscribe(options).then(function(pushSubscription) { ... } );
+PushManager.subscribe(options).then(function(pushSubscription) { /* ... */ } );
 ```
 
 ### Parameters

--- a/files/en-us/web/api/pushsubscription/unsubscribe/index.md
+++ b/files/en-us/web/api/pushsubscription/unsubscribe/index.md
@@ -22,7 +22,7 @@ current subscription is successfully unsubscribed.
 ## Syntax
 
 ```js
-PushSubscription.unsubscribe().then(function(Boolean) { ... });
+PushSubscription.unsubscribe().then(function(Boolean) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/screenorientation/onchange/index.md
+++ b/files/en-us/web/api/screenorientation/onchange/index.md
@@ -20,8 +20,8 @@ The **`onchange`** property of the
 ## Syntax
 
 ```js
-screen.orientation.addEventListener('change', function(e) { ... })
-screen.orientation.onchange = function(e) { ... }
+screen.orientation.addEventListener('change', function(e) { /* ... */ })
+screen.orientation.onchange = function(e) { /* ... */ }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.md
+++ b/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.md
@@ -21,7 +21,7 @@ The `onaudioprocess` event handler of the {{domxref("ScriptProcessorNode")}} int
 ```js
 var audioCtx = new AudioContext();
 var scriptNode = audioCtx.createScriptProcessor(4096, 1, 1);
-scriptNode.onaudioprocess = function() { ... }
+scriptNode.onaudioprocess = function() { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/sensor/onactivate/index.md
+++ b/files/en-us/web/api/sensor/onactivate/index.md
@@ -23,7 +23,7 @@ called when one of the Sensor interface's child interfaces becomes active.
 
 ```js
 sensorInstance.onactivate = function
-   sensorInstance.addEventListener('activate', function() { ... })
+   sensorInstance.addEventListener('activate', function() { /* ... */ })
 ```
 
 Because {{domxref('Sensor')}} is a base class, `onactivate` may only be used

--- a/files/en-us/web/api/sensor/onerror/index.md
+++ b/files/en-us/web/api/sensor/onerror/index.md
@@ -24,7 +24,7 @@ interfaces of the {{domxref("Sensor")}} interface.
 
 ```js
 sensorInstance.onerror = function
-  sensorInstance.addEventListener('error', function() { ... })
+  sensorInstance.addEventListener('error', function() { /* ... */ })
 ```
 
 Because {{domxref('Sensor')}} is a base class, `onerror` may only be used on

--- a/files/en-us/web/api/sensor/onreading/index.md
+++ b/files/en-us/web/api/sensor/onreading/index.md
@@ -24,7 +24,7 @@ interfaces of the {{domxref("Sensor")}} interface.
 
 ```js
 sensorInstance.onreading = function
-  sensorInstance.addEventListener('reading', function() { ... })
+  sensorInstance.addEventListener('reading', function() { /* ... */ })
 ```
 
 Because {{domxref('Sensor')}} is a base class, `onreading` may only be used

--- a/files/en-us/web/api/serviceworker/onerror/index.md
+++ b/files/en-us/web/api/serviceworker/onerror/index.md
@@ -19,7 +19,7 @@ The **`onerror`** property of the {{domxref("ServiceWorker")}} interface represe
 ## Syntax
 
 ```js
-myServiceWorker.onerror = function(event) { ... };
+myServiceWorker.onerror = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworker/onstatechange/index.md
+++ b/files/en-us/web/api/serviceworker/onstatechange/index.md
@@ -19,8 +19,8 @@ An {{domxref("EventListener")}} property called whenever an event of type
 ## Syntax
 
 ```js
-ServiceWorker.onstatechange = function(statechangeevent) { ... }
-ServiceWorker.addEventListener('statechange', function(statechangeevent) { ... } )
+ServiceWorker.onstatechange = function(statechangeevent) { /* ... */ }
+ServiceWorker.addEventListener('statechange', function(statechangeevent) { /* ... */ } )
 ```
 
 ## Examples

--- a/files/en-us/web/api/serviceworkercontainer/getregistration/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/getregistration/index.md
@@ -21,7 +21,7 @@ a {{domxref("ServiceWorkerRegistration")}} or `undefined`.
 ## Syntax
 
 ```js
-serviceWorkerContainer.getRegistration(clientURL).then(function(serviceWorkerRegistration) { ... });
+serviceWorkerContainer.getRegistration(clientURL).then(function(serviceWorkerRegistration) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serviceworkercontainer/getregistrations/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/getregistrations/index.md
@@ -23,7 +23,7 @@ The **`getRegistrations()`** method of the
 ## Syntax
 
 ```js
-serviceWorkerContainer.getRegistrations().then(function(serviceWorkerRegistrations) { ... });
+serviceWorkerContainer.getRegistrations().then(function(serviceWorkerRegistrations) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serviceworkercontainer/oncontrollerchange/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/oncontrollerchange/index.md
@@ -24,7 +24,7 @@ The **`oncontrollerchange`** property of the
 ## Syntax
 
 ```js
-serviceWorkerContainer.oncontrollerchange = function(controllerchangeevent) { ... }
+serviceWorkerContainer.oncontrollerchange = function(controllerchangeevent) { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkercontainer/onerror/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/onerror/index.md
@@ -21,7 +21,7 @@ The **`onerror`** property of the
 ## Syntax
 
 ```js
-serviceWorkerContainer.onerror = function(errorevent) { ... }
+serviceWorkerContainer.onerror = function(errorevent) { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkercontainer/onmessage/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/onmessage/index.md
@@ -28,7 +28,7 @@ The **`onmessage`** property of the
 ## Syntax
 
 ```js
-serviceWorkerContainer.onmessage = function(messageevent) { ... }
+serviceWorkerContainer.onmessage = function(messageevent) { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkercontainer/ready/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/ready/index.md
@@ -24,7 +24,7 @@ the {{domxref("ServiceWorkerRegistration")}}.
 ## Syntax
 
 ```js
-navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) { ... });
+navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) { /* ... */ });
 ```
 
 ### Value

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -31,7 +31,7 @@ service worker can't have a scope broader than its own location, only use the
 
 ```js
 serviceWorkerContainer.register(scriptURL, options)
-  .then(function(serviceWorkerRegistration) { ... });
+  .then(function(serviceWorkerRegistration) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serviceworkerglobalscope/onactivate/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onactivate/index.md
@@ -19,7 +19,7 @@ The **onactivate** property of the {{domxref("ServiceWorkerGlobalScope")}} inter
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onactivate = function(event) { ... };
+ServiceWorkerGlobalScope.onactivate = function(event) { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.md
@@ -17,7 +17,7 @@ The **`oncontentdelete`** property of the {{domxref("ServiceWorkerGlobalScope")}
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.oncontentdelete = function(event) { ... };
+ServiceWorkerGlobalScope.oncontentdelete = function(event) { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/serviceworkerglobalscope/onfetch/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onfetch/index.md
@@ -21,7 +21,7 @@ when the {{domxref("fetch()")}} method is called.)
 ## Syntax
 
 ```js
-serviceWorkerGlobalScope.onfetch = function(fetchEvent) { ... };
+serviceWorkerGlobalScope.onfetch = function(fetchEvent) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkerglobalscope/oninstall/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/oninstall/index.md
@@ -17,7 +17,7 @@ The **`oninstall`** property of the {{domxref("ServiceWorkerGlobalScope")}} inte
 ## Syntax
 
 ```js
-self.oninstall = function(event) { ... };
+self.oninstall = function(event) { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/serviceworkerglobalscope/onmessage/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onmessage/index.md
@@ -33,7 +33,7 @@ incoming messages are received.
 ## Syntax
 
 ```js
-serviceWorkerGlobalScope.onmessage = function(extendableMessageEvent) { ... };
+serviceWorkerGlobalScope.onmessage = function(extendableMessageEvent) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkerglobalscope/onnotificationclick/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onnotificationclick/index.md
@@ -22,7 +22,7 @@ Notifications created on the main thread or in workers which aren't service work
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onnotificationclick = function(NotificationEvent) { ... };
+ServiceWorkerGlobalScope.onnotificationclick = function(NotificationEvent) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkerglobalscope/onnotificationclose/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onnotificationclose/index.md
@@ -32,8 +32,8 @@ itself.
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onnotificationclose = function(NotificationEvent) { ... };
-ServiceWorkerGlobalScope.addEventListener('notificationclose', function(NotificationEvent) { ... });
+ServiceWorkerGlobalScope.onnotificationclose = function(NotificationEvent) { /* ... */ };
+ServiceWorkerGlobalScope.addEventListener('notificationclose', function(NotificationEvent) { /* ... */ });
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkerglobalscope/onperiodicsync/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onperiodicsync/index.md
@@ -16,7 +16,7 @@ The **`onperiodicsync`** property of the {{domxref("ServiceWorkerGlobalScope")}}
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onperiodicsync = function(event) { ... };
+ServiceWorkerGlobalScope.onperiodicsync = function(event) { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/serviceworkerglobalscope/onpush/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onpush/index.md
@@ -21,8 +21,8 @@ received by a service worker via a push server.
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onpush = function(PushEvent) { ... }
-self.addEventListener('push', function(PushEvent) { ... })
+ServiceWorkerGlobalScope.onpush = function(PushEvent) { /* ... */ }
+self.addEventListener('push', function(PushEvent) { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.md
@@ -27,8 +27,8 @@ happen if, for example, the push service sets an expiration time a subscription.
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onpushsubscriptionchange = function() { ... }
-self.addEventListener('pushsubscriptionchange', function() { ... })
+ServiceWorkerGlobalScope.onpushsubscriptionchange = function() { /* ... */ }
+self.addEventListener('pushsubscriptionchange', function() { /* ... */ })
 ```
 
 ## Example

--- a/files/en-us/web/api/serviceworkerglobalscope/onsync/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/onsync/index.md
@@ -10,8 +10,8 @@ The **`ServiceWorkerGlobalScope.onsync`** event of the {{domxref("ServiceWorkerG
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.onsync = function(SyncEvent) { ... }
-self.addEventListener('sync', function(SyncEvent) { ... })
+ServiceWorkerGlobalScope.onsync = function(SyncEvent) { /* ... */ }
+self.addEventListener('sync', function(SyncEvent) { /* ... */ })
 ```
 
 ## Specifications

--- a/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
@@ -28,7 +28,7 @@ that same origin.
 
 ```js
 serviceWorkerRegistration.getNotifications(options)
-.then(function(notificationsList) { ... });
+.then(function(notificationsList) { /* ... */ });
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serviceworkerregistration/onupdatefound/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/onupdatefound/index.md
@@ -23,7 +23,7 @@ service worker.
 ## Syntax
 
 ```js
-serviceWorkerRegistration.onupdatefound = function() { ... };
+serviceWorkerRegistration.onupdatefound = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/sharedworker/onerror/index.md
+++ b/files/en-us/web/api/sharedworker/onerror/index.md
@@ -19,7 +19,7 @@ The **`onerror`** property of the {{domxref("SharedWorker")}} interface represen
 ## Syntax
 
 ```js
-mySharedWorker.onerror = function(event) { ... };
+mySharedWorker.onerror = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/sharedworkerglobalscope/onconnect/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/onconnect/index.md
@@ -17,7 +17,7 @@ The **`onconnect`** property of the {{domxref("SharedWorkerGlobalScope")}} inter
 ## Syntax
 
 ```js
-onconnect = function() { ... };
+onconnect = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onaudioend/index.md
+++ b/files/en-us/web/api/speechrecognition/onaudioend/index.md
@@ -24,7 +24,7 @@ event fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onaudioend = function() { ... };
+mySpeechRecognition.onaudioend = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onaudiostart/index.md
+++ b/files/en-us/web/api/speechrecognition/onaudiostart/index.md
@@ -23,7 +23,7 @@ fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onaudiostart = function() { ... };
+mySpeechRecognition.onaudiostart = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onend/index.md
+++ b/files/en-us/web/api/speechrecognition/onend/index.md
@@ -24,7 +24,7 @@ fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onend = function() { ... };
+mySpeechRecognition.onend = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onerror/index.md
+++ b/files/en-us/web/api/speechrecognition/onerror/index.md
@@ -22,7 +22,7 @@ when a speech recognition error occurs (when the [error](/en-US/docs/Web/API/Spe
 ## Syntax
 
 ```js
-mySpeechRecognition.onerror = function() { ... };
+mySpeechRecognition.onerror = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onnomatch/index.md
+++ b/files/en-us/web/api/speechrecognition/onnomatch/index.md
@@ -32,7 +32,7 @@ This may involve some degree of recognition, which doesn't meet or exceed the
 ## Syntax
 
 ```js
-mySpeechRecognition.onnomatch = function() { ... };
+mySpeechRecognition.onnomatch = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onresult/index.md
+++ b/files/en-us/web/api/speechrecognition/onresult/index.md
@@ -24,7 +24,7 @@ event](/en-US/docs/Web/API/SpeechRecognition/result_event) fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onresult = function() { ... };
+mySpeechRecognition.onresult = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onsoundend/index.md
+++ b/files/en-us/web/api/speechrecognition/onsoundend/index.md
@@ -24,7 +24,7 @@ event fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onsoundend = function() { ... };
+mySpeechRecognition.onsoundend = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onsoundstart/index.md
+++ b/files/en-us/web/api/speechrecognition/onsoundstart/index.md
@@ -23,7 +23,7 @@ fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onsoundstart = function() { ... };
+mySpeechRecognition.onsoundstart = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onspeechend/index.md
+++ b/files/en-us/web/api/speechrecognition/onspeechend/index.md
@@ -25,7 +25,7 @@ event fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onspeechend = function() { ... };
+mySpeechRecognition.onspeechend = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onspeechstart/index.md
+++ b/files/en-us/web/api/speechrecognition/onspeechstart/index.md
@@ -25,7 +25,7 @@ event fires.)
 ## Syntax
 
 ```js
-mySpeechRecognition.onspeechstart = function() { ... };
+mySpeechRecognition.onspeechstart = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechrecognition/onstart/index.md
+++ b/files/en-us/web/api/speechrecognition/onstart/index.md
@@ -24,7 +24,7 @@ recognize grammars associated with the current `SpeechRecognition` (when the
 ## Syntax
 
 ```js
-mySpeechRecognition.onstart = function() { ... };
+mySpeechRecognition.onstart = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.md
+++ b/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.md
@@ -28,7 +28,7 @@ installed/uninstalled while a speech synthesis application is running.
 ## Syntax
 
 ```js
-speechSynthesisInstance.onvoiceschanged = function() { ... };
+speechSynthesisInstance.onvoiceschanged = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onboundary/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onboundary/index.md
@@ -24,7 +24,7 @@ event fires.)
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onboundary = function() { ... };
+speechSynthesisUtteranceInstance.onboundary = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onend/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onend/index.md
@@ -22,7 +22,7 @@ run when the utterance has finished being spoken (when the [end](/en-US/docs/Web
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onend = function() { ... };
+speechSynthesisUtteranceInstance.onend = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onerror/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onerror/index.md
@@ -22,7 +22,7 @@ the {{event("error_(SpeechSynthesis)", "error")}} event fires.)
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onerror = function() { ... };
+speechSynthesisUtteranceInstance.onerror = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onmark/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onmark/index.md
@@ -24,7 +24,7 @@ event fires.)
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onmark = function() { ... };
+speechSynthesisUtteranceInstance.onmark = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onpause/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onpause/index.md
@@ -25,7 +25,7 @@ This occurs when the {{domxref("SpeechSynthesis.pause()")}} method is invoked.
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onpause = function() { ... };
+speechSynthesisUtteranceInstance.onpause = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onresume/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onresume/index.md
@@ -26,7 +26,7 @@ paused speech synthesis instance.
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onresume = function() { ... };
+speechSynthesisUtteranceInstance.onresume = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisutterance/onstart/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/onstart/index.md
@@ -25,7 +25,7 @@ This occurs when the {{domxref("SpeechSynthesis.speak()")}} method is invoked.
 ## Syntax
 
 ```js
-speechSynthesisUtteranceInstance.onstart = function() { ... };
+speechSynthesisUtteranceInstance.onstart = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/storagemanager/persist/index.md
+++ b/files/en-us/web/api/storagemanager/persist/index.md
@@ -19,7 +19,7 @@ is granted and box mode is persistent, and `false` otherwise.
 ## Syntax
 
 ```js
-navigator.storage.persist().then(function(persistent) { ... })
+navigator.storage.persist().then(function(persistent) { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/api/storagemanager/persisted/index.md
+++ b/files/en-us/web/api/storagemanager/persisted/index.md
@@ -18,7 +18,7 @@ to `true` if box mode is persistent for your site's storage.
 ## Syntax
 
 ```js
-navigator.storage.persisted().then(function(persistent) { ... })
+navigator.storage.persisted().then(function(persistent) { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/api/syncmanager/gettags/index.md
+++ b/files/en-us/web/api/syncmanager/gettags/index.md
@@ -20,7 +20,7 @@ The **`SyncManager.getTags`** method of the
 ## Syntax
 
 ```js
-SyncManager.getTags().then(function(tags[]) { ... })
+SyncManager.getTags().then(function(tags[]) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/syncmanager/register/index.md
+++ b/files/en-us/web/api/syncmanager/register/index.md
@@ -20,7 +20,7 @@ The **`SyncManager.register`** method of the
 ## Syntax
 
 ```js
-SyncManager.register([options]).then(function(syncRegistration) { ... })
+SyncManager.register([options]).then(function(syncRegistration) { /* ... */ })
 ```
 
 ### Returns

--- a/files/en-us/web/api/visualviewport/onresize/index.md
+++ b/files/en-us/web/api/visualviewport/onresize/index.md
@@ -24,7 +24,7 @@ is fired.
 ## Syntax
 
 ```js
-VisualViewport.onresize = function(e) { ... }
+VisualViewport.onresize = function(e) { /* ... */ }
 ```
 
 ## Examples

--- a/files/en-us/web/api/visualviewport/onscroll/index.md
+++ b/files/en-us/web/api/visualviewport/onscroll/index.md
@@ -24,7 +24,7 @@ is fired.
 ## Syntax
 
 ```js
-VisualViewport.onscroll = function(e) { ... }
+VisualViewport.onscroll = function(e) { /* ... */ }
 ```
 
 ## Examples

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
@@ -142,7 +142,7 @@ Now onto our first WebVR-specific code. First of all, we check to see if {{domxr
       console.log('WebVR 1.1 supported');
 ```
 
-Inside our `if() { /* ... */ }` block, we run the {{domxref("Navigator.getVRDisplays()")}} function. This returns a promise, which is fulfilled with an array containing all the VR display devices connected to the computer. If none are connected, the array will be empty.
+Inside our `if() { ... }` block, we run the {{domxref("Navigator.getVRDisplays()")}} function. This returns a promise, which is fulfilled with an array containing all the VR display devices connected to the computer. If none are connected, the array will be empty.
 
 ```js
       // Then get the displays attached to the computer

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
@@ -142,7 +142,7 @@ Now onto our first WebVR-specific code. First of all, we check to see if {{domxr
       console.log('WebVR 1.1 supported');
 ```
 
-Inside our `if() { ... }` block, we run the {{domxref("Navigator.getVRDisplays()")}} function. This returns a promise, which is fulfilled with an array containing all the VR display devices connected to the computer. If none are connected, the array will be empty.
+Inside our `if() { /* ... */ }` block, we run the {{domxref("Navigator.getVRDisplays()")}} function. This returns a promise, which is fulfilled with an array containing all the VR display devices connected to the computer. If none are connected, the array will be empty.
 
 ```js
       // Then get the displays attached to the computer

--- a/files/en-us/web/api/window/onappinstalled/index.md
+++ b/files/en-us/web/api/window/onappinstalled/index.md
@@ -22,7 +22,7 @@ dispatched once the web application is successfully installed as a [progressive 
 ## Syntax
 
 ```js
-window.onappinstalled = function(event) { ... };
+window.onappinstalled = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/window/onbeforeinstallprompt/index.md
+++ b/files/en-us/web/api/window/onbeforeinstallprompt/index.md
@@ -21,7 +21,7 @@ used to prompt the user at a more suitable time.
 ## Syntax
 
 ```js
-window.addEventListener("beforeinstallprompt", function(event) { ... });
+window.addEventListener("beforeinstallprompt", function(event) { /* ... */ });
 window.onbeforeinstallprompt = function(event) { ...};
 ```
 

--- a/files/en-us/web/api/window/ondeviceorientation/index.md
+++ b/files/en-us/web/api/window/ondeviceorientation/index.md
@@ -19,8 +19,8 @@ information about a relative device orientation change.
 ## Syntax
 
 ```js
-window.ondeviceorientation = function(event) { ... };
-window.addEventListener('deviceorientation', function(event) { ... });
+window.ondeviceorientation = function(event) { /* ... */ };
+window.addEventListener('deviceorientation', function(event) { /* ... */ });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/window/ondeviceorientationabsolute/index.md
+++ b/files/en-us/web/api/window/ondeviceorientationabsolute/index.md
@@ -19,8 +19,8 @@ containing information about an absolute device orientation change.
 ## Syntax
 
 ```js
-window.ondeviceorientationabsolute = function(event) { ... };
-window.addEventListener('deviceorientationabsolute', function(event) { ... });
+window.ondeviceorientationabsolute = function(event) { /* ... */ };
+window.addEventListener('deviceorientationabsolute', function(event) { /* ... */ });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/window/ongamepadconnected/index.md
+++ b/files/en-us/web/api/window/ongamepadconnected/index.md
@@ -23,7 +23,7 @@ The event object is of type {{domxref("GamepadEvent")}}.
 ## Syntax
 
 ```js
-window.ongamepadconnected = function() { ... };
+window.ongamepadconnected = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/ongamepaddisconnected/index.md
+++ b/files/en-us/web/api/window/ongamepaddisconnected/index.md
@@ -23,7 +23,7 @@ The event object is of type {{domxref("GamepadEvent")}}.
 ## Syntax
 
 ```js
-window.ongamepaddisconnected = function() { ... };
+window.ongamepaddisconnected = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/onvrdisplayactivate/index.md
+++ b/files/en-us/web/api/window/onvrdisplayactivate/index.md
@@ -30,7 +30,7 @@ The event object is of type {{domxref("VRDisplayEvent")}}.
 ## Syntax
 
 ```js
-window.onvrdisplayactivate = function() { ... };
+window.onvrdisplayactivate = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/onvrdisplayblur/index.md
+++ b/files/en-us/web/api/window/onvrdisplayblur/index.md
@@ -36,7 +36,7 @@ The event object is of type {{domxref("VRDisplayEvent")}}.
 ## Syntax
 
 ```js
-window.onvrdisplayblur = function() { ... };
+window.onvrdisplayblur = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/onvrdisplayconnect/index.md
+++ b/files/en-us/web/api/window/onvrdisplayconnect/index.md
@@ -28,7 +28,7 @@ The event object is of type {{domxref("VRDisplayEvent")}}.
 ## Syntax
 
 ```js
-window.onvrdisplayconnect = function() { ... };
+window.onvrdisplayconnect = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/onvrdisplaydeactivate/index.md
+++ b/files/en-us/web/api/window/onvrdisplaydeactivate/index.md
@@ -29,7 +29,7 @@ The event object is of type {{domxref("VRDisplayEvent")}}.
 ## Syntax
 
 ```js
-window.onvrdisplaydeactivate = function() { ... };
+window.onvrdisplaydeactivate = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/onvrdisplaydisconnect/index.md
+++ b/files/en-us/web/api/window/onvrdisplaydisconnect/index.md
@@ -27,7 +27,7 @@ The event object is of type {{domxref("VRDisplayEvent")}}.
 ## Syntax
 
 ```js
-window.onvrdisplaydisconnect = function() { ... };
+window.onvrdisplaydisconnect = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/onvrdisplayfocus/index.md
+++ b/files/en-us/web/api/window/onvrdisplayfocus/index.md
@@ -29,7 +29,7 @@ The event object is of type {{domxref("VRDisplayEvent")}}.
 ## Syntax
 
 ```js
-window.onvrdisplayfocus = function() { ... };
+window.onvrdisplayfocus = function() { /* ... */ };
 ```
 
 ## Examples

--- a/files/en-us/web/api/windoweventhandlers/onafterprint/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onafterprint/index.md
@@ -28,8 +28,8 @@ CSS at-rule, but it may be necessary to use these events in some cases.
 ## Syntax
 
 ```js
-window.addEventListener("afterprint", function(event) { ... });
-window.onafterprint = function(event) { ... };
+window.addEventListener("afterprint", function(event) { /* ... */ });
+window.onafterprint = function(event) { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/windoweventhandlers/onbeforeprint/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onbeforeprint/index.md
@@ -28,8 +28,8 @@ CSS at-rule, but it may be necessary to use these events in some cases.
 ## Syntax
 
 ```js
-window.addEventListener("beforeprint", function(event) { ... });
-window.onbeforeprint = function(event) { ... };
+window.addEventListener("beforeprint", function(event) { /* ... */ });
+window.onbeforeprint = function(event) { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/windoweventhandlers/onbeforeunload/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onbeforeunload/index.md
@@ -31,8 +31,8 @@ event is still cancelable.
 ## Syntax
 
 ```js
-window.addEventListener("beforeunload", function(event) { ... });
-window.onbeforeunload = function(event) { ... };
+window.addEventListener("beforeunload", function(event) { /* ... */ });
+window.onbeforeunload = function(event) { /* ... */ };
 ```
 
 Typically, it is better to use {{domxref("EventTarget.addEventListener",

--- a/files/en-us/web/api/windoweventhandlers/onmessage/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onmessage/index.md
@@ -22,8 +22,8 @@ whenever an object receives a {{event("message")}} event.
 ## Syntax
 
 ```js
-window.addEventListener('message', function(event) { ... })
-window.onmessage = function(event) { ... }
+window.addEventListener('message', function(event) { /* ... */ })
+window.onmessage = function(event) { /* ... */ }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/windoweventhandlers/onmessageerror/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onmessageerror/index.md
@@ -24,7 +24,7 @@ that cannot be {{glossary("Deserialization", "deserialized")}}.
 ## Syntax
 
 ```js
-window.onmessageerror = function() { ... };
+window.onmessageerror = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/windoweventhandlers/onrejectionhandled/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onrejectionhandled/index.md
@@ -24,7 +24,7 @@ processing {{event("rejectionhandled")}} events. These events are raised when
 ## Syntax
 
 ```js
-window.addEventListener("rejectionhandled", function(event) { ... });
+window.addEventListener("rejectionhandled", function(event) { /* ... */ });
 window.onrejectionhandled = function(event) { ...};
 ```
 

--- a/files/en-us/web/api/windoweventhandlers/onunload/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onunload/index.md
@@ -37,8 +37,8 @@ its content and resources. The resource removal is processed _after_ the
 ## Syntax
 
 ```js
-window.addEventListener("unload", function(event) { ... });
-window.onunload = function(event) { ... };
+window.addEventListener("unload", function(event) { /* ... */ });
+window.onunload = function(event) { /* ... */ };
 ```
 
 Typically, it is better to use {{domxref("EventTarget.addEventListener",

--- a/files/en-us/web/api/worker/onerror/index.md
+++ b/files/en-us/web/api/worker/onerror/index.md
@@ -19,7 +19,7 @@ The **`onerror`** property of the {{domxref("Worker")}} interface represents an 
 ## Syntax
 
 ```js
-myWorker.onerror = function(event) { ... };
+myWorker.onerror = function(event) { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/worker/onmessage/index.md
+++ b/files/en-us/web/api/worker/onmessage/index.md
@@ -22,7 +22,7 @@ Note that deserializing the message sent by {{domxref("DedicatedWorkerGlobalScop
 ## Syntax
 
 ```js
-myWorker.onmessage = function(e) { ... }
+myWorker.onmessage = function(e) { /* ... */ }
 ```
 
 ## Example

--- a/files/en-us/web/api/worker/onmessageerror/index.md
+++ b/files/en-us/web/api/worker/onmessageerror/index.md
@@ -23,7 +23,7 @@ The **`onmessageerror`** event handler of the
 ## Syntax
 
 ```js
-Worker.onmessageerror = function() { ... };
+Worker.onmessageerror = function() { /* ... */ };
 ```
 
 ## Specifications

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -134,11 +134,11 @@ self.onmessage = function handleMessageFromMain(msg) {
 buf.byteLength in main BEFORE transfer to worker:        8                     main.js:19
 buf.byteLength in main AFTER transfer to worker:         0                     main.js:27
 
-message from main received in worker:                    MessageEvent { ... }  myWorker.js:3
+message from main received in worker:                    MessageEvent { /* ... */ }  myWorker.js:3
 buf.byteLength in worker BEFORE transfer back to main:   8                     myWorker.js:7
 buf.byteLength in worker AFTER transfer back to main:    0                     myWorker.js:15
 
-message from worker received in main:                    MessageEvent { ... }  main.js:6
+message from worker received in main:                    MessageEvent { /* ... */ }  main.js:6
 buf.byteLength in main AFTER transfer back from worker:  8                     main.js:10
 ```
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -134,11 +134,11 @@ self.onmessage = function handleMessageFromMain(msg) {
 buf.byteLength in main BEFORE transfer to worker:        8                     main.js:19
 buf.byteLength in main AFTER transfer to worker:         0                     main.js:27
 
-message from main received in worker:                    MessageEvent { /* ... */ }  myWorker.js:3
+message from main received in worker:                    MessageEvent { ... }  myWorker.js:3
 buf.byteLength in worker BEFORE transfer back to main:   8                     myWorker.js:7
 buf.byteLength in worker AFTER transfer back to main:    0                     myWorker.js:15
 
-message from worker received in main:                    MessageEvent { /* ... */ }  main.js:6
+message from worker received in main:                    MessageEvent { ... }  main.js:6
 buf.byteLength in main AFTER transfer back from worker:  8                     main.js:10
 ```
 

--- a/files/en-us/web/api/workerglobalscope/onerror/index.md
+++ b/files/en-us/web/api/workerglobalscope/onerror/index.md
@@ -18,7 +18,7 @@ The **`onerror`** property of the {{domxref("WorkerGlobalScope")}} interface rep
 ## Syntax
 
 ```js
-self.onerror = function() { ... };
+self.onerror = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/workerglobalscope/onlanguagechange/index.md
+++ b/files/en-us/web/api/workerglobalscope/onlanguagechange/index.md
@@ -17,7 +17,7 @@ The **`onlanguagechange`** property of the {{domxref("WorkerGlobalScope")}} inte
 ## Syntax
 
 ```js
-self.onlanguagechange = function() { ... };
+self.onlanguagechange = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/workerglobalscope/onoffline/index.md
+++ b/files/en-us/web/api/workerglobalscope/onoffline/index.md
@@ -17,7 +17,7 @@ The **`onoffline`** property of the {{domxref("WorkerGlobalScope")}} interface r
 ## Syntax
 
 ```js
-self.onoffline = function() { ... };
+self.onoffline = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/api/workerglobalscope/ononline/index.md
+++ b/files/en-us/web/api/workerglobalscope/ononline/index.md
@@ -17,7 +17,7 @@ The **`ononline`** property of the {{domxref("WorkerGlobalScope")}} interface re
 ## Syntax
 
 ```js
-self.ononline = function() { ... };
+self.ononline = function() { /* ... */ };
 ```
 
 ## Example

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.md
@@ -17,13 +17,13 @@ The **`FinalizationRegistry`** constructor creates a {{jsxref("FinalizationRegis
 
 ```js
 // Arrow callback function
-new FinalizationRegistry(heldValue => { ... } )
+new FinalizationRegistry(heldValue => { /* ... */ } )
 
 // Callback function
 new FinalizationRegistry(callbackFn)
 
 // Inline callback function
-new FinalizationRegistry(function(heldValue) { ... })
+new FinalizationRegistry(function(heldValue) { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.md
@@ -15,9 +15,7 @@ browser-compat: javascript.builtins.Math.max
 ---
 {{JSRef}}
 
-The **`Math.max()`** function returns
-the largest of the zero or more numbers given as input parameters, or {{jsxref("NaN")}} if any parameter
-isn't a number and can't be converted into one.
+The **`Math.max()`** function returns the largest of the zero or more numbers given as input parameters, or {{jsxref("NaN")}} if any parameter isn't a number and can't be converted into one.
 
 {{EmbedInteractiveExample("pages/js/math-max.html")}}
 
@@ -27,12 +25,12 @@ isn't a number and can't be converted into one.
 Math.max()
 Math.max(value0)
 Math.max(value0, value1)
-Math.max(value0, value1, ... , valueN)
+Math.max(value0, value1, /* ... ,*/ valueN)
 ```
 
 ### Parameters
 
-- `value1, value2, ...`
+- `value1`, `value2`, ... , `valueN`
   - : Zero or more numbers among which the largest value will be selected and returned.
 
 ### Return value


### PR DESCRIPTION
Fixes #10937

@Elchi3 @jugglinmike This updates the syntax guidance for use of ellipses in code blocks and for sequences. It also updates all instances in the web/api tree of ellipses in code blocks.

This does not update the cases for sequences or generally stuff in the javascript tree (e.g. global objects etc). I figure I'll look at those if this goes in.

