### PR TITLE
WebDriver conformance updates for Firefox 96 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -64,7 +64,7 @@ No notable changes.
 
 ### WebDriver conformance (Marionette)
 
-- Added the command `WebDriver:GetElementShadowRoot` to retrieve the root node of a DOM subtree for a given element ({{bug(1700073)}}).
+- Added the command `WebDriver:GetElementShadowRoot` to retrieve the shadow root (open or closed) hosted by a given element ({{bug(1700073)}}).
 - Fixed a bug in `WebDriver:ExecuteScript` and `WebDriver:ExecuteAsyncScript` that caused a `cyclic object value` error when trying to return the `ShadowRoot` of an element ({{bug(1489490)}}).
 - `WebDriver:Print` has been enhanced to support page ranges when printing documents as PDF ({{bug(1678347)}}).
 

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -62,6 +62,11 @@ No notable changes.
 - A number of deprecated non-standard statistics fields have been removed from the [WebRTC Statistics API](/en-US/docs/Web/API/WebRTC_Statistics_API), including: `bitrateMean`, `bitrateStdDev`,`framerateMean`, `framerateStdDev`, and `droppedFrames`.
   ({{bug(1367562)}}).
 
+### WebDriver conformance (Marionette)
+
+- Added the command `WebDriver:GetElementShadowRoot` to retrieve the root node of a DOM subtree for a given element ({{bug(1700073)}}).
+- Fixed a bug in `WebDriver:ExecuteScript` and `WebDriver:ExecuteAsyncScript` that caused a `cyclic object value` error when trying to return the `ShadowRoot` of an element ({{bug(1489490)}}).
+- `WebDriver:Print` has been enhanced to support page ranges when printing documents as PDF ({{bug(1678347)}}).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Related changes for Marionette in Firefox 96 can be found [in this query](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&v1=fixed&component=Marionette&v2=verified&product=Testing&f1=cf_status_firefox96&list_id=15958615).

@juliandescottes could you please pre-review? Thanks.