### PR TITLE
Fix typo in JavaScript reference

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -52,7 +52,7 @@ Below is a table with the available collation types, taken from the [Unicode col
         <div class="notecard warning">
           <p>
             <strong>Warning:</strong> The <code>direct</code> collation type has
-            been deprected. Do not use.
+            been deprecated. Do not use.
           </p>
         </div>
         <p>direct</p>


### PR DESCRIPTION
#### Summary
In `docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation`, fix incorrect spelling of "deprecated."

#### Motivation
The spelling was incorrect.

#### Supporting details
Probably not applicable.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error