### PR TITLE
FF96 Canvas supports exporting images as webp

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -11,30 +11,31 @@ browser-compat: api.HTMLCanvasElement.toBlob
 ---
 {{APIRef("Canvas API")}}
 
-The **`HTMLCanvasElement.toBlob()`** method creates a {{domxref("Blob")}} object representing the image contained in the canvas; this file may be cached on the disk or stored in memory at the discretion of the user agent.
+The **`HTMLCanvasElement.toBlob()`** method creates a {{domxref("Blob")}} object representing the image contained in the canvas.
+This file may be cached on the disk or stored in memory at the discretion of the user agent.
 
-The created image is in a resolution of 96dpi.
+The desired file format and image quality may be specified.
+If the file format is not specified, or if the given format is not supported, then the data will be exported as `image/png`.
+Browsers are required to support `image/png`; many will support additional formats including `image/jpg` and `image/webp`.
+
+The created image will have a resolution of 96dpi for file formats that support encoding resolution metadata.
 
 ## Syntax
 
 ```js
-canvas.toBlob(callback, type, quality);
+toBlob(callback, type, quality)
 ```
 
 ### Parameters
 
 - `callback`
   - : A callback function with the resulting {{domxref("Blob")}} object as a single argument.
+    `null` may be passed if the image cannot be created for any reason.
 - `type` {{optional_inline}}
   - : A {{domxref("DOMString")}} indicating the image format.
     The default type is `image/png`; that type is also used if the given type isn't supported.
 - `quality` {{optional_inline}}
-
-  - : A {{jsxref("Number")}} between `0` and `1`, indicating image quality if the requested type is `image/jpeg` or `image/webp`.
-    If this argument is anything else, the default values 0.92 and 0.80 are used for image/jpeg and image/webp respectively.
-    Other arguments are ignored.
-
-    This argument is used when creating images using lossy compression (such as `image/jpeg`), to specify the quality of the output.
+  - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using lossy compression (such as `image/jpeg`).
 
 ### Return value
 
@@ -43,7 +44,7 @@ None.
 ### Exceptions
 
 - `SecurityError`
-  - : The canvas's bitmap is not origin clean; at least some of its contents come from secure
+  - : The canvas's bitmap is not origin clean; at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
 
 ## Examples
 
@@ -69,16 +70,16 @@ canvas.toBlob(function(blob) {
 });
 ```
 
-Note that here we're creating a PNG image; if you add a second parameter to the `toBlob()` call, you can specify the image type.
+Note that here we're creating a PNG image; if you add a second parameter to the `toBlob()` call, you can specify another image type supported by the user agent.
 For example, to get the image in JPEG format:
 
 ```js
-canvas.toBlob(function(blob){...}, 'image/jpeg', 0.95); // JPEG at 95% quality
+canvas.toBlob(function(blob){ /*...*/ }, 'image/jpeg', 0.95); // JPEG at 95% quality
 ```
 
-### A way to convert a canvas to an ico (Mozilla only)
+### Convert a canvas to an ico (Mozilla only)
 
-This uses `-moz-parse` to convert the canvas to ico.
+This uses `-moz-parse` to convert the canvas to ico, and hence only works on Firefox.
 Windows XP doesn't support converting from PNG to ico, so it uses bmp instead.
 A download link is created by setting the download attribute. The value of the download attribute is the name it will use as the file name.
 
@@ -108,13 +109,13 @@ canvas.toBlob(blobCallback('passThisString'), 'image/vnd.microsoft.icon',
               '-moz-parse-options:format=bmp;bpp=32');
 ```
 
