### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/svganimatedrect/index.md
+++ b/files/en-us/web/api/svganimatedrect/index.md
@@ -30,7 +30,7 @@ The `SVGAnimatedRect` interface is used for attributes of basic {{ domxref("SVGR
       <td>
         <ul>
           <li>
-            readonly {{ domxref("SVGRect") }} <code>baseVal</code>
+            {{ domxref("SVGRect") }} <code>baseVal</code>
           </li>
           <li>
             readonly {{ domxref("SVGRect") }} <code>animVal</code>


### PR DESCRIPTION
baseVal isn't readonly

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Deleted 'readonly'

#### Motivation
Adding  onclick='this.viewBox.baseVal.height+=100;'  to an <SVG> element works, so baseVal isn't readonly.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
