### PR TITLE
Media @rule for speech removed

### DIFF
--- a/files/en-us/glossary/media/css/index.md
+++ b/files/en-us/glossary/media/css/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 In the context of {{Glossary("CSS")}} (Cascading Style Sheets), the term **_media_** refers to the destination to which the document is to be drawn by the {{Glossary("rendering engine")}}.
 
-Typically, this is a screen—but it may also be a printer, a speech synthesizer, Braille display, or another type of device.
+Typically, this is a screen—but it may also be a printer, Braille display, or another type of device.
 
 CSS offers several features that allow you to tweak your document's styles—or even offer different styles—according to the media **type** (such as screen or print, to name two) or media **capabilities** (such as width, resolution, or other values) of the viewer's device.
 

--- a/files/en-us/learn/css/css_layout/media_queries/index.md
+++ b/files/en-us/learn/css/css_layout/media_queries/index.md
@@ -59,7 +59,6 @@ The possible types of media you can specify are:
 - `all`
 - `print`
 - `screen`
-- `speech`
 
 The following media query will only set the body to 12pt if the page is printed. It will not apply when the page is loaded in a browser.
 

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -52,11 +52,8 @@ Except when using the `not` or `only` logical operators, the media type is optio
   - : Intended for paged material and documents viewed on a screen in print preview mode. (Please see [paged media](/en-US/docs/Web/CSS/Paged_Media) for information about formatting issues that are specific to these formats.)
 - `screen`
   - : Intended primarily for screens.
-- `speech`
-  - : Intended for speech synthesizers.
 
 > **Note:** CSS2.1 and [Media Queries 3](https://drafts.csswg.org/mediaqueries-3/#background) defined several additional media types (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, and `aural`), but they were deprecated in [Media Queries 4](https://dev.w3.org/csswg/mediaqueries/#media-types) and shouldn't be used.
-> The `aural` type has been replaced by `speech`, which is similar.
 
 ### Media features
 

--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -54,7 +54,7 @@ A subset of nested statements, which can be used as a statement of a style sheet
 
 Much like the values of properties, each at-rule has a different syntax. Nevertheless, several of them can be grouped into a special category named **conditional group rules**. These statements share a common syntax and each of them can include _nested statements_—either _rulesets_ or _nested at-rules_. Furthermore, they all convey a common semantic meaning—they all link some type of condition, which at any time evaluates to either **true** or **false**. If the condition evaluates to **true**, then all of the statements within the group will be applied.
 
-Conditional group rules are defined in [CSS Conditionals Level 3](http://dev.w3.org/csswg/css3-conditional/) and are:
+Conditional group rules are defined in [CSS Conditionals Level 3](https://dev.w3.org/csswg/css3-conditional/) and are:
 
 - {{cssxref("@media")}},
 - {{cssxref("@supports")}},

--- a/files/en-us/web/css/media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries/index.md
@@ -27,7 +27,7 @@ Media queries are used for the following:
 A media query is composed of an optional _media type_ and any number of _media feature_ expressions, which may optionally be combined in various ways using _logical operators_.
 Media queries are case-insensitive.
 
-- [Media types](/en-US/docs/Web/CSS/@media#media_types) define the broad category of device for which the media query applies: `all`, `print`, `screen`, `speech`.
+- [Media types](/en-US/docs/Web/CSS/@media#media_types) define the broad category of device for which the media query applies: `all`, `print`, `screen`.
   
   The type is optional (assumed to be `all`) except when using the `not` or `only` logical operators.
 - [Media feature](/en-US/docs/Web/CSS/@media#media_features) describe a specific characterisic of the {{glossary("user agent")}}, output device, or environment: {{cssxref("@media/any-hover", "any-hover")}}, {{cssxref("@media/any-pointer", "any-pointer")}}, {{cssxref("@media/aspect-ratio", "aspect-ratio")}}, {{cssxref("@media/color", "color")}}, {{cssxref("@media/color-gamut", "color-gamut")}}, {{cssxref("@media/color-index", "color-index")}}, {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}} {{deprecated_inline}}, {{cssxref("@media/device-height", "device-height")}} {{deprecated_inline}}, {{cssxref("@media/device-width", "device-width")}} {{deprecated_inline}}, {{cssxref("@media/display-mode", "display-mode")}}, {{cssxref("@media/forced-colors", "forced-colors")}}, {{cssxref("@media/grid", "grid")}}, {{cssxref("@media/height", "height")}}, {{cssxref("@media/hover", "hover")}}, {{cssxref("@media/inverted-colors", "inverted-colors")}}, {{cssxref("@media/monochrome", "monochrome")}}, {{cssxref("@media/orientation", "orientation")}}, {{cssxref("@media/overflow-block", "overflow-block")}}, {{cssxref("@media/overflow-inline", "overflow-inline")}}, {{cssxref("@media/pointer", "pointer")}}, {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}, {{cssxref("@media/prefers-contrast", "prefers-contrast")}}, {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}, {{cssxref("@media/resolution", "resolution")}}, {{cssxref("@media/scripting", "scripting")}}, {{cssxref("@media/update-frequency", "update")}}, {{cssxref("@media/width", "width")}}
@@ -92,11 +92,6 @@ For example, this CSS will apply to any device with a color screen:
 ```
 
 If a feature doesn't apply to the device on which the browser is running, expressions involving that media feature are always false.
-For example, the styles nested inside the following query will never be used, because no speech-only device has a screen aspect ratio:
-
-```css
-@media speech and (aspect-ratio: 11/5) { ... }
-```
 
 For more [Media feature](/en-US/docs/Web/CSS/@media#media_features) examples, please see the reference page for each specific feature.
 
@@ -188,8 +183,8 @@ _It has no effect on modern browsers._
 The Media Queries Level 4 specification includes some syntax improvements to make media queries using features that have a "range" type, for example width or height, less verbose.
 Level 4 adds a _range context_ for writing such queries. For example, using the `max-` functionality for width we might write the following:
 
-> **Note:** The Media Queries Level 4 specification has reasonable support in modern browsers, but some media features are not well supported.
-> See the [`@media` browser compatibility table](/en-US/docs/Web/CSS/@media#Browser_compatibility) for more details.
+> **Note:** The Media Queries Level 4 specification has reasonable support in modern browsers, but some media features are not well supported.
+> See the [`@media` browser compatibility table](/en-US/docs/Web/CSS/@media#browser_compatibility) for more details.
 
 ```css
 @media (max-width: 30em) { ... }
@@ -235,6 +230,6 @@ For example, the following query tests for devices that have a monochrome displa
 ## See also
 
 - [Testing media queries programmatically](/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries)
-- [CSS Animations Between Media Queries](http://davidwalsh.name/animate-media-queries)
-- [Extended Mozilla media features](/en-US/docs/Web/CSS/Mozilla_Extensions#Media_features)
-- [Extended WebKit media features](/en-US/docs/Web/CSS/Webkit_Extensions#Media_features)
+- [CSS Animations Between Media Queries](https://davidwalsh.name/animate-media-queries)
+- [Extended Mozilla media features](/en-US/docs/Web/CSS/Mozilla_Extensions#media_features)
+- [Extended WebKit media features](/en-US/docs/Web/CSS/Webkit_Extensions#media_features)


### PR DESCRIPTION
Fixes #11317

The speech @query is now considered irrelevant. I have therefore stripped it from BCD in https://github.com/mdn/browser-compat-data/pull/14077

This PR similarly scrubs all mentions of the speech media query from MDN.