### PR TITLE
Notes caveats that make :target difficult to use with dynamic content

### DIFF
--- a/files/en-us/web/css/_colon_target/index.md
+++ b/files/en-us/web/css/_colon_target/index.md
@@ -39,13 +39,9 @@ The following element would be selected by a `:target` selector when the current
 
 There are two caveats that make the `:target` selector unsuitable for use with dynamic content.
 
-1. The target element is determined at the time of `DOMContentLoad`, upon navigations triggered by clicking on links, 
-and when setting `window.location` or `window.location.hash`. It does NOT update when changing the location hash via 
-`window.history.pushState()` or `window.history.replaceState()`. Pages relying on `history` to navigate cannot rely
-on `:target` to highlight content.
+1. The target element is determined at the time of `DOMContentLoad`, upon navigations triggered by clicking on links, and when setting `window.location` or `window.location.hash`. It does NOT update when changing the location hash via `window.history.pushState()` or `window.history.replaceState()`. Pages relying on `history` to navigate cannot rely on `:target` to highlight content.
 
-2. Because the target element has already been determined on `DOMContentLoaded`, the `:target` selector does not select 
-a matching element added to the DOM at some time after `DOMContentLoaded`.
+2. Because the target element has already been determined on `DOMContentLoaded`, the `:target` selector does not select a matching element added to the DOM at some time after `DOMContentLoaded`.
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_target/index.md
+++ b/files/en-us/web/css/_colon_target/index.md
@@ -12,7 +12,7 @@ browser-compat: css.selectors.target
 ---
 {{CSSRef}}
 
-The **`:target`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents a unique element (the _target element_) with an {{htmlattrxref("id")}} matching the URL's fragment.
+The **`:target`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents a unique element (the _target element_) with an {{htmlattrxref("id")}} matching the URL's fragment at the time the page loaded.
 
 ```css
 /* Selects an element with an ID matching the current URL's fragment */
@@ -34,6 +34,18 @@ The following element would be selected by a `:target` selector when the current
 ## Syntax
 
 {{csssyntax}}
+
+## Caveats
+
+There are two caveats that make the `:target` selector unsuitable for use with dynamic content.
+
+1. The target element is determined at the time of `DOMContentLoad`, upon navigations triggered by clicking on links, 
+and when setting `window.location` or `window.location.hash`. It does NOT update when changing the location hash via 
+`window.history.pushState()` or `window.history.replaceState()`. Pages relying on `history` to navigate cannot rely
+on `:target` to highlight content.
+
+2. Because the target element has already been determined on `DOMContentLoaded`, the `:target` selector does not select 
+a matching element added to the DOM at some time after `DOMContentLoaded`.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
These caveats are not well documented anywhere else on the web, and only become evident reading the spec – or in my case, after hours of head scratching, testing and refactoring.

#### Motivation
I would like to allow others to avoid the head scratching, testing and refactoring.

#### Supporting details
Test case for dynamic :target styles and explanation of the problem is here: https://stephen.band/target/

#### Related issues
Changes to :targets behaviour are being discussed in the App History API (https://github.com/WICG/app-history/issues/162) but the consensus is it can't be changed.

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
