### PR TITLE
Adding documentation to Gamepad vibrationActuator and playEffect

### DIFF
--- a/files/en-us/web/api/gamepad/hapticactuators/index.md
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.md
@@ -30,7 +30,7 @@ An array containing {{domxref("GamepadHapticActuator")}} objects.
 ```js
 const gamepad = navigator.getGamepads()[0];
 
-gamepad.hapticActuators[0].pulse();
+gamepad.hapticActuators[0].pulse(1.0, 200);
 ````
 
 ## Specifications

--- a/files/en-us/web/api/gamepad/hapticactuators/index.md
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.md
@@ -27,7 +27,11 @@ An array containing {{domxref("GamepadHapticActuator")}} objects.
 
 ## Examples
 
-TBC
+```js
+const gamepad = navigator.getGamepads()[0];
+
+gamepad.hapticActuators[0].pulse();
+````
 
 ## Specifications
 

--- a/files/en-us/web/api/gamepad/index.md
+++ b/files/en-us/web/api/gamepad/index.md
@@ -29,6 +29,8 @@ A Gamepad object can be returned in one of two ways: via the `gamepad` property 
   - : An enum defining what hand the controller is being held in, or is most likely to be held in.
 - {{domxref("Gamepad.hapticActuators")}} {{readonlyInline}}
   - : An array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.
+- {{domxref("Gamepad.vibrationActuator")}} {{readonlyInline}}
+  - : A {{domxref("GamepadHapticActuator")}} object, which represents haptic feedback hardware available on the controller.
 - {{domxref("Gamepad.id")}} {{readonlyInline}}
   - : A {{domxref("DOMString")}} containing identifying information about the controller.
 - {{domxref("Gamepad.index")}} {{readonlyInline}}

--- a/files/en-us/web/api/gamepad/vibrationactuator/index.md
+++ b/files/en-us/web/api/gamepad/vibrationactuator/index.md
@@ -14,14 +14,7 @@ browser-compat: api.Gamepad.vibrationActuator
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 
 The **`vibrationActuator`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadHapticActuator")}} object, which represents haptic feedback hardware available on the controller.
-
-## Syntax
-
-```js
-var myHapticActuator = gamepadInstance.vibrationActuator;
-```
-
-### Value
+## Value
 
 A {{domxref("GamepadHapticActuator")}} object.
 

--- a/files/en-us/web/api/gamepad/vibrationactuator/index.md
+++ b/files/en-us/web/api/gamepad/vibrationactuator/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Gamepad.vibrationActuator
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 
-The **`vibrationActuator`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadHapticActuator")}} object, represents haptic feedback hardware available on the controller.
+The **`vibrationActuator`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadHapticActuator")}} object, which represents haptic feedback hardware available on the controller.
 
 ## Syntax
 

