### PR TITLE
manifest: specify JSON schema

### DIFF
--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -26,6 +26,7 @@ Web manifests can contain the following keys. Click on each one to link through 
 
 ```json
 {
+  "$schema": "https://json.schemastore.org/web-manifest-combined.json",
   "name": "HackerWeb",
   "short_name": "HackerWeb",
   "start_url": ".",


### PR DESCRIPTION
Referencing `$schema` improves developer experience since editors provide auto completion.
