### PR TITLE
Correcting an old exception `INVALID_STATE_ERR`

### DIFF
--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -96,7 +96,7 @@ table above), or if the `step` value is set to `any`, an
 
   - : Decrements the {{htmlattrxref("value","input")}} by
     ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws
-    an INVALID_STATE_ERR exception:
+    an `InvalidStateError` exception:
 
     - if the method is not applicable to for the current
       {{htmlattrxref("type","input")}} value,


### PR DESCRIPTION
Correcting an old exception name from `INVALID_STATE_ERR` to `InvalidStateError`

I missed it last time when I edited this page.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
