### PR TITLE
opensearch: Remove non standard Param element

### DIFF
--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -29,11 +29,7 @@ The XML file that describes a search engine follows the basic template below. Se
   <Description>[Search engine full name and summary]</Description>
   <InputEncoding>[UTF-8]</InputEncoding>
   <Image width="16" height="16" type="image/x-icon">[https://example.com/favicon.ico]</Image>
-  <Url type="text/html" template="[searchURL]">
-    <Param name="[key name]" value="{searchTerms}"/>
-    <!-- other Params if you need them… -->
-    <Param name="[other key name]" value="[parameter value]"/>
-  </Url>
+  <Url type="text/html" template="[searchURL]"/>
   <Url type="application/x-suggestions+json" template="[suggestionURL]"/>
   <moz:SearchForm>[https://example.com/search]</moz:SearchForm>
 </OpenSearchDescription>
@@ -77,8 +73,6 @@ The XML file that describes a search engine follows the basic template below. Se
 
     For search suggestions, the `application/x-suggestions+json` URL template is used to fetch a suggestion list in [JSON](/en-US/docs/Glossary/JSON) format. For details on how to implement search suggestion support on a server, see [Supporting search suggestions in search plugins](/en-US/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins).
 
-- Param
-  - : The parameters that must be passed in along with the search query as key/value pairs. When specifying values, you can use `{searchTerms}` to insert the search terms entered by the user in the search bar.
 - moz:SearchForm
 
   - : The URL for the site's search initiation page for the plugin. This lets Firefox users visit the web site, and search from the site directly.


### PR DESCRIPTION
(see full commit message for details)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This MR removes the use (and hence recommendation) of the `<Param>` element within OpenSearch description files in its MDN documentation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I'm working on some app so that it gets OpenSearch search engines support w/ autodiscovery and suggestions. But I came across a blog post that explained how this person setup OpenSearch for their own blog, and it used this non-standard Param element and linked to the MDN docs. Since I had already read the whole specification, I knew this wasn't a standard element, and after checking again with grep, it didn't show up either (only Parameter did). I didn't mention it in the commit message, but there was a mention of "Param" (not Parameter) in the spec, but that was for the first 1.1 OpenSearch spec draft, _in 2005_, then another mention was _in 2006_ for Draft 3 where it was moved to a separate extension. I can't find the revision change that renamed it to "Parameters", since they started putting the specifications on a MediaWiki (and hence getting revisions changes support) on 2006-07-23 and the Parameter extension wiki page appeared on 2006-08-09 (and Draft 3 was published on the wiki on 2006-07-25). I believe Param was renamed to Parameter when they moved it to an extension specification, with Draft 3. Anyway, even if we could recommend the param:Parameter elements, the validation features it provides isn't used, so there's no point in using that spec when `?q={searchTerms}` inlined in the URL works fine.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[Latest OpenSearch specification](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-11-parameters)
[Latest OpenSearch Parameter extension specification](https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Parameter/1.0/Draft%202.wiki)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
