### PR TITLE
MediaQueryList removeListener depreciation

### DIFF
--- a/files/en-us/web/css/media_queries/testing_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/testing_media_queries/index.md
@@ -41,7 +41,7 @@ if (mediaQueryList.matches) {
 
 ## Receiving query notifications
 
-If you need to be aware of changes to the evaluated result of the query on an ongoing basis, it's more efficient to register a [listener](/en-US/docs/Web/API/EventTarget/addEventListener) than to poll the query's result. To do this, call the `addListener()` method on the {{domxref("MediaQueryList")}} object, with a callback function to invoke when the media query status changes (e.g., the media query test goes from `true` to `false`):
+If you need to be aware of changes to the evaluated result of the query on an ongoing basis, it's more efficient to register a [listener](/en-US/docs/Web/API/EventTarget/addEventListener) than to poll the query's result. To do this, call the `addEventListener()` method on the {{domxref("MediaQueryList")}} object, with a callback function to invoke when the media query status changes (e.g., the media query test goes from `true` to `false`):
 
 ```js
 // Create the query list.
@@ -79,10 +79,10 @@ This event object also includes the {{domxref("MediaQueryListEvent.media","media
 
 ## Ending query notifications
 
-To stop receiving notifications about changes to the value of your media query, call `removeListener()` on the `MediaQueryList`, passing it the name of the previously-defined callback function:
+To stop receiving notifications about changes to the value of your media query, call `removeEventListener()` on the `MediaQueryList`, passing it the name of the previously-defined callback function:
 
 ```js
-mediaQueryList.removeListener(handleOrientationChange);
+mediaQueryList.removeEventListener(handleOrientationChange);
 ```
 
 ## Browser compatibility


### PR DESCRIPTION
Affected page: https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries

#### Summary
The previous example is using deprecated `addListener` in text and `removeListener`  in both text and example code. Updated to use `addEventListener` and `removeEventListener` consistently. 

Notice for older browsers and older implementation is referenced in the text already but the example was not consistent with the text.

This PR fixes updates example's text and code.