### PR TITLE
Fix incorrect property value description

### DIFF
--- a/files/en-us/web/api/document/plugins/index.md
+++ b/files/en-us/web/api/document/plugins/index.md
@@ -27,8 +27,7 @@ embedArrayObj = document.plugins
 
 ### Value
 
-An {{domxref("HTMLCollection")}}, or `null` if there are no embeds in the
-document.
+An {{domxref("HTMLCollection")}}.
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary

Fixed incorrect description of the `document.plugins` property value.

#### Motivation

The `document.plugins` property always contains an `HTMLCollection` object even if there are no embeds in the document. For example, `document.embeds` property works the same way.

#### Supporting details

https://html.spec.whatwg.org/multipage/dom.html#dom-document-plugins-dev

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
