### PR TITLE
Typo - using singular form instead of plural.

### DIFF
--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -446,7 +446,7 @@ function MyObject(name, message) {
 }
 ```
 
-Because the previous code does not take advantage of the benefits of using closures in this particular instance, we could instead rewrite it to avoid using closure as follows:
+Because the previous code does not take advantage of the benefits of using closures in this particular instance, we could instead rewrite it to avoid using closures as follows:
 
 ```js
 function MyObject(name, message) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Simple typo, missing `s` on the end of the word `closure` when it should be pluralised.


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Formatting. Correct usage of english.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
