### PR TITLE
Add clarification to Array.prototype.splice() article

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -45,7 +45,7 @@ splice(start, deleteCount, item1, item2, itemN)
 
   - : An integer indicating the number of elements in the array to remove from `start`.
 
-    If `deleteCount` is omitted, or if its value is equal to or larger than `array.length - start` (that is, if it is equal to or greater than the number of elements left in the array, starting at `start`), then all the elements from `start` to the end of the array will be deleted.
+    If `deleteCount` is omitted, or if its value is equal to or larger than `array.length - start` (that is, if it is equal to or greater than the number of elements left in the array, starting at `start`), then all the elements from `start` to the end of the array will be deleted. However, it must not be omitted if there is any `item1` parameter.
 
     If `deleteCount` is `0` or negative, no elements are removed.
     In this case, you should specify at least one new element (see below).


### PR DESCRIPTION
Add restriction on optionality of deleteCount parameter. Otherwise, readers can interpret “If … is omitted” to imply that it may be omitted under all conditions. The fact that the syntax section does not show a case of omitted deleteCount with item1 present may not be enough to make this clear.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add a sentence describing a restriction that is not explicitly stated.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Readers can interpret “If … is omitted” to imply that deleteCount may be omitted under all conditions, but it cannot if any item1 parameter is specified. The fact that the syntax section does not show a case of omitted deleteCount with item1 present may not be enough to make this clear.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
