### PR TITLE
ScreenOrientation.lock() updates for FF97

### DIFF
--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -42,7 +42,7 @@ screen.orientation.lock(orientation)
     - `"portrait-primary"`
       - : The "primary" portrait mode.
         If the natural orientation is a portrait mode (screen height is greater than width), this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
-        If the natural orientation is a landscape mode, then the user agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`: one of these will will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
+        If the natural orientation is a landscape mode, then the user agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`; one of those will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
     - `"portrait-secondary"`
       - : The secondary portrait orientation.
         If the natural orientation is a portrait mode, this will have an angle of 180 degrees (in other words, the device is upside down relative to its natural orientation).
@@ -78,7 +78,7 @@ The promise may be rejected with the following exceptions:
 ## Example
 
 This example shows how to lock the screen to the opposite orientation of the current one.
-Note that this example will only work on mobile devices, and other devices that support orientation changes.
+Note that this example will only work on mobile devices and other devices that support orientation changes.
 
 ```html
 <div id="example_container">

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -39,7 +39,7 @@ screen.orientation.lock(orientation)
     - `"portrait-primary"`
       - : The "primary" portrait mode.
         If the natural orientation is a portrait mode (screen height is greater than width) this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
-        If the natural orientation is a landscape mode then the user-agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`: one of these will will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
+        If the natural orientation is a landscape mode then the user agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`: one of these will will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
     - `"portrait-secondary"`
       - : The secondary portrait orientation.
         If the natural orientation is a portrait mode this will have an angle of 180 degrees (in other words, the device is upside down relative to its natural orientation).
@@ -47,7 +47,7 @@ screen.orientation.lock(orientation)
     - `"landscape-primary"`
       - : The "primary" landscape mode.
         If the natural orientation is a landscape mode (screen width is greater than height) this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
-        If the natural orientation is a portrait mode then the user-agent can choose either portrait orientation as the `landscape-primary` with an angle of either 90 or 270 degrees (`portrait-secondary` will be the other orientation and angle).
+        If the natural orientation is a portrait mode then the user agent can choose either portrait orientation as the `landscape-primary` with an angle of either 90 or 270 degrees (`portrait-secondary` will be the other orientation and angle).
     - `"landscape-secondary"`
       - : The secondary landscape mode.
         If the natural orientation is a landscape mode this orientation is upside down relative to the natural orientation, and will have an angle of 180 degrees.
@@ -65,7 +65,7 @@ The promise may be rejected with the following exceptions:
   - : The user agent does not support locking the screen orientation.
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : The user-agent does not meet the pre-lock conditions to perform an orientation change, or the document has sandboxed the orientation lock browsing context.
+  - : The user agent does not meet the pre-lock conditions to perform an orientation change, or the document has sandboxed the orientation lock browsing context.
 
 
 ## Example

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -38,20 +38,20 @@ screen.orientation.lock(orientation)
         Depending on the platform convention, this may be `portrait-primary`, `portrait-secondary`, or both.
     - `"portrait-primary"`
       - : The "primary" portrait mode.
-        If the natural orientation is a portrait mode (screen height is greater than width) this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
-        If the natural orientation is a landscape mode then the user agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`: one of these will will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
+        If the natural orientation is a portrait mode (screen height is greater than width), this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
+        If the natural orientation is a landscape mode, then the user agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`: one of these will will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
     - `"portrait-secondary"`
       - : The secondary portrait orientation.
-        If the natural orientation is a portrait mode this will have an angle of 180 degrees (in other words, the device is upside down relative to its natural orientation).
-        If the natural orientation is a landscape mode this can be either orientation as selected by the user agent: whichever was not selected for `landscape-primary`.
+        If the natural orientation is a portrait mode, this will have an angle of 180 degrees (in other words, the device is upside down relative to its natural orientation).
+        If the natural orientation is a landscape mode, this can be either orientation as selected by the user agent: whichever was not selected for `landscape-primary`.
     - `"landscape-primary"`
       - : The "primary" landscape mode.
-        If the natural orientation is a landscape mode (screen width is greater than height) this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
-        If the natural orientation is a portrait mode then the user agent can choose either portrait orientation as the `landscape-primary` with an angle of either 90 or 270 degrees (`portrait-secondary` will be the other orientation and angle).
+        If the natural orientation is a landscape mode (screen width is greater than height), this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
+        If the natural orientation is a portrait mode, then the user agent can choose either portrait orientation as the `landscape-primary` with an angle of either 90 or 270 degrees (`portrait-secondary` will be the other orientation and angle).
     - `"landscape-secondary"`
       - : The secondary landscape mode.
-        If the natural orientation is a landscape mode this orientation is upside down relative to the natural orientation, and will have an angle of 180 degrees.
-        If the natural orientation is a portrait mode this can be either orientation as selected by the user agent: whichever was not selected for `landscape-primary`.
+        If the natural orientation is a landscape mode, this orientation is upside down relative to the natural orientation, and will have an angle of 180 degrees.
+        If the natural orientation is a portrait mode, this can be either orientation as selected by the user agent: whichever was not selected for `landscape-primary`.
 
 ### Return value
 

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -13,9 +13,7 @@ browser-compat: api.ScreenOrientation.lock
 ---
 {{APIRef("Screen Orientation")}}
 
-The **`lock()`** property of the
-{{domxref("ScreenOrientation")}} interface locks the orientation of the containing
-document to its default orientation.
+The **`lock()`** property of the {{domxref("ScreenOrientation")}} interface locks the orientation of the containing document to the specified orientation.
 
 ## Syntax
 
@@ -25,23 +23,100 @@ screen.orientation.lock(orientation)
 
 ### Parameters
 
-- orientation
+- `orientation`
   - : An orientation lock type. One of the following:
 
-<!---->
-
-- `"any"`
-- `"natural"`
-- `"landscape"`
-- `"portrait"`
-- `"portrait-primary"`
-- `"portrait-secondary"`
-- `"landscape-primary"`
-- `"landscape-secondary"`
+    - `"any"`
+      - : Any of `portrait-primary`, `portrait-secondary`, `landscape-primary` or `landscape-secondary`.
+    - `"natural"`
+      - : The natural orientation of the screen from the underlying operating system: either `portrait-primary` or `landscape-primary`.
+    - `"landscape"`
+      - : An orientation where screen width is greater than the screen height.
+        Depending on the platform convention, this may be `landscape-primary`, `landscape-secondary`, or both.
+    - `"portrait"`
+      - : An orientation where screen height is greater than the screen width.
+        Depending on the platform convention, this may be `portrait-primary`, `portrait-secondary`, or both.
+    - `"portrait-primary"`
+      - : The "primary" portrait mode.
+        If the natural orientation is a portrait mode (screen height is greater than width) this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
+        If the natural orientation is a landscape mode then the user-agent can choose either portrait orientation as the `portrait-primary` and `portrait-secondary`: one of these will will be assigned the angle of 90 degrees and the other will have an angle of 270 degrees.
+    - `"portrait-secondary"`
+      - : The secondary portrait orientation.
+        If the natural orientation is a portrait mode this will have an angle of 180 degrees (in other words, the device is upside down relative to its natural orientation).
+        If the natural orientation is a landscape mode this can be either orientation as selected by the user agent: whichever was not selected for `landscape-primary`.
+    - `"landscape-primary"`
+      - : The "primary" landscape mode.
+        If the natural orientation is a landscape mode (screen width is greater than height) this will be the same as the natural orientation, and correspond to an angle of 0 degrees.
+        If the natural orientation is a portrait mode then the user-agent can choose either portrait orientation as the `landscape-primary` with an angle of either 90 or 270 degrees (`portrait-secondary` will be the other orientation and angle).
+    - `"landscape-secondary"`
+      - : The secondary landscape mode.
+        If the natural orientation is a landscape mode this orientation is upside down relative to the natural orientation, and will have an angle of 180 degrees.
+        If the natural orientation is a portrait mode this can be either orientation as selected by the user agent: whichever was not selected for `landscape-primary`.
 
 ### Return value
 
 A {{jsxref("Promise")}}.
+
+### Exceptions
+
+The promise may be rejected with the following exceptions:
+
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : The user agent does not support locking the screen orientation.
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The user-agent does not meet the pre-lock conditions to perform an orientation change, or the document has sandboxed the orientation lock browsing context.
+
+
+## Example
+
+```html
+<button id="lock_button">Lock</button>
+<button id="unlock_button">Unlock</button>
+<textarea id="log" rows="5" cols="100"></textarea>
+```
+
+```js
+const log = document.getElementById("log");
+
+const rotate_btn = document.querySelector('#lock_button');
+rotate_btn.addEventListener('click', () => { 
+  log.textContent+=`Lock pressed \n`;
+  
+  screen.orientation.lock('portrait-secondary')
+    .then( () => {
+      log.textContent = `Lock to portrait-secondary`
+      }
+    )
+    .catch ( failureval => {
+      log.textContent = `This fiailed`;
+      log.textContent = failureval;
+    }
+
+    );
+} );
+
+
+const unlock_btn = document.querySelector('#unlock_button');
+
+unlock_btn.addEventListener('click', () => { 
+  log.textContent+=`Unlock pressed \n`;
+  screen.orientation.unlock();
+} );
+
+
+let orientation = (screen.orientation || {}).type || screen.mozOrientation || screen.msOrientation;
+
+if (orientation === undefined) {
+   log.textContent="Orientation API not supported";
+}
+else {
+    log.textContent+=`Orientation: ${ orientation } \n`
+}
+```
+
+{{EmbedLiveSample('Example')}}:
+
 
 ## Specifications
 

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -100,7 +100,7 @@ rotate_btn.addEventListener('click', () => {
   const oppositeOrientation = screen.orientation.type.startsWith("portrait") ? "landscape" : "portrait";
   screen.orientation.lock(oppositeOrientation)
     .then( () => {
-      log.textContent = `Lock to ${oppositeOrientation}\n`
+      log.textContent = `Locked to ${oppositeOrientation}\n`
       }
     )
     .catch ( error => {

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -71,9 +71,12 @@ The promise may be rejected with the following exceptions:
 ## Example
 
 ```html
