### PR TITLE
Events link added to the Web technology references section

### DIFF
--- a/files/en-us/web/index.md
+++ b/files/en-us/web/index.md
@@ -26,6 +26,8 @@ The open Web presents incredible opportunities for developers. To take full adva
   - : Cascading Style Sheets are used to describe the appearance of Web content.
 - [JavaScript](/en-US/docs/Web/JavaScript)
   - : JavaScript is a programming language used to add interactivity to a website.
+- [Events](/en-US/docs/Web/Events)
+  - : Events are actions or occurrences that happen in the system you are programming, which the system tells you about so your code can react to them.
 - [SVG](/en-US/docs/Web/SVG)
   - : Scalable Vector Graphics let you describe images as sets of vectors and shapes in order to allow them to scale smoothly regardless of the size at which they're drawn.
 - [MathML](/en-US/docs/Web/MathML)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I have added a link directing to "The Events" reference '/en-US/docs/Web/Events' in the "Web technology references" section in '/en-US/docs/Web' page.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
because I wanted to open this page '/en-US/docs/Web/Events' from the MDN website, but I haven't found any link leads to it, so I had to open it using a link to it in adifferent website.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
