### PR TITLE
Added safe/unsafe keyword references (#10924)

### DIFF
--- a/files/en-us/web/css/place-content/index.md
+++ b/files/en-us/web/css/place-content/index.md
@@ -86,6 +86,10 @@ The first value is the {{CSSxRef("align-content")}} property value, the second t
   - : The items are evenly distributed within the alignment container. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
 - `stretch`
   - : If the combined size of the items is less than the size of the alignment container, any `auto`-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by {{CSSxRef("max-height")}}/{{CSSxRef("max-width")}} (or equivalent functionality), so that the combined size exactly fills the alignment container
+- `safe`
+  - : Used alongside an alignment keyword. If the chosen keyword means that the item overflows the alignment container causing data loss, the item is instead aligned as if the alignment mode were `start`.
+- `unsafe`
+  - : Used alongside an alignment keyword. Regardless of the relative sizes of the item and alignment container, and regardless of whether overflow which causes data loss might happen, the given alignment value is honored.
 
 ## Formal definition
 


### PR DESCRIPTION
References to and brief explanations for the `safe` and `unsafe` keyword values have been added to the property's value list.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Addresses issue #10924 by adding in references and info for the `safe` and `unsafe` keywords.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Make the `place-content` page a more complete informational document.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.w3.org/TR/css-align-3/#overflow-values

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [✅] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
