### PR TITLE
Remove polyfills from Number.parseInt and parseFloat

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -32,14 +32,6 @@ A floating point number parsed from the given `string`.
 
 Or {{jsxref("NaN")}} when the first non-whitespace character cannot be converted to a number.
 
-## Polyfill
-
-```js
-if (Number.parseFloat === undefined) {
-  Number.parseFloat = parseFloat;
-}
-```
-
 ## Examples
 
 ### Number.parseFloat vs parseFloat

--- a/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
@@ -45,14 +45,6 @@ If the `radix` is smaller than `2` or bigger than
 `36`, or the first non-whitespace character cannot be converted to a number,
 {{jsxref("NaN")}} is returned.
 
-## Polyfill
-
-```js
-if (Number.parseInt === undefined) {
-    Number.parseInt = window.parseInt
-}
-```
-
 ## Examples
 
 ### Number.parseInt vs parseInt


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove polyfill sections under `Number.parseInt` and `Number.parseFloat`.

#### Motivation
Despite its simplicity, I'd like to remove them for the core-js polyfill links.

#### Supporting details


#### Related issues


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
