### PR TITLE
Adjust types for getRandomValues and ArrayBufferView

### DIFF
--- a/files/en-us/web/api/arraybufferview/index.md
+++ b/files/en-us/web/api/arraybufferview/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 {{APIRef}}
 
-**`ArrayBufferView`** is a helper type representing any of the following JavaScript {{jsxref("TypedArray")}} types:
+**`ArrayBufferView`** is a helper type representing any of the following JavaScript types:
 
 - {{jsxref("Int8Array")}},
 - {{jsxref("Uint8Array")}},
@@ -20,8 +20,12 @@ tags:
 - {{jsxref("Int32Array")}},
 - {{jsxref("Uint32Array")}},
 - {{jsxref("Float32Array")}},
-- {{jsxref("Float64Array")}} or
+- {{jsxref("Float64Array")}},
+- {{jsxref("BigInt64Array")}},
+- {{jsxref("BigUint64Array")}} or
 - {{jsxref("DataView")}}.
+
+All of them, except for `DataView`, are {{jsxref("TypedArray")}} objects.
 
 This is a helper type to simplify the specification; it isn't an interface, and there are no objects implementing it.
 

--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -37,8 +37,8 @@ crypto.getRandomValues(typedArray)
 ### Parameters
 
 - `typedArray`
-  - : An integer-based {{jsxref("TypedArray")}}, that is an {{jsxref("Int8Array")}}, a {{jsxref("Uint8Array")}}, an {{jsxref("Int16Array")}}, a {{jsxref("Uint16Array")}}, an
-    {{jsxref("Int32Array")}}, or a {{jsxref("Uint32Array")}}.
+  - : An integer-based {{jsxref("TypedArray")}}, that is one of: {{jsxref("Int8Array")}}, {{jsxref("Uint8Array")}}, {{jsxref("Uint8ClampedArray")}}, {{jsxref("Int16Array")}}, {{jsxref("Uint16Array")}},
+    {{jsxref("Int32Array")}}, {{jsxref("Uint32Array")}}, {{jsxref("BigInt64Array")}}, {{jsxref("BigUint64Array")}} (but **not** `Float32Array` nor `Float64Array`).
     All elements in the array are overwritten with random numbers.
 
 ### Return value


### PR DESCRIPTION
- Add `BigInt64Array` and `BigUint64Array` to TypedArray family
- Reword type lists to avoid misinterpretation and explicitly point out exceptions
- Add `Uint8ClampedArray`