### PR TITLE
Clarify CORS and File urls

### DIFF
--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -49,10 +49,13 @@ Some examples won't run if you open them as local files. This can be due to a va
 
 - **They feature asynchronous requests**. Some browsers (including Chrome) will not run async requests (see [Fetching data from the server](/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data)) if you just run the example from a local file. This is because of security restrictions (for more on web security, read [Website security](/en-US/docs/Learn/Server-side/First_steps/Website_security)).
 - **They feature a server-side language**. Server-side languages (such as PHP or Python) require a special server to interpret the code and deliver the results.
+- **They include other files**. Browsers commonly treat requests to load resources using the `file://` schema as cross-origin requests.
+  So if you load a local file that includes other local files, this may trigger a {{Glossary("CORS")}} error.
 
 ## Running a simple local HTTP server
 
-To get around the problem of async requests, we need to test such examples by running them through a local web server. One of the easiest ways to do this for our purposes is to use Python's `http.server` module.
+To get around the problem of async requests, we need to test such examples by running them through a local web server.
+One of the easiest ways to do this for our purposes is to use Python's `http.server` module.
 
 > **Note:** Older versions of Python (up to version 2.7) provided a similar module named `SimpleHTTPServer`. If you are using Python 2.x, you can follow this guide by replacing all uses of `http.server` with `SimpleHTTPServer`. However, we recommend you use the latest version of Python.
 

--- a/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
@@ -24,31 +24,27 @@ Reason: CORS request not HTTP
 
 ## What went wrong?
 
-{{Glossary("CORS")}} requests may only use the HTTPS URL scheme, but the URL specified
-by the request is of a different type. This often occurs if the URL specifies a local
-file, using a `file:///` URL.
+{{Glossary("CORS")}} requests may only use the HTTP or HTTPS URL scheme, but the URL specified by the request is of a different type.
+This often occurs if the URL specifies a local file, using the `file:///` scheme.
 
-To fix this problem, make sure you use HTTPS URLs when issuing requests involving CORS,
-such as {{domxref("XMLHttpRequest")}}, [Fetch](/en-US/docs/Web/API/Fetch_API)
-APIs, Web Fonts (`@font-face`), and [WebGL
-textures](/en-US/docs/Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL), and XSL stylesheets.
+To fix this problem, make sure you use HTTPS URLs when issuing requests involving CORS, such as {{domxref("XMLHttpRequest")}}, [Fetch](/en-US/docs/Web/API/Fetch_API) APIs, Web Fonts (`@font-face`), and [WebGL textures](/en-US/docs/Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL), and XSL stylesheets.
 
-### Local File Security in Firefox 68
+### Loading a local file
 
-When a user opened a page using a `file:///` URI in Firefox 67 and earlier,
-the origin of the page was defined as the directory from which the page was opened.
-Resources in the same directory and its subdirectories were treated as having the same
-origin for purposes of the CORS same-origin rule.
+Local files from the same directory and subdirectories were historically treated as being from the [same origin](/en-US/docs/Web/Security/Same-origin_policy).
+This meant that a file and all its resources could be loaded from a local directory or subdirectory during testing, without triggering a CORS error.
 
