### PR TITLE
Fix comment for `export * as ns from "mod"` syntax

### DIFF
--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -54,7 +54,7 @@ export { name1 as default, … };
 
 // Aggregating modules
 export * from …; // does not set the default export
-export * as name1 from …; // Draft ECMAScript® 2O21
+export * as name1 from …; // ECMAScript® 2O20
 export { name1, name2, …, nameN } from …;
 export { import1 as name1, import2 as name2, …, nameN } from …;
 export { default, … } from …;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixes comment for `export * as ns from "mod"` syntax. `Draft ECMAScript® 2O21` -> `ECMAScript® 2O20`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

`export * as ns from "mod".` syntax has been merged into ecma262 in 2019. So it's included in ES2020.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- https://github.com/tc39/ecma262/pull/1174

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
