### PR TITLE
Create MDN pages for Global Privacy Control

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -44,6 +44,11 @@ Default values for these properties tend to vary across browsers.
     - `"never"`: HTTPS-Only mode is off.
     - `"private_browsing"`: HTTPS-Only mode is on in private browsing windows only.
 
+- `globalPrivacyControl`
+
+  - : this setting allows your extension to determine if a user has enabled
+    [Global Privacy Control](/en-US/docs/Web/API/Navigator/globalPrivacyControl). This property is read-only on all platforms. Its underlying value is a boolean where `true` indicates that the browser sends Global Privacy Control signals and `false` indicates the browser does not send the signals.
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -46,6 +46,8 @@ No notable changes
 
 - Added `overrideContentColorScheme` in {{WebExtAPIRef("browserSettings")}} to provide the ability to control the preference `layout.css.prefers-color-scheme.content-override` and set pages' preferred color scheme (light or dark) independently of the browser theme ({{bug(1733461)}}).
 
+- Added `globalPrivacyControl` in {{WebExtAPIRef("privacy.network")}} to provide visibility into whether the user has enabled Global Privacy Control inside the browser. ({{bug(1670058)}}).
+
 ## Older versions
 
 {{Firefox_for_developers(94)}}

--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -1,0 +1,45 @@
+---
+title: Navigator.globalPrivacyControl
+slug: Web/API/Navigator/globalPrivacyControl
+tags:
+  - API
+  - Experimental
+  - HTML DOM
+  - Navigator
+  - Property
+  - Reference
+browser-compat: api.Navigator.globalPrivacyControl
+---
+The **`Navigator.globalPrivacyControl`** property returns the user's Global Privacy Control setting. This setting indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+
+The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP header.
+
+| Sec-GPC Value | Meaning                                                       |
+|---------------|---------------------------------------------------------------|
+| 1             | User _does not_ provide consent to sell or share their data.  |
+| 0             | User _does_ provide consent to sell or share their data.      |
+| unspecified   | User has not yet provided consent with regard to their data. |
+
+## Example
+
+```js
+console.log(navigator.globalPrivacyControl);
+// prints "1" indicating user does not want their data shared or sold.
+// prints "0" if the user consents to their data being shared or sold.
+// prints "specified" if Sec-GPC header is not present.
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{HTTPHeader("Sec-GPC")}} header
+- [globalprivacycontrol.org](https://globalprivacycontrol.org/)
+- [Global Privacy Control Spec](https://globalprivacycontrol.github.io/gpc-spec/)
+- [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -88,6 +88,8 @@ _Doesn't inherit any properties._
   - : Returns the build identifier of the browser. In modern browsers this property now returns a fixed timestamp as a privacy measure, e.g. `20181001000000` in Firefox 64 onwards.
 - {{domxref("Navigator.contacts")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('ContactsManager')}} interface which allows users to select entries from their contact list and share limited details of the selected entries with a website or application.
+- {{domxref("Navigator.globalPrivacyControl")}} {{Non-standard_Inline}}
+  - : Returns a boolean indicating a user's consent to their information being shared or sold.
 - {{domxref("Navigator.securitypolicy")}} {{Non-standard_Inline}}
   - : Returns an empty string. In Netscape 4.7x, returns "US & CA domestic policy" or "Export policy".
 - {{domxref("Navigator.standalone")}} {{Non-standard_Inline}}

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -1,0 +1,61 @@
+---
+title: Sec-GPC
+slug: Web/HTTP/Headers/Sec-GPC
+tags:
+  - GPC
+  - HTTP
+  - Reference
+  - header
+browser-compat: http.headers.Sec-GPC
+---
+The **`Sec-GPC`** (**G**lobal **P**rivacy **C**ontrol) request header indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Request header")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```
+Sec-GPC: 1
+```
+
+## Directives
+
+If `Sec-GPC` is enabled the header is sent with a value of `1` indicating the user prefers their information not be shared with or sold to third parties. Otherwise, the header is not sent to indicate the user has not made a decision or the user is okay with their information being shared with or sold to third parties.
+
+## Examples
+
+### Reading Global Privacy Control status from JavaScript
+
+The user's GPC preference can also be read from JavaScript using the {{domxref("Navigator.globalPrivacyControl")}} property:
+
+```js
+navigator.globalPrivacyControl; // "0" or "1"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Navigator.globalPrivacyControl")}}
+- {{HTTPHeader("DNT")}} header
+- {{HTTPHeader("Tk")}} header
+- [globalprivacycontrol.org](https://globalprivacycontrol.org/)
+- [Global Privacy Control Spec](https://globalprivacycontrol.github.io/gpc-spec/)
+- [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)


### PR DESCRIPTION
#### Summary
Adds pages describing the Global Privacy Control Navigator property and HTTP header.

#### Motivation
Now that we've shipped support for the Global Privacy Control signals in release I thought it would be helpful to add corresponding MDN pages. These are based on the Do Not Track pages so this PR may be incomplete with regards to all of what I would need to do to add a new pages and have the page content be up to our standards.

Please let me know if there's anything you would like me to add or change!

#### Supporting details
https://bugzilla.mozilla.org/show_bug.cgi?id=1670058

#### Related issues


#### Metadata

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
