### PR TITLE
Corrected description and syntax definitions of rgb(), rgba(), hsl(), and hsla()

### DIFF
--- a/files/en-us/web/css/color_value/hsl()/index.md
+++ b/files/en-us/web/css/color_value/hsl()/index.md
@@ -29,7 +29,7 @@ hsl(235 100% 50% / .5); /* #0015ff with 50% opacity, using CSS Colors 4 space-se
 
 ### Values
 
-- Functional notation: `hsl[a](H, S, L[, A])`
+- Functional notation: `hsl(H, S, L[, A])`
 
   - : `H` (hue) is an {{cssxref("&lt;angle&gt;")}} of the color circle given in `deg`s, `rad`s, `grad`s, or `turn`s in {{SpecName("CSS4 Colors","#the-hsl-notation")}}. When written as a unitless {{cssxref("&lt;number&gt;")}}, it is interpreted as degrees, as specified in {{SpecName("CSS3 Colors", "#hsl-color")}}. By definition, red=0deg=360deg, with the other colors spread around the circle, so green=120deg, blue=240deg, etc. As an `<angle>`, it implicitly wraps around such that -120deg=240deg, 480deg=120deg, -1turn=1turn, etc.
 
@@ -37,7 +37,7 @@ hsl(235 100% 50% / .5); /* #0015ff with 50% opacity, using CSS Colors 4 space-se
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
-- Functional notation: `hsl[a](H S L[ / A])`
+- Functional notation: `hsl(H S L[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
 ## Browser compatibility

--- a/files/en-us/web/css/color_value/hsla()/index.md
+++ b/files/en-us/web/css/color_value/hsla()/index.md
@@ -26,7 +26,7 @@ hsla(235 100% 50% / 1); /* CSS Colors 4 space-separated values */
 
 ### Values
 
-- Functional notation: `hsl[a](H, S, L[, A])`
+- Functional notation: `hsla(H, S, L[, A])`
 
   - : `H` (hue) is an {{cssxref("&lt;angle&gt;")}} of the color circle given in `deg`s, `rad`s, `grad`s, or `turn`s in {{SpecName("CSS4 Colors","#the-hsl-notation")}}. When written as a unitless {{cssxref("&lt;number&gt;")}}, it is interpreted as degrees, as specified in {{SpecName("CSS3 Colors", "#hsl-color")}}. By definition, red=0deg=360deg, with the other colors spread around the circle, so green=120deg, blue=240deg, etc. As an `<angle>`, it implicitly wraps around such that -120deg=240deg, 480deg=120deg, -1turn=1turn, etc.
 
@@ -34,7 +34,7 @@ hsla(235 100% 50% / 1); /* CSS Colors 4 space-separated values */
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
-- Functional notation: `hsl[a](H S L[ / A])`
+- Functional notation: `hsla(H S L[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
 ## Browser compatibility

--- a/files/en-us/web/css/color_value/rgb()/index.md
+++ b/files/en-us/web/css/color_value/rgb()/index.md
@@ -21,17 +21,17 @@ The **`rgb()`** functional notation expresses a color according to its red, gree
 ## Syntax
 
 ```css
-rgb(255,255,255) /* white */
-rgb(255,255,255,.5) /* white with 50% opacity */
+rgb(255, 255, 255) /* white */
+rgb(255, 255, 255,.5) /* white with 50% opacity */
 rgb(255 255 255) /* CSS Colors 4 space-separated values */
 rgb(255 255 255 / .5); /* white with 50% opacity, using CSS Colors 4 space-separated values */
 ```
 
 ### Values
 
-- Functional notation: `rgb[a](R, G, B[, A])`
+- Functional notation: `rgb(R, G, B[, A])`
   - : `R` (red), `G` (green), and `B` (blue) can be either {{cssxref("&lt;number&gt;")}}s or {{cssxref("&lt;percentage&gt;")}}s, where the number `255` corresponds to `100%`. `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
-- Functional notation: `rgb[a](R G B[ / A])`
+- Functional notation: `rgb(R G B[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
 ## Browser compatibility

--- a/files/en-us/web/css/color_value/rgba()/index.md
+++ b/files/en-us/web/css/color_value/rgba()/index.md
@@ -19,15 +19,16 @@ The **`rgba()`** functional notation expresses a color according to its red, gre
 ## Syntax
 
 ```css
-rgba(255,255,255,.5) /* white with 50% opacity */
+rgba(255, 255, 255) /* white */
+rgba(255, 255, 255, .5) /* white with 50% opacity */
 rgba(255 255 255 / 0.5); /* CSS Colors 4 space-separated values */
 ```
 
 ### Values
 
-- Functional notation: `rgb[a](R, G, B[, A])`
+- Functional notation: `rgba(R, G, B[, A])`
   - : `R` (red), `G` (green), and `B` (blue) can be either {{cssxref("&lt;number&gt;")}}s or {{cssxref("&lt;percentage&gt;")}}s, where the number `255` corresponds to `100%`. `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
-- Functional notation: `rgb[a](R G B[ / A])`
+- Functional notation: `rgba(R G B[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
 ## Browser compatibility


### PR DESCRIPTION
#### Summary
This corrects the syntax definition of the `rgb()`, `rgba()`, `hsl()`, and `hsla()` CSS functions so that they only refer to their syntax. It adds a syntax example without alpha value to `rgba()` like it is already there for `hsla()` and unifies the separation in the syntax examples.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error