### PR TITLE
FF96 Relnote: WebRTC Stats removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -48,6 +48,9 @@ This article provides information about the changes in Firefox 96 that will affe
 
 #### Media, WebRTC, and Web Audio
 
+- A number of deprecated non-standard statistics fields have been removed from the [WebRTC Statistics API](/en-US/docs/Web/API/WebRTC_Statistics_API), including: `bitrateMean`, `bitrateStdDev`,`framerateMean`, `framerateStdDev`, and `droppedFrames`.
+  ({{bug(1367562)}}).
+
 #### Removals
 
 ### WebAssembly


### PR DESCRIPTION
This is release note for https://bugzilla.mozilla.org/show_bug.cgi?id=136756 , which removes a number of deprecated non-standard statistics. Other work for this in #10858