### PR TITLE
fix: add `private fields` section

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -39,7 +39,9 @@ class ClassWithPrivateStaticMethod {
 
 ## Examples
 
-### Private instance fields
+### Private fields
+
+#### Private instance fields
 
 Private instance fields are declared with **# names** (pronounced
 "_hash names_"), which are identifiers prefixed with `#`. The
@@ -94,7 +96,7 @@ new SubClass();
 // SubClass {#privateField: 42, #subPrivateField: 23}
 ```
 
-### Private static fields
+#### Private static fields
 
 Private static fields are added to the class constructor at class evaluation time.
 The limitation of static variables being called by only static methods still holds.

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -41,6 +41,8 @@ class ClassWithPrivateStaticMethod {
 
 ### Private fields
 
+Private fields include private instance fields and private static fields.
+
 #### Private instance fields
 
 Private instance fields are declared with **# names** (pronounced


### PR DESCRIPTION
#### Summary

add HTML section `private fields`

#### Motivation

Keep the same as `private methods`, using `private fields` to lead instance and static fields.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
