### PR TITLE
Performance.measure() - update with measureoptions

### DIFF
--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -47,12 +47,12 @@ If only `measureName` is specified, the start timestamp is set to zero, and the 
         - : Arbitrary metadata to be included in the measure.
       - `start`
         - : Timestamp {{domxref("DOMHighResTimeStamp")}} to be used as the start time, or {{domxref("DOMString")}} to be used as start mark.
-          If this represents the name of a start mark then it is defined in the same way as `startMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
+          If this represents the name of a start mark, then it is defined in the same way as `startMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
       - `duration`
         - : Duration between the start and end mark times ({{domxref("DOMHighResTimeStamp")}}).
       - `end`
         - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or {{domxref("DOMString")}} to be used as end mark.
-          If this represents the name of an end mark then it is defined in the same way as `endMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
+          If this represents the name of an end mark, then it is defined in the same way as `endMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
 
 - `startMark` {{optional_inline}}
   - : A {{domxref("DOMString")}} representing the name of the measure's starting mark.
@@ -74,18 +74,18 @@ The returned _measure_ will have the following property values:
 - {{domxref("PerformanceEntry.entryType","entryType")}} - set to "`measure`".
 - {{domxref("PerformanceEntry.name","name")}} - set to the "`name`" argument.
 - {{domxref("PerformanceEntry.startTime","startTime")}} - set to:
-  - a {{domxref("DOMHighResTimeStamp","timestamp")}} if specified in `MeasureOptions.start`.
-  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of a start mark if specified in `MeasureOptions.start` or `startMark`
+  - a {{domxref("DOMHighResTimeStamp","timestamp")}}, if specified in `MeasureOptions.start`.
+  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of a start mark, if specified in `MeasureOptions.start` or `startMark`
   - a timestamp calculated from the `MeasureOptions.end` and `MeasureOptions.duration` (if `MeasureOptions.start` was not specified)
