### PR TITLE
Added clarification on value returned by methods

### DIFF
--- a/files/en-us/web/api/treewalker/index.md
+++ b/files/en-us/web/api/treewalker/index.md
@@ -54,7 +54,24 @@ _This interface doesn't inherit any method._
 - {{domxref("TreeWalker.parentNode()")}}
   - : Moves the current {{domxref("Node")}} to the first _visible_ ancestor node in the document order, and returns the found node. It also moves the current node to this one. If no such node exists, or if it is before that the _root node_ defined at the object construction, returns `null` and the current node is not changed.
 - {{domxref("TreeWalker.firstChild()")}}
-  - : Moves the current {{domxref("Node")}} to the first _visible_ child of the current node, and returns the found child. It also moves the current node to this child. If no such child exists, returns `null` and the current node is not changed.
+  - : Moves the current {{domxref("Node")}} to the first _visible_ child of the current node, and returns the found child. It also moves the current node to this child. If no such child exists, returns `null` and the current node is not changed. Note that the node returned by `firstChild()` is dependent on the value of `whatToShow` set during instantiation of the `TreeWalker` object. Assuming the following HTML tree, and if you set the `whatToShow` to `NodeFilter.SHOW_ALL` a call to `firstChild()` will return a `Text` node and not an `HTMLDivElement` ojbect.
+  ```html
+  <!DOCTYPE html>
+  <html>
+    <head><title>Demo</title>
+    <body>
+      <div id="container"></div>
+    </body>
+  </html>
+  ```
+  ```js
+  let walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ALL);
+  let node = walker.firstChild(); // nodeName: "#text"
+  // But if we do:
+  let walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+  let node = walker.firstChild(); // nodeName: "DIV"
+  ```
+  The same applies to `nextSibling()`, `previousSibling()`, `firstChild()` and `lastChild()`
 - {{domxref("TreeWalker.lastChild()")}}
   - : Moves the current {{domxref("Node")}} to the last _visible_ child of the current node, and returns the found child. It also moves the current node to this child. If no such child exists, `null` is returned and the current node is not changed.
 - {{domxref("TreeWalker.previousSibling()")}}


### PR DESCRIPTION
I have added some clarifications and simple example on the value returned by `TreeWalker` methods depending on the value set for `whatToShow`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
