### PR TITLE
Fix data in the "positions" array

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -180,10 +180,10 @@ function initBuffers(gl) {
   // Now create an array of positions for the square.
 
   const positions = [
-    -1.0,  1.0,
-     1.0,  1.0,
-    -1.0, -1.0,
-     1.0, -1.0,
+     1.0,  1.0,
+    -1.0,  1.0,
+     1.0, -1.0,
+    -1.0, -1.0,
   ];
 
   // Now pass the list of positions into WebGL to build the


### PR DESCRIPTION
The winding order was wrong, CW instead of CCW. The data also did not match the real sample code at /webgl-examples/blob/gh-pages/tutorial/sample2/webgl-demo.js, which has the correct winding order. The fix is to mirror the sample code.

#### Summary
Fix the data in the "positions" array so it has the correct (CCW) winding order.

#### Motivation
Having the wrong winding order means the box won't display, if you're working from the docs instead of the sample code.

#### Supporting details
The correct data is in the sample code (which this should mirror) at /webgl-examples/blob/gh-pages/tutorial/sample2/webgl-demo.js

#### Related issues
None

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error