### PR TITLE
Fix typo in AbortController documentation

### DIFF
--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -54,7 +54,7 @@ abortBtn.addEventListener('click', function() {
 
 function fetchVideo() {
   controller = new AbortController();  // Set new controller for this request.
-  fetch(url, {controller.signal}).then(function(response) {
+  fetch(url, { signal }).then(function(response) {
   }).catch(function(e) {
    reports.textContent = 'Download error: ' + e.message;
   })


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixes a typo in the `fetch` example.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The example referenced, and related line is: https://github.com/mdn/dom-examples/blob/master/abort-api/index.html#L67

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
