### PR TITLE
Correct page about Access-Control-Expose-Headers

### DIFF
--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -40,7 +40,6 @@ Access-Control-Expose-Headers: *
   - : A list of zero or more comma-separated [header names](/en-US/docs/Web/HTTP/Headers) that clients are allowed to access from a response. These are _in addition_ to the {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}}.
 - `*` (wildcard)
   - : The value "`*`" only counts as a special wildcard value for requests without credentials (requests without [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information). In requests with credentials, it is treated as the literal header name "`*`" without special semantics.
-    Note that the {{HTTPHeader("Authorization")}} header can't be wildcarded and always needs to be listed explicitly.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary

[The page about the `Access-Control-Expose-Headers` response header][aceh] makes some incorrect claim about special treatment of headers named `Authorization`. This PR removes this erroneous claim.

#### Motivation

[The page about the `Access-Control-Expose-Headers` response header][aceh] has this to say about the wildcard directive:

> The value "`*`" only counts as a special wildcard value for requests without credentials (requests without HTTP cookies or HTTP authentication information). In requests with credentials, it is treated as the literal header name "`*`" without special semantics. **Note that the `Authorization` header can't be wildcarded and always needs to be listed explicitly.**

(my emphasis)

It's true that the [Fetch standard][fetch-std-authorization] lists `Authorization` as the sole _CORS non-wildcard request-header name_; accordinly, if `Authorization` is to be allowed, it must indeed be explicitly listed in the  `Access-Control-Allow-Headers` response header.

However, `Authorization` is a _request_ header, not a _response_ header, and the [Fetch standard][fetch-std-aceh] doesn't mention any special treatment of a header named `Authorization` in the context of the `Access-Control-Expose-Headers` response header. Therefore, the sentence I've emphasised in the quote above is out of place. It was most likely added as a result of a copy/paste error from [the page about `Access-Control-Allow-Headers` response header][acah], and it should be removed.

#### Supporting details

* Fetch standard

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

[acah]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#directives
[aceh]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers#directives
[fetch-std-authorization]: https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name
[fetch-std-aceh]: https://fetch.spec.whatwg.org/#ref-for-http-access-control-expose-headers%E2%91%A4