### PR TITLE
AbortSignal.throwIfAborted() improve examples

### DIFF
--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -104,7 +104,7 @@ myCoolPromiseAPI({ ..., signal })
 controller.abort();
 ```
 
-APIs that do not return promises might react in similar manner.
+APIs that do not return promises might react in a similar manner.
 In some cases it may make sense to absorb the signal. 
 
 ## Specifications

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -15,7 +15,8 @@ browser-compat: api.AbortSignal.throwIfAborted
 
 The **`throwIfAborted()`** method throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.
 
-This can be used when you want to abort operations at particular points in your own code, rather than passing to functions that take a signal.
+An API that needs to support aborting can accept an {{domxref("AbortSignal")}} object and use **`throwIfAborted()`** to test and throw when the `abort` event is signalled.
+This method can also be used to abort operations at particular points in code, rather than passing to functions that take a signal.
 
 ## Syntax
 
@@ -30,8 +31,11 @@ throwIfAborted()
 
 ## Examples
 
-The example below comes from the specification.
-It demonstrates how you can use `throwIfAborted()` to abort a polling operation.
+The examples below come from the specification.
+
+### Aborting a polling operation 
+
+This example demonstrates how you can use `throwIfAborted()` to abort a polling operation.
 
 Consider an aysnchronous `waitForCondition()` function that is called with another asynchronous function "`func`", a target value "`targetValue`, and an `AbortSignal`.
 The method compares the result of `func` with `targetValue` in a loop, returning when they match.
@@ -52,6 +56,56 @@ async function waitForCondition(func, targetValue, { signal } = {}) {
 On each iteration of the loop, we use `throwIfAborted()` to throw the signal's `reason` if the operation has been aborted (and otherwise do nothing).
 If the signal is aborted, this will cause the `waitForCondition()` promise to be rejected .
 
+### Implementing an abortable API
+
+An API that needs to support aborting can accept an `AbortSignal` object, and use its state to trigger abort signal handling when needed.
+
+A {{domxref("Promise")}}-based API should should respond to the abort signal by rejecting any unsettled promise with the `AbortSignal` abort {{domxref("AbortSignal.reason", "reason")}}.
+For example, consider the following `myCoolPromiseAPI`, which takes a signal and returns a promise.
+The promise is rejected immediately if the signal is already aborted, or if the abort event is detected.
+Otherwise it completes normally and then resolves the promise.
+
+```js
+function myCoolPromiseAPI(..., {signal}) {
+  return new Promise((resolve, reject) => {
+    //If the signal is already aborted, immediately throw in order to reject the promise.
+    signal.throwIfAborted();
+
+    // Perform the main purpose of the API
+    // Call resolve(result) when done.
+
+    // Watch for 'abort' signals
+    signal.addEventListener('abort', () => {
+      // Stop the main operation
+      // Reject the promise wth the abort reason.
+      reject(signal.reason);
+    });
+  });
+}
+```
+
+The API might then be used as shown.
+Note that {{domxref("AbortController.abort()")}} is called to abort the operation.
+
+```js
+const controller = new AbortController();
+const signal = controller.signal;
+
+startSpinner();
+
+myCoolPromiseAPI({ ..., signal })
+  .then(result => ...)
+  .catch(err => {
+    if (err.name == 'AbortError') return;
+    showUserErrorMessage();
+  })
+  .then(() => stopSpinner());
+
+controller.abort();
+```
+
+APIs that do not return promises might react in similar manner.
+In some cases it may make sense to absorb the signal. 
 
 ## Specifications
 


### PR DESCRIPTION
This is a follow on to #11804. It highlights that another main use of `AbortSignal.throwIfAborted()` is in the implementation of your own abortable APIs.

It also shows an example of this ("heavily influenced" by the spec).

Associated docs work can be tracked in #11593