### PR TITLE
Fix typo: Unnecessary parenthesis

### DIFF
--- a/files/en-us/web/api/htmlaudioelement/audio/index.md
+++ b/files/en-us/web/api/htmlaudioelement/audio/index.md
@@ -60,7 +60,7 @@ playback to begin:
   audio through to the end without interruption.
 - Listen for the {{domxref("HTMLMediaElement.canplay_event", "canplay")}} event. It
   is sent to the `<audio>` element when there's enough audio
-  available to begin playback, although interruptions may occur).
+  available to begin playback, although interruptions may occur.
 - Listen for the {{domxref("HTMLMediaElement.canplaythrough_event",
 		"canplaythrough")}} event. It is sent when it's estimated that the audio should be
   able to play to the end without interruption.


### PR DESCRIPTION
Removes unnecessary parenthesis at the end of the second bullet in *Determining when playback can begin*

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
