### PR TITLE
Fix #10981

### DIFF
--- a/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -124,6 +124,7 @@ The `computeFrame()` method, shown below, is responsible for actually fetching 
     this.ctx1.drawImage(this.video, 0, 0, this.width, this.height);
     const frame = this.ctx1.getImageData(0, 0, this.width, this.height);
     const length = frame.data.length;
+    const data = frame.data;
 
     for (let i = 0; i < length; i += 4) {
       const red = data[i + 0];


### PR DESCRIPTION
#### Summary
Adding missing `data` var to fix example code in "Manipulating the video frame data"

#### Motivation
Fixing issue #10981

#### Supporting details
NA

#### Related issues
Fixing issue #10981

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

