### PR TITLE
Firefox source docs - better redirects

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5683,6 +5683,7 @@
 /en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Bundled_web_pages	/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 /en-US/docs/Mozilla/Add-ons/WebExtensions/web-ext	https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/
 /en-US/docs/Mozilla/Debugging/HTTP_logging	https://firefox-source-docs.mozilla.org/networking/http/logging.html
+/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build/Linux_and_MacOS_build_preparation	https://firefox-source-docs.mozilla.org/setup/linux_build.html
 /en-US/docs/Mozilla/Developer_guide/ESLint	https://firefox-source-docs.mozilla.org/code-quality/lint/index.html
 /en-US/docs/Mozilla/Firefox/Privacy	/en-US/docs/Web/Privacy
 /en-US/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/en-US/docs/Web/Privacy/Redirect_tracking_protection

--- a/files/en-us/mozilla/firefox/index.md
+++ b/files/en-us/mozilla/firefox/index.md
@@ -16,12 +16,13 @@ Learn how to create add-ons for [Firefox](https://www.mozilla.org/firefox/), how
 
 ## Key resources
 
+- Firefox developer guide
+  - : Our [developer guide](https://firefox-source-docs.mozilla.org/contributing/index.html) explains how to get Firefox source code, how to build it on Linux, macOS and Windows, how to find your way around, and how to contribute to the project.
+- Firefox add-on guide
+  - : The [Add-on guide](/en-US/docs/Mozilla/Add-ons) provides information about developing and deploying Firefox extensions.
 - Developer release notes
   - : [Developer-focused release notes](/en-US/docs/Mozilla/Firefox/Releases); learn what new capabilities for both Web sites and add-ons arrive in each version of Firefox.
-- Project documentation
-  - : Get detailed information about [the internals of Firefox](/en-US/docs/Mozilla) and its build system, so you can find your way around in the code.
-- Developer guide
-  - : Our [developer guide](https://firefox-source-docs.mozilla.org/contributing/index.html) provides details on how to get and compile the Firefox source code, how to find your way around, and how to contribute to the project.
+
 
 ## Firefox channels
 


### PR DESCRIPTION
Fixes #11849

This adds some redirects that have been reported to exist to moved FF source code docs (i.e. how to build linux).
