### PR TITLE
Fixes incorrect number of precedence levels

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -230,7 +230,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
 
 ## Table
 
-The following table lists operators in order from highest precedence (21) to lowest precedence (1).
+The following table lists operators in order from highest precedence (19) to lowest precedence (1).
 
 Note that [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) is intentionally not included in the table — because, to quote an [an answer at Stack Overflow](https://stackoverflow.com/a/48656377), “[Spread syntax is not an operator](https://stackoverflow.com/q/44934828/1048572) and therefore does not have a precedence. It is part of the array literal and function call (and object literal) syntax.”
 


### PR DESCRIPTION
Follows on from #11509 

Above the table it said there were 21 levels, but there are only 19. The number of items was reduced in https://github.com/mdn/content/pull/10479