--- a/files/en-us/web/api/gamepad/vibrationactuator/index.md
+++ b/files/en-us/web/api/gamepad/vibrationactuator/index.md
@@ -1,0 +1,51 @@
+---
+title: Gamepad.vibrationActuator
+slug: Web/API/Gamepad/vibrationActuator
+tags:
+  - API
+  - Experimental
+  - Gamepad
+  - Gamepad API
+  - Property
+  - Reference
+  - vibrationActuator
+browser-compat: api.Gamepad.vibrationActuator
+---
+{{APIRef("Gamepad")}}{{SeeCompatTable}}
+
+The **`vibrationActuator`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadHapticActuator")}} object, represents haptic feedback hardware available on the controller.
+
+## Syntax
+
+```js
+var myHapticActuator = gamepadInstance.vibrationActuator;
+```
+
+### Value
+
+A {{domxref("GamepadHapticActuator")}} object.
+
+## Examples
+
+```js
+const gamepad = navigator.getGamepads()[0];
+
+gamepad.vibrationActuator.playEffect('dual-rumble', {
+  startDelay: 0,
+  duration: 200,
+  weakMagnitude: 1.0,
+  strongMagnitude: 1.0,
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Gamepad API](/en-US/docs/Web/API/Gamepad_API)

--- a/files/en-us/web/api/gamepadhapticactuator/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/index.md
@@ -29,9 +29,23 @@ This interface is accessible through the {{domxref("Gamepad.hapticActuators")}} 
 - {{domxref("GamepadHapticActuator.pulse()")}} {{readonlyInline}}
   - : Makes the hardware pulse at a certain intensity for a specified duration.
 
+- {{domxref("GamepadHapticActuator.playEffect()")}} {{readonlyInline}}
+  - : Makes the hardware play a specific vibration pattern.
+
 ## Examples
 
-TBD.
+```js
+const gamepad = navigator.getGamepads()[0];
+
+gamepad.hapticActuators[0].pulse();
+
+gamepad.vibrationActuator.playEffect('dual-rumble', {
+  startDelay: 0,
+  duration: 200,
+  weakMagnitude: 1.0,
+  strongMagnitude: 1.0,
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/gamepadhapticactuator/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/index.md
@@ -37,7 +37,7 @@ This interface is accessible through the {{domxref("Gamepad.hapticActuators")}} 
 ```js
 const gamepad = navigator.getGamepads()[0];
 
-gamepad.hapticActuators[0].pulse();
+gamepad.hapticActuators[0].pulse(1.0, 200);
 
 gamepad.vibrationActuator.playEffect('dual-rumble', {
   startDelay: 0,

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -1,0 +1,72 @@
+---
+title: GamepadHapticActuator.playEffect()
+slug: Web/API/GamepadHapticActuator/playEffect
+tags:
+  - API
+  - Experimental
+  - Gamepad
+  - Gamepad API
+  - GamepadHapticActuator
+  - Method
+  - Reference
+  - playEffect
+browser-compat: api.GamepadHapticActuator.playEffect
+---
+{{APIRef("Gamepad")}}{{SeeCompatTable}}
+
+The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interface Makes the hardware play a specific vibration pattern.
+
+## Syntax
+
+```js
+gamepadHapticActuatorInstance.playEffect(type, params).then(function(result) { /* ... */ });
+```
+
+### Parameters
+
+- _type_
+  - : A string representing the desired effect. This can vary depending on the hardware type, possible values are "dual-rumble" or "vibration".
+- _params_
+  - : A double representing the duration of the playEffect, in milliseconds.
+
+- _params_
+
+  - : An object to describe a desired haptic effect.
+
+    Expected values are:
+
+    - `duration`: The duration of the effect in milliseconds.
+    - `startDelay`: The delay in milliseconds before the effect is started.
+    - `strongMagnitude`: Rumble intensity of the low-frequency (strong) rumble motors, normalized to the range between 0.0 and 1.0.
+    - `weakMagnitude`: Rumble intensity of the high-frequency (weak) rumble motors, normalized to the range between 0.0 and 1.0.
+
+> **Note:** Repeated calls to `playEffect()` override the previous calls if they are still ongoing.
+
+### Return value
+
+A promise that resolves with a value of `true` when the playEffect has successfully completed.
+
+## Examples
+
+```js
+const gamepad = navigator.getGamepads()[0];
+
+gamepad.vibrationActuator.playEffect('dual-rumble', {
+  startDelay: 0,
+  duration: 200,
+  weakMagnitude: 1.0,
+  strongMagnitude: 1.0,
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Gamepad API](/en-US/docs/Web/API/Gamepad_API)

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -19,7 +19,7 @@ The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interf
 ## Syntax
 
 ```js
-gamepadHapticActuatorInstance.playEffect(type, params).then(function(result) { /* ... */ });
+playEffect(type, params);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -26,8 +26,6 @@ gamepadHapticActuatorInstance.playEffect(type, params).then(function(result) { /
 
 - _type_
   - : A string representing the desired effect. This can vary depending on the hardware type, possible values are "dual-rumble" or "vibration".
-- _params_
-  - : A double representing the duration of the playEffect, in milliseconds.
 
 - _params_
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -42,7 +42,7 @@ playEffect(type, params);
 
 ### Return value
 
-A promise that resolves with a value of `true` when the playEffect has successfully completed.
+A promise that resolves with `true` when the playEffect successfully completes.
 
 ## Examples
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -14,7 +14,7 @@ browser-compat: api.GamepadHapticActuator.playEffect
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 
-The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interface Makes the hardware play a specific vibration pattern.
+The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interface makes the hardware play a specific vibration pattern.
 
 ## Syntax
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -25,7 +25,7 @@ playEffect(type, params);
 ### Parameters
 
 - _type_
-  - : A string representing the desired effect. This can vary depending on the hardware type, possible values are "dual-rumble" or "vibration".
+  - : A string representing the desired effect. This can vary depending on the hardware type. Possible values are "dual-rumble" or "vibration".
 
 - _params_
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -38,7 +38,7 @@ playEffect(type, params);
     - `strongMagnitude`: Rumble intensity of the low-frequency (strong) rumble motors, normalized to the range between 0.0 and 1.0.
     - `weakMagnitude`: Rumble intensity of the high-frequency (weak) rumble motors, normalized to the range between 0.0 and 1.0.
 
-> **Note:** Repeated calls to `playEffect()` override the previous calls if they are still ongoing.
+> **Note:** A new call to `playEffect()` overrides a previous ongoing call.
 
 ### Return value
 

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
@@ -37,7 +37,11 @@ A promise that resolves with a value of `true` when the pulse has successfully c
 
 ## Examples
 
-TBC
+```js
+const gamepad = navigator.getGamepads()[0];
+
+gamepad.hapticActuators[0].pulse(1.0, 200);
+````
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Adding documentation to `Gamepad.vibrationActuator` and `GamepadHapticActuator.playEffect()` following the current [Gamepad Haptics API proposal](https://docs.google.com/document/d/1jPKzVRNzzU4dUsvLpSXm1VXPQZ8FP-0lKMT-R_p-s6g/edit#) implemented in browsers and providing examples of its usage.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

`vibrationActuator` and `playEffect` are available features on browsers, and besides the proposal document and some random issues on Github, there's no documentation available about them.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- [Gamepad Haptics API proposal](https://docs.google.com/document/d/1jPKzVRNzzU4dUsvLpSXm1VXPQZ8FP-0lKMT-R_p-s6g/edit#)
- [Vibrate feature for Gamepad #19](https://github.com/w3c/gamepad/issues/19#issuecomment-321424335)
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
