### PR TITLE
FF97 CSS cap and ic units updates

### DIFF
--- a/files/en-us/glossary/advance_measure/index.md
+++ b/files/en-us/glossary/advance_measure/index.md
@@ -1,0 +1,18 @@
+---
+title: Advance measure
+slug: Glossary/advance_measure
+tags:
+  - Accessibility
+  - Glossary
+---
+
+The **advance measure** of a glyph is its _advance width_ or _advance height_, whichever is in the inline axis of the element.
+
+This term is used in the definition of a number of CSS {{cssxref("&lt;length&gt;")}} units.
+For example, `ch` is the _advance measure_ of the "0" character in the given typeface.
+For a horizontal inline axis, this will be the width of the character.
+
+## See also
+
+- {{cssxref("&lt;length&gt;")}}
+

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -21,6 +21,9 @@ This article provides information about the changes in Firefox 97 that will affe
 
 ### CSS
 
+- The CSS units `cap` and `ic` are now supported for use with {{cssxref("&lt;length&gt;")}} and {{cssxref("&lt;length-percentage&gt;")}} data types.
+  For more information see {{bug(1702924)}} and {{bug(1531223)}}.
+
 #### Removals
 
 ### JavaScript

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -39,7 +39,7 @@ Font-relative lengths define the `<length>` value in terms of the size of a part
   - : Represents the "cap height" (nominal height of capital letters) of the element’s {{Cssxref("font")}}.
 - `ch`
 
-  - : Represents the width, or more precisely the advance measure, of the glyph "0" (zero, the Unicode character U+0030) in the element's {{Cssxref("font")}}.
+  - : Represents the width, or more precisely the {{Glossary("advance measure")}}, of the glyph "0" (zero, the Unicode character U+0030) in the element's {{Cssxref("font")}}.
 
     In the cases where it is impossible or impractical to determine the measure of the “0” glyph, it must be assumed to be 0.5em wide by 1em tall.
 
@@ -48,7 +48,7 @@ Font-relative lengths define the `<length>` value in terms of the size of a part
 - `ex`
   - : Represents the [x-height](https://en.wikipedia.org/wiki/X-height) of the element's {{Cssxref("font")}}. On fonts with the "x" letter, this is generally the height of lowercase letters in the font; `1ex ≈ 0.5em` in many fonts.
 - `ic` {{experimental_inline}}
-  - : Equal to the used advance measure of the "水" glyph (CJK water ideograph, U+6C34), found in the font used to render it.
+  - : Equal to the used {{Glossary("advance measure")}} of the "水" glyph (CJK water ideograph, U+6C34), found in the font used to render it.
 - `lh` {{experimental_inline}}
   - : Equal to the computed value of the {{Cssxref("line-height")}} property of the element on which it is used, converted to an absolute length.
 - `rem`


### PR DESCRIPTION
FF97 now supports CSS units `cap` and `ic` units, as delivered in https://bugzilla.mozilla.org/show_bug.cgi?id=1531223 and https://bugzilla.mozilla.org/show_bug.cgi?id=1702924

This adds a release note. The docs already had a definition. However this also adds a glossary item for "advance measure" because it wasn't clear to me what this meant.

Other docs work for this can be tracked in #11592