### PR TITLE
HTTP UA Client Hint headers

### DIFF
--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -81,7 +81,7 @@ The different categories of client hints are listed below.
 
 ### User agent client hints
 
-The UA client hints are request headers that provide information about the user agent and the platform/architecture on which it is running:
+The [UA client hints](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) are request headers that provide information about the user agent and the platform/architecture on which it is running:
 
 - {{HTTPHeader("Sec-CH-UA")}} {{experimental_inline}}
   - : User agent's branding and version.

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -1,0 +1,87 @@
+---
+title: Sec-CH-UA-Arch
+slug: Web/HTTP/Headers/Sec-CH-UA-Arch
+tags:
+  - Sec-CH-UA-Arch
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Arch
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Arch`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's underlying CPU architecture, such as arm or x86.
+
+This might be used by a server, for example, to select and offer the correct binary format of an executable for a user to download.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Arch: <arch>
+```
+
+### Directives
+
+- `<arch>`
+  - : A string indicating the underlying platform architecture, such as: `"x86"`, `"ARM"`.
+
+
+## Examples
+
+A server requests the `Sec-CH-UA-Arch` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to some request from the client, using the name of the desired header as a token:
+
+```http
+HTTP/1.1 200 OK
+Accept-CH: Sec-CH-UA-Arch
+```
+
+The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Arch` header to subsequent requests.
+For example, on a Windows X86 based computer, the client might add the header as shown:
+
+```http
+GET /GET /my/page HTTP/1.1
+Host: example.site
+
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
+Sec-CH-UA-Mobile: ?0
+Sec-CH-UA-Platform: "Windows"
+Sec-CH-UA-Arch: "x86"
+```
+
+Note above that the [low entropy headers](/en-US/docs/Glossary/Client_hints#low_entropy_hints) are added to the request even though not specified in the server response.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Arch
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Arch`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's underlying CPU architecture, such as arm or x86.
+The **`Sec-CH-UA-Arch`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's underlying CPU architecture, such as ARM or x86.
 
 This might be used by a server, for example, to select and offer the correct binary format of an executable for a user to download.
 
@@ -48,14 +48,14 @@ Sec-CH-UA-Arch: <arch>
 
 ## Examples
 
-A server requests the `Sec-CH-UA-Arch` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to some request from the client, using the name of the desired header as a token:
+A server requests the `Sec-CH-UA-Arch` header by including the {{HTTPHeader("Accept-CH")}} in a response to some request from the client, using the name of the desired header as a token:
 
 ```http
 HTTP/1.1 200 OK
 Accept-CH: Sec-CH-UA-Arch
 ```
 
-The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Arch` header to subsequent requests.
+The client may choose to provide the hint, and add the `Sec-CH-UA-Arch` header to subsequent requests.
 For example, on a Windows X86 based computer, the client might add the header as shown:
 
 ```http

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -1,0 +1,87 @@
+---
+title: Sec-CH-UA-Bitness
+slug: Web/HTTP/Headers/Sec-CH-UA-Bitness
+tags:
+  - Sec-CH-UA-Bitness
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Bitness
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Bitness`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the "bitness" of the user-agent's underlying CPU architecture. 
+This is the size in bits of an integer or memory address—typically 64 or 32 bits.
+
+This might be used by a server, for example, to select and offer the correct binary format of an executable for a user to download.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Bitness: <bitness>
+```
+
+## Directives
+
+- `<bitness>`
+  - : A string indicating the underlying platform architecture bitness, such as: `"64"`, `"32"`.
+
+
+## Examples
+
+A server requests the `Sec-CH-UA-Bitness` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to any request from the client, using the name of the desired header as a token:
+
+```http
+HTTP/1.1 200 OK
+Accept-CH: Sec-CH-UA-Bitness
+```
+
+The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Bitness` header to subsequent requests.
+For example, on a Windows based 64-bit computer, the client might add the header as shown:
+
+```http
+GET /GET /my/page HTTP/1.1
+Host: example.site
+
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
+Sec-CH-UA-Mobile: ?0
+Sec-CH-UA-Platform: "Windows"
+Sec-CH-UA-Bitness: "64"
+```
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -56,7 +56,7 @@ HTTP/1.1 200 OK
 Accept-CH: Sec-CH-UA-Bitness
 ```
 
-The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Bitness` header to subsequent requests.
+The client may choose to provide the hint, and add the `Sec-CH-UA-Bitness` header to subsequent requests.
 For example, on a Windows based 64-bit computer, the client might add the header as shown:
 
 ```http

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Full-Version-List
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and full semantic version information.
+The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and full version information.
 
 <table class="properties">
   <tbody>
@@ -31,7 +31,7 @@ The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Gloss
   </tbody>
 </table>
 
