### PR TITLE
Remove outdated and unnecessary editorial comment

### DIFF
--- a/files/en-us/web/html/viewport_meta_tag/index.md
+++ b/files/en-us/web/html/viewport_meta_tag/index.md
@@ -93,6 +93,6 @@ If you want to know what mobile and tablet devices have which viewport widths, t
   </tbody>
 </table>
 
-There is clearly demand for the viewport meta tag, since it is supported by most popular mobile browsers and used by thousands of web sites. It would be good to have a true standard for web pages to control viewport properties. As the standardization process proceeds, we at Mozilla will work to keep up to date with any changes.
+There is clearly demand for the viewport meta tag, since it is supported by most popular mobile browsers and used by basically all popular sites. It would be good to have a true standard for web pages to control viewport properties. As the standardization process proceeds, we at Mozilla will work to keep up to date with any changes.
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/HTML")}}

--- a/files/en-us/web/html/viewport_meta_tag/index.md
+++ b/files/en-us/web/html/viewport_meta_tag/index.md
@@ -93,6 +93,5 @@ If you want to know what mobile and tablet devices have which viewport widths, t
   </tbody>
 </table>
 
-There is clearly demand for the viewport meta tag, since it is supported by most popular mobile browsers and used by basically all popular sites. It would be good to have a true standard for web pages to control viewport properties. As the standardization process proceeds, we at Mozilla will work to keep up to date with any changes.
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/HTML")}}


### PR DESCRIPTION
The text "...viewport meta tag, since it is supported by most popular mobile browsers and used by thousands of web sites..." really reveals this page was written long time ago. It is used almost everywhere nowadays.

#### Summary
Change
There is clearly demand for the viewport meta tag, since it is supported by most popular mobile browsers and used by THOUSANDS OF WEB SITES.
to
There is clearly demand for the viewport meta tag, since it is supported by most popular mobile browsers and used by BASICALLY ALL POPULAR SITES.

#### Motivation
I am both a big fan of MDN and a beginner in GitHub contributions.
