### PR TITLE
added type hint

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -34,11 +34,11 @@ void ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
     {{domxref("HTMLCanvasElement")}}, an {{domxref("ImageBitmap")}}, or an
     {{domxref("OffscreenCanvas")}}.
 - `sx` {{optional_inline}}
-  - : The x-axis coordinate of the top left corner of the sub-rectangle of the source
+  - : The x-axis _int_ coordinate of the top left corner of the sub-rectangle of the source
     `image` to draw into the destination context. Use the 3- or 5-argument syntax
     to omit this argument.
 - `sy` {{optional_inline}}
-  - : The y-axis coordinate of the top left corner of the sub-rectangle of the source
+  - : The y-axis _int_ coordinate of the top left corner of the sub-rectangle of the source
     `image` to draw into the destination context. Use the 3- or 5-argument syntax
     to omit this argument.
 - `sWidth` {{optional_inline}}


### PR DESCRIPTION
I just had a bad experience because on iOs 15.1 drawImage wont render if you pass a float as second or third argument. It's pretty irritating but happens in every browser. I think it's at least a good hint.

#### Summary

Clarified type requirement for certain platform

#### Motivation
I just spent hours debugging my code on iPhone until I realized that the problem was me passing floats as sx and sy. Every other platforms accepts floats

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [] Fixes a typo, bug, or other error
- [x] might help others figuring out why their code doesn't workd