-In response to [CVE-2019-11730](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730),
-Firefox 68 and later define the origin of a page opened using a `file:///`
-URI as unique. Therefore, other resources in the same directory or its subdirectories no
-longer satisfy the CORS same-origin rule. This new behavior is enabled by default using
-the `privacy.file_unique_origin` preference.
+Unfortunately this had security implications, as noted in this advisory: [CVE-2019-11730](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).
+Many browsers, including Firefox and Chrome, now treat all local files as having _opaque origins_ (by default).
+As a result, loading the a local file with included local resources will now result in CORS errors.
+
+Developers who need to perform local testing should now [set up a local server](/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server).
+As all files are served from the same scheme and domain (`localhost`) they all have the same origin, and do not trigger cross-origin errors.
+
+> **Note:** This change is in line with the [URL specification](https://url.spec.whatwg.org/#origin), which leaves the origin behaviour for files to the implementation, but recommends that file origins are treated as opaque if in doubt.
 
 ## See also
 
 - [CORS errors](/en-US/docs/Web/HTTP/CORS/Errors)
-- Glossary: {{Glossary("CORS")}}
 - [CORS introduction](/en-US/docs/Web/HTTP/CORS)
 - [What is a URL?](/en-US/docs/Learn/Common_questions/What_is_a_URL)

--- a/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
@@ -36,12 +36,12 @@ This meant that a file and all its resources could be loaded from a local direct
 
 Unfortunately this had security implications, as noted in this advisory: [CVE-2019-11730](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).
 Many browsers, including Firefox and Chrome, now treat all local files as having _opaque origins_ (by default).
-As a result, loading the a local file with included local resources will now result in CORS errors.
+As a result, loading a local file with included local resources will now result in CORS errors.
 
 Developers who need to perform local testing should now [set up a local server](/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server).
 As all files are served from the same scheme and domain (`localhost`) they all have the same origin, and do not trigger cross-origin errors.
 
-> **Note:** This change is in line with the [URL specification](https://url.spec.whatwg.org/#origin), which leaves the origin behaviour for files to the implementation, but recommends that file origins are treated as opaque if in doubt.
+> **Note:** This change is in line with the [URL specification](https://url.spec.whatwg.org/#origin), which leaves the origin behavior for files to the implementation, but recommends that file origins are treated as opaque if in doubt.
 
 ## See also
 

--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -53,9 +53,9 @@ These exceptions are nonstandard and unsupported in any other browser.
 ### File origins
 
 Modern browsers usually treat the origin of files loaded using the `file:///` schema as _opaque origins_.
-What this means is that if a file includes other files from the same folder (say) they are not assumed to come from the same origin, and may trigger {{Glossary("CORS")}} errors.
+What this means is that if a file includes other files from the same folder (say), they are not assumed to come from the same origin, and may trigger {{Glossary("CORS")}} errors.
 
-Note that the [URL specification](https://url.spec.whatwg.org/#origin) states that the origin of files is implementation dependent, and some browsers may treat files in the same directory or subdirectory as same-origin even though this has [security implications](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).
+Note that the [URL specification](https://url.spec.whatwg.org/#origin) states that the origin of files is implementation-dependent, and some browsers may treat files in the same directory or subdirectory as same-origin even though this has [security implications](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).
 
 ## Changing origin
 

--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -50,6 +50,13 @@ Internet Explorer has two major exceptions to the same-origin policy:
 
 These exceptions are nonstandard and unsupported in any other browser.
 
+### File origins
+
+Modern browsers usually treat the origin of files loaded using the `file:///` schema as _opaque origins_.
+What this means is that if a file includes other files from the same folder (say) they are not assumed to come from the same origin, and may trigger {{Glossary("CORS")}} errors.
+
+Note that the [URL specification](https://url.spec.whatwg.org/#origin) states that the origin of files is implementation dependent, and some browsers may treat files in the same directory or subdirectory as same-origin even though this has [security implications](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).
+
 ## Changing origin
 
 > **Warning:** The approach described here (using the {{domxref("document.domain")}} setter) is deprecated because it undermines the security protections provided by the same origin policy, and complicates the origin model in browsers, leading to interoperability problems and security bugs.


### PR DESCRIPTION
Fixes #11338
Fixes #11426 

On Firefox and Chrome you get a CORS error if you try to load a file locally that includes other resources. That's because we follow  the spec recommendation that "if in doubt" a file origin should be considered opaque: if a page tries to load a resource with an opaque origin it is by definition not same-origin.

Anyway, our docs suggested the old workaround of a now non-existent preference, and were specific to Firefox. This attempts to explain the problem in terms of origins and the spec. It also offers suggestions on more generic fix - start a local server