### PR TITLE
Update CustomEvent

### DIFF
--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -39,16 +39,26 @@ configured according to the dictionary if one was provided.
 ## Example
 
 ```js
-// add an appropriate event listener
-obj.addEventListener("cat", function(e) { process(e.detail) });
-
-// create and dispatch the event
-var event = new CustomEvent("cat", {
+// create custom events
+const catFound = new CustomEvent('animalfound', {
   detail: {
-    hazcheeseburger: true
+    name: 'cat'
   }
 });
-obj.dispatchEvent(event);
+const dogFound = new CustomEvent('animalfound', {
+  detail: {
+    name: 'dog'
+  }
+});
+
+// add an appropriate event listener
+obj.addEventListener('animalfound', (e) => console.log(e.detail.name));
+
+// dispatch the events
+obj.dispatchEvent(catFound);
+obj.dispatchEvent(dogFound);
+
+// "cat" and "dog" logged in the console
 ```
 
 Additional examples can be found at [Creating and triggering events](/en-US/docs/Web/Events/Creating_and_triggering_events).

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -23,18 +23,13 @@ CustomEvent(typeArg, options);
   - : A string representing the name of the event.
 - `options` {{optional_inline}}
 
-  - : An object, with the following fields:
+  - : An object, with the following properties:
 
     - `"detail"`, optional and defaulting to `null`, of any type,
       containing an event-dependent value associated with the event.
       This is available to the handler using the {{domxref("CustomEvent.detail")}} property.
 
-    - Any field that can be used in the init object of the {{domxref("Event.Event", "Event()")}} constructor.
-
-### Return value
-
-A new `CustomEvent` object of the specified type, with any other properties
-configured according to the dictionary if one was provided.
+    - Any properties that can be used in the init object of the {{domxref("Event.Event", "Event()")}} constructor.
 
 ## Example
 

--- a/files/en-us/web/api/customevent/detail/index.md
+++ b/files/en-us/web/api/customevent/detail/index.md
@@ -19,19 +19,26 @@ Whatever data the event was initialized with.
 ## Example
 
 ```js
-// add an appropriate event listener
-obj.addEventListener("cat", function(e) { process(e.detail) });
-
-// create and dispatch the event
-let event = new CustomEvent("cat", {
+// create custom events
+const catFound = new CustomEvent('animalfound', {
   detail: {
-    hazcheeseburger: true
+    name: 'cat'
   }
 });
-obj.dispatchEvent(event);
+const dogFound = new CustomEvent('animalfound', {
+  detail: {
+    name: 'dog'
+  }
+});
 
-// Will return an object containing the hazcheeseburger property
-let myDetail = event.detail;
+// add an appropriate event listener
+obj.addEventListener('animalfound', (e) => console.log(e.detail.name));
+
+// dispatch the events
+obj.dispatchEvent(catFound);
+obj.dispatchEvent(dogFound);
+
+// "cat" and "dog" logged in the console
 ```
 
 ## Specifications


### PR DESCRIPTION
#### Summary
Updated `CustomEvent` examples, remove "Return value" section of `CustomEvent()`.

#### Motivation
`CustomEvent` example can be improved.
- The choice of words, "cat" and "hazcheeseburger", is somewhat puzzling.
- Show that two `CustomEvent`s with the same name can be listened with a single listener.
- `let`s to `const`s.

In addition to this, I've removed `CustomEvent()`'s "Return value" section for a few reasons:
- The term "dictionary". (https://github.com/mdn/content/pull/9920#discussion_r736705510)
- This section provides no useful information in its current form, I think.
- Its parent constructor, `Event()`, has no "Return value" section as well.

#### Supporting details

#### Related issues

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
