### PR TITLE
Add a workaround of Blob Constructor in IE10

### DIFF
--- a/files/en-us/web/api/blob/blob/index.md
+++ b/files/en-us/web/api/blob/blob/index.md
@@ -53,6 +53,15 @@ var aFileParts = ['<a id="a"><b id="b">hey!</b></a>']; // an array consisting of
 var oMyBlob = new Blob(aFileParts, {type : 'text/html'}); // the blob
 ```
 
+*Notice: IE10 will error out "InvalidStateError" when constructing with a given {{jsxref("TypedArray")}}, we can use {{domxref("BlobBuilder")}} as an alternative.*
+
+```js
+var typedArray = new Uint8Array();
+var blobBuilder = new MSBlobBuilder();
+blobBuilder.append(typedArray.buffer);
+var oMyBlob = blobBuilder.getBlob();
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Add a workaround of Blob Constructor in IE10 to show how to create blob with a given typed array.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details

https://github.com/mdn/browser-compat-data/pull/14374
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
