### PR TITLE
Document ended event not fired on .stop()

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -36,7 +36,8 @@ using the source, the source may actually be completely stopped.
 
 Immediately after calling `stop()`, the
 {{domxref("MediaStreamTrack.readyState", "readyState")}} property is set to
-`ended`.
+`ended` but does not fire the 
+[`ended`](/en-US/docs/Web/API/MediaStreamTrack/ended_event) event.
 
 ## Examples
 

--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -36,8 +36,7 @@ using the source, the source may actually be completely stopped.
 
 Immediately after calling `stop()`, the
 {{domxref("MediaStreamTrack.readyState", "readyState")}} property is set to
-`ended` but does not fire the 
-[`ended`](/en-US/docs/Web/API/MediaStreamTrack/ended_event) event.
+`ended`. Note that the [`ended`](/en-US/docs/Web/API/MediaStreamTrack/ended_event) event will not be fired in this situation.
 
 ## Examples
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Document that even though `.stop()` sets the `readyState` to `ended`, it does not fire the `ended`
event.

#### Motivation
According to the spec at https://www.w3.org/2019/06/mediacapture-diff.html#event-summary
the `ended` event is not fired when manually calling `.stop()` and this behavior is confirmed by 
users on StackOverflow: https://stackoverflow.com/a/55960232/3243814

This commit/change should make it easier to understand and correctly implement the behaviors. 

#### Supporting details
- https://www.w3.org/2019/06/mediacapture-diff.html#event-summary
- https://stackoverflow.com/a/55960232/3243814

#### Related issues
N/A

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [x] Adds a small elaboration to avoid confusion

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
