### PR TITLE
correct error in html_dom_api/microtask_guide doc

### DIFF
--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.md
@@ -39,7 +39,7 @@ Tasks get added to the task queue when:
 - An event fires, adding the event's callback function to the task queue.
 - A timeout or interval created with {{domxref("setTimeout()")}} or {{domxref("setInterval()")}} is reached, causing the corresponding callback to be added to the task queue.
 
-The event loop driving your code handles these tasks one after another, in the order in which they were enqueued. The oldest runnable task in task queue will be executed during a single iteration of event loop. After execution, microtasks will be executed until microtask queue is empty, and then the browser may choose to update rendering. This sums up one iteration of event loop, leading to next iteration.
+The event loop driving your code handles these tasks one after another, in the order in which they were enqueued. The oldest runnable task in the task queue will be executed during a single iteration of the event loop. After that, microtasks will be executed until the microtask queue is empty, and then the browser may choose to update rendering. Then the browser moves on to the next iteration of event loop.
 
 ### Microtasks
 

--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.md
@@ -39,7 +39,7 @@ Tasks get added to the task queue when:
 - An event fires, adding the event's callback function to the task queue.
 - A timeout or interval created with {{domxref("setTimeout()")}} or {{domxref("setInterval()")}} is reached, causing the corresponding callback to be added to the task queue.
 
-The event loop driving your code handles these tasks one after another, in the order in which they were enqueued. Only tasks which were _already in the task queue_ when the event loop pass began will be executed during the current iteration. The rest will have to wait until the following iteration.
+The event loop driving your code handles these tasks one after another, in the order in which they were enqueued. The oldest runnable task in task queue will be executed during a single iteration of event loop. After execution, microtasks will be executed until microtask queue is empty, and then the browser may choose to update rendering. This sums up one iteration of event loop, leading to next iteration.
 
 ### Microtasks
 


### PR DESCRIPTION
Updated description on event loop. Please refer to #11840 for detailed explanation.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changed content of html_dom_api/microtask_guide doc, in order to fix wrong description on event loop and task.

#### Motivation
As mentioned in #11840, current description seems to provide incorrect description. 
This PR will fix it.

#### Supporting details
The decription in the following MDN doc describes event loop to perform one task per iteration. 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#stack
This PR will make "microtask guide" doc to be coherent to "event loop" doc.
For more explanation including html spec doc, please refer to #11840 

#### Related issues
#11840 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
