### PR TITLE
FF96 ElementInternals.willValidate behind pref

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1267,9 +1267,10 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
 New {{domxref("ElementInternals")}} properties and methods that allow a custom elements to interact with a form:
 - property: {{domxref("ElementInternals.form","form")}} gets the form associated with the element
 - property: {{domxref("ElementInternals.labels","labels")}} gets the list of labels associated with the element
+- property: {{domxref("ElementInternals.willValidate", "willValidate")}} checks if a custom form element will be validated.
 - method: {{domxref("ElementInternals.setFormValue()","setFormValue()")}} set the sanitized value and user-entered data, if needed.
 
-See these bugs for details: {{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556449)}}.
+See these bugs for details: {{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556365)}}, {{bug(1556449)}}.
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -56,7 +56,6 @@ This article provides information about the changes in Firefox 96 that will affe
 #### DOM
 
 - The {{domxref("IntersectionObserver.IntersectionObserver()","IntersectionObserver()")}} constructor now sets the default `rootMargin` if an empty string is passed in the associated parameter option, instead of throwing an exception ({{bug(1738791)}}).
-- {{domxref("ElementInternals.willValidate")}} is now supported, allowing code to check if a custom form element will be validated ({{bug(1556365)}}).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
Fixes up changes from #11165

`ElementInternals.willValidate` is supported in FF96 but behind a preference. This removes the feature from the release note and adds it to experimental features.