-  - 0 if it isn't specified and can't be determined from other values.
+  - 0, if it isn't specified and can't be determined from other values.
   
 - {{domxref("PerformanceEntry.duration","duration")}} - set to a {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure calculated by subtracting the `startTime` from the end timestamp.
 
   The end timestamp is one of:
-  - a {{domxref("DOMHighResTimeStamp","timestamp")}} if specified in `MeasureOptions.end`.
-  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of an end mark if one is specified in `MeasureOptions.end` or `endMark`
+  - a {{domxref("DOMHighResTimeStamp","timestamp")}}, if specified in `MeasureOptions.end`.
+  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of an end mark, if one is specified in `MeasureOptions.end` or `endMark`
   - a timestamp calculated from the `MeasureOptions.start` and `MeasureOptions.duration` (if `MeasureOptions.end` was not specified)
-  - the value returned by {{domxref("Performance.now()")}} if no end mark is specified or can be determined from other values.
+  - the value returned by {{domxref("Performance.now()")}}, if no end mark is specified or can be determined from other values.
 - {{domxref("PerformanceMeasure","detail")}} - set to the value passed in `MeasureOptions`.
 
 ## Exceptions

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -11,68 +11,110 @@ browser-compat: api.Performance.measure
 ---
 {{APIRef("User Timing API")}}
 
-The **`measure()`** method creates a named
-{{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's _performance entry
-buffer_ between marks, the navigation start time, or the current time. When
-measuring between two marks, there is a _start mark_ and _end mark_,
-respectively. The named timestamp is referred to as a _measure_.
+The **`measure()`** method creates a named {{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's _performance entry buffer_ between marks, the navigation start time, or the current time.
 
-The `measure` can also be retrieved by one of the {{domxref("Performance")}}
-interfaces: ({{domxref("Performance.getEntries","getEntries()")}},
+When measuring between two marks, there is a _start mark_ and _end mark_, respectively.
+The named timestamp is referred to as a _measure_.
+
+The `measure` can be retrieved using any of the {{domxref("Performance")}} interfaces:
+({{domxref("Performance.getEntries","getEntries()")}},
 {{domxref("Performance.getEntriesByName","getEntriesByName()")}} or
 {{domxref("Performance.getEntriesByType","getEntriesByType()")}}).
 
-The `measure`'s {{domxref("PerformanceEntry","performance entry")}} will
-have the following property values:
-
-- {{domxref("PerformanceEntry.entryType","entryType")}} - set to
-  "`measure`".
-- {{domxref("PerformanceEntry.name","name")}} - set to the "`name`" given
-  when the measure was created.
-- {{domxref("PerformanceEntry.startTime","startTime")}} - set to the start mark
-  {{domxref("DOMHighResTimeStamp","timestamp")}}.
-- {{domxref("PerformanceEntry.duration","duration")}} - set to a
-  {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure (typically, the
-  end mark timestamp minus the start mark timestamp).
 
 {{AvailableInWorkers}}
 
 ## Syntax
 
 ```js
-performance.measure(name);
-performance.measure(name, startMark);
-performance.measure(name, startMark, endMark);
-performance.measure(name, undefined, endMark);
+measure(measureName)
+measure(measureName, MeasureOptions)
+measure(measureName, startMark)
+measure(measureName, startMark, endMark)
 ```
+
+If only `measureName` is specified the start timestamp is set to zero, the end timestamp (which is used to calculate the duration) is the value that would be returned by {{domxref("Performance.now()")}}.
 
 ### Arguments
 
-- name
+- `measureName`
   - : A {{domxref("DOMString")}} representing the name of the measure.
-- startMark {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the measure's starting mark. May
-    also be the name of a {{domxref("PerformanceTiming")}} property. If it is omitted,
-    then the start time will be the navigation start time. Specifying a name that does not
-    represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}}
-    raises a {{domxref("DOMException")}}.
-- endMark {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the measure's ending mark. May
-    also be the name of a {{domxref("PerformanceTiming")}} property. If it is omitted,
-    then the current time is used. Specifying a name that does not represent an existing 
-    {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a 
-    {{domxref("DOMException")}}.
+
+- `MeasureOptions` {{optional_inline}}
+  - : An object that may contain all measure options (the `startMark` and `endMark` may be specified in this object or as their own arguments):
+
+      - `detail`
+        - : Arbitrary metadata to be included in the measure.
+      - `start`
+        - : Timestamp {{domxref("DOMHighResTimeStamp")}} to be used as the start time, or {{domxref("DOMString")}} to be used as start mark.
+          If this represents the name of a start mark then it is defined in the same way as `startMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
+      - `duration`
+        - : Duration between the start and end mark times ({{domxref("DOMHighResTimeStamp")}}).
+      - `end`
+        - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or {{domxref("DOMString")}} to be used as end mark.
+          If this represents the name of an end mark then it is defined in the same way as `endMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
+
+- `startMark` {{optional_inline}}
+  - : A {{domxref("DOMString")}} representing the name of the measure's starting mark.
+    May also be the name of a {{domxref("PerformanceTiming")}} property.
+    Specifying a name that does not represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a `SyntaxError` {{domxref("DOMException")}}.
+
+- `endMark` {{optional_inline}}
+  - : A {{domxref("DOMString")}} representing the name of the measure's ending mark.
+    This may also be the name of a {{domxref("PerformanceTiming")}} property.
+    Specifying a name that does not represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a `SyntaxError` {{domxref("DOMException")}}.
+
 
 ### Return value
 
-- entry
-  - : The {{domxref("PerformanceMeasure")}} entry that was created.
+The {{domxref("PerformanceMeasure")}} entry that was created.
+
+The returned _measure_ will have the following property values:
+
+- {{domxref("PerformanceEntry.entryType","entryType")}} - set to "`measure`".
+- {{domxref("PerformanceEntry.name","name")}} - set to the "`name`" argument.
+- {{domxref("PerformanceEntry.startTime","startTime")}} - set to:
+  - a {{domxref("DOMHighResTimeStamp","timestamp")}} if specified in `MeasureOptions.start`.
+  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of a start mark if specified in `MeasureOptions.start` or `startMark`
+  - a timestamp calculated from the `MeasureOptions.end` and `MeasureOptions.duration` (if `MeasureOptions.start` was not specified)
+  - 0 if it isn't specified and can't be determined from other values.
+  
+- {{domxref("PerformanceEntry.duration","duration")}} - set to a {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure calculated by subtracting the `startTime` from the end timestamp.
+
+  The end timestamp is one of:
+  - a {{domxref("DOMHighResTimeStamp","timestamp")}} if specified in `MeasureOptions.end`.
+  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of an end mark if one is specified in `MeasureOptions.end` or `endMark`
+  - a timestamp calculated from the `MeasureOptions.start` and `MeasureOptions.duration` (if `MeasureOptions.end` was not specified)
+  - the value returned by {{domxref("Performance.now()")}} if no end mark is specified or can be determined from other values.
+- {{domxref("PerformanceMeasure","detail")}} - set to the value passed in `MeasureOptions`.
+
+## Exceptions
+
+- `TypeError` {{domxref("DOMException")}}
+  - : This can be thrown in any case where the start, end or duration might be ambiguous:
+    
+    - Both `endMark` and `MeasureOptions` are specified.
+    - `MeasureOptions` is specified without either `start` and `end` members.
+    - `MeasureOptions` is specified with all of `start`, `end`, and `duration` members (which might then be inconsistent).
+
+- `SyntaxError` {{domxref("DOMException")}}
+  - : The named mark does not exist.
+
+    - An end mark is specified using either `endMark` or `MeasureOptions.end`, but there is no {{domxref('PerformanceMark')}} in the performance buffer with the matching name.
+    - An end mark is specified using either `endMark` or `MeasureOptions.end`, but it cannot be converted to match that of a read only attribute in the {{domxref("PerformanceTiming")}} interface.
+    - A start mark is specified using either `startMark` or `MeasureOptions.start`, but there is no {{domxref('PerformanceMark')}} in the performance buffer with the matching name.
+    - A start mark is specified using either `startMark` or `MeasureOptions.start`, but it cannot be converted to match that of a read only attribute in the {{domxref("PerformanceTiming")}} interface.
+
+- `DataCloneError` {{domxref("DOMException")}}
+  - : The `MeasureOptions.detail` value is non-`null` and cannot be serialized using the HTML "StructuredSerialize" algorithm.
+
+- `RangeError`
+  - : The `MeasureOptions.detail` value is non-`null` and memory cannot be allocated during serialization using the HTML "StructuredSerialize" algorithm.
+
 
 ## Example
 
-The following example shows how `measure()` is used to create a new
-_measure_ {{domxref("PerformanceEntry","performance entry")}} in the browser's
-performance entry buffer.
+The following example shows how `measure()` is used to create a new _measure_ {{domxref("PerformanceEntry","performance entry")}} in the browser's performance entry buffer.
 
 ```js
 const markerNameA = "example-marker-a"

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -33,7 +33,7 @@ measure(measureName, startMark)
 measure(measureName, startMark, endMark)
 ```
 
-If only `measureName` is specified the start timestamp is set to zero, the end timestamp (which is used to calculate the duration) is the value that would be returned by {{domxref("Performance.now()")}}.
+If only `measureName` is specified, the start timestamp is set to zero, and the end timestamp (which is used to calculate the duration) is the value that would be returned by {{domxref("Performance.now()")}}.
 
 ### Arguments
 

--- a/files/en-us/web/api/performancemeasure/index.md
+++ b/files/en-us/web/api/performancemeasure/index.md
@@ -19,7 +19,14 @@ browser-compat: api.PerformanceMeasure
 
 ## Properties
 
-This interface has no properties but it extends the following {{domxref("PerformanceEntry")}} properties by qualifying/constrainting the properties as follows:
+This interface defines:
+
+- `PerformanceMeasure.detail`
+  - : Contains arbitrary metatdata about the measure.
+    This may be passed in as a property of the {{domxref("Performance.measure()","performance.measure()")}} argument `MeasureOptions`.
+
+
+In addition, it extends the following {{domxref("PerformanceEntry")}} properties by qualifying/constraining the properties as follows:
 
 - {{domxref("PerformanceEntry.entryType")}}
   - : Returns "`measure`".
@@ -29,6 +36,7 @@ This interface has no properties but it extends the following {{domxref("Perform
   - : Returns a {{domxref("DOMHighResTimeStamp","timestamp")}} given to the measure when {{domxref("Performance.measure()","performance.measure()")}} was called.
 - {{domxref("PerformanceEntry.duration")}}
   - : Returns a {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure (typically, the measure's end mark timestamp minus its start mark timestamp).
+
 
 ## Methods
 


### PR DESCRIPTION
[Performance.measure()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) spec now indicates that it can take an options object defining the start/end marks name (or timestamps) OR these start/end marks can be specified as names in separate string arguments.

This updates with that argument and also attempts to record the exceptions and the value of the resulting PerformanceMeasure. In particular the startTime/duration if these values are not specified or inferred.

This follows on from #11307