### PR TITLE
fix a typo

### DIFF
--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -116,7 +116,7 @@ For information and examples see [`let` > temporal dead zone](/en-US/docs/Web/Ja
 ## `class` hoisting
 
 Classes defined using a [class declaration](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) are hoisted, which means that JavaScript has a reference to the class.
-However the class is not intialized by default, so any code that uses it before the line in which it is initialized is executed will throw a `ReferenceError`.
+However the class is not initialized by default, so any code that uses it before the line in which it is initialized is executed will throw a `ReferenceError`.
 
 
 ## Function and class expression hoisting


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix a typo at line 119.
Original contents: "However the class is not intialized by default, ..."
Changed word: **intialized** -> **initialized**

#### Motivation
A typo founded.

#### Supporting details
No

#### Related issues
No

#### Metadata
No

This PR…
- [✅ ] Fixes a typo, bug, or other error
