### PR TITLE
Adds namedGroups Param. Thanks @JohnyL

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -95,6 +95,7 @@ The arguments to the function are as follows:
 | `offset`      | The offset of the matched substring within the whole string being examined. (For example, if the whole string was `'abcd'`, and the matched substring was `'bc'`, then this argument will be `1`.)                                                                                     |
 | `string`      | The whole string being examined.                                                                                                                                                                                                                                                       |
 | `namedGroups` | An object of all named capturing groups. The keys are the names of the capturing groups and each value is the substring matching the named capture group. If the regular expression doesn't contain any capturing groups, `namedGroups` is undefined.                               |
+
 (The exact number of arguments depends on whether the first argument is a
 {{jsxref("RegExp")}} object—and, if so, how many parenthesized submatches it specifies.)
 

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -94,7 +94,7 @@ The arguments to the function are as follows:
 | `p1, p2, ...` | The *n*th string found by a parenthesized capture group, provided the first argument to `replaceAll()` was a {{jsxref("RegExp")}} object. (Corresponds to `$1`, `$2`, etc. above.) For example, if `/(\a+)(\b+)/`, was given, `p1` is the match for `\a+`, and `p2` for `\b+`. |
 | `offset`      | The offset of the matched substring within the whole string being examined. (For example, if the whole string was `'abcd'`, and the matched substring was `'bc'`, then this argument will be `1`.)                                                                                     |
 | `string`      | The whole string being examined.                                                                                                                                                                                                                                                       |
-
+| `namedGroups` | An object of all named capturing groups. The keys are the names of the capturing groups and each value is the substring matching the named capture group. If the regular expression doesn't contain any capturing groups, `namedGroups` is undefined.                               |
 (The exact number of arguments depends on whether the first argument is a
 {{jsxref("RegExp")}} object—and, if so, how many parenthesized submatches it specifies.)
 


### PR DESCRIPTION
#### Summary
An additonal parameter passed to the function was not mentioned. Verified behavior in Firefox and Chrome using provided sample. Thanks @JohnyL

#### Motivation
Low hanging :mango:

#### Supporting details
Borrows named capturing group description from :-
1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
2. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges

#### Related issues
Fixes #2350

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
