### PR TITLE
SpeechSynthesis - some objects are not experimental

### DIFF
--- a/files/en-us/web/api/speechrecognition/abort/index.md
+++ b/files/en-us/web/api/speechrecognition/abort/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.abort()
 slug: Web/API/SpeechRecognition/abort
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.abort
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`abort()`** method of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) stops the speech
 recognition service from listening to incoming audio, and doesn't attempt to return a
@@ -22,7 +21,7 @@ recognition service from listening to incoming audio, and doesn't attempt to ret
 ## Syntax
 
 ```js
-mySpeechRecognition.abort();
+abort()
 ```
 
 ### Returns

--- a/files/en-us/web/api/speechrecognition/audioend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/audioend_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.audioend_event
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`audioend`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when the user agent has finished capturing audio for speech recognition.
 

--- a/files/en-us/web/api/speechrecognition/audiostart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/audiostart_event/index.md
@@ -10,7 +10,7 @@ tags:
   - onaudiostart
 browser-compat: api.SpeechRecognition.audiostart_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`audiostart`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when the user agent has started to capture audio for speech recognition.
 

--- a/files/en-us/web/api/speechrecognition/continuous/index.md
+++ b/files/en-us/web/api/speechrecognition/continuous/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.continuous
 slug: Web/API/SpeechRecognition/continuous
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.continuous
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`continuous`** property of the
 {{domxref("SpeechRecognition")}} interface controls whether continuous results are
@@ -21,14 +20,7 @@ returned for each recognition, or only a single result.
 
 It defaults to single results (`false`.)
 
-## Syntax
-
-```js
-var myContinuous = mySpeechRecognition.continuous;
-mySpeechRecognition.continuous = true;
-```
-
-### Value
+## Value
 
 A boolean value representing the current `SpeechRecognition`'s
 continuous status. `true` means continuous, and `false` means not

--- a/files/en-us/web/api/speechrecognition/end_event/index.md
+++ b/files/en-us/web/api/speechrecognition/end_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.end_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`end`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechRecognition")}} object is fired when the speech recognition service has disconnected.
 

--- a/files/en-us/web/api/speechrecognition/error_event/index.md
+++ b/files/en-us/web/api/speechrecognition/error_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.error_event
 ---
-{{SeeCompatTable}} {{APIRef("Web Speech API")}}
+{{APIRef("Web Speech API")}}
 
 The **`error`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechRecognition")}} object is fired when a speech recognition error occurs.
 

--- a/files/en-us/web/api/speechrecognition/grammars/index.md
+++ b/files/en-us/web/api/speechrecognition/grammars/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.grammars
 slug: Web/API/SpeechRecognition/grammars
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,21 +12,14 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.grammars
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`grammars`** property of the
 {{domxref("SpeechRecognition")}} interface returns and sets a collection of
 {{domxref("SpeechGrammar")}} objects that represent the grammars that will be understood
 by the current `SpeechRecognition`.
 
-## Syntax
-
-```js
-var myGrammars = mySpeechRecognition.grammars;
-mySpeechRecognition.grammars = mySpeechGrammarList;
-```
-
-### Value
+## Value
 
 A {{domxref("SpeechGrammarList")}} containing the {{domxref("SpeechGrammar")}} objects
 that represent your grammar for your app.

