### PR TITLE
An array of cookieStoreId supported in the tabs.query API

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -40,7 +40,7 @@ let querying = browser.tabs.query(queryObj)
     - `autoDiscardable`{{optional_inline}}
       - : `boolean`. Whether the tabs can be discarded automatically by the browser when resources are low.
     - `cookieStoreId` {{optional_inline}}
-      - : `string`. Use this to return only tabs whose cookie store ID is `cookieStoreId`. This option is only available if the add-on has the `"cookies"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
+      - : `string` or `array` of `string`. Use this to return tabs whose cookie store ID matches any of one or more `cookieStoreId`s. This option is only available if the add-on has the `"cookies"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
     - `currentWindow`{{optional_inline}}
       - : `boolean`. Whether the tabs are in the current window.
     - `discarded`{{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -40,7 +40,7 @@ let querying = browser.tabs.query(queryObj)
     - `autoDiscardable`{{optional_inline}}
       - : `boolean`. Whether the tabs can be discarded automatically by the browser when resources are low.
     - `cookieStoreId` {{optional_inline}}
-      - : `string` or `array` of `string`. Use this to return tabs whose cookie store ID matches any of one or more `cookieStoreId`s. This option is only available if the add-on has the `"cookies"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
+      - : `string` or `array` of `string`. Use this to return tabs whose `tab.cookieStoreId` matches any of the `cookieStoreId` strings. This option is only available if the add-on has the `"cookies"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
     - `currentWindow`{{optional_inline}}
       - : `boolean`. Whether the tabs are in the current window.
     - `discarded`{{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -53,7 +53,7 @@ This article provides information about the changes in Firefox 97 that will affe
 
 ## Changes for add-on developers
 
-- `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID.
+- `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID ({{bug(1730931)}}).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 97 that will affe
 
 ## Changes for add-on developers
 
+- `cookieStoreId` in the {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID.
+
 #### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -53,7 +53,7 @@ This article provides information about the changes in Firefox 97 that will affe
 
 ## Changes for add-on developers
 
-- `cookieStoreId` in the {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID.
+- `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID.
 
 #### Removals
 


### PR DESCRIPTION
#### Summary
Adding information about the support for an array of `cookieStoreId`s in the `tabs.query` API.

#### Related issues
Addresses documentation requirements of [Bug 1730931](https://bugzilla.mozilla.org/show_bug.cgi?id=1730931) Supporting an array of cookieStoreId in the tabs.query API.

Supporting browser compatibility data updates changes made in An array of cookieStoreId supported in the tabs.query API [#13940 ](https://github.com/mdn/browser-compat-data/pull/13940)

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
