### PR TITLE
DOMTokenList.add() - add exceptions and fixup syntax

### DIFF
--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -36,7 +36,7 @@ None.
 
 ## Examples
 
-In the following example we retrieve the list of classes set on a {{htmlelement("span")}} element as a `DOMTokenList` using {{domxref("Element.classList")}}.
+In the following example, we retrieve the list of classes set on a {{htmlelement("span")}} element as a `DOMTokenList`, using {{domxref("Element.classList")}}.
 We then add a new token to the list, and write the list into the `<span>`'s {{domxref("Node.textContent")}}.
 
 First, the HTML:

--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -8,32 +8,36 @@ browser-compat: api.DOMTokenList.add
 ---
 {{APIRef("DOM")}}
 
-The **`add()`** method of the {{domxref("DOMTokenList")}} interface adds the given _tokens_, except those already present, to the list.
+The **`add()`** method of the {{domxref("DOMTokenList")}} interface adds the given tokens to the list, omitting any that are already present.
 
 ## Syntax
 
 ```js
-add(token);
-add(token, token);
-add(token, token, token);
-...
+add(token0);
+add(token0, token1);
+add(token0, token1, /* ... ,*/ tokenN)
 ```
 
 ### Parameters
 
-- `token`
+- `tokenN`
   - : A string representing a token (or tokens) to add to the `DOMTokenList`.
 
 ### Return value
 
 None.
 
+### Exceptions
+
+- `SyntaxError` {{domxref("DOMException")}}
+  - : One of the arguments is the empty string
+- `InvalidCharacterError` {{domxref("DOMException")}}
+  - : A token contains ASCII whitespace.
+
 ## Examples
 
-In the following example we retrieve the list of classes set on a
-{{htmlelement("span")}} element as a `DOMTokenList` using
-{{domxref("Element.classList")}}. We then add a new token to the list, and write the
-list into the `<span>`'s {{domxref("Node.textContent")}}.
+In the following example we retrieve the list of classes set on a {{htmlelement("span")}} element as a `DOMTokenList` using {{domxref("Element.classList")}}.
+We then add a new token to the list, and write the list into the `<span>`'s {{domxref("Node.textContent")}}.
 
 First, the HTML:
 


### PR DESCRIPTION
Fix up [DOMTokenList.add()](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add) to include possible exceptions and make the syntax match [style guidance](https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#syntax_for_arbitrary_number_of_parameters)