--- a/files/en-us/web/api/speechrecognition/index.md
+++ b/files/en-us/web/api/speechrecognition/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition
 slug: Web/API/SpeechRecognition
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechRecognition
@@ -12,7 +11,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechRecognition`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is the controller interface for the recognition service; this also handles the {{domxref("SpeechRecognitionEvent")}} sent from the recognition service.
 

--- a/files/en-us/web/api/speechrecognition/interimresults/index.md
+++ b/files/en-us/web/api/speechrecognition/interimresults/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.interimResults
 slug: Web/API/SpeechRecognition/interimResults
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -12,7 +11,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.interimResults
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`interimResults`** property of the
 {{domxref("SpeechRecognition")}} interface controls whether interim results should be
@@ -22,14 +21,7 @@ is `false`.)
 
 The default value for **`interimResults`** is `false`.
 
-## Syntax
-
-```js
-var myInterimResult = mySpeechRecognition.interimResults;
-mySpeechRecognition.interimResults = false;
-```
-
-### Value
+## Value
 
 A boolean value representing the state of the current
 `SpeechRecognition`'s interim results. `true` means interim

--- a/files/en-us/web/api/speechrecognition/lang/index.md
+++ b/files/en-us/web/api/speechrecognition/lang/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.lang
 slug: Web/API/SpeechRecognition/lang
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,24 +12,15 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.lang
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
-
+{{APIRef("Web Speech API")}}
 The **`lang`** property of the {{domxref("SpeechRecognition")}}
 interface returns and sets the language of the current `SpeechRecognition`.
 If not specified, this defaults to the HTML {{htmlattrxref("lang","html")}} attribute
 value, or the user agent's language setting if that isn't set either.
 
-## Syntax
+## Value
 
-```js
-var myLang = mySpeechRecognition.lang;
-mySpeechRecognition.lang = 'en-US';
-```
-
-### Value
-
-A {{domxref("DOMString")}} representing the BCP 47 language tag for the current
-`SpeechRecognition`.
+A {{domxref("DOMString")}} representing the BCP 47 language tag for the current `SpeechRecognition`.
 
 ## Examples
 

--- a/files/en-us/web/api/speechrecognition/maxalternatives/index.md
+++ b/files/en-us/web/api/speechrecognition/maxalternatives/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.maxAlternatives
 slug: Web/API/SpeechRecognition/maxAlternatives
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.maxAlternatives
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`maxAlternatives`** property of the
 {{domxref("SpeechRecognition")}} interface sets the maximum number of
@@ -22,14 +21,7 @@ The **`maxAlternatives`** property of the
 
 The default value is 1.
 
-## Syntax
-
-```js
-var myMaxAlternativeNumber = mySpeechRecognition.maxAlternatives;
-mySpeechRecognition.maxAlternatives = 2;
-```
-
-### Value
+## Value
 
 A number representing the maximum returned alternatives for each result.
 

--- a/files/en-us/web/api/speechrecognition/nomatch_event/index.md
+++ b/files/en-us/web/api/speechrecognition/nomatch_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.nomatch_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`nomatch`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when the speech recognition service returns a final result with no significant recognition.
 

--- a/files/en-us/web/api/speechrecognition/onaudioend/index.md
+++ b/files/en-us/web/api/speechrecognition/onaudioend/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onaudioend
 slug: Web/API/SpeechRecognition/onaudioend
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onaudioend
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onaudioend`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onaudiostart/index.md
+++ b/files/en-us/web/api/speechrecognition/onaudiostart/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onaudiostart
 slug: Web/API/SpeechRecognition/onaudiostart
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onaudiostart
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onaudiostart`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onend/index.md
+++ b/files/en-us/web/api/speechrecognition/onend/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onend
 slug: Web/API/SpeechRecognition/onend
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onend
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onend`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onerror/index.md
+++ b/files/en-us/web/api/speechrecognition/onerror/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onerror
 slug: Web/API/SpeechRecognition/onerror
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onerror
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onerror`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onnomatch/index.md
+++ b/files/en-us/web/api/speechrecognition/onnomatch/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onnomatch
 slug: Web/API/SpeechRecognition/onnomatch
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onnomatch
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onnomatch`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onresult/index.md
+++ b/files/en-us/web/api/speechrecognition/onresult/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onresult
 slug: Web/API/SpeechRecognition/onresult
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,13 +12,12 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onresult
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onresult`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run
 when the speech recognition service returns a result — a word or phrase has been
-positively recognized and this has been communicated back to the app (when the [`result`
-event](/en-US/docs/Web/API/SpeechRecognition/result_event) fires.)
+positively recognized and this has been communicated back to the app (when the [`result` event](/en-US/docs/Web/API/SpeechRecognition/result_event) fires.)
 
 ## Syntax
 

--- a/files/en-us/web/api/speechrecognition/onsoundend/index.md
+++ b/files/en-us/web/api/speechrecognition/onsoundend/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onsoundend
 slug: Web/API/SpeechRecognition/onsoundend
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onsoundend
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onsoundend`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onsoundstart/index.md
+++ b/files/en-us/web/api/speechrecognition/onsoundstart/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onsoundstart
 slug: Web/API/SpeechRecognition/onsoundstart
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,12 +12,10 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onsoundstart
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
-The **`onsoundstart`** property of the
-{{domxref("SpeechRecognition")}} interface represents an event handler that will run
-when any sound — recognisable speech or not — has been detected (when the [soundstart event](/en-US/docs/Web/API/SpeechRecognition/soundstart_event)
-fires.)
+The **`onsoundstart`** property of the {{domxref("SpeechRecognition")}} interface represents an event handler that will run
+when any sound — recognisable speech or not — has been detected (when the [soundstart event](/en-US/docs/Web/API/SpeechRecognition/soundstart_event) fires.)
 
 ## Syntax
 

