### PR TITLE
FF96 Relnote: Web Locks API enabled

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -43,6 +43,7 @@ This article provides information about the changes in Firefox 96 that will affe
 - {{domxref("navigator.canShare()")}} is now supported on Android, allowing code to check whether {{domxref("navigator.share()")}} will succeed for particular targets.
   The feature is behind a preference on desktop operating systems.
   ({{bug(1666203)}}).
+- The [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) is enabled by default, allowing web apps running in multiple tabs or workers to coordinate the use of resources. ({{bug(1740044)}}).
 
 #### DOM
 


### PR DESCRIPTION
FF96 enables the Web Locks API by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1740044. This adds a release note.

Related docs work can be tracked in https://github.com/mdn/content/issues/10859