### PR TITLE
HTMLElement .offset[height|left|parent|top|width] are stable removed experimental icon

### DIFF
--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -64,15 +64,15 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}, and implements tho
   - : A boolean value indicating whether an import script can be executed in user agents that support module scripts.
 - {{DOMxRef("HTMLElement.nonce")}}
   - : Returns the cryptographic number used once that is used by Content Security Policy to determine whether a given fetch will be allowed to proceed.
-- {{DOMxRef("HTMLElement.offsetHeight")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("HTMLElement.offsetHeight")}} {{ReadOnlyInline}}
   - : Returns a `double` containing the height of an element, relative to the layout.
-- {{DOMxRef("HTMLElement.offsetLeft")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("HTMLElement.offsetLeft")}} {{ReadOnlyInline}}
   - : Returns a `double`, the distance from this element's left border to its `offsetParent`'s left border.
-- {{DOMxRef("HTMLElement.offsetParent")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("HTMLElement.offsetParent")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("Element")}} that is the element from which all offset calculations are currently computed.
-- {{DOMxRef("HTMLElement.offsetTop")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("HTMLElement.offsetTop")}} {{ReadOnlyInline}}
   - : Returns a `double`, the distance from this element's top border to its `offsetParent`'s top border.
-- {{DOMxRef("HTMLElement.offsetWidth")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("HTMLElement.offsetWidth")}} {{ReadOnlyInline}}
   - : Returns a `double` containing the width of an element, relative to the layout.
 - {{DOMxRef("HTMLElement.properties")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns a {{DOMxRef("HTMLPropertiesCollection")}}…


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
HTMLElement .offset[height|left|parent|top|width] have been stable for many many years. I removed experimental icon from the main content section. This must have either been overlooked or just a simple mistake.


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It is important to properly show what attrs/properties are and are not experimental to properly encourage or discourage use in applications/websites. When the wrong information is shown, it can lead to confusion or the use/non-use of standards compliant or cross-browser features.

This page in itself needs a lot of work, there are many missing features and attributes. I will edit them and flesh the page out as well. This is not my first contribution, but I want to make sure that I do a small first initial commit and see the lag for merge before deciding if I want to continue with small incremental PRs or a larger one with more updates in a chunk for the next updates.


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The pages on the offset* themselves do not say they are experimental, and the browser support is green across the board from extremely old browser versions. Also, nowhere else on MDN are the offset* attributes listed as experimental. I know I have been using them since at least 2009.

[Example of offsetHeight on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight) where the page clearly shows it is not experimental and has long looong time browser support, since version 1 of several browsers.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
