### PR TITLE
Fix statement about allowed Content-Type values

### DIFF
--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -73,7 +73,7 @@ Some requests don't trigger a {{Glossary("Preflight_request","CORS preflight")}}
   - {{HTTPHeader("Content-Language")}}
   - {{HTTPHeader("Content-Type")}} (please note the additional requirements below)
 
-- The only allowed values for the {{HTTPHeader("Content-Type")}} header are:
+- The only type/subtype combinations allowed for the {{Glossary("MIME type","media type")}} specified in the {{HTTPHeader("Content-Type")}} header are:
 
   - `application/x-www-form-urlencoded`
   - `multipart/form-data`


### PR DESCRIPTION
#### Summary
Correct imprecise statement about allowed `Content-Type` values for simple requests.

#### Motivation
The [page about CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) claims the following:

> The only allowed values for the `Content-Type` header are:
> * `application/x-www-form-urlencoded`
> * `multipart/form-data`
> * `text/plain`

However, this statement is imprecise; for instance, a value of `text/plain; application/json` is allowed and does _not_ (all other things being equal) trigger a preflight request. For more about this, refer to [the relevant section of the Fetch standard][fetch-std].

This statement may mislead practitioners and lull them into a false sense of security in the face of cross-origin attacks. In particular, practitioners [may](https://discord.com/channels/1110206757227216916/1168685918920638614/1232774760363196568) believe that finding a match for `application/json` in the value of the `Content-Type` request header is a sufficient indicator that the request was preflighted.

#### Supporting details

* [Fetch standard][fetch-std]

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

[fetch-std]: https://fetch.spec.whatwg.org/#ref-for-mime-type-essence