### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/htmlareaelement/index.md
+++ b/files/en-us/web/api/htmlareaelement/index.md
@@ -68,7 +68,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLAreaElement.toString()")}}
-  - : Returns a {{domxref("USVString")}} containing the whole URL of the script executed in the {{domxref("Worker")}}. It is a synonym for {{domxref("HTMLAreaElement.href")}}.
+  - : Returns a {{domxref("USVString")}} containing the whole URL. It is a synonym for {{domxref("HTMLAreaElement.href")}}.
 
 ## Specifications
 


### PR DESCRIPTION
The documentation states:
`Returns a USVString containing the whole URL of the script executed in the Worker.`, but I think it should rather state: `Returns a USVString containing the whole URL` similar to [anchor](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement#methods)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
