### PR TITLE
rewrite examples for HTMLSelectElement.form

### DIFF
--- a/files/en-us/web/api/htmlselectelement/form/index.md
+++ b/files/en-us/web/api/htmlselectelement/form/index.md
@@ -19,39 +19,35 @@ it returns `null`.
 ## Syntax
 
 ```js
-aForm = aSelectElement.form.selectname;
+const formElement = selectElement.form;
 ```
 
 ## Example
 
-### HTML
-
 ```html
-<form action="http://www.google.com/search" method="get">
- <label>Google: <input type="search" name="q"></label> <input type="submit" value="Search...">
+<form id="pet-form">
+  <label for="pet-select">Choose a pet</label>
+  <select name="pets" id="pet-select">
+    <option value="dog">Dog</option>
+    <option value="cat">Cat</option>
+    <option value="parrot">Parrot</option>
+  </select>
+
+  <button type="submit">Submit</button>
 </form>
-```
 
-### Javascript
+<label for="lunch-select">Choose your lunch</label>
+<select name="lunch" id="lunch-select">
+    <option value="salad">Salad</option>
+    <option value="sandwich">Sandwich</option>
+</select>
 
-A property available on all form elements, "type" returns the type of the calling form
-element. For SELECT, the two possible values are "`select-one`" or
-"`select-multiple`", depending on the type of selection list. The below code
-gives all SELECT elements in a particular form a CSS class of
-"`selectclass`":
+<script>
+  const petSelect = document.getElementById("pet-select");
+  const petForm = petSelect.form; // <form id="pet-form">
 
-```html
-<script type="text/javascript">
-var form_element = document.getElementById('subscribe_form');
-var vist = form_element.style;
-if (vist.display=='' || vist.display=='none')
-{
-  vist.display = 'block';
-}
-else
-{
-  vist.display = 'none';
-}
+  const lunchSelect = document.getElementById("lunch-select");
+  const lunchForm = lunchSelect.form; // null
 </script>
 ```
 

--- a/files/en-us/web/api/htmlselectelement/form/index.md
+++ b/files/en-us/web/api/htmlselectelement/form/index.md
@@ -16,12 +16,6 @@ The **`HTMLSelectElement.form`** read-only property returns a
 with. If the element is not associated with of a {{HTMLElement("form")}} element, then
 it returns `null`.
 
-## Syntax
-
-```js
-const formElement = selectElement.form;
-```
-
 ## Example
 
 ```html


### PR DESCRIPTION
#### Summary
Replaces the existing, irrelevant examples on the HTMLSelectElement's `form` property's page with relevant ones.

#### Motivation
To help people understand how to use the HTMLSelectElement;s `form` property.

#### Supporting details
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form-dev

#### Related issues
Fixes #5704

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
