### PR TITLE
CSS hyphenate-character property - add docs

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -553,6 +553,50 @@ The [`@layer`](en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which a
   </tbody>
 </table>
 
+
+### Property: hyphenate-character
+
+The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break.
+It can also be used to specify that the character is selected to be appropriate for the language conventions of the affected content. 
+(See {{bug(1746187)}} for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>97</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.hyphenate-character.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
+
 ## SVG
 
 ### Presentation attribute: d

--- a/files/en-us/web/css/css_text/wrapping_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_text/index.md
@@ -55,11 +55,14 @@ In the example below there is a checkbox and label. Let's say, you want the labe
 
 ## Adding hyphens
 
-To add hyphens when words are broken, use the CSS {{cssxref("hyphens")}} property. Using a value of `auto`, the browser is free to automatically break words at appropriate hyphenation points, following whatever rules it chooses. To have some control over the process, use a value of `manual`, then insert a hard or soft break character into the string. A hard break (`‐`) will always break, even if it is not necessary to do so. A soft break (`­`) only breaks if breaking is needed.
+To add hyphens when words are broken, use the CSS {{cssxref("hyphens")}} property. Using a value of `auto`, the browser is free to automatically break words at appropriate hyphenation points, following whatever rules it chooses. To have some control over the process, use a value of `manual`, then insert a hard or soft break character into the string. A hard break (`‐`) will always break, even if it is not necessary to do so. A soft break (`&shy;`) only breaks if breaking is needed.
 
-{{EmbedGHLiveSample("css-examples/css-text/hyphens.html", '100%', 660)}}
+{{EmbedGHLiveSample("css-examples/css-text/hyphens.html", '100%', 600)}}
 
-## The \<wbr> element
+You can also use the {{cssxref("hyphenate-character")}} property to use the string of your choice instead of the hyphen character at the end of the line (before the hyphenation line break).
+This property also takes the value `auto`, which will select the correct value to mark a mid-word line break according to the typographic conventions of the current content language.
+
+## The `<wbr>` element
 
 If you know where you want a long string to break, then it is also possible to insert the HTML {{HTMLElement("wbr")}} element. This can be useful in cases such as displaying a long URL on a page. You can then add the property in order to break the string in sensible places that will make it easier to read.
 

--- a/files/en-us/web/css/css_text/wrapping_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_text/index.md
@@ -60,6 +60,7 @@ To add hyphens when words are broken, use the CSS {{cssxref("hyphens")}} propert
 {{EmbedGHLiveSample("css-examples/css-text/hyphens.html", '100%', 600)}}
 
 You can also use the {{cssxref("hyphenate-character")}} property to use the string of your choice instead of the hyphen character at the end of the line (before the hyphenation line break).
+
 This property also takes the value `auto`, which will select the correct value to mark a mid-word line break according to the typographic conventions of the current content language.
 
 ## The `<wbr>` element

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -1,0 +1,108 @@
+---
+title: hyphenate-character
+slug: Web/CSS/hyphenate-character
+tags:
+  - CSS
+  - CSS Property
+  - Reference
+browser-compat: css.properties.hyphenate-character
+---
+{{CSSRef}}
+
+The **`hyphenate-character`** [CSS](/en-US/docs/Web/CSS) property sets the character (or string) used at the end of a line before a hyphenation break.
+
+<!--
+
+{{EmbedInteractiveExample("pages/css/text-overflow.html")}}
+
+-->
+
+Both automatic and soft hyphens are displayed according to the specified hyphenate-character value.
+
+
+## Syntax
+
+The value either sets the string to use instead of a "hyphen", or indicates that the user agent should select an appropriate string based on the current typographic conventions.
+
+```css
+hyphenate-character: auto;
+hyphenate-character: <string>;
+```
+
+### Values
+
+- `auto`
+  - : The user-agent selects an appropriate string based on the content language’s typographic conventions.
+- `<string>`
+  - : The {{cssxref("&lt;string&gt;")}} to use at the end of the line before a hyphenation break.
+    The user agent may truncate this value if too many characters are used.
+
+
+## Formal definition
+
+{{CSSInfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+EXPERIMENT!
+
+#### HTML
+
+```html
+<div id="examplecontainer">
+  <p id="nochar" lang="en">nochar Extremely long lines. Superc&shy;alifragilisticexpialidocious </p>
+  <p id="breakauto" lang="en">auto Extremely long lines. Superc&shy;alifragilisticexpialidocious </p>
+  <p id="breakequals" lang="en">equals Extremely long lines. Superc&shy;alifragilisticexpialidocious</p>
+  <p id="webauto" lang="en">webauto Extremely long lines. Superc&shy;alifragilisticexpialidocious </p>
+  <p id="webequals" lang="en">webequalsExtremely long lines.Superc&shy;alifragilisticexpialidocious </p> 
+</div>
+```
+
+#### CSS
+
+```css
+#examplecontainer  {
+  width: 75px;
+  border: 1px solid black;
+  hyphens: auto;
+ }
+#nochar {
+  /* hyphenate-character: "="; */
+}
+#breakauto {
+  hyphenate-character: auto;
+}
+#breakequals {
+  hyphenate-character: "=";
+
+}
+#webequals {
+  -webkit-hyphenate-character: "᐀";
+}
+#webauto {
+  -webkit-hyphenate-character: auto;
+}
+
+```
+
+#### Result
+
+{{EmbedLiveSample("Examples", "100%", 490)}}
+
+
+## Specifications
+
+{{Specifications}}
+
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Related CSS properties: {{cssxref("hyphens")}}, {{cssxref("overflow-wrap")}}.

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -13,7 +13,6 @@ The **`hyphenate-character`** [CSS](/en-US/docs/Web/CSS) property sets the chara
 
 Both automatic and soft hyphens are displayed according to the specified hyphenate-character value.
 
-
 ## Syntax
 
 The value either sets the string to use instead of a "hyphen", or indicates that the user agent should select an appropriate string based on the current typographic conventions.
@@ -31,7 +30,6 @@ hyphenate-character: <string>;
   - : The {{cssxref("&lt;string&gt;")}} to use at the end of the line before a hyphenation break.
     The user agent may truncate this value if too many characters are used.
 
-
 ## Formal definition
 
 {{CSSInfo}}
@@ -42,10 +40,8 @@ hyphenate-character: <string>;
 
 ## Examples
 
-This example shows three identical blocks of text that have {{cssxref("hyphens")}} set to ensure that they break whereever needed, and on soft hyphen breaks (created using `&shy;`).
-The first block has the value of the hyphen changed to the equals symbol ("`=`").
-The second block has `hyphenate-character: auto`, while the third does not apply `hyphenate-character`
-Note that in this case there is no difference in the rendering of the last two blocks.
+This example shows three identical blocks of text that have {{cssxref("hyphens")}} set to ensure that they break wherever needed, and on soft hyphen breaks (created using `&shy;`). The first block has the value of the hyphen changed to the equals symbol ("`=`"). The second block has `hyphenate-character: auto`, while the third does not apply `hyphenate-character` Note that in this case there is no difference in the rendering of the last two blocks.
+
 #### HTML
 
 ```html

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -11,12 +11,6 @@ browser-compat: css.properties.hyphenate-character
 
 The **`hyphenate-character`** [CSS](/en-US/docs/Web/CSS) property sets the character (or string) used at the end of a line before a hyphenation break.
 
-<!--
-
-{{EmbedInteractiveExample("pages/css/text-overflow.html")}}
-
--->
-
 Both automatic and soft hyphens are displayed according to the specified hyphenate-character value.
 
 
@@ -48,50 +42,46 @@ hyphenate-character: <string>;
 
 ## Examples
 
-EXPERIMENT!
-
+This example shows three identical blocks of text that have {{cssxref("hyphens")}} set to ensure that they break whereever needed, and on soft hyphen breaks (created using `&shy;`).
+The first block has the value of the hyphen changed to the equals symbol ("`=`").
+The second block has `hyphenate-character: auto`, while the third does not apply `hyphenate-character`
+Note that in this case there is no difference in the rendering of the last two blocks.
 #### HTML
 
 ```html
-<div id="examplecontainer">
-  <p id="nochar" lang="en">nochar Extremely long lines. Superc&shy;alifragilisticexpialidocious </p>
-  <p id="breakauto" lang="en">auto Extremely long lines. Superc&shy;alifragilisticexpialidocious </p>
-  <p id="breakequals" lang="en">equals Extremely long lines. Superc&shy;alifragilisticexpialidocious</p>
-  <p id="webauto" lang="en">webauto Extremely long lines. Superc&shy;alifragilisticexpialidocious </p>
-  <p id="webequals" lang="en">webequalsExtremely long lines.Superc&shy;alifragilisticexpialidocious </p> 
-</div>
+<dl>
+  <dt><code>hyphenate-character: "="</code></dt>
+  <dd id="string" lang="en">Superc&shy;alifragilisticexpialidocious</dd>
+  <dt><code>hyphenate-character: auto</code></dt>
+  <dd id="auto" lang="en">Superc&shy;alifragilisticexpialidocious</dd>
+  <dt><code>hyphenate-character is not set</code></dt>
+  <dd lang="en">Superc&shy;alifragilisticexpialidocious</dd>
+</dl>
 ```
 
 #### CSS
 
 ```css
-#examplecontainer  {
-  width: 75px;
+dd {
+  width: 90px;
   border: 1px solid black;
   hyphens: auto;
- }
-#nochar {
-  /* hyphenate-character: "="; */
 }
-#breakauto {
+
+dd#string {
+  -webkit-hyphenate-character: "᐀";
+  hyphenate-character: "=";
+}
+
+dd#auto {
+  -webkit-hyphenate-character: auto;
   hyphenate-character: auto;
 }
-#breakequals {
-  hyphenate-character: "=";
-
-}
-#webequals {
-  -webkit-hyphenate-character: "᐀";
-}
-#webauto {
-  -webkit-hyphenate-character: auto;
-}
-
 ```
 
 #### Result
 
-{{EmbedLiveSample("Examples", "100%", 490)}}
+{{EmbedLiveSample("Examples", "100%", 350)}}
 
 
 ## Specifications

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -42,13 +42,14 @@ hyphenate-character: auto;
 ## Examples
 
 This example shows two identical blocks of text that have {{cssxref("hyphens")}} set to ensure that they break wherever needed, and on soft hyphen breaks (created using `&shy;`).
-The first block has the value of the hyphen changed to the equals symbol ("`=`"). The second block has no hyphenate-chacter set, which is equivalent to `hyphenate-character: auto` for user agents that support this property.
+The first block has the value of the hyphen changed to the equals symbol ("`*`").
+The second block has no hyphenate-chacter set, which is equivalent to `hyphenate-character: auto` for user agents that support this property.
 
 #### HTML
 
 ```html
 <dl>
