### PR TITLE
FF96: Toggle display password

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -144,6 +144,46 @@ Layout for `input type="search"` has been updated. This causes a search field t
   </tbody>
 </table>
 
+### Toggle password display
+
+HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/Element/input/password)) include an "eye" icon that can be toggled to display or obscure the password text ({{bug(502258)}}).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>96</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>96</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>96</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>96</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.forms.input-type-show-password-button.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## CSS
 
 ### Display stray control characters in CSS as hex boxes

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -21,13 +21,17 @@ browser-compat: html.elements.input.input-password
 
 `<input>` elements of type **`password`** provide a way for the user to securely enter a password.
 
-The element is presented as a one-line plain text editor control in which the text is obscured so that it cannot be read, usually by replacing each character with a symbol such as the asterisk ("\*") or a dot ("•"). This character will vary depending on the {{Glossary("user agent")}} and {{Glossary("OS")}}.
+The element is presented as a one-line plain text editor control in which the text is obscured so that it cannot be read, usually by replacing each character with a symbol such as the asterisk ("\*") or a dot ("•").
+This character will vary depending on the {{Glossary("user agent")}} and operating system.
 
 {{EmbedInteractiveExample("pages/tabbed/input-password.html", "tabbed-standard")}}
 
-Specifics of how the entry process works may vary from browser to browser; mobile devices, for example, often display the typed character for a moment before obscuring it, to allow the user to be sure they pressed the key they meant to press; this is helpful given the small size of keys and the ease with which the wrong one can be pressed, especially on virtual keyboards.
+The precise behaviour of the entry process may vary from browser to browser.
+Some browsers display the typed character for a moment before obscuring it, while others allow the user to toggle the display of plain-text on and off.
+Both approaches help a user check that they entered the intended password, which can be particularly difficult on mobile devices.
 
-> **Note:** Any forms involving sensitive information like passwords (e.g. login forms) should be served over HTTPS; Many browsers now implement mechanisms to warn against insecure login forms; see [Insecure passwords](/en-US/docs/Web/Security/Insecure_passwords).
+> **Note:** Any forms involving sensitive information like passwords (such as login forms) should be served over HTTPS.
+> Many browsers now implement mechanisms to warn against insecure login forms; see [Insecure passwords](/en-US/docs/Web/Security/Insecure_passwords).
 
 <table class="properties">
   <tbody>
@@ -121,7 +125,7 @@ If the control's content has one directionality ({{Glossary("LTR")}} or {{Glossa
 
 ### readonly
 
-A Boolean attribute which, if present, means this field cannot be edited by the user. Its `value` can, however, still be changed from JavaScript code that directly sets the value of the {{domxref("HTMLInputElement.value")}} property.
+A Boolean attribute which, if present, means this field cannot be edited by the user. Its `value` can, however, still be changed from JavaScript code that directly sets the value of the {{domxref("HTMLInputElement","HTMLInputElement.value")}} property.
 
 > **Note:** Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
 


### PR DESCRIPTION
FF96 adds support for a "show password" icon in [`<input type="password">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password) inputs behind the preference `layout.forms.input-type-show-password-button.enabled`.
![image](https://user-images.githubusercontent.com/5368500/145744437-d4e55bed-92dc-40f9-80ab-6fde2ac5d49d.png)

This adds it as an experimental feature and also updates the main doc to indicate that this one way that a browser might manage data entry (it already covered the case of displaying last-pressed button briefly) 

Other docs work, if any, tracked in https://github.com/mdn/content/issues/10855