--- a/files/en-us/web/api/speechrecognition/onspeechend/index.md
+++ b/files/en-us/web/api/speechrecognition/onspeechend/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onspeechend
 slug: Web/API/SpeechRecognition/onspeechend
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onspeechend
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onspeechend`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onspeechstart/index.md
+++ b/files/en-us/web/api/speechrecognition/onspeechstart/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onspeechstart
 slug: Web/API/SpeechRecognition/onspeechstart
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onspeechstart
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onspeechstart`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/onstart/index.md
+++ b/files/en-us/web/api/speechrecognition/onstart/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.onstart
 slug: Web/API/SpeechRecognition/onstart
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.onstart
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onstart`** property of the
 {{domxref("SpeechRecognition")}} interface represents an event handler that will run

--- a/files/en-us/web/api/speechrecognition/result_event/index.md
+++ b/files/en-us/web/api/speechrecognition/result_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.result_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`result`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when the speech recognition service returns a result — a word or phrase has been positively recognized and this has been communicated back to the app
 

--- a/files/en-us/web/api/speechrecognition/serviceuri/index.md
+++ b/files/en-us/web/api/speechrecognition/serviceuri/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.serviceURI
 slug: Web/API/SpeechRecognition/serviceURI
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognition
@@ -11,23 +10,17 @@ tags:
   - recognition
   - serviceURI
   - speech
+  - Deprecated
 browser-compat: api.SpeechRecognition.serviceURI
 ---
-{{APIRef("Web Speech API")}}{{Deprecated_Header}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}{{Deprecated_Header}}
 
 The **`serviceURI`** property of the
 {{domxref("SpeechRecognition")}} interface specifies the location of the speech
 recognition service used by the current `SpeechRecognition` to handle the
 actual recognition. The default is the user agent's default speech service.
 
-## Syntax
-
-```js
-var myServiceURI = mySpeechRecognition.serviceURI;
-mySpeechRecognition.serviceURI = 'path/to/my/service/';
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the URI of the speech recognition service.
 

--- a/files/en-us/web/api/speechrecognition/soundend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/soundend_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.soundend_event
 ---
-{{SeeCompatTable}} {{APIRef("Web Speech API")}}
+{{APIRef("Web Speech API")}}
 
 The **`soundend`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when any sound — recognisable speech or not — has stopped being detected.
 

--- a/files/en-us/web/api/speechrecognition/soundstart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/soundstart_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.soundstart_event
 ---
