### PR TITLE
Missing documentation on exception thrown

### DIFF
--- a/files/en-us/web/api/characterdata/insertdata/index.md
+++ b/files/en-us/web/api/characterdata/insertdata/index.md
@@ -31,6 +31,11 @@ characterData.insertData(offset, data)
 
 None.
 
+## Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if offset is negative or greater than the length of the contained data.
+
 ## Example
 
 ```html


### PR DESCRIPTION
No documentation is provided on the exception thrown when the offset value is inadequate.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
