### PR TITLE
Replace incorrect UTF-16 surrogate pair

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -66,7 +66,7 @@ Unicode order. All `undefined` elements are sorted to the end of the array.
 > encoded as two surrogate code units, of the range
 > `\uD800`-`\uDFFF`. The value of each code unit is taken
 > separately into account for the comparison. Thus the character formed by the surrogate
-> pair `\uD655\uDE55` will be sorted before the character
+> pair `\uD855\uDE51` will be sorted before the character
 > `\uFF3A`.
 
 If `compareFunction` is supplied, all non-`undefined` array


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Corrects example UTF-16 surrogate pair to have in-range high and low surrogate values.

#### Motivation
Corrects a recently reported issue.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #11639 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
