### PR TITLE
Use const in place of var

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -30,7 +30,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var inserting = browser.tabs.insertCSS(
+const inserting = browser.tabs.insertCSS(
   tabId,           // optional integer
   details          // object
 )
@@ -73,7 +73,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 This example inserts into the currently active tab CSS which is taken from a string.
 
 ```js
-var css = "body { border: 20px dotted pink; }";
+const css = "body { border: 20px dotted pink; }";
 
 browser.browserAction.onClicked.addListener(() => {
 
@@ -81,7 +81,7 @@ browser.browserAction.onClicked.addListener(() => {
     console.log(`Error: ${error}`);
   }
 
-  var insertingCSS = browser.tabs.insertCSS({code: css});
+  const insertingCSS = browser.tabs.insertCSS({code: css});
   insertingCSS.then(null, onError);
 });
 ```
@@ -95,7 +95,7 @@ browser.browserAction.onClicked.addListener(() => {
     console.log(`Error: ${error}`);
   }
 
-  var insertingCSS = browser.tabs.insertCSS(2, {file: "content-style.css"});
+  const insertingCSS = browser.tabs.insertCSS(2, {file: "content-style.css"});
   insertingCSS.then(null, onError);
 });
 ```


### PR DESCRIPTION
#### Summary
Replace the `var` keyword for the `const` keyword. The values are not mutated so `const` is the appropriate initialiser to use.

#### Motivation
The `var` keyword is deprecated.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error