### PR TITLE
Fix some awkward hyperlink formatting

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.statements.for_in
 {{jsSidebar("Statements")}}
 
 The **`for...in` statement** iterates over all [enumerable
-properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object that are keyed by strings (ignoring ones keyed by [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)s),
+properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object that are keyed by strings (ignoring ones keyed by [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbols)),
 including inherited enumerable properties.
 
 {{EmbedInteractiveExample("pages/js/statement-forin.html")}}

--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.statements.for_in
 {{jsSidebar("Statements")}}
 
 The **`for...in` statement** iterates over all [enumerable
-properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object that are keyed by strings (ignoring ones keyed by [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbols)),
+properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object that are keyed by strings (ignoring ones keyed by [Symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)),
 including inherited enumerable properties.
 
 {{EmbedInteractiveExample("pages/js/statement-forin.html")}}


### PR DESCRIPTION
fixed typo on line 13

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

I fixed a simple typo on a hyperlink, the entire word was not clickable.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Rids of a simple distraction, hopefully leads to less miss clicks on the single letter that was left without a hyperlink

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