-The **`Sec-CH-UA-Full-Version-List`** header provides the brand and full semantic version for each brand associated with the browser, in a comma-separated list.
+The **`Sec-CH-UA-Full-Version-List`** header provides the brand and full version information for each brand associated with the browser, in a comma-separated list.
 
 A brand is a commercial name for the user agent like: Chromium, Opera, Google Chrome, Microsoft Edge, Firefox, and Safari.
 A user agent might have several associated brands.
@@ -42,23 +42,23 @@ The header therefore allows the server to customise its response based on both s
 The header may include "fake" brands in any position and with any name.
 This is a feature designed to prevent servers from rejecting unknown user agents outright, forcing user agents to lie about their brand identity.
 
-> **Note:** This is similar to {{HTTPHeader("Sec-CH-UA")}}, but includes the full semantic version number instead of the signficant version number for each brand.
+> **Note:** This is similar to {{HTTPHeader("Sec-CH-UA")}}, but includes the full version number instead of the significant version number for each brand.
 
 ## Syntax
 
-A comma separated list of brands in the user agent brand list, and their associated full semantic version number.
+A comma separated list of brands in the user agent brand list, and their associated full version number.
 The syntax for a single entry has the following format:
 
 ```http
-Sec-CH-UA-Full-Version-List: "<brand>";v="<semantic version>", ...
+Sec-CH-UA-Full-Version-List: "<brand>";v="<full version>", ...
 ```
 
 ### Directives
 
 - `<brand>`
   - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `"Not A;Brand"`.
-- `<semantic version>`
-  - : A full semantic build number, such as 98.0.4750.0.
+- `<full version>`
+  - : A full version number, such as 98.0.4750.0.
 
 
 ## Examples
@@ -70,7 +70,7 @@ HTTP/1.1 200 OK
 Accept-CH: Sec-CH-UA-Full-Version-List
 ```
 
-The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Full-Version-List` header to subsequent requests, as shown below:
+The client may choose to provide the hint, and add the `Sec-CH-UA-Full-Version-List` header to subsequent requests, as shown below:
 
 ```http
 GET /my/page HTTP/1.1

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -1,0 +1,99 @@
+---
+title: Sec-CH-UA-Full-Version-List
+slug: Web/HTTP/Headers/Sec-CH-UA-Full-Version-List
+tags:
+  - Sec-CH-UA-Full-Version-List
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Full-Version-List
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and full semantic version information.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+The **`Sec-CH-UA-Full-Version-List`** header provides the brand and full semantic version for each brand associated with the browser, in a comma-separated list.
+
+A brand is a commercial name for the user agent like: Chromium, Opera, Google Chrome, Microsoft Edge, Firefox, and Safari.
+A user agent might have several associated brands.
+For example, Opera, Chrome, and Edge are all based on Chromium, and will provide both brands in the **`Sec-CH-UA-Full-Version-List`** header.
+
+The header therefore allows the server to customise its response based on both shared brands and on particular customisations in their specific respective builds.
+
+The header may include "fake" brands in any position and with any name.
+This is a feature designed to prevent servers from rejecting unknown user agents outright, forcing user agents to lie about their brand identity.
+
+> **Note:** This is similar to {{HTTPHeader("Sec-CH-UA")}}, but includes the full semantic version number instead of the signficant version number for each brand.
+
+## Syntax
+
+A comma separated list of brands in the user agent brand list, and their associated full semantic version number.
+The syntax for a single entry has the following format:
+
+```http
+Sec-CH-UA-Full-Version-List: "<brand>";v="<semantic version>", ...
+```
+
+### Directives
+
+- `<brand>`
+  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `"Not A;Brand"`.
+- `<semantic version>`
+  - : A full semantic build number, such as 98.0.4750.0.
+
+
+## Examples
+
+A server requests the `Sec-CH-UA-Full-Version-List` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to any request from the client, using the name of the desired header as a token:
+
+```http
+HTTP/1.1 200 OK
+Accept-CH: Sec-CH-UA-Full-Version-List
+```
+
+The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Full-Version-List` header to subsequent requests, as shown below:
+
+```http
+GET /my/page HTTP/1.1
+Host: example.site
+
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="98", "Google Chrome";v="98"
+Sec-CH-UA-Mobile: ?0
+Sec-CH-UA-Full-Version-List: " Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4750.0", "Google Chrome";v="98.0.4750.0"
+Sec-CH-UA-Platform: "Linux"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -1,0 +1,85 @@
+---
+title: Sec-CH-UA-Full-Version
+slug: Web/HTTP/Headers/Sec-CH-UA-Full-Version
+tags:
+  - Sec-CH-UA-Full-Version
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Full-Version
+---
+{{HTTPSidebar}} {{deprecated_header}} {{securecontext_header}}
+
+> **Note:** This is being replaced by the {{HTTPHeader("Sec-CH-UA-Full-Version-List")}}.
+
+The **`Sec-CH-UA-Full-Version`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's full semantic version string.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Full-Version: <version>
+```
+
+### Directives
+
+- `<version>`
+  - : A string containing the full semantic version number, like "96.0.4664.93".
+
+
+## Examples
+
+A server requests the `Sec-CH-UA-Full-Version` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to any request from the client, using the name of the desired header as a token:
+
+```http
+HTTP/1.1 200 OK
+Accept-CH: Sec-CH-UA-Full-Version
+```
+
+The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Full-Version` header to subsequent requests.
+For example, the client might add the header as shown:
+
+```http
+GET /GET /my/page HTTP/1.1
+Host: example.site
+
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
+Sec-CH-UA-Mobile: ?0
+Sec-CH-UA-Full-Version: "96.0.4664.110"
+Sec-CH-UA-Platform: "Windows"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -15,7 +15,7 @@ browser-compat: http.headers.Sec-CH-UA-Full-Version
 
 > **Note:** This is being replaced by the {{HTTPHeader("Sec-CH-UA-Full-Version-List")}}.
 
