### PR TITLE
Correct the readyState value after abort

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -23,7 +23,7 @@ browser-compat: api.XMLHttpRequest.abort
 The **`XMLHttpRequest.abort()`** method aborts the request if
 it has already been sent. When a request is aborted, its
 {{domxref("XMLHttpRequest.readyState", "readyState")}} is changed to
-{{domxref("XMLHttpRequest.UNSENT")}} (0) and the request's
+{{domxref("XMLHttpRequest.DONE")}} (4) and the request's
 {{domxref("XMLHttpRequest.status", "status")}} code is set to 0.
 
 ## Syntax


### PR DESCRIPTION
On Chrome and Safari, when a request is aborted, its readyState is changed to XMLHttpRequest.DONE (4).

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Change the readyState value when a request is aborted to XMLHttpRequest.DONE (4).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I actually tested it in Chrome and Safari, when a request is aborted, its readyState is changed to XMLHttpRequest.DONE (4).

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://xhr.spec.whatwg.org/#dom-xmlhttprequest-abort

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
