### PR TITLE
Add glossary pages for code unit and code point

### DIFF
--- a/files/en-us/glossary/code_point/index.md
+++ b/files/en-us/glossary/code_point/index.md
@@ -5,7 +5,7 @@ tags:
   - Glossary
 ---
 
-A *code point* is a number assigned to represent an abstract character in a system for representing text (such as Unicode). In Unicode a code point is expressed in the form "U+1234" where "1234" is the assigned number. For example, the character "A" is assigned a code point of U+0041.
+A *code point* is a number assigned to represent an abstract character in a system for representing text (such as Unicode). In Unicode, a code point is expressed in the form "U+1234" where "1234" is the assigned number. For example, the character "A" is assigned a code point of U+0041.
 
 Character encoding forms, such as UTF-8 and UTF-16, determine how a Unicode code point should be encoded as a sequence of bytes. Different encoding forms may encode the same code point as different byte sequences: for example, the Cyrillic character "Ф", whose code point is U+0424, is encoded as `0xd0a4` in UTF-8 and as `0x0424` in UTF-16.
 

--- a/files/en-us/glossary/code_point/index.md
+++ b/files/en-us/glossary/code_point/index.md
@@ -7,7 +7,7 @@ tags:
 
 A *code point* is a number assigned to represent an abstract character in a system for representing text (such as Unicode). In Unicode a code point is expressed in the form "U+1234" where "1234" is the assigned number. For example, the character "A" is assigned a code point of U+0041.
 
-Character encoding forms, such as UTF-8 and UTF-16, determine how a code point should be encoded as a sequence of bytes. Different encoding forms may encode the same code point as different byte sequences: for example, the Cyrillic character "Ф", whose code point is U+0424, is encoded as `0xd0a4` in UTF-8 and as `0x0424` in UTF-16.
+Character encoding forms, such as UTF-8 and UTF-16, determine how a Unicode code point should be encoded as a sequence of bytes. Different encoding forms may encode the same code point as different byte sequences: for example, the Cyrillic character "Ф", whose code point is U+0424, is encoded as `0xd0a4` in UTF-8 and as `0x0424` in UTF-16.
 
 ## See also
 

--- a/files/en-us/glossary/code_point/index.md
+++ b/files/en-us/glossary/code_point/index.md
@@ -1,0 +1,14 @@
+---
+title: Code point
+slug: Glossary/Code_point
+tags:
+  - Glossary
+---
+
+A *code point* is a number assigned to represent an abstract character in a system for representing text (such as Unicode). In Unicode a code point is expressed in the form "U+1234" where "1234" is the assigned number. For example, the character "A" is assigned a code point of U+0041.
+
+Character encoding forms, such as UTF-8 and UTF-16, determine how a code point should be encoded as a sequence of bytes. Different encoding forms may encode the same code point as different byte sequences: for example, the Cyrillic character "Ф", whose code point is U+0424, is encoded as `0xd0a4` in UTF-8 and as `0x0424` in UTF-16.
+
+## See also
+
+- [The Unicode Standard: Code Points and Characters](http://www.unicode.org/versions/Unicode14.0.0/ch02.pdf#G25564)

--- a/files/en-us/glossary/code_unit/index.md
+++ b/files/en-us/glossary/code_unit/index.md
@@ -6,7 +6,7 @@ tags:
 ---
 A *code unit* is the basic component used by a character encoding system (such as UTF-8 or UTF-16). A character encoding system uses one or more code units to encode a Unicode {{Glossary("code point")}}.
 
-In UTF-16 (the encoding system used for JavaScript strings) code units are 16-bit values. This means that operations like indexing into a string or getting the length of a string operate on these 16-bit units. These units do not always map 1-1 onto what we might consider characters.
+In UTF-16 (the encoding system used for JavaScript strings) code units are 16-bit values. This means that operations such as indexing into a string or getting the length of a string operate on these 16-bit units. These units do not always map 1-1 onto what we might consider characters.
 
 For example, sometimes characters with diacritics such as accents are represented using two Unicode code points:
 

--- a/files/en-us/glossary/code_unit/index.md
+++ b/files/en-us/glossary/code_unit/index.md
@@ -16,7 +16,7 @@ myString.length;
 // 2
 ```
 
-Also, since not all of the code points defined by Unicode fit into 16 bits, many Unicode code points are encoded as a pair of code points, which is called a *surrogate pair*:
+Also, since not all of the code points defined by Unicode fit into 16 bits, many Unicode code points are encoded as a pair of code units, which is called a *surrogate pair*:
 
 ```js
 const face = '🥵';

--- a/files/en-us/glossary/code_unit/index.md
+++ b/files/en-us/glossary/code_unit/index.md
@@ -1,0 +1,37 @@
+---
+title: Code unit
+slug: Glossary/Code_unit
+tags:
+  - Glossary
+---
+A *code unit* is the basic component used by a character encoding system (such as UTF-8 or UTF-16). A character encoding system uses one or more code units to encode a Unicode {{Glossary("code point")}}.
+
+In UTF-16 (the encoding system used for JavaScript strings) code units are 16-bit values. This means that operations like indexing into a string or getting the length of a string operate on these 16-bit units. These units do not always map 1-1 onto what we might consider characters.
+
+For example, sometimes characters with diacritics such as accents are represented using two Unicode code points:
+
+```js
+const myString = 'ñ';
+myString.length;
+// 2
+```
+
+Also, since not all of the code points defined by Unicode fit into 16 bits, many Unicode code points are encoded as a pair of code points, which is called a *surrogate pair*:
+
+```js
+const face = '🥵';
+face.length;
+// 2
+```
+
+The {{jsxref("String/codePointAt", "codePointAt()")}} method of the JavaScript {{jsxref("String")}}  object enables you to retrieve the Unicode code point from its encoded form:
+
+```js
+const face = '🥵';
+face.codePointAt(0)
+// 129397
+```
+
+## See also
+
+- [Unicode encoding FAQ](https://www.unicode.org/faq/utf_bom.html)

--- a/files/en-us/glossary/code_unit/index.md
+++ b/files/en-us/glossary/code_unit/index.md
@@ -16,7 +16,7 @@ myString.length;
 // 2
 ```
 
-Also, since not all of the code points defined by Unicode fit into 16 bits, many Unicode code points are encoded as a pair of code units, which is called a *surrogate pair*:
+Also, since not all of the code points defined by Unicode fit into 16 bits, many Unicode code points are encoded as a pair of UTF-16 code units, which is called a *surrogate pair*:
 
 ```js
 const face = '🥵';
@@ -24,7 +24,7 @@ face.length;
 // 2
 ```
 
-The {{jsxref("String/codePointAt", "codePointAt()")}} method of the JavaScript {{jsxref("String")}}  object enables you to retrieve the Unicode code point from its encoded form:
+The {{jsxref("String/codePointAt", "codePointAt()")}} method of the JavaScript {{jsxref("String")}} object enables you to retrieve the Unicode code point from its encoded form:
 
 ```js
 const face = '🥵';


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11799, which came out of https://github.com/mdn/content/pull/8402, which refers to "code unit" in a couple of places.

This PR adds glossary pages for "code unit" and "code point".