### PR TITLE
Typo correction: it's/its

### DIFF
--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/package_management/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/package_management/index.md
@@ -300,7 +300,7 @@ This makes a lot of sense as we want to reduce file size and thus make our app l
 
 Although the list grows by the month, there are three main offerings for tools that generate bundles from our source code: Webpack, [Rollup](https://rollupjs.org/guide/en/), and Parcel. There will be more available than this, but these are popular ones:
 
-- The RollUp tool offers tree shaking and code splitting as it’s core features.
+- The RollUp tool offers tree shaking and code splitting as its core features.
 - Webpack requires some configuration (though “some” might be understating the complexity of some developers’ Webpack configurations).
 - In the case of Parcel (prior to Parcel version 2), there's a special flag required — `--experimental-scope-hoisting` — which will tree shake while building.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Correcting a typo. "it's" was used instead of "its".

I have not contributed to MDN before - if I am approaching this incorrectly, my apologies.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
