### PR TITLE
Update example

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -47,6 +47,7 @@ button.addEventListener("click", async () => {
     await dateInput.showPicker();
     // A date picker is shown.
   } catch (error) {
+    window.alert(error);
     // Use external library when this fails.
   }
 });


### PR DESCRIPTION
Since the example lives in a cross-origin iframe, `showPicker()` is not allowed. By showing the error with `alert()`, users understand why it is happening.