### PR TITLE
Link to glossary page for Bézier curve instead of Wikipedia

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -293,7 +293,7 @@ function draw() {
 
 ### Bezier and quadratic curves
 
-The next type of paths available are [Bézier curves](https://en.wikipedia.org/wiki/B%C3%A9zier_curve), available in both cubic and quadratic varieties. These are generally used to draw complex organic shapes.
+The next type of paths available are [Bézier curves](/en-US/docs/Glossary/Bézier_curve), available in both cubic and quadratic varieties. These are generally used to draw complex organic shapes.
 
 - {{domxref("CanvasRenderingContext2D.quadraticCurveTo", "quadraticCurveTo(cp1x, cp1y, x, y)")}}
   - : Draws a quadratic Bézier curve from the current pen position to the end point specified by `x` and `y`, using the control point specified by `cp1x` and `cp1y`.

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.bezierCurveTo
 
 The
 **`CanvasRenderingContext2D.bezierCurveTo()`**
-method of the Canvas 2D API adds a cubic [Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve) to the current
+method of the Canvas 2D API adds a cubic [Bézier curve](/en-US/docs/Glossary/Bézier_curve) to the current
 sub-path. It requires three points: the first two are control points and the third one
 is the end point. The starting point is the latest point in the current path, which can
 be changed using {{domxref("CanvasRenderingContext2D.moveTo", "moveTo()")}} before
@@ -134,5 +134,4 @@ ctx.stroke();
 ## See also
 
 - The interface defining this method: {{domxref("CanvasRenderingContext2D")}}
-- [Wikipedia article on
-  Bézier curves](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+- [Bézier curve](/en-US/docs/Glossary/Bézier_curve)

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
@@ -13,7 +13,7 @@ browser-compat: api.CanvasRenderingContext2D.quadraticCurveTo
 
 The
 **`CanvasRenderingContext2D.quadraticCurveTo()`**
-method of the Canvas 2D API adds a quadratic [Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve) to the current
+method of the Canvas 2D API adds a quadratic [Bézier curve](/en-US/docs/Glossary/Bézier_curve) to the current
 sub-path. It requires two points: the first one is a control point and the second one is
 the end point. The starting point is the latest point in the current path, which can be
 changed using {{domxref("CanvasRenderingContext2D.moveTo", "moveTo()")}} before creating
@@ -122,5 +122,4 @@ ctx.stroke();
 ## See also
 
 - The interface defining this method: {{domxref("CanvasRenderingContext2D")}}
-- [Wikipedia article on
-  Bézier curves](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+- [Bézier curve](/en-US/docs/Glossary/Bézier_curve)

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -28,13 +28,10 @@ However, certain properties will restrict the output if it goes outside an allow
 
 ![](tf_with_output_gt_than_1_clipped.png)
 
-## Syntax
-
-There are three types of [easing function](/en-US/docs/Web/CSS/easing-function#easing_functions): linear, [cubic Bézier curves](https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves), and staircase functions. The value of an `<easing-function>` type describes the easing function using one of those three types.
-
 ### Easing functions
 
-CSS supports three kinds of easing functions: linear, the subset of the cubic Bézier curves that are functions, and staircase functions. The most useful of these functions are given a keyword that allows them to be easily referenced.
+The value of an `<easing-function>` type describes the easing function using one of the three types that
+CSS supports: linear, the subset of the [cubic Bézier curves](/en-US/docs/Glossary/Bézier_curve) that are functions, and staircase functions. The most useful of these functions are given a keyword that allows them to be easily referenced.
 
 #### The linear class of easing functions
 
@@ -48,7 +45,7 @@ The interpolation is done at a constant rate from beginning to end. This keyword
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio.' A curved line extends from the origin to the X 1 Y 1 position. The X 0 Y 0 point of the line is labeled  'P₀ = (0, 0)'. Extending from the X 0 Y 0 point is a Bezier handle labeled 'P₁ = (0.075, 0.75)'. The X 1 Y 1 point of the line is labeled 'P₃ = (1, 1)'. Extending from the X 1 Y 1 point is a Bezier handle labeled 'P₂ = (0.0875, 0.36)'.](cubic-bezier-example.png)
 
-The `cubic-bezier()` functional notation defines a [cubic Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves). As these curves are continuous, they are often used to smooth down the start and end of the interpolation and are therefore sometimes called _easing functions_.
+The `cubic-bezier()` functional notation defines a [cubic Bézier curve](/en-US/docs/Glossary/Bézier_curve). As these curves are continuous, they are often used to smooth down the start and end of the interpolation and are therefore sometimes called _easing functions_.
 
 A cubic Bézier curve is defined by four points P0, P1, P2, and P3. P0 and P3 are the start and the end of the curve and, in CSS these points are fixed as the coordinates are ratios (the abscissa the ratio of time, the ordinate the ratio of the output range). P0 is `(0, 0)` and represents the initial time or position and the initial state, P3 is `(1, 1)` and represents the final time or position and the final state.
 

--- a/files/en-us/web/svg/attribute/d/index.md
+++ b/files/en-us/web/svg/attribute/d/index.md
@@ -406,7 +406,7 @@ html,body,svg { height:100% }
 
 ### Cubic Bézier Curve
 
-*Cubic [Bézier curves](https://en.wikipedia.org/wiki/Bézier_curve)* are smooth curve definitions using four points:
+*Cubic [Bézier curves](/en-US/docs/Glossary/Bézier_curve)* are smooth curve definitions using four points:
 
 *   starting point (current point)
     *   : (*P<sub>o</sub>* = {*x<sub>o</sub>*, *y<sub>o</sub>*})
@@ -619,7 +619,7 @@ html,body,svg { height:100% }
 
 ### Quadratic Bézier Curve
 
-*Quadratic [Bézier curves](https://en.wikipedia.org/wiki/Bézier_curve)* are smooth curve definitions using three points:
+*Quadratic [Bézier curves](/en-US/docs/Glossary/Bézier_curve)* are smooth curve definitions using three points:
 
 *   starting point (current point)
     *   : *P<sub>o</sub>* = {*x<sub>o</sub>*, *y<sub>o</sub>*}

--- a/files/en-us/web/svg/attribute/keysplines/index.md
+++ b/files/en-us/web/svg/attribute/keysplines/index.md
@@ -8,7 +8,7 @@ browser-compat: svg.elements.animate.keySplines
 ---
 {{SVGRef}}
 
-The **`keySplines`** attribute defines a set of {{Glossary("Bézier curve")}} control points associated with the {{SVGAttr("keyTimes")}} list, defining a cubic Bézier function that controls interval pacing.
+The **`keySplines`** attribute defines a set of [Bézier curve](/en-US/docs/Glossary/Bézier_curve) control points associated with the {{SVGAttr("keyTimes")}} list, defining a cubic Bézier function that controls interval pacing.
 
 This attribute is ignored unless the {{SVGAttr("calcMode")}} attribute is set to `spline`.
 
@@ -107,4 +107,4 @@ The attribute value is a semicolon-separated list of control point descriptions.
 
 ## See also
 
-*   [Wikipedia article on Bézier curves](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+* [Bézier curve](/en-US/docs/Glossary/Bézier_curve)

--- a/files/en-us/web/svg/tutorial/paths/index.md
+++ b/files/en-us/web/svg/tutorial/paths/index.md
@@ -111,7 +111,7 @@ In these examples, it would probably be simpler to use the {{SVGElement("polygon
 
 ## Curve commands
 
-There are three different commands that can be used to create smooth curves. Two of those curves are Bézier curves, and the third is an "arc" or part of a circle. You might have already gained practical experience with Bézier curves using path tools in Inkscape, Illustrator or Photoshop. For a complete description of the math behind Bézier curves, go to a reference like the one on [Wikipedia](https://en.wikipedia.org/wiki/B%C3%A9zier_curve). There are an infinite number of Bézier curves, but only two simple ones are available in `<path>` elements: a cubic one, called with `C`, and a quadratic one, called with `Q`.
+There are three different commands that can be used to create smooth curves. Two of those curves are [Bézier curves](/en-US/docs/Glossary/Bézier_curve), and the third is an "arc" or part of a circle. You might have already gained practical experience with Bézier curves using path tools in Inkscape, Illustrator or Photoshop. There are an infinite number of Bézier curves, but only two simple ones are available in `<path>` elements: a cubic one, called with `C`, and a quadratic one, called with `Q`.
 
 ### Bézier Curves
 


### PR DESCRIPTION
#### Summary
This adds links to the MDN glossary page for Bézier curve instead of Wikipedia, and removes repeated sentences on the
<easing-function> page.

#### Motivation
The glossary page should be used more so that web specific content can be added and found in one place. The Wikipedia link
is still on that page.