### PR TITLE
Add HTMLInputElement.showPicker()

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -1,0 +1,71 @@
+---
+title: HTMLInputElement.showPicker()
+slug: Web/API/HTMLInputElement/showPicker
+tags:
+  - API
+  - HTML DOM
+  - HTMLInputElement
+  - Method
+  - NeedsCompatTable
+  - Reference
+browser-compat: api.HTMLInputElement.showPicker
+---
+{{ APIRef("HTML DOM") }}
+
+The **`HTMLInputElement.showPicker()`** method returns a promise that resolves
+when a browser picker is shown to the user. It must be called in response to a
+user gesture such as touch or mouse click, otherwise it will reject. For
+security reasons, it also rejects when it's called in a cross-origin iframe.
+
+## Syntax
+
+```js
+element.showPicker().then(() => {
+  // A browser picker is shown.
+});
+```
+
+## Example
+
+Click the button in this example to show a browser date picker.
+
+### HTML
+
+```html
+<input type="date">
+<button>Show the date picker</button>
+```
+
+### JavaScript
+
+```js
+const button = document.querySelector("button");
+const dateInput = document.querySelector("input");
+
+button.addEventListener("click", async () => {
+  try {
+    await dateInput.showPicker();
+    // A date picker is shown.
+  } catch (error) {
+    // Use external library when this fails.
+  }
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Example")}}
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{ HTMLElement("input") }}
+- {{ domxref("HTMLInputElement") }}

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLInputElement.showPicker
 
 The **`HTMLInputElement.showPicker()`** method returns a promise that resolves
 when a browser picker is shown to the user. It must be called in response to a
-user gesture such as touch or mouse click, otherwise it will reject. For
+user gesture such as a touch gesture or mouse click; otherwise it will reject. For
 security reasons, it also rejects when it's called in a cross-origin iframe.
 
 ## Syntax


### PR DESCRIPTION
This PR adds HTMLInputElement.showPicker()

- [WHATWG explainer][explainer]
- [WHATWG specification][spec]
- [TAG review][tag]
- [Chromium bug][cr-bug]
- [ChromeStatus.com entry][cr-status]

[explainer]: https://github.com/whatwg/html/pull/7319
[spec]: https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker
[tag]: https://github.com/w3ctag/design-reviews/issues/688
[cr-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=939561
[cr-status]: https://www.chromestatus.com/feature/5692248021794816

#### Metadata
This PR…
- [x] Adds a new document

See related PR at https://github.com/mdn/browser-compat-data/pull/14444