### PR TITLE
Fix recurring error in event syntax boxes

### DIFF
--- a/files/en-us/web/api/usb/connect_event/index.md
+++ b/files/en-us/web/api/usb/connect_event/index.md
@@ -18,9 +18,9 @@ The **`connect`** event of the {{DOMxRef("USB")}} interface is fired whenever a 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('connect', event => { });
+addEventListener('connect', event => { })
 
-onconnect = event => { };
+onconnect = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/usb/disconnect_event/index.md
+++ b/files/en-us/web/api/usb/disconnect_event/index.md
@@ -18,9 +18,9 @@ The **`connect`** event of the {{DOMxRef("USB")}} interface is fired whenever a 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('disconnect', event => { });
+addEventListener('disconnect', event => { })
 
-ondisconnect = event => { };
+ondisconnect = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/visualviewport/resize_event/index.md
+++ b/files/en-us/web/api/visualviewport/resize_event/index.md
@@ -18,9 +18,9 @@ The **`resize`** event of the [`VisualViewport`](/en-US/docs/Web/API/VisualViewp
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('resize', event => { });
+addEventListener('resize', event => { })
 
-onresize = event => { };
+onresize = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/visualviewport/scroll_event/index.md
+++ b/files/en-us/web/api/visualviewport/scroll_event/index.md
@@ -18,9 +18,9 @@ The **`scroll`** event of the [`VisualViewport`](/en-US/docs/Web/API/VisualViewp
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('scroll', event => { });
+addEventListener('scroll', event => { })
 
-onscroll = event => { };
+onscroll = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/wakelocksentinel/release_event/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release_event/index.md
@@ -25,9 +25,9 @@ power save mode.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event-handler property.
 
 ```js
-addEventListener('release', event => { });
+addEventListener('release', event => { })
 
-onrelease = event => { };
+onrelease = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/wakelocksentinel/release_event/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release_event/index.md
@@ -25,9 +25,9 @@ power save mode.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event-handler property.
 
 ```js
-addEventListener('release', (event) => { });
+addEventListener('release', event => { });
 
-onrelease = event => { });
+onrelease = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/websocket/close_event/index.md
+++ b/files/en-us/web/api/websocket/close_event/index.md
@@ -20,9 +20,9 @@ The `close` event is fired when a connection with a `WebSocket` is closed.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('close', event => { });
+addEventListener('close', event => { })
 
-onclose = event => { };
+onclose = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/websocket/error_event/index.md
+++ b/files/en-us/web/api/websocket/error_event/index.md
@@ -19,9 +19,9 @@ The `error` event is fired when a connection with a `WebSocket` has been closed 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('error', event => { });
+addEventListener('error', event => { })
 
-onerror = event => { };
+onerror = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/websocket/message_event/index.md
+++ b/files/en-us/web/api/websocket/message_event/index.md
@@ -17,9 +17,9 @@ The `message` event is fired when data is received through a `WebSocket`.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('message', event => { });
+addEventListener('message', event => { })
 
-onmessage = event => { };
+onmessage = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/websocket/open_event/index.md
+++ b/files/en-us/web/api/websocket/open_event/index.md
@@ -18,9 +18,9 @@ The `open` event is fired when a connection with a `WebSocket` is opened.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('open', event => { });
+addEventListener('open', event => { })
 
-onopen = event => { };
+onopen = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
@@ -20,14 +20,16 @@ This only applies to Progressive Web Apps installed on desktop operating systems
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('geometrychange', (event) => { });
-ongeometrychange = (event) => { });
+addEventListener('geometrychange', event => { });
+
+ongeometrychange = event => { };
 ```
 
 ## Event type
 
 A {{domxref("WindowControlsOverlayGeometryChangeEvent")}}. Inherits from {{domxref("Event")}}.
-{{InheritanceDiagram(600, 70, 50, "WindowControlsOverlayGeometryChangeEvent")}}
+
+{{InheritanceDiagram("WindowControlsOverlayGeometryChangeEvent")}}
 
 ## Event properties
 

--- a/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
@@ -20,9 +20,9 @@ This only applies to Progressive Web Apps installed on desktop operating systems
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('geometrychange', event => { });
+addEventListener('geometrychange', event => { })
 
-ongeometrychange = event => { };
+ongeometrychange = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrcubelayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcubelayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", (event) => { });
+addEventListener("redraw", event => { });
 
-onredraw = (event) => { });
+onredraw = event => { };
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrcubelayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcubelayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", event => { });
+addEventListener('redraw', event => { })
 
-onredraw = event => { };
+onredraw = event => { }
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", (event) => { });
+addEventListener("redraw", event => { });
 
-onredraw = (event) => { });
+onredraw = event => { };
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", event => { });
+addEventListener('redraw', event => { })
 
-onredraw = event => { };
+onredraw = event => { }
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", (event) => { });
+addEventListener("redraw", event => { });
 
-onredraw = (event) => { });
+onredraw = event => { };
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", event => { });
+addEventListener('redraw', event => { })
 
-onredraw = event => { };
+onredraw = event => { }
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -22,9 +22,9 @@ The WebXR **`reflectionchange`** event fires each time the estimated reflection 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('reflectionchange', event => { });
+addEventListener('reflectionchange', event => { })
 
-onreflectionchange = event => { };
+onreflectionchange = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -22,9 +22,9 @@ The WebXR **`reflectionchange`** event fires each time the estimated reflection 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('reflectionchange', (event) => { });
+addEventListener('reflectionchange', event => { });
 
-onreflectionchange = (event) => { });
+onreflectionchange = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrquadlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrquadlayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", (event) => { });
+addEventListener("redraw", event => { });
 
-onredraw = (event) => { });
+onredraw = event => { };
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrquadlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrquadlayer/redraw_event/index.md
@@ -23,9 +23,9 @@ See also the {{domxref("XRCompositionLayer.needsRedraw")}} property which is als
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("redraw", event => { });
+addEventListener('redraw', event => { })
 
-onredraw = event => { };
+onredraw = event => { }
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.md
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.md
@@ -34,9 +34,9 @@ This event is not cancelable.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("reset", event => { });
+addEventListener('reset', event => { })
 
-onreset = event => { };
+onreset = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.md
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.md
@@ -34,9 +34,9 @@ This event is not cancelable.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener("reset", (event) => { });
+addEventListener("reset", event => { });
 
-onreset = (event) => { });
+onreset = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/end_event/index.md
+++ b/files/en-us/web/api/xrsession/end_event/index.md
@@ -19,9 +19,9 @@ An `end` event is fired at an {{DOMxRef("XRSession")}} object when the WebXR se
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('end', event => { });
+addEventListener('end', event => { })
 
-onend = event => { };
+onend = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/end_event/index.md
+++ b/files/en-us/web/api/xrsession/end_event/index.md
@@ -19,9 +19,9 @@ An `end` event is fired at an {{DOMxRef("XRSession")}} object when the WebXR se
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('end', (event) => { });
+addEventListener('end', event => { });
 
-onend = (event) => { });
+onend = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
@@ -20,9 +20,9 @@ The **`inputsourceschange`** event is sent to an {{domxref("XRSession")}} when t
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('inputsourceschange', event => { });
+addEventListener('inputsourceschange', event => { })
 
-oninputsourceschange = event => { };
+oninputsourceschange = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
@@ -20,9 +20,9 @@ The **`inputsourceschange`** event is sent to an {{domxref("XRSession")}} when t
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('inputsourceschange', (event) => { });
+addEventListener('inputsourceschange', event => { });
 
-oninputsourceschange = (event) => { });
+oninputsourceschange = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -19,9 +19,9 @@ The WebXR **`select`** event is sent to an {{domxref("XRSession")}} when one of 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('select', event => { });
+addEventListener('select', event => { })
 
-onselect = event => { };
+onselect = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -19,9 +19,9 @@ The WebXR **`select`** event is sent to an {{domxref("XRSession")}} when one of 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('select', (event) => { });
+addEventListener('select', event => { };
 
-onselect = (event) => { });
+onselect = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -19,7 +19,7 @@ The WebXR **`select`** event is sent to an {{domxref("XRSession")}} when one of 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('select', event => { };
+addEventListener('select', event => { });
 
 onselect = event => { };
 ```

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -31,9 +31,9 @@ The WebXR event **`selectend`** is sent to an {{domxref("XRSession")}} when one 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('selectend', (event) => { });
+addEventListener('selectend', event => { });
 
