### PR TITLE
Replace deprecated xlink:href by href

### DIFF
--- a/files/en-us/web/svg/element/defs/index.md
+++ b/files/en-us/web/svg/element/defs/index.md
@@ -32,7 +32,7 @@ html,body,svg { height:100% }
   </defs>
 
   <!-- using my graphical objects -->
-  <use x="5" y="5" xlink:href="#myCircle" fill="url('#myGradient')" />
+  <use x="5" y="5" href="#myCircle" fill="url('#myGradient')" />
 </svg>
 ```
 


### PR DESCRIPTION
#### Summary
Replace deprecated `xlink:href` by `href`

#### Motivation
as described in https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href, `href` should now be used instead.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


