### PR TITLE
Remove reference to pref privacy.file_unique_origin

### DIFF
--- a/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
@@ -43,8 +43,7 @@ origin for purposes of the CORS same-origin rule.
 In response to [CVE-2019-11730](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730),
 Firefox 68 and later define the origin of a page opened using a `file:///`
 URI as unique. Therefore, other resources in the same directory or its subdirectories no
-longer satisfy the CORS same-origin rule. This new behavior is enabled by default using
-the `privacy.file_unique_origin` preference.
+longer satisfy the CORS same-origin rule.
 
 ## See also
 


### PR DESCRIPTION
This pref was removed by https://bugzilla.mozilla.org/show_bug.cgi?id=1732052 in Firefox 95.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
