### PR TITLE
Add postMessage call to MessageChannel: postMessage example

### DIFF
--- a/files/en-us/web/api/messageport/postmessage/index.md
+++ b/files/en-us/web/api/messageport/postmessage/index.md
@@ -43,8 +43,9 @@ port.postMessage(message, transferList);
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor. When the
 IFrame has loaded, we pass {{domxref("MessageChannel.port2")}} to the IFrame using
-{{domxref("window.postMessage")}} along with a message. The `handleMessage`
-handler then responds to a message being sent back from the IFrame using
+{{domxref("window.postMessage")}} along with a message. The IFrame receives the message,
+and sends a message back on the MessageChannel using {{domxref("MessageChannel.postMessage")}}.
+The `handleMessage` handler then responds to a message being sent back from the IFrame using
 `onmessage`, putting it into a paragraph —
 {{domxref("MessageChannel.port1")}} is listened to, to check when the message arrives.
 
@@ -58,13 +59,20 @@ var otherWindow = ifr.contentWindow;
 ifr.addEventListener("load", iframeLoaded, false);
 
 function iframeLoaded() {
-  otherWindow.postMessage('Hello from the main page!', '*', [channel.port2]);
+  otherWindow.postMessage('Transferring message port', '*', [channel.port2]);
 }
 
 channel.port1.onmessage = handleMessage;
 function handleMessage(e) {
   para.innerHTML = e.data;
 }
+
+// in the IFrame...
+
+window.addEventListener('message', function (event) {
+  const messagePort = event.ports?.[0];
+  messagePort.postMessage("Hello from the iframe!");
+});
 ```
 
 For a full working example, see our [channel

--- a/files/en-us/web/api/messageport/postmessage/index.md
+++ b/files/en-us/web/api/messageport/postmessage/index.md
@@ -43,9 +43,9 @@ port.postMessage(message, transferList);
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor. When the
 IFrame has loaded, we pass {{domxref("MessageChannel.port2")}} to the IFrame using
-{{domxref("window.postMessage")}} along with a message. The IFrame receives the message,
+{{domxref("window.postMessage")}} along with a message. The iframe receives the message,
 and sends a message back on the MessageChannel using {{domxref("MessageChannel.postMessage")}}.
-The `handleMessage` handler then responds to a message being sent back from the IFrame using
+The `handleMessage` handler then responds to a message being sent back from the iframe using
 `onmessage`, putting it into a paragraph —
 {{domxref("MessageChannel.port1")}} is listened to, to check when the message arrives.
 
@@ -67,7 +67,7 @@ function handleMessage(e) {
   para.innerHTML = e.data;
 }
 
-// in the IFrame...
+// in the iframe...
 
 window.addEventListener('message', function (event) {
   const messagePort = event.ports?.[0];


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The example code for the `MessageChannel.postMessage` method didn't actually show the method being called. This PR adds additional code to show this.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I was trying to post messages using MessageChannel and found the documentation not as helpful as it could have been.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
