### PR TITLE
Clarification about surprising behaviour

### DIFF
--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -48,7 +48,7 @@ parameter, would have resulted in `16:45`, as `n` defaults to
 <input type="month" max="2019-12" step="12">
 ```
 
-However, calling `stepDown` on `<input type="time" max="17:00" step="900">` would not set the value to `17:00` as one would expect and as it does for `stepUp` when the input is `<input type="time" min="17:00" step="900">`. Instead, the first call to `stepDown` will set the initial value to `23:45` even though the `max` attribute is set, the second call will set the value to `17:00` and the third call to `16:45`
+However, calling `stepDown` on `<input type="time" max="17:00" step="900">` would not set the value to `17:00`, as one would expect — and as it does for `stepUp` when the input is `<input type="time" min="17:00" step="900">`. Instead, the first call to `stepDown` will set the initial value to `23:45` even though the `max` attribute is set. The second call will set the value to `17:00`. And the third call to will set the value to `16:45`.
 
 ```js
 let input1 = document.createElement('input');

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -48,6 +48,30 @@ parameter, would have resulted in `16:45`, as `n` defaults to
 <input type="month" max="2019-12" step="12">
 ```
 
+However, calling `stepDown` on `<input type="time" max="17:00" step="900">` would not set the value to `17:00` as one would expect and as it does for `stepUp` when the input is `<input type="time" min="17:00" step="900">`. Instead, the first call to `stepDown` will set the initial value to `23:45` even though the `max` attribute is set, the second call will set the value to `17:00` and the third call to `16:45`
+
+```js
+let input1 = document.createElement('input');
+input1.setAttribute('type', 'time');
+input1.setAttribute('min', '17:00');
+input1.setAttribute('step', 900);
+console.log(input1.value); // ""
+input1.stepUp();
+console.log(input1.value); // "17:00"
+// However
+let input2 = document.createElement('input');
+input2.setAttribute('type', 'time');
+input2.setAttribute('max', '17:00');
+input2.setAttribute('step', 900);
+console.log(input2.value); // ""
+input2.stepDown();
+console.log(input2.value); // "23:45"
+input2.stepDown();
+console.log(input2.value); // "17:00"
+input2.stepDown();
+console.log(input2.value); // "16:45"
+```
+
 The method, when invoked, changes the form control's value by the value given in the
 `step` attribute, multiplied by the parameter, within the constraints set
 within the form control. The default value for the parameter, if not is passed, is 1.


### PR DESCRIPTION
Clarification about surprising behaviour when calling `stepDown` on an `input` with `max` attribute set with no initial value.
A [bug report was filed to that effect](https://bugzilla.mozilla.org/show_bug.cgi?id=1749427)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
