### PR TITLE
fix wrong statement

### DIFF
--- a/files/en-us/web/css/inherit/index.md
+++ b/files/en-us/web/css/inherit/index.md
@@ -18,7 +18,7 @@ browser-compat: css.types.global_keywords.inherit
 
 The **`inherit`** CSS keyword causes the element for which it is specified to take the [computed value](/en-US/docs/Web/CSS/computed_value) of the property from its parent element. It can be applied to any CSS property, including the CSS shorthand {{cssxref("all")}}.
 
-For [inherited properties](/en-US/docs/Web/CSS/inheritance#Inherited_properties), this reinforces the default behavior, and is only needed to override another rule. For [non-inherited properties](/en-US/docs/Web/CSS/inheritance#Non-inherited_properties), this specifies a behavior that typically makes relatively little sense and you may consider using {{cssxref("initial")}} instead, or {{cssxref("unset")}} on the {{cssxref("all")}} property.
+For [inherited properties](/en-US/docs/Web/CSS/inheritance#Inherited_properties), this reinforces the default behavior, and is only needed to override another rule. 
 
 Inheritance is always from the parent element in the document tree, even when the parent element is not the containing block.
 


### PR DESCRIPTION
the original sentence is wrong. in this statement, when inherited properties got explicit inherit value is little strange.so it can be write for a note ,but non-inherited properties is needless.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
