### PR TITLE
Fix typo in Web NFC API

### DIFF
--- a/files/en-us/web/api/web_nfc_api/index.md
+++ b/files/en-us/web/api/web_nfc_api/index.md
@@ -10,7 +10,7 @@ tags:
 
 The Web NFC API allows exchanging data over NFC via light-weight NFC Data Exchange Format (NDEF) messages.
 
-> **Note:** Devices and tags have to be formatted and recorded specifically to support NDEF record format to be used with Web NFC. Low-level operations are currently not supported by the API, however there is a public discussion about API that would add such functuionality.
+> **Note:** Devices and tags have to be formatted and recorded specifically to support NDEF record format to be used with Web NFC. Low-level operations are currently not supported by the API, however there is a public discussion about API that would add such functionality.
 
 ## Interfaces
 


### PR DESCRIPTION
#### Summary
Change `functuionality` to `functionality`.

#### Motivation
There is a typo.

#### Supporting details
N/A

#### Related issues
None.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
