### PR TITLE
Clarify when change event fires on radio and checkbox

### DIFF
--- a/files/en-us/web/api/htmlelement/change_event/index.md
+++ b/files/en-us/web/api/htmlelement/change_event/index.md
@@ -39,8 +39,8 @@ The `change` event is fired for {{HTMLElement("input")}}, {{HTMLElement("select"
 
 Depending on the kind of element being changed and the way the user interacts with the element, the `change` event fires at a different moment:
 
-- When a `{{HTMLElement('input/radio', '&lt;input type="radio"&gt;')}}` element is checked (by clicking or using the keyboard);
-- When a `{{HTMLElement('input/checkbox', '&lt;input type="checkbox"&gt;')}}` element is checked or unchecked;
+- When a `{{HTMLElement('input/checkbox', '&lt;input type="checkbox"&gt;')}}` element is checked or unchecked (by clicking or using the keyboard);
+- When a `{{HTMLElement('input/radio', '&lt;input type="radio"&gt;')}}` element is checked (but not when unchecked);
 - When the user commits the change explicitly (e.g., by selecting a value from a {{HTMLElement("select")}}'s dropdown with a mouse click, by selecting a date from a date picker for `{{HTMLElement('input/date', '&lt;input type="date"&gt;')}}`, by selecting a file in the file picker for `{{HTMLElement('input/file', '&lt;input type="file"&gt;')}}`, etc.);
 - When the element loses focus after its value was changed, but not committed (e.g., after editing the value of {{HTMLElement("textarea")}} or `{{HTMLElement('input/text', '&lt;input type="text"&gt;')}}`).
 

--- a/files/en-us/web/api/htmlelement/change_event/index.md
+++ b/files/en-us/web/api/htmlelement/change_event/index.md
@@ -39,7 +39,8 @@ The `change` event is fired for {{HTMLElement("input")}}, {{HTMLElement("select"
 
 Depending on the kind of element being changed and the way the user interacts with the element, the `change` event fires at a different moment:
 
-- When the element is `:checked` (by clicking or using the keyboard) for `{{HTMLElement('input/radio', '&lt;input type="radio"&gt;')}}` and `{{HTMLElement('input/checkbox', '&lt;input type="checkbox"&gt;')}}`;
+- When a `{{HTMLElement('input/radio', '&lt;input type="radio"&gt;')}}` element is checked (by clicking or using the keyboard);
+- When a `{{HTMLElement('input/checkbox', '&lt;input type="checkbox"&gt;')}}` element is checked or unchecked;
 - When the user commits the change explicitly (e.g., by selecting a value from a {{HTMLElement("select")}}'s dropdown with a mouse click, by selecting a date from a date picker for `{{HTMLElement('input/date', '&lt;input type="date"&gt;')}}`, by selecting a file in the file picker for `{{HTMLElement('input/file', '&lt;input type="file"&gt;')}}`, etc.);
 - When the element loses focus after its value was changed, but not committed (e.g., after editing the value of {{HTMLElement("textarea")}} or `{{HTMLElement('input/text', '&lt;input type="text"&gt;')}}`).
 


### PR DESCRIPTION
#### Summary

Make it more clear that the change event also fires when a checkbox is unchecked, not just when it is checked.

#### Motivation

Make this more clear for myself and others.

#### Supporting details

When I try the following in a modern browser, it matches the behavior described in this proposed documentation change:

```
<!doctype html>
<html>
    <head>
        <meta charset="utf-8">
    </head>
    <body>
        <input type="checkbox" id="checkbox">
        <div class="checkbox-change-result"></div>

        <input type="radio" id="radio1" name="radios" value="radio1">
        <div class="radio1-change-result"></div>
        <input type="radio" id="radio2" name="radios" value="radio2">
        <div class="radio2-change-result"></div>

        <script>
            function createAndAppendResultDiv(parentSelector, message) {
                const newEl = document.createElement('div');
                newEl.textContent = message;
                document.querySelector(parentSelector).append(newEl);
            }
            document.querySelector('#checkbox').addEventListener('change', (event) => {
                createAndAppendResultDiv(
                    '.checkbox-change-result',
                    event.target.checked
                );
            });
            document.querySelector('#radio1').addEventListener('change', (event) => {
                createAndAppendResultDiv(
                    '.radio1-change-result',
                    event.target.checked
                );
            });
            document.querySelector('#radio2').addEventListener('change', (event) => {
                createAndAppendResultDiv(
                    '.radio2-change-result',
                    event.target.checked
                );
            });
        </script>
    </body>
</html>
```

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
