### PR TITLE
Corrects attribute to audioTracks

### DIFF
--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -323,11 +323,11 @@ For example, to detect when audio tracks are added to or removed from a `<video>
 ```js
 var elem = document.querySelector("video");
 
-elem.audioTrackList.onaddtrack = function(event) {
+elem.audioTracks.onaddtrack = function(event) {
   trackEditor.addTrack(event.track);
 };
 
-elem.audioTrackList.onremovetrack = function(event) {
+elem.audioTracks.onremovetrack = function(event) {
   trackEditor.removeTrack(event.track);
 };
 ```


### PR DESCRIPTION
#### Summary
The correct attribute name is `audioTracks` not `audioTrackList`. Could not verify as don't have a setup of IE9. The correct attribute is not supported anywhere else.

#### Motivation
Low hanging :mango:

#### Supporting details
See example here https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/onremovetrack

#### Related issues
Fixes #11002

#### Metadata
- [x] Fixes a typo, bug, or other error