-{{SeeCompatTable}} {{APIRef("Web Speech API")}}
+{{APIRef("Web Speech API")}}
 
 The **`soundstart`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when any sound — recognisable speech or not — has been detected.
 

--- a/files/en-us/web/api/speechrecognition/speechend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/speechend_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.speechend_event
 ---
-{{SeeCompatTable}} {{APIRef("Web Speech API")}}
+{{APIRef("Web Speech API")}}
 
 The **`speechend`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when speech recognized by the speech recognition service has stopped being detected.
 

--- a/files/en-us/web/api/speechrecognition/speechrecognition/index.md
+++ b/files/en-us/web/api/speechrecognition/speechrecognition/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognition/SpeechRecognition
 tags:
   - API
   - Constructor
-  - Experimental
   - Reference
   - SpeechRecognition
   - Web Speech API
@@ -12,7 +11,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognition.SpeechRecognition
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechRecognition()`** constructor creates a new
 {{domxref("SpeechRecognition")}} object instance.
@@ -20,7 +19,7 @@ The **`SpeechRecognition()`** constructor creates a new
 ## Syntax
 
 ```js
-var myRecognition = new SpeechRecognition();
+new SpeechRecognition()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/speechrecognition/speechstart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/speechstart_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.speechstart_event
 ---
-{{SeeCompatTable}} {{APIRef("Web Speech API")}}
+{{APIRef("Web Speech API")}}
 
 The **`speechstart`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when sound recognized by the speech recognition service as speech has been detected.
 

--- a/files/en-us/web/api/speechrecognition/start/index.md
+++ b/files/en-us/web/api/speechrecognition/start/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.start()
 slug: Web/API/SpeechRecognition/start
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - start
 browser-compat: api.SpeechRecognition.start
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`start()`** method of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) starts the speech
 recognition service listening to incoming audio with intent to recognize grammars
@@ -22,7 +21,7 @@ associated with the current {{domxref("SpeechRecognition")}}.
 ## Syntax
 
 ```js
-mySpeechRecognition.start();
+start()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/speechrecognition/start_event/index.md
+++ b/files/en-us/web/api/speechrecognition/start_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechRecognition.start_event
 ---
-{{SeeCompatTable}} {{APIRef("Web Speech API")}}
+{{APIRef("Web Speech API")}}
 
 The **`start`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) {{domxref("SpeechRecognition")}} object is fired when the speech recognition service has begun listening to incoming audio with intent to recognize grammars associated with the current `SpeechRecognition`.
 

--- a/files/en-us/web/api/speechrecognition/stop/index.md
+++ b/files/en-us/web/api/speechrecognition/stop/index.md
@@ -3,7 +3,6 @@ title: SpeechRecognition.stop()
 slug: Web/API/SpeechRecognition/stop
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechRecognition
@@ -13,7 +12,7 @@ tags:
   - stop
 browser-compat: api.SpeechRecognition.stop
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`stop()`** method of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) stops the speech
 recognition service from listening to incoming audio, and attempts to return a
@@ -22,7 +21,7 @@ recognition service from listening to incoming audio, and attempts to return a
 ## Syntax
 
 ```js
-mySpeechRecognition.stop();
+stop();
 ```
 
 ### Returns

--- a/files/en-us/web/api/speechsynthesis/cancel/index.md
+++ b/files/en-us/web/api/speechsynthesis/cancel/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.cancel()
 slug: Web/API/SpeechSynthesis/cancel
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.cancel
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`cancel()`** method of the {{domxref("SpeechSynthesis")}}
 interface removes all utterances from the utterance queue.
@@ -23,7 +22,7 @@ If an utterance is currently being spoken, speaking will stop immediately.
 ## Syntax
 
 ```js
-speechSynthesisInstance.cancel();
+cancel()
 ```
 
 ### Returns

--- a/files/en-us/web/api/speechsynthesis/getvoices/index.md
+++ b/files/en-us/web/api/speechsynthesis/getvoices/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.getVoices()
 slug: Web/API/SpeechSynthesis/getVoices
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.getVoices
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`getVoices()`** method of the
 {{domxref("SpeechSynthesis")}} interface returns a list of
@@ -23,7 +22,7 @@ current device.
 ## Syntax
 
 ```js
