### PR TITLE
FF96 relnote: CSS counter-reset: reversed()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -21,6 +21,12 @@ This article provides information about the changes in Firefox 96 that will affe
 
 ### CSS
 
+- The {{CSSxRef("counter-reset")}} property now supports the `reversed()` function for creating _reversed_ [CSS counters](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters), which are intended for numbering elements in descending order.
+  This can be used with the `list-item` counter to automatically number ordered lists in reverse order, starting from the number of elements in the list
+  (`list-item` is a counter that is automatically applied for ordered lists, such as those created using {{HTMLElement("ol")}}).
+  Firefox uses this feature internally to support the `<ol>` [`reversed` attribute](/en-US/docs/Web/HTML/Element/ol#attr-reversed).
+  ({{bug(1706346)}}).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
FF96 adds support for creating CSS "reversed" counters using [counter-reset](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset) in https://bugzilla.mozilla.org/show_bug.cgi?id=1706346

This does the release note. Other docs work can be tracked in #10856.