### PR TITLE
Properly mark Warning HTTP-Header as deprecated

### DIFF
--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -63,7 +63,7 @@ Headers can also be grouped according to how {{Glossary("Proxy_server", "proxies
   - : The date/time after which the response is considered stale.
 - {{HTTPHeader("Pragma")}}
   - : Implementation-specific header that may have various effects anywhere along the request-response chain. Used for backwards compatibility with HTTP/1.0 caches where the `Cache-Control` header is not yet present.
-- {{HTTPHeader("Warning")}}
+- {{HTTPHeader("Warning")}} {{deprecated_inline}}
   - : General warning information about possible problems.
 
 ## Client hints

--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -12,17 +12,11 @@ browser-compat: http.headers.Warning
 ---
 {{HTTPSidebar}} {{deprecated_header}}
 
-> **Note:** The `Warning` header has been deprecated; see
-> [Warning
-> (https://github.com/httpwg/http-core/issues/139)](https://github.com/httpwg/http-core/issues/139) and [Warning: header &
-> stale-while-revalidate (https://github.com/whatwg/fetch/issues/913)](https://github.com/whatwg/fetch/issues/913) for more
-> details.
+The **`Warning`** HTTP header contains information about possible problems with the status of the message.
+More than one `Warning` header may appear in a response.
 
-The **`Warning`** HTTP header contains information
-about possible problems with the status of the message. More than one
-`Warning` header may appear in a response.
-
-`Warning` header fields can, in general, be applied to any message. However, some warn-codes are specific to caches and can only be applied to response messages.
+`Warning` header fields can, in general, be applied to any message.
+However, some warn-codes are specific to caches and can only be applied to response messages.
 
 <table class="properties">
   <tbody>
@@ -50,24 +44,17 @@ Warning: <warn-code> <warn-agent> <warn-text> [<warn-date>]
 
 - \<warn-code>
 
-  - : A three-digit warning number. The first digit indicates whether the
-    `Warning` is required to be deleted from a stored response after
-    validation.
+  - : A three-digit warning number. The first digit indicates whether the `Warning` is required to be deleted from a stored response after validation.
 
-    - `1xx` warn-codes describe the freshness or validation status of the
-      response and will be deleted by a cache after deletion.
-    - `2xx` warn-codes describe some aspect of the representation that is
-      not rectified by a validation and will not be deleted by a cache after validation
-      unless a full response is sent.
+    - `1xx` warn-codes describe the freshness or validation status of the response and will be deleted by a cache after deletion.
+    - `2xx` warn-codes describe some aspect of the representation that is not rectified by a validation and will not be deleted by a cache after validation unless a full response is sent.
 
 - \<warn-agent>
-  - : The name or pseudonym of the server or software adding the `Warning`
-    header (might be "-" when the agent is unknown).
+  - : The name or pseudonym of the server or software adding the `Warning` header (might be "-" when the agent is unknown).
 - \<warn-text>
   - : An advisory text describing the error.
 - \<warn-date>
-  - : A date. This is optional. If more than one `Warning` header is sent, include a date that
-    matches the {{HTTPHeader("Date")}} header.
+  - : A date. This is optional. If more than one `Warning` header is sent, include a date that matches the {{HTTPHeader("Date")}} header.
 
 ## Warning codes
 

--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -6,10 +6,11 @@ tags:
   - HTTP Header
   - Request header
   - Response header
+  - Deprecated
   - Reference
 browser-compat: http.headers.Warning
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}} {{deprecated_header}}
 
 > **Note:** The `Warning` header has been deprecated; see
 > [Warning


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR will properly mark the Warning HTTP-Header as deprecated.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
The page of the Warning-Header already states it is deprecated. It was just not properly marked as deprecated.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://github.com/httpwg/http-core/issues/139
https://github.com/whatwg/fetch/issues/913

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
