### PR TITLE
Fix typo in Event»target doc

### DIFF
--- a/files/en-us/web/api/event/target/index.md
+++ b/files/en-us/web/api/event/target/index.md
@@ -34,8 +34,8 @@ ul.appendChild(li1);
 ul.appendChild(li2);
 
 function hide(evt) {
-  // e.target refers to the clicked <li> element
-  // This is different than e.currentTarget, which would refer to the parent <ul> in this context
+  // evt.target refers to the clicked <li> element
+  // This is different than evt.currentTarget, which would refer to the parent <ul> in this context
   evt.target.style.visibility = 'hidden';
 }
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Typo: `e.target` should be `evt.target` instead.
Attempting to execute `e.target` will produce a `ReferenceError: e is not defined`.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
