### PR TITLE
🩹 fix Return type for HTMLStyleElement.sheet: StyleSheet -> CSSStyleSheet

### DIFF
--- a/files/en-us/web/api/htmlstyleelement/index.md
+++ b/files/en-us/web/api/htmlstyleelement/index.md
@@ -47,4 +47,4 @@ _No specific method; inherits properties from its parent, {{domxref("HTMLElement
 ## See also
 
 - The HTML element implementing this interface: {{HTMLElement("style")}}.
-- [Using dynamic styling information](/en-US/docs/DOM/Using_dynamic_styling_information) to see how to manipulate CSS.
+- [Using dynamic styling information](/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information) to see how to manipulate CSS.

--- a/files/en-us/web/api/htmlstyleelement/index.md
+++ b/files/en-us/web/api/htmlstyleelement/index.md
@@ -28,7 +28,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLStyleElement.disabled")}}
   - : Is a boolean value reflecting the HTML attribute representing whether or not the stylesheet is disabled (true) or not (false).
 - {{domxref("HTMLStyleElement.sheet")}} {{readonlyInline}}
-  - : Returns the {{domxref("StyleSheet")}} object associated with the given element, or `null` if there is none
+  - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none
 - {{domxref("HTMLStyleElement.scoped")}} {{non-standard_inline}} {{deprecated_inline}}
   - : Is a boolean value indicating if the element applies to the whole document (`false`) or only to the parent's sub-tree (`true`).
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`HTMLStyleElement.sheet` returns `CSSStyleSheet` object not `StyleSheet` object
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Open-source
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet#obtaining_a_stylesheet
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Closes #11752 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
