### PR TITLE
Page macro: CSP header directives - duplicate source info

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -32,18 +32,18 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} **`base-uri`** directive rest
 
 ## Syntax
 
-One or more*sources* can be allowed for the base-uri policy:
+One or more *sources* can be allowed for the base-uri policy:
 
-```
+```http
 Content-Security-Policy: base-uri <source>;
 Content-Security-Policy: base-uri <source> <source>;
 ```
 
 ### Sources
 
-While this directive uses the same arguments as other CSP directives, some of them don’t make sense for \`\<base>\`, such as the keywords `'unsafe-inline'` and `'strict-dynamic'`
+This directive uses most of the same source values for arguments as other CSP directives: [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
+Note however that some of the values don't make sense for `base-uri`, such as the keywords `'unsafe-inline'` and `'strict-dynamic'`.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -43,16 +43,18 @@ network errors by the user agent.
 
 ## Syntax
 
-One or more sources can be allowed for the child-src policy:
+One or more sources can be allowed for the `child-src` policy:
 
-```
+```http
 Content-Security-Policy: child-src <source>;
 Content-Security-Policy: child-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -60,7 +62,7 @@ Content-Security-Policy: child-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: child-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -52,14 +52,16 @@ loaded using script interfaces. The APIs that are restricted are:
 
 One or more sources can be allowed for the connect-src policy:
 
-```
+```http
 Content-Security-Policy: connect-src <source>;
 Content-Security-Policy: connect-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -67,7 +69,7 @@ Content-Security-Policy: connect-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: connect-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -58,49 +58,9 @@ Content-Security-Policy: default-src <source> <source>;
 
 ### Sources
 
-\<source> can be one of the following:
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-- `<host-source>`
-
-  - : Internet hosts by name or IP address, as well as an optional [URL scheme](/en-US/docs/Learn/Common_questions/What_is_a_URL) and/or port number. The site's address may include an optional leading wildcard (the asterisk character, `'*'`), and you may use a wildcard (again, `'*'`) as the port number, indicating that all legal ports are valid for the source.
-    Examples:
-
-    - `http://*.example.com`: Matches all attempts to load from any subdomain of example.com using the `http:` URL scheme.
-    - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
-    - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
-    - `*.example.com`: Matches all attempts to load from any subdomain of example.com using the current protocol.
-
-- `<scheme-source>`
-
-  - : A scheme such as `http:` or `https:`. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
-
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
-    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
-    - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
-    - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
-
-- `'self'`
-  - : Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude `blob` and `filesystem` from source directives. Sites needing to allow these content types can specify them using the Data attribute.
-- `'unsafe-eval'`
-  - : Allows the use of `eval()` and similar methods for creating code from strings. You must include the single quotes.
-- `'unsafe-hashes'`
-  - : Allows enabling specific inline [event handlers](/en-US/docs/Web/Events/Event_handlers). If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or `javascript:` URLs, this is a safer method than using the `unsafe-inline` expression.
-- `'unsafe-inline'`
-  - : Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, `javascript:` URLs, inline event handlers, and inline {{HTMLElement("style")}} elements. The single quotes are required.
-- `'none'`
-  - : Refers to the empty set; that is, no URLs match. The single quotes are required.
-- `'nonce-<base64-value>'`
-
-  - : An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example. Specifying nonce makes a modern browser ignore `'unsafe-inline'` which could still be set for older browsers without nonce support.
-
-    > **Note:** The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
-
-- `'<hash-algorithm>-<base64-value>'`
-  - : A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the \<script> or \<style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of `script-src` for external scripts.
-- `'strict-dynamic'`
-  - : The `strict-dynamic` source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as `'self'` or `'unsafe-inline'` are ignored. See [script-src](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) for an example.
-- `'report-sample'`
-  - : Requires a sample of the violating code to be included in the violation report.
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -42,14 +42,16 @@ valid sources for fonts loaded using {{cssxref("@font-face")}}.
 
 One or more sources can be allowed for the `font-src` policy:
 
