### PR TITLE
Fix levels of headings in CSS Cookbook

### DIFF
--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -47,7 +47,7 @@ I have used the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/ari
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### Flexbox
+### Flexbox
 
 {{Compat("css.properties.flex")}}
 

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -64,11 +64,11 @@ Depending on the content of your card there may be things you could, or should d
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### grid-template-columns
+### grid-template-columns
 
 {{Compat("css.properties.grid-template-columns")}}
 
-#### grid-template-rows
+### grid-template-rows
 
 {{Compat("css.properties.grid-template-rows")}}
 

--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.md
@@ -39,11 +39,11 @@ In the future we may be able to center elements without needing to turn the pare
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### align-items
+### align-items
 
 {{Compat("css.properties.align-items")}}
 
-#### justify-content
+### justify-content
 
 {{Compat("css.properties.justify-content")}}
 

--- a/files/en-us/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/en-us/web/css/layout_cookbook/column_layouts/index.md
@@ -93,23 +93,23 @@ Use Grid:
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### column-width
+### column-width
 
 {{Compat("css.properties.column-width")}}
 
-#### column-rule
+### column-rule
 
 {{Compat("css.properties.column-rule")}}
 
-#### flex
+### flex
 
 {{Compat("css.properties.flex")}}
 
-#### flex-wrap
+### flex-wrap
 
 {{Compat("css.properties.flex-wrap")}}
 
-#### grid-template-columns
+### grid-template-columns
 
 {{Compat("css.properties.grid-template-columns")}}
 

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -49,7 +49,7 @@ The various layout methods have different browser support. See the charts below 
 
 _Include the compat data for key properties you used, as in the example below which includes align-items._
 
-#### align-items
+### align-items
 
 {{Compat("css.properties.align-items")}}
 

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -71,7 +71,7 @@ Although Grid enables us to position items anywhere (within reason), it is impor
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### grid-template-columns
+### grid-template-columns
 
 {{Compat("css.properties.grid-template-columns")}}
 

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -40,11 +40,11 @@ To align the content horizontally, I use the {{cssxref("align-items")}} property
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### justify-content
+### justify-content
 
 {{Compat("css.properties.justify-content")}}
 
-#### align-items
+### align-items
 
 {{Compat("css.properties.align-items")}}
 

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.md
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.md
@@ -73,10 +73,10 @@ What you will need to do is remove any margins applied to the item, and any widt
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
 
-#### grid-template-areas
+### grid-template-areas
 
 {{Compat("css.properties.grid-template-areas")}}
 
-#### float
+### float
 
 {{Compat("css.properties.float")}}

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -63,11 +63,11 @@ The various layout methods have different browser support. See the charts below 
 
 _Include the compat data for key properties you used, as in the example below which includes align-items._
 
-#### justify-content
+### justify-content
 
 {{Compat("css.properties.justify-content")}}
 
-#### column-gap in Flex layout
+### column-gap in Flex layout
 
 {{Compat("css.properties.column-gap.flex_context")}}
 

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -49,19 +49,19 @@ The flexbox example starts out in the same way, but we use `display:flex` rather
 
 ## Browser compatibility
 
-#### grid-template-rows
+### grid-template-rows
 
 {{Compat("css.properties.grid-template-rows")}}
 
-#### flex-direction
+### flex-direction
 
 {{Compat("css.properties.flex-direction")}}
 
-#### flex-grow
+### flex-grow
 
 {{Compat("css.properties.flex-grow")}}
 
-#### flex-shrink
+### flex-shrink
 
 {{Compat("css.properties.flex-shrink")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Some levels of heading in CSS Cookbook are incorrect.

#### Motivation
This issue causes wrong appearance of the "Browser compatibility" section.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
