### PR TITLE
substring(string ,start, [length] )

### DIFF
--- a/files/en-us/web/xpath/functions/substring/index.md
+++ b/files/en-us/web/xpath/functions/substring/index.md
@@ -24,7 +24,7 @@ substring(string, start, length)
   - : The position within*`string`* the substring begins
 - `length` {{optional_inline}}
   - : The length of the substring.
-    If omitted, the returned string will contain every character from the*`start`* position to the end of*`string`*.
+    If omitted, the returned string will contain every character from the `start` position to the end of `string`.
 
 ### Returns
 

--- a/files/en-us/web/xpath/functions/substring/index.md
+++ b/files/en-us/web/xpath/functions/substring/index.md
@@ -11,16 +11,20 @@ The `substring` function returns a part of a given string.
 
 ### Syntax
 
-    substring(string ,start, [length] )
+```
+substring(string, start)
+substring(string, start, length)
+```
 
 ### Arguments
 
-- _`string`_
+- `string`
   - : The string to evaluate.
-- _`start`_
+- `start`
   - : The position within*`string`* the substring begins
-- _`length`_(optional)
-  - : The length of the substring. If omitted, the returned string will contain every character from the*`start`* position to the end of*`string`*.
+- `length` {{optional_inline}}
+  - : The length of the substring.
+    If omitted, the returned string will contain every character from the*`start`* position to the end of*`string`*.
 
 ### Returns
 

--- a/files/en-us/web/xpath/functions/substring/index.md
+++ b/files/en-us/web/xpath/functions/substring/index.md
@@ -11,7 +11,7 @@ The `substring` function returns a part of a given string.
 
 ### Syntax
 
-    substring(string ,start [,length] )
+    substring(string ,start, [length] )
 
 ### Arguments
 


### PR DESCRIPTION
The parameters was substring(string, start [, length])  instead of substring(string, start, [length])

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The parameters of the substring had an error
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
 saw a syntax error, thought to contribute to improving the page
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
