### PR TITLE
Fix the doc for VideoEncoder() constructor (Close #11820)

### DIFF
--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -29,7 +29,7 @@ new VideoEncoder(init);
             - `codec`
               - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry).
             - `description` {{Optional_Inline}}
-              - : A {{domxref("BufferSource")}} containing a sequence of codec specific bytes, commonly known as extradata.
+              - : A {{domxref("BufferSource")}} containing a sequence of codec-specific bytes, commonly known as “extradata”.
             - `codedWidth` {{Optional_Inline}}
               - : An integer representing the width of the {{domxref("VideoFrame")}} in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
             - `codedHeight` {{Optional_Inline}}

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -23,7 +23,7 @@ new VideoEncoder(init);
 - `init`
   - : An object containing two required callbacks.
     - `output`
-      - : A callback which takes a {{domxref("EncodedVideoChunk")}} object as the first argument, and an optional metadata object as the second. The metadata object has three members:
+      - : A callback which takes an {{domxref("EncodedVideoChunk")}} object as the first argument, and an optional metadata object as the second. The metadata object has three members:
         - `decoderconfig` {{Optional_Inline}}
           - : An object containing:
             - `codec`

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -39,16 +39,16 @@ new VideoEncoder(init);
             - `displayAspectHeight` {{Optional_Inline}}
               - : An integer representing the vertical dimension of the {{domxref("VideoFrame")}}’s aspect ratio when displayed.
             - `colorSpace` {{Optional_Inline}}
-              - : An object you pass to {{domxref("VideoColorSpace")}} constructor as the `init` argument, configuring the {{domxref("VideoFrame.colorSpace")}} for {{domxref("VideoFrame","VideoFrames")}} associated with this `decoderconfig` object. If `colorSpace` exists, the provided values will override any in-band values from the bitsream.
+              - : An object you pass to the {{domxref("VideoColorSpace")}} constructor as the `init` argument, configuring the {{domxref("VideoFrame.colorSpace")}} for {{domxref("VideoFrame","VideoFrames")}} associated with this `decoderconfig` object. If `colorSpace` exists, the provided values will override any in-band values from the bitstream.
             - `hardwareAcceleration` {{Optional_Inline}}
               - : A string that configures hardware acceleration for this codec. Defaults to `"no-preference"`. Options are:
                 - `"no-preference"`
                 - `"prefer-hardware"`
                 - `"prefer-software"`
             - `optimizeForLatency` {{Optional_Inline}}
-              - : A bool representing whether the selected decoder should be configured to minimize the number of {{domxref("EncodedVideoChunk","EncodedVideoChunks")}} that have to be decoded before a {{domxref("VideoFrame")}} is output.
+              - : A boolean representing whether the selected decoder should be configured to minimize the number of {{domxref("EncodedVideoChunk","EncodedVideoChunks")}} that have to be decoded before a {{domxref("VideoFrame")}} is output.
         - `svc` {{Optional_Inline}}
-          - : an optional object with an only member: `temporalLayerId`, which is a number that identifies the [temporal layer](https://w3c.github.io/webcodecs/#temporal-layer) for the associated {{domxref("EncodedVideoChunk")}}.
+          - : An optional object with only one member: `temporalLayerId`, which is a number that identifies the [temporal layer](https://w3c.github.io/webcodecs/#temporal-layer) for the associated {{domxref("EncodedVideoChunk")}}.
         - `alphaSideData` {{Optional_Inline}}
           - : A {{domxref("BufferSource")}} that contains the {{domxref("EncodedVideoChunk")}}'s extra alpha channel data.
     - `error`

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -23,7 +23,34 @@ new VideoEncoder(init);
 - `init`
   - : An object containing two required callbacks.
     - `output`
-      - : A callback which takes a {{domxref("VideoFrame")}} object as its only argument.
+      - : A callback which takes a {{domxref("EncodedVideoChunk")}} object as the first argument, and an optional metadata object as the second. The metadata object has three members:
+        - `decoderconfig` {{Optional_Inline}}
+          - : An object containing:
+            - `codec`
+              - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry).
+            - `description` {{Optional_Inline}}
+              - : A {{domxref("BufferSource")}} containing a sequence of codec specific bytes, commonly known as extradata.
+            - `codedWidth` {{Optional_Inline}}
+              - : An integer representing the width of the {{domxref("VideoFrame")}} in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
+            - `codedHeight` {{Optional_Inline}}
+              - : An integer representing the height of the {{domxref("VideoFrame")}} in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
+            - `displayAspectWidth` {{Optional_Inline}}
+              - : An integer representing the horizontal dimension of the {{domxref("VideoFrame")}}’s aspect ratio when displayed.
+            - `displayAspectHeight` {{Optional_Inline}}
+              - : An integer representing the vertical dimension of the {{domxref("VideoFrame")}}’s aspect ratio when displayed.
+            - `colorSpace` {{Optional_Inline}}
+              - : An object you pass to {{domxref("VideoColorSpace")}} constructor as the `init` argument, configuring the {{domxref("VideoFrame.colorSpace")}} for {{domxref("VideoFrame","VideoFrames")}} associated with this `decoderconfig` object. If `colorSpace` exists, the provided values will override any in-band values from the bitsream.
+            - `hardwareAcceleration` {{Optional_Inline}}
+              - : A string that configures hardware acceleration for this codec. Defaults to `"no-preference"`. Options are:
+                - `"no-preference"`
+                - `"prefer-hardware"`
+                - `"prefer-software"`
+            - `optimizeForLatency` {{Optional_Inline}}
+              - : A bool representing whether the selected decoder should be configured to minimize the number of {{domxref("EncodedVideoChunk","EncodedVideoChunks")}} that have to be decoded before a {{domxref("VideoFrame")}} is output.
+        - `svc` {{Optional_Inline}}
+          - : an optional object with an only member: `temporalLayerId`, which is a number that identifies the [temporal layer](https://w3c.github.io/webcodecs/#temporal-layer) for the associated {{domxref("EncodedVideoChunk")}}.
+        - `alphaSideData` {{Optional_Inline}}
+          - : A {{domxref("BufferSource")}} that contains the {{domxref("EncodedVideoChunk")}}'s extra alpha channel data.
     - `error`
       - : A callback which takes an {{jsxref("Error")}} object as its only argument.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix the document error in #11820.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The error mentioned above seems to be a result of copy-pasting `VideoDecoder` without changes. This makes the document nearly completely useless.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
This PR is mostly a shameless copy-paste of the spec: https://w3c.github.io/webcodecs/#dictdef-videodecoderinit

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #11820 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
