### PR TITLE
Fix macro syntax error introduced in previous commit

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -31,7 +31,7 @@ var pathArr = FileSystemDirectoryHandle.resolve(possibleDescendant);
 ### Return value
 
 A {{jsxref('Promise')}} which resolves with an {{jsxref('Array')}} of
-{{jsxref('USVString','strings')}}, or `null` if `possibleDescendant` is not a descendant of this {{domxref('FileSystemDirectoryHandle'}}.
+{{jsxref('USVString','strings')}}, or `null` if `possibleDescendant` is not a descendant of this {{domxref('FileSystemDirectoryHandle')}}.
 
 ### Exceptions
 


### PR DESCRIPTION
a550659 (https://github.com/mdn/content/pull/11846) introduced a macro syntax error that I overlooked when reviewing it. This fixes it.