### PR TITLE
Docs for window-controls-overlay value of the display_override manifest member

### DIFF
--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -36,7 +36,6 @@ Display override objects are display-mode strings, the possible values are:
     <tr>
       <th scope="col">Display Mode</th>
       <th scope="col">Description</th>
-      <th scope="col">Fallback Display Mode</th>
     </tr>
   </thead>
   <tbody>
@@ -46,7 +45,6 @@ Display override objects are display-mode strings, the possible values are:
         All of the available display area is used and no user agent
         {{Glossary("chrome")}} is shown.
       </td>
-      <td><code>standalone</code></td>
     </tr>
     <tr>
       <td><code>standalone</code></td>
@@ -57,7 +55,6 @@ Display override objects are display-mode strings, the possible values are:
         UI elements for controlling navigation, but can include other UI
         elements such as a status bar.
       </td>
-      <td><code>minimal-ui</code></td>
     </tr>
     <tr>
       <td><code>minimal-ui</code></td>
@@ -66,7 +63,6 @@ Display override objects are display-mode strings, the possible values are:
         will have a minimal set of UI elements for controlling navigation. The
         elements will vary by browser.
       </td>
-      <td><code>browser</code></td>
     </tr>
     <tr>
       <td><code>browser</code></td>
@@ -74,7 +70,17 @@ Display override objects are display-mode strings, the possible values are:
         The application opens in a conventional browser tab or new window,
         depending on the browser and platform. This is the default.
       </td>
-      <td>(None)</td>
+    </tr>
+    <tr>
+      <td><code>window-controls-overlay</code></td>
+      <td>
+        This display mode only applies when the application is in a separate PWA
+        window and on a desktop operating system. The application will opt-in to
+        the Window Controls Overlay feature, where the full window surface area
+        will be available for the app's web content and the window control buttons
+        (maximize, minimize, close, and other PWA-specific buttons) will appear
+        as an overlay above the web content.
+      </td>
     </tr>
   </tbody>
 </table>
@@ -101,3 +107,4 @@ In the example below, the browser will consider the following display-mode fallb
 ## See also
 
 - [Preparing for the display modes of tomorrow](https://web.dev/display-override/)
+- [Customize the window controls overlay of your PWA's title bar](https://web.dev/window-controls-overlay/)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR adds the `window-controls-overlay` mode to the `display_override` docs.

#### Motivation
PWA manifests can use the `display_override` member to specify the fallback display modes they prefer.

A new display_mode was added: `window-controls-overlay` to Chromium browsers.
This new mode lets desktop apps (only those displayed in a separate PWA window) opt-in to hide their title bars, and use the full PWA window surface area.

#### Supporting details
These 2 web.dev articles both mention the new display mode:
* https://web.dev/display-override/
* https://web.dev/window-controls-overlay/

And here is the spec: https://wicg.github.io/window-controls-overlay/#addition-of-window-controls-overlay-to-the-manifest

#### Related issues
This is part of this umbrella issue where I'm adding docs for the Window Controls Overlay feature: https://github.com/mdn/content/issues/10539

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error