### PR TITLE
Bad anchor for method item

### DIFF
--- a/files/en-us/web/api/filelist/index.md
+++ b/files/en-us/web/api/filelist/index.md
@@ -31,7 +31,7 @@ var file = document.getElementById('fileItem').files[0];
   <tbody>
     <tr>
       <td>
-        <code>File <a href="#item()">item</a>(index);</code>
+        <code>File <a href="#item">item</a>(index);</code>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
In the method overview section, the anchor is set to `item()` where it ought to be just `item`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
