### PR TITLE
Updates to themes related links

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5584,6 +5584,7 @@
 /en-US/docs/Mobile/Mobile_Web_Development	/en-US/docs/Web/Guide/Mobile
 /en-US/docs/MouseEvent.initMouseEvent	/en-US/docs/Web/API/MouseEvent/initMouseEvent
 /en-US/docs/Mozilla's_Quirks_Mode	/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
+/en-US/docs/Mozilla/Add-ons/Themes	https://extensionworkshop.com/documentation/themes/
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/update	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/update
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/browserSettings.closeTabsByDoubleClick	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/closeTabsByDoubleClick

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5585,6 +5585,7 @@
 /en-US/docs/MouseEvent.initMouseEvent	/en-US/docs/Web/API/MouseEvent/initMouseEvent
 /en-US/docs/Mozilla's_Quirks_Mode	/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
 /en-US/docs/Mozilla/Add-ons/Themes	https://extensionworkshop.com/documentation/themes/
+/en-US/docs/Mozilla/Add-ons/Themes/Theme_concepts	https://extensionworkshop.com/documentation/themes/
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/update	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/update
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/browserSettings.closeTabsByDoubleClick	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/closeTabsByDoubleClick

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
@@ -13,7 +13,7 @@ browser-compat: webextensions.api.theme.onUpdated
 
 Fires when a theme supplied as a browser extension is applied or removed. Specifically:
 
-- when a [static theme](/en-US/docs/Mozilla/Add-ons/Themes/Theme_concepts#static_themes) is installed
+- when a [static theme](https://extensionworkshop.com/documentation/themes/static-themes/) is installed
 - when a [dynamic theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme) calls [`theme.update()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/update) or [`theme.reset()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/update)
 - when a theme gets uninstalled.
 

--- a/files/en-us/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -17,7 +17,7 @@ An extension adds features and functions to a browser. It’s created using fami
 
 Examples: [Amazon Assistant for Firefox](https://addons.mozilla.org/en-US/firefox/addon/amazon-browser-bar/), [OneNote Web Clipper](https://addons.mozilla.org/en-US/firefox/addon/onenote-clipper/), and [Grammarly for Firefox](https://addons.mozilla.org/en-US/firefox/addon/grammarly-1/)
 
-**Let users show their personality**: Browser extensions can manipulate the content of web pages; for example, letting users add their favorite logo or picture as a background to every page they visit. Extensions may also enable users to update the look of the Firefox UI, the same way standalone [theme add-ons](/en-US/docs/Mozilla/Add-ons/Themes/Theme_concepts) do.
+**Let users show their personality**: Browser extensions can manipulate the content of web pages; for example, letting users add their favorite logo or picture as a background to every page they visit. Extensions may also enable users to update the look of the Firefox UI, the same way standalone [theme add-ons](https://extensionworkshop.com/documentation/themes/) do.
 
 ![](myweb_new_tab_add_on.png)
 


### PR DESCRIPTION
#### Summary
As a consequence of  Content bug: /docs/Mozilla/Add-ons/Themes 404's [#11214](https://github.com/mdn/content/issues/11214) – which is fixed in [Themes menu item link to extension workshop #5089](https://github.com/mdn/yari/pull/5089) - added redirects and updated links for themed related content to point them to extension workshop.

#### Motivation
To direct all themes related links to extension workshop.

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
