### PR TITLE
Add externref as value for tableDescriptor.element

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/table/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/table/index.md
@@ -26,8 +26,7 @@ new WebAssembly.Table(tableDescriptor)
   - : An object that can contain the following members:
 
     - _element_
-      - : A string representing the type of value to be stored in the table. At the moment
-        this can only have a value of `"anyfunc"` (functions).
+      - : A string representing the type of value to be stored in the table. This can have a value of `"anyfunc"` (functions) or `"externref"` (host references).
     - _initial_
       - : The initial number of elements of the WebAssembly Table.
     - _maximum {{optional_inline}}_


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Adds `"externref"` as a possible value for `tableDescriptor.element` when constructing a WebAssembly.Table.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
`"externref"` is supported in chrome and firefox, and is part of the spec, so it makes sense to document it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://webassembly.github.io/spec/js-api/#dom-tablekind-externref

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
