### PR TITLE
Remove unsupported notifications create example

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -45,15 +45,9 @@ var creating = browser.notifications.create(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled when the notification is created and the display process has been started, which is before the notification is actually displayed to the user. It is fulfilled with a string representing the notification's ID.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
-Create and display a basic notification periodically, using an {{WebExtAPIRef("alarms", "alarm")}}. Clicking the browser action dismisses the notification.
-
-Note that you'll need the "alarms" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) to create alarms (as well as the "notifications" permission to create notifications).
+This example displays a notification periodically, using {{WebExtAPIRef("alarms", "alarm")}}. Clicking the browser action dismisses the notification. You need the "alarms" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) to create alarms (as well as the "notifications" permission to create notifications).
 
 ```js
 var cakeNotification = "cake-notification"
@@ -88,56 +82,11 @@ browser.browserAction.onClicked.addListener(()=> {
 });
 ```
 
-Display a similar notification, but add buttons naming cakes, and log the selected cake when a button is clicked:
-
-```js
-var cakeNotification = "cake-notification"
-
-/*
-
-CAKE_INTERVAL is set to 6 seconds in this example.
-Such a short period is chosen to make the extension's behavior
-more obvious, but this is not recommended in real life.
-Note that in Chrome, alarms cannot be set for less
-than a minute.
-
-*/
-var CAKE_INTERVAL = 0.1;
-
-var buttons = [
-  {
-    "title": "Chocolate"
-  }, {
-    "title": "Battenberg"
-  }
-];
-
-browser.alarms.create("", {periodInMinutes: CAKE_INTERVAL});
-
-browser.alarms.onAlarm.addListener(function(alarm) {
-  browser.notifications.create(cakeNotification, {
-    "type": "basic",
-    "iconUrl": browser.runtime.getURL("icons/cake-96.png"),
-    "title": "Time for cake!",
-    "message": "Something something cake",
-    "buttons": buttons
-  });
-});
-
-browser.browserAction.onClicked.addListener(()=> {
-  var clearing = browser.notifications.clear(cakeNotification);
-  clearing.then(() => {
-    console.log("cleared");
-  });
-});
-
-browser.notifications.onButtonClicked.addListener((id, index) => {
-  browser.notifications.clear(id);
-  console.log("You chose: " + buttons[index].title);
-});
-```
-
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > **Note:** This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/extensions/notifications#method-create) API.
 >


### PR DESCRIPTION
#### Summary
Made the following changes:

- removed the second code example. This includes use of `onButtonClicked` and `buttons` which are not supporting Firefox 
- tidied up the introduction to the example section
- move the example of section above the compatibility table

#### Motivation
Avoid giving developers the impression that `onButtonClicked` and `buttons` are supported in Firefox.

#### Related issues
Addresses  Issue with "notifications.create()": buttons not supported in FF but not indicated on the page [#6350](https://github.com/mdn/content/issues/6350).

#### Metadata
This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
