### PR TITLE
Mention possible null return value in FileSystemDirectoryHandle.resolve()

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -31,7 +31,7 @@ var pathArr = FileSystemDirectoryHandle.resolve(possibleDescendant);
 ### Return value
 
 A {{jsxref('Promise')}} which resolves with an {{jsxref('Array')}} of
-{{jsxref('USVString','strings')}}.
+{{jsxref('USVString','strings')}}, or `null` if `possibleDescendant` is not a descendant of this {{domxref('FileSystemDirectoryHandle'}}.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add a note to the `Return` section of `FileSystemDirectoryHandle.resolve()` that `null` is returned if the parameter `possibleDescendant` is not a descendant of the `FileSystemDirectoryHandle`.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was wondering about the behaviour in this case myself. By making this change, others won't need to run the same check (described below).
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Verify on supported browsers:
```js
const parent = await showDirectoryPicker()
const notADescendant = await showDirectoryPicker() // Choose a directory that's not inside `parent`
console.log(await parent.resolve(notADescendant))
```
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
