### PR TITLE
Corrected NodeIterator:whatToShow example to use bit values

### DIFF
--- a/files/en-us/web/api/nodeiterator/whattoshow/index.md
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.md
@@ -127,7 +127,7 @@ var nodeIterator = document.createNodeIterator(
     { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-if( (nodeIterator.whatToShow == NodeFilter.SHOW_ALL) ||
+if( (nodeIterator.whatToShow & NodeFilter.SHOW_ALL) ||
     (nodeIterator.whatToShow & NodeFilter.SHOW_COMMENT ) > 0 ) {
     // nodeIterator will show comments
 }

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.md
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.md
@@ -127,7 +127,7 @@ var nodeIterator = document.createNodeIterator(
     { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-if( (nodeIterator.whatToShow & NodeFilter.SHOW_ALL) ||
+if ((nodeIterator.whatToShow & NodeFilter.SHOW_ALL) ||
     (nodeIterator.whatToShow & NodeFilter.SHOW_COMMENT)) {
     // nodeIterator will show comments
 }

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.md
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.md
@@ -123,12 +123,12 @@ The values that can be combined to form the bitmask are:
 ```js
 var nodeIterator = document.createNodeIterator(
     document.body,
-    NodeFilter.SHOW_ELEMENT + NodeFilter.SHOW_COMMENT + NodeFilter.SHOW_TEXT,
+    ( NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT ),
     { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
 if( (nodeIterator.whatToShow == NodeFilter.SHOW_ALL) ||
-    (nodeIterator.whatToShow % (NodeFilter.SHOW_COMMENT*2)) >= NodeFilter.SHOW_COMMENT) {
+    (nodeIterator.whatToShow & NodeFilter.SHOW_COMMENT ) > 0 ) {
     // nodeIterator will show comments
 }
 ```

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.md
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.md
@@ -128,7 +128,7 @@ var nodeIterator = document.createNodeIterator(
     false
 );
 if( (nodeIterator.whatToShow & NodeFilter.SHOW_ALL) ||
-    (nodeIterator.whatToShow & NodeFilter.SHOW_COMMENT ) > 0 ) {
+    (nodeIterator.whatToShow & NodeFilter.SHOW_COMMENT)) {
     // nodeIterator will show comments
 }
 ```


### PR DESCRIPTION
Corrected the example to use bit values and bit AND operator rather than addition.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
