### PR TITLE
string.padstring - improve presentation of padding string

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
@@ -37,8 +37,8 @@ padStart(targetLength, padString)
 - `padString` {{optional_inline}}
   - : The string to pad the current `str` with. If
     `padString` is too long to stay within the
-    `targetLength`, it will be truncated from the end. The default
-    value is "` `" (`U+0020 'SPACE'`).
+    `targetLength`, it will be truncated from the end.
+    The default value is the unicode "space" character (U+0020).
 
 ### Return value
 


### PR DESCRIPTION
Fixes #11577

The assertion was that the presentation format of the space is a bit odd. I disagree, but either way this removes the perceived problem:
![image](https://user-images.githubusercontent.com/5368500/147717002-3eb08ec9-17f5-4f9d-b5a1-dbeff4c7f2ca.png)