+<div id="example_container">
+<button id="fullscreen_button">Fullscreen</button>
 <button id="lock_button">Lock</button>
 <button id="unlock_button">Unlock</button>
 <textarea id="log" rows="5" cols="100"></textarea>
+</div>
 ```
 
 ```js
@@ -89,21 +92,26 @@ rotate_btn.addEventListener('click', () => {
       }
     )
     .catch ( failureval => {
-      log.textContent = `This fiailed`;
+      log.textContent = 'This failed';
       log.textContent = failureval;
     }
 
     );
 } );
 
-
 const unlock_btn = document.querySelector('#unlock_button');
 
 unlock_btn.addEventListener('click', () => { 
-  log.textContent+=`Unlock pressed \n`;
+  log.textContent+='Unlock pressed \n';
   screen.orientation.unlock();
 } );
 
+const fullscreen_btn = document.querySelector('#fullscreen_button');
+
+fullscreen_btn.addEventListener('click', () => { 
+  log.textContent+='Fullscreen button pressed \n';
+  document.querySelector("#example_container").requestFullscreen();
+} );
 
 let orientation = (screen.orientation || {}).type || screen.mozOrientation || screen.msOrientation;
 

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -15,6 +15,9 @@ browser-compat: api.ScreenOrientation.lock
 
 The **`lock()`** property of the {{domxref("ScreenOrientation")}} interface locks the orientation of the containing document to the specified orientation.
 