-  <dt><code>hyphenate-character: "="</code></dt>
+  <dt><code>hyphenate-character: "*"</code></dt>
   <dd id="string" lang="en">Superc&shy;alifragilisticexpialidocious</dd>
   <dt><code>hyphenate-character is not set</code></dt>
   <dd lang="en">Superc&shy;alifragilisticexpialidocious</dd>
@@ -65,8 +66,8 @@ dd {
 }
 
 dd#string {
-  -webkit-hyphenate-character: "᐀";
-  hyphenate-character: "=";
+  -webkit-hyphenate-character: "*";
+  hyphenate-character: "*";
 }
 ```
 

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -15,20 +15,21 @@ Both automatic and soft hyphens are displayed according to the specified hyphena
 
 ## Syntax
 
-The value either sets the string to use instead of a "hyphen", or indicates that the user agent should select an appropriate string based on the current typographic conventions.
+The value either sets the string to use instead of a hyphen, or indicates that the user agent should select an appropriate string based on the current typographic conventions (default).
 
 ```css
-hyphenate-character: auto;
 hyphenate-character: <string>;
+hyphenate-character: auto;
 ```
 
 ### Values
 
-- `auto`
-  - : The user-agent selects an appropriate string based on the content language’s typographic conventions.
 - `<string>`
   - : The {{cssxref("&lt;string&gt;")}} to use at the end of the line before a hyphenation break.
     The user agent may truncate this value if too many characters are used.
+- `auto`
+  - : The user-agent selects an appropriate string based on the content language’s typographic conventions.
+    This is the default property value, and only needs to be explicitly set in order to override a different inherited value.
 
 ## Formal definition
 
@@ -40,7 +41,8 @@ hyphenate-character: <string>;
 
 ## Examples
 
-This example shows three identical blocks of text that have {{cssxref("hyphens")}} set to ensure that they break wherever needed, and on soft hyphen breaks (created using `&shy;`). The first block has the value of the hyphen changed to the equals symbol ("`=`"). The second block has `hyphenate-character: auto`, while the third does not apply `hyphenate-character` Note that in this case there is no difference in the rendering of the last two blocks.
+This example shows two identical blocks of text that have {{cssxref("hyphens")}} set to ensure that they break wherever needed, and on soft hyphen breaks (created using `&shy;`).
+The first block has the value of the hyphen changed to the equals symbol ("`=`"). The second block has no hyphenate-chacter set, which is equivalent to `hyphenate-character: auto` for user agents that support this property.
 
 #### HTML
 
@@ -48,8 +50,6 @@ This example shows three identical blocks of text that have {{cssxref("hyphens")
 <dl>
   <dt><code>hyphenate-character: "="</code></dt>
   <dd id="string" lang="en">Superc&shy;alifragilisticexpialidocious</dd>
-  <dt><code>hyphenate-character: auto</code></dt>
-  <dd id="auto" lang="en">Superc&shy;alifragilisticexpialidocious</dd>
   <dt><code>hyphenate-character is not set</code></dt>
   <dd lang="en">Superc&shy;alifragilisticexpialidocious</dd>
 </dl>
@@ -67,11 +67,6 @@ dd {
 dd#string {
   -webkit-hyphenate-character: "᐀";
   hyphenate-character: "=";
-}
-
-dd#auto {
-  -webkit-hyphenate-character: auto;
-  hyphenate-character: auto;
 }
 ```
 

