### PR TITLE
Restore line breaks in the `<dd>`s

### DIFF
--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -17,63 +17,72 @@ tags:
 ## Basic selectors
 
 - [Universal selector](/en-US/docs/Web/CSS/Universal_selectors)
-  - : Selects all elements. Optionally, it may be restricted to a specific namespace or to all namespaces.
-    **Syntax:** `*` `ns|*` `*|*`
-    **Example:** `*` will match all the elements of the document.
+  - : Selects all elements. Optionally, it may be restricted to a specific namespace or to all namespaces.  
+    **Syntax:** `*` `ns|*` `*|*`  
+    **Example:** `*` will match all the elements of the document.  
+
 - [Type selector](/en-US/docs/Web/CSS/Type_selectors)
-  - : Selects all elements that have the given node name.
-    **Syntax:** `elementname`
-    **Example:** `input` will match any {{HTMLElement("input")}} element.
+  - : Selects all elements that have the given node name.  
+    **Syntax:** `elementname`  
+    **Example:** `input` will match any {{HTMLElement("input")}} element.  
+
 - [Class selector](/en-US/docs/Web/CSS/Class_selectors)
-  - : Selects all elements that have the given `class` attribute.
-    **Syntax:** `.classname`
-    **Example:** `.index` will match any element that has a class of "index".
+  - : Selects all elements that have the given `class` attribute.  
+    **Syntax:** `.classname`  
+    **Example:** `.index` will match any element that has a class of "index".  
+
 - [ID selector](/en-US/docs/Web/CSS/ID_selectors)
-  - : Selects an element based on the value of its `id` attribute. There should be only one element with a given ID in a document.
-    **Syntax:** `#idname`
-    **Example:** `#toc` will match the element that has the ID "toc".
+  - : Selects an element based on the value of its `id` attribute. There should be only one element with a given ID in a document.  
+    **Syntax:** `#idname`  
+    **Example:** `#toc` will match the element that has the ID "toc".  
+
 - [Attribute selector](/en-US/docs/Web/CSS/Attribute_selectors)
-  - : Selects all elements that have the given attribute.
-    **Syntax:** `[attr]` `[attr=value]` `[attr~=value]` `[attr|=value]` `[attr^=value]` `[attr$=value]` `[attr*=value]`
-    **Example:** `[autoplay]` will match all elements that have the `autoplay` attribute set (to any value).
+  - : Selects all elements that have the given attribute.  
+    **Syntax:** `[attr]` `[attr=value]` `[attr~=value]` `[attr|=value]` `[attr^=value]` `[attr$=value]` `[attr*=value]`  
+    **Example:** `[autoplay]` will match all elements that have the `autoplay` attribute set (to any value).  
 
 ## Grouping selectors
 
 - [Selector list](/en-US/docs/Web/CSS/Selector_list)
-  - : The `,` selector is a grouping method that selects all the matching nodes.
+  - : The `,` selector is a grouping method that selects all the matching nodes.  
     **Syntax:** `A, B`
-    **Example:** `div, span` will match both {{HTMLElement("span")}} and {{HTMLElement("div")}} elements.
+    **Example:** `div, span` will match both {{HTMLElement("span")}} and {{HTMLElement("div")}} elements.  
 
 ## Combinators
 
 - [Descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator)
-  - : The ` ` (space) combinator selects nodes that are descendants of the first element.
-    **Syntax:** `A B`
-    **Example:** `div span` will match all {{HTMLElement("span")}} elements that are inside a {{HTMLElement("div")}} element.
+  - : The ` ` (space) combinator selects nodes that are descendants of the first element.  
+    **Syntax:** `A B`  
+    **Example:** `div span` will match all {{HTMLElement("span")}} elements that are inside a {{HTMLElement("div")}} element.  
+
 - [Child combinator](/en-US/docs/Web/CSS/Child_combinator)
-  - : The `>` combinator selects nodes that are direct children of the first element.
-    **Syntax:** `A > B`
-    **Example:** `ul > li` will match all {{HTMLElement("li")}} elements that are nested directly inside a {{HTMLElement("ul")}} element.
+  - : The `>` combinator selects nodes that are direct children of the first element.  
+    **Syntax:** `A > B`  
+    **Example:** `ul > li` will match all {{HTMLElement("li")}} elements that are nested directly inside a {{HTMLElement("ul")}} element.  
+
 - [General sibling combinator](/en-US/docs/Web/CSS/General_sibling_combinator)
-  - : The `~` combinator selects siblings. This means that the second element follows the first (though not necessarily immediately), and both share the same parent.
-    **Syntax:** `A ~ B`
-    **Example:** `p ~ span` will match all {{HTMLElement("span")}} elements that follow a {{HTMLElement("p")}}, immediately or not.
+  - : The `~` combinator selects siblings. This means that the second element follows the first (though not necessarily immediately), and both share the same parent.  
+    **Syntax:** `A ~ B`  
+    **Example:** `p ~ span` will match all {{HTMLElement("span")}} elements that follow a {{HTMLElement("p")}}, immediately or not.  
+
 - [Adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinator)
-  - : The `+` combinator matches the second element only if it _immediately_ follows the first element.
-    **Syntax:** `A + B`
-    **Example:** `h2 + p` will match all {{HTMLElement("p")}} elements that _immediately_ follows {{HTMLElement("h2")}} element.
+  - : The `+` combinator matches the second element only if it _immediately_ follows the first element.  
+    **Syntax:** `A + B`  
+    **Example:** `h2 + p` will match all {{HTMLElement("p")}} elements that _immediately_ follows {{HTMLElement("h2")}} element.  
+
 - [Column combinator](/en-US/docs/Web/CSS/Column_combinator) {{Experimental_Inline}}
-  - : The `||` combinator selects nodes which belong to a column.
-    **Syntax:** `A || B`
-    **Example:** `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
+  - : The `||` combinator selects nodes which belong to a column.  
+    **Syntax:** `A || B`  
+    **Example:** `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.  
 
 ## Pseudo
 
 - [Pseudo classes](/en-US/docs/Web/CSS/Pseudo-classes)
-  - : The `:` pseudo allow the selection of elements based on state information that is not contained in the document tree.
+  - : The `:` pseudo allow the selection of elements based on state information that is not contained in the document tree.  
     **Example:** `a:visited` will match all {{HTMLElement("a")}} elements that have been visited by the user.
+
 - [Pseudo elements](/en-US/docs/Web/CSS/Pseudo-elements)
-  - : The `::` pseudo represent entities that are not included in HTML.
+  - : The `::` pseudo represent entities that are not included in HTML.  
     **Example:** `p::first-line` will match the first line of all {{HTMLElement("p")}} elements.
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Insert line breaks before **Syntax:** and **Example:**.

#### Motivation
Originally there were line breaks in there, but they are vanished when the document is converted to Markdown.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
