### PR TITLE
Fixed Incorrect Calculations

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -142,7 +142,7 @@ With the `flex-grow` property set to a positive integer, flex items can grow alo
 
 If we gave all of our items in the example above a `flex-grow` value of 1 then the available space in the flex container would be equally shared between our items and they would stretch to fill the container on the main axis.
 
-The flex-grow property can be used to distribute space in proportion. If we give our first item a `flex-grow` value of 2, and the other items a value of 1 each, 2 parts will be given to the first item (250px out of 500px in the case of the example above), 1 part each the other two (125px each out of the 500px total).
+The flex-grow property can be used to distribute space in proportion. If we give our first item a `flex-grow` value of 2, and the other items a value of 1 each, 2 parts of the available space will be given to the first item (100px out of 200px in the case of the example above), 1 part each the other two (50px each out of the 200px total).
 
 ### The flex-shrink property
 


### PR DESCRIPTION
 Here is a [Codepen](https://codepen.io/vthukral94/pen/NWazPmN) to justify new numbers.

#### Summary
`flex-grow` lets a flex item specify how it's main-size can grow when their is free space available in the parent container. When `flex-grow` is a positive number, it specifies the proportion of the free space that can be added to the item's main size. The existing calculations in the document were made on the total space instead of free space.

#### Motivation
To fix incorrect model of computation.

#### Supporting details
A [demo](https://codepen.io/vthukral94/pen/NWazPmN) justifying new numbers.


This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

