### PR TITLE
Fix macro redirects on Firefox 29 release page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/29/index.md
+++ b/files/en-us/mozilla/firefox/releases/29/index.md
@@ -71,13 +71,13 @@ _See the [Mozilla Hacks blog post](https://hacks.mozilla.org/2014/02/css-source-
 ### Interfaces/APIs/DOM
 
 - A new type of workers, {{domxref("SharedWorker")}}, is now available by default ({{bug(924089)}}).
-- The {{domxref("URL")}} interface now supports the {{domxref("URL.searchParams", "searchParams")}} property returning a {{domxref("URLSearchParams")}} object, allowing to modify the search params of an URL ({{bug(887836)}}). The {{domxref("URLSearchParams")}} constructor allows easier parsing of query strings.
-- The {{domxref("NavigatorOnLine.onLine")}} property is now supported on {{domxref("WorkerNavigator")}} , allowing to know the online/offline status in workers ({{bug(925437)}}).
+- The {{domxref("URL")}} interface now supports the {{domxref("URL.searchParams", "searchParams")}} property returning a {{domxref("URLSearchParams")}} object, allowing to modify the search params of an URL ({{bug(887836)}}). The {{domxref("URLSearchParams.URLSearchParams", "URLSearchParams()")}} constructor allows easier parsing of query strings.
+- The {{domxref("WorkerNavigator.onLine", "navigator.onLine")}} property is now supported on {{domxref("WorkerNavigator")}}, allowing to know the online/offline status in workers ({{bug(925437)}}).
 - As part of the implementation of Web Components, the {{domxref("HTMLShadowElement")}} interface has been implemented behind the `dom.webcomponents.enabled`. Flip it to `true` if you want to use it. ({{bug(887538)}})
 - The read-only property {{domxref("HTMLIFrameElement.sandbox")}} is no longer a {{domxref("DOMString")}} but a {{domxref("DOMTokenList")}} ({{bug(845057)}}).
 - On {{domxref("HTMLCanvasElement.getContext()")}}, the value `moz-webgl` is no longer supported. Use the standard `webgl` value ({{bug(913597)}}).
 - The constructor for {{domxref("ImageData")}} has been added. This interface can be used in a {{domxref("Worker")}}. ({{bug(959958)}})
-- The property {{domxref("URLUtilsReadOnly.origin", "location.origin")}} is now available in workers (via {{domxref("WorkerLocation")}}) ({{bug(964148)}}).
+- The property {{domxref("WorkerLocation.origin", "location.origin")}} is now available in workers (via {{domxref("WorkerLocation")}}) ({{bug(964148)}}).
 - The {{domxref("ValidityState.badInput")}} property has been implemented ({{bug(827161)}}).
 - The deprecated `Window.pkcs11` property has been removed; it was returning `null` since Firefox 3.0.14. ({{bug(964964)}})
 - The {{domxref("Node.cloneNode()")}} and {{domxref("Document.importNode()")}} methods take the Boolean `deep` argument. Until now, if omitted, these methods acted as if the value of `deep` was `true`. But this behavior has been changed as per the latest spec, and if omitted, the methods will act as if the value was `false`. ({{bug(937461)}})


### PR DESCRIPTION
This fixes two MacroRedirectedLinkError flaws.