### PR TITLE
Update template for glossary entries

### DIFF
--- a/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
@@ -8,28 +8,41 @@ tags:
 ---
 {{MDNSidebar}}
 
-### Title and slug
+> **Note:** _Remove this whole explanatory note before publishing_
+>
+> ---
+>
+> **Page front matter:**
+>
+> The frontmatter at the top of the page is used to define "page metadata".
+> The values should be updated appropriately for the particular method.
+>
+> ```
+> ---
+> title: Term being defined
+> slug: Glossary/Term_being_defined
+> tags:
+>   - Glossary
+>   - The term
+> ---
+> ```
+> - **title**
+>   - : Title heading displayed at top of page.
+>       Format as: `Term being defined`.
+> - **slug**
+>   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
+>       This will be formatted as snake case of the title: `Glossary/Term_being_defined`.
+> - **tags**
+>   - : Always include the following tags: **Glossary**, _Term being defined_.
+> ---
+> _Remember to remove this whole explanatory note before publishing_
 
-A glossary page should have a _title_ and _slug_ of _TermBeingDefined_. Simple
 
-### Tags
-
-In a glossary page, you need to include the following tags (see the _Tags_ section at the bottom of the editor UI): **Glossary**, and **TermBeingDefined**. You can also include further descriptive tags as appropriate.
-
-The TermBeingDefined is ... (include concise definition of the term being defined).
+The **TermBeingDefined** is ... (include concise definition of the term being defined).
 
 Include further supporting information as required, but not much — no more than 2 more small paragraphs. Any further detailed information, code examples, tutorials, etc. should go in separate articles.
 
-## Learn more
+## See also
 
-### General knowledge
-
-- Include list of links pointing to
-- more detailed general information.
-- For example Wikipedia articles, other encyclopedia entries.
-
-### Technical information
-
-- Include list of links pointing to
-- more detailed technical information.
-- For example technical tutorials, specifications.
+- Include list of links pointing to more detailed general and technical information.
+- For example Wikipedia articles, other encyclopedia entries, technical tutorials, specifications.


### PR DESCRIPTION
The glossary page template did not match the format used since moving to markdown. This updates it in line with that - mostly just changing the list of related topics to be called "See also"

https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/Glossary_page_template