### PR TITLE
fix(11818): Change `Intl.ListFormat.prototype.formatToParts` `list` parameter description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
@@ -27,7 +27,7 @@ formatToParts(list)
 ### Parameters
 
 - `list`
-  - : An {{jsxref("Array")}} of values to be formatted according to a locale.
+  - : An iterable object, such as an {{jsxref("Array")}}, to be formatted according to a locale.
 
 ### Return value
 


### PR DESCRIPTION
#### Summary
Changes the `list` parameter description to include the detail that it accepts an iterable.

#### Supporting details
* https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.formatToParts

#### Related issues
Fixes #11818

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