-```
+```http
 Content-Security-Policy: font-src <source>;
 Content-Security-Policy: font-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -57,7 +59,7 @@ Content-Security-Policy: font-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: font-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -39,14 +39,16 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`form-action`** direc
 
 One or more sources can be set for the `form-action` policy:
 
-```
+```http
 Content-Security-Policy: form-action <source>;
 Content-Security-Policy: form-action <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -45,14 +45,16 @@ browsing contexts loading using elements such as {{HTMLElement("frame")}} and
 
 One or more sources can be allowed for the `frame-src` policy:
 
-```
+```http
 Content-Security-Policy: frame-src <source>;
 Content-Security-Policy: frame-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -60,7 +62,7 @@ Content-Security-Policy: frame-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: frame-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -15,9 +15,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.img-src
 ---
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}}
-**`img-src`** directive specifies valid sources of images and
-favicons.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} **`img-src`** directive specifies valid sources of images and favicons.
 
 <table class="properties">
   <tbody>
@@ -43,14 +41,16 @@ favicons.
 
 One or more sources can be allowed for the `img-src` policy:
 
-```
+```http
 Content-Security-Policy: img-src <source>;
 Content-Security-Policy: img-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -58,7 +58,7 @@ Content-Security-Policy: img-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: img-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -46,12 +46,11 @@ where `<policy-directive>` consists of:
 
 ### Fetch directives
 
-Fetch directives control the locations from which certain resource types may be loaded.
+{{Glossary("Fetch directive","Fetch directives")}} control the locations from which certain resource types may be loaded.
 
 - {{CSP("child-src")}}
 
-  - : Defines the valid sources for [web
-    workers](/en-US/docs/Web/API/Web_Workers_API) and nested browsing contexts loaded using elements such as
+  - : Defines the valid sources for [web workers](/en-US/docs/Web/API/Web_Workers_API) and nested browsing contexts loaded using elements such as
     {{HTMLElement("frame")}} and {{HTMLElement("iframe")}}.
 
     > **Warning:** Instead of **`child-src`**,
@@ -193,6 +192,9 @@ Reporting directives control the reporting process of CSP violations. See also t
 
 ## Values
 
+An overview of the allowed values are listed below.
+For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources) and the documentation for individual directives.
+
 ### Keyword values
 
 - `none`
@@ -200,9 +202,9 @@ Reporting directives control the reporting process of CSP violations. See also t
 - `self`
   - : Only allow resources from the current origin.
 - `strict-dynamic` {{experimental_inline}}
-  - : TBD
+  - : The trust granted to a script in the page due to an accompanying nonce or hash is extended to the scripts it loads.
 - `report-sample` {{experimental_inline}}
-  - : TBD
+  - : Require a sample of the violating code to be included in the violation report.
 
 ### Unsafe keyword values
 
@@ -211,7 +213,7 @@ Reporting directives control the reporting process of CSP violations. See also t
 - `unsafe-eval`
   - : Allow use of dynamic code evaluation such as {{jsxref("Global_Objects/eval", "eval")}}, {{domxref("Window.setImmediate", "setImmediate")}}{{non-standard_inline}}, and `window.execScript` {{non-standard_inline}}.
 - `unsafe-hashes` {{experimental_inline}}
-  - : TBD
+  - : Allows enabling specific inline event handlers.
 - `unsafe-allow-redirects` {{experimental_inline}}
   - : TBD
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -44,14 +44,16 @@ to the resource.
 
 One or more sources can be allowed for the `manifest-src` policy:
 
