### PR TITLE
Add cookieStoreId to contentScripts.register

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -40,7 +40,7 @@ var registering = browser.contentScripts.register(
     - `allFrames`{{optional_inline}}
       - : Same as `all_frames` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
     - `cookieStoreId` {{optional_inline}}
-      - : Registers the content script in the tabs that belong to the cookie store ID. This enable scripts to be registered for a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities).
+      - : Registers the content script in the tabs that belong to one or more cookie store IDs. This enable scripts to be registered for all default or non-contextual identity tabs, private browsing tabs (if extensions are enabled in private browsing), the tabs of a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities), or a combination of these.
     - `css`{{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a CSS file to register, or a property named `code`, which is some CSS code to register.
     - `excludeGlobs`{{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -40,7 +40,7 @@ var registering = browser.contentScripts.register(
     - `allFrames`{{optional_inline}}
       - : Same as `all_frames` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
     - `cookieStoreId` {{optional_inline}}
-      - : Registers the content script in the tabs that belong to one or more cookie store IDs. This enable scripts to be registered for all default or non-contextual identity tabs, private browsing tabs (if extensions are enabled in private browsing), the tabs of a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities), or a combination of these.
+      - : Registers the content script in the tabs that belong to one or more cookie store IDs. This enables scripts to be registered for all default or non-contextual identity tabs, private browsing tabs (if extensions are enabled in private browsing), the tabs of a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities), or a combination of these.
     - `css`{{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a CSS file to register, or a property named `code`, which is some CSS code to register.
     - `excludeGlobs`{{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -39,6 +39,8 @@ var registering = browser.contentScripts.register(
 
     - `allFrames`{{optional_inline}}
       - : Same as `all_frames` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
+    - `cookieStoreId` {{optional_inline}}
+      - : Registers the content script in the tabs that belong to the cookie store ID. This enable scripts to be registered for a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities).
     - `css`{{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a CSS file to register, or a property named `code`, which is some CSS code to register.
     - `excludeGlobs`{{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -54,7 +54,7 @@ This article provides information about the changes in Firefox 97 that will affe
 ## Changes for add-on developers
 
 - `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID ({{bug(1730931)}}).
-- `cookieStoreId` added to {{WebExtAPIRef("contentScripts.register")}}. This allows extensions to register container-specific content scripts ({{bug(1470651)}}).
+- `cookieStoreId` added to {{WebExtAPIRef("contentScripts.register")}}. This enables extensions to register container-specific content scripts ({{bug(1470651)}}).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -54,7 +54,7 @@ This article provides information about the changes in Firefox 97 that will affe
 ## Changes for add-on developers
 
 - `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID ({{bug(1730931)}}).
-- `cookieStoreId` added to {{WebExtAPIRef("contentScripts.register")}}. This enables script to be registered to the tabs for a contextual identity ({{bug(1470651)}}).
+- `cookieStoreId` added to {{WebExtAPIRef("contentScripts.register")}}. This allows extensions to register container-specific content scripts ({{bug(1470651)}}).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -54,6 +54,7 @@ This article provides information about the changes in Firefox 97 that will affe
 ## Changes for add-on developers
 
 - `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID ({{bug(1730931)}}).
+- `cookieStoreId` added to {{WebExtAPIRef("contentScripts.register")}}. This enables script to be registered to the tabs for a contextual identity ({{bug(1470651)}}).
 
 #### Removals
 


### PR DESCRIPTION
#### Summary
Add details about the addition of `cookieStoreId` to `contentScripts.register` including release note.

#### Supporting details
Addresses MDN documentation requirements for [bug 1470651](https://bugzilla.mozilla.org/show_bug.cgi?id=1470651).

#### Related issues
The related compatibility data is updated in [PR #14058](https://github.com/mdn/browser-compat-data/pull/14058).
 
#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
