### PR TITLE
FF96 RelNote: IntersectionObserver constructor sets default rootmargi…

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -55,6 +55,8 @@ This article provides information about the changes in Firefox 96 that will affe
 
 #### DOM
 
+- The {{domxref("IntersectionObserver.IntersectionObserver()","IntersectionObserver()")}} constructor now sets the default `rootMargin` if an empty string is passed in the associated parameter option, instead of throwing an exception ({{bug(1738791)}}).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
FF96 Release note for bug fixed in https://bugzilla.mozilla.org/show_bug.cgi?id=1738791

The other docs work for this can be tracked in #10854