### PR TITLE
Update flex shorthand one-value syntax summary

### DIFF
--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -60,7 +60,8 @@ The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax:** the value must be one of:
 
-  - a `<number>`: In this case it is interpreted as `flex: <number> 1 0`; the {{cssxref("flex-shrink")}} value is assumed to be 1 and the {{cssxref("flex-basis")}} value is assumed to be `0`.
+  - a `<number>`: In this case it is interpreted as `flex: <number> 1 0`; the {{cssxref("flex-shrink")}} value is assumed to be `1` and the {{cssxref("flex-basis")}} value is assumed to be `0`.
+  - a `<width>`: In this case it is interpreted as `flex: 1 1 <width>`; the {{cssxref("flex-grow")}} value is assumed to be `1` and the {{cssxref("flex-shrink")}} value is assumed to be `1`.
   - one of the keywords: `none`, `auto`, or `initial`.
 
 - **Two-value syntax:**


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The flex shorthand one-value syntax listing does not include the case where the one value is a flex basis value, a number followed by a unit. This change makes one edit, a change to the listing to include a flex basis case. 
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The flex property shorthand includes a one-valued syntax option of a number with units, meant to include a width, or flex-basis value. Including it in the summary of one-value syntax lets readers know that fact.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.w3.org/TR/css-flexbox-1/#flex-property
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
