### PR TITLE
Fix some instances of \*\* in markdown

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -38,7 +38,7 @@ exports.author_delete_get = function(req, res, next) {
 };
 ```
 
-The controller gets the id of the `Author` instance to be deleted from the URL parameter (`req.params.id`). It uses the `async.parallel()` method to get the author record and all associated books in parallel. When both operations have completed it renders the **`author_delete`.pug** view, passing variables for the `title`, `author`, and `author_books`.
+The controller gets the id of the `Author` instance to be deleted from the URL parameter (`req.params.id`). It uses the `async.parallel()` method to get the author record and all associated books in parallel. When both operations have completed it renders the **author_delete.pug** view, passing variables for the `title`, `author`, and `author_books`.
 
 > **Note:** If `findById()` returns no results the author is not in the database. In this case there is nothing to delete, so we immediately render the list of all authors.
 >
@@ -46,7 +46,7 @@ The controller gets the id of the `Author` instance to be deleted from the URL p
 >   function(err, results) {
 >     if (err) { return next(err); }
 >     if (results.author==null) { // No results.
->       res.redirect('/catalog/authors');
+>         res.redirect('/catalog/authors');
 >     }
 > ```
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -9,7 +9,9 @@ tags:
 ---
 This subarticle shows how to define a page to delete `Author` objects.
 
