### PR TITLE
Clarifications about Safari in the building cross-browser extensions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -120,7 +120,7 @@ The differences in the [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensio
 2.  **Extension features.**
     For example, at the time of writing, Chrome did not support the [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#browser_compatibility) key.
 3.  **Key optionality.**
-    At the time of writing, except for Safari, only `"manifest_version"`, `"version"`, and `"name"` are mandatory keys. Safari has a more comprehensive set of mandatory requirements, such as setting `"background"` to `false` for iOS.
+    At the time of writing, generally, only `"manifest_version"`, `"version"`, and `"name"` are mandatory keys.
 
 Browser compatibility information is included with each key in the Mozilla Developer Network [`manifest.json` key reference pages](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json).
 

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -52,7 +52,7 @@ Firefox also supports callbacks for the APIs that support the `chrome.*` namespa
 
 So, how do you take advantage of promises easily? The solution is to code for Firefox using promises and use the [WebExtension browser API Polyfill](https://github.com/mozilla/webextension-polyfill/) to address Chrome, Opera, and Edge.
 
-This polyfill addresses the API namespace and asynchronous event handling across Firefox, Chrome, Opera, and Edge. However, at the time of writing (December 2021), support for Opera and Edge was unofficial.
+This polyfill addresses the API namespace and asynchronous event handling across Firefox, Chrome, Opera, and Edge.
 
 To use the polyfill, install it into your development environment using npm or download it directly from [GitHub releases](https://github.com/mozilla/webextension-polyfill/releases).
 
@@ -120,7 +120,7 @@ The differences in the [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensio
 2.  **Extension features.**
     For example, at the time of writing, Chrome did not support the [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#browser_compatibility) key.
 3.  **Key optionality.**
-    At the time of writing, except for Safari, only `"manifest_version"`, `"version"`, and `"name"` are mandatory keys. Safari has a more comprehensive set of mandatory requirements, such as setting `"background"` to `false`.
+    At the time of writing, except for Safari, only `"manifest_version"`, `"version"`, and `"name"` are mandatory keys. Safari has a more comprehensive set of mandatory requirements, such as setting `"background"` to `false` for iOS.
 
 Browser compatibility information is included with each key in the Mozilla Developer Network [`manifest.json` key reference pages](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json).
 

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -93,7 +93,7 @@ The differences in the API functions offered in each of the main browsers fall i
 3.  **Proprietary functions, supporting browser-specific features.**
     For example, at the time of writing, containers was a Firefox-specific feature supported by the {{WebExtAPIRef("contextualIdentities")}} function.
 
-Details about the support for the extension APIs among the main browsers, Firefox for Android, and Safari on iOS can be found on the Mozilla Developer Network [Browser support for JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs) page. Browser compatibility information is also included with each function and its methods, types, and events in the Mozilla Developer Network [JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) reference pages.
+Details about the support for the extension APIs among the main browsers and Firefox for Android and Safari on iOS can be found on the Mozilla Developer Network [Browser support for JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs) page. Browser compatibility information is also included with each function and its methods, types, and events in the Mozilla Developer Network [JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) reference pages.
 
 #### Handling API differences
 
@@ -152,13 +152,13 @@ This table summarizes the approach and features of each store:
   </thead>
   <tbody>
     <tr>
-    <tr>
       <th><p>Chrome</p></th>
       <td><p>Yes</p></td>
       <td><p>Yes</p></td>
       <td><p>Automatic, less than an hour</p></td>
       <td><p>Yes</p></td>
     </tr>
+    <tr>
       <th><p>Edge</p></th>
       <td><p>No</p></td>
       <td><p>No</p></td>

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -11,11 +11,9 @@ tags:
 
 > **Note:** This article discusses building cross-browser extensions for manifest v2. At the time of writing (December 2021), manifest v3 is being introduced by the major browser vendors. Manifest v3 is likely to change the way cross-browser extension development is undertaken. However, work on Manifest v3 is not complete. The major browser vendors are collaborating (with community members) to ease the development of a cross-browser extension in the [W3C WebExtensions Community Group](https://github.com/w3c/webextensions). 
 
-The introduction of the browser extensions API created a uniform landscape for the development of browser extensions. However, among the browsers that use the extensions API (the major ones being Chrome, Firefox, Opera, and Edge), there are differences in the API's implementation and the scope of coverage. And then, Safari uses its own proprietary Safari Extensions JS.
+The introduction of the browser extensions API created a uniform landscape for the development of browser extensions. However, there are differences in the API implementations and the scope of coverage among the browsers that use the extensions API (the major ones being Chrome, Edge, Firefox, Opera, and Safari). 
 
-Maximizing the reach of your browser extension means developing it for at least two browsers, possibly more. This article looks at six of the main challenges faced when creating a cross-browser extension, and in each case suggests how to address the challenge.
-
-This article doesn’t discuss creating browser extensions for Safari. Sharing some resources with a Safari extension may be possible, such as images and HTML content. However, the JavaScript coding needs to be undertaken as a separate development project unless you wish to create a polyfill.
+Maximizing the reach of your browser extension means developing it for at least two browsers, possibly more. This article looks at six of the main challenges faced when creating a cross-browser extension and suggests how to address these challenges.
 
 ## Cross-platform extension coding hurdles
 
@@ -30,9 +28,9 @@ There are six areas you need to address when tackling a cross-platform extension
 
 ### API namespace
 
-There are two API namespaces in use among the four main browsers:
+There are two API namespaces in use among the main browsers:
 
-- `browser.*`, the proposed standard for the extensions API used by Firefox.
+- `browser.*`, the proposed standard for the extensions API used by Firefox and Safari.
 - `chrome.*` used by Chrome, Opera, and Edge.
 
 Firefox also supports the `chrome.*` namespace for APIs that are compatible with Chrome, primarily to assist with [porting](https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/). However, using the `browser.*` namespace is preferred. In addition to being the proposed standard, `browser.*` uses promises—a modern and convenient mechanism for handling asynchronous events.
@@ -41,9 +39,9 @@ Only in the most trivial extensions is namespace likely to be the only cross-pla
 
 ### API asynchronous event handling
 
-There are two approaches to handling asynchronous events in use among the four main browsers:
+There are two approaches to handling asynchronous events in use among the main browsers:
 
-- _Promises_, the proposed standard for the extensions API used by Firefox.
+- _Promises_, the proposed standard for the extensions API used by Firefox and Safari.
 - _Callbacks_, used by Chrome, Edge, and Opera.
 
 Firefox also supports callbacks for the APIs that support the `chrome.*` namespace. However, using promises (and the `browser.*` namespace) is recommended. Promises have been adopted as part of the proposed standard. It greatly simplifies asynchronous event handling, particularly where you need to chain events together.
@@ -52,7 +50,7 @@ Firefox also supports callbacks for the APIs that support the `chrome.*` namespa
 
 #### The WebExtension browser API Polyfill
 
-So, how do you take advantage of promises easily when Firefox is the only browser supporting it? The solution is to code for Firefox using promises and use the [WebExtension browser API Polyfill](https://github.com/mozilla/webextension-polyfill/).
+So, how do you take advantage of promises easily? The solution is to code for Firefox using promises and use the [WebExtension browser API Polyfill](https://github.com/mozilla/webextension-polyfill/) to address Chrome, Opera, and Edge.
 
 This polyfill addresses the API namespace and asynchronous event handling across Firefox, Chrome, Opera, and Edge. However, at the time of writing (December 2021), support for Opera and Edge was unofficial.
 
@@ -86,7 +84,7 @@ There are other polyfill options. However, at the time of writing, none of the o
 
 ### API function coverage
 
-The differences in the API functions offered in each of the four main browsers fall into three broad categories:
+The differences in the API functions offered in each of the main browsers fall into three broad categories:
 
 1.  **Lack of support for an entire function.**
     For example, at the time of writing, Edge didn’t support the {{WebExtAPIRef("browserSettings")}} function.
@@ -95,11 +93,11 @@ The differences in the API functions offered in each of the four main browsers f
 3.  **Proprietary functions, supporting browser-specific features.**
     For example, at the time of writing, containers was a Firefox-specific feature supported by the {{WebExtAPIRef("contextualIdentities")}} function.
 
-Details about the support for the extension APIs among the five main browsers and Firefox for Android on the Mozilla Developer Network [Browser support for JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs) page. Browser compatibility information is also included with each function and its methods, types, and events in the Mozilla Developer Network [JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) reference pages.
+Details about the support for the extension APIs among the main browsers, Firefox for Android, and Safari on iOS can be found on the Mozilla Developer Network [Browser support for JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs) page. Browser compatibility information is also included with each function and its methods, types, and events in the Mozilla Developer Network [JavaScript APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) reference pages.
 
 #### Handling API differences
 
-A simple approach to addressing these differences is to limit the functions used in your extension to functions that offer the same functionality across your range of targeted browsers. In practice, this approach is likely to be too restrictive for most extensions.
+A simple approach to addressing API differences is to limit the functions used in your extension to functions that offer the same functionality across your range of targeted browsers. In practice, this approach is likely to be too restrictive for most extensions.
 
 Instead, where there are differences among the APIs, you should either offer alternative implementations or fallback functionality. (Remember: you may also need to do this to allow for differences in API support between versions of the _same_ browser.)
 
@@ -115,14 +113,14 @@ if (typeof <function> === "function") {
 
 ### Manifest keys
 
-The differences in the [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json) file keys supported by the four main browsers fall broadly into three categories:
+The differences in the [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json) file keys supported by the main browsers fall broadly into three categories:
 
 1.  **Extension information attributes.**
     For example, at the time of writing, Firefox and Opera include the [`developer`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer#browser_compatibility) key for details about the developer of the extension.
 2.  **Extension features.**
     For example, at the time of writing, Chrome did not support the [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#browser_compatibility) key.
 3.  **Key optionality.**
-    At the time of writing, there are no differences in the optionality for keys. In all of the `manifest.json` formats, `"manifest_version"`, `"version"`, and `"name"` are the only mandatory keys.
+    At the time of writing, except for Safari, only `"manifest_version"`, `"version"`, and `"name"` are mandatory keys. Safari has a more comprehensive set of mandatory requirements, such as setting `"background"` to `false`.
 
 Browser compatibility information is included with each key in the Mozilla Developer Network [`manifest.json` key reference pages](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json).
 
@@ -130,13 +128,13 @@ As `manifest.json` files tend to change little—except for release numbers, whi
 
 ### Extension packaging
 
-Packaging an extension for distribution through the browser extension stores is relatively straightforward. Firefox, Chrome, Edge, and Opera all use a simple zip format that requires the `manifest.json` file to be at the root of the zip package.
+Packaging an extension for distribution through the browser extension stores is relatively straightforward. Firefox, Chrome, Edge, and Opera all use a simple zip format that requires the `manifest.json` file to be at the root of the zip package. Safari requires extensions to be packaged in a similar way to apps.
 
 For details on packaging, refer to the guidance on the respective extension’s developer portals.
 
 ### Extension publishing
 
-Each of the four major browsers maintains browser extension stores. Each store also reviews your extension to check for security vulnerabilities.
+Each of the major browsers maintains browser extension stores. Each store also reviews your extension to check for security vulnerabilities.
 
 As a consequence, you need to approach adding and updating your extension for each store separately. In some cases, you can upload your extension using a utility.
 
@@ -153,6 +151,20 @@ This table summarizes the approach and features of each store:
     </tr>
   </thead>
   <tbody>
+    <tr>
+    <tr>
+      <th><p>Chrome</p></th>
+      <td><p>Yes</p></td>
+      <td><p>Yes</p></td>
+      <td><p>Automatic, less than an hour</p></td>
+      <td><p>Yes</p></td>
+    </tr>
+      <th><p>Edge</p></th>
+      <td><p>No</p></td>
+      <td><p>No</p></td>
+      <td><p>No SLA provided</p></td>
+      <td><p>Yes</p></td>
+    </tr>
     <tr>
       <th><p>Firefox</p></th>
       <td><p>No</p></td>
@@ -175,13 +187,6 @@ This table summarizes the approach and features of each store:
       <td><p>Yes</p></td>
     </tr>
     <tr>
-      <th><p>Chrome</p></th>
-      <td><p>Yes</p></td>
-      <td><p>Yes</p></td>
-      <td><p>Automatic, less than an hour</p></td>
-      <td><p>Yes</p></td>
-    </tr>
-    <tr>
       <th><p>Opera</p></th>
       <td><p>No</p></td>
       <td><p>No</p></td>
@@ -189,10 +194,10 @@ This table summarizes the approach and features of each store:
       <td><p>No</p></td>
     </tr>
     <tr>
-      <th><p>Edge</p></th>
+      <th><p>Safari</p></th>
+      <td><p>Yes</p></td>
       <td><p>No</p></td>
-      <td><p>No</p></td>
-      <td><p>No SLA provided</p></td>
+      <td><p>Yes with, according to Apple, on average, 50% of apps reviewed in 24 hours and over 90% reviewed in 48 hours.</p></td>
       <td><p>Yes</p></td>
     </tr>
   </tbody>
@@ -203,14 +208,6 @@ This table summarizes the approach and features of each store:
 #### Version numbering
 
 The Firefox, Chrome, and Edge stores require that each uploaded version has a different version number. This means you cannot revert to an earlier version number if you come across issues in a release.
-
-#### Share content
-
-When you also develop extensions for Safari, there are several assets you can potentially share across all of your implementations. These include:
-
-- Images
-- HTML
-- CSS
 
 ## Conclusion
 


### PR DESCRIPTION
#### Summary
Updating information regarding Safari in the [Building a cross-browser extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension) article.

#### Motivation
Information about Safari is out of date as it now supports web extensions.

#### Related issues
Fixes feedback on  Updating information about Edge [#11005](https://github.com/mdn/content/pull/11005) 

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
