### PR TITLE
Update description for `arguments` object

### DIFF
--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -76,8 +76,8 @@ There are three main differences between rest parameters and the
 - The `...restParam` bundles all the extra parameters into a single array,
   therefore it does not contain any named argument defined **before** the
   `...restParam`. Whereas the `arguments` object contains all of
-  the parameters -- including all of the stuff in the `...restParam` --
-  **un**bundled.
+  the parameters -- including the parameters in the `...restParam` array --
+  bundled into one array-like object.
 
 ### From arguments to an array
 

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -76,7 +76,7 @@ There are three main differences between rest parameters and the
 - The `...restParam` bundles all the extra parameters into a single array,
   therefore it does not contain any named argument defined **before** the
   `...restParam`. Whereas the `arguments` object contains all of
-  the parameters -- including the parameters in the `...restParam` array --
+  the parameters — including the parameters in the `...restParam` array —
   bundled into one array-like object.
 
 ### From arguments to an array


### PR DESCRIPTION
Changes the usage of the word "unbundled" to a more explicit description.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This updates the usage of the word "unbundled" to a more explicit description.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
As I was reading the documentation for `restParam` and the `arguments` object, I was confused by the section describing the differences between the two. The docs say that `arguments` contains all of the function parameters as "unbundled," but in the previous sentence the docs say that `...restParams` "bundles all the extra parameters into a single array."

The usage of the verb "bundles" in the first sentence describes putting the parameters in an array, yet in the second sentence, "unbundled" is describing an object that (in my mind) does indeed "bundle" the function's parameters together. This caused some confusion for me, and I hope that my change clarifies things for future developers!

Please feel free to let me know if I am misunderstanding the underlying concept, or if any of my proposed changes are unclear.

Cheers!

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
