### PR TITLE
update the link of attribute titles

### DIFF
--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -23,9 +23,9 @@ In addition to the basic HTML global attributes, the following global attributes
 
 ## List of global attributes
 
-- [{{HTMLAttrDef("accesskey")}}](/en-US/docs/Web/HTML/Global_attributes/accesskey)
+- [accesskey](/en-US/docs/Web/HTML/Global_attributes/accesskey)
   - : Provides a hint for generating a keyboard shortcut for the current element. This attribute consists of a space-separated list of characters. The browser should use the first one that exists on the computer keyboard layout.
-- [{{HTMLAttrDef("autocapitalize")}}](/en-US/docs/Web/HTML/Global_attributes/autocapitalize)
+- [autocapitalize](/en-US/docs/Web/HTML/Global_attributes/autocapitalize)
 
   - : Controls whether and how text input is automatically capitalized as it is entered/edited by the user. It can have the following values:
 
@@ -34,22 +34,22 @@ In addition to the basic HTML global attributes, the following global attributes
     - `words`, the first letter of each word defaults to a capital letter; all other letters default to lowercase
     - `characters`, all letters should default to uppercase
 
-- [{{HTMLAttrDef("autofocus")}}](/en-US/docs/Web/HTML/Global_attributes/autofocus)
+- [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus)
   - : Indicates that an element is to be focused on page load, or as soon as the {{HTMLElement("dialog")}} it is part of is displayed. This attribute is a boolean, initially false.
-- [{{HTMLAttrDef("class")}}](/en-US/docs/Web/HTML/Global_attributes/class)
+- [class](/en-US/docs/Web/HTML/Global_attributes/class)
   - : A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the method {{DOMxRef("Document.getElementsByClassName()")}}.
-- [{{HTMLAttrDef("contenteditable")}}](/en-US/docs/Web/HTML/Global_attributes/contenteditable)
+- [contenteditable](/en-US/docs/Web/HTML/Global_attributes/contenteditable)
 
   - : An enumerated attribute indicating if the element should be editable by the user. If so, the browser modifies its widget to allow editing. The attribute must take one of the following values:
 
     - `true` or the _empty string_, which indicates that the element must be editable;
     - `false`, which indicates that the element must not be editable.
 
-- [{{HTMLAttrDef("contextmenu")}}](/en-US/docs/Web/HTML/Global_attributes/contextmenu) {{deprecated_inline}}
+- [contextmenu](/en-US/docs/Web/HTML/Global_attributes/contextmenu) {{deprecated_inline}}
   - : The [**`id`**](#attr-id) of a {{HTMLElement("menu")}} to use as the contextual menu for this element.
-- [{{HTMLAttrDef("data-*")}}](/en-US/docs/Web/HTML/Global_attributes/data-*)
+- [data-*](/en-US/docs/Web/HTML/Global_attributes/data-*)
   - : Forms a class of attributes, called custom data attributes, that allow proprietary information to be exchanged between the [HTML](/en-US/docs/Web/HTML) and its {{glossary("DOM")}} representation that may be used by scripts. All such custom data are available via the {{DOMxRef("HTMLElement")}} interface of the element the attribute is set on. The {{DOMxRef("HTMLElement.dataset")}} property gives access to them.
-- [{{HTMLAttrDef("dir")}}](/en-US/docs/Web/HTML/Global_attributes/dir)
+- [dir](/en-US/docs/Web/HTML/Global_attributes/dir)
 
   - : An enumerated attribute indicating the directionality of the element's text. It can have the following values:
 
@@ -57,56 +57,56 @@ In addition to the basic HTML global attributes, the following global attributes
     - `rtl`, which means _right to left_ and is to be used for languages that are written from the right to the left (like Arabic);
     - `auto`, which lets the user agent decide. It uses a basic algorithm as it parses the characters inside the element until it finds a character with a strong directionality, then it applies that directionality to the whole element.
 
-- [{{HTMLAttrDef("draggable")}}](/en-US/docs/Web/HTML/Global_attributes/draggable)
+- [draggable](/en-US/docs/Web/HTML/Global_attributes/draggable)
 
   - : An enumerated attribute indicating whether the element can be dragged, using the [Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API). It can have the following values:
 
     - `true`, which indicates that the element may be dragged
     - `false`, which indicates that the element may not be dragged.
 
-- [{{HTMLAttrDef("enterkeyhint")}}](/en-US/docs/Web/HTML/Global_attributes/enterkeyhint)
+- [enterkeyhint](/en-US/docs/Web/HTML/Global_attributes/enterkeyhint)
   - : Hints what action label (or icon) to present for the enter key on virtual keyboards.
-- [{{HTMLAttrDef("exportparts")}}](/en-US/docs/Web/HTML/Global_attributes/exportparts) {{Experimental_Inline}}
+- [exportparts](/en-US/docs/Web/HTML/Global_attributes/exportparts) {{Experimental_Inline}}
   - : Used to transitively export shadow parts from a nested shadow tree into a containing light tree.
-- [{{HTMLAttrDef("hidden")}}](/en-US/docs/Web/HTML/Global_attributes/hidden)
+- [hidden](/en-US/docs/Web/HTML/Global_attributes/hidden)
   - : A Boolean attribute indicates that the element is not yet, or is no longer, _relevant_. For example, it can be used to hide elements of the page that can't be used until the login process has been completed. The browser won't render such elements. This attribute must not be used to hide content that could legitimately be shown.
-- [{{HTMLAttrDef("id")}}](/en-US/docs/Web/HTML/Global_attributes/id)
+- [id](/en-US/docs/Web/HTML/Global_attributes/id)
   - : Defines a unique identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a fragment identifier), scripting, or styling (with CSS).
