### PR TITLE
Remove duplicate documentation for fetch()

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -19,13 +19,7 @@ resource from the network, returning a promise which is fulfilled once the respo
 available.
 
 The promise resolves to the {{domxref("Response")}} object
-representing the response to your request. The promise _does not_ reject on HTTP
-errors — it only rejects on network errors. You must use `then` handlers to
-check for HTTP errors.
-
-`WindowOrWorkerGlobalScope` is implemented by both {{domxref("Window")}} and
-{{domxref("WorkerGlobalScope")}}, which means that the `fetch()` method is
-available in pretty much any context in which you might want to fetch resources.
+representing the response to your request.
 
 A {{domxref("fetch()")}} promise only rejects when a
 network error is encountered (which is usually when there’s a permissions issue or
@@ -33,6 +27,10 @@ similar). A {{domxref("fetch()")}} promise _does
 not_ reject on HTTP errors (`404`, etc.). Instead, a
 `then()` handler must check the {{domxref("Response.ok")}} and/or
 {{domxref("Response.status")}} properties.
+
+`WindowOrWorkerGlobalScope` is implemented by both {{domxref("Window")}} and
+{{domxref("WorkerGlobalScope")}}, which means that the `fetch()` method is
+available in pretty much any context in which you might want to fetch resources.
 
 The `fetch()` method is controlled by the `connect-src` directive
 of [Content Security Policy](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)


### PR DESCRIPTION

#### Summary

Removes duplicate information by moving most descriptive content up and deleting a more general statement.

#### Motivation

The change places similar contexts together and puts the most common mistake up-front with its initial introduction.

Not repeating the same content after a context change also makes documentation easier to understand. 

#### Supporting details

None. This PR introduces no new content. 

#### Related issues

None

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

