### PR TITLE
Adds support for AbortSignal.reason and related items

### DIFF
--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -27,7 +27,7 @@ abort(reason)
 
 - `reason`
   - : The reason why the operation was aborted, which can be any JavaScript value.
-    If not specified, the reason set to "AbortError" {{domxref("DOMException")}}. 
+    If not specified, the reason is set to "AbortError" {{domxref("DOMException")}}. 
 
 ### Return value
 

--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -13,17 +13,21 @@ browser-compat: api.AbortController.abort
 ---
 {{APIRef("DOM")}}
 
-The **`abort()`** method of the {{domxref("AbortController")}} interface aborts a DOM request before it has completed. This is able to abort [fetch requests](/en-US/docs/Web/API/fetch), the consumption of any response bodies, or streams.
+The **`abort()`** method of the {{domxref("AbortController")}} interface aborts a DOM request before it has completed.
+This is able to abort [fetch requests](/en-US/docs/Web/API/fetch), the consumption of any response bodies, or streams.
 
 ## Syntax
 
 ```js
-controller.abort();
+abort()
+abort(reason)
 ```
 
 ### Parameters
 
-None.
+- `reason`
+  - : The reason why the operation was aborted, which can be any JavaScript value.
+    If not specified, the reason set to "AbortError" {{domxref("DOMException")}}. 
 
 ### Return value
 

--- a/files/en-us/web/api/abortsignal/abort/index.md
+++ b/files/en-us/web/api/abortsignal/abort/index.md
@@ -23,19 +23,25 @@ return controller.signal;
 
 This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organised such that the abort logic should be run even if the intended fetch operation has not been started).
 
-> **Note:** The method is similar in purpose to {{JSxRef("Promise.reject")}}
+> **Note:** The method is similar in purpose to {{JSxRef("Promise.reject")}}.
+
 
 ## Syntax
 
 ```js
-AbortSignal.abort();
+abort()
+abort(reason)
 ```
+
+### Parameters
+
+- `reason`
+  - : The reason why the operation was aborted, which can be any JavaScript value.
+    If not specified, the reason is set to "AbortError" {{domxref("DOMException")}}. 
 
 ### Return value
 
-An `AbortSignal` instance with the {{domxref("AbortSignal.aborted")}} property set to `true`.
-
-.
+An `AbortSignal` instance with the {{domxref("AbortSignal.aborted")}} property set to `true`, and {{domxref("AbortSignal.reason")}} set to the specified or default reason value.
 
 ## Specifications
 

--- a/files/en-us/web/api/abortsignal/aborted/index.md
+++ b/files/en-us/web/api/abortsignal/aborted/index.md
@@ -14,19 +14,14 @@ browser-compat: api.AbortSignal.aborted
 
 The **`aborted`** read-only property returns a value that indicates whether the DOM requests the signal is communicating with are aborted (`true`) or not (`false`).
 
-## Syntax
-
-```js
-abortSignal.aborted;
-```
-
-### Value
+## Value
 
 `true` (aborted) or `false`
 
 ## Examples
 