+Typically orientation locking is only enabled on mobile devices, and when the browser context is full screen.
+If locking is supported, then it must work for all the parameter values listed below.
+
 ## Syntax
 
 ```js
@@ -55,7 +58,7 @@ screen.orientation.lock(orientation)
 
 ### Return value
 
-A {{jsxref("Promise")}}.
+A {{jsxref("Promise")}} that resolves after locking succeeds.
 
 ### Exceptions
 
@@ -65,66 +68,65 @@ The promise may be rejected with the following exceptions:
   - : The user agent does not support locking the screen orientation.
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : The user agent does not meet the pre-lock conditions to perform an orientation change, or the document has sandboxed the orientation lock browsing context.
+  - : The user-agent's pre-lock conditions are not met.
+    For example, a browser may require that the top-level browsing context's `Document` is full screen.
+    The promise may also be rejected with this error if the document has the sandboxed orientation lock browsing context flag set.
 
+- `TypeError`
+  - : The `orientation` argument was not supplied.
 
 ## Example
+
+This example shows how to lock the screen to the opposite orientation of the current one.
+Note that this example will only work on mobile devices, and other devices that support orientation changes.
 
 ```html
 <div id="example_container">
 <button id="fullscreen_button">Fullscreen</button>
 <button id="lock_button">Lock</button>
 <button id="unlock_button">Unlock</button>
