### PR TITLE
Replace deprecated xlink:href by href

### DIFF
--- a/files/en-us/web/svg/element/clippath/index.md
+++ b/files/en-us/web/svg/element/clippath/index.md
@@ -36,7 +36,7 @@ html,body,svg { height:100% }
     Only the portion of the red heart
     inside the clip circle is visible.
   -->
-  <use clip-path="url(#myClip)" xlink:href="#heart" fill="red" />
+  <use clip-path="url(#myClip)" href="#heart" fill="red" />
 </svg>
 ```
 


### PR DESCRIPTION
#### Summary
Replace deprecated xlink:href by href

#### Motivation
as described in https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href, href should now be used instead.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
