### PR TITLE
Incorrect information

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
@@ -16,7 +16,7 @@ The **`Number.MAX_VALUE`** property represents the maximum numeric value represe
 
 ## Description
 
-The `MAX_VALUE` property has a value of approximately `1.79E+308`, or 2^1024. Values larger than `MAX_VALUE` are represented as {{jsxref("Infinity")}}.
+The `MAX_VALUE` property has a value of approximately `1.79E+308`, or 1.7976931348623157 * (10^308). Values larger than `MAX_VALUE` are represented as {{jsxref("Infinity")}}.
 
 Because `MAX_VALUE` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_VALUE`, rather than as a property of a {{jsxref("Number")}} object you created.
 


### PR DESCRIPTION
The documentation states that MAX_VALUE is roughly equal to `2^1024` and that any number above are represented as infinity, but this is incorrect. `2^1024` is already infinity:

```js
console.log( Math.pow(2,104) ); // Infinity
```

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