-speechSynthesisInstance.getVoices();
+getVoices()
 ```
 
 ### Parameters
@@ -33,10 +32,6 @@ None.
 ### Return value
 
 A list (array) of {{domxref("SpeechSynthesisVoice")}} objects.
-
-> **Note:** The spec wrongly lists this method as returning as a
-> `SpeechSynthesisVoiceList` object, but this was in fact removed from the
-> spec.
 
 ## Example
 

--- a/files/en-us/web/api/speechsynthesis/index.md
+++ b/files/en-us/web/api/speechsynthesis/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis
 slug: Web/API/SpeechSynthesis
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechSynthesis
@@ -12,7 +11,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechSynthesis`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is the controller interface for the speech service; this can be used to retrieve information about the synthesis voices available on the device, start and pause speech, and other commands besides.
 

--- a/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.md
+++ b/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.onvoiceschanged
 slug: Web/API/SpeechSynthesis/onvoiceschanged
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.onvoiceschanged
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`onvoiceschanged`** property of the
 {{domxref("SpeechSynthesis")}} interface represents an event handler that will run when

--- a/files/en-us/web/api/speechsynthesis/pause/index.md
+++ b/files/en-us/web/api/speechsynthesis/pause/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.pause()
 slug: Web/API/SpeechSynthesis/pause
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.pause
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`pause()`** method of the {{domxref("SpeechSynthesis")}}
 interface puts the `SpeechSynthesis` object into a paused state.
@@ -21,7 +20,7 @@ interface puts the `SpeechSynthesis` object into a paused state.
 ## Syntax
 
 ```js
-speechSynthesisInstance.pause();
+pause()
 ```
 
 ### Returns

--- a/files/en-us/web/api/speechsynthesis/paused/index.md
+++ b/files/en-us/web/api/speechsynthesis/paused/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.paused
 slug: Web/API/SpeechSynthesis/paused
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesis
@@ -13,12 +12,11 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.paused
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`paused`** read-only property of the
 {{domxref("SpeechSynthesis")}} interface is a boolean value that returns
-`true` if the `SpeechSynthesis` object is in a paused state, or
-`false` if not.
+`true` if the `SpeechSynthesis` object is in a paused state, or `false` if not.
 
 It can be set to {{domxref("SpeechSynthesis.pause()", "paused")}} even if nothing is
 currently being spoken through it. If
@@ -26,13 +24,7 @@ currently being spoken through it. If
 queue, they will not be spoken until the `SpeechSynthesis` object is
 unpaused, using {{domxref("SpeechSynthesis.resume()")}}.
 
-## Syntax
-
-```js
-var amIPaused = speechSynthesisInstance.paused;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/speechsynthesis/pending/index.md
+++ b/files/en-us/web/api/speechsynthesis/pending/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.pending
 slug: Web/API/SpeechSynthesis/pending
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesis
@@ -13,19 +12,13 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.pending
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`pending`** read-only property of the
 {{domxref("SpeechSynthesis")}} interface is a boolean value that returns
 `true` if the utterance queue contains as-yet-unspoken utterances.
 
-## Syntax
-
-```js
-var amIPending = speechSynthesisInstance.pending;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/speechsynthesis/resume/index.md
+++ b/files/en-us/web/api/speechsynthesis/resume/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.resume()
 slug: Web/API/SpeechSynthesis/resume
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.resume
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`resume()`** method of the {{domxref("SpeechSynthesis")}}
 interface puts the `SpeechSynthesis` object into a non-paused state:
@@ -22,7 +21,7 @@ resumes it if it was already paused.
 ## Syntax
 
 ```js
-speechSynthesisInstance.resume();
+resume()
 ```
 
 ### Returns
