### PR TITLE
variable typo, `docHTML` -> `docInnerHtml`

### DIFF
--- a/files/en-us/web/guide/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/guide/parsing_and_serializing_xml/index.md
@@ -104,7 +104,7 @@ If the DOM you have is an HTML document, you can serialize using `serializeToStr
 const docInnerHtml = document.documentElement.innerHTML;
 ```
 
-As a result, `docHTML` is a {{domxref("DOMString")}} containing the HTML of the contents of the document; that is, the {{HTMLElement("body")}} element's contents.
+As a result, `docInnerHtml` is a {{domxref("DOMString")}} containing the HTML of the contents of the document; that is, the {{HTMLElement("body")}} element's contents.
 
 You can get HTML corresponding to the `<body>` _and_ its descendants with this code:
 


### PR DESCRIPTION
I couldn't find any reference to `docHTML` so I presume it's supposed to be `docInnerHtml`, which is in the code block above.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
