### PR TITLE
HTMLAreaElement.hostname - add live example

### DIFF
--- a/files/en-us/web/api/htmlareaelement/hostname/index.md
+++ b/files/en-us/web/api/htmlareaelement/hostname/index.md
@@ -10,25 +10,39 @@ browser-compat: api.HTMLAreaElement.hostname
 ---
 {{ApiRef("HTML DOM")}}
 
-The **`HTMLAreaElement.hostname`** property is a
-{{domxref("USVString")}} containing the domain of the URL.
+The **`HTMLAreaElement.hostname`** property is a {{domxref("USVString")}} containing the domain of the URL.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.hostname;
-// Setter
-area.hostname = string;
-```
+A {{domxref("USVString")}} containing the domain of the URL associated with the area element.
+It can be used as both a setter and getter.
+
 
 ## Examples
 
-```js
-// An <area id="myArea" href="/en-US/docs/HTMLAreaElement"> element is in the document
-const area = document.getElementById("myArea");
-HTMLAreaElement.hostname; // returns 'developer.mozilla.org'
+```html
+<textarea id="log" rows="4" cols="100"></textarea>
+<map name="infographic">
+    <area id="area1" shape="rect" coords="184,6,253,27"
+          href="/en-US/docs/HTMLAreaElement"
+          target="_blank" alt="Mozilla" />
+    <area  id="area2" shape="circle" coords="130,136,60"
+          href="https://coolexample.com/"
+          target="_blank" alt="MDN" />
+</map>
 ```
+
+```js
+// An  element is in the document
+const area1 = document.getElementById("area1");
+const area2 = document.getElementById("area2");
+
+const log = document.getElementById("log");
+log.textContent = `area1 hostname: ${ area1.hostname } \n`; // 'developer.mozilla.org'
+log.textContent += `area2 hostname: ${ area2.hostname }`;  // 'coolexample.com'
+```
+
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlareaelement/hostname/index.md
+++ b/files/en-us/web/api/htmlareaelement/hostname/index.md
@@ -14,7 +14,7 @@ The **`HTMLAreaElement.hostname`** property is a {{domxref("USVString")}} contai
 
 ## Value
 
-A {{domxref("USVString")}} containing the domain of the URL associated with the area element.
+A {{domxref("USVString")}} containing the domain of the URL associated with the `area` element.
 It can be used as both a setter and getter.
 
 


### PR DESCRIPTION
[HTMLAreaElement/hostname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAreaElement/hostname) had old-style property syntax block and a very simple example.

Modified to new style syntax and also embedded a live example.