### PR TITLE
Wrong header type

### DIFF
--- a/files/en-us/web/http/headers/last-modified/index.md
+++ b/files/en-us/web/http/headers/last-modified/index.md
@@ -21,7 +21,7 @@ headers make use of this field.
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Response header")}}</td>
+      <td>{{Glossary("Entity header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/last-modified/index.md
+++ b/files/en-us/web/http/headers/last-modified/index.md
@@ -21,7 +21,7 @@ headers make use of this field.
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Entity header")}}</td>
+      <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>


### PR DESCRIPTION
"Last-Modified" is not a response header, actually is a Entity header. 
Source: https://datatracker.ietf.org/doc/html/rfc2616#section-14.29

#### Summary

I changed the word "response" for the word "Entity".

#### Motivation

Because it's wrong, doesn't correspond with rfc2616 documentation.

#### Supporting details

https://datatracker.ietf.org/doc/html/rfc2616#section-14.29

#### Related issues


#### Metadata


This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

