### PR TITLE
FF96 ElementInternals.willValidate - relnote and update

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -56,6 +56,7 @@ This article provides information about the changes in Firefox 96 that will affe
 #### DOM
 
 - The {{domxref("IntersectionObserver.IntersectionObserver()","IntersectionObserver()")}} constructor now sets the default `rootMargin` if an empty string is passed in the associated parameter option, instead of throwing an exception ({{bug(1738791)}}).
+- {{domxref("ElementInternals.willValidate")}} is now supported, allowing code to check if a custom form element will be validated ({{bug(1556365)}}).
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/web/api/elementinternals/willvalidate/index.md
+++ b/files/en-us/web/api/elementinternals/willvalidate/index.md
@@ -11,17 +11,13 @@ browser-compat: api.ElementInternals.willValidate
 ---
 {{DefaultAPISidebar("DOM")}}
 
-The **`willValidate`** read-only property of the {{domxref("ElementInternals")}} interface returns true if the element is a submittable element that is a candidate for [constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation).
+The **`willValidate`** read-only property of the {{domxref("ElementInternals")}} interface returns `true` if the element is a submittable element that is a candidate for [constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation).
 
-## Syntax
+Elements that are barred from being candidates for constraint validation include those that have the attributes: `disabled`, `hidden` or `readonly`, input elements of `type=button` or `type=reset`, or any element that is a {{htmlelement("datalist")}} element or has a `<datalist>` element ancestor.
 
-```js
-let willValidate = ElementInternals.willValidate;
-```
+## Value
 
-### Value
-
-A boolean value, true if the element is a candidate for constraint validation.
+`true` if the element is a candidate for constraint validation, otherwise `false`.
 
 ### Exceptions
 


### PR DESCRIPTION
FF96 adds support for  [ElementInternals.willValidate](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/willValidate) in https://bugzilla.mozilla.org/show_bug.cgi?id=1556365

This PR adds a release note and updates the docs for the property to current syntax. Also added a bit more information about things that might bar a custom element from returning true - seems relevant.

other docs work for this tracked in https://github.com/mdn/content/issues/10851#issuecomment-987594191