### PR TITLE
Adds a generator#return example that includes try...finally

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generator/return/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generator/return/index.md
@@ -72,6 +72,41 @@ g.return(); // { value: undefined, done: true }
 g.return(1); // { value: 1, done: true }
 ```
 
+### Using return() with try...finally
+
+When the `return` method is called on a generator that is suspended within a `try` block, execution in the generator proceeds to the `finally` block since the `finally` block of `try...finally` statements always executes.
+
+```js
+function* gen() {
+  yield 1;
+  try {
+    yield 2;
+    yield 3;
+  } finally {
+    yield 'cleanup';
+  }
+}
+
+const g1 = gen();
+g1.next(); // { value: 1, done: false }
+
+// Execution is suspended before the try...finally.
+g1.return('early return'); // { value: 'early return', done: true }
+
+const g2 = gen();
+g2.next(); // { value: 1, done: false }
+g2.next(); // { value: 2, done: false }
+
+// Execution is suspended within the try...finally.
+g2.return('early return'); // { value: 'cleanup', done: false }
+
+// The completion value is preserved
+g2.next(); // { value: 'early return', done: true }
+
+// Generator is in the completed state
+g2.return('not so early return'); // { value: 'not so early return', done: true }
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/generator/return/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generator/return/index.md
@@ -74,7 +74,7 @@ g.return(1); // { value: 1, done: true }
 
 ### Using return() with try...finally
 
-When the `return` method is called on a generator that is suspended within a `try` block, execution in the generator proceeds to the `finally` block since the `finally` block of `try...finally` statements always executes.
+When the `return` method is called on a generator that is suspended within a `try` block, execution in the generator proceeds to the `finally` block — since the `finally` block of `try...finally` statements always executes.
 
 ```js
 function* gen() {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Since finally blocks always execute, there is some nuance with the generator's return method
when the generator is suspended within a try...finally statement.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

This came from me tinkering with generators with `try...finally` and wondering what happened to the value I provided to `return`. The pattern of using try/catch/finally in a generator is great for cancelation patterns, but I stopped at documenting the interaction. What patterns are possible can be left as an exercise for the reader.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Here's a repl.it link of this example for convenience: https://replit.com/@DingoEatingFuzz/GeneratorReturn#index.js

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
