### PR TITLE
Save-Data HTTP header is low entropy

### DIFF
--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -12,7 +12,11 @@ browser-compat: http.headers.Save-Data
 ---
 {{HTTPSidebar}}
 
-The **`Save-Data`** {{Glossary("Client hints","network client hint")}} request header field is a boolean which indicates the client's preference for reduced data usage. This could be for reasons such as high transfer costs, slow connection speeds, etc.
+The **`Save-Data`** [network client hint](/en-US/docs/Web/HTTP/Client_hints#network_client_hints) request header field is a boolean which indicates the client's preference for reduced data usage.
+This could be for reasons such as high transfer costs, slow connection speeds, etc.
+
+**`Save-Data`** is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints), and hence may be sent by the client even if not requested by the server using an {{HTTPHeader("Accept-CH")}} response.
+Further, it should be used to reduce data sent to the client irrespective of the values of other client hints that indicate network capability, like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}.
 
 <table class="properties">
   <tbody>
@@ -20,7 +24,7 @@ The **`Save-Data`** {{Glossary("Client hints","network client hint")}} request h
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -41,28 +45,25 @@ mode on the client, and when communicated to origins allows them to deliver alte
 content to reduce the data downloaded such as smaller image and video resources,
 different markup and styling, disabled polling and automatic updates, and so on.
 
-> **Note:** Disabling HTTP/2 Server Push ({{RFC("7540", "Server Push",
-    "8.2")}}) might be desirable too for reducing data downloads.
-
-> **Note:** The **`Save-Data`** {{Glossary("Client hints","network client hint")}} should be used to reduce data set to the client irrespective of the values of other client client hints that indicate network capability, like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}.
+> **Note:** Disabling HTTP/2 Server Push ({{RFC("7540", "Server Push", "8.2")}}) might be desirable too for reducing data downloads.
 
 ## Syntax
 
-    Save-Data: <sd-token>
+```http
+Save-Data: <sd-token>
+```
 
 ## Directives
 
-- \<sd-token>
-  - : A value indicating whether the client wants to opt in to reduced data
-    usage mode. `on` indicates yes, while `off` (the default)
-    indicates no.
+- `<sd-token>`
+  - : A value indicating whether the client wants to opt in to reduced data usage mode.
+    `on` indicates yes, while `off` (the default) indicates no.
 
 ## Examples
 
 The {{HTTPHeader("Vary")}} header ensures that the content is cached properly (for
 instance ensuring that the user is not served a lower-quality image from the cache when
-`Save-Data` header is no longer present \[_e.g._ after having switched
-from cellular to Wi-Fi]).
+`Save-Data` header is no longer present \[_e.g._ after having switched from cellular to Wi-Fi]).
 
 ### With `Save-Data: on`
 
@@ -116,15 +117,9 @@ Content-Type: image/jpeg
 
 ## See also
 
-- [Help Your Users \`Save-Data\` - CSS Tricks](https://css-tricks.com/help-users-save-data/)
+- [Help Your Users `Save-Data` - CSS Tricks](https://css-tricks.com/help-users-save-data/)
 - [Delivering Fast and Light Applications with Save-Data - Google Developers](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/save-data/)
-- {{HTTPHeader("Vary")}} header which indicate that the content served varies by `Save-Data` (see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses))
+- {{HTTPHeader("Vary")}} header which indicates that the content served varies depending on the value of `Save-Data` (see [HTTP Caching > Varying responses](/en-US/docs/Web/HTTP/Caching#varying_responses))
 - CSS @media feature [`prefers-reduced-data`](/en-US/docs/Web/CSS/@media/prefers-reduced-data) {{experimental_inline}}
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
-- Network client hints
-
-  - {{HTTPHeader("Downlink")}}
-  - {{HTTPHeader("RTT")}}
-  - {{HTTPHeader("ECT")}}
-
 - {{domxref("NetworkInformation.saveData")}}

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -15,7 +15,7 @@ browser-compat: http.headers.Save-Data
 The **`Save-Data`** [network client hint](/en-US/docs/Web/HTTP/Client_hints#network_client_hints) request header field is a boolean which indicates the client's preference for reduced data usage.
 This could be for reasons such as high transfer costs, slow connection speeds, etc.
 
-**`Save-Data`** is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints), and hence may be sent by the client even if not requested by the server using an {{HTTPHeader("Accept-CH")}} response.
+**`Save-Data`** is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints), and hence may be sent by the client even if not requested by the server using an {{HTTPHeader("Accept-CH")}} response header.
 Further, it should be used to reduce data sent to the client irrespective of the values of other client hints that indicate network capability, like {{HTTPHeader("Downlink")}} and {{HTTPHeader("RTT")}}.
 
 <table class="properties">


### PR DESCRIPTION
[Save-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Save-Data) is a low entropy hint according to spec and https://github.com/WICG/client-hints-infrastructure/issues/90#issuecomment-993040505

This PR adds that information and does other minor typo fixes etc.