### PR TITLE
Add `NaN` return types to Date.getUTC*() methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.md
@@ -24,9 +24,11 @@ getUTCDate()
 
 ### Return value
 
-An integer number ranging from 1 to 31 representing day of month for the given date,
-according to universal time.
-
+A `number`.
+If the `Date` object represents a valid date, an integer number ranging from 1 to 31
+representing day of month for the given date, according to universal time.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 ## Examples
 
 ### Using getUTCDate()

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.md
@@ -24,8 +24,12 @@ getUTCDay()
 
 ### Return value
 
-An integer number corresponding to the day of the week for the given date, according to
-universal time: 0 for Sunday, 1 for Monday, 2 for Tuesday, and so on.
+A `number`.
+If the `Date` object represents a valid date, an integer number corresponding to the day
+of the week for the given date, according to universal time: 0 for Sunday, 1 for Monday,
+2 for Tuesday, and so on.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -24,7 +24,11 @@ getUTCFullYear()
 
 ### Return value
 
-A number representing the year in the given date according to universal time.
+A `number`.
+If the `Date` object represents a valid date, an integer representing the year in the given date
+according to universal time.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.md
@@ -24,8 +24,11 @@ getUTCHours()
 
 ### Return value
 
-An integer number, between 0 and 23, representing the hours in the given date according
-to universal time.
+A `number`.
+If the `Date` object represents a valid date, an integer between 0 and 23, representing the hours in the given date according
+to Coordinated Universal Time.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
@@ -30,9 +30,6 @@ the milliseconds portion of the given `Date` object according to universal time
 Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn’t represent a valid date.
 
-This method is a companion to the other UTC based methods that give
-hour portion ([`getUTCHours`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours)),
-minute portion ([`getUTCMinutes`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes)), etc.; this method gives milliseconds portion.
 
 Not to be confused with Unix epoch time. To get the total milliseconds since 1970/01/01,
 use the [`Date.getTime()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime) method.

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Date.getUTCMilliseconds
 {{JSRef}}
 
 The **`getUTCMilliseconds()`** method returns the milliseconds
-portion of the time object's value.
+portion of the time object's value according to universal time.
 
 {{EmbedInteractiveExample("pages/js/date-getutcmilliseconds.html","shorter")}}
 
@@ -24,12 +24,18 @@ getUTCMilliseconds()
 
 ### Return value
 
-An integer number, between 0 and 999, representing the milliseconds portion of the
-given date object.  This method is a companion to the other UTC based methods that give
-hour portion, minute portion, etc.; this method gives milliseconds portion.
+A `number`.
+If the `Date` object represents a valid date, an integer between 0 and 999, representing
+the milliseconds portion of the given `Date` object according to universal time.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 
-Not to be confused with Unix epoch time.  To get total milliseconds since 1970/01/01,
-use the method ".getTime()".
+This method is a companion to the other UTC based methods that give
+hour portion ([`getUTCHours`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours)),
+minute portion ([`getUTCMinutes`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes)), etc.; this method gives milliseconds portion.
+
+Not to be confused with Unix epoch time. To get the total milliseconds since 1970/01/01,
+use the [`Date.getTime()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime) method.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.md
@@ -24,8 +24,11 @@ getUTCMinutes()
 
 ### Return value
 
-An integer number, between 0 and 59, representing the minutes in the given date
-according to universal time.
+A `number`.
+If the `Date` object represents a valid date, an integer between 0 and 59,
+representing the minutes in the given date according to universal time.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.md
@@ -24,8 +24,11 @@ getUTCSeconds()
 
 ### Return value
 
-An integer number, between 0 and 59, representing the seconds in the given date
-according to universal time.
+A `number`.
+If the `Date` object represents a valid date, an integer between 0 and 59, representing
+the seconds in the given date according to universal time.
+Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+if the `Date` object doesn’t represent a valid date.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary

Adds the number `NaN` as a possible return type to `Date.getUTC*` methods

#### Motivation

This is a possible return type from these methods. The change was accepted to `getUTCMonths` in #6031.

#### Supporting details

```js
const day = new Date("an invalid date").getUTCDay();

Number.isNaN(day); // returns true
```

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
