### PR TITLE
Fixing link to env() CSS page

### DIFF
--- a/files/en-us/web/api/window_controls_overlay_api/index.md
+++ b/files/en-us/web/api/window_controls_overlay_api/index.md
@@ -44,7 +44,7 @@ PWAs can use the API to position content in this area, and avoid having content 
 
 ## CSS environment variables
 
-Progressive Web Apps can position their web content in the are that the title bar normally occupies by using the `titlebar-area-x`, `titlebar-area-y`, `titlebar-area-width`, and `titlebar-area-height` CSS environment variables. See [Using env() to ensure content is not obscured by window control buttons in desktop PWAs](en-US/docs/Web/CSS/env()#using_env_to_ensure_content_is_not_obscured_by_window_control_buttons_in_desktop_pwa).
+Progressive Web Apps can position their web content in the are that the title bar normally occupies by using the `titlebar-area-x`, `titlebar-area-y`, `titlebar-area-width`, and `titlebar-area-height` CSS environment variables. See [Using env() to ensure content is not obscured by window control buttons in desktop PWAs](/en-US/docs/Web/CSS/env()#using_env_to_ensure_content_is_not_obscured_by_window_control_buttons_in_desktop_pwas).
 
 ## Interfaces
 


### PR DESCRIPTION
#### Summary
The link from the Window Controls Overlay API page to one of the CSS env() page sections was wrong.
It was missing the initial `/` character, and the anchor was wrong too.

This PR fixes this.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error