### PR TITLE
GeolocationPosition.timestamp is time acquired

### DIFF
--- a/files/en-us/web/api/epochtimestamp/index.md
+++ b/files/en-us/web/api/epochtimestamp/index.md
@@ -13,9 +13,6 @@ The **`EpochTimeStamp`** type represents a timestamp value in milliseconds (excl
 
 This was previously known as {{domxref("DOMTimeStamp")}}.
 
-> **Note:** The use of `EpochTimeStamp` is discouraged.
-> Where possible {{domxref("DOMHighResTimeStamp")}} should be used instead.
-
 
 ## Specifications
 

--- a/files/en-us/web/api/epochtimestamp/index.md
+++ b/files/en-us/web/api/epochtimestamp/index.md
@@ -1,0 +1,25 @@
+---
+title: EpochTimeStamp
+slug: Web/API/EpochTimeStamp
+tags:
+  - API
+  - DOM
+  - Interface
+  - Reference
+---
+{{APIRef("DOM")}}
+
+The **`EpochTimeStamp`** type represents a timestamp value in milliseconds (excluding leap seconds), relative to 01 January, 1970 00:00:00 UTC.
+
+This was previously known as {{domxref("DOMTimeStamp")}}.
+
+> **Note:** The use of `EpochTimeStamp` is discouraged.
+> Where possible {{domxref("DOMHighResTimeStamp")}} should be used instead.
+
+
+## Specifications
+
+| Specification                                                                        | Status                   | Comment               |
+| ------------------------------------------------------------------------------------ | ------------------------ | --------------------- |
+| {{SpecName("Highres Time Level 3", "#the-epochtimestamp-typedef", "EpochTimeStamp")}} | {{Spec2("Highres Time Level 3")}} | Initial specification |
+

--- a/files/en-us/web/api/geolocationposition/timestamp/index.md
+++ b/files/en-us/web/api/geolocationposition/timestamp/index.md
@@ -12,17 +12,12 @@ browser-compat: api.GeolocationPosition.timestamp
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 
-The **`GeolocationPosition.timestamp`** read-only property returns a {{domxref("DOMTimeStamp")}} object, represents the date and the time of the creation of the {{domxref("GeolocationPosition")}} object it belongs to. The precision is to the millisecond.
+The **`GeolocationPosition.timestamp`** read-only property returns a {{domxref("EpochTimeStamp")}} object that represents the date and time that the position was acquired by the device.
 
-## Syntax
+## Value
 
-```js
-var timestamp = geolocationPositionInstance.timestamp
-```
-
-### Value
-
-A {{domxref("DOMTimeStamp")}} object instance.
+A {{domxref("EpochTimeStamp")}} object instance indicating the time that the position was acquired.
+This is a value in in milliseconds (excluding leap seconds), relative to 01 January, 1970 00:00:00 UTC.
 
 ## Specifications
 

--- a/files/en-us/web/api/geolocationposition/timestamp/index.md
+++ b/files/en-us/web/api/geolocationposition/timestamp/index.md
@@ -17,7 +17,6 @@ The **`GeolocationPosition.timestamp`** read-only property returns a {{domxref("
 ## Value
 
 An {{domxref("EpochTimeStamp")}} object instance indicating the time that the position was acquired.
-This is a value in in milliseconds (excluding leap seconds), relative to 01 January, 1970 00:00:00 UTC.
 
 ## Specifications
 

--- a/files/en-us/web/api/geolocationposition/timestamp/index.md
+++ b/files/en-us/web/api/geolocationposition/timestamp/index.md
@@ -16,7 +16,7 @@ The **`GeolocationPosition.timestamp`** read-only property returns a {{domxref("
 
 ## Value
 
-A {{domxref("EpochTimeStamp")}} object instance indicating the time that the position was acquired.
+An {{domxref("EpochTimeStamp")}} object instance indicating the time that the position was acquired.
 This is a value in in milliseconds (excluding leap seconds), relative to 01 January, 1970 00:00:00 UTC.
 
 ## Specifications

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -27,7 +27,7 @@ The **`HTMLInputElement`** interface provides special properties and methods for
   </caption>
   <tbody>
     <tr>
-      <td><code>form </code>{{readonlyInline}}</td>
+      <td>{{domxref("HTMLInputElement.form", "form")}} {{readonlyInline}}</td>
       <td>
         <em>{{domxref("HTMLFormElement")}} object:</em>
         <strong>Returns</strong> a reference to the parent


### PR DESCRIPTION
Fixes #11669

As noted in the spec, the timestamp is from when the device got the position, not when the object was created.