### PR TITLE
Fix issue 11133: clarify printing on load

### DIFF
--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -11,9 +11,11 @@ browser-compat: api.Window.print
 ---
 {{ ApiRef() }}
 
-Opens the Print Dialog to print the current document.
+Opens the print dialog to print the current document.
 
-In most browsers, this method will block while the print dialog is open. However in more recent versions of Safari, it may return immediately.
+If the document is still loading when this function is called, then the document will finish loading before opening the print dialog.
+
+This method will block while the print dialog is open.
 
 ## Syntax
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11133: clarify that printing is deferred while the document is still loading.

I also removed the bit about Safari because it was vague and as far as I could tell not true.