### PR TITLE
Update Unlayered styles always winning over Layered styles

### DIFF
--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -56,11 +56,11 @@ Or, multiple layers can be defined at once. For example:
 
 This is useful because the initial order in which layers are declared indicates which layer has precedence. As with declarations, the last layer to be listed will win if declarations are found in multiple layers. Therefore, with the preceding example, if a competing rule was found in `theme` and `utilities` the one in `utilities` would win and be applied.
 
-The rule in `utilities` would be applied _even if it has lower specificity_ than the rule in `theme`. This is because once layer order has been established, specificity and order of appearance are ignored. This enables the creation of simpler CSS selectors, as you do not have to ensure that a selector will have high enough specificity to override competing rules, all you need to ensure is that it appears in a later layer.
+The rule in `utilities` would be applied _even if it has lower specificity_ than the rule in `theme`. This is because once layer order has been established, specificity and order of appearance matter only relatively to their own layer and the last layer will always be stronger than the previous ones. This enables the creation of simpler CSS selectors, as you do not have to ensure that a selector will have high enough specificity to override competing rules, all you need to ensure is that it appears in a later layer.
 
 > **Note:** Having declared your layer names, thus setting their order, you can add CSS rules to the layer by redeclaring the name. The styles are then appended to the layer and the layer order will not be changed.
 
-Any styles not in a layer are gathered together and placed into an anonymous layer that comes first in the order of layers, this means that anything in a layer will override things not in a layer.
+**N.B.**: any styles not in a layer (i.e. _Unlayered styles_) are gathered together and placed into an anonymous layer that comes last in the order of layers, this means that anything out of a layer will override things in a layer.
 
 ### Nesting layers
 
@@ -108,7 +108,7 @@ Then an anonymous, unnamed, layer is created. This functions in the same way as 
 
 In the following example, two CSS rules are created. One for the {{htmlelement("p")}} element, which is inside a layer named `type`. In addition a rule is created outside of any layer for `.box p`.
 
-Without layers, the selector `box p` would have the highest specificity and therefore the text `Hello, world!` will display in green. With layers, specificity and order outside of layers is ignored. As the `type` layer comes after the anonymous layer created to hold non-layer content, the text will be purple.
+Without layers, the selector `box p` would have the highest specificity and therefore the text `Hello, world!` will display in rebeccapurple. With layers, the anonymous _Unlayered style_ layer always wins over the declared ones. Therefore, as the `type` layer comes before the anonymous layer created to hold non-layer content, the text will be green and bold.
 
 #### HTML
 
@@ -122,12 +122,12 @@ Without layers, the selector `box p` would have the highest specificity and ther
 
 ```css
 @layer type {
-  p {
+  .box p {
     color: rebeccapurple;
   }
 }
 
-.box p {
+p {
   font-weight: bold;
   color: green;
 }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

I updated the docs to the current spec in a very important aspect of it: the position of the **Unlayered style layer**.
Initially, it was supposed to be first (so overridable by layers), now it's last (overrides any layer).


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The spec changed 3 months ago, time to update your docs :)

The docs now should be correct at least, I'm not sure whether it's the better formulation as English is not my mother tongue.

Extra: the last LiveSample looks broken, no styling is applied at the moment.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
 https://github.com/w3c/csswg-drafts/issues/6284#issuecomment-937262197

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
