### PR TITLE
Update aligning items in a flex container: remove wrong sentence

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -112,8 +112,6 @@ Once again we can switch our `flex-direction` to `column` in order to see how th
 
 > **Note:** The value `space-evenly` is not defined in the flexbox specification and is a later addition to the Box Alignment specification. Browser support for this value is not as good as that of the values defined in the flexbox spec.
 
-See the [documentation for `justify-content` on MDN](/en-US/docs/Web/CSS/justify-content) for more details on all of these values and browser support.
-
 ## Aligning content on the main axis
 
 Now that we have seen how alignment works on the cross axis, we can take a look at the main axis. Here we only have one property available to us — `justify-content`. This is because we are only dealing with items as a group on the main axis. With `justify-content` we control what happens with available space, should there be more space than is needed to display the items.


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The sentence links to justify-content but the section it belongs to is talking about align-content. Also, the links to these properties already appeared at the start of the article

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It's abrupt to see this sentence

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
