### PR TITLE
Fix key usage requirement of deriveBits

### DIFF
--- a/files/en-us/web/api/subtlecrypto/derivebits/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.md
@@ -82,7 +82,7 @@ The promise is rejected when one of the following exceptions are encountered:
 - {{exception("InvalidAccessError")}}
   - : Raised when the base key is not a key for the requested derivation algorithm or if
     the [`CryptoKey.usages`](/en-US/docs/Web/API/CryptoKey) value of that key doesn't contain
-    `deriveKey`.
+    `deriveBits`.
 - {{exception("NotSupported")}}
   - : Raised when trying to use an algorithm that is either unknown or isn't suitable for
     derivation, or if the algorithm requested for the derived key doesn't define a key


### PR DESCRIPTION
As defined in https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits (number 8) and as seen in the ECDH examples on this very page deriveBits does not need the deriveKey key usage, but rather the deriveBits key usage.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes key usage for deriveBits function.

#### Motivation
As defined in https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits (number 8) and as seen in the ECDH examples on this very page deriveBits does not need the deriveKey key usage, but rather the deriveBits key usage.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
