### PR TITLE
Add HTMLInputElement: checkValidity() and setCustomValidity()

### DIFF
--- a/files/en-us/web/api/constraint_validation/index.md
+++ b/files/en-us/web/api/constraint_validation/index.md
@@ -51,11 +51,11 @@ The constraint validation API extends the interfaces for the form-associated ele
 
 #### Methods
 
-- {{domxref('HTMLObjectElement.checkValidity', 'checkValidity()')}}
+- {{domxref('HTMLInputElement.checkValidity', 'checkValidity()')}}
   - : Checks the element's value against its constraints. If the value is invalid, it fires an [invalid](/en-US/docs/Web/API/HTMLInputElement/invalid_event) event at the element and returns `false`; otherwise it returns `true`.
 - {{domxref('HTMLFormElement.reportValidity','reportValidity()')}} HTMLFormElement method
   - : Checks the element's value against its constraints and also reports the validity status; if the value is invalid, it fires an [invalid](/en-US/docs/Web/API/HTMLInputElement/invalid_event) event at the element, returns `false`, and then reports the validity status to the user in whatever way the user agent has available. Otherwise, it returns `true`.
-- {{domxref('HTMLObjectElement.setCustomValidity','setCustomValidity(<em>message</em>)')}}
+- {{domxref('HTMLInputElement.setCustomValidity','setCustomValidity(<em>message</em>)')}}
   - : Sets a custom error message string to be shown to the user upon submitting the form, explaining why the value is not valid — when a message is set, the validity state is set to invalid. To clear this state, invoke the function with an empty string passed as its argument. In this case the custom error message is cleared, the element is considered valid, and no message is shown.
 
 ## Examples

--- a/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
@@ -24,7 +24,7 @@ element.checkValidity();
 
 ### Return value
 
-It returns `true` if the value of the element has no validity problems. Otherwise it returns `false`.
+Returns `true` if the value of the element has no validity problems; otherwise returns `false`.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
@@ -1,0 +1,41 @@
+---
+title: HTMLInputElement.checkValidity()
+slug: Web/API/HTMLInputElement/checkValidity
+tags:
+  - API
+  - HTML DOM
+  - HTMLInputElement
+  - Method
+  - NeedsExample
+  - Reference
+  - checkValidity
+  - checkValidity()
+browser-compat: api.HTMLObjectElement.checkValidity
+---
+{{APIRef("HTML DOM")}}
+
+The **`HTMLInputElement.checkValidity()`** method returns a boolean value which indicates validity of the value of the element. If the value is invalid, this method also fires the {{domxref("HTMLInputElement/invalid_event", "invalid")}} event on the element.
+
+## Syntax
+
+```js
+element.checkValidity();
+```
+
+### Return value
+
+It returns `true` if the value of the element has no validity problems. Otherwise it returns `false`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Learn: Client-side form validation](/en-US/docs/Learn/Forms/Form_validation)
+- [Guide: Constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation)
+- [Constraint validation API](/en-US/docs/Web/API/Constraint_validation)

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -655,7 +655,9 @@ The **`HTMLInputElement`** interface provides special properties and methods for
       <td>Replaces a range of text in the input element with new text.</td>
     </tr>
     <tr>
-      <td><code>setCustomValidity()</code></td>
+      <td>
+        {{domxref("HTMLInputElement.setCustomValidity()", "setCustomValidity()")}}
+      </td>
       <td>
         Sets a custom validity message for the element. If this message is not
         the empty string, then the element is suffering from a custom validity
@@ -663,7 +665,9 @@ The **`HTMLInputElement`** interface provides special properties and methods for
       </td>
     </tr>
     <tr>
-      <td><code>checkValidity()</code></td>
+      <td>
+        {{domxref("HTMLInputElement.checkValidity()", "checkValidity()")}}
+      </td>
       <td>
         Returns a boolean value that is <code>false</code> if the element is a
         candidate for constraint validation, and it does not satisfy its

--- a/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -38,9 +38,9 @@ None.
 ## Examples
 
 In this example, we pass the ID of an input element, and set different error messages
-depending on whether the value is missing, too low or too high. Additionally you
+depending on whether the value is missing, too low, or too high. Additionally you
 _must_ call the [`reportValidity()`](/en-US/docs/Web/API/HTMLInputElement/reportValidity)
-method on the same element or nothing will happen.
+method on the same element or else nothing will happen.
 
 ```js
 function validate(inputID) {

--- a/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -1,0 +1,81 @@
+---
+title: HTMLInputElement.setCustomValidity()
+slug: Web/API/HTMLInputElement/setCustomValidity
+tags:
+  - API
+  - HTML DOM
+  - HTMLInputElement
+  - Method
+  - NeedsExample
+  - Reference
+  - setCustomValidity
+  - setCustomValidity()
+browser-compat: api.HTMLObjectElement.setCustomValidity
+---
+{{APIRef("HTML DOM")}}
+
+The **`HTMLInputElement.setCustomValidity()`** method sets a custom validity message for the element.
+
+## Syntax
+
+```js
+element.setCustomValidity(message);
+```
+
+### Parameters
+
+- `message`
+  - : The message to use for validity errors.
+
+### Return value
+
+{{jsxref('undefined')}}
+
+### Exceptions
+
+None.
+
+## Examples
+
+In this example, we pass the ID of an input element, and set different error messages
+depending on whether the value is missing, too low or too high. Additionally you
+_must_ call the [`reportValidity()`](/en-US/docs/Web/API/HTMLInputElement/reportValidity)
+method on the same element or nothing will happen.
+
+```js
+function validate(inputID) {
+  const input = document.getElementById(inputID);
+  const validityState = input.validity;
+
+  if (validityState.valueMissing) {
+    input.setCustomValidity('You gotta fill this out, yo!');
+  } else if (validityState.rangeUnderflow) {
+    input.setCustomValidity('We need a higher number!');
+  } else if (validityState.rangeOverflow) {
+    input.setCustomValidity('Thats too high!');
+  } else {
+    input.setCustomValidity('');
+  }
+
+  input.reportValidity();
+}
+```
+
+It's vital to set the message to an empty string if there are no errors. As long as the
+error message is not empty, the form will not pass validation and will not be
+submitted.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Learn: Client-side form validation](/en-US/docs/Learn/Forms/Form_validation)
+- [Guide: Constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation)
+- [Constraint validation API](/en-US/docs/Web/API/Constraint_validation)
+- {{domxref('ValidityState')}}


### PR DESCRIPTION
#### Summary
Add checkValidity() and setCustomValidity() methods of the HTMLInputElement interface.

#### Motivation
The reference pages of these methods is only for HTMLObjectElement interface. However they are mostly used for HTMLInputElement rather than HTMLObjectElement.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [X] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
