### PR TITLE
Fix code typo

### DIFF
--- a/files/en-us/webassembly/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/understanding_the_text_format/index.md
@@ -406,7 +406,7 @@ In JavaScript, the equivalent calls to create such a table instance would look s
 ```js
 function() {
   // table section
-  var tbl = new WebAssembly.Table({initial:2, element:"funcref"});
+  var tbl = new WebAssembly.Table({initial:2, element:"anyfunc"});
 
   // function sections:
   var f1 = ... /* some imported WebAssembly function */
@@ -542,7 +542,7 @@ After converting to assembly, we then use `shared0.wasm` and `shared1.wasm` in J
 var importObj = {
   js: {
     memory : new WebAssembly.Memory({ initial: 1 }),
-    table : new WebAssembly.Table({ initial: 1, element: "funcref" })
+    table : new WebAssembly.Table({ initial: 1, element: "anyfunc" })
   }
 };
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
in JavaScript create WebAssembly.Table to store function index, the element property's value should be **anyfunc** not **funcref** which is used in wat.

#### Supporting details
the source of the demo also use `anyfunc`, but not updated to document

https://github.com/mdn/webassembly-examples/blob/master/understanding-text-format/shared-address-space.html

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
