### PR TITLE
Corrections for crisp-edges and pixelated

### DIFF
--- a/files/en-us/web/css/image-rendering/index.md
+++ b/files/en-us/web/css/image-rendering/index.md
@@ -44,7 +44,7 @@ image-rendering: unset;
 - `crisp-edges`
   - : The image is scaled with the nearest-neighbor algorithm.
 - `pixelated`
-  - : Using the nearest-neighbor algorithm, the image is scaled up to the next integer multiple that is larger or equal to than its original size, then scaled down to the target size as for `smooth`. When scaling up to integer multiples of the original size, this will have the same effect as `crisp-edges`.
+  - : Using the nearest-neighbor algorithm, the image is scaled up to the next integer multiple that is greater than or equal to its original size, then scaled down to the target size, as for `smooth`. When scaling up to integer multiples of the original size, this will have the same effect as `crisp-edges`.
 
 > **Note:** The values `optimizeQuality` and `optimizeSpeed` present in an early draft (and coming from its SVG counterpart {{SVGAttr("image-rendering")}}) are defined as synonyms for the `smooth` and `pixelated` values respectively.
 

--- a/files/en-us/web/css/image-rendering/index.md
+++ b/files/en-us/web/css/image-rendering/index.md
@@ -42,9 +42,9 @@ image-rendering: unset;
 - `high-quality` {{Experimental_Inline}}
   - : Identical to `smooth`, but with a preference for higher-quality scaling. If system resources are constrained, images with `high-quality` should be prioritized over those with any other value, when considering which images to degrade the quality of and to what degree.
 - `crisp-edges`
-  - : The image must be scaled with an algorithm that preserves contrast and edges in the image, and which does not smooth colors or introduce blur to the image in the process. Suitable algorithms include nearest-neighbor and [other non-smoothing scaling algorithms](https://en.wikipedia.org/wiki/Pixel-art_scaling_algorithms) such as 2×SaI and [hqx-family](https://en.wikipedia.org/wiki/Hqx) algorithms. This value is intended for pixel-art images, such as in browser games.
+  - : The image is scaled with the nearest-neighbor algorithm.
 - `pixelated`
-  - : When scaling the image up, the nearest-neighbor algorithm must be used, so that the image appears to be composed of large pixels. When scaling down, this is the same as `auto`.
+  - : Using the nearest-neighbor algorithm, the image is scaled up to the next integer multiple that is larger or equal to than its original size, then scaled down to the target size as for `smooth`. When scaling up to integer multiples of the original size, this will have the same effect as `crisp-edges`.
 
 > **Note:** The values `optimizeQuality` and `optimizeSpeed` present in an early draft (and coming from its SVG counterpart {{SVGAttr("image-rendering")}}) are defined as synonyms for the `smooth` and `pixelated` values respectively.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->Corrections for the crisp-edges and pixelated options for image-rendering.

#### Supporting details
The standard linked in the page notes the following:

For crisp-edges:
> The image must be scaled with the "nearest neighbor" algorithm: treating the original image’s pixel grid as a literal grid of rectangles, scale those to the desired size, then each pixel of the final image takes its color solely from the nearest pixel of the scaled original image.

The current revision of the MDN article claims that multiple algorithms are acceptable, while the standard mandates the usage of nearest-neighbor.

For pixelated:
> Scale it to this integer-multiple-size as for crisp-edges, then scale it the rest of the way to the target size as for smooth.

This two-step process is not described in the current MDN article.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