-The **`Sec-CH-UA-Full-Version`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's full semantic version string.
+The **`Sec-CH-UA-Full-Version`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's full version string.
 
 <table class="properties">
   <tbody>
@@ -43,7 +43,7 @@ Sec-CH-UA-Full-Version: <version>
 ### Directives
 
 - `<version>`
-  - : A string containing the full semantic version number, like "96.0.4664.93".
+  - : A string containing the full version number, like "96.0.4664.93".
 
 
 ## Examples
@@ -55,7 +55,7 @@ HTTP/1.1 200 OK
 Accept-CH: Sec-CH-UA-Full-Version
 ```
 
-The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Full-Version` header to subsequent requests.
+The client may choose to provide the hint, and add the `Sec-CH-UA-Full-Version` header to subsequent requests.
 For example, the client might add the header as shown:
 
 ```http

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -1,0 +1,81 @@
+---
+title: Sec-CH-UA-Mobile
+slug: Web/HTTP/Headers/Sec-CH-UA-Mobile
+tags:
+  - Sec-CH-UA-Mobile
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Mobile
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Mobile`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header indicates whether the browser is on a mobile device.
+It can also be used by a desktop browser to indicate a preference for a "mobile" user experience.
+
+`Sec-CH-UA-Mobile` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+Unless blocked by a user agent permission policy, it is sent by default, without the server opting in by sending {{HTTPHeader("Accept-CH")}}.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Mobile: <boolean>
+```
+
+### Directives
+
+- `<boolean>`
+  - : `?1` indicates that the user-agent prefers a mobile experience (true).
+    `?0` indicates that user-agent does not prefer a mobile experience (false).
+
+
+## Examples
+
+As `Sec-CH-UA-Mobile` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints) it is typically sent in all requests.
+
+A desktop browser would usually send requests with the following header:
+
+```http
+Sec-CH-UA-Mobile: ?0
+```
+
+A browser on a mobile device would usually send requests with the following header:
+```http
+Sec-CH-UA-Mobile: ?1
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -53,7 +53,7 @@ HTTP/1.1 200 OK
 Accept-CH: Sec-CH-UA-Model
 ```
 
-The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Model` header to subsequent requests.
+The client may choose to provide the hint, and add the `Sec-CH-UA-Model` header to subsequent requests.
 For example, on mobile phone the client might add the header as shown:
 
 ```http

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -1,0 +1,84 @@
+---
+title: Sec-CH-UA-Model
+slug: Web/HTTP/Headers/Sec-CH-UA-Model
+tags:
+  - Sec-CH-UA-Model
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Model
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Model`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header indicates the device model on which the browser is running.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Model: <device-version>
+```
+
+### Directives
+
+- `<device-version>`
+  - : A string containing the device version. For example "Pixel 3".
+
+
+## Examples
+
+A server requests the `Sec-CH-UA-Model` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to any request from the client, using the name of the desired header as a token:
+
+```http
+HTTP/1.1 200 OK
+Accept-CH: Sec-CH-UA-Model
+```
+
+The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Model` header to subsequent requests.
+For example, on mobile phone the client might add the header as shown:
+
+```http
+GET /GET /my/page HTTP/1.1
+Host: example.site
+
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
+Sec-CH-UA-Mobile: ?1
+Sec-CH-UA-Platform: "Android"
+Sec-CH-UA-Bitness: "64"
+Sec-CH-UA-Model: "Pixel 3 XL"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -56,7 +56,7 @@ HTTP/1.1 200 OK
 Accept-CH: Sec-CH-UA-Platform-Version
 ```
 
