### PR TITLE
Remove unnecessary namespace declaration

### DIFF
--- a/files/en-us/web/svg/element/defs/index.md
+++ b/files/en-us/web/svg/element/defs/index.md
@@ -19,8 +19,7 @@ html,body,svg { height:100% }
 ```
 
 ```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
   <!-- Some graphical objects to use -->
   <defs>
     <circle id="myCircle" cx="0" cy="0" r="5" />


### PR DESCRIPTION
#### Summary
The xlink namespace is not used anymore in the document


- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

