### PR TITLE
Update index.md where there is an unneeded "Assessment: " in the title

### DIFF
--- a/files/en-us/learn/html/tables/structuring_planet_data/index.md
+++ b/files/en-us/learn/html/tables/structuring_planet_data/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Assessment: Structuring planet data'
+title: Structuring planet data
 slug: Learn/HTML/Tables/Structuring_planet_data
 tags:
   - Assessment


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The other assessment page titles do not have the "Assessment: " written before. This should be added automatically in front of them, right? If so, the change should fit like this for the consistency of the doc?!

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
For consistency. 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
