### PR TITLE
corrected Response.redirect example

### DIFF
--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -45,7 +45,7 @@ A {{domxref("Response")}} object.
 ## Example
 
 ```js
-responseObj.redirect('https://www.example.com', 302);
+Response.redirect('https://www.example.com', 302);
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changed the example of Response.redirect() according to the explanation above in the documentation.

#### Motivation
Redirect is a static method of Response, not an instance method

#### Supporting details
(https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect%E2%91%A0)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
