### PR TITLE
Clarify that Notification.requestPermission is not supported in the worker context

### DIFF
--- a/files/en-us/web/api/notification/requestpermission/index.md
+++ b/files/en-us/web/api/notification/requestpermission/index.md
@@ -10,9 +10,7 @@ tags:
   - Reference
 browser-compat: api.Notification.requestPermission
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
-
-> **Note:** This feature is **not** available in {{domxref("SharedWorker")}}
+{{APIRef("Web Notifications")}}{{securecontext_header}}
 
 > **Note:** Safari still uses the callback syntax to get the permission. Read [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API) for a good example of how to feature detect this and run code as appropriate.
 


### PR DESCRIPTION
Clarify that Notification.requestPermission is not supported in the worker context
FIXED=#11824

#### Summary
Discussed in the tracking bug

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata

- [ x ] Fixes a typo, bug, or other error

