### PR TITLE
Unicode not UTF-16

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.String.codePointAt
 {{JSRef}}
 
 The **`codePointAt()`** method returns a non-negative integer
-that is the UTF-16 code point value.
+that is the Unicode code point value at the given position.
 
 {{EmbedInteractiveExample("pages/js/string-codepointat.html","shorter")}}
 


### PR DESCRIPTION
A code point is a Unicode thing, not a UTF-16 thing.