### PR TITLE
Fix typo in property name

### DIFF
--- a/files/en-us/web/api/element/openorclosedshadowroot/index.md
+++ b/files/en-us/web/api/element/openorclosedshadowroot/index.md
@@ -20,7 +20,7 @@ browser-compat: api.Element.openOrClosedShadowRoot
 
 > **Note:** This API is available only to [WebExtensions](/en-US/docs/Mozilla/Add-ons/WebExtensions).
 
-The `Element.openOrCloseShadowRoot` read-only
+The `Element.openOrClosedShadowRoot` read-only
 property represents the shadow root hosted by the element, regardless if its
 {{DOMxRef("ShadowRoot.mode", "mode")}} is `open` or
 `closed`.
@@ -31,7 +31,7 @@ root to an existing element.
 ## Syntax
 
 ```js
-var shadowroot = element.openOrCloseShadowRoot;
+var shadowroot = element.openOrClosedShadowRoot;
 ```
 
 ### Value


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The property name is missing a "d" in two places; this fixes those typos.

#### Motivation
We don't like typos!

#### Supporting details
N/A
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
N/A
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