--- a/files/en-us/web/css/hyphens/index.md
+++ b/files/en-us/web/css/hyphens/index.md
@@ -15,11 +15,13 @@ The **`hyphens`** [CSS](/en-US/docs/Web/CSS) property specifies how words should
 
 {{EmbedInteractiveExample("pages/css/hyphens.html")}}
 
-> **Note:** In the above demo, the string "An extra­ordinarily long English word!" contains the hidden `&shy;` character: `An extra&shy;­ordinarily long English word!`. This character is used to indicate a potential place to insert a hyphen when `hyphens: manual;` is specified.
+> **Note:** In the above demo, the string "An extraordinarily long English word!" contains the hidden `&shy;` (soft hyphen) character: `An extra&shy;ordinarily long English word!`. This character is used to indicate a potential place to insert a hyphen when `hyphens: manual;` is specified.
 
 Hyphenation rules are language-specific. In HTML, the language is determined by the [`lang`](/en-US/docs/Web/HTML/Global_attributes/lang) attribute, and browsers will hyphenate only if this attribute is present and the appropriate hyphenation dictionary is available. In XML, the [`xml:lang`](/en-US/docs/Web/SVG/Attribute/xml:lang) attribute must be used.
 
 > **Note:** The rules defining how hyphenation is performed are not explicitly defined by the specification, so the exact hyphenation may vary from browser to browser.
+
+If supported, {{cssxref("hyphenate-character")}} may be used to specify an alternative hyphenation character to use at the end of the line being broken.
 
 ## Syntax
 
@@ -125,7 +127,7 @@ dd.auto {
 
 ## See also
 
-- {{Cssxref("content")}}
+- {{cssxref("content")}}
 - {{cssxref("overflow-wrap")}} (formerly `word-wrap`)
 - {{cssxref("word-break")}}
 - [Guide to wrapping and breaking text](/en-US/docs/Web/CSS/CSS_Text/Wrapping_text)


### PR DESCRIPTION
FF97 adds support for the CSS `hyphenate-character` property (behind a pref). This adds a document for that, along with some cross linking. It also adds the preference to the experimental features
