### PR TITLE
showPicker() returns undefined

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -17,7 +17,7 @@ user.
 
 A browser picker is shown when the element is one of these types: `"date"`,
 `"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`. It
-can also be prepopulated with items from `<datalist>` or "autocomplete".
+can also be prepopulated with items from a {{htmlelement("datalist")}} element or {{htmlattrdef("autocomplete")}} attribute.
 
 ### Return value
 

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -12,17 +12,29 @@ browser-compat: api.HTMLInputElement.showPicker
 ---
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLInputElement.showPicker()`** method returns a promise that resolves
-when a browser picker is shown to the user. It must be called in response to a
-user gesture such as a touch gesture or mouse click; otherwise it will reject. For
-security reasons, it also rejects when it's called in a cross-origin iframe.
+The **`HTMLInputElement.showPicker()`** method shows a browser picker to the
+user. 
+
+A browser picker is shown when the element is one of these types: `"date"`,
+`"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`. It
+can also be prepopulated with items from `<datalist>` or "autocomplete".
+
+### Return value
+
+{{jsxref("undefined")}}.
+
+### Exceptions
+
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : Thrown if not called in response to a user gesture such as a touch gesture
+    or mouse click.
+- `SecurityError` {{domxref("DOMException")}}
+  - : Thrown if called in a cross-origin iframe.
 
 ## Syntax
 
 ```js
-element.showPicker().then(() => {
-  // A browser picker is shown.
-});
+element.showPicker();
 ```
 
 ## Example
@@ -42,9 +54,9 @@ Click the button in this example to show a browser date picker.
 const button = document.querySelector("button");
 const dateInput = document.querySelector("input");
 
-button.addEventListener("click", async () => {
+button.addEventListener("click", () => {
   try {
-    await dateInput.showPicker();
+    dateInput.showPicker();
     // A date picker is shown.
   } catch (error) {
     window.alert(error);

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -17,7 +17,7 @@ user.
 
 A browser picker is shown when the element is one of these types: `"date"`,
 `"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`. It
-can also be prepopulated with items from a {{htmlelement("datalist")}} element or {{htmlattrdef("autocomplete")}} attribute.
+can also be prepopulated with items from a {{htmlelement("datalist")}} element or [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
 
 ### Return value
 


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker says `showPicker()` returns undefined, not a promise. This PR fixes it and adds details like supported types about the browser implementation.