### PR TITLE
Clarification of class of objects returned

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -90,9 +90,9 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
 - {{domxref("HTMLMediaElement.srcObject")}}
   - : Is a {{domxref('MediaStream')}} representing the media to play or that has played in the current `HTMLMediaElement`, or `null` if not assigned.
 - {{domxref("HTMLMediaElement.textTracks")}} {{readonlyinline}}
-  - : Returns the list of {{domxref("TextTrack")}} objects contained in the element.
+  - : Returns a {{domxref('TextTrackList')}} object containing the list of {{domxref("TextTrack")}} objects contained in the element.
 - {{domxref("HTMLMediaElement.videoTracks")}} {{readonlyinline}}
-  - : Returns the list of {{domxref("VideoTrack")}} objects contained in the element.
+  - : Returns a {{domxref('VideoTrackList')}} object containing the list of {{domxref("VideoTrack")}} objects contained in the element.
 - {{domxref("HTMLMediaElement.volume")}}
   - : Is a `double` indicating the audio volume, from 0.0 (silent) to 1.0 (loudest).
 
@@ -119,7 +119,7 @@ These properties are obsolete and should not be used, even if a browser still su
 _This interface also inherits methods from its ancestors {{domxref("HTMLElement")}}, {{domxref("Element")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
 - {{domxref("HTMLMediaElement.addTextTrack()")}}
-  - : Adds a text track (such as a track for subtitles) to a media element.
+  - : Adds a new {{domxref("TextTrack")}} object (such as a track for subtitles) to a media element. This is a programmatic interface only and does not affect the DOM.
 - {{domxref("HTMLMediaElement.captureStream()")}} {{experimental_inline}}
   - : Returns {{domxref("MediaStream")}}, captures a stream of the media content.
 - {{domxref("HTMLMediaElement.canPlayType()")}}


### PR DESCRIPTION
Clarified the objects returned by the properties `textTracks` and `videoTracks` and provided clearer description for `addTextTrack`
Incidentally, I think the documentation needs to make it more clear the role of `TextTrack` interface that can be instantiated directly by this `addTextTrack` method and the `HTMLTrackElement` itself that has this `track` method pointing to `TextTrack` class.
It could be useful to explain that `TextTrack` class is only a programmatic interface with no impact on the DOM whereas `HTMLTrackElement` accesses and modifies the DOM and makes use of this programmatic interface with `TextTrack` through its method `track`.
Or did I understand it wrong?

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
