### PR TITLE
Update index.md where glossary linking was wrong

### DIFF
--- a/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
@@ -371,7 +371,7 @@ The following might not be a good idea if you use "real" subdomains for certain 
 
 ## Frame Options
 
-The example below sends the `X-Frame-Options` response header with DENY as the value, informing browsers not to display the content of the web page in any frame to protect the website against [clickjacking](/en-us/Glossary/Clickjacking).
+The example below sends the `X-Frame-Options` response header with DENY as the value, informing browsers not to display the content of the web page in any frame to protect the website against [clickjacking](/en-US/docs/Glossary/Clickjacking).
 
 This might not be the best setting for everyone. You should read about [the other two possible values for the `X-Frame-Options` header](https://datatracker.ietf.org/doc/html/rfc7034#section-2.1): `SAMEORIGIN` and `ALLOW-FROM`.
 
@@ -473,7 +473,7 @@ Be aware that Strict Transport Security is not revokable and you must ensure bei
 3.  Only allows form submissions are from the current origin with: `form-action 'self'`
 4.  Prevents all websites (including your own) from embedding your webpages within e.g. the `<iframe>` or `<object>` element by setting: `frame-ancestors 'none'`.
 
-    - The `frame-ancestors`directive helps avoid [clickjacking](/en-us/Glossary/Clickjacking) attacks and is similar to the `X-Frame-Options` header
+    - The `frame-ancestors`directive helps avoid [clickjacking](/en-US/docs/Glossary/Clickjacking) attacks and is similar to the `X-Frame-Options` header
     - Browsers that support the CSP header will ignore `X-Frame-Options` if `frame-ancestors` is also specified
 
 5.  Forces the browser to treat all the resources that are served over HTTP as if they were loaded securely over HTTPS by setting the `upgrade-insecure-requests` directive


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
missing "docs" path when linking to the glossary entry of "Clickjacking" & "US" in en-US in lowercase
added ...-US/docs/... to the 2 links where it was incorrect (Clickjacking glossary linking)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'm currently learning with MDN and want to give everyone else a perfect learning experience.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
I just saw that also on other pages the link to the Clickjacking Glossary entry is wrong in the same way. I am going to track down the "clickjacking links" and fix them.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
