### PR TITLE
Update index.md where Assessments section is missing

### DIFF
--- a/files/en-us/learn/css/css_layout/index.md
+++ b/files/en-us/learn/css/css_layout/index.md
@@ -67,6 +67,11 @@ These articles will provide instruction on the fundamental layout tools and tech
   - : Grid systems are a very common feature used in CSS layouts. Prior to **CSS Grid Layout**, they tended to be implemented using floats or other layout features. You'd first imagine your layout as a set number of columns (e.g., 4, 6, or 12), and then you'd fit your content columns inside these imaginary columns. In this article, we'll explore how these older methods work so that you understand how they were used if you work on an older project.
 - [Supporting older browsers](/en-US/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers)
   - : In this module, we recommend using Flexbox and Grid as the main layout methods for your designs. However, there are bound to be visitors to a site you develop in the future who use older browsers, or browsers which do not support the methods you have used. This will always be the case on the web — as new features are developed, different browsers will prioritise different features. This article explains how to use modern web techniques without excluding users of older technology.
+
+## Assessments
+
+The following assessment will test your understanding of the CSS layout methods covered in the guides above:
+
 - [Assessment: Fundamental layout comprehension](/en-US/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension)
   - : An assessment to test your knowledge of different layout methods by laying out a webpage.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The assessment page linking was only part of the "Guides" section, but there should be an "Assessments" section if there is one or more assessments, right?

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Apart from the problem from [issue #11822](https://github.com/mdn/content/issues/11822), that the assessments are not displayed in the navigation on the left, it is easy to overlook the assessments and assume that there are none for this module.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
