### PR TITLE
Hide JS code in "Active Learning" sample

### DIFF
--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -757,7 +757,7 @@ p {
 </div>
 ```
 
-```js
+```js hidden
 const htmlInput = document.querySelector(".html-input");
 const cssInput = document.querySelector(".css-input");
 const reset = document.getElementById("reset");


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Hides the JavaScript code (with `js hidden`) in https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#active_learning_playing_with_styling_text.

#### Motivation
The JS used for live code samples is usually hidden to users/readers, but was not on this page.

#### Supporting details
No other live code sample or active learning section shows the JS.

#### Related issues

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