-The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Platform-Version` header to subsequent requests.
+The client may choose to provide the hint, and add the `Sec-CH-UA-Platform-Version` header to subsequent requests.
 For example, the following request headers might be sent from a browser running on Windows 10.
 
 ```http

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -1,0 +1,86 @@
+---
+title: Sec-CH-UA-Platform-Version
+slug: Web/HTTP/Headers/Sec-CH-UA-Platform-Version
+tags:
+  - Sec-CH-UA-Platform-Version
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Platform-Version
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the version of the operating system on which the user agent is running. 
+
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Platform-Version: <version>
+```
+
+### Directives
+
+- `<version>`
+  - : The version string typically contains the operating system version in a string, consisting of dot-separated major, minor and patch version numbers.
+     For example, `"11.0.0"`
+
+     The version string on Linux is always empty.
+
+## Examples
+
+A server requests the `Sec-CH-UA-Platform-Version` header by including the {{HTTPHeader("Accept-CH")}} in a _response_ to any request from the client, using the name of the desired header as a token:
+
+```http
+HTTP/1.1 200 OK
+Accept-CH: Sec-CH-UA-Platform-Version
+```
+
+The client may then opt-in to providing the hint, and add the `Sec-CH-UA-Platform-Version` header to subsequent requests.
+For example, the following request headers might be sent from a browser running on Windows 10.
+
+```http
+GET /GET /my/page HTTP/1.1
+Host: example.site
+
+Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
+Sec-CH-UA-Mobile: ?0
+Sec-CH-UA-Platform: "Windows"
+Sec-CH-UA-Platform-Version: "10.0.0"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -1,0 +1,75 @@
+---
+title: Sec-CH-UA-Platform
+slug: Web/HTTP/Headers/Sec-CH-UA-Platform
+tags:
+  - Sec-CH-UA-Platform
+  - Client hint
+  - HTTP
+  - HTTP Header
+  - Reference
+  - Request header
+  - Exerimental
+browser-compat: http.headers.Sec-CH-UA-Platform
+---
+{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+
+The **`Sec-CH-UA-Platform`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the platform or operating system on which the user agent is running. 
+For example: "Windows" or "Android".
+
+`Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+Unless blocked by a user agent permission policy, it is sent by default (without the server opting in by sending {{HTTPHeader("Accept-CH")}}).
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>
+        {{Glossary("Request header")}},
+        {{Glossary("Client hints","Client hint")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Syntax
+
+```http
+Sec-CH-UA-Platform: <platform>
+```
+
+### Directives
+
+- `<platform>`
+  - : One of the following strings: `"Android"`, `"Chrome OS"`, `"iOS"`, `"Linux"`, `"macOS"`, `"Windows"`, or `"Unknown"`.
+
+
+## Examples
+
+As `Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints) it is typically sent in all requests.
+
+A browser running on a macOS computer might add the following header to all requests.
+
+```http
+Sec-CH-UA-Platform: "macOS"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
+- {{HTTPHeader("Accept-CH")}}
+- [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Headers#user_agent_client_hints) request header provides the user-agent's branding and significant version information.
+The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and significant version information.
 
 <table class="properties">
   <tbody>
@@ -59,7 +59,7 @@ The syntax for a single entry has the following format:
 Sec-CH-UA: "<brand>";v="<significant version>", ...
 ```
 
-## Directives
+### Directives
 
 - `<brand>`
   - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `"Not A;Brand"`.
@@ -70,7 +70,7 @@ Sec-CH-UA: "<brand>";v="<significant version>", ...
 ## Examples
 
 `Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
-Unless explicitly blocked by a user agent policy, and if supported it will be sent in all requests, without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}.
+Unless explicitly blocked by a user agent policy, it will be sent in all requests (without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}).
 
 Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below. 
 Note that they all share the "Chromium" brand, but have an additional brand indicating their origin.
@@ -99,6 +99,8 @@ Sec-CH-UA: "Opera";v="81", " Not;A Brand";v="99", "Chromium";v="95"
 
 ## See also
 
+- {{Glossary("Client hints")}}
+- [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}
 - [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses) and {{HTTPHeader("Vary")}}


### PR DESCRIPTION
This follows on from #10715 by adding docs for the remaining client hint headers.

Note that there are some associated changes in BCD which mean compat tables might not yet render.
- https://github.com/mdn/browser-compat-data/pull/13990 
- https://github.com/mdn/browser-compat-data/pull/13989
- I also can't yet do the Full-Version-List yet because it isn't in a release build https://chromestatus.com/feature/5703317813460992

