### PR TITLE
Correct MediaQueryListEvent constructor arguments

### DIFF
--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.md
@@ -18,12 +18,15 @@ The **`MediaQueryListEvent()`** constructor creates a new
 ## Syntax
 
 ```js
-var myMqlEvent = new MediaQueryListEvent(init);
+var myMqlEvent = new MediaQueryListEvent(typeArg, init);
 ```
 
 ### Parameters
 
-- `init`
+- `typeArg`
+  - : A string representing the name of the event.
+
+- `init` {{optional_inline}}
 
   - : An init object that defines features of the new object instance. The available
     properties are:
@@ -38,7 +41,7 @@ var myMqlEvent = new MediaQueryListEvent(init);
 var media = '(max-width: 600px)';
 var matches = true;
 
-var myMediaQueryListEvent = new MediaQueryListEvent({media, matches});
+var myMediaQueryListEvent = new MediaQueryListEvent("change", {media, matches});
 ```
 
 ## Specifications


### PR DESCRIPTION
#### Summary

Per implementation and the spec, it takes two arguments, not one.

#### Motivation

Correct an error.

#### Supporting details

See [spec](https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-mediaquerylistevent).

#### Related issues

None.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