@@ -35,17 +34,18 @@ None.
 
 ## Examples
 
-    var synth = window.speechSynthesis;
+```js
+let synth = window.speechSynthesis;
 
-    var utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
-    var utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
+let utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
+let utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
 
-    synth.speak(utterance1);
-    synth.speak(utterance2);
+synth.speak(utterance1);
+synth.speak(utterance2);
 
-    synth.pause(); // pauses utterances being spoken
-
-    synth.resume() // resumes speaking
+synth.pause(); // pauses utterances being spoken
+synth.resume() // resumes speaking
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/speechsynthesis/speak/index.md
+++ b/files/en-us/web/api/speechsynthesis/speak/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.speak()
 slug: Web/API/SpeechSynthesis/speak
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.speak
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`speak()`** method of the {{domxref("SpeechSynthesis")}}
 interface adds an {{domxref("SpeechSynthesisUtterance", "utterance")}} to the utterance
@@ -22,7 +21,7 @@ queue; it will be spoken when any other utterances queued before it have been sp
 ## Syntax
 
 ```js
-speechSynthesisInstance.speak(utterance);
+speak(utterance)
 ```
 
 ### Returns
@@ -31,13 +30,12 @@ speechSynthesisInstance.speak(utterance);
 
 ### Parameters
 
-- utterance
+- `utterance`
   - : A {{domxref("SpeechSynthesisUtterance")}} object.
 
 ## Examples
 
-This snippet is excerpted from our [Speech
-synthesiser demo](https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis). When a form containing the text we want to speak is submitted,
+This snippet is excerpted from our [Speech synthesiser demo](https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis). When a form containing the text we want to speak is submitted,
 we (amongst other things) create a new utterance containing this text, then speak it by
 passing it into `speak()` as a parameter.
 

--- a/files/en-us/web/api/speechsynthesis/speaking/index.md
+++ b/files/en-us/web/api/speechsynthesis/speaking/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesis.speaking
 slug: Web/API/SpeechSynthesis/speaking
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesis
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesis.speaking
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`speaking`** read-only property of the
 {{domxref("SpeechSynthesis")}} interface is a boolean value that returns
@@ -21,13 +20,7 @@ The **`speaking`** read-only property of the
 if `SpeechSynthesis` is in a
 {{domxref("SpeechSynthesis/pause()","paused")}} state.
 
-## Syntax
-
-```js
-var amISpeaking = speechSynthesisInstance.speaking;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.md
+++ b/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.md
@@ -7,7 +7,7 @@ tags:
   - Web Speech API
 browser-compat: api.SpeechSynthesis.voiceschanged_event
 ---