-<textarea id="log" rows="5" cols="100"></textarea>
+<textarea id="log" rows="7" cols="85"></textarea>
 </div>
 ```
 
 ```js
 const log = document.getElementById("log");
 
+// Lock button: Lock the screen to the other orientation (rotated by 90 degrees) 
 const rotate_btn = document.querySelector('#lock_button');
 rotate_btn.addEventListener('click', () => { 
   log.textContent+=`Lock pressed \n`;
-  
-  screen.orientation.lock('portrait-secondary')
+
+  const oppositeOrientation = screen.orientation.type.startsWith("portrait") ? "landscape" : "portrait";
+  screen.orientation.lock(oppositeOrientation)
     .then( () => {
-      log.textContent = `Lock to portrait-secondary`
+      log.textContent = `Lock to ${oppositeOrientation}\n`
       }
     )
-    .catch ( failureval => {
-      log.textContent = 'This failed';
-      log.textContent = failureval;
-    }
+    .catch ( error => {
+      log.textContent += `${error}\n`;
+    });
+});
 
-    );
-} );
-
+// Unlock button: Unlock the screen orientation (if locked)
 const unlock_btn = document.querySelector('#unlock_button');
-
 unlock_btn.addEventListener('click', () => { 
   log.textContent+='Unlock pressed \n';
   screen.orientation.unlock();
 } );
 
+// Full screen button: Set the example to full-screen.
 const fullscreen_btn = document.querySelector('#fullscreen_button');
-
 fullscreen_btn.addEventListener('click', () => { 
-  log.textContent+='Fullscreen button pressed \n';
+  log.textContent+='Fullscreen pressed \n';
   document.querySelector("#example_container").requestFullscreen();
 } );
-
-let orientation = (screen.orientation || {}).type || screen.mozOrientation || screen.msOrientation;
-
-if (orientation === undefined) {
-   log.textContent="Orientation API not supported";
-}
-else {
-    log.textContent+=`Orientation: ${ orientation } \n`
-}
 ```
 
-{{EmbedLiveSample('Example')}}:
+To test the example, first press the Fullscreen button.
+Once the example is full screen, press the Lock button to switch the orientation, and Unlock to return to the natural orientation.
 
+{{EmbedLiveSample('Example')}}:
 
 ## Specifications
 


### PR DESCRIPTION
[ScreenOrientation.lock()](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) has been updated for FF97 - see https://bugzilla.mozilla.org/show_bug.cgi?id=1697647. This does general improvements including an example.

This is in draft because I'm still testing/working on the example. 

Rest of work for this tracked in #11594