### PR TITLE
removed warning

### DIFF
--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -29,8 +29,6 @@ The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected result
 
 The `:not()` pseudo-class requires a comma-separated list of one or more selectors as its argument. The list must not contain another negation selector or a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements).
 
-> **Warning:** The ability to list more than one selector is experimental and not yet widely supported.
-
 {{csssyntax}}
 
 ## Description


### PR DESCRIPTION
Last 5 to 10 versions of browsers support this, so warning is no longer needed.
https://caniuse.com/css-not-sel-list

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [X] Removes a warning that is outdated

