### PR TITLE
(typo) Fix link in Element Timing API

### DIFF
--- a/files/en-us/web/api/element_timing_api/index.md
+++ b/files/en-us/web/api/element_timing_api/index.md
@@ -18,7 +18,7 @@ The aim of the Element Timing API is to give web developers or analytics tools t
 
 The API supports timing information on {{htmlelement("img")}} elements, {{SVGElement("image")}} elements inside an {{htmlelement("svg")}}, poster images of {{htmlelement("video")}} elements, elements which have a {{cssxref("background-image")}}, and groups of text nodes, such as a {{htmlelement("p")}}.
 
-The author flags an element for observation by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/for) attribute on the element.
+The author flags an element for observation by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute on the element.
 
 ## Interfaces
 


### PR DESCRIPTION
The link to the "elementtiming" attribute currently points to the "for" attribute

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Updates the link to https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/elementtiming

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
