### PR TITLE
performance.measure() exception not documented

### DIFF
--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -53,11 +53,15 @@ performance.measure(name, undefined, endMark);
 - startMark {{optional_inline}}
   - : A {{domxref("DOMString")}} representing the name of the measure's starting mark. May
     also be the name of a {{domxref("PerformanceTiming")}} property. If it is omitted,
-    then the start time will be the navigation start time.
+    then the start time will be the navigation start time. Specifying a name that does not
+    represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}}
+    raises a {{domxref("DOMException")}}.
 - endMark {{optional_inline}}
   - : A {{domxref("DOMString")}} representing the name of the measure's ending mark. May
     also be the name of a {{domxref("PerformanceTiming")}} property. If it is omitted,
-    then the current time is used.
+    then the current time is used. Specifying a name that does not represent an existing 
+    {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a 
+    {{domxref("DOMException")}}.
 
 ### Return value
 


### PR DESCRIPTION
#### Summary
The documented use of a function raised `DOMException` and that was not documented.

There is also another usage in which [Firefox](https://searchfox.org/mozilla-central/source/testing/web-platform/meta/user-timing/measure_exception.html.ini#2) and Chrome throw another exception - `TypeError` - and which the [spec also requires](https://w3c.github.io/user-timing/#measure-method). But, the `TypeError` comes only when `performance.measure()` is used with another arguably unnecessary argument `startOrMeasureOptions`. This usage itself is not documented on MDN. To keep the doc simple I haven't tried to address that here. That is not the core of this specific issue either.

#### Motivation
:hand_over_mouth:  

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #6563

#### Metadata
- [x] Fixes a typo, bug, or other error