### PR TITLE
Missing argument in replaceWith method call in example section

### DIFF
--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -46,7 +46,7 @@ let text = document.getElementById('myText').firstChild;
 let em = document.createElement("em");
 em.textContent = "Italic text";
 
-text.replaceWith(); // Replace `Some text` by `Italic text`
+text.replaceWith(em); // Replace `Some text` by `Italic text`
 ```
 
 {{EmbedLiveSample("Example", "100%", 30)}}


### PR DESCRIPTION
In the example section, the replaceWith method call is missing the node parameter used to replace the current CharacterData.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I have added the missing argument `em` to method call

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To make the example work as intended.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
