### PR TITLE
Remove not working CSS from ::target-text example

### DIFF
--- a/files/en-us/web/css/_doublecolon_target-text/index.md
+++ b/files/en-us/web/css/_doublecolon_target-text/index.md
@@ -32,7 +32,6 @@ The **`::target-text`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/
 ::target-text {
   background-color: rebeccapurple;
   color: white;
-  font-weight: bold;
 }
 ```
 


### PR DESCRIPTION
#### Summary
[According to the spec](https://drafts.csswg.org/css-pseudo-4/#highlight-selectors) there is no way to change font-weight for the highlighting pseudos.

#### Motivation
Let's save hours of debugging for developers :)

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
