### PR TITLE
Fix: bring gl.FRAMEBUFFER target in line with  the spec

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -28,14 +28,12 @@ void gl.bindFramebuffer(target, framebuffer);
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
 
     - `gl.FRAMEBUFFER`: Collection buffer data storage of color, alpha,
-      depth and stencil buffers used to render an image.
+      depth and stencil buffers used as both a destination for drawing and as a source for reading (see below).
     - When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
       the following values are available additionally:
 
-      - `gl.DRAW_FRAMEBUFFER`: Equivalent to `gl.FRAMEBUFFER`.
-        Used as a destination for drawing, rendering, clearing, and writing
-        operations.
-      - `gl.READ_FRAMEBUFFER`: Used as a source for reading operations.
+      - `gl.DRAW_FRAMEBUFFER`: Used as a destination for drawing operations such as `gl.draw*`, `gl.clear*` and `gl.blitFramebuffer`.
+      - `gl.READ_FRAMEBUFFER`: Used as a source for reading operations such as `gl.readPixels` and `gl.blitFramebuffer`
 
 - framebuffer
   - : A {{domxref("WebGLFramebuffer")}} object to bind.


### PR DESCRIPTION
OpenGL ES 3 section 4.4.1:  "Calling BindFramebuffer with target set to `FRAMEBUFFER` binds framebuffer to both the draw and read targets."

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed the meaning of the `gl.FRAMEBUFFER` target

#### Motivation
Incompliance with the spec

#### Supporting details
[OpenGL ES 3](https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf) section 4.4.1: "Calling BindFramebuffer with target set to FRAMEBUFFER binds framebuffer to both the draw and read targets."

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
