### PR TITLE
Update index.md where glossary linking was wrong

### DIFF
--- a/files/en-us/glossary/csp/index.md
+++ b/files/en-us/glossary/csp/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP
   - Infrastructure
 ---
-A CSP ([Content Security Policy](/en-US/docs/Web/HTTP/CSP)) is used to detect and mitigate certain types of website related attacks like {{Glossary("Cross-site_scripting")}}, [clickjacking](/en-us/Glossary/Clickjacking) and data injections.
+A CSP ([Content Security Policy](/en-US/docs/Web/HTTP/CSP)) is used to detect and mitigate certain types of website related attacks like {{Glossary("Cross-site_scripting")}}, [clickjacking](/en-US/docs/Glossary/Clickjacking) and data injections.
 
 The implementation is based on an {{Glossary("HTTP")}} header called {{HTTPHeader("Content-Security-Policy")}}.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
missing "docs" path when linking to the glossary entry of "Clickjacking" & "US" in en-US in lowercase
added ...-US/docs/... to the one link where it was incorrect (Clickjacking glossary linking)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'm currently learning with MDN and want to give everyone else a perfect learning experience.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
I just saw that also on other pages, e.g. CSP Glossary entry, the link to the Clickjacking Glossary entry is wrong in the same way. I am going to track down the "clickjacking links" and fix them.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