-### Save toBlob to disk with OS.File (chrome/add-on context only)
+### Save toBlob to disk with OS.File (Chrome/add-on context only)
 
 > **Note:** This technique saves it to the desktop and is only useful in Firefox chrome context or add-on code, as OS APIs are not present on web sites.
 
 ```js
-var canvas = document.getElementById('canvas');
-var d = canvas.width;
+const canvas = document.getElementById('canvas');
+const d = canvas.width;
 ctx = canvas.getContext('2d');
 ctx.beginPath();
 ctx.moveTo(d / 2, 0);
@@ -126,13 +127,13 @@ ctx.fill();
 
 function blobCallback(iconName) {
   return function(b) {
-    var r = new FileReader();
+    const r = new FileReader();
     r.onloadend = function () {
     // r.result contains the ArrayBuffer.
     Cu.import('resource://gre/modules/osfile.jsm');
-    var writePath = OS.Path.join(OS.Constants.Path.desktopDir,
+    const writePath = OS.Path.join(OS.Constants.Path.desktopDir,
                                  iconName + '.ico');
-    var promise = OS.File.writeAtomic(writePath, new Uint8Array(r.result),
+    const promise = OS.File.writeAtomic(writePath, new Uint8Array(r.result),
                                       {tmpPath:writePath + '.tmp'});
     promise.then(
       function() {
@@ -161,5 +162,4 @@ canvas.toBlob(blobCallback('passThisString'), 'image/vnd.microsoft.icon',
 
 ## See also
 
-- The interface defining it, {{domxref("HTMLCanvasElement")}}.
 - {{domxref("Blob")}}

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -35,7 +35,8 @@ toBlob(callback, type, quality)
   - : A {{domxref("DOMString")}} indicating the image format.
     The default type is `image/png`; that type is also used if the given type isn't supported.
 - `quality` {{optional_inline}}
-  - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using lossy compression (such as `image/jpeg`).
+  - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
+    A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
 
 ### Return value
 

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -45,7 +45,7 @@ None.
 ### Exceptions
 
 - `SecurityError`
-  - : The canvas's bitmap is not origin clean; at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
+  - : The canvas's bitmap is not origin-clean; at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -11,12 +11,16 @@ browser-compat: api.HTMLCanvasElement.toDataURL
 ---
 {{APIRef("Canvas API")}}
 
-The **`HTMLCanvasElement.toDataURL()`** method returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)).
-The returned image is in a resolution of 96 dpi.
+The **`HTMLCanvasElement.toDataURL()`** method returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) containing a representation of the image in the format specified by the `type` parameter.
 
-- If the height or width of the canvas is `0` or larger than the [maximum canvas size](/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size), the string `"data:,"` is returned.
-- If the requested type is not `image/png`, but the returned value starts with `data:image/png`, then the requested type is not supported.
-- Chrome also supports the `image/webp` type.
+The desired file format and image quality may be specified.
+If the file format is not specified, or if the given format is not supported, then the data will be exported as `image/png`.
+In other words, if the returned value starts with `data:image/png` for any other requested `type`, then that format is not supported.
+
+Browsers are required to support `image/png`; many will support additional formats including `image/jpg` and `image/webp`.
+
+The created image data will have a resolution of 96dpi for file formats that support encoding resolution metadata.
+
 
 ## Syntax
 
@@ -27,15 +31,17 @@ canvas.toDataURL(type, encoderOptions);
 ### Parameters
 
 - `type` {{optional_inline}}
-  - : A {{domxref("DOMString")}} indicating the image format. The default format type is `image/png`.
+  - : A {{domxref("DOMString")}} indicating the image format.
+    The default type is `image/png`; this image format will be also used if the specified type is not supported.
 - `encoderOptions` {{optional_inline}}
-  - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to use for image formats that use lossy compression such as `image/jpeg` and `image/webp`.
-    If this argument is anything else, the default value for image quality is used.
-    The default value is `0.92`. Other arguments are ignored.
+  - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
+    A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
 
 ### Return value
 
 A {{domxref("DOMString")}} containing the requested [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+
+If the height or width of the canvas is `0` or larger than the [maximum canvas size](/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size), the string `"data:,"` is returned.
 
 ### Exceptions
 
@@ -135,5 +141,4 @@ function removeColors() {
 
 ## See also
 
-- The interface defining it, {{domxref("HTMLCanvasElement")}}.
 - [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) in the [HTTP](/en-US/docs/Web/HTTP) reference.

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.md
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.md
@@ -12,13 +12,19 @@ browser-compat: api.OffscreenCanvas.convertToBlob
 ---
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 
-The **`OffscreenCanvas.convertToBlob()`** method creates a {{domxref("Blob")}} object representing the image contained in the canvas.
+The **`OffscreenCanvas.convertToBlob()`** method creates a {{domxref("Blob")}} object representing the image contained in the canvas.
+
+The desired file format and image quality may be specified.
+If the file format is not specified, or if the given format is not supported, then the data will be exported as `image/png`.
+Browsers are required to support `image/png`; many will support additional formats including `image/jpg` and `image/webp`.
+
+The created image will have a resolution of 96dpi for file formats that support encoding resolution metadata.
 
 ## Syntax
 
 ```js
-OffscreenCanvas.convertToBlob()
-OffscreenCanvas.convertToBlob(options)
+convertToBlob()
+convertToBlob(options)
 ```
 
 ### Parameters
@@ -27,14 +33,32 @@ OffscreenCanvas.convertToBlob(options)
 
   - : An object with the following properties:
     - `type`
-      - : A string indicating the image format. The default type is `image/png`.
+      - : A string indicating the image format.
+         The default type is `image/png`; this image format will be also used if the specified type is not supported.
     - `quality`
-      - : If the `type` option is `image/jpeg` or `image/webp`, this is a number between `0` and `1` indicating image quality.
-        If the `type` option is anything else, the default value for image quality is used.
+      - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
+        A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
 
 ### Return value
 
 A {{jsxref("Promise")}} returning a {{domxref("Blob")}} object representing the image contained in the canvas.
+
+### Exceptions
+
+The promise may be rejected with the following exceptions:
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : The `OffscreenCanvas` is not detached; in other words it still associated with the DOM and not the current worker.
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The canvas context mode is 2d and the bitmap is not origin clean; at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : The canvas bitmap has no pixels (either the horizontal or veritical dimension is zero).
+
+- `EncodingError` {{domxref("DOMException")}}
+  - : The blob could not be created due to an encoding error.
+
 
 ## Examples
 

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.md
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.md
@@ -51,10 +51,10 @@ The promise may be rejected with the following exceptions:
   - : The `OffscreenCanvas` is not detached; in other words it still associated with the DOM and not the current worker.
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : The canvas context mode is 2d and the bitmap is not origin clean; at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
+  - : The canvas context mode is 2d and the bitmap is not origin-clean; at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : The canvas bitmap has no pixels (either the horizontal or veritical dimension is zero).
+  - : The canvas bitmap has no pixels (either the horizontal or vertical dimension is zero).
 
 - `EncodingError` {{domxref("DOMException")}}
   - : The blob could not be created due to an encoding error.

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -1362,6 +1362,7 @@ Provide a fallback in either {{anch("JPEG")}} or {{anch("PNG")}} format, such as
             </tr>
           </tbody>
         </table>
+        <p>WebP can also be used for <em>exporting</em> images from a Canvas from Firefox 96 and Chrome 50 (see <a href="/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility"><code>HTMLCanvasElement.toBlob()</code></a> for more detailed support version information).</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
FF96 adds a webp image encoder used by a number of canvas APIs - https://bugzilla.mozilla.org/show_bug.cgi?id=1511670

This updates the affected APIs where they differ from what the spec says and mentions the possibility of webp being supported. Note that the actual support for webp is going to indicated in BCD.

It also updates the image guide to note that webp is supported for image export. Wasn't so sure on that one. 

Other docs work for this can be tracked in #10853