### PR TITLE
fix: -webkit-text-stroke constituent properties lacked "-text-"

### DIFF
--- a/files/en-us/web/css/-webkit-text-stroke/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke/index.md
@@ -32,8 +32,8 @@ text-stroke: unset;
 
 This property is a shorthand for the following CSS properties:
 
-- [`-webkit-stroke-color`](/en-US/docs/Web/CSS/-webkit-text-stroke-color)
-- [`-webkit-stroke-width`](/en-US/docs/Web/CSS/-webkit-text-stroke-width)
+- [`-webkit-text-stroke-color`](/en-US/docs/Web/CSS/-webkit-text-stroke-color)
+- [`-webkit-text-stroke-width`](/en-US/docs/Web/CSS/-webkit-text-stroke-width)
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The constituent properties for `-webkit-text-stroke` were missing the `-text-` part
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
It was broken.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
They are now the same as the pages they link to.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
n/a
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
