### PR TITLE
Clear-Site-Data cache - behind pref in 94

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1615,6 +1615,51 @@ This also changes the console warning; if the upgrade succeeds, the message indi
   </tbody>
 </table>
 
+
+### Clear-Site-Data
+
+The [Clear-Site-Data](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP response header clears browsing data (cookies, storage, cache) associated with the requesting website. It allows web developers to have more control over the data stored by a client browser for their origins.
+
+> **Note:** This was originally enabled by default, but put behind a preference in version 94 ({{bug(1729291)}}).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>63</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>63</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>63</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>63</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+        <code>privacy.clearsitedata.cache.enabled</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Developer tools
 
 Mozilla's developer tools are constantly evolving. We experiment with new ideas, add new features, and test them on the Nightly and Developer Edition channels before letting them go through to beta and release. The features below are the current crop of experimental developer tool features.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1616,9 +1616,9 @@ This also changes the console warning; if the upgrade succeeds, the message indi
 </table>
 
 
-### Clear-Site-Data
+### Clear-Site-Data "cache" directive
 
-The [Clear-Site-Data](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP response header clears browsing data (cookies, storage, cache) associated with the requesting website. It allows web developers to have more control over the data stored by a client browser for their origins.
+The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP response header `cache` directive clears the browser cache for the requesting website.
 
 > **Note:** This was originally enabled by default, but put behind a preference in version 94 ({{bug(1729291)}}).
 

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -39,6 +39,11 @@ No notable changes
 
 - `WebDriver:GetWindowHandle` and `WebDriver:GetWindowHandles` now return handles for browser windows instead of tabs, when chrome scope is enabled ({{bug(1729291)}})
 
+### HTTP
+
+- [Clear-Site-Data](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) is has been disabled by default.
+  It can be enabled using the preference `privacy.clearsitedata.cache.enabled` ({{bug(1729291)}}).
+
 ## Changes for add-on developers
 
 - Support for `partitionKey`, the first-party URL of a cookie when it's in storage that is partitioned by top-level site, is added to {{WebExtAPIRef('cookies.get')}}, {{WebExtAPIRef('cookies.getAll')}}, {{WebExtAPIRef('cookies.set')}}, {{WebExtAPIRef('cookies.remove')}}, and {{WebExtAPIRef('cookies.cookie')}}. ({{bug(1669716)}})

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -41,7 +41,7 @@ No notable changes
 
 ### HTTP
 
-- [Clear-Site-Data](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) is has been disabled by default.
+- The `cache` directive of the [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) response header has been disabled by default.
   It can be enabled using the preference `privacy.clearsitedata.cache.enabled` ({{bug(1729291)}}).
 
 ## Changes for add-on developers


### PR DESCRIPTION
Fixes #11395

The [Clear-Site-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#directives) "`cache`" directive was disabled by default in FF94. This updates the docs appropriately a release note and experimental features entry. BCD was sorted a few weeks ago.