### PR TITLE
Link to correct GitHub labels

### DIFF
--- a/files/en-us/mdn/contribute/fixing_mdn_content_bugs/index.md
+++ b/files/en-us/mdn/contribute/fixing_mdn_content_bugs/index.md
@@ -18,12 +18,15 @@ To help you choose what content issues to work on, we've sorted them using GitHu
 
 The labels below help you find tasks based on how much time you have available.
 
-| Label                                                                                                                                                                                                                                                                             | Description                                                           |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [10-minute tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%2210+minute+task%22) [10-minute tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%2210+minute+task%22)                 | A really quick task, which will probably take you 10 minutes or less. |
-| [30-minute tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%2230+minute+task%22) [30-minute tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%2230+minute+task%22)                 | A slightly more involved task — might take around 30 minutes.         |
-| [1-hour tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%221+hour+task%22) [1-hour tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%221+hour+task%22)                             | A long task — will take an hour, or maybe even two.                   |
-| [multiple hour tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%22multiple+hour+task%22) [multiple hour tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%22multiple+hour+task%22) | A very in-depth task taking multiple hours to complete.               |
+| Label                                                                                                                                       | Description                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Less-than-30-minute tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%22time%3A+-30mins%22) | A task that will probably take less than 30 minutes.              |
+| [Less-than-3-hour tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%22time%3A+-3hr%22)       | A task that will probably take less than 3 hours.                 |
+| [Less-than-2-day tasks on the content repo](https://github.com/mdn/content/issues?q=is%3Aissue+is%3Aopen+label%3A%22time%3A+-2days%22)      | A task that will probably take less than 2 days.                  |
+| [10-minute tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%2210+minute+task%22)            | A really quick task, which will probably take 10 minutes or less. |
+| [30-minute tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%2230+minute+task%22)            | A slightly more involved task — might take around 30 minutes.     |
+| [1-hour tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%221+hour+task%22)                  | A long task — will take an hour, or maybe even two.               |
+| [multiple hour tasks on the sprints repo](https://github.com/mdn/sprints/issues?q=is%3Aissue+is%3Aopen+label%3A%22multiple+hour+task%22)    | A very in-depth task taking multiple hours to complete.           |
 
 If you'd prefer to browse your tasks and choose by technology category instead, you can also find the same issues organized into project boards:
 


### PR DESCRIPTION
#### Summary

Link to correct GitHub labels from "Fixing MDN content bugs" article:
- Put one link in each table row instead of two.
- Put rows for mdn/content repo before rows for mdn/sprints repo.
- Modify links for mdn/content repo: the 4 existing links were removed and 3 new links were added.

#### Motivation

Help potential new contributors find things they might want to work on more quickly.

There might be better ideas for the link text, descriptions, etc. I mostly just want to link to correct labels.

#### Supporting details

The 4 labels that were linked before for mdn/content are no longer referenced because none of the issues in the mdn/content repo have those labels.

The 3 new labels for mdn/content appear to be the only labels related to estimating task time, when I look at https://github.com/mdn/content/labels, and they've all been used in the past year.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error