### PR TITLE
Fix outputs of macros

### DIFF
--- a/files/en-us/web/css/@counter-style/symbols/index.md
+++ b/files/en-us/web/css/@counter-style/symbols/index.md
@@ -40,7 +40,7 @@ symbols: url('first.svg') url('second.svg') url('third.svg');
 symbols: indic-numbers;
 ```
 
-The `symbols` descriptor must be specified when the value of the {{cssxref('@counter-style/system')}} descriptor is `cyclic`, `numeric`, `alphabetic`, `symbolic`, or `fixed`. When the `additive` system is used, use the {{cssxref('@counter-style/additive-symbols')}} descriptor instead to specify the symbols.
+The `symbols` descriptor must be specified when the value of the {{cssxref('@counter-style/system', 'system')}} descriptor is `cyclic`, `numeric`, `alphabetic`, `symbolic`, or `fixed`. When the `additive` system is used, use the {{cssxref('@counter-style/additive-symbols', 'additive-symbols')}} descriptor instead to specify the symbols.
 
 ## Formal definition
 
@@ -95,5 +95,5 @@ The `symbols` descriptor must be specified when the value of the {{cssxref('@cou
 
 - The `symbols` descriptor is used within the {{cssxref("@counter-style")}} at-rule.
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
-- {{cssxref("symbols()", "symbols()")}}, the functional notation creating anonymous counter styles
+- {{cssxref("symbols()")}}, the functional notation creating anonymous counter styles
 - {{cssxref("url()", "url()")}} function


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix outputs of macros

#### Motivation
These macros should produce descriptor names without '@counter-style'.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