-As discussed in the [form design](/en-US/docs/Learn/Server-side/Express_Nodejs/forms#form_design) section, our strategy will be to only allow deletion of objects that are not referenced by other objects (in this case that means we won't allow an `Author` to be deleted if it is referenced by a `Book`). In terms of implementation this means that the form needs to confirm that there are no associated books before the author is deleted. If there are associated books, it should display them, and state that they must be deleted before the `Author` object can be deleted.
+As discussed in the [form design](/en-US/docs/Learn/Server-side/Express_Nodejs/forms#form_design) section, our strategy will be to only allow deletion of objects that are not referenced by other objects (in this case that means we won't allow an `Author` to be deleted if it is referenced by a `Book`).
+In terms of implementation this means that the form needs to confirm that there are no associated books before the author is deleted.
+If there are associated books, it should display them, and state that they must be deleted before the `Author` object can be deleted.
 
 ## Controller—get route
 
@@ -24,7 +26,7 @@ exports.author_delete_get = function(req, res, next) {
             Author.findById(req.params.id).exec(callback)
         },
         authors_books: function(callback) {
-          Book.find({ 'author': req.params.id }).exec(callback)
+            Book.find({ 'author': req.params.id }).exec(callback)
         },
     }, function(err, results) {
         if (err) { return next(err); }
@@ -38,9 +40,12 @@ exports.author_delete_get = function(req, res, next) {
 };
 ```
 
-The controller gets the id of the `Author` instance to be deleted from the URL parameter (`req.params.id`). It uses the `async.parallel()` method to get the author record and all associated books in parallel. When both operations have completed it renders the **author_delete.pug** view, passing variables for the `title`, `author`, and `author_books`.
+The controller gets the id of the `Author` instance to be deleted from the URL parameter (`req.params.id`).
+It uses the `async.parallel()` method to get the author record and all associated books in parallel.
+When both operations have completed it renders the **author_delete.pug** view, passing variables for the `title`, `author`, and `author_books`.
 
-> **Note:** If `findById()` returns no results the author is not in the database. In this case there is nothing to delete, so we immediately render the list of all authors.
+> **Note:** If `findById()` returns no results the author is not in the database.
+> In this case there is nothing to delete, so we immediately render the list of all authors.
 >
 > ```js
 >   function(err, results) {
@@ -85,9 +90,13 @@ exports.author_delete_post = function(req, res, next) {
 };
 ```
 
-First we validate that an id has been provided (this is sent via the form body parameters, rather than using the version in the URL). Then we get the author and their associated books in the same way as for the `GET` route. If there are no books then we delete the author object and redirect to the list of all authors. If there are still books then we just re-render the form, passing in the author and list of books to be deleted.
+First we validate that an id has been provided (this is sent via the form body parameters, rather than using the version in the URL).
+Then we get the author and their associated books in the same way as for the `GET` route.
+If there are no books then we delete the author object and redirect to the list of all authors.
+If there are still books then we just re-render the form, passing in the author and list of books to be deleted.
 
-> **Note:** We could check if the call to `findById()` returns any result, and if not, immediately render the list of all authors. We've left the code as it is above for brevity (it will still return the list of authors if the id is not found, but this will happen after `findByIdAndRemove()`).
+> **Note:** We could check if the call to `findById()` returns any result, and if not, immediately render the list of all authors.
+> We've left the code as it is above for brevity (it will still return the list of authors if the id is not found, but this will happen after `findByIdAndRemove()`).
 
 ## View
 
@@ -124,16 +133,19 @@ block content
       button.btn.btn-primary(type='submit') Delete
 ```
 
-The view extends the layout template, overriding the block named `content`. At the top it displays the author details. It then includes a conditional statement based on the number of **`author_books`** (the `if` and `else` clauses).
+The view extends the layout template, overriding the block named `content`. At the top it displays the author details.
+It then includes a conditional statement based on the number of **`author_books`** (the `if` and `else` clauses).
 
 - If there _are_ books associated with the author then the page lists the books and states that these must be deleted before this `Author` may be deleted.
-- If there _are no_ books then the page displays a confirmation prompt. If the **Delete** button is clicked then the author id is sent to the server in a `POST` request and that author's record will be deleted.
+- If there _are no_ books then the page displays a confirmation prompt.
+- If the **Delete** button is clicked then the author id is sent to the server in a `POST` request and that author's record will be deleted.
 
 ## Add a delete control
 
 Next we will add a **Delete** control to the _Author detail_ view (the detail page is a good place from which to delete a record).
 
-> **Note:** In a full implementation the control would be made visible only to authorized users. However at this point we haven't got an authorization system in place!
+> **Note:** In a full implementation the control would be made visible only to authorized users.
+> However at this point we haven't got an authorization system in place!
 
 Open the **author_detail.pug** view and add the following lines at the bottom.
 
@@ -149,17 +161,21 @@ The control should now appear as a link, as shown below on the _Author detail_ p
 
 ## What does it look like?
 
-Run the application and open your browser to <http://localhost:3000/>. Then select the _All authors_ link, and then select a particular author. Finally select the _Delete author_ link.
+Run the application and open your browser to <http://localhost:3000/>.
+Then select the _All authors_ link, and then select a particular author. Finally select the _Delete author_ link.
 
-If the author has no books, you'll be presented with a page like this. After pressing delete, the server will delete the author and redirect to the author list.
+If the author has no books, you'll be presented with a page like this.
+After pressing delete, the server will delete the author and redirect to the author list.
 
 ![](locallibary_express_author_delete_nobooks.png)
 
-If the author does have books, then you'll be presented with a view like the following. You can then delete the books from their detail pages (once that code is implemented!).
+If the author does have books, then you'll be presented with a view like the following.
+You can then delete the books from their detail pages (once that code is implemented!).
 
 ![](locallibary_express_author_delete_withbooks.png)
 
-> **Note:** The other pages for deleting objects can be implemented in much the same way. We've left that as a challenge.
+> **Note:** The other pages for deleting objects can be implemented in much the same way.
+> We've left that as a challenge.
 
 ## Next steps
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -38,15 +38,15 @@ exports.author_delete_get = function(req, res, next) {
 };
 ```
 
-The controller gets the id of the `Author` instance to be deleted from the URL parameter (`req.params.id`). It uses the `async.parallel()` method to get the author record and all associated books in parallel. When both operations have completed it renders the **`author_delete`\*\***.pug\*\* view, passing variables for the `title`, `author`, and `author_books`.
+The controller gets the id of the `Author` instance to be deleted from the URL parameter (`req.params.id`). It uses the `async.parallel()` method to get the author record and all associated books in parallel. When both operations have completed it renders the **`author_delete`.pug** view, passing variables for the `title`, `author`, and `author_books`.
 
-> **Note:** If  `findById()` returns no results the author is not in the database. In this case there is nothing to delete, so we immediately render the list of all authors.
+> **Note:** If `findById()` returns no results the author is not in the database. In this case there is nothing to delete, so we immediately render the list of all authors.
 >
 > ```js
-> }, function(err, results) {
+>   function(err, results) {
 >     if (err) { return next(err); }
 >     if (results.author==null) { // No results.
->         res.redirect('/catalog/authors')
+>       res.redirect('/catalog/authors');
 >     }
 > ```
 
@@ -87,7 +87,7 @@ exports.author_delete_post = function(req, res, next) {
 
 First we validate that an id has been provided (this is sent via the form body parameters, rather than using the version in the URL). Then we get the author and their associated books in the same way as for the `GET` route. If there are no books then we delete the author object and redirect to the list of all authors. If there are still books then we just re-render the form, passing in the author and list of books to be deleted.
 
-> **Note:** We could check if the call to `findById()` returns any result, and if not,  immediately render the list of all authors.  We've left the code as it is above for brevity (it will still return the list of authors if the id is not found, but this will happen after `findByIdAndRemove()`).
+> **Note:** We could check if the call to `findById()` returns any result, and if not, immediately render the list of all authors. We've left the code as it is above for brevity (it will still return the list of authors if the id is not found, but this will happen after `findByIdAndRemove()`).
 
 ## View
 
@@ -127,7 +127,7 @@ block content
 The view extends the layout template, overriding the block named `content`. At the top it displays the author details. It then includes a conditional statement based on the number of **`author_books`** (the `if` and `else` clauses).
 
 - If there _are_ books associated with the author then the page lists the books and states that these must be deleted before this `Author` may be deleted.
-- If there _are no_ books then the page displays a confirmation prompt. If the **Delete** button is clicked then the author id is sent to the server in a `POST` request and that author's record will be deleted.
+- If there _are no_ books then the page displays a confirmation prompt. If the **Delete** button is clicked then the author id is sent to the server in a `POST` request and that author's record will be deleted.
 
 ## Add a delete control
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -28,7 +28,7 @@ The rest of this page summarizes these and other incompatibilities.
 
 ## JavaScript APIs
 
-### *chrome.\** and *browser.*\* namespace
+### _chrome.\*_ and _browser.\*_ namespace
 
 - **In Firefox:** The equivalent APIs are accessed using the `browser` namespace.
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -28,7 +28,7 @@ The rest of this page summarizes these and other incompatibilities.
 
 ## JavaScript APIs
 
-### \*chrome.\** and *browser.\*\* namespace
+### *chrome.\** and *browser.*\* namespace
 
 - **In Firefox:** The equivalent APIs are accessed using the `browser` namespace.
 
@@ -78,7 +78,7 @@ The rest of this page summarizes these and other incompatibilities.
   );
   ```
 
-### Firefox supports both the *chrome* and *browser* namespaces
+### Firefox supports both the *chrome* and *browser* namespaces
 
 As a porting aid, the Firefox implementation of WebExtensions supports `chrome`, using callbacks, as well as `browser`, using promises. This means that many Chrome extensions will just work in Firefox without any changes.
 
@@ -202,7 +202,7 @@ When calling `tabs.remove()`:
 
 #### Content script lifecycle during navigation
 
-- **In Firefox:** Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets `window.prop1 = "prop"`  and the user then navigates away and returns to the page `window.prop1` is undefined. This issue is tracked in {{bug(1525400)}}.
+- **In Firefox:** Content scripts remain injected in a web page after the user has navigated away, however, window object properties are destroyed. For example, if a content script sets `window.prop1 = "prop"` and the user then navigates away and returns to the page `window.prop1` is undefined. This issue is tracked in {{bug(1525400)}}.
 
   To mimic the behavior of Chrome, listen for the [pageshow](/en-US/docs/Web/API/Window/pageshow_event) and [pagehide](/en-US/docs/Web/API/Window/pagehide_event) events. Then simulate the injection or destruction of the content script.
 

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -93,7 +93,7 @@ The value for the _path_ matches against the string which is the URL path plus t
 
 Neither the [URL fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier), nor the `#` which precedes it, are considered as part of the _path_.
 
-> **Note:** The path pattern string should not include a port number. Adding a port, as in: _"http\://localhost:1234/\*"_ causes the match pattern to be ignored. However, _"http\://localhost:1234"_ will match with _"http\://localhost/\*"_.
+> **Note:** The path pattern string should not include a port number. Adding a port, as in: `http://localhost:1234/*` causes the match pattern to be ignored. However, `http://localhost:1234` will match with `http://localhost/*`.
 
 ### \<all_urls>
 

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -93,7 +93,7 @@ The value for the _path_ matches against the string which is the URL path plus t
 
 Neither the [URL fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier), nor the `#` which precedes it, are considered as part of the _path_.
 
-> **Note:** The path pattern string should not include a port number. Adding a port, as in: _"http\://localhost:1234/\*"_ causes the match pattern to be ignored. However, "_http\://localhost:1234_" will match with "\*http\://localhost/\*\*"
+> **Note:** The path pattern string should not include a port number. Adding a port, as in: _"http\://localhost:1234/\*"_ causes the match pattern to be ignored. However, _"http\://localhost:1234"_ will match with _"http\://localhost/\*"_.
 
 ### \<all_urls>
 

--- a/files/en-us/mozilla/firefox/releases/53/index.md
+++ b/files/en-us/mozilla/firefox/releases/53/index.md
@@ -25,7 +25,7 @@ Firefox 53 was released on April 19, 2017. This article lists key changes that a
 
 - The `mask-*` longhand properties (see [CSS Masks](/en-US/docs/Web/CSS/CSS_Masking)) are all supported and available by default (see {{bug(1251161)}}).
 - Added {{cssxref("caret-color")}} property ({{bug(1063162)}}).
-- Implemented the {{cssxref("place-items")}}/{{cssxref("place-self")}}/{{cssxref("place-content")}} shorthands ({{bug(1319958)}}).
+- Implemented the {{cssxref("place-items")}}/{{cssxref("place-self")}}/{{cssxref("place-content")}} shorthands ({{bug(1319958)}}).
 - Added `flow-root` value to {{cssxref("display")}} property ({{bug(1322191)}}).
 - {{cssxref("tab-size", "-moz-tab-size")}} now accepts {{cssxref("&lt;length&gt;")}} values ({{bug(943918)}}), and is now animatable ({{bug(1308110)}}).
 - {{cssxref("mask-mode")}}:luminance doesn't work on gradient masks ({{bug(1346265)}}).
@@ -49,20 +49,20 @@ Firefox 53 was released on April 19, 2017. This article lists key changes that a
 - {{jsxref("SharedArrayBuffer")}} can now be used in {{jsxref("DataView")}} objects ({{bug(1246597)}}).
 - In earlier versions of the specification, {{jsxref("SharedArrayBuffer")}} objects needed to be explicitly transferred during [structured cloning](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). In the new specification they aren't [transferable objects](/en-US/docs/Web/API/Transferable) anymore and thus must not be in the transfer list. The new behavior used to present a console warning only, but will now throw an error ({{bug(1302037)}}).
 - The {{jsxref("ArrayBuffer")}} length is now limited to {{jsxref("Number.MAX_SAFE_INTEGER")}} (>= 2 \*\* 53) ({{bug(1255128)}}).
-- {{jsxref("Error")}} and other native error object prototypes like {{jsxref("RangeError")}} etc. are now ordinary objects instead of proper Error objects. (In particular, `Object.prototype.toString.call(Error.prototype)` is now `"[object Object]"` instead of `"[object Error]"`.) ({{bug(1213341)}}).
+- {{jsxref("Error")}} and other native error object prototypes like {{jsxref("RangeError")}} etc. are now ordinary objects instead of proper Error objects. (In particular, `Object.prototype.toString.call(Error.prototype)` is now `"[object Object]"` instead of `"[object Error]"`.) ({{bug(1213341)}}).
 
 ### Events
 
-- CSS Transitions: The {{event("transitionstart")}}, {{event("transitionrun")}}, and {{event("transitioncancel")}} events have been implemented (see {{bug(1264125)}} and {{bug(1287983)}}).
+- CSS Transitions: The {{event("transitionstart")}}, {{event("transitionrun")}}, and {{event("transitioncancel")}} events have been implemented (see {{bug(1264125)}} and {{bug(1287983)}}).
 - The {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent")}} constructor has been implemented (see {{bug(1002256)}}).
-- The {{domxref("MouseEvent.x")}} and {{domxref("MouseEvent.y")}} aliases of {{domxref("MouseEvent.clientX")}}/{{domxref("MouseEvent.clientY")}} have been implemented (see {{bug(424390)}}).
+- The {{domxref("MouseEvent.x")}} and {{domxref("MouseEvent.y")}} aliases of {{domxref("MouseEvent.clientX")}}/{{domxref("MouseEvent.clientY")}} have been implemented (see {{bug(424390)}}).
 - The {{Event("auxclick")}} event and corresponding {{domxref("GlobalEventHandlers.onauxclick")}} handler have been implemented (see {{bug(1304044)}}).
 - The {{Event("transitioncancel")}} event is now fired after a [transition](/en-US/docs/Web/CSS/CSS_Transitions) is cancelled. See {{domxref("GlobalEventHandlers.ontransitioncancel")}} for more details and an example ({{bug("1264125")}}).
 
 ### DOM
 
 - The {{domxref("HTMLAnchorElement/pathname", "pathname")}} and {{domxref("HTMLAnchorElement/search", "search")}} {{domxref("HTMLHyperLinkElementUtils")}} properties previously returned the wrong parts of the URL. For example, for a URL of `http://z.com/x?a=true&b=false`, `pathname` would return "`/x?a=true&b=false"` and `search` would return "", rather than "`/x`" and "`?a=true&b=false"` respectively. This has now been fixed ({{bug(1310483)}}).
-- The {{domxref("URLSearchParams.URLSearchParams", "URLSearchParams()")}} constructor now accepts a {{domxref("USVString")}} or sequence of {{domxref("USVString")}}s as an init object ({{bug("1330678")}}).
+- The {{domxref("URLSearchParams.URLSearchParams", "URLSearchParams()")}} constructor now accepts a {{domxref("USVString")}} or sequence of {{domxref("USVString")}}s as an init object ({{bug("1330678")}}).
 - The {{domxref("Selection.setBaseAndExtent()")}} method of the [Selection API](/en-US/docs/Web/API/Selection) is now implemented (see {{bug(1321623)}}).
 - The ["fakepath"](https://html.spec.whatwg.org/multipage/forms.html#fakepath-srsly) addition to `file` type {{htmlelement("input")}} `values` has been implemented in Gecko, giving it parity with other browsers (see {{bug(1274596)}}).
 - {{domxref("Node.getRootNode()")}} has been implemented, replacing the deprecated `Node.rootNode` property ({{bug(1269155)}}).

--- a/files/en-us/web/api/vreyeparameters/offset/index.md
+++ b/files/en-us/web/api/vreyeparameters/offset/index.md
@@ -16,7 +16,7 @@ browser-compat: api.VREyeParameters.offset
 ---
 {{APIRef("WebVR API")}}{{Deprecated_header}}
 
-The **`offset`** read-only property of the {{domxref("VREyeParameters")}} interface *r\*\*epresents the o*ffset from the center point between the user's eyes to the center of the eye, measured in meters.
+The **`offset`** read-only property of the {{domxref("VREyeParameters")}} interface represents the offset from the center point between the user's eyes to the center of the eye, measured in meters.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation
- Fixes/removes a few occurences of `\*\*` in Markdown files
- Replaces "invisible U+00a0" characters with regular spaces
- Small formatting fixes (mostly fixing double/extra spaces)

I had some difficulty "guessing" what the intended formatting was where there were escaped asterisks (`\*`), if something is still incorrect I'll be happy to fix it :)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
