### PR TITLE
Wrong variable name used

### DIFF
--- a/files/en-us/web/api/nodefilter/acceptnode/index.md
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.md
@@ -105,7 +105,7 @@ var nodeIterator = document.createNodeIterator(
 // Show the content of every non-empty text node that is a child of root
 var node;
 
-while ((node = iterator.nextNode())) {
+while ((node = nodeIterator.nextNode())) {
   alert(node.data);
 }
 ```


### PR DESCRIPTION
On the main page of [NodeFilter](https://developer.mozilla.org/en-US/docs/Web/API/NodeFilter) the right variable name is used for the same example, but here not.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
