### PR TITLE
fix: the output should be `true` not `"true"`

### DIFF
--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -434,7 +434,7 @@ Destructuring can be used with property names that are not valid JavaScript {{gl
 const foo = { 'fizz-buzz': true };
 const { 'fizz-buzz': fizzBuzz } = foo;
 
-console.log(fizzBuzz); // "true"
+console.log(fizzBuzz); // true
 ```
 
 #### Combined Array and Object Destructuring


### PR DESCRIPTION
#### Summary

Correct the example output.

#### Motivation

Replace the output `"true"` with `true`.

#### Supporting details

Reference: mdn/translated-content#3290

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
