### PR TITLE
Clarify that some input types use Event; others InputEvent

### DIFF
--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -32,7 +32,7 @@ The **`input`** event fires when the `value` of an {{HTMLElement("input")}}, {{H
     </tr>
     <tr>
       <th scope="row">Interface</th>
-      <td>{{DOMxRef("InputEvent")}}</td>
+      <td>{{DOMxRef("InputEvent")}} or {{DOMxRef("Event")}}</td>
     </tr>
     <tr>
       <th scope="row">Event handler property</th>
@@ -44,6 +44,8 @@ The **`input`** event fires when the `value` of an {{HTMLElement("input")}}, {{H
 The event also applies to elements with {{domxref("HTMLElement.contentEditable", "contenteditable")}} enabled, and to any element when {{domxref("Document.designMode", "designMode")}} is turned on. In the case of `contenteditable` and `designMode`, the event target is the _editing host_. If these properties apply to multiple elements, the editing host is the nearest ancestor element whose parent isn't editable.
 
 For `<input>` elements with `type=checkbox` or `type=radio`, the `input` event should fire whenever a user toggles the control, per [the HTML5 specification](https://html.spec.whatwg.org/multipage/input.html#the-input-element:event-input-2). However, historically this has not always been the case. Check compatibility, or use the {{domxref("HTMLElement/change_event", "change")}} event instead for elements of these types.
+
+For `<textarea>` and`<input>` elements that accept text input `type=text`, `type=tel`, etc the interface is {{DOMxRef("InputEvent")}}, for others the interface is {{DOMxRef("Event")}}.
 
 > **Note:** The `input` event is fired every time the `value` of the element changes. This is unlike the {{domxref("HTMLElement/change_event", "change")}} event, which only fires when the value is committed, such as by pressing the enter key, selecting a value from a list of options, and the like.
 

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -45,7 +45,7 @@ The event also applies to elements with {{domxref("HTMLElement.contentEditable",
 
 For `<input>` elements with `type=checkbox` or `type=radio`, the `input` event should fire whenever a user toggles the control, per [the HTML5 specification](https://html.spec.whatwg.org/multipage/input.html#the-input-element:event-input-2). However, historically this has not always been the case. Check compatibility, or use the {{domxref("HTMLElement/change_event", "change")}} event instead for elements of these types.
 
-For `<textarea>` and`<input>` elements that accept text input `type=text`, `type=tel`, etc the interface is {{DOMxRef("InputEvent")}}, for others the interface is {{DOMxRef("Event")}}.
+For {{htmlelement("textarea")}} and {{htmlelement("input")}} elements that accept text input (`type=text`, `type=tel`, etc.), the interface is {{DOMxRef("InputEvent")}}; for others, the interface is {{DOMxRef("Event")}}.
 
 > **Note:** The `input` event is fired every time the `value` of the element changes. This is unlike the {{domxref("HTMLElement/change_event", "change")}} event, which only fires when the value is committed, such as by pressing the enter key, selecting a value from a list of options, and the like.
 


### PR DESCRIPTION
#### Summary
Change interface type of Input Event. For a few elements, the interface is `InputEvent`, for others it is `Event`

#### Motivation
The interface type mentioned is not accurate for input event.

#### Supporting details
For `<textarea>`, `<input>` that accept text input, the interface is `InputEvent`. 
Evaluated the type of event in `oninput` event handler for `<textarea>` and `input` with types:
- email
- number
- password
- text
- tel
- url 

For `select` and all other input types the interface is `Event`.

#### Related issues
Fixes #11120 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

