### PR TITLE
HTTP Client hints - move big glossary into guide

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -3603,6 +3603,7 @@
 /en-US/docs/Glossary/Block/Block_(scripting)	/en-US/docs/Glossary/Block/Scripting
 /en-US/docs/Glossary/CSS_property	/en-US/docs/Glossary/property/CSS
 /en-US/docs/Glossary/Cleartext	/en-US/docs/Glossary/Plaintext
+/en-US/docs/Glossary/Client_hints	/en-US/docs/Web/HTTP/Client_hints
 /en-US/docs/Glossary/Condition	/en-US/docs/Glossary/Conditional
 /en-US/docs/Glossary/Content_type	/en-US/docs/Glossary/MIME_type
 /en-US/docs/Glossary/DTD	/en-US/docs/Glossary/Doctype

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -1861,14 +1861,6 @@
       "sushant1221"
     ]
   },
-  "Glossary/Client_hints": {
-    "modified": "2019-07-01T18:32:07.538Z",
-    "contributors": [
-      "Malvoz",
-      "jswisher",
-      "estelle"
-    ]
-  },
   "Glossary/Closure": {
     "modified": "2019-03-23T23:10:57.372Z",
     "contributors": [
@@ -123409,6 +123401,14 @@
       "anthony-geoghegan",
       "teoli",
       "kohei.yoshino"
+    ]
+  },
+  "Web/HTTP/Client_hints": {
+    "modified": "2019-07-01T18:32:07.538Z",
+    "contributors": [
+      "Malvoz",
+      "jswisher",
+      "estelle"
     ]
   },
   "Web/HTTP/Compression": {

--- a/files/en-us/web/api/device_memory_api/index.md
+++ b/files/en-us/web/api/device_memory_api/index.md
@@ -22,7 +22,7 @@ var RAM = navigator.deviceMemory;
 
 ### Client Hints
 
-You may also use the [Client Hints](/en-US/docs/Glossary/Client_hints) HTTP Header with the `Device-Memory` directive to retrieve the same approximate RAM capacity.
+You may also use the [Client Hints](/en-US/docs/Web/HTTP/Client_hints) HTTP Header with the `Device-Memory` directive to retrieve the same approximate RAM capacity.
 
 ## Specifications
 

--- a/files/en-us/web/api/user-agent_client_hints_api/index.md
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.md
@@ -10,7 +10,7 @@ browser-compat: api.NavigatorUAData
 ---
 {{DefaultAPISidebar("User-Agent Client Hints API")}}
 
-The User-Agent Client Hints API extends [Client Hints](/en-US/docs/Glossary/Client_hints) to provide a way of exposing browser and platform information via User-Agent response and request headers, and a JavaScript API.
+The User-Agent Client Hints API extends [Client Hints](/en-US/docs/Web/HTTP/Client_hints) to provide a way of exposing browser and platform information via User-Agent response and request headers, and a JavaScript API.
 
 ## Concepts and Usage
 

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -1,12 +1,11 @@
 ---
-title: Client hints
-slug: Glossary/Client_hints
+title: HTTP Client hints
+slug: Web/HTTP/Client_hints
 tags:
   - Client hints
-  - Glossary
+  - Guide
+  - HTTP
   - Performance
-  - Reference
-  - Web Performance
 ---
 **Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client to get information about the device, network, user and user-agent specific preferences.
 The server can determine which resources to send, based on the information that the client chooses to provide.

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP
   - Performance
 ---
-**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client to get information about the device, network, user, and user-agent specific preferences.
+**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client to get information about the device, network, user, and user-agent-specific preferences.
 The server can determine which resources to send, based on the information that the client chooses to provide.
 
 The set of "hint" headers are listed in the topic [HTTP Headers](/en-US/docs/Web/HTTP/Headers#client_hints) and [summarized below](#hint_types).

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP
   - Performance
 ---
-**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client to get information about the device, network, user and user-agent specific preferences.
+**Client Hints** are a set of [HTTP request header](/en-US/docs/Web/HTTP/Headers) fields that a server can proactively request from a client to get information about the device, network, user, and user-agent specific preferences.
 The server can determine which resources to send, based on the information that the client chooses to provide.
 
 The set of "hint" headers are listed in the topic [HTTP Headers](/en-US/docs/Web/HTTP/Headers#client_hints) and [summarized below](#hint_types).

--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.md
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.md
@@ -17,7 +17,7 @@ browser-compat: http.headers.Accept-CH-Lifetime
 > **Warning:** The header was removed from the specification in [draft 8](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-08).
 
 The **`Accept-CH-Lifetime`** header is set by the server to
-specify the persistence of the [client hint headers](/en-US/docs/Glossary/Client_hints) it specified using {{HTTPHeader("Accept-CH")}}, that the client should
+specify the persistence of the [client hint headers](/en-US/docs/Web/HTTP/Client_hints) it specified using {{HTTPHeader("Accept-CH")}}, that the client should
 include in subsequent requests.
 
 <table class="properties">

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -12,7 +12,7 @@ browser-compat: http.headers.Accept-CH
 {{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
 
 The **`Accept-CH`** header may be set by a server to specify
-which [client hints](/en-US/docs/Glossary/Client_hints) headers a client
+which [client hints](/en-US/docs/Web/HTTP/Client_hints) headers a client
 should include in subsequent requests.
 
 <table class="properties">
@@ -50,7 +50,7 @@ Accept-CH: Viewport-Width, Width
 Vary: Viewport-Width, Width
 ```
 
-> **Note:** Remember to [vary the response](/en-US/docs/Glossary/Client_hints#varying_client_hints)
+> **Note:** Remember to [vary the response](/en-US/docs/Web/HTTP/Client_hints#varying_client_hints)
 > based on the accepted client hints.
 
 ## Specifications

--- a/files/en-us/web/http/headers/content-dpr/index.md
+++ b/files/en-us/web/http/headers/content-dpr/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.Content-DPR
 ---
 {{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
 
-The **`Content-DPR`** response header is used to confirm the _image_ device to pixel ratio in requests where the screen {{HTTPHeader("DPR")}} [client hint](/en-US/docs/Glossary/Client_hints) was used to select an image resource.
+The **`Content-DPR`** response header is used to confirm the _image_ device to pixel ratio in requests where the screen {{HTTPHeader("DPR")}} [client hint](/en-US/docs/Web/HTTP/Client_hints) was used to select an image resource.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.DPR
 ---
 {{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
 
-The **`DPR`** [device client hint](/en-US/docs/Glossary/Client_hints) request header provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every {{Glossary("CSS pixel")}}.
+The **`DPR`** [device client hint](/en-US/docs/Web/HTTP/Client_hints) request header provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every {{Glossary("CSS pixel")}}.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -81,7 +81,7 @@ The different categories of client hints are listed below.
 
 ### User agent client hints
 
-The [UA client hints](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) are request headers that provide information about the user agent and the platform/architecture on which it is running:
+The [UA client hints](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) are request headers that provide information about the user agent and the platform/architecture on which it is running:
 
 - {{HTTPHeader("Sec-CH-UA")}} {{experimental_inline}}
   - : User agent's branding and version.

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Arch
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Arch`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's underlying CPU architecture, such as ARM or x86.
+The **`Sec-CH-UA-Arch`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's underlying CPU architecture, such as ARM or x86.
 
 This might be used by a server, for example, to select and offer the correct binary format of an executable for a user to download.
 
@@ -68,7 +68,7 @@ Sec-CH-UA-Platform: "Windows"
 Sec-CH-UA-Arch: "x86"
 ```
 
-Note above that the [low entropy headers](/en-US/docs/Glossary/Client_hints#low_entropy_hints) are added to the request even though not specified in the server response.
+Note above that the [low entropy headers](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints) are added to the request even though not specified in the server response.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Bitness
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Bitness`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the "bitness" of the user-agent's underlying CPU architecture. 
+The **`Sec-CH-UA-Bitness`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the "bitness" of the user-agent's underlying CPU architecture. 
 This is the size in bits of an integer or memory address—typically 64 or 32 bits.
 
 This might be used by a server, for example, to select and offer the correct binary format of an executable for a user to download.

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Full-Version-List
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and full version information.
+The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and full version information.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -15,7 +15,7 @@ browser-compat: http.headers.Sec-CH-UA-Full-Version
 
 > **Note:** This is being replaced by the {{HTTPHeader("Sec-CH-UA-Full-Version-List")}}.
 
-The **`Sec-CH-UA-Full-Version`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's full version string.
+The **`Sec-CH-UA-Full-Version`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's full version string.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -13,10 +13,10 @@ browser-compat: http.headers.Sec-CH-UA-Mobile
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Mobile`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header indicates whether the browser is on a mobile device.
+The **`Sec-CH-UA-Mobile`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header indicates whether the browser is on a mobile device.
 It can also be used by a desktop browser to indicate a preference for a "mobile" user experience.
 
-`Sec-CH-UA-Mobile` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+`Sec-CH-UA-Mobile` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints).
 Unless blocked by a user agent permission policy, it is sent by default, without the server opting in by sending {{HTTPHeader("Accept-CH")}}.
 
 <table class="properties">
@@ -51,7 +51,7 @@ Sec-CH-UA-Mobile: <boolean>
 
 ## Examples
 
-As `Sec-CH-UA-Mobile` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints) it is typically sent in all requests.
+As `Sec-CH-UA-Mobile` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints) it is typically sent in all requests.
 
 A desktop browser would usually send requests with the following header:
 

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Model
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Model`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header indicates the device model on which the browser is running.
+The **`Sec-CH-UA-Model`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header indicates the device model on which the browser is running.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Platform-Version
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the version of the operating system on which the user agent is running. 
+The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the version of the operating system on which the user agent is running. 
 
 
 <table class="properties">

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -13,10 +13,10 @@ browser-compat: http.headers.Sec-CH-UA-Platform
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Platform`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the platform or operating system on which the user agent is running. 
+The **`Sec-CH-UA-Platform`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the platform or operating system on which the user agent is running. 
 For example: "Windows" or "Android".
 
-`Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+`Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints).
 Unless blocked by a user agent permission policy, it is sent by default (without the server opting in by sending {{HTTPHeader("Accept-CH")}}).
 
 <table class="properties">
@@ -50,7 +50,7 @@ Sec-CH-UA-Platform: <platform>
 
 ## Examples
 
-As `Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints) it is typically sent in all requests.
+As `Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints) it is typically sent in all requests.
 
 A browser running on a macOS computer might add the following header to all requests.
 

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Glossary/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and significant version information.
+The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and significant version information.
 
 <table class="properties">
   <tbody>
@@ -42,7 +42,7 @@ For example a Chromium build with _full version number_ "96.0.4664.45" has a sig
 
 The header therefore allows the server to customise its response based on both shared brands and on particular customisations in their respective versions.
 
-`Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+`Sec-CH-UA` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints).
 Unless blocked by a user agent permission policy, it is sent by default, without the server opting in by sending {{HTTPHeader("Accept-CH")}}.
 
 The header may include "fake" brands in any position and with any name.
@@ -69,7 +69,7 @@ Sec-CH-UA: "<brand>";v="<significant version>", ...
 
 ## Examples
 
-`Sec-CH-UA` is a [low entropy hint](/en-US/docs/Glossary/Client_hints#low_entropy_hints).
+`Sec-CH-UA` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints).
 Unless explicitly blocked by a user agent policy, it will be sent in all requests (without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}).
 
 Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below. 

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.Viewport-Width
 ---
 {{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
 
-The **`Viewport-Width`** [device client hint](/en-US/docs/Glossary/Client_hints) request header provides the client's layout viewport width in {{Glossary("CSS pixel","CSS pixels")}}. The value is rounded up to the smallest following integer (i.e. ceiling value).
+The **`Viewport-Width`** [device client hint](/en-US/docs/Web/HTTP/Client_hints) request header provides the client's layout viewport width in {{Glossary("CSS pixel","CSS pixels")}}. The value is rounded up to the smallest following integer (i.e. ceiling value).
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -26,6 +26,9 @@ Learn how to use HTTP with guides and tutorials.
   - : How cookies work is defined by [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265). When serving an HTTP request, a server can send a `Set-Cookie` HTTP header with the response. The client then returns the cookie's value with every request to the same server in the form of a `Cookie` request header. The cookie can also be set to expire on a certain date, or restricted to a specific domain and path.
 - [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
   - : **Cross-site HTTP requests** are HTTP requests for resources from a **different domain** than the domain of the resource making the request. For instance, an HTML page from Domain A (`http://domaina.example/`) makes a request for an image on Domain B (`http://domainb.foo/image.jpg`) via the `img` element. Web pages today very commonly load cross-site resources, including CSS stylesheets, images, scripts, and other resources. CORS allows web developers to control how their site reacts to cross-site requests.
+- [HTTP Client Hints](/en-US/docs/Web/HTTP/Client_hints)
+  - : **Client Hints** are a set of response headers that a server can use to proactively request information from a client about the device, network, user and user-agent specific preferences.
+    The server can then determine which resources to send, based on the information that the client chooses to provide.
 - [Evolution of HTTP](/en-US/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP)
   - : A brief description of the changes between the early versions of HTTP, to the modern HTTP/2, the emergent HTTP/3 and beyond.
 - [Mozilla web security guidelines](https://wiki.mozilla.org/Security/Guidelines/Web_Security)

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -27,7 +27,7 @@ Learn how to use HTTP with guides and tutorials.
 - [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
   - : **Cross-site HTTP requests** are HTTP requests for resources from a **different domain** than the domain of the resource making the request. For instance, an HTML page from Domain A (`http://domaina.example/`) makes a request for an image on Domain B (`http://domainb.foo/image.jpg`) via the `img` element. Web pages today very commonly load cross-site resources, including CSS stylesheets, images, scripts, and other resources. CORS allows web developers to control how their site reacts to cross-site requests.
 - [HTTP Client Hints](/en-US/docs/Web/HTTP/Client_hints)
-  - : **Client Hints** are a set of response headers that a server can use to proactively request information from a client about the device, network, user, and user-agent specific preferences.
+  - : **Client Hints** are a set of response headers that a server can use to proactively request information from a client about the device, network, user, and user-agent-specific preferences.
     The server can then determine which resources to send, based on the information that the client chooses to provide.
 - [Evolution of HTTP](/en-US/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP)
   - : A brief description of the changes between the early versions of HTTP, to the modern HTTP/2, the emergent HTTP/3 and beyond.

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -27,7 +27,7 @@ Learn how to use HTTP with guides and tutorials.
 - [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
   - : **Cross-site HTTP requests** are HTTP requests for resources from a **different domain** than the domain of the resource making the request. For instance, an HTML page from Domain A (`http://domaina.example/`) makes a request for an image on Domain B (`http://domainb.foo/image.jpg`) via the `img` element. Web pages today very commonly load cross-site resources, including CSS stylesheets, images, scripts, and other resources. CORS allows web developers to control how their site reacts to cross-site requests.
 - [HTTP Client Hints](/en-US/docs/Web/HTTP/Client_hints)
-  - : **Client Hints** are a set of response headers that a server can use to proactively request information from a client about the device, network, user and user-agent specific preferences.
+  - : **Client Hints** are a set of response headers that a server can use to proactively request information from a client about the device, network, user, and user-agent specific preferences.
     The server can then determine which resources to send, based on the information that the client chooses to provide.
 - [Evolution of HTTP](/en-US/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP)
   - : A brief description of the changes between the early versions of HTTP, to the modern HTTP/2, the emergent HTTP/3 and beyond.


### PR DESCRIPTION
The [Client hints](https://developer.mozilla.org/en-US/docs/Glossary/Client_hints) topic is no longer appropriate as a glossary entry. This moves it to a top level guide for HTTP. I redirected, but also moved all the internal glossary links to the new location.