### PR TITLE
Deprecated property is missing the icon

### DIFF
--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -24,7 +24,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
   - : A list of origins the frame is allowed to display content from. This attribute also accepts the values `self` and `src` which represent the origin in the iframe's src attribute. The default value is `src`.
 - {{domxref("HTMLIFrameElement.allowfullscreen")}} {{experimental_inline}}
   - : A boolean value indicating whether the inline frame is willing to be placed into full screen mode. See [Using full-screen mode](/en-US/docs/Web/API/Fullscreen_API) for details.
-- {{domxref("HTMLIFrameElement.allowPaymentRequest")}}
+- {{domxref("HTMLIFrameElement.allowPaymentRequest")}} {{deprecated_inline}}
   - : A boolean value indicating whether the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) may be invoked inside a cross-origin iframe.
 - {{domxref("HTMLIFrameElement.contentDocument")}} {{readonlyInline}}
   - : Returns a {{domxref("Document")}}, the active document in the inline frame's nested browsing context.


### PR DESCRIPTION
The iFrame `allowPaymentRequest` property is missing the `deprecated` icon.
It is, however, well stated to be deprecated on the [detail page](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/allowPaymentRequest)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
