### PR TITLE
Update EventTarget.removeEventListener

### DIFF
--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.md
@@ -9,7 +9,7 @@ browser-compat: api.EventTarget.removeEventListener
 {{APIRef("DOM")}}
 
 The **`removeEventListener()`** method of the {{domxref("EventTarget")}} interface
-removes from the target an event listener previously registered with {{domxref("EventTarget.addEventListener()")}}.
+removes an event listener previously registered with {{domxref("EventTarget.addEventListener()")}} from the target.
 The event listener to be removed is identified using a combination of the event type,
 the event listener function itself, and various optional options that may affect the matching process;
 see {{anch("Matching event listeners for removal")}}.
@@ -18,22 +18,18 @@ Calling `removeEventListener()` with arguments that do not identify any
 currently registered {{domxref("EventListener")}} on the `EventTarget` has no
 effect.
 
-If an {{domxref("EventListener")}} is removed from an {{domxref("EventTarget")}} while
-it is processing an event, it will not be triggered by the current actions. An
-{{domxref("EventListener")}} will not be invoked for the event it was registered for
-after being removed. However, it can be reattached.
+If an {{domxref("EventListener")}} is removed from an {{domxref("EventTarget")}} while another listener of the target is processing an event, it will not be triggered by the event. However, it can be reattached.
 
-> **Warning:** If a listener is registered twice, one with the _capture_ flag set and one without, you must remove each one separately.
-  > Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.
+> **Warning:** If a listener is registered twice, one with the _capture_ flag set and one without, you must remove each one separately. Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.
 
 Event listeners can also be removed by passing an {{domxref("AbortSignal")}} to an {{domxref("EventTarget/addEventListener()", "addEventListener()")}} and then later calling {{domxref("AbortController/abort()", "abort()")}} on the controller owning the signal.
 
 ## Syntax
 
 ```js
-target.removeEventListener(type, listener);
-target.removeEventListener(type, listener, options);
-target.removeEventListener(type, listener, useCapture);
+removeEventListener(type, listener);
+removeEventListener(type, listener, options);
+removeEventListener(type, listener, useCapture);
 ```
 
 ### Parameters
@@ -44,21 +40,15 @@ target.removeEventListener(type, listener, useCapture);
   - : The {{domxref("EventListener")}} function of the event handler to remove from the
     event target.
 - `options` {{optional_inline}}
-
   - : An options object that specifies characteristics about the event listener.
 
     The available options are:
 
-    - `capture`: A boolean value which indicates that
-      events of this type will be dispatched to the registered
-      `listener` before being dispatched to any
-      {{domxref("EventTarget")}} beneath it in the DOM tree.
+    - `capture`:  A boolean value that specifies whether the {{domxref("EventListener")}} to be removed is registered as a capturing listener or not. If this parameter is absent, a default value of `false` is assumed.
 
 - `useCapture` {{optional_inline}}
-
   - : A boolean value that specifies whether the {{domxref("EventListener")}} to be removed is registered as a
-    capturing listener or not. If this parameter is absent, a default value of
-    `false` is assumed.
+    capturing listener or not. If this parameter is absent, a default value of `false` is assumed.
 
 ### Return value
 
@@ -137,25 +127,25 @@ const mouseOverTarget = document.getElementById('mouse-over-target')
 
 let toggle = false;
 function makeBackgroundYellow() {
-    if (toggle) {
-        body.style.backgroundColor = 'white';
-    } else {
-        body.style.backgroundColor = 'yellow';
-    }
+  if (toggle) {
+    body.style.backgroundColor = 'white';
+  } else {
+    body.style.backgroundColor = 'yellow';
+  }
 
-    toggle = !toggle;
+  toggle = !toggle;
 }
 
 clickTarget.addEventListener('click',
-    makeBackgroundYellow,
-    false
+  makeBackgroundYellow,
+  false
 );
 
 mouseOverTarget.addEventListener('mouseover', function () {
-    clickTarget.removeEventListener('click',
-        makeBackgroundYellow,
-        false
-    );
+  clickTarget.removeEventListener('click',
+    makeBackgroundYellow,
+    false
+  );
 });
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Rephrased some sentences, formatted syntax and example code boxes.

#### Motivation

Prefer non-inverted sentence for simplicity:

> The **`removeEventListener()`** method of the {{domxref("EventTarget")}} interface removes (?) from the target ...

---

What "it" is ambiguous:

> If an {{domxref("EventListener")}} is removed from an {{domxref("EventTarget")}} while
*it* is processing an event, it will not be triggered by the current actions.

Is it the `EventListener` or the `EventTarget`? It reads like the former but what it actually means must be the latter, because this works:

```js
function handler() {
  console.log(handler)
  foo.removeEventListener('click', handler)
  console.log('post')
}

foo.addEventListener('click', handler)
// "post" still logs
```

---

- `options.capture` parameter description was copied from `addEventListener()` and doesn't fit.
- Updated syntax section to follow the newer style guide.
- Code style: 4 spaces to 2 spaces.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
