### PR TITLE
Correct and complete ByteLengthQueuingStrategy.

### DIFF
--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -19,15 +19,17 @@ instance.
 ## Syntax
 
 ```js
-var byteLengthQueuingStrategy = new ByteLengthQueuingStrategy({highWaterMark});
+var byteLengthQueuingStrategy = new ByteLengthQueuingStrategy(QueuingStrategy);
 ```
 
 ### Parameters
 
-- {highWaterMark}
-  - : An object containing a `highWaterMark` property. This is a non-negative
-    integer defining the total number of chunks that can be contained in the internal
-    queue before backpressure is applied.
+- `QueuingStrategy`
+  - : An object with the following properties:
+    - highWaterMark
+      - : A non-negative integer defining the total number of chunks that can be contained in the internal queue before backpressure is applied.
+    - size
+      - : A reference to an script- or app-defined function that computes and returns the finite non-negative size of the given chunk value. Typically, this function just returns `chucnk.length`. For readable byte streams, this function is not used. This function must not cause any side effects.
 
 ### Return value
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/highwatermark/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/highwatermark/index.md
@@ -1,0 +1,30 @@
+---
+title: ByteLengthQueuingStrategy.highWaterMark
+slug: Web/API/ByteLengthQueuingStrategy/highWaterMark
+tags:
+  - API
+  - ByteLengthQueuingStrategy
+  - Experimental
+  - Property
+  - Reference
+  - Streams
+  - highWaterMark
+browser-compat: api.ByteLengthQueuingStrategy.highWaterMark
+---
+{{DefaultAPISidebar("")}}
+
+The **`highWaterMark`** property of the {{domxref("ByteLengthQueuingStrategy")}} interface returns the total number of chunks that can be in the streaming queue before backpressure will be applied. This is the value suplied by the `highWaterMark` property passed to the {{domxref("ByteLengthQueuingStrategy.ByteLengthQueuingStrategy", "ByteLengthQueuingStrategy()")}} constructor.
+
+## Value
+
+An {{jsxref('Integer')}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.md
@@ -12,7 +12,7 @@ browser-compat: api.ByteLengthQueuingStrategy
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 
-The **`ByteLengthQueuingStrategy`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) provides a built-in byte length queuing strategy that can be used when constructing streams.
+The **`ByteLengthQueuingStrategy`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) provides a built-in byte length queuing strategy that can be used when constructing streams.
 
 ## Constructor
 
@@ -21,12 +21,15 @@ The **`ByteLengthQueuingStrategy`** interface of the [Streams API](/en-US/docs/W
 
 ## Properties
 
-None.
+- {{domxref("ByteLengthQueuingStrategy.size")}}
+  - : Returns a reference to the `size` function passed in the object's constructor.
+
+- {{comxref("ByteLengthQueuingStrategy.highWaterMark")}}
+  - : Returns the total number of chunks that can be in the streaming queue before backpressure will be applied. This is the value suplied by the `highWaterMark` property passed to the object's constructor.
 
 ## Methods
 
-- {{domxref("ByteLengthQueuingStrategy.size()")}}
-  - : Returns the given chunk’s `byteLength` property.
+None.
 
 ## Examples
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
@@ -5,7 +5,7 @@ tags:
   - API
   - ByteLengthQueuingStrategy
   - Experimental
-  - Method
+  - Property
   - Reference
   - Streams
   - size
@@ -13,9 +13,7 @@ browser-compat: api.ByteLengthQueuingStrategy.size
 ---
 {{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}
 
-The **`size()`** method of the
-{{domxref("ByteLengthQueuingStrategy")}} interface returns the given chunk’s
-`byteLength` property.
+The **`size`** property of the {{domxref("ByteLengthQueuingStrategy")}} interface a reference to the `size` function passed in the{{domxref("ByteLengthQueuingStrategy.ByteLengthQueuingStrategy", "ByteLengthQueuingStrategy()")}} constructor.
 
 ## Syntax
 


### PR DESCRIPTION
As per the [compat data](https://developer.mozilla.org/en-US/docs/Web/API/ByteLengthQueuingStrategy#browser_compatibility) the `highWaterMark` property has been supported by a number of browsers for a while. While I was doing that, I corrected a deficiency in how the `size` property is documented. 

I submit this with apologies. The `size()` is still described a little unclearly, but it reflects the best information that I could find. At last it's better than it was.