-{{APIRef("Web Speech API")}} {{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`voiceschanged`** event of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is fired when the list of {{domxref("SpeechSynthesisVoice")}} objects that would be returned by the {{domxref("SpeechSynthesis.getVoices()")}} method has changed (when the `voiceschanged` event fires.)
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechSynthesisErrorEvent/error
 tags:
   - API
   - Error
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisErrorEvent
@@ -13,19 +12,12 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisErrorEvent.error
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`error`** property of the
-{{domxref("SpeechSynthesisErrorEvent")}} interface returns an error code indicating what
-has gone wrong with a speech synthesis attempt.
+{{domxref("SpeechSynthesisErrorEvent")}} interface returns an error code indicating what has gone wrong with a speech synthesis attempt.
 
-## Syntax
-
-```js
-myError = event.error;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an error code. Possible codes are:
 

--- a/files/en-us/web/api/speechsynthesisvoice/default/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/default/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisVoice.default
 slug: Web/API/SpeechSynthesisVoice/default
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisVoice
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisVoice.default
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`default`** read-only property of the
 {{domxref("SpeechSynthesisVoice")}} interface returns a boolean value
@@ -24,13 +23,7 @@ indicating whether the voice is the default voice for the current app
 > voice's language. The spec is not very clear on which it should be, so some
 > implementations may differ.
 
-## Syntax
-
-```js
-var amIDefault = speechSynthesisVoiceInstance.default;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/speechsynthesisvoice/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisVoice
 slug: Web/API/SpeechSynthesisVoice
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechSynthesisVoice
@@ -12,9 +11,10 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisVoice
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
-The **`SpeechSynthesisVoice`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a voice that the system supports. Every `SpeechSynthesisVoice` has its own relative speech service including information about language, name and URI.
+The **`SpeechSynthesisVoice`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a voice that the system supports.
+Every `SpeechSynthesisVoice` has its own relative speech service including information about language, name and URI.
 
 ## Properties
 

--- a/files/en-us/web/api/speechsynthesisvoice/lang/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/lang/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisVoice.lang
 slug: Web/API/SpeechSynthesisVoice/lang
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisVoice
@@ -13,19 +12,11 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisVoice.lang
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
-The **`lang`** read-only property of the
-{{domxref("SpeechSynthesisVoice")}} interface returns a BCP 47 language tag indicating
-the language of the voice.
+The **`lang`** read-only property of the {{domxref("SpeechSynthesisVoice")}} interface returns a BCP 47 language tag indicating the language of the voice.
 
-## Syntax
-
-```js
-var myLang = speechSynthesisVoiceInstance.lang;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the language of the device.
 

--- a/files/en-us/web/api/speechsynthesisvoice/localservice/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/localservice/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisVoice.localService
 slug: Web/API/SpeechSynthesisVoice/localService
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisVoice
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisVoice.localService
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`localService`** read-only property of the
 {{domxref("SpeechSynthesisVoice")}} interface returns a boolean value
@@ -24,13 +23,7 @@ This property is provided to allow differentiation in the case that some voice o
 are provided by a remote service; it is possible that remote voices might have extra
 latency, bandwidth or cost associated with them, so such distinction may be useful.
 
-## Syntax
-
-```js
-var amILocal = speechSynthesisVoiceInstance.localService;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/speechsynthesisvoice/name/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/name/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisVoice.name
 slug: Web/API/SpeechSynthesisVoice/name
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisVoice
@@ -13,19 +12,13 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisVoice.name
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`name`** read-only property of the
 {{domxref("SpeechSynthesisVoice")}} interface returns a human-readable name that
 represents the voice.
 
-## Syntax
-
-```js
-var voiceName = speechSynthesisVoiceInstance.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the name of the voice.
 

--- a/files/en-us/web/api/speechsynthesisvoice/voiceuri/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/voiceuri/index.md
@@ -3,7 +3,6 @@ title: SpeechSynthesisVoice.voiceURI
 slug: Web/API/SpeechSynthesisVoice/voiceURI
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechSynthesisVoice
@@ -13,23 +12,16 @@ tags:
   - voiceURI
 browser-compat: api.SpeechSynthesisVoice.voiceURI
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`voiceURI`** read-only property of the
 {{domxref("SpeechSynthesisVoice")}} interface returns the type of URI and location of
 the speech synthesis service for this voice.
 
-## Syntax
-
-```js
-var myVoiceURI = speechSynthesisVoiceInstance.voiceURI;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the URI of the voice. This is a generic URI and
-can point to local or remote services, e.g. it could be a proprietary system URN or a
-URL to a remote service.
+can point to local or remote services, e.g. it could be a proprietary system URN or a URL to a remote service.
 
 ## Examples
 


### PR DESCRIPTION
`SpeechSynthesisVoice`, `SpeechSynthesisErrorEvent.error`, `SpeechSynthesis` and `SpeechRecognition` are not deprecated - as discussed in https://github.com/mdn/browser-compat-data/pull/13682.

This PR removes the compat macro, Experimental tag from the above. In some cases it also tidies the Syntax sections in line with the current templates.