### PR TITLE
Fix javascript syntax blocks to use comment around elipses

### DIFF
--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -16,7 +16,9 @@ The **`getAttributeType()`** method of the {{domxref("TrustedTypePolicyFactory")
 ## Syntax
 
 ```js
-var attributeType = TrustedTypePolicyFactory.getAttributeType(tagName,attribute[,elementNs,attrNs]);
+TrustedTypePolicyFactory.getAttributeType(tagName, attribute)
+TrustedTypePolicyFactory.getAttributeType(tagName, attribute, elementNs)
+TrustedTypePolicyFactory.getAttributeType(tagName, attribute, elementNs, attrNs)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -16,7 +16,8 @@ The **`getPropertyType()`** method of the {{domxref("TrustedTypePolicyFactory")}
 ## Syntax
 
 ```js
-var null = TrustedTypePolicyFactory.getPropertyType(tagName,property[, elementNS]);
+TrustedTypePolicyFactory.getPropertyType(tagName, property)
+TrustedTypePolicyFactory.getPropertyType(tagName, property, elementNS)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/classes/class_static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/class_static_initialization_blocks/index.md
@@ -25,7 +25,7 @@ This means that static blocks can also be used to share information between clas
 ## Syntax
 
 ```js
-static { ... }
+static { /* ... */ }
 ```
 
 

--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -17,10 +17,10 @@ The `constructor` method is a special method of a {{jsxref("Statements/class", 
 ## Syntax
 
 ```js
-constructor() { ... }
-constructor(argument0) { ... }
-constructor(argument0, argument1) { ... }
-constructor(argument0, argument1, ... , argumentN) { ... }
+constructor() { /* ... */ }
+constructor(argument0) { /* ... */ }
+constructor(argument0, argument1) { /* ... */ }
+constructor(argument0, argument1, ... , argumentN) { /* ... */ }
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -19,7 +19,7 @@ create a class that is a child of another class.
 ## Syntax
 
 ```js
-class ChildClass extends ParentClass { ... }
+class ChildClass extends ParentClass { /* ... */ }
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -25,7 +25,7 @@ Static methods are often utility functions, such as functions to create or clone
 ## Syntax
 
 ```js
-static methodName() { ... }
+static methodName() { /* ... */ }
 static propertyName [= value];
 
 // Class static initialization block

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -19,7 +19,7 @@ is passed.
 ## Syntax
 
 ```js
-function fnName(param1 = defaultValue1, ..., paramN = defaultValueN) { ... }
+function fnName(param1 = defaultValue1, ..., paramN = defaultValueN) { /* ... */ }
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -20,8 +20,8 @@ that will be called when that property is looked up.
 ## Syntax
 
 ```js
-{get prop() { ... } }
-{get [expression]() { ... } }
+{get prop() { /* ... */ } }
+{get [expression]() { /* ... */ } }
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.md
@@ -17,10 +17,10 @@ The **`Array()`** constructor is used to create
 
 ```js
 // literal constructor
-[element0, element1, ..., elementN]
+[element0, element1, /* ... ,*/ elementN]
 
 // construct from elements
-new Array(element0, element1, ..., elementN)
+new Array(element0, element1, /* ... ,*/ elementN)
 
 // construct from array length
 new Array(arrayLength)

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -22,19 +22,19 @@ returns a Boolean value.
 
 ```js
 // Arrow function
-every((element) => { ... } )
-every((element, index) => { ... } )
-every((element, index, array) => { ... } )
+every((element) => { /* ... */ } )
+every((element, index) => { /* ... */ } )
+every((element, index, array) => { /* ... */ } )
 
 // Callback function
 every(callbackFn)
 every(callbackFn, thisArg)
 
 // Inline callback function
-every(function(element) { ... })
-every(function(element, index) { ... })
-every(function(element, index, array){ ... })
-every(function(element, index, array) { ... }, thisArg)
+every(function(element) { /* ... */ })
+every(function(element, index) { /* ... */ })
+every(function(element, index, array){ /* ... */ })
+every(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -21,19 +21,19 @@ The **`filter()`** method **creates a new array** with all elements that pass th
 
 ```js
 // Arrow function
-filter((element) => { ... } )
-filter((element, index) => { ... } )
-filter((element, index, array) => { ... } )
+filter((element) => { /* ... */ } )
+filter((element, index) => { /* ... */ } )
+filter((element, index, array) => { /* ... */ } )
 
 // Callback function
 filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function(element) { ... })
-filter(function(element, index) { ... })
-filter(function(element, index, array){ ... })
-filter(function(element, index, array) { ... }, thisArg)
+filter(function(element) { /* ... */ })
+filter(function(element, index) { /* ... */ })
+filter(function(element, index, array){ /* ... */ })
+filter(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -35,19 +35,19 @@ values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 ```js
 // Arrow function
-find((element) => { ... } )
-find((element, index) => { ... } )
-find((element, index, array) => { ... } )
+find((element) => { /* ... */ } )
+find((element, index) => { /* ... */ } )
+find((element, index, array) => { /* ... */ } )
 
 // Callback function
 find(callbackFn)
 find(callbackFn, thisArg)
 
 // Inline callback function
-find(function(element) { ... })
-find(function(element, index) { ... })
-find(function(element, index, array){ ... })
-find(function(element, index, array) { ... }, thisArg)
+find(function(element) { /* ... */ })
+find(function(element, index) { /* ... */ })
+find(function(element, index, array){ /* ... */ })
+find(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -27,19 +27,19 @@ See also the {{jsxref("Array.find", "find()")}} method, which returns the
 
 ```js
 // Arrow function
-findIndex((element) => { ... } )
-findIndex((element, index) => { ... } )
-findIndex((element, index, array) => { ... } )
+findIndex((element) => { /* ... */ } )
+findIndex((element, index) => { /* ... */ } )
+findIndex((element, index, array) => { /* ... */ } )
 
 // Callback function
 findIndex(callbackFn)
 findIndex(callbackFn, thisArg)
 
 // Inline callback function
-findIndex(function(element) { ... })
-findIndex(function(element, index) { ... })
-findIndex(function(element, index, array){ ... })
-findIndex(function(element, index, array) { ... }, thisArg)
+findIndex(function(element) { /* ... */ })
+findIndex(function(element, index) { /* ... */ })
+findIndex(function(element, index, array){ /* ... */ })
+findIndex(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -24,19 +24,19 @@ efficient than calling those two methods separately.
 
 ```js
 // Arrow function
-flatMap((currentValue) => { ... } )
-flatMap((currentValue, index) => { ... } )
-flatMap((currentValue, index, array) => { ... } )
+flatMap((currentValue) => { /* ... */ } )
+flatMap((currentValue, index) => { /* ... */ } )
+flatMap((currentValue, index, array) => { /* ... */ } )
 
 // Callback function
 flatMap(callbackFn)
 flatMap(callbackFn, thisArg)
 
 // Inline callback function
-flatMap(function(currentValue) { ... })
-flatMap(function(currentValue, index) { ... })
-flatMap(function(currentValue, index, array){ ... })
-flatMap(function(currentValue, index, array) { ... }, thisArg)
+flatMap(function(currentValue) { /* ... */ })
+flatMap(function(currentValue, index) { /* ... */ })
+flatMap(function(currentValue, index, array){ /* ... */ })
+flatMap(function(currentValue, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -22,19 +22,19 @@ for each array element.
 
 ```js
 // Arrow function
-forEach((element) => { ... } )
-forEach((element, index) => { ... } )
-forEach((element, index, array) => { ... } )
+forEach((element) => { /* ... */ } )
+forEach((element, index) => { /* ... */ } )
+forEach((element, index, array) => { /* ... */ } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function(element) { ... })
-forEach(function(element, index) { ... })
-forEach(function(element, index, array){ ... })
-forEach(function(element, index, array) { ... }, thisArg)
+forEach(function(element) { /* ... */ })
+forEach(function(element, index) { /* ... */ })
+forEach(function(element, index, array){ /* ... */ })
+forEach(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -22,18 +22,18 @@ iterable object.
 
 ```js
 // Arrow function
-Array.from(arrayLike, (element) => { ... } )
-Array.from(arrayLike, (element, index) => { ... } )
+Array.from(arrayLike, (element) => { /* ... */ } )
+Array.from(arrayLike, (element, index) => { /* ... */ } )
 
 // Mapping function
 Array.from(arrayLike, mapFn)
 Array.from(arrayLike, mapFn, thisArg)
 
 // Inline mapping function
-Array.from(arrayLike, function mapFn(element) { ... })
-Array.from(arrayLike, function mapFn(element, index) { ... })
-Array.from(arrayLike, function mapFn(element) { ... }, thisArg)
-Array.from(arrayLike, function mapFn(element, index) { ... }, thisArg)
+Array.from(arrayLike, function mapFn(element) { /* ... */ })
+Array.from(arrayLike, function mapFn(element, index) { /* ... */ })
+Array.from(arrayLike, function mapFn(element) { /* ... */ }, thisArg)
+Array.from(arrayLike, function mapFn(element, index) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -23,19 +23,19 @@ every element in the calling array.
 
 ```js
 // Arrow function
-map((element) => { ... })
-map((element, index) => { ... })
-map((element, index, array) => { ... })
+map((element) => { /* ... */ })
+map((element, index) => { /* ... */ })
+map((element, index, array) => { /* ... */ })
 
 // Callback function
 map(callbackFn)
 map(callbackFn, thisArg)
 
 // Inline callback function
-map(function(element) { ... })
-map(function(element, index) { ... })
-map(function(element, index, array){ ... })
-map(function(element, index, array) { ... }, thisArg)
+map(function(element) { /* ... */ })
+map(function(element, index) { /* ... */ })
+map(function(element, index, array){ /* ... */ })
+map(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.md
@@ -36,7 +36,7 @@ Array(1, 2, 3);    // [1, 2, 3]
 ```js
 Array.of(element0)
 Array.of(element0, element1)
-Array.of(element0, element1, ... , elementN)
+Array.of(element0, element1, /* ... ,*/ elementN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -21,7 +21,7 @@ an array and returns the new length of the array.
 ```js
 push(element0)
 push(element0, element1)
-push(element0, element1, ... , elementN)
+push(element0, element1, /* ... ,*/ elementN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -32,20 +32,20 @@ The reducer walks through the array element-by-element, at each step adding the 
 
 ```js
 // Arrow function
-reduce((previousValue, currentValue) => { ... } )
-reduce((previousValue, currentValue, currentIndex) => { ... } )
-reduce((previousValue, currentValue, currentIndex, array) => { ... } )
-reduce((previousValue, currentValue, currentIndex, array) => { ... }, initialValue)
+reduce((previousValue, currentValue) => { /* ... */ } )
+reduce((previousValue, currentValue, currentIndex) => { /* ... */ } )
+reduce((previousValue, currentValue, currentIndex, array) => { /* ... */ } )
+reduce((previousValue, currentValue, currentIndex, array) => { /* ... */ }, initialValue)
 
 // Callback function
 reduce(callbackFn)
 reduce(callbackFn, initialValue)
 
 // Inline callback function
-reduce(function(previousValue, currentValue) { ... })
-reduce(function(previousValue, currentValue, currentIndex) { ... })
-reduce(function(previousValue, currentValue, currentIndex, array) { ... })
-reduce(function(previousValue, currentValue, currentIndex, array) { ... }, initialValue)
+reduce(function(previousValue, currentValue) { /* ... */ })
+reduce(function(previousValue, currentValue, currentIndex) { /* ... */ })
+reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ })
+reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ }, initialValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -24,20 +24,20 @@ See also {{jsxref("Array.prototype.reduce()")}} for left-to-right.
 
 ```js
 // Arrow function
-reduceRight((accumulator, currentValue) => { ... } )
-reduceRight((accumulator, currentValue, index) => { ... } )
-reduceRight((accumulator, currentValue, index, array) => { ... } )
-reduceRight((accumulator, currentValue, index, array) => { ... }, initialValue)
+reduceRight((accumulator, currentValue) => { /* ... */ } )
+reduceRight((accumulator, currentValue, index) => { /* ... */ } )
+reduceRight((accumulator, currentValue, index, array) => { /* ... */ } )
+reduceRight((accumulator, currentValue, index, array) => { /* ... */ }, initialValue)
 
 // Callback function
 reduceRight(callbackFn)
 reduceRight(callbackFn, initialValue)
 
 // Callback reducer function
-reduceRight(function(accumulator, currentValue) { ... })
-reduceRight(function(accumulator, currentValue, index) { ... })
-reduceRight(function(accumulator, currentValue, index, array){ ... })
-reduceRight(function(accumulator, currentValue, index, array) { ... }, initialValue)
+reduceRight(function(accumulator, currentValue) { /* ... */ })
+reduceRight(function(accumulator, currentValue, index) { /* ... */ })
+reduceRight(function(accumulator, currentValue, index, array){ /* ... */ })
+reduceRight(function(accumulator, currentValue, index, array) { /* ... */ }, initialValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -23,19 +23,19 @@ function. It returns true if, in the array, it finds an element for which the pr
 
 ```js
 // Arrow function
-some((element) => { ... } )
-some((element, index) => { ... } )
-some((element, index, array) => { ... } )
+some((element) => { /* ... */ } )
+some((element, index) => { /* ... */ } )
+some((element, index, array) => { /* ... */ } )
 
 // Callback function
 some(callbackFn)
 some(callbackFn, thisArg)
 
 // Inline callback function
-some(function(element) { ... })
-some(function(element, index) { ... })
-some(function(element, index, array){ ... })
-some(function(element, index, array) { ... }, thisArg)
+some(function(element) { /* ... */ })
+some(function(element, index) { /* ... */ })
+some(function(element, index, array){ /* ... */ })
+some(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -29,13 +29,13 @@ implementation.
 sort()
 
 // Arrow function
-sort((firstEl, secondEl) => { ... } )
+sort((firstEl, secondEl) => { /* ... */ } )
 
 // Compare function
 sort(compareFn)
 
 // Inline compare function
-sort(function compareFn(firstEl, secondEl) { ... })
+sort(function compareFn(firstEl, secondEl) { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
@@ -21,7 +21,7 @@ beginning of an array and returns the new length of the array.
 ```js
 unshift(element0)
 unshift(element0, element1)
-unshift(element0, element1, ... , elementN)
+unshift(element0, element1, /* ... ,*/ elementN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -282,10 +282,10 @@ can (and should) write:
 
 ```js
 // instead of setTimeout(" ... ", 1000) use:
-setTimeout(function() { ... }, 1000);
+setTimeout(function() { /* ... */ }, 1000);
 
 // instead of elt.setAttribute("onclick", "...") use:
-elt.addEventListener('click', function() { ... } , false); 
+elt.addEventListener('click', function() { /* ... */ } , false); 
 ```
 
 [Closures](/en-US/docs/Web/JavaScript/Closures) are also helpful as a way to

--- a/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
@@ -21,21 +21,21 @@ pair in the `Map` object, in insertion order.
 
 ```js
 // Arrow function
-forEach(() => { ... } )
-forEach((value) => { ... } )
-forEach((value, key) => { ... } )
-forEach((value, key, map) => { ... } )
+forEach(() => { /* ... */ } )
+forEach((value) => { /* ... */ } )
+forEach((value, key) => { /* ... */ } )
+forEach((value, key, map) => { /* ... */ } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function() { ... })
-forEach(function(value) { ... })
-forEach(function(value, key) { ... })
-forEach(function(value, key, map) { ... })
-forEach(function(value, key, map) { ... }, thisArg)
+forEach(function() { /* ... */ })
+forEach(function(value) { /* ... */ })
+forEach(function(value, key) { /* ... */ })
+forEach(function(value, key, map) { /* ... */ })
+forEach(function(value, key, map) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -127,12 +127,12 @@ function OtherClass() {
 let obj1 = Reflect.construct(OneClass, args)
 // Output:
 //     OneClass
-//     function OneClass { ... }
+//     function OneClass { /* ... */ }
 
 let obj2 = Reflect.construct(OneClass, args, OtherClass)
 // Output:
 //     OneClass
-//     function OtherClass { ... }
+//     function OtherClass { /* ... */ }
 
 let obj3 = Object.create(OtherClass.prototype);
 OneClass.apply(obj3, args)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -127,12 +127,12 @@ function OtherClass() {
 let obj1 = Reflect.construct(OneClass, args)
 // Output:
 //     OneClass
-//     function OneClass { /* ... */ }
+//     function OneClass { ... }
 
 let obj2 = Reflect.construct(OneClass, args, OtherClass)
 // Output:
 //     OneClass
-//     function OtherClass { /* ... */ }
+//     function OtherClass { ... }
 
 let obj3 = Object.create(OtherClass.prototype);
 OneClass.apply(obj3, args)

--- a/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
@@ -21,21 +21,21 @@ for each value in the `Set` object, in insertion order.
 
 ```js
 // Arrow function
-forEach(() => { ... } )
-forEach((value) => { ... } )
-forEach((value, key) => { ... } )
-forEach((value, key, set) => { ... } )
+forEach(() => { /* ... */ } )
+forEach((value) => { /* ... */ } )
+forEach((value, key) => { /* ... */ } )
+forEach((value, key, set) => { /* ... */ } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function() { ... })
-forEach(function(value) { ... })
-forEach(function(value, key) { ... })
-forEach(function(value, key, set) { ... })
-forEach(function(value, key, set) { ... }, thisArg)
+forEach(function() { /* ... */ })
+forEach(function(value) { /* ... */ })
+forEach(function(value, key) { /* ... */ })
+forEach(function(value, key, set) { /* ... */ })
+forEach(function(value, key, set) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -25,19 +25,19 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-every((element) => { ... } )
-every((element, index) => { ... } )
-every((element, index, array) => { ... } )
+every((element) => { /* ... */ } )
+every((element, index) => { /* ... */ } )
+every((element, index, array) => { /* ... */ } )
 
 // Callback function
 every(callbackFn)
 every(callbackFn, thisArg)
 
 // Inline callback function
-every(function(element) { ... })
-every(function(element, index) { ... })
-every(function(element, index, array){ ... })
-every(function(element, index, array) { ... }, thisArg)
+every(function(element) { /* ... */ })
+every(function(element, index) { /* ... */ })
+every(function(element, index, array){ /* ... */ })
+every(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -25,19 +25,19 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-filter((element) => { ... } )
-filter((element, index) => { ... } )
-filter((element, index, array) => { ... } )
+filter((element) => { /* ... */ } )
+filter((element, index) => { /* ... */ } )
+filter((element, index, array) => { /* ... */ } )
 
 // Callback function
 filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function(element) { ... })
-filter(function(element, index) { ... })
-filter(function(element, index, array){ ... })
-filter(function(element, index, array) { ... }, thisArg)
+filter(function(element) { /* ... */ })
+filter(function(element, index) { /* ... */ })
+filter(function(element, index, array){ /* ... */ })
+filter(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -28,19 +28,19 @@ the **index** of a found element in the typed array instead of its value.
 
 ```js
 // Arrow function
-find((element) => { ... } )
-find((element, index) => { ... } )
-find((element, index, array) => { ... } )
+find((element) => { /* ... */ } )
+find((element, index) => { /* ... */ } )
+find((element, index, array) => { /* ... */ } )
 
 // Callback function
 find(callbackFn)
 find(callbackFn, thisArg)
 
 // Inline callback function
-find(function(element) { ... })
-find(function(element, index) { ... })
-find(function(element, index, array){ ... })
-find(function(element, index, array) { ... }, thisArg)
+find(function(element) { /* ... */ })
+find(function(element, index) { /* ... */ })
+find(function(element, index, array){ /* ... */ })
+find(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -27,19 +27,19 @@ See also the {{jsxref("TypedArray.find", "find()")}} method, which returns the
 
 ```js
 // Arrow function
-findIndex((element) => { ... } )
-findIndex((element, index) => { ... } )
-findIndex((element, index, array) => { ... } )
+findIndex((element) => { /* ... */ } )
+findIndex((element, index) => { /* ... */ } )
+findIndex((element, index, array) => { /* ... */ } )
 
 // Callback function
 findIndex(callbackFn)
 findIndex(callbackFn, thisArg)
 
 // Inline callback function
-findIndex(function(element) { ... })
-findIndex(function(element, index) { ... })
-findIndex(function(element, index, array){ ... })
-findIndex(function(element, index, array) { ... }, thisArg)
+findIndex(function(element) { /* ... */ })
+findIndex(function(element, index) { /* ... */ })
+findIndex(function(element, index, array){ /* ... */ })
+findIndex(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -23,19 +23,19 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-forEach((element) => { ... } )
-forEach((element, index) => { ... } )
-forEach((element, index, array) => { ... } )
+forEach((element) => { /* ... */ } )
+forEach((element, index) => { /* ... */ } )
+forEach((element, index, array) => { /* ... */ } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function(element) { ... })
-forEach(function(element, index) { ... })
-forEach(function(element, index, array){ ... })
-forEach(function(element, index, array) { ... }, thisArg)
+forEach(function(element) { /* ... */ })
+forEach(function(element, index) { /* ... */ })
+forEach(function(element, index, array){ /* ... */ })
+forEach(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
@@ -23,18 +23,18 @@ array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray
 
 ```js
 // Arrow function
-TypedArray.from(arrayLike, (element) => { ... } )
-TypedArray.from(arrayLike, (element, index) => { ... } )
+TypedArray.from(arrayLike, (element) => { /* ... */ } )
+TypedArray.from(arrayLike, (element, index) => { /* ... */ } )
 
 // Mapping function
 TypedArray.from(arrayLike, mapFn)
 TypedArray.from(arrayLike, mapFn, thisArg)
 
 // Inline mapping function
-TypedArray.from(arrayLike, function mapFn(element) { ... })
-TypedArray.from(arrayLike, function mapFn(element, index) { ... })
-TypedArray.from(arrayLike, function mapFn(element) { ... }, thisArg)
-TypedArray.from(arrayLike, function mapFn(element, index) { ... }, thisArg)
+TypedArray.from(arrayLike, function mapFn(element) { /* ... */ })
+TypedArray.from(arrayLike, function mapFn(element, index) { /* ... */ })
+TypedArray.from(arrayLike, function mapFn(element) { /* ... */ }, thisArg)
+TypedArray.from(arrayLike, function mapFn(element, index) { /* ... */ }, thisArg)
 ```
 
 Where `TypedArray` is one of:

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -25,19 +25,19 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-map((currentValue) => { ... } )
-map((currentValue, index) => { ... } )
-map((currentValue, index, array) => { ... } )
+map((currentValue) => { /* ... */ } )
+map((currentValue, index) => { /* ... */ } )
+map((currentValue, index, array) => { /* ... */ } )
 
 // Callback function
 map(callbackFn)
 map(callbackFn, thisArg)
 
 // Inline callback function
-map(function(currentValue) { ... })
-map(function(currentValue, index) { ... })
-map(function(currentValue, index, array){ ... })
-map(function(currentValue, index, array) { ... }, thisArg)
+map(function(currentValue) { /* ... */ })
+map(function(currentValue, index) { /* ... */ })
+map(function(currentValue, index, array){ /* ... */ })
+map(function(currentValue, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -23,7 +23,7 @@ array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray
 ```js
 TypedArray.of(element0)
 TypedArray.of(element0, element1)
-TypedArray.of(element0, element1, ... , elementN)
+TypedArray.of(element0, element1, /* ... ,*/ elementN)
 ```
 
 Where `TypedArray` is one of:

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -25,20 +25,20 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-reduce((accumulator, currentValue) => { ... } )
-reduce((accumulator, currentValue, index) => { ... } )
-reduce((accumulator, currentValue, index, array) => { ... } )
-reduce((accumulator, currentValue, index, array) => { ... }, initialValue)
+reduce((accumulator, currentValue) => { /* ... */ } )
+reduce((accumulator, currentValue, index) => { /* ... */ } )
+reduce((accumulator, currentValue, index, array) => { /* ... */ } )
+reduce((accumulator, currentValue, index, array) => { /* ... */ }, initialValue)
 
 // Callback function
 reduce(callbackFn)
 reduce(callbackFn, initialValue)
 
 // Inline callback function
-reduce(function(accumulator, currentValue) { ... })
-reduce(function(accumulator, currentValue, index) { ... })
-reduce(function(accumulator, currentValue, index, array){ ... })
-reduce(function(accumulator, currentValue, index, array) { ... }, initialValue)
+reduce(function(accumulator, currentValue) { /* ... */ })
+reduce(function(accumulator, currentValue, index) { /* ... */ })
+reduce(function(accumulator, currentValue, index, array){ /* ... */ })
+reduce(function(accumulator, currentValue, index, array) { /* ... */ }, initialValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -23,20 +23,20 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-reduceRight((accumulator, currentValue) => { ... } )
-reduceRight((accumulator, currentValue, index) => { ... } )
-reduceRight((accumulator, currentValue, index, array) => { ... } )
-reduceRight((accumulator, currentValue, index, array) => { ... }, initialValue)
+reduceRight((accumulator, currentValue) => { /* ... */ } )
+reduceRight((accumulator, currentValue, index) => { /* ... */ } )
+reduceRight((accumulator, currentValue, index, array) => { /* ... */ } )
+reduceRight((accumulator, currentValue, index, array) => { /* ... */ }, initialValue)
 
 // Callback function
 reduceRight(callbackFn)
 reduceRight(callbackFn, initialValue)
 
 // Inline callback function
-reduceRight(function(accumulator, currentValue) { ... })
-reduceRight(function(accumulator, currentValue, index) { ... })
-reduceRight(function(accumulator, currentValue, index, array){ ... })
-reduceRight(function(accumulator, currentValue, index, array) { ... }, initialValue)
+reduceRight(function(accumulator, currentValue) { /* ... */ })
+reduceRight(function(accumulator, currentValue, index) { /* ... */ })
+reduceRight(function(accumulator, currentValue, index, array){ /* ... */ })
+reduceRight(function(accumulator, currentValue, index, array) { /* ... */ }, initialValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -25,19 +25,19 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 
 ```js
 // Arrow function
-some((element) => { ... } )
-some((element, index) => { ... } )
-some((element, index, array) => { ... } )
+some((element) => { /* ... */ } )
+some((element, index) => { /* ... */ } )
+some((element, index, array) => { /* ... */ } )
 
 // Callback function
 some(callbackFn)
 some(callbackFn, thisArg)
 
 // Inline callback function
-some(function(element) { ... })
-some(function(element, index) { ... })
-some(function(element, index, array){ ... })
-some(function(element, index, array) { ... }, thisArg)
+some(function(element) { /* ... */ })
+some(function(element, index) { /* ... */ })
+some(function(element, index, array){ /* ... */ })
+some(function(element, index, array) { /* ... */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -28,13 +28,13 @@ array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Type
 sort()
 
 // Arrow function
-sort((firstEl, secondEl) => { ... } )
+sort((firstEl, secondEl) => { /* ... */ } )
 
 // Compare function
 sort(compareFn)
 
 // Inline compare function
-sort(function compareFn(firstEl, secondEl) { ... })
+sort(function compareFn(firstEl, secondEl) { /* ... */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/statements/do...while/index.md
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.md
@@ -27,7 +27,7 @@ while (condition);
 - `statement`
   - : A statement that is executed at least once and is re-executed each time the
     condition evaluates to true. To execute multiple statements within the loop, use a
-    {{jsxref("Statements/block", "block", "", 1)}} statement (`{ ... }`) to
+    {{jsxref("Statements/block", "block", "", 1)}} statement (`{ /* ... */ }`) to
     group those statements.
 - `condition`
   - : An expression evaluated after each pass through the loop. If `condition`

--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -79,7 +79,7 @@ export { myFunction, myVariable };
 // export individual features (can export var, let,
 // const, function, class)
 export let myVariable = Math.sqrt(2);
-export function myFunction() { ... };
+export function myFunction() { /* ... */ };
 ```
 
 Default exports:
@@ -89,7 +89,7 @@ Default exports:
 export { myFunction as default };
 
 // export individual features as default
-export default function () { ... }
+export default function () { /* ... */ }
 export default class { .. }
 
 // each export overwrites the previous one

--- a/files/en-us/web/javascript/reference/statements/for/index.md
+++ b/files/en-us/web/javascript/reference/statements/for/index.md
@@ -50,7 +50,7 @@ for ([initialization]; [condition]; [final-expression])
 - `statement`
   - : A statement that is executed as long as the condition evaluates to true. To execute
     multiple statements within the loop, use a {{jsxref("Statements/block", "block", "",
-    0)}} statement (`{ ... }`) to group those statements. To execute no
+    0)}} statement (`{ /* ... */ }`) to group those statements. To execute no
     statement within the loop, use an {{jsxref("Statements/empty", "empty", "", 0)}}
     statement (`;`).
 

--- a/files/en-us/web/javascript/reference/statements/if...else/index.md
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.md
@@ -35,7 +35,7 @@ if (condition) {
   - : Statement that is executed if _condition_ is {{Glossary("truthy")}}. Can be
     any statement, including further nested `if` statements. To execute
     multiple statements, use a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block) statement
-    (`{ ... }`) to group those statements. To execute no statements, use an [empty](/en-US/docs/Web/JavaScript/Reference/Statements/Empty) statement.
+    (`{ /* ... */ }`) to group those statements. To execute no statements, use an [empty](/en-US/docs/Web/JavaScript/Reference/Statements/Empty) statement.
 - `statement2`
   - : Statement that is executed if `condition` is
     {{Glossary("falsy")}} and the `else` clause exists. Can be any statement,
@@ -73,7 +73,7 @@ else
 ```
 
 To execute multiple statements within a clause, use a block statement
-(`{ ... }`) to group those statements. In general, it is a good practice to
+(`{ /* ... */ }`) to group those statements. In general, it is a good practice to
 always use block statements, especially in code involving nested `if`
 statements:
 

--- a/files/en-us/web/javascript/reference/statements/while/index.md
+++ b/files/en-us/web/javascript/reference/statements/while/index.md
@@ -32,7 +32,7 @@ while (condition)
 
   - : An optional statement that is executed as long as the condition evaluates to true.
     To execute multiple statements within the loop, use a [block](/en-US/docs/JavaScript/Reference/Statements/block) statement
-    (`{ ... }`) to group those statements.
+    (`{ /* ... */ }`) to group those statements.
 
     Note: Use the `break` statement to stop a loop before condition evaluates
     to true.


### PR DESCRIPTION
Follows on from #10937

Ellipses in syntax blocks should be commented, as should the ellipses indicating a series of elements.