### PR TITLE
String.slice: clarify negative endIndex sentence

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -52,7 +52,7 @@ slice(beginIndex, endIndex)
     `slice()` also extracts to the end of the string.
     (E.g. `"test".slice(2, 10)` returns `"st"`)
 
-    If `endIndex` is negative, `slice()` is treated as
+    If `endIndex` is negative, `slice()` treats it as
     `str.length + endIndex`. (E.g, if
     `endIndex` is `-2`, it is treated as
     `str.length - 2` and `"test".slice(1, -2)` returns `"e"`) .


### PR DESCRIPTION
#### Summary
Replace "If `endIndex` is negative, `slice()` is treated as `str.length + endIndex`" text with "If `endIndex` is negative, `slice()` treats it as `str.length + endIndex`" which seems to make more sense.

#### Motivation
This is a minor typo.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
