### PR TITLE
Add missing `showPicker()` method

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -654,6 +654,12 @@ The **`HTMLInputElement`** interface provides special properties and methods for
       </td>
     </tr>
     <tr>
+      <td>{{domxref("HTMLInputElement.showPicker()", "showPicker()")}}</td>
+      <td>
+        Show a browser picker for date, time, color, and files.
+      </td>
+    </tr>
+    <tr>
       <td>{{domxref("HTMLInputElement.checkValidity()", "checkValidity()")}}</td>
       <td>
         Returns a boolean value that is <code>false</code> if the element is a

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -656,7 +656,7 @@ The **`HTMLInputElement`** interface provides special properties and methods for
     <tr>
       <td>{{domxref("HTMLInputElement.showPicker()", "showPicker()")}}</td>
       <td>
-        Show a browser picker for date, time, color, and files.
+        Shows a browser picker for date, time, color, and files.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Following with https://github.com/mdn/content/pull/11753, this PR adds a missing `showPicker()` method.