### PR TITLE
Legacy exception constant in documentation

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -691,7 +691,7 @@ The **`HTMLInputElement`** interface provides special properties and methods for
 
 - {{domxref("HTMLInputElement.stepDown()")}}
 
-  - : Decrements the {{htmlattrxref("value","input")}} by ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
+  - : Decrements the {{htmlattrxref("value","input")}} by ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws an `InvalidStateError` exception:
 
     - if the method is not applicable to for the current {{htmlattrxref("type","input")}} value,
     - if the element has no {{htmlattrxref("step","input")}} value,
@@ -700,7 +700,7 @@ The **`HTMLInputElement`** interface provides special properties and methods for
 
 - {{domxref("HTMLInputElement.stepUp()")}}
 
-  - : Increments the {{htmlattrxref("value","input")}} by ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
+  - : Increments the {{htmlattrxref("value","input")}} by ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws an `InvalidStateError` exception:
 
     - if the method is not applicable to for the current {{htmlattrxref("type","input")}} value.,
     - if the element has no {{htmlattrxref("step","input")}} value,


### PR DESCRIPTION
According to the [documentation on exception](https://developer.mozilla.org/en-US/docs/Web/API/DOMException), the constants mentioned are legacy.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
