### PR TITLE
Be precise about Document properties that return HTMLcollection

### DIFF
--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -49,13 +49,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.documentURI")}}{{ReadOnlyInline}}
   - : Returns the document location as a string.
 - {{DOMxRef("Document.embeds")}}{{ReadOnlyInline}}
-  - : Returns an {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements within the current document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements in the document.
 - {{domxref("Document.firstElementChild")}} {{readonlyInline}}
   - : Returns the first child element of the current document.
 - {{DOMxRef("Document.fonts")}}
   - : Returns the {{DOMxRef("FontFaceSet")}} interface of the current document.
 - {{DOMxRef("Document.forms")}}{{ReadOnlyInline}}
-  - : Returns an {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements within the current document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements in the document.
 - {{DOMxRef("Document.fullscreenElement")}} {{ReadOnlyInline}}
   - : The element that's currently in full screen mode for this document.
 - {{DOMxRef("Document.head")}}{{ReadOnlyInline}}
@@ -63,7 +63,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.hidden")}}{{ReadOnlyInline}}
   - : Returns a Boolean value indicating if the page is considered hidden or not.
 - {{DOMxRef("Document.images")}}{{ReadOnlyInline}}
-  - : Returns an {{DOMxRef("HTMLCollection")}} of the images in the current document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the images in the document.
 - {{DOMxRef("Document.implementation")}}{{ReadOnlyInline}}
   - : Returns the DOM implementation associated with the current document.
 - {{domxref("Document.lastElementChild")}} {{readonlyInline}}

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -49,13 +49,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.documentURI")}}{{ReadOnlyInline}}
   - : Returns the document location as a string.
 - {{DOMxRef("Document.embeds")}}{{ReadOnlyInline}}
-  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements within the current document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements within the current document.
 - {{domxref("Document.firstElementChild")}} {{readonlyInline}}
   - : Returns the first child element of the current document.
 - {{DOMxRef("Document.fonts")}}
   - : Returns the {{DOMxRef("FontFaceSet")}} interface of the current document.
 - {{DOMxRef("Document.forms")}}{{ReadOnlyInline}}
-  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements within the current document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements within the current document.
 - {{DOMxRef("Document.fullscreenElement")}} {{ReadOnlyInline}}
   - : The element that's currently in full screen mode for this document.
 - {{DOMxRef("Document.head")}}{{ReadOnlyInline}}
@@ -63,13 +63,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.hidden")}}{{ReadOnlyInline}}
   - : Returns a Boolean value indicating if the page is considered hidden or not.
 - {{DOMxRef("Document.images")}}{{ReadOnlyInline}}
-  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the images in the current document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the images in the current document.
 - {{DOMxRef("Document.implementation")}}{{ReadOnlyInline}}
   - : Returns the DOM implementation associated with the current document.
 - {{domxref("Document.lastElementChild")}} {{readonlyInline}}
   - : Returns the last child element of the current document.
 - {{DOMxRef("Document.links")}}{{ReadOnlyInline}}
-  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of all the hyperlinks in the document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of all the hyperlinks in the document.
 - {{DOMxRef("Document.mozSyntheticDocument")}} {{Non-standard_Inline}}
   - : Returns a {{JSxRef("Boolean")}} that is `true` only if this document is synthetic, such as a standalone image, video, audio file, or the like.
 - {{DOMxRef("Document.pictureInPictureElement")}} {{ReadOnlyInline}}
@@ -77,13 +77,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.pictureInPictureEnabled")}} {{ReadOnlyInline}}
   - : Returns true if the picture-in-picture feature is enabled.
 - {{DOMxRef("Document.plugins")}}{{ReadOnlyInline}}
-  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the available plugins.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the available plugins.
 - {{DOMxRef("Document.pointerLockElement")}} {{ReadOnlyInline}}
   - : Returns the element set as the target for mouse events while the pointer is locked. `null` if lock is pending, pointer is unlocked, or if the target is in another document.
 - {{DOMxRef("Document.featurePolicy")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.
 - {{DOMxRef("Document.scripts")}}{{ReadOnlyInline}}
-  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of all the {{HTMLElement("script")}} elements on the document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of all the {{HTMLElement("script")}} elements on the document.
 - {{DOMxRef("Document.scrollingElement")}}{{ReadOnlyInline}}
   - : Returns a reference to the {{DOMxRef("Element")}} that scrolls the document.
 - {{DOMxRef("Document.styleSheets")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -49,13 +49,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.documentURI")}}{{ReadOnlyInline}}
   - : Returns the document location as a string.
 - {{DOMxRef("Document.embeds")}}{{ReadOnlyInline}}
-  - : Returns a list of the embedded {{HTMLElement('embed')}} elements within the current document.
+  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements within the current document.
 - {{domxref("Document.firstElementChild")}} {{readonlyInline}}
   - : Returns the first child element of the current document.
 - {{DOMxRef("Document.fonts")}}
   - : Returns the {{DOMxRef("FontFaceSet")}} interface of the current document.
 - {{DOMxRef("Document.forms")}}{{ReadOnlyInline}}
-  - : Returns a list of the {{HTMLElement("form")}} elements within the current document.
+  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements within the current document.
 - {{DOMxRef("Document.fullscreenElement")}} {{ReadOnlyInline}}
   - : The element that's currently in full screen mode for this document.
 - {{DOMxRef("Document.head")}}{{ReadOnlyInline}}
@@ -63,13 +63,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.hidden")}}{{ReadOnlyInline}}
   - : Returns a Boolean value indicating if the page is considered hidden or not.
 - {{DOMxRef("Document.images")}}{{ReadOnlyInline}}
-  - : Returns a list of the images in the current document.
+  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the images in the current document.
 - {{DOMxRef("Document.implementation")}}{{ReadOnlyInline}}
   - : Returns the DOM implementation associated with the current document.
 - {{domxref("Document.lastElementChild")}} {{readonlyInline}}
   - : Returns the last child element of the current document.
 - {{DOMxRef("Document.links")}}{{ReadOnlyInline}}
-  - : Returns a list of all the hyperlinks in the document.
+  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of all the hyperlinks in the document.
 - {{DOMxRef("Document.mozSyntheticDocument")}} {{Non-standard_Inline}}
   - : Returns a {{JSxRef("Boolean")}} that is `true` only if this document is synthetic, such as a standalone image, video, audio file, or the like.
 - {{DOMxRef("Document.pictureInPictureElement")}} {{ReadOnlyInline}}
@@ -77,13 +77,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.pictureInPictureEnabled")}} {{ReadOnlyInline}}
   - : Returns true if the picture-in-picture feature is enabled.
 - {{DOMxRef("Document.plugins")}}{{ReadOnlyInline}}
-  - : Returns a list of the available plugins.
+  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the available plugins.
 - {{DOMxRef("Document.pointerLockElement")}} {{ReadOnlyInline}}
   - : Returns the element set as the target for mouse events while the pointer is locked. `null` if lock is pending, pointer is unlocked, or if the target is in another document.
 - {{DOMxRef("Document.featurePolicy")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.
 - {{DOMxRef("Document.scripts")}}{{ReadOnlyInline}}
-  - : Returns all the {{HTMLElement("script")}} elements on the document.
+  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of all the {{HTMLElement("script")}} elements on the document.
 - {{DOMxRef("Document.scrollingElement")}}{{ReadOnlyInline}}
   - : Returns a reference to the {{DOMxRef("Element")}} that scrolls the document.
 - {{DOMxRef("Document.styleSheets")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -69,7 +69,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{domxref("Document.lastElementChild")}} {{readonlyInline}}
   - : Returns the last child element of the current document.
 - {{DOMxRef("Document.links")}}{{ReadOnlyInline}}
-  - : Returns an {{DOMxRef("HTMLCollection")}} of all the hyperlinks in the document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the hyperlinks in the document.
 - {{DOMxRef("Document.mozSyntheticDocument")}} {{Non-standard_Inline}}
   - : Returns a {{JSxRef("Boolean")}} that is `true` only if this document is synthetic, such as a standalone image, video, audio file, or the like.
 - {{DOMxRef("Document.pictureInPictureElement")}} {{ReadOnlyInline}}
@@ -83,7 +83,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.featurePolicy")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.
 - {{DOMxRef("Document.scripts")}}{{ReadOnlyInline}}
-  - : Returns an {{DOMxRef("HTMLCollection")}} of all the {{HTMLElement("script")}} elements on the document.
+  - : Returns an {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("script")}} elements in the document.
 - {{DOMxRef("Document.scrollingElement")}}{{ReadOnlyInline}}
   - : Returns a reference to the {{DOMxRef("Element")}} that scrolls the document.
 - {{DOMxRef("Document.styleSheets")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -49,13 +49,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.documentURI")}}{{ReadOnlyInline}}
   - : Returns the document location as a string.
 - {{DOMxRef("Document.embeds")}}{{ReadOnlyInline}}
-  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements within the current document.
+  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the embedded {{HTMLElement('embed')}} elements within the current document.
 - {{domxref("Document.firstElementChild")}} {{readonlyInline}}
   - : Returns the first child element of the current document.
 - {{DOMxRef("Document.fonts")}}
   - : Returns the {{DOMxRef("FontFaceSet")}} interface of the current document.
 - {{DOMxRef("Document.forms")}}{{ReadOnlyInline}}
-  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements within the current document.
+  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the {{HTMLElement("form")}} elements within the current document.
 - {{DOMxRef("Document.fullscreenElement")}} {{ReadOnlyInline}}
   - : The element that's currently in full screen mode for this document.
 - {{DOMxRef("Document.head")}}{{ReadOnlyInline}}
@@ -63,13 +63,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.hidden")}}{{ReadOnlyInline}}
   - : Returns a Boolean value indicating if the page is considered hidden or not.
 - {{DOMxRef("Document.images")}}{{ReadOnlyInline}}
-  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the images in the current document.
+  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the images in the current document.
 - {{DOMxRef("Document.implementation")}}{{ReadOnlyInline}}
   - : Returns the DOM implementation associated with the current document.
 - {{domxref("Document.lastElementChild")}} {{readonlyInline}}
   - : Returns the last child element of the current document.
 - {{DOMxRef("Document.links")}}{{ReadOnlyInline}}
-  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of all the hyperlinks in the document.
+  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of all the hyperlinks in the document.
 - {{DOMxRef("Document.mozSyntheticDocument")}} {{Non-standard_Inline}}
   - : Returns a {{JSxRef("Boolean")}} that is `true` only if this document is synthetic, such as a standalone image, video, audio file, or the like.
 - {{DOMxRef("Document.pictureInPictureElement")}} {{ReadOnlyInline}}
@@ -77,13 +77,13 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.pictureInPictureEnabled")}} {{ReadOnlyInline}}
   - : Returns true if the picture-in-picture feature is enabled.
 - {{DOMxRef("Document.plugins")}}{{ReadOnlyInline}}
-  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of the available plugins.
+  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of the available plugins.
 - {{DOMxRef("Document.pointerLockElement")}} {{ReadOnlyInline}}
   - : Returns the element set as the target for mouse events while the pointer is locked. `null` if lock is pending, pointer is unlocked, or if the target is in another document.
 - {{DOMxRef("Document.featurePolicy")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.
 - {{DOMxRef("Document.scripts")}}{{ReadOnlyInline}}
-  - : Returns a list as a {{DOMxRef("HTMLCollection")}} of all the {{HTMLElement("script")}} elements on the document.
+  - : Returns a list as an {{DOMxRef("HTMLCollection")}} of all the {{HTMLElement("script")}} elements on the document.
 - {{DOMxRef("Document.scrollingElement")}}{{ReadOnlyInline}}
   - : Returns a reference to the {{DOMxRef("Element")}} that scrolls the document.
 - {{DOMxRef("Document.styleSheets")}} {{ReadOnlyInline}}


### PR DESCRIPTION
The documentation refers to `list` whereas it ought to refer more precisely to `HTMLCollection`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
