### PR TITLE
Fix ordering of aria-labeledby ids

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -64,7 +64,7 @@ In this example, that accessible name is "Yellow".
    ```html
    <h2 id="attr" class="article-title">13 ARIA attributes you need to know</h2>
    <p>There are over 50 ARIA states and properties, but 13 of them stand out &helip; 
-     <a href="13.html" id="rm13" aria-labelledby="attr rm13">read more</a>
+     <a href="13.html" id="rm13" aria-labelledby="rm13 attr">read more</a>
    </p>
    ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Reversed order of `aria-labeledby` IDs to match the description text `"read more 13 ARIA attributes you need to know"`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It is confusing, especially with the follow up example:
> Had we written aria-labelledby="attr rm13">, the accessible name would have been "13 ARIA attributes you need to know read more".

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
