### PR TITLE
Missing the media resize event

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -184,6 +184,8 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}_ , defined in the 
   - : Fired periodically as the browser loads a resource.
 - {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}}
   - : Fired when the playback rate has changed.
+- {{domxref("HTMLMediaElement.resize_event", 'resize ')}}
+  - : Fired when one or both of the `videoWidth` and `videoHeight` attributes have just been updated. 
 - {{domxref("HTMLMediaElement.seeked_event", 'seeked ')}}
   - : Fired when a seek operation completes
 - {{domxref("HTMLMediaElement.seeking_event", 'seeking')}}


### PR DESCRIPTION
Among the list of possible events for the media elements, the `resize` event is missing.

Reference: [https://html.spec.whatwg.org/multipage/media.html#mediaevents](https://html.spec.whatwg.org/multipage/media.html#mediaevents)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
