### PR TITLE
fix: link to The Service Worker Cookbook

### DIFF
--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -83,7 +83,7 @@ if ('serviceWorker' in navigator) {
 
 ## See also
 
-- [The Offline (Service Worker) Cookbook](https://web.dev/offline-cookbook/)
+- [The Offline Cookbook](https://web.dev/offline-cookbook/)(service workers)
 - [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
 - [Service worker basic code example](https://github.com/mdn/sw-test)
 - [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -83,7 +83,7 @@ if ('serviceWorker' in navigator) {
 
 ## See also
 
-- [ServiceWorker Cookbook](https://serviceworke.rs)
+- [The Offline (Service Worker) Cookbook](https://web.dev/offline-cookbook/)
 - [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
 - [Service worker basic code example](https://github.com/mdn/sw-test)
 - [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)


### PR DESCRIPTION
#### Summary
This PR updates the link to the "The Service Worker Cookbook", an additional resource at the bottom of the docs.

The original domain `https://serviceworke.rs/` leads to a parked domain. 

Linked to an updated article written by Jake Archibald called "The Offline Cookbook", but the original site was an interactive site, it is not being hosted at the moment.


#### Motivation
Was upset that the cookbook link lead to a parked domain.

#### Supporting details

- Original source code of the site shows the repo being active in 2019 https://github.com/mozilla/serviceworker-cookbook/

- Looked at cached version of site here: https://web.archive.org/web/20200313222303/https://serviceworke.rs/

#### Related issues
(Should I open an issue, and or try to re-host this resource?) 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
