### PR TITLE
fix: invalid re-assignment to constant in example

### DIFF
--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -105,7 +105,7 @@ Sometimes you might end up with a number that is stored as a string type, which 
 For example, try typing these lines into your console:
 
 ```js
-const myNumber = '74';
+let myNumber = '74';
 myNumber += 3;
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Before:
<!-- ✍️ In a sentence or two, describe your changes -->
```js
const myNumber = '74';
myNumber += 3;          // assingment to constant(myNumber)
```
After:
```js
let myNumber = '74';
myNumber += 3;
```
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Open-source
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Closes #11142 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
