### PR TITLE
HTTP client hint headers - fix up additional glossary links

### DIFF
--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -83,7 +83,7 @@ This should ideally be 1 or 2 short sentences.
         Include header category (or categories), e.g.
         {{Glossary("Request header")}},
         {{Glossary("Response header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/content-dpr/index.md
+++ b/files/en-us/web/http/headers/content-dpr/index.md
@@ -22,7 +22,7 @@ The **`Content-DPR`** response header is used to confirm the _image_ device to p
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Response header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/device-memory/index.md
+++ b/files/en-us/web/http/headers/device-memory/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Device-Memory
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Device-Memory`** {{Glossary("Client hints","device client hint")}} request header field indicates the approximate amount of available RAM on the client device. The header is part of the [Device Memory API](/en-US/docs/Web/API/Device_Memory_API).
+The **`Device-Memory`** [device client hint](/en-US/docs/Web/HTTP/Client_hints#device_client_hints) request header field indicates the approximate amount of available RAM on the client device. The header is part of the [Device Memory API](/en-US/docs/Web/API/Device_Memory_API).
 
 <table class="properties">
   <tbody>
@@ -21,7 +21,7 @@ The **`Device-Memory`** {{Glossary("Client hints","device client hint")}} reques
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/downlink/index.md
+++ b/files/en-us/web/http/headers/downlink/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.downlink
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 
-The **`Downlink`** {{Glossary("Client hints","network client hint")}} request header field provides the approximate bandwidth of the client's connection to the server, in Mbps.
+The **`Downlink`** [Client hint](/en-US/docs/Web/HTTP/Client_hints) request header field provides the approximate bandwidth of the client's connection to the server, in Mbps.
 
 <table class="properties">
   <tbody>
@@ -21,7 +21,7 @@ The **`Downlink`** {{Glossary("Client hints","network client hint")}} request he
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -22,7 +22,7 @@ The **`DPR`** [device client hint](/en-US/docs/Web/HTTP/Client_hints) request he
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/ect/index.md
+++ b/files/en-us/web/http/headers/ect/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.ect
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 
-The **`ECT`** {{Glossary("Client hints","network client hint")}} request header field indicates the {{Glossary("effective connection type")}}: `slow-2g`, `2g`, `3g`, `4g`.
+The **`ECT`** [Client hint](/en-US/docs/Web/HTTP/Client_hints) request header field indicates the {{Glossary("effective connection type")}}: `slow-2g`, `2g`, `3g`, `4g`.
 
 <table class="properties">
   <tbody>
@@ -21,7 +21,7 @@ The **`ECT`** {{Glossary("Client hints","network client hint")}} request header 
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/rtt/index.md
+++ b/files/en-us/web/http/headers/rtt/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.rtt
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 
-The **`RTT`** {{Glossary("Client hints","network client hint")}} request header field provides the approximate round trip time on the application layer, in milliseconds. The RTT hint, unlike transport layer RTT, includes server processing time.
+The **`RTT`** [Client hint](/en-US/docs/Web/HTTP/Client_hints) request header field provides the approximate round trip time on the application layer, in milliseconds. The RTT hint, unlike transport layer RTT, includes server processing time.
 
 <table class="properties">
   <tbody>
@@ -21,7 +21,7 @@ The **`RTT`** {{Glossary("Client hints","network client hint")}} request header 
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -23,7 +23,7 @@ This might be used by a server, for example, to select and offer the correct bin
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -80,7 +80,7 @@ Note above that the [low entropy headers](/en-US/docs/Web/HTTP/Client_hints#low_
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -24,7 +24,7 @@ This might be used by a server, for example, to select and offer the correct bin
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -80,7 +80,7 @@ Sec-CH-UA-Bitness: "64"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -21,7 +21,7 @@ The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Web/H
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -92,7 +92,7 @@ Sec-CH-UA-Platform: "Linux"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -23,7 +23,7 @@ The **`Sec-CH-UA-Full-Version`** [user agent client hint](/en-US/docs/Web/HTTP/C
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -78,7 +78,7 @@ Sec-CH-UA-Platform: "Windows"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -25,7 +25,7 @@ Unless blocked by a user agent permission policy, it is sent by default, without
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -74,7 +74,7 @@ Sec-CH-UA-Mobile: ?1
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -21,7 +21,7 @@ The **`Sec-CH-UA-Model`** [user agent client hint](/en-US/docs/Web/HTTP/Client_h
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -77,7 +77,7 @@ Sec-CH-UA-Model: "Pixel 3 XL"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -22,7 +22,7 @@ The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Web/HT
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -79,7 +79,7 @@ Sec-CH-UA-Platform-Version: "10.0.0"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -25,7 +25,7 @@ Unless blocked by a user agent permission policy, it is sent by default (without
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>
@@ -68,7 +68,7 @@ Sec-CH-UA-Platform: "macOS"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -21,7 +21,7 @@ The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#u
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        [Client hint](/en-US/docs/Web/HTTP/Client_hints)
       </td>
     </tr>
     <tr>
@@ -99,7 +99,7 @@ Sec-CH-UA: "Opera";v="81", " Not;A Brand";v="99", "Chromium";v="95"
 
 ## See also
 
-- {{Glossary("Client hints")}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - [User-Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Improving user privacy and developer experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints/) (web.dev)
 - {{HTTPHeader("Accept-CH")}}

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -22,7 +22,7 @@ The **`Viewport-Width`** [device client hint](/en-US/docs/Web/HTTP/Client_hints)
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/width/index.md
+++ b/files/en-us/web/http/headers/width/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.Width
 ---
 {{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
 
-The **`Width`** {{Glossary("Client hints","device client hint")}} request header field indicates the desired resource width in physical pixels — the intrinsic size of an image. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).
+The **`Width`** [device client hint](/en-US/docs/Web/HTTP/Client_hints#device_client_hints) request header field indicates the desired resource width in physical pixels — the intrinsic size of an image. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).
 
 <table class="properties">
   <tbody>
@@ -22,7 +22,7 @@ The **`Width`** {{Glossary("Client hints","device client hint")}} request header
       <th scope="row">Header type</th>
       <td>
         {{Glossary("Request header")}},
-        {{Glossary("Client hints","Client hint")}}
+        <a href="/en-US/docs/Web/HTTP/Client_hints">Client hint</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
The Client hints glossary moved to a main topic under HTTP yesterday. This fixes up all the glossary links (that I missed yesterday) to point to the moved doc.