### PR TITLE
Fix minor grammatical error in Request.clone()

### DIFF
--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -17,7 +17,7 @@ The **`clone()`** method of the {{domxref("Request")}} interface creates a copy 
 
 `clone()` throws a {{jsxref("TypeError")}} if the request body has already been used. In fact, the main reason `clone()` exists is to allow multiple uses of body objects (when they are one-use only.)
 
-If intend to modify the request, you may prefer the {{domxref("Request")}} constructor.
+If you intend to modify the request, you may prefer the {{domxref("Request")}} constructor.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This fixes a small grammatical error in Request.clone()'s documentation.

#### Motivation
Just PRing a typo I noticed while reading.

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