-```
+```http
 Content-Security-Policy: manifest-src <source>;
 Content-Security-Policy: manifest-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -59,7 +61,7 @@ Content-Security-Policy: manifest-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: manifest-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -43,14 +43,16 @@ media using the {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements.
 
 One or more sources can be allowed for the `media-src` policy:
 
-```
+```http
 Content-Security-Policy: media-src <source>;
 Content-Security-Policy: media-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -58,7 +60,7 @@ Content-Security-Policy: media-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: media-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/navigate-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/navigate-to/index.md
@@ -46,14 +46,16 @@ on what this document is allowed to navigate to.
 
 One or more sources can be set for the `navigate-to` policy:
 
-```
+```http
 Content-Security-Policy: navigate-to <source>;
 Content-Security-Policy: navigate-to <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -51,16 +51,18 @@ To set allowed types for {{HTMLElement("object")}}, {{HTMLElement("embed")}}, an
 
 ## Syntax
 
-One or more sources can be allowed for the object-src policy:
+One or more sources can be allowed for the `object-src` policy:
 
-```
+```http
 Content-Security-Policy: object-src <source>;
 Content-Security-Policy: object-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -68,7 +70,7 @@ Content-Security-Policy: object-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: object-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -40,14 +40,16 @@ be prefetched or prerendered.
 
 One or more sources can be allowed for the `prefetch-src` policy:
 
-```
+```http
 Content-Security-Policy: prefetch-src <source>;
 Content-Security-Policy: prefetch-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/default-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Example
 
@@ -55,7 +57,7 @@ Content-Security-Policy: prefetch-src <source> <source>;
 
 Given a page with the following Content Security Policy:
 
-```
+```http
 Content-Security-Policy: prefetch-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -35,9 +35,8 @@ elements.
     <tr>
       <th scope="row">{{CSP("default-src")}} fallback</th>
       <td>
-        Yes. If this directive is absent, the user agent will look for
-        the {{CSP("script-src")}} directive, and if both of them are
-        absent, fallback to <code>default-src</code> directive.
+        Yes.
+        If this directive is absent, the user agent will look for the {{CSP("script-src")}} directive, and if both of them are absent, fallback to <code>default-src</code> directive.
       </td>
     </tr>
   </tbody>
@@ -45,70 +44,32 @@ elements.
 
 ## Syntax
 
-One or more sources can be allowed for the `script-src-attr` policy:
+One or more sources can be allowed for the `script-src-attr` policy:
 
-```
+```http
 Content-Security-Policy: script-src-attr <source>;
 Content-Security-Policy: script-src-attr <source> <source>;
 ```
 
-`script-src-attr` can be used in conjunction with {{CSP("script-src")}}:
+`script-src-attr` can be used in conjunction with {{CSP("script-src")}}:
 
-```
+```http
 Content-Security-Policy: script-src <source>;
 Content-Security-Policy: script-src-attr <source>;
 ```
 
 ### Sources
 
-- `<host-source>`
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-  - : Internet hosts by name or IP address, as well as an optional [URL scheme](/en-US/docs/Learn/Common_questions/What_is_a_URL) and/or port number. The site's address may include an optional leading wildcard (the asterisk character, `'*'`), and you may use a wildcard (again, `'*'`) as the port number, indicating that all legal ports are valid for the source.
-    Examples:
-
-    - `http://*.example.com`: Matches all attempts to load from any subdomain of example.com using the `http:` URL scheme.
-    - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
-    - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
-    - `*.example.com`: Matches all attempts to load from any subdomain of example.com using the current protocol.
-
-- `<scheme-source>`
-
-  - : A scheme such as `http:` or `https:`. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
-
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
-    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
-    - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
-    - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
-
-- `'self'`
-  - : Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude `blob` and `filesystem` from source directives. Sites needing to allow these content types can specify them using the Data attribute.
-- `'unsafe-eval'`
-  - : Allows the use of `eval()` and similar methods for creating code from strings. You must include the single quotes.
-- `'unsafe-hashes'`
-  - : Allows enabling specific inline [event handlers](/en-US/docs/Web/Events/Event_handlers). If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or `javascript:` URLs, this is a safer method than using the `unsafe-inline` expression.
-- `'unsafe-inline'`
-  - : Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, `javascript:` URLs, and inline event handlers. The single quotes are required.
-- `'none'`
-  - : Refers to the empty set; that is, no URLs match. The single quotes are required.
-- `'nonce-<base64-value>'`
-
-  - : An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource^s policy is otherwise trivial. See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example. Specifying nonce makes a modern browser ignore `'unsafe-inline'` which could still be set for older browsers without nonce support.
-
-    > **Note:** The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
-
-- `'<hash-algorithm>-<base64-value>'`
-  - : A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the \<script> or \<style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of `script-src` for external scripts.
-- `'strict-dynamic'`
-  - : The `strict-dynamic` source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as `'self'` or `'unsafe-inline'` are ignored. See [script-src](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) for an example.
-- `'report-sample'`
-  - : Requires a sample of the violating code to be included in the violation report.
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
 ### Fallback to script-src
 
 If `script-src-attr` is absent, User Agent falls back to
-the {{CSP("script-src")}} directive, and if that is absent as well, to
+the {{CSP("script-src")}} directive, and if that is absent as well, to
 {{CSP("default-src")}}.
 
 ## Specifications

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -43,61 +43,23 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-elem`** d
 
 One or more sources can be allowed for the `script-src-elem` policy:
 
-```html
+```http
 Content-Security-Policy: script-src-elem <source>;
 Content-Security-Policy: script-src-elem <source> <source>;
 ```
 
 `script-src-elem` can be used in conjunction with {{CSP("script-src")}}:
 
-```html
+```http
 Content-Security-Policy: script-src <source>;
 Content-Security-Policy: script-src-elem <source>;
 ```
 
 ### Sources
 
-- `<host-source>`
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-  - : Internet hosts by name or IP address, as well as an optional [URL scheme](/en-US/docs/Learn/Common_questions/What_is_a_URL) and/or port number. The site's address may include an optional leading wildcard (the asterisk character, `'*'`), and you may use a wildcard (again, `'*'`) as the port number, indicating that all legal ports are valid for the source.
-    Examples:
-
-    - `http://*.example.com`: Matches all attempts to load from any subdomain of example.com using the `http:` URL scheme.
-    - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
-    - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
-    - `*.example.com`: Matches all attempts to load from any subdomain of example.com using the current protocol.
-
-- \<scheme-source>
-
-  - : A scheme such as `http:` or `https:`. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
-
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
-    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
-    - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
-    - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
-
-- `'self'`
-  - : Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude `blob` and `filesystem` from source directives. Sites needing to allow these content types can specify them using the Data attribute.
-- `'unsafe-eval'`
-  - : Allows the use of `eval()` and similar methods for creating code from strings. You must include the single quotes.
-- `'unsafe-hashes'`
-  - : Allows enabling specific inline [event handlers](/en-US/docs/Web/Events/Event_handlers). If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or `javascript:` URLs, this is a safer method than using the `unsafe-inline` expression.
-- `'unsafe-inline'`
-  - : Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, `javascript:` URLs, and inline event handlers. The single quotes are required.
-- `'none'`
-  - : Refers to the empty set; that is, no URLs match. The single quotes are required.
-- `'nonce-<base64-value>'`
-
-  - : An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example. Specifying nonce makes a modern browser ignore `'unsafe-inline'` which could still be set for older browsers without nonce support.
-
-    > **Note:** The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
-
-- `'<hash-algorithm>-<base64-value>'`
-  - : A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the \<script> or \<style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of `script-src` for external scripts.
-- `'strict-dynamic'`
-  - : The `strict-dynamic` source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as `'self'` or `'unsafe-inline'` are ignored. See [script-src](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) for an example.
-- `'report-sample'`
-  - : Requires a sample of the violating code to be included in the violation report.
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -42,57 +42,16 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src`** direct
 
 One or more sources can be allowed for the `script-src` policy:
 
-```
+```http
 Content-Security-Policy: script-src <source>;
 Content-Security-Policy: script-src <source> <source>;
 ```
 
 ### Sources
 
-- `<host-source>`
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-  - : Internet hosts by name or IP address, as well as an optional [URL scheme](/en-US/docs/Learn/Common_questions/What_is_a_URL) and/or port number. The site's address may include an optional leading wildcard (the asterisk character, `'*'`), and you may use a wildcard (again, `'*'`) as the port number, indicating that all legal ports are valid for the source.
-    Examples:
-
-    - `http://*.example.com`: Matches all attempts to load from any subdomain of example.com using the `http:` URL scheme.
-    - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
-    - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
-    - `*.example.com`: Matches all attempts to load from any subdomain of example.com using the current protocol.
-
-- `<scheme-source>`
-
-  - : A scheme such as `http:` or `https:`. The colon is required. Unlike other values below, single quotes shouldn't be used. You can also specify data schemes (not recommended).
-
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
-    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
-    - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
-    - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
-
-- `'self'`
-  - : Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude `blob` and `filesystem` from source directives. Sites needing to allow these content types can specify them using the Data attribute.
-- `'unsafe-eval'`
-  - : Allows the use of `eval()` and similar methods for creating code from strings. You must include the single quotes.
-- `'unsafe-hashes'`
-  - : Allows enabling specific inline [event handlers](/en-US/docs/Web/Events/Event_handlers). If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or `javascript:` URLs, this is a safer method than using the `unsafe-inline` expression.
-
-    For every inline event-handler attribute in the document, you must generate a hash from the value of the attribute (that is, the complete code in the attribute’s value), using a particular hash algorithm (e.g., `sha256`, `sha384`, or `sha512`), and then add a `<hash-algorithm>-<base64-value>` source expression for that hash to the value of the `script-src` directive.
-
-- `'unsafe-inline'`
-  - : Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, `javascript:` URLs, and inline event handlers. The single quotes are required.
-- `'none'`
-  - : Refers to the empty set; that is, no URLs match. The single quotes are required.
-- `'nonce-<base64-value>'`
-
-  - : An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See [unsafe inline script](#unsafe_inline_script) for an example. Specifying nonce makes a modern browser ignore `'unsafe-inline'` which could still be set for older browsers without nonce support.
-
-    > **Note:** The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
-
-- `'<hash-algorithm>-<base64-value>'`
-  - : A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the \<script> or \<style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See [unsafe inline script](#unsafe_inline_script) for an example. In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of `script-src` for external scripts.
-- `'strict-dynamic'`
-  - : The `strict-dynamic` source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allow-list or source expressions such as `'self'` or `'unsafe-inline'` are ignored.
-- `'report-sample'`
-  - : Requires a sample of the violating code to be included in the violation report.
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -100,7 +59,7 @@ Content-Security-Policy: script-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: script-src https://example.com/
 ```
 
@@ -184,20 +143,20 @@ The `'unsafe-eval'` source expression controls several script execution methods 
 
 The `'strict-dynamic'` source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allowlist or source expressions such as `'self'` or `'unsafe-inline'` will be ignored. For example, a policy such as `script-src 'strict-dynamic' 'nonce-R4nd0m' https://allowlisted.example.com/` would allow loading of a root script with `<script nonce="R4nd0m" src="https://example.com/loader.js">` and propagate that trust to any script loaded by `loader.js`, but disallow loading scripts from `https://allowlisted.example.com/` unless accompanied by a nonce or loaded from a trusted script.
 
-```
+```http
 Content-Security-Policy: script-src 'strict-dynamic' 'nonce-someNonce'
 ```
 
 Or:
 
-```
+```http
 Content-Security-Policy: script-src 'strict-dynamic' 'sha256-base64EncodedHash'
 ```
 
 It is possible to deploy `strict-dynamic` in a backwards compatible way, without requiring user-agent sniffing.
 The policy:
 
-```
+```http
 Content-Security-Policy: script-src 'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -1,0 +1,113 @@
+---
+title: 'CSP Source Values'
+slug: Web/HTTP/Headers/Content-Security-Policy/Sources
+tags:
+  - CSP
+  - Content-Security-Policy
+  - Directive
+  - HTTP
+  - Reference
+  - Security
+  - source
+---
+{{HTTPSidebar}}
+
+HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) header directives that specify a `<source>` from which resources may be loaded can use any one of the values listed below.
+Relevant directives include the {{Glossary("fetch directive", "fetch directives")}}, along with others [listed below](#relevant_directives).
+
+### Sources
+
+- `<host-source>`
+
+  - : Internet hosts by name or IP address, as well as an optional [URL scheme](/en-US/docs/Learn/Common_questions/What_is_a_URL) and/or port number. The site's address may include an optional leading wildcard (the asterisk character, `'*'`), and you may use a wildcard (again, `'*'`) as the port number, indicating that all legal ports are valid for the source.
+    Examples:
+
+    - `http://*.example.com`: Matches all attempts to load from any subdomain of example.com using the `http:` URL scheme.
+    - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
+    - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
+    - `*.example.com`: Matches all attempts to load from any subdomain of example.com using the current protocol.
+
+- `<scheme-source>`
+
+  - : A scheme such as `http:` or `https:`.
+    The colon is required.
+    Unlike other values below, single quotes shouldn't be used.
+    You can also specify data schemes (not recommended).
+
+    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source.
+      _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
+    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
+    - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
+    - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
+
+- `'self'`
+  - : Refers to the origin from which the protected document is being served, including the same URL scheme and port number.
+    You must include the single quotes. Some browsers specifically exclude `blob` and `filesystem` from source directives.
+    Sites needing to allow these content types can specify them using the Data attribute.
+- `'unsafe-eval'`
+  - : Allows the use of `eval()` and similar methods for creating code from strings.
+    You must include the single quotes.
+- `'unsafe-hashes'`
+  - : Allows enabling specific inline [event handlers](/en-US/docs/Web/Events/Event_handlers).
+    If you only need to allow inline event handlers and not inline {{HTMLElement("script")}} elements or `javascript:` URLs, this is a safer method than using the `unsafe-inline` expression.
+- `'unsafe-inline'`
+  - : Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, `javascript:` URLs, inline event handlers, and inline {{HTMLElement("style")}} elements.
+    The single quotes are required.
+- `'none'`
+  - : Refers to the empty set; that is, no URLs match.
+    The single quotes are required.
+- `'nonce-<base64-value>'`
+
+  - : An allow-list for specific inline scripts using a cryptographic nonce (number used once).
+    The server must generate a unique nonce value each time it transmits a policy.
+    It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial.
+    See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example.
+    Specifying nonce makes a modern browser ignore `'unsafe-inline'` which could still be set for older browsers without nonce support.
+
+    > **Note:** The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
+
+- `'<hash-algorithm>-<base64-value>'`
+  - : A sha256, sha384 or sha512 hash of scripts or styles.
+    The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style.
+    When generating the hash, don't include the \<script> or \<style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace.
+    See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example.
+    In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of `script-src` for external scripts.
+- `'strict-dynamic'`
+  - : The `strict-dynamic` source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script.
+    At the same time, any allow-list or source expressions such as `'self'` or `'unsafe-inline'` are ignored.
+    See [script-src](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) for an example.
+- `'report-sample'`
+  - : Requires a sample of the violating code to be included in the violation report.
+
+## Relevant directives
+
+Directives for which the above sources apply include:
+
+- {{Glossary("fetch directive", "Fetch directives")}} (all):
+
+  - {{CSP("default-src")}}
+  - {{CSP("child-src")}}
+  - {{CSP("connect-src")}}
+  - {{CSP("font-src")}}
+  - {{CSP("frame-src")}}
+  - {{CSP("img-src")}}
+  - {{CSP("manifest-src")}}
+  - {{CSP("media-src")}}
+  - {{CSP("object-src")}}
+  - {{CSP("prefetch-src")}}
+  - {{CSP("script-src")}}
+  - {{CSP("script-src-elem")}}
+  - {{CSP("script-src-attr")}}
+  - {{CSP("style-src")}}, {{CSP("style-src-elem")}}
+  - {{CSP("style-src-attr")}}
+  - {{CSP("worker-src")}}
+
+- {{Glossary("Document directive", "Document directives")}}:
+  - {{CSP("base-uri")}}
+
+- {{Glossary("Navigation directive", "Navigation directives")}}: 
+
+  - {{CSP("navigate-to")}}
+  - {{CSP("form-action")}}
+
+ 

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'CSP Source Values'
+title: 'CSP source values'
 slug: Web/HTTP/Headers/Content-Security-Policy/Sources
 tags:
   - CSP

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -15,7 +15,7 @@ tags:
 HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) header directives that specify a `<source>` from which resources may be loaded can use any one of the values listed below.
 Relevant directives include the {{Glossary("fetch directive", "fetch directives")}}, along with others [listed below](#relevant_directives).
 
-### Sources
+## Sources
 
 - `<host-source>`
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -35,9 +35,8 @@ specifies valid sources for inline styles applied to individual DOM elements.
       <th scope="row">{{CSP("default-src")}} fallback</th>
       <td>
         <p>
-          Yes. If this directive is absent, the user agent will look for
-          the {{CSP("style-src")}} directive, and if both of them are
-          absent, fallback to <code>default-src</code> directive.
+          Yes. If this directive is absent, the user agent will look for the {{CSP("style-src")}} directive, and if both of them are
+          absent, fallback to <code>default-src</code> directive.
         </p>
       </td>
     </tr>
@@ -48,24 +47,23 @@ specifies valid sources for inline styles applied to individual DOM elements.
 
 One or more sources can be allowed for the `style-src-attr` policy:
 
-```
+```http
 Content-Security-Policy: style-src-attr <source>;
 Content-Security-Policy: style-src-attr <source> <source>;
 ```
 
-`style-src-attr` can be used in conjunction with {{CSP("style-src")}}:
+`style-src-attr` can be used in conjunction with {{CSP("style-src")}}:
 
-```
+```http
 Content-Security-Policy: style-src <source>;
 Content-Security-Policy: style-src-attr <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-- 'report-sample'
-  - : Requires a sample of the violating code to be included in the violation report.
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -49,21 +49,23 @@ specifies valid sources for stylesheets {{HTMLElement("style")}} elements and
 
 One or more sources can be allowed for the `style-src-elem` policy:
 
-```
+```http
 Content-Security-Policy: style-src-elem <source>;
 Content-Security-Policy: style-src-elem <source> <source>;
 ```
 
 `style-src-elem` can be used in conjunction with {{CSP("style-src")}}:
 
-```
-    Content-Security-Policy: style-src <source>;
-    Content-Security-Policy: style-src-elem <source>;
+```http
+Content-Security-Policy: style-src <source>;
+Content-Security-Policy: style-src-elem <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -42,14 +42,16 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`style-src`** directi
 
 One or more sources can be allowed for the `style-src` policy:
 
-```
+```http
 Content-Security-Policy: style-src <source>;
 Content-Security-Policy: style-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -57,7 +59,7 @@ Content-Security-Policy: style-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: style-src https://example.com/
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -47,14 +47,16 @@ scripts.
 
 One or more sources can be allowed for the `worker-src` policy:
 
-```
+```http
 Content-Security-Policy: worker-src <source>;
 Content-Security-Policy: worker-src <source> <source>;
 ```
 
 ### Sources
 
-{{page("Web/HTTP/Headers/Content-Security-Policy/connect-src", "Sources")}}
+`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+
+Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
 
 ## Examples
 
@@ -62,7 +64,7 @@ Content-Security-Policy: worker-src <source> <source>;
 
 Given this CSP header:
 
-```
+```http
 Content-Security-Policy: worker-src https://example.com/
 ```
 


### PR DESCRIPTION
Part of #3196

The CSP headers all (more or less) included the directive information for sources using the page macro. This directly includes the source in each of the relevant pages.

Chose to duplicate rather than link to this material.