### PR TITLE
Fix documents in `MouseEvent`

### DIFF
--- a/files/en-us/web/api/mouseevent/button/index.md
+++ b/files/en-us/web/api/mouseevent/button/index.md
@@ -16,7 +16,7 @@ browser-compat: api.MouseEvent.button
 The **`MouseEvent.button`** read-only property indicates which button was pressed on the mouse to trigger the event.
 
 This property only guarantees to indicate which buttons are pressed during events caused by pressing or releasing one or multiple buttons.
-As such, it is not reliable for events such as {{event("mouseenter")}}, {{event("mouseleave")}}, {{event("mouseover")}}, {{event("mouseout")}} or {{event("mousemove")}}.
+As such, it is not reliable for events such as {{domxref("Element/mouseenter_event", "mouseenter")}}, {{domxref("Element/mouseleave_event", "mouseleave")}}, {{domxref("Element/mouseover_event", "mouseover")}}, {{domxref("Element/mouseout_event", "mouseout")}}, or {{domxref("Element/mousemove_event", "mousemove")}}.
 
 Users may change the configuration of buttons on their pointing device so that if an event's button property is zero, it may not have been caused by the button that is physically left–most on the pointing device; however, it should behave as if the left button was clicked in the standard button layout.
 

--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -38,7 +38,7 @@ For more than one button pressed simultaneously, the values are combined (e.g., 
 
 ## Example
 
-This example logs the `buttons` property when you trigger a {{Event("mousedown")}} event.
+This example logs the `buttons` property when you trigger a {{domxref("Element/mousedown_event", "mousedown")}} event.
 
 ### HTML
 

--- a/files/en-us/web/api/mouseevent/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.md
@@ -74,8 +74,8 @@ The **`MouseEvent()`** constructor creates a new
 
     - `"relatedTarget"`, optional {{domxref("EventTarget")}}, defaulting to `null`
       that is the element just left
-      (in case of a {{event("mouseenter")}} or {{event("mouseover")}})
-      or is entering (in case of a {{event("mouseout")}} or {{event("mouseleave")}}).
+      (in case of a {{domxref("Element/mouseenter_event", "mouseenter")}} or {{domxref("Element/mouseover_event", "mouseover")}})
+      or is entering (in case of a {{domxref("Element/mouseout_event", "mouseout")}} or {{domxref("Element/mouseleave_event", "mouseleave")}}).
     - `"region"`, optional {{domxref("DOMString")}}, defaulting to `null`,
       that is the ID of the hit region affected by the event.
       The absence of any affected hit region is represented with the `null` value.

--- a/files/en-us/web/api/mouseevent/movementx/index.md
+++ b/files/en-us/web/api/mouseevent/movementx/index.md
@@ -16,7 +16,7 @@ browser-compat: api.MouseEvent.movementX
 ---
 {{APIRef("DOM Events")}}
 
-The **`movementX`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the X coordinate of the mouse pointer between the given event and the previous {{event("mousemove")}} event.
+The **`movementX`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the X coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
 In other words, the value of the property is computed like this: `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
 
 ## Value

--- a/files/en-us/web/api/mouseevent/movementy/index.md
+++ b/files/en-us/web/api/mouseevent/movementy/index.md
@@ -16,7 +16,7 @@ browser-compat: api.MouseEvent.movementY
 ---
 {{APIRef("DOM Events")}}
 
-The **`movementY`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the Y coordinate of the mouse pointer between the given event and the previous {{event("mousemove")}} event.
+The **`movementY`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the Y coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
 In other words, the value of the property is computed like this: `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
 
 ## Value

--- a/files/en-us/web/api/mouseevent/pagex/index.md
+++ b/files/en-us/web/api/mouseevent/pagex/index.md
@@ -98,7 +98,7 @@ box.addEventListener("mouseenter", updateDisplay, false);
 box.addEventListener("mouseleave", updateDisplay, false);
 ```
 
-The JavaScript code uses {{domxref("EventTarget.addEventListener", "addEventListener()")}} to register the function `updateDisplay()` as the event handler for the {{event("mousemove")}}, {{event("mouseenter")}}, and {{event("mouseleave")}} events.
+The JavaScript code uses {{domxref("EventTarget.addEventListener", "addEventListener()")}} to register the function `updateDisplay()` as the event handler for the {{domxref("Element/mousemove_event", "mousemove")}}, {{domxref("Element/mouseenter_event", "mouseenter")}}, and {{domxref("Element/mouseleave_event", "mouseleave")}} events.
 
 `updateDisplay()` replaces the contents of the {{HTMLElement("span")}} elements meant to contain the X and Y coordinates with the values of `pageX`
 and {{domxref("MouseEvent.pageY", "pageY")}}.

--- a/files/en-us/web/api/mouseevent/region/index.md
+++ b/files/en-us/web/api/mouseevent/region/index.md
@@ -22,7 +22,7 @@ A {{domxref("DOMString")}} representing the id of the hit region.
 
 ## Example
 
-Example of using the `event.region` combined with `CanvasRenderingContext2D.addHitRegion()` method.
+Example of using the `event.region` combined with `CanvasRenderingContext2D.addHitRegion()` method.
 
 ```html
 <canvas id="canvas"></canvas>

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.md
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.md
@@ -27,7 +27,7 @@ That is:
   </thead>
   <tbody>
     <tr>
-      <td>{{Event("mouseenter")}}</td>
+      <td>{{domxref("Element/mouseenter_event", "mouseenter")}}</td>
       <td>
         The {{domxref("EventTarget")}} the pointing device entered to
       </td>
@@ -36,7 +36,7 @@ That is:
       </td>
     </tr>
     <tr>
-      <td>{{Event("mouseleave")}}</td>
+      <td>{{domxref("Element/mouseleave_event", "mouseleave")}}</td>
       <td>
         The {{domxref("EventTarget")}} the pointing device exited from
       </td>
@@ -45,7 +45,7 @@ That is:
       </td>
     </tr>
     <tr>
-      <td>{{Event("mouseout")}}</td>
+      <td>{{domxref("Element/mouseout_event", "mouseout")}}</td>
       <td>
         The {{domxref("EventTarget")}} the pointing device exited from
       </td>
@@ -54,7 +54,7 @@ That is:
       </td>
     </tr>
     <tr>
-      <td>{{Event("mouseover")}}</td>
+      <td>{{domxref("Element/mouseover_event", "mouseover")}}</td>
       <td>
         The {{domxref("EventTarget")}} the pointing device entered to
       </td>

--- a/files/en-us/web/api/mouseevent/screenx/index.md
+++ b/files/en-us/web/api/mouseevent/screenx/index.md
@@ -33,14 +33,14 @@ Early versions of the spec defined this as an integer referring to the number of
 
 This example displays your mouse's coordinates whenever you trigger the {{Event("mousemove")}} event.
 
-#### HTML
+### HTML
 
 ```html
 <p>Move your mouse to see its position.</p>
 <p id="screen-log"></p>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 let screenLog = document.querySelector('#screen-log');
@@ -53,7 +53,7 @@ function logKey(e) {
 }
 ```
 
-#### Result
+### Result
 
 {{EmbedLiveSample("Example")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
- replace {{event}} macros with {{domxref}}
- fix space characters which obstruct word wrapping.
- fix incorrect heading levels

#### Motivation
The {{event}} macros often cause link error in i11n versions.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
