### PR TITLE
Small fixes for CSS setProperty page

### DIFF
--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -62,7 +62,7 @@ example at the end of this section).
 
 We know that the rule we want to alter to do this is contained inside the second
 stylesheet applied to the page, so we grab a reference to it using
-[`document.styleSheets[1]`](/en-US/docs/Web/API/Document/styleSheetSets).
+[`document.styleSheets[1]`](/en-US/docs/Web/API/Document/styleSheets).
 We then loop through the different rules contained inside the stylesheet, which are
 contained in the array found at
 [`stylesheet.cssRules`](/en-US/docs/Web/API/CSSStyleSheet/cssRules);
@@ -74,7 +74,7 @@ want.
 If so, we store a reference to this `CSSStyleRule` object in a variable. We
 then use three functions to generate random values for the properties in question, and
 update the rule with these values. In each case, this is done with the
-`setProperty()` method, for example `boxParaRule.style.setProperty('border', newBorder);`
+`setProperty()` method, for example `boxParaRule.style.setProperty('border', newBorder);`.
 
 ### HTML
 
@@ -157,7 +157,7 @@ function randomColor() {
   return 'rgb(' + random(0,255) + ', ' + random(0,255) + ', ' + random(0,255) +  ')';
 }
 
-const stylesheet = document.styleSheets[0];
+const stylesheet = document.styleSheets[1];
 let boxParaRule;
 
 for(let i = 0; i < stylesheet.cssRules.length; i++) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
- Changes link from (deprecated) `document.styleSheetSets` to `document.styleSheets` for link text `document.styleSheets[1]` and minor typofix
- Fixes live sample by changing `document.styleSheets[0]` to `document.styleSheets[1]` in the JavaScript code

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The live sample allows readers to visualize the code on the page, and the proposed correction is also what corresponds with this passage: "We know that the rule we want to alter to do this is contained inside the second stylesheet applied to the page, so we grab a reference to it using **document.styleSheets[1]**."

#### Supporting details
I tested the fix locally, and the (fixed) live sample code would also match the Japanese translation, which has a working live sample.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
