### PR TITLE
Remove `which` property from `MouseEvent`

### DIFF
--- a/files/en-us/web/api/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/index.md
@@ -69,8 +69,6 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
   - : The Y coordinate of the mouse pointer in global (screen) coordinates.
 - {{domxref("MouseEvent.shiftKey")}} {{readonlyinline}}
   - : Returns `true` if the <kbd>shift</kbd> key was down when the mouse event was fired.
-- {{domxref("MouseEvent.which")}} {{non-standard_inline}} {{readonlyinline}}
-  - : The button being pressed when the mouse event was fired.
 - {{domxref("MouseEvent.mozPressure")}} {{non-standard_inline()}} {{deprecated_inline}} {{readonlyinline}}
   - : The amount of pressure applied to a touch or tablet device when generating the event; this value ranges between `0.0` (minimum pressure) and `1.0` (maximum pressure).
     Instead of using this deprecated (and non-standard) property, you should use {{domxref("PointerEvent")}} and look at its {{domxref("PointerEvent.pressure", "pressure")}} property.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove `which` property from `MouseEvent`

#### Motivation
Because the "which" property has been moved into `UIEvent` by PR #8751. And this article doesn't include properties inherited from `UIEvent`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
