### PR TITLE
Update index.md where glossary linking was wrong

### DIFF
--- a/files/en-us/web/security/types_of_attacks/index.md
+++ b/files/en-us/web/security/types_of_attacks/index.md
@@ -8,7 +8,7 @@ This article describes various types of security attacks and techniques to mitig
 
 ## Click-jacking
 
-[Clickjacking](/en-us/Glossary/Clickjacking) is the practice of tricking a user into clicking on a link, button, etc. that is other than what the user thinks it is. This can be used, for example, to steal login credentials or to get the user's unwitting permission to install a piece of malware. (Click-jacking is sometimes called "user interface redressing", though this is a misuse of the term "redress".)
+[Clickjacking](/en-US/docs/Glossary/Clickjacking) is the practice of tricking a user into clicking on a link, button, etc. that is other than what the user thinks it is. This can be used, for example, to steal login credentials or to get the user's unwitting permission to install a piece of malware. (Click-jacking is sometimes called "user interface redressing", though this is a misuse of the term "redress".)
 
 ## Cross-site scripting (XSS)
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
missing "docs" path when linking to the glossary entry of "Clickjacking" & "US" in en-US in lowercase
added ...-US/docs/... to the one link where it was incorrect (Clickjacking glossary linking)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'm currently learning with MDN and want to give everyone else a perfect learning experience.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
I just saw that also on other pages the link to the Clickjacking Glossary entry is wrong in the same way. I am going to track down the "clickjacking links" and fix them.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