-In the following snippet, we create a new `AbortController` object, and get its {{domxref("AbortSignal")}} (available using the `signal` property). Later on we check whether or not the signal has been aborted using the `aborted` property, and send an appropriate log to the console.
+In the following snippet, we create a new `AbortController` object, and get its {{domxref("AbortSignal")}} (available using the `signal` property).
+Later on we check whether or not the signal has been aborted using the `aborted` property, and send an appropriate log to the console.
 
 ```js
 var controller = new AbortController();

--- a/files/en-us/web/api/abortsignal/aborted/index.md
+++ b/files/en-us/web/api/abortsignal/aborted/index.md
@@ -21,7 +21,7 @@ The **`aborted`** read-only property returns a value that indicates whether the 
 ## Examples
 
 In the following snippet, we create a new `AbortController` object, and get its {{domxref("AbortSignal")}} (available using the `signal` property).
-Later on we check whether or not the signal has been aborted using the `aborted` property, and send an appropriate log to the console.
+Later on, using the `aborted` property, we check whether or not the signal has been aborted, and send an appropriate log to the console.
 
 ```js
 var controller = new AbortController();

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -21,7 +21,7 @@ _The AbortSignal interface also inherits properties from its parent interface, {
 - {{domxref("AbortSignal.aborted")}} {{readonlyInline}}
   - : A {{Glossary("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (`true`) or not (`false`).
 - {{domxref("AbortSignal.reason")}} {{readonlyInline}}
-  - : A javascript value providing the abort reason once the signal has aborted.
+  - : A JavaScript value providing the abort reason, once the signal has aborted.
 
 ## Events
 

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -20,6 +20,8 @@ _The AbortSignal interface also inherits properties from its parent interface, {
 
 - {{domxref("AbortSignal.aborted")}} {{readonlyInline}}
   - : A {{Glossary("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (`true`) or not (`false`).
+- {{domxref("AbortSignal.reason")}} {{readonlyInline}}
+  - : A javascript value providing the abort reason once the signal has aborted.
 
 ## Events
 

--- a/files/en-us/web/api/abortsignal/reason/index.md
+++ b/files/en-us/web/api/abortsignal/reason/index.md
@@ -1,0 +1,49 @@
+---
+title: AbortSignal.reason
+slug: Web/API/AbortSignal/reason
+tags:
+  - API
+  - AbortSignal
+  - Experimental
+  - Property
+  - Reference
+  - reason
+browser-compat: api.AbortSignal.reason
+---
+{{APIRef("DOM")}}
+
+The **`reason`** read-only property returns a JavaScript value that indicates the abort reason.
+
+The property is `undefined` when the signal has not been aborted.
+It can be set to a specific value when the signal is aborted, using {{domxref("AbortController.abort()")}} or {{domxref("AbortSignal.abort()")}}.
+If not explicitly set in those methods, it defaults to the "AbortError" {{domxref("DOMException")}}.
+
+## Value
+
+A JavaScript value that indicates the abort reason, or `undefined`, if not aborted.
+
+## Examples
+
+In the following snippet, we create a new `AbortController` object, and get its {{domxref("AbortSignal")}} (available using the `signal` property).
+Later on we check whether or not the signal has been aborted using the `aborted` property, and log the abort status and reason to the console.
+
+```js
+var controller = new AbortController();
+var signal = controller.signal;
+
+// ...
+
+signal.aborted ? console.log(`Request aborted with reason: ${signal.reason}`) : console.log('Request not aborted');
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Fetch API](/en-US/docs/Web/API/Fetch_API)

--- a/files/en-us/web/api/abortsignal/reason/index.md
+++ b/files/en-us/web/api/abortsignal/reason/index.md
@@ -16,7 +16,7 @@ The **`reason`** read-only property returns a JavaScript value that indicates th
 
 The property is `undefined` when the signal has not been aborted.
 It can be set to a specific value when the signal is aborted, using {{domxref("AbortController.abort()")}} or {{domxref("AbortSignal.abort()")}}.
-If not explicitly set in those methods, it defaults to the "AbortError" {{domxref("DOMException")}}.
+If not explicitly set in those methods, it defaults to "AbortError" {{domxref("DOMException")}}.
 
 ## Value
 
@@ -25,7 +25,7 @@ A JavaScript value that indicates the abort reason, or `undefined`, if not abort
 ## Examples
 
 In the following snippet, we create a new `AbortController` object, and get its {{domxref("AbortSignal")}} (available using the `signal` property).
-Later on we check whether or not the signal has been aborted using the `aborted` property, and log the abort status and reason to the console.
+Later on, using the `aborted` property, we check whether or not the signal has been aborted, and log the abort status and reason to the console.
 
 ```js
 var controller = new AbortController();


### PR DESCRIPTION
`AbortSignal` has been updated with a `reason` property that is `undefined` normally but can be set to any value when the signal is aborted. This PR does the first part of the work of documenting this property and the associated setters.

This is part of the work for #11593

Note, that I am not "done". 
- This is no worse than before but it could be improved with some better examples, ideally live examples.
- AbortSignal has another method I will need to add too https://dom.spec.whatwg.org/#dom-abortsignal-throwifaborted
- I don't full understand the cases where you need to set a reason.