### PR TITLE
Correcting documentation mistake

### DIFF
--- a/files/en-us/web/html/attributes/step/index.md
+++ b/files/en-us/web/html/attributes/step/index.md
@@ -56,7 +56,7 @@ The default stepping value for `number` inputs is 1, allowing only integers to b
       <td>
         {{HTMLElement("input/datetime-local", "datetime-local")}}
       </td>
-      <td>1 (day)</td>
+      <td>1 (second)</td>
       <td>
         <code
           >&#x3C;input type="datetime-local" min="2019-12-25T19:30"


### PR DESCRIPTION
The documentation claims the unit for input of type `datetime-local` is 1 day whereas it is actually 1 second:

```js
let input = document.createElement('input');
input.setAttribute('type','datetime-local');
input.setAttribute('step',1);
input.value = "2022-01-12T09:10:11";
console.log( input.value ); // 2022-01-12T09:10:11
input.stepUp();
console.log( input.value ); // 2022-01-12T09:10:12

let input2 = document.createElement('input');
input2.setAttribute('type','datetime-local');
input2.setAttribute('step',1);
input2.value = "2022-01-12T09:10";
console.log( input2.value ); // 2022-01-12T09:10
input2.stepUp();
console.log( input2.value ); // 2022-01-12T09:10:01
```

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
