### PR TITLE
Update index.md where live example is missing

### DIFF
--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -287,6 +287,8 @@ Quite often in examples here in the learn section or elsewhere on MDN you will s
 
 **Try playing with different color values in the live examples below, to get more of an idea how they work.**
 
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-keywords.html", '100%', 700)}}
+
 ### Hexadecimal RGB values
 
 The next type of color value you are likely to encounter is hexadecimal codes. Each hex value consists of a hash/pound symbol (#) followed by six hexadecimal numbers, each of which can take one of 16 values between 0 and f (which represents 15) — so `0123456789abcdef`. Each pair of values represents one of the channels — red, green and blue — and allows us to specify any of the 256 available values for each (16 x 16 = 256.)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The color keywords live example is missing.
Added the proper live example located in the color-keywords.html (css-examples/learn/values-units/color-keywords.html)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It is noted in a highlighted sentence to "try out the different color values in the live example below". Unfortunately, the live example _below_ is missing.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[The link to the relevant section of the page](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#color_keywords)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
