### PR TITLE
[Remove]: 'window' namespace

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -297,7 +297,7 @@ Now let's look at what we have to do in the first place, to actually set up a da
     ```js
     // Open our database; it is created if it doesn't already exist
     // (see onupgradeneeded below)
-    let request = window.indexedDB.open('notes_db', 1);
+    let request = indexedDB.open('notes_db', 1);
     ```
 
     This line creates a `request` to open version `1` of a database called `notes_db`. If this doesn't already exist, it will be created for you by subsequent code. You will see this request pattern used very often throughout IndexedDB. Database operations take time. You don't want to hang the browser while you wait for the results, so database operations are {{Glossary("asynchronous")}}, meaning that instead of happening immediately, they will happen at some point in the future, and you get notified when they're done.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Since, 'window' is a global object, IndexedDB can be referenced even without it, so remove the 'window' object

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This is beneficial for the readers (especially beginners) because this will not confuse them. Moreover, 'window' object is totally useless there because it's global

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
None

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
None
<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
