### PR TITLE
Fix typo (`avod` -> `avoid`)

### DIFF
--- a/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
+++ b/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
@@ -91,7 +91,7 @@ animator.requestAnimationFrame =
 };
 ```
 
-The game’s _redraw_ function does all drawing, and the animation callbacks just update state. When you request a redraw outside of animations, the animator’s `activeAnimations` property is queried first to avod mistakenly drawing multiple times in a single animation frame. This gives nice, synchronised animations at a very low cost. Puzzowl isn’t out yet, but here’s a little screencast of it running on a Nexus 5:
+The game’s _redraw_ function does all drawing, and the animation callbacks just update state. When you request a redraw outside of animations, the animator’s `activeAnimations` property is queried first to avoid mistakenly drawing multiple times in a single animation frame. This gives nice, synchronised animations at a very low cost. Puzzowl isn’t out yet, but here’s a little screencast of it running on a Nexus 5:
 
 {{EmbedYouTube("hap4iQTMh70")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixed a small typo in the efficient animation for web games document.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I noticed this typo nearing the end of the article and wanted to fix it. I checked over the rest of the document and it seems this is the only typo.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[Link to Highlight](https://developer.mozilla.org/en-US/docs/Games/Techniques/Efficient_animation_for_web_games#:~:text=queried%20first%20to-,avod,-mistakenly%20drawing%20multiple)
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
