### PR TITLE
Disambiguate/correct throttling speed indications

### DIFF
--- a/files/en-us/tools/responsive_design_mode/index.html
+++ b/files/en-us/tools/responsive_design_mode/index.html
@@ -143,7 +143,7 @@ tags:
  <li>Minimum latency</li>
 </ul>
 
-<p>The table below lists the numbers associated with each network type, but please do not rely on this feature for exact performance measurements; it's intended to give an approximate idea of the user experience in different conditions.</p>
+<p>The table below lists the numbers associated with each network type, but please do not rely on this feature for exact performance measurements; it's intended to give an approximate idea of the user experience in different conditions. Speeds are specified in <a href="https://en.wikipedia.org/wiki/Byte#Multiple-byte_units">Kibibits and Mebibits per second</a>.</p>
 
 <table class="fullwidth-table standard-table">
  <thead>
@@ -157,50 +157,50 @@ tags:
  <tbody>
   <tr>
    <td>GPRS</td>
-   <td>50 KB/s</td>
-   <td>20 KB/s</td>
+   <td>50 Kib/s</td>
+   <td>20 Kib/s</td>
    <td>500</td>
   </tr>
   <tr>
    <td>Regular 2G</td>
-   <td>250 KB/s</td>
-   <td>50 KB/s</td>
+   <td>250 Kib/s</td>
+   <td>50 Kib/s</td>
    <td>300</td>
   </tr>
   <tr>
    <td>Good 2G</td>
-   <td>450 KB/s</td>
-   <td>150 KB/s</td>
+   <td>450 Kib/s</td>
+   <td>150 Kib/s</td>
    <td>150</td>
   </tr>
   <tr>
    <td>Regular 3G</td>
-   <td>750 KB/s</td>
-   <td>250 KB/s</td>
+   <td>750 Kib/s</td>
+   <td>250 Kib/s</td>
    <td>100</td>
   </tr>
   <tr>
    <td>Good 3G</td>
-   <td>1.5 MB/s</td>
-   <td>750 KB/s</td>
+   <td>1.5 Mib/s</td>
+   <td>750 Kib/s</td>
    <td>40</td>
   </tr>
   <tr>
    <td>Regular 4G/LTE</td>
-   <td>4 MB/s</td>
-   <td>3 MB/s</td>
+   <td>4 Mib/s</td>
+   <td>3 Mib/s</td>
    <td>20</td>
   </tr>
   <tr>
    <td>DSL</td>
-   <td>2 MB/s</td>
-   <td>1 MB/s</td>
+   <td>2 Mib/s</td>
+   <td>1 Mib/s</td>
    <td>5</td>
   </tr>
   <tr>
    <td>Wi-Fi</td>
-   <td>30 MB/s</td>
-   <td>15 MB/s</td>
+   <td>30 Mib/s</td>
+   <td>15 Mib/s</td>
    <td>2</td>
   </tr>
  </tbody>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removed/corrected unclear/wrong throttling speeds.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Original throttling speeds were given in "KB/s" and "MB/s", which suggests kilo**bytes** and mega**bytes** per second, respectively. The uppercase `B` suggests bytes, not bits, thus causing the casual reader to be off by almost a magnitude.

Further inspection of the [source code](https://searchfox.org/mozilla-central/source/devtools/client/shared/components/throttling/profiles.js) suggested that the multiples are not actually powers of 10 (as `k` (or the not really correct `K`) and `M` would indicate), but [powers of 2 (which should be indicated by `Ki` and `Mi` to avoid ambiguity)](https://en.wikipedia.org/wiki/Binary_prefix).

Both were corrected.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* [The actual source code indicating binary prefixes and bits: `…/throttling/profiles.js`.](https://searchfox.org/mozilla-central/source/devtools/client/shared/components/throttling/profiles.js)
* [Explanation of the Binary Prefixes](https://en.wikipedia.org/wiki/Binary_prefix) and [their use/history](https://en.wikipedia.org/wiki/Byte#Multiple-byte_units)
* [Abbreviations for "Bit": `bit` or `b`](https://en.wikipedia.org/wiki/Bit)
* [Abbreviations for "Byte": `B` or `o` (octet)](https://en.wikipedia.org/wiki/Byte)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