-onselectend = (event) => { });
+onselectend = event => { };
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -31,9 +31,9 @@ The WebXR event **`selectend`** is sent to an {{domxref("XRSession")}} when one 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('selectend', event => { });
+addEventListener('selectend', event => { })
 
-onselectend = event => { };
+onselectend = event => { }
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -31,9 +31,9 @@ The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) **`selectstart`** event is sen
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('selectstart', (event) => { });
+addEventListener('selectstart', event => { });
 
-onselectstart = (event) => { });
+onselectstart = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -31,9 +31,9 @@ The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) **`selectstart`** event is sen
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('selectstart', event => { });
+addEventListener('selectstart', event => { })
 
-onselectstart = event => { };
+onselectstart = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/squeeze_event/index.md
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.md
@@ -35,9 +35,9 @@ For details on how the {{domxref("XRSession.squeezestart_event", "squeezestart")
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('squeeze', (event) => { });
+addEventListener('squeeze', event => { });
 
-onsqueeze = (event) => { });
+onsqueeze = event => { };
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrsession/squeeze_event/index.md
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.md
@@ -35,9 +35,9 @@ For details on how the {{domxref("XRSession.squeezestart_event", "squeezestart")
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('squeeze', event => { });
+addEventListener('squeeze', event => { })
 
-onsqueeze = event => { };
+onsqueeze = event => { }
 ```
 ## Event type
 

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.md
@@ -34,9 +34,9 @@ Primary squeeze actions include things like users pressing triggers or buttons, 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('squeezeend', event => { });
+addEventListener('squeezeend', event => { })
 
-onsqueezeend = event => { };
+onsqueezeend = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.md
@@ -34,9 +34,9 @@ Primary squeeze actions include things like users pressing triggers or buttons, 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('squeezeend', (event) => { });
+addEventListener('squeezeend', event => { });
 
-onsqueezeend = (event) => { });
+onsqueezeend = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.md
@@ -35,9 +35,9 @@ Primary squeeze actions are actions which are meant to represent gripping or squ
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('squeezestart', event => { });
+addEventListener('squeezestart', event => { })
 
-onsqueezestart = event => { };
+onsqueezestart = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.md
@@ -35,9 +35,9 @@ Primary squeeze actions are actions which are meant to represent gripping or squ
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('squeezestart', (event) => { });
+addEventListener('squeezestart', event => { });
 
-onsqueezestart = (event) => { });
+onsqueezestart = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.md
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.md
@@ -19,9 +19,9 @@ The **`visibilitychange`** event is sent to an {{domxref("XRSession")}} to infor
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('visibilitychange', (event) => { });
+addEventListener('visibilitychange', event => { });
 
-onvisibilitychange = (event) => { });
+onvisibilitychange = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.md
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.md
@@ -19,9 +19,9 @@ The **`visibilitychange`** event is sent to an {{domxref("XRSession")}} to infor
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('visibilitychange', event => { });
+addEventListener('visibilitychange', event => { })
 
-onvisibilitychange = event => { };
+onvisibilitychange = event => { }
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.md
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.md
@@ -25,9 +25,9 @@ A **`devicechange`** event is fired on an {{DOMxRef("XRSystem")}} object whene
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('devicechange', (event) => { });
+addEventListener('devicechange', event => { });
 
-ondevicechange = (event) => { });
+ondevicechange = event => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.md
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.md
@@ -25,9 +25,9 @@ A **`devicechange`** event is fired on an {{DOMxRef("XRSystem")}} object whene
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('devicechange', event => { });
+addEventListener('devicechange', event => { })
 
-ondevicechange = event => { };
+ondevicechange = event => { }
 ```
 
 ## Event type


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
@ddbeck noted there is a recurring syntax error in the new event page syntax boxes. 

I think we could omit the braces also and have an easier life / more readable syntax boxes.

#### Motivation

It gets copy pasted to more new-style event pages and we should stop this plague.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
