### PR TITLE
Typo in example datetime-local

### DIFF
--- a/files/en-us/web/html/attributes/step/index.md
+++ b/files/en-us/web/html/attributes/step/index.md
@@ -59,7 +59,7 @@ The default stepping value for `number` inputs is 1, allowing only integers to b
       <td>1 (day)</td>
       <td>
         <code
-          >&#x3C;input type="datetime-local" min="019-12-25T19:30"
+          >&#x3C;input type="datetime-local" min="2019-12-25T19:30"
           step="7"></code
         >
       </td>


### PR DESCRIPTION
In the example for `datetime-local` there is a type whereby the year in the date is missing the number `2`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
