### PR TITLE
[Web Share] Add list of usually shareable file types

### DIFF
--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -113,6 +113,7 @@ The following is a list of usually shareable file types. However, you should alw
   - `.ogm` - `video/ogg`
   - `.ogv` - `video/ogg`
   - `.webm` - `video/webm`
+
 ## Examples
 
 The example below shows a button click invoking the Web Share API to share MDN's URL.

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -38,7 +38,7 @@ navigator.share(data)
     - `url`: A {{domxref("USVString")}} representing a URL to be shared.
     - `text`: A {{domxref("USVString")}} representing text to be shared.
     - `title`: A {{domxref("USVString")}} representing a title to be shared. May be ignored by the target.
-    - `files`: An array of {{domxref("File")}} objects representing files to be shared. See [below](#shareable-file-types) for shareable file types.
+    - `files`: An array of {{domxref("File")}} objects representing files to be shared. See [below](#shareable_file_types) for shareable file types.
 
 ### Return value
 

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -38,9 +38,7 @@ navigator.share(data)
     - `url`: A {{domxref("USVString")}} representing a URL to be shared.
     - `text`: A {{domxref("USVString")}} representing text to be shared.
     - `title`: A {{domxref("USVString")}} representing a title to be shared. May be ignored by the target.
-    - `files`: An array of {{domxref("File")}} objects representing files to be shared.
-      > **Note:** Each vendor may accept different file types. Chromium's list can be seen in this
-      > [document](https://docs.google.com/document/d/1tKPkHA5nnJtmh2TgqWmGSREUzXgMUFDL6yMdVZHqUsg/edit).
+    - `files`: An array of {{domxref("File")}} objects representing files to be shared. See [below](#shareable-file-types) for shareable file types.
 
 ### Return value
 
@@ -65,6 +63,56 @@ The {{jsxref("Promise")}} may be rejected with one of the following `DOMExceptio
   - : The user canceled the share operation or there are no share targets available.
 - `DataError`
   - : There was a problem starting the share target or transmitting the data.
+
+## Shareable file types
+
+| Category    | Extension - `MIME type                           |
+| ----------- | ------------------------------------------------ |
+| Application |                                                  |
+|             | `.pdf` - `application/pdf` (from Chromium 93)    |
+| Audio       |                                                  |
+|             | `.flac` - `audio/flac`                           |
+|             | `.m4a` - `audio/x-m4a`                           |
+|             | `.mp3` - `audio/mpeg` (also accepts `audio/mp3`) |
+|             | `.oga` - `audio/ogg`                             |
+|             | `.ogg` - `audio/ogg`                             |
+|             | `.opus` - `audio/ogg`                            |
+|             | `.wav` - `audio/wav`                             |
+|             | `.weba` - `audio/webm`                           |
+| Image       |                                                  |
+|             | `.bmp` - `image/bmp`                             |
+|             | `.gif` - `image/gif`                             |
+|             | `.ico` - `image/x-icon`                          |
+|             | `.jfif` - `image/jpeg`                           |
+|             | `.jpeg` - `image/jpeg`                           |
+|             | `.jpg` - `image/jpeg`                            |
+|             | `.pjp` - `image/jpeg`                            |
+|             | `.pjpeg` - `image/jpeg`                          |
+|             | `.png` - `image/png`                             |
+|             | `.svg` - `image/svg+xml`                         |
+|             | `.svgz` - `image/svg+xml`                        |
+|             | `.tif` - `image/tiff`                            |
+|             | `.tiff` - `image/tiff`                           |
+|             | `.webp` - `image/webp`                           |
+|             | `.xbm` - `image/x-xbitmap`                       |
+| Text        |                                                  |
+|             | `.css` - `text/css`                              |
+|             | `.csv` - `text/csv`                              |
+|             | `.ehtml` - `text/html`                           |
+|             | `.htm` - `text/html`                             |
+|             | `.html` - `text/html`                            |
+|             | `.shtm` - `text/html`                            |
+|             | `.shtml` - `text/html`                           |
+|             | `.text` - `text/plain`                           |
+|             | `.txt` - `text/plain`                            |
+| Video       |                                                  |
+|             | `.m4v` - `video/mp4`                             |
+|             | `.mp4` - `video/mp4`                             |
+|             | `.mpeg` - `video/mpeg`                           |
+|             | `.mpg` - `video/mpeg`                            |
+|             | `.ogm` - `video/ogg`                             |
+|             | `.ogv` - `video/ogg`                             |
+|             | `.webm` - `video/webm`                           |
 
 ## Examples
 

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -39,6 +39,8 @@ navigator.share(data)
     - `text`: A {{domxref("USVString")}} representing text to be shared.
     - `title`: A {{domxref("USVString")}} representing a title to be shared. May be ignored by the target.
     - `files`: An array of {{domxref("File")}} objects representing files to be shared.
+      > **Note:** Each vendor may accept different file types. Chromium's list can be seen in this
+      > [document](https://docs.google.com/document/d/1tKPkHA5nnJtmh2TgqWmGSREUzXgMUFDL6yMdVZHqUsg/edit).
 
 ### Return value
 

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -66,7 +66,7 @@ The {{jsxref("Promise")}} may be rejected with one of the following `DOMExceptio
 
 ## Shareable file types
 
-| Category    | Extension - `MIME type                           |
+| Category    | Extension - MIME type                            |
 | ----------- | ------------------------------------------------ |
 | Application |                                                  |
 |             | `.pdf` - `application/pdf` (from Chromium 93)    |

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -66,54 +66,53 @@ The {{jsxref("Promise")}} may be rejected with one of the following `DOMExceptio
 
 ## Shareable file types
 
-| Category    | Extension - MIME type                            |
-| ----------- | ------------------------------------------------ |
-| Application |                                                  |
-|             | `.pdf` - `application/pdf` (from Chromium 93)    |
-| Audio       |                                                  |
-|             | `.flac` - `audio/flac`                           |
-|             | `.m4a` - `audio/x-m4a`                           |
-|             | `.mp3` - `audio/mpeg` (also accepts `audio/mp3`) |
-|             | `.oga` - `audio/ogg`                             |
-|             | `.ogg` - `audio/ogg`                             |
-|             | `.opus` - `audio/ogg`                            |
-|             | `.wav` - `audio/wav`                             |
-|             | `.weba` - `audio/webm`                           |
-| Image       |                                                  |
-|             | `.bmp` - `image/bmp`                             |
-|             | `.gif` - `image/gif`                             |
-|             | `.ico` - `image/x-icon`                          |
-|             | `.jfif` - `image/jpeg`                           |
-|             | `.jpeg` - `image/jpeg`                           |
-|             | `.jpg` - `image/jpeg`                            |
-|             | `.pjp` - `image/jpeg`                            |
-|             | `.pjpeg` - `image/jpeg`                          |
-|             | `.png` - `image/png`                             |
-|             | `.svg` - `image/svg+xml`                         |
-|             | `.svgz` - `image/svg+xml`                        |
-|             | `.tif` - `image/tiff`                            |
-|             | `.tiff` - `image/tiff`                           |
-|             | `.webp` - `image/webp`                           |
-|             | `.xbm` - `image/x-xbitmap`                       |
-| Text        |                                                  |
-|             | `.css` - `text/css`                              |
-|             | `.csv` - `text/csv`                              |
-|             | `.ehtml` - `text/html`                           |
-|             | `.htm` - `text/html`                             |
-|             | `.html` - `text/html`                            |
-|             | `.shtm` - `text/html`                            |
-|             | `.shtml` - `text/html`                           |
-|             | `.text` - `text/plain`                           |
-|             | `.txt` - `text/plain`                            |
-| Video       |                                                  |
-|             | `.m4v` - `video/mp4`                             |
-|             | `.mp4` - `video/mp4`                             |
-|             | `.mpeg` - `video/mpeg`                           |
-|             | `.mpg` - `video/mpeg`                            |
-|             | `.ogm` - `video/ogg`                             |
-|             | `.ogv` - `video/ogg`                             |
-|             | `.webm` - `video/webm`                           |
+The following is a list of usually shareable file types. However, you should always test with {{domxref("navigator.canShare()")}} if sharing would succeed.
 
+- Application
+  - `.pdf` - `application/pdf` (from Chromium 93)
+- Audio
+  - `.flac` - `audio/flac`
+  - `.m4a` - `audio/x-m4a`
+  - `.mp3` - `audio/mpeg` (also accepts `audio/mp3`)
+  - `.oga` - `audio/ogg`
+  - `.ogg` - `audio/ogg`
+  - `.opus` - `audio/ogg`
+  - `.wav` - `audio/wav`
+  - `.weba` - `audio/webm`
+- Image
+  - `.bmp` - `image/bmp`
+  - `.gif` - `image/gif`
+  - `.ico` - `image/x-icon`
+  - `.jfif` - `image/jpeg`
+  - `.jpeg` - `image/jpeg`
+  - `.jpg` - `image/jpeg`
+  - `.pjp` - `image/jpeg`
+  - `.pjpeg` - `image/jpeg`
+  - `.png` - `image/png`
+  - `.svg` - `image/svg+xml`
+  - `.svgz` - `image/svg+xml`
+  - `.tif` - `image/tiff`
+  - `.tiff` - `image/tiff`
+  - `.webp` - `image/webp`
+  - `.xbm` - `image/x-xbitmap`
+- Text
+  - `.css` - `text/css`
+  - `.csv` - `text/csv`
+  - `.ehtml` - `text/html`
+  - `.htm` - `text/html`
+  - `.html` - `text/html`
+  - `.shtm` - `text/html`
+  - `.shtml` - `text/html`
+  - `.text` - `text/plain`
+  - `.txt` - `text/plain`
+- Video
+  - `.m4v` - `video/mp4`
+  - `.mp4` - `video/mp4`
+  - `.mpeg` - `video/mpeg`
+  - `.mpg` - `video/mpeg`
+  - `.ogm` - `video/ogg`
+  - `.ogv` - `video/ogg`
+  - `.webm` - `video/webm`
 ## Examples
 
 The example below shows a button click invoking the Web Share API to share MDN's URL.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add note about Chromium's list of accepted file types for `navigator.share()`.

#### Motivation
 Questions about this keep coming up.

#### Supporting details
https://docs.google.com/document/d/1tKPkHA5nnJtmh2TgqWmGSREUzXgMUFDL6yMdVZHqUsg/edit

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
