### PR TITLE
Remove WebSocket.close(reason) syntax

### DIFF
--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -26,10 +26,6 @@ WebSocket.close(code);
 ```
 
 ```js
-WebSocket.close(reason);
-```
-
-```js
 WebSocket.close(code, reason);
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I have removed the `WebSocket.close(reason)` syntax from the documentation for `WebSocket.close()`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I have tried this syntax on Chrome 96.0.4664.110 and Firefox 95.0.2 and it doesn't appear to work.

To reproduce, create a WebSocket server on "ws://localhost:8080" and run the following in the browser:
```javascript
const ws = new WebSocket('ws://localhost:8080'); 
ws.close('Example reason');
```

Chrome returns the following error:
> Uncaught DOMException: Failed to execute 'close' on 'WebSocket': The code must be either 1000, or between 3000 and 4999. 0 is neither.

Firefox returns the following error:
> Uncaught DOMException: A parameter or an operation is not supported by the underlying object

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
