### PR TITLE
Add HTML DOM API to web apis

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -588,6 +588,7 @@
       "events": []
     },
     "HTML DOM": {
+      "overview": ["HTML DOM API"],
       "interfaces": [
         "BeforeUnloadEvent",
         "DOMStringMap",


### PR DESCRIPTION
Fixes #11498

This makes the HTML Dom API overview link from the main [Web API](https://developer.mozilla.org/en-US/docs/Web/API) page.