### PR TITLE
Add a link to structured-clone polyfill

### DIFF
--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -102,3 +102,4 @@ const transferred = structuredClone(
 ## See also
 
 - [Structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
+- [Structured clone polyfill](https://github.com/ungap/structured-clone)


### PR DESCRIPTION
The polyfill misses some non-serializable data and it cannot enforce transferable buffers, but it does reflect most primitives cloning capabilities, and I believe it's worth mentioning it exists in this page.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added a link to the only existent polyfill in npm to date.

#### Motivation
People should be aware there is a polyfill that works in older browsers.

#### Supporting details
The [repository](https://github.com/ungap/structured-clone#readme) has 100% code coverage for all explicitly supported data types.

#### Related issues
Transferable cannot be enforced/polyfilled, and ArrayBuffer or File, ImageData, are also not supported (and probably cant be implemented).

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
