### PR TITLE
Fix error types for TextDecoder

### DIFF
--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -17,8 +17,7 @@ The **`TextDecoder()`** constructor returns a newly created
 
 If the value for _utfLabel_ is unknown, or is one of the two values leading to a
 `'replacement'` decoding algorithm ( "`iso-2022-cn`" or
-"`iso-2022-cn-ext`"), a {{DOMxRef("DOMException")}} with the
-`"TypeError"` value is thrown.
+"`iso-2022-cn-ext`"), a {{jsxref("RangeError")}} is thrown.
 
 ## Syntax
 
@@ -38,16 +37,15 @@ decoder = new TextDecoder(utfLabel, options);
     - `fatal`
       - : A [`Boolean`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean "The Boolean object is an object wrapper for a boolean value.")
         flag indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a
-        {{DOMxRef("DOMException")}} with the `"EncodingError"` value when an
-        coding error is found. It defaults to `false`.
+        {{jsxref("TypeError")}} when an coding error is found. It defaults to `false`.
 
 ## Example
 
 ```js
 var textDecoder1 = new TextDecoder("iso-8859-2");
 var textDecoder2 = new TextDecoder();
-var textDecoder3 = new TextDecoder("csiso2022kr", {fatal: true}); // Allows EncodingError exception to be thrown.
-var textDecoder4 = new TextDecoder("iso-2022-cn"); // Throw a TypeError exception.
+var textDecoder3 = new TextDecoder("csiso2022kr", {fatal: true}); // Allows TypeError exception to be thrown.
+var textDecoder4 = new TextDecoder("iso-2022-cn"); // Throw a RangeError exception.
 ```
 
 ## Specifications


### PR DESCRIPTION
#### Summary

Previous types do not match current behaviour and refer to behaviour defined in a previous draft specification.

#### Motivation

These types are wrong, which broke my error handling, so it'd be useful if they were correct :smile:.

#### Supporting details

Old outdated draft spec that does reference the `EncodingError` value used here: https://www.w3.org/TR/2014/WD-encoding-20140603/

Current spec: https://encoding.spec.whatwg.org/

The current spec for [TextDecoder](https://encoding.spec.whatwg.org/#textdecoder) says:

> If label is either not a label or is a label for replacement, throws a RangeError. 

> If the error mode is "fatal" and encoding’s decoder returns error, throws a TypeError.

This can be confirmed in a browser console with:

```javascript
// Throws a RangeError due to invalid encoding, not a DOMException:
new TextDecoder('invalid-encoding')

// Throws a TypeError due to failed decoding, not a DOMException:
new TextDecoder('utf8', { fatal: true }).decode(new Uint8Array([0xff]));
```

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
