### PR TITLE
Fix description of passive listeners in EventTarget.addEventListener

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -816,7 +816,7 @@ To prevent this problem, some browsers (specifically, Chrome and Firefox) have c
 the default value of the `passive` option to `true` for the
 {{event("touchstart")}} and {{event("touchmove")}} events on the document-level nodes
 {{domxref("Window")}}, {{domxref("Document")}}, and {{domxref("Document.body")}}. This
-prevents the event listener from being called, so it can't block page rendering while
+prevents the event listener from [canceling the event](/en-US/docs/Web/API/Event/preventDefault), so it can't block page rendering while
 the user is scrolling.
 
 > **Note:** See the compatibility table below if you need to know which


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
(Passive option) ... prevents listener from being called -> ... prevents listener from canceling the event

#### Motivation
Passive listeners don't prevent their handlers from _being called_.

#### Supporting details
https://dom.spec.whatwg.org/#observing-event-listeners

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
