### PR TITLE
Confusing description of form property

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/index.md
@@ -26,8 +26,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLButtonElement.disabled")}}
   - : Is a boolean value indicating whether or not the control is disabled, meaning that it does not accept any clicks.
 - {{domxref("HTMLButtonElement.form")}} {{readonlyInline}}
-  - : Is a {{domxref("HTMLFormElement")}} reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is the ID of that form element.
-    If the button is not a descendant of a form element, then the attribute can be the ID of any form element in the same document it is related to, or the `null` value if none matches.
+  - : Is a {{domxref("HTMLFormElement")}} reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is the object of that form element.
+    If the button is not a descendant of a form element, then the attribute can be the object of any form element in the same document it is related to, or the `null` value if none matches.
 - {{domxref("HTMLButtonElement.formAction")}}
   - : Is a {{domxref("DOMString")}} reflecting the URI of a resource that processes information submitted by the button. If specified, this attribute overrides the {{htmlattrxref("action", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.formEnctype")}}

--- a/files/en-us/web/api/htmlbuttonelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/index.md
@@ -26,8 +26,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLButtonElement.disabled")}}
   - : Is a boolean value indicating whether or not the control is disabled, meaning that it does not accept any clicks.
 - {{domxref("HTMLButtonElement.form")}} {{readonlyInline}}
-  - : Is a {{domxref("HTMLFormElement")}} reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is the object of that form element.
-    If the button is not a descendant of a form element, then the attribute can be the object of any form element in the same document it is related to, or the `null` value if none matches.
+  - : Is an {{domxref("HTMLFormElement")}} reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is a reference to that form's associated `HTMLFormElement`.
+    If the button is not a descendant of a form element, then the attribute can be a reference to any `HTMLFormElement` element in the same document it is related to, or the `null` value if none matches.
 - {{domxref("HTMLButtonElement.formAction")}}
   - : Is a {{domxref("DOMString")}} reflecting the URI of a resource that processes information submitted by the button. If specified, this attribute overrides the {{htmlattrxref("action", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.formEnctype")}}


### PR DESCRIPTION
In the documentation, it is written:
"Is a HTMLFormElement reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is the ID of that form element."
So, which is it? an object or an id? After checking it turns out `button.form` always returns a `HTMLFormElement` object.

```
var form = document.createElement('form');
var button = document.createElement('button');
form.appendChild( button );
button.form instanceof( HTMLFormElement ); // true
```

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
