### PR TITLE
aria-expanded is not expected on the list but on the combobox element

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
@@ -32,7 +32,7 @@ When implementing a list of values, DOM focus should remain on the text input wh
  - include [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) with the value of the id of the suggested list of values.
  - include [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) matching the role of the element that contains the collection of suggested values.
  - manage focus, if required, including using [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant) if the collection container supports.
- - use the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) state _on the list_ to communicate that the list is displayed.
+ - use the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) state on the element with role [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) to communicate that the list is displayed.
 
 If an autocomplete list value is automatically accepted when the field loses focus, the list must be contained in a role that supports `aria-activedescendant`, with the value of `aria-activedescendant` on the input field dynamically adjusted to refer to the element containing the selected suggestion.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The aria-expanded attribute is incorrectly mentionned as being expected on the list of proposals of a combobox while it should be set on the trigger element (button or text input) of the list control instead.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Current recommendation seems wrong.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.w3.org/TR/wai-aria-practices-1.1/#wai-aria-roles-states-and-properties-6

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