-- [{{HTMLAttrDef("inputmode")}}](/en-US/docs/Web/HTML/Global_attributes/inputmode)
+- [inputmode](/en-US/docs/Web/HTML/Global_attributes/inputmode)
   - : Provides a hint to browsers as to the type of virtual keyboard configuration to use when editing this element or its contents. Used primarily on {{HTMLElement("input")}} elements, but is usable on any element while in {{HTMLAttrxRef("contenteditable")}} mode.
-- [{{HTMLAttrDef("is")}}](/en-US/docs/Web/HTML/Global_attributes/is)
+- [is](/en-US/docs/Web/HTML/Global_attributes/is)
   - : Allows you to specify that a standard HTML element should behave like a registered custom built-in element (see [Using custom elements](/en-US/docs/Web/Web_Components/Using_custom_elements) for more details).
 
 > **Note:** The `item*` attributes are part of the [WHATWG HTML Microdata feature](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
 
-- [{{HTMLAttrDef("itemid")}}](/en-US/docs/Web/HTML/Global_attributes/itemid)
+- [itemid](/en-US/docs/Web/HTML/Global_attributes/itemid)
   - : The unique, global identifier of an item.
-- [{{HTMLAttrDef("itemprop")}}](/en-US/docs/Web/HTML/Global_attributes/itemprop)
+- [itemprop](/en-US/docs/Web/HTML/Global_attributes/itemprop)
   - : Used to add properties to an item. Every HTML element may have an `itemprop` attribute specified, where an `itemprop` consists of a name and value pair.
-- [{{HTMLAttrDef("itemref")}}](/en-US/docs/Web/HTML/Global_attributes/itemref)
+- [itemref](/en-US/docs/Web/HTML/Global_attributes/itemref)
   - : Properties that are not descendants of an element with the `itemscope` attribute can be associated with the item using an `itemref`. It provides a list of element ids (not `itemid`s) with additional properties elsewhere in the document.
-- [{{HTMLAttrDef("itemscope")}}](/en-US/docs/Web/HTML/Global_attributes/itemscope)
+- [itemscope](/en-US/docs/Web/HTML/Global_attributes/itemscope)
   - : `itemscope` (usually) works along with {{HTMLAttrxRef("itemtype")}} to specify that the HTML contained in a block is about a particular item. `itemscope` creates the Item and defines the scope of the `itemtype` associated with it. `itemtype` is a valid URL of a vocabulary (such as [schema.org](https://schema.org/)) that describes the item and its properties context.
-- [{{HTMLAttrDef("itemtype")}}](/en-US/docs/Web/HTML/Global_attributes/itemtype)
+- [itemtype](/en-US/docs/Web/HTML/Global_attributes/itemtype)
   - : Specifies the URL of the vocabulary that will be used to define `itemprop`s (item properties) in the data structure. {{HTMLAttrxRef("itemscope")}} is used to set the scope of where in the data structure the vocabulary set by `itemtype` will be active.
-- [{{HTMLAttrDef("lang")}}](/en-US/docs/Web/HTML/Global_attributes/lang)
+- [lang](/en-US/docs/Web/HTML/Global_attributes/lang)
   - : Helps define the language of an element: the language that non-editable elements are in, or the language that editable elements should be written in by the user. The attribute contains one “language tag” (made of hyphen-separated “language subtags”) in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. [**xml:lang**](#attr-xml:lang) has priority over it.
-- [{{HTMLAttrDef("nonce")}}](/en-US/docs/Web/HTML/Global_attributes/nonce)
+- [nonce](/en-US/docs/Web/HTML/Global_attributes/nonce)
   - : A cryptographic nonce ("number used once") which can be used by [Content Security Policy](/en-US/docs/Web/HTTP/CSP) to determine whether or not a given fetch will be allowed to proceed.
-- [{{HTMLAttrDef("part")}}](/en-US/docs/Web/HTML/Global_attributes/part)
+- [part](/en-US/docs/Web/HTML/Global_attributes/part)
   - : A space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the {{CSSxRef("::part")}} pseudo-element.
-- [{{HTMLAttrDef("slot")}}](/en-US/docs/Web/HTML/Global_attributes/slot)
+- [slot](/en-US/docs/Web/HTML/Global_attributes/slot)
   - : Assigns a slot in a [shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM) shadow tree to an element: An element with a `slot` attribute is assigned to the slot created by the {{HTMLElement("slot")}} element whose {{HTMLAttrxRef("name", "slot")}} attribute's value matches that `slot` attribute's value.
-- [{{HTMLAttrDef("spellcheck")}}](/en-US/docs/Web/HTML/Global_attributes/spellcheck)
+- [spellcheck](/en-US/docs/Web/HTML/Global_attributes/spellcheck)
 
   - : An enumerated attribute defines whether the element may be checked for spelling errors. It may have the following values:
 
     - `true`, which indicates that the element should be, if possible, checked for spelling errors;
     - `false`, which indicates that the element should not be checked for spelling errors.
 
-- [{{HTMLAttrDef("style")}}](/en-US/docs/Web/HTML/Global_attributes/style)
+- [style](/en-US/docs/Web/HTML/Global_attributes/style)
   - : Contains [CSS](/en-US/docs/Web/CSS) styling declarations to be applied to the element. Note that it is recommended for styles to be defined in a separate file or files. This attribute and the {{HTMLElement("style")}} element have mainly the purpose of allowing for quick styling, for example for testing purposes.
-- [{{HTMLAttrDef("tabindex")}}](/en-US/docs/Web/HTML/Global_attributes/tabindex)
+- [tabindex](/en-US/docs/Web/HTML/Global_attributes/tabindex)
 
   - : An integer attribute indicating if the element can take input focus (is _focusable_), if it should participate to sequential keyboard navigation, and if so, at what position. It can take several values:
 
@@ -114,9 +114,9 @@ In addition to the basic HTML global attributes, the following global attributes
     - `0` means that the element should be focusable and reachable via sequential keyboard navigation, but its relative order is defined by the platform convention;
     - a _positive value_ means that the element should be focusable and reachable via sequential keyboard navigation; the order in which the elements are focused is the increasing value of the [**tabindex**](#attr-tabindex). If several elements share the same tabindex, their relative order follows their relative positions in the document.
 
-- [{{HTMLAttrDef("title")}}](/en-US/docs/Web/HTML/Global_attributes/title)
+- [title](/en-US/docs/Web/HTML/Global_attributes/title)
   - : Contains a text representing advisory information related to the element it belongs to. Such information can typically, but not necessarily, be presented to the user as a tooltip.
-- [{{HTMLAttrDef("translate")}}](/en-US/docs/Web/HTML/Global_attributes/translate)
+- [translate](/en-US/docs/Web/HTML/Global_attributes/translate)
 
   - : An enumerated attribute that is used to specify whether an element's attribute values and the values of its {{DOMxRef("Text")}} node children are to be translated when the page is localized, or whether to leave them unchanged. It can have the following values:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The HTML global attribute links were only link to its section on the same page, I update them make sure each global attribute will link to their detail page.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
When I read through the HTML Global Attributes documents, there are shot descriptions for each of them, but when I click them, it only link the their section and I found out there are detail page for each of them, so I am trying to fix this issue for others, will be more easy for others redirect to their detail page.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] ✅ Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
