### PR TITLE
javascript: fix broken link

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -96,7 +96,7 @@ There are five basic forms for the `Date()` constructor:
 
         Values from `0` to `99` map to the years
         `1900` to `1999`. All other values are the actual year.
-        See the [example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#two_digit_years_map_to_1900_%e2%80%93_1999).
+        See the [example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years).
 
     - `monthIndex`
       - : Integer value representing the month, beginning with `0` for January


### PR DESCRIPTION
#### Summary
The section link to examples on Date construction with 2 digit years appears broken.

So, update it with the appropriate link.

#### Motivation
Noticed the broken link while reading the doc. So, thought of fixing it.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
