### PR TITLE
AbortSignal.throwIfAborted() - basic docs

### DIFF
--- a/files/en-us/web/api/abortsignal/abort/index.md
+++ b/files/en-us/web/api/abortsignal/abort/index.md
@@ -11,7 +11,7 @@ browser-compat: api.AbortSignal.abort
 ---
 {{APIRef("DOM")}}
 
-The static **`AbortSignal.abort()`** method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an abort event).
+The static **`AbortSignal.abort()`** method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an {{domxref("AbortSignal/abort_event","abort")}} event).
 
 This is shorthand for the following code:
 

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -35,6 +35,9 @@ Listen to this event using [`addEventListener()`](/en-US/docs/Web/API/EventTarge
 
 _The **`AbortSignal`** interface inherits methods from its parent interface, {{domxref("EventTarget")}}._
 
+- {{domxref("AbortSignal.throwIfAborted()")}}
+  - : Throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.
+
 ## Static methods
 
 - {{domxref("AbortSignal.abort()")}}
@@ -42,11 +45,11 @@ _The **`AbortSignal`** interface inherits methods from its parent interface, {{d
 
 ## Examples
 
-In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
+The following snippet shows how we might use a signal to abort downloading a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-We first create a controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+We first create an abort controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
 
-When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request, and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 
 ```js
 var controller = new AbortController();

--- a/files/en-us/web/api/abortsignal/reason/index.md
+++ b/files/en-us/web/api/abortsignal/reason/index.md
@@ -10,7 +10,7 @@ tags:
   - reason
 browser-compat: api.AbortSignal.reason
 ---
-{{APIRef("DOM")}}
+{{APIRef("DOM")}} {{SeeCompatTable}}
 
 The **`reason`** read-only property returns a JavaScript value that indicates the abort reason.
 

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -49,7 +49,7 @@ async function waitForCondition(func, targetValue, { signal } = {}) {
 }
 ```
 
-On each iteration of the loop we use `throwIfAborted()` to throw the signal's `reason` if the operation has been aborted (and otherwise do nothing).
+On each iteration of the loop, we use `throwIfAborted()` to throw the signal's `reason` if the operation has been aborted (and otherwise do nothing).
 If the signal is aborted, this will cause the `waitForCondition()` promise to be rejected .
 
 

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -1,0 +1,66 @@
+---
+title: AbortSignal.throwIfAborted()
+slug: Web/API/AbortSignal/throwIfAborted
+tags:
+  - API
+  - AbortSignal
+  - throwIfAborted
+  - Experimental
+  - method
+  - Reference
+  - reason
+browser-compat: api.AbortSignal.throwIfAborted
+---
+{{APIRef("DOM")}} {{SeeCompatTable}}
+
+The **`throwIfAborted()`** method throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.
+
+This can be used when you want to abort operations at particular points in your own code, rather than passing to functions that take a signal.
+
+## Syntax
+
+```js
+throwIfAborted()
+```
+
+### Return value
+
+{{jsxref('undefined')}}
+
+
+## Examples
+
+The example below comes from the specification.
+It demonstrates how you can use `throwIfAborted()` to abort a polling operation.
+
+Consider an aysnchronous `waitForCondition()` function that is called with another asynchronous function "`func`", a target value "`targetValue`, and an `AbortSignal`.
+The method compares the result of `func` with `targetValue` in a loop, returning when they match.
+
+```js
+async function waitForCondition(func, targetValue, { signal } = {}) {
+  while (true) {
+    signal?.throwIfAborted();
+
+    const result = await func();
+    if (result === targetValue) {
+      return;
+    }
+  }
+}
+```
+
+On each iteration of the loop we use `throwIfAborted()` to throw the signal's `reason` if the operation has been aborted (and otherwise do nothing).
+If the signal is aborted, this will cause the `waitForCondition()` promise to be rejected .
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Fetch API](/en-US/docs/Web/API/Fetch_API)


### PR DESCRIPTION
This adds basic docs for `AbortSignal.throwIfAborted()`. This is supported from FF97 - other docs work in #11593.

I say "basic" because the example is taken from the spec and not very interesting. 

