### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMTokenList.add
 ---
 {{APIRef("DOM")}}
 
-The **`add()`** method of the {{domxref("DOMTokenList")}} interface adds the given _tokens_ to the list.
+The **`add()`** method of the {{domxref("DOMTokenList")}} interface adds the given _tokens_, except those already present, to the list.
 
 ## Syntax
 


### PR DESCRIPTION
Correct the description by including a restriction from the specification. This prevents users from inferring that it is possible to add a token to the list when the token is already a member of the list, perhaps causing the list to contain duplicate members. Making that inference could cause them to do the unnecessary work of checking the list for the existence of a member before adding it.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add an exception in the specification missing from this description.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I needed to refer to the spec to determine what `classList.add()` does when the class is already in the list. Others are likely to want to know that, but the existing description suggests that a duplicate class would be added.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
