### PR TITLE
Add references to HTTP Link header

### DIFF
--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -51,7 +51,9 @@ Link: <https://one.example.com>; rel="preconnect", <https://two.example.com>; re
 
 ## Specifications
 
-{{Specifications}}
+| Specification                                            | Title       |
+| -------------------------------------------------------- | ----------- |
+| {{RFC(8288, "Link Serialisation in HTTP Headers", "3")}} | Web Linking |
 
 ## Browser compatibility
 
@@ -60,3 +62,4 @@ Link: <https://one.example.com>; rel="preconnect", <https://two.example.com>; re
 ## See also
 
 - {{HTTPStatus(103, "103 Early Hints")}}
+- {{HTMLElement("link")}}


### PR DESCRIPTION
#### Summary
Add relevant rfc and mdn document to http link header page.

#### Motivation
Was searching for attribute meaning of the link header. Found it in the http link attribute. Adding the reference for better discoverability. Added link to rfc for better discoverability too.

#### Supporting details
* RFC8288 Section 3: https://datatracker.ietf.org/doc/html/rfc8288#section-3

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
