### PR TITLE
Remove experimental banner for a couple of canvas features

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
@@ -9,7 +9,7 @@ tags:
   - Property
 browser-compat: api.CanvasRenderingContext2D.filter
 ---
-{{APIRef}} {{SeeCompatTable}}
+{{APIRef}}
 
 The
 **`CanvasRenderingContext2D.filter`**

--- a/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.CanvasRenderingContext2D.resetTransform
 ---
-{{APIRef}} {{SeeCompatTable}}
+{{APIRef}}
 
 The
 **`CanvasRenderingContext2D.resetTransform()`**


### PR DESCRIPTION
Partial fix for https://github.com/mdn/content/issues/11401.

Based on https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D#browser_compatibility, there were a couple of APIs with `{{SeeCompatTable}}` set where it shouldn't be, as the features have good cross-browser compatibility.