### PR TITLE
Fix wrong data types in sort example return values

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -195,8 +195,8 @@ numericStringArray.sort(); // [700, 80, 9]
 numericStringArray.sort(compareNumbers); // [9, 80, 700]
 
 mixedNumericArray.join(); // '80,9,700,40,1,5,200'
-mixedNumericArray.sort(); // [1, 200, 40, 5, 700, 80, 9]
-mixedNumericArray.sort(compareNumbers); // [1, 5, 9, 40, 80, 200, 700]
+mixedNumericArray.sort(); // [1, 200, 40, 5, '700', '80', '9']
+mixedNumericArray.sort(compareNumbers); // [1, 5, '9', 40, '80', 200, '700']
 ```
 
 ### Sorting non-ASCII characters


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The `mixedNumericArray` array contains both `number`s and `string`s and yet the return values unexpectedly converts the `string`s into `number`s

#### Motivation
The incorrect information can be misleading for people try to lean

#### Supporting details
[<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#creating_displaying_and_sorting_an_array)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
