### PR TITLE
clarify nth-of-type searches within type

### DIFF
--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -12,7 +12,7 @@ browser-compat: css.selectors.nth-child
 ---
 {{CSSRef}}
 
-The **`:nth-child()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position in a group of siblings.
+The **`:nth-child()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position among a group of siblings.
 
 ```css
 /* Selects the second <li> element in a list */

--- a/files/en-us/web/css/_colon_nth-last-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-last-of-type/index.md
@@ -12,7 +12,7 @@ browser-compat: css.selectors.nth-last-of-type
 ---
 {{CSSRef}}
 
-The **`:nth-last-of-type()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements of a given type, based on their position among a group of siblings, counting from the end.
+The **`:nth-last-of-type()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position among siblings of the same type (tag name), counting from the end.
 
 ```css
 /* Selects every fourth <p> element

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -12,7 +12,7 @@ browser-compat: css.selectors.nth-of-type
 ---
 {{CSSRef}}
 
-The **`:nth-of-type()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements of a given type (tag name), based on their position among a group of siblings.
+The **`:nth-of-type()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position among siblings of the same type (tag name).
 
 ```css
 /* Selects every fourth <p> element


### PR DESCRIPTION
#### Summary
Makes minor revisions to the descriptions of a few of the `nth-` CSS selectors.

#### Motivation
Clarify the difference between `nth-child`, `nth-of-type`, `nth-last-child`, and `nth-last-of-type`.

#### Supporting details
NA

#### Related issues
Fixes #11055

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
