### PR TITLE
FF96 RelNote: WebP encoder format and canvas

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -44,6 +44,14 @@ This article provides information about the changes in Firefox 96 that will affe
   The feature is behind a preference on desktop operating systems.
   ({{bug(1666203)}}).
 
+
+#### Canvas
+
+- Image encoder support has been added for the [WebP](/en-US/docs/Web/Media/Formats/Image_types#webp_image) image format.
+  This allows canvas elements to export their content as webp data when using the methods: {{domxref("HTMLCanvasElement.toDataURL()")}}, {{domxref("HTMLCanvasElement.toBlob()")}}, and {{domxref("OffscreenCanvas.convertToBlob", "OffscreenCanvas.toBlob")}}.
+  ({{bug(1511670)}}).
+
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF96 adds support for a WebP image encoder in https://bugzilla.mozilla.org/show_bug.cgi?id=1511670. This is used in several canvas methods (it could be used elswhere, but there do not appear to be other uses in Firefox). This PR adds a release note.

Other work with this can be tracked in #10853