### PR TITLE
Refine the WAI-ARIA Roles intro doc a bit

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/index.md
+++ b/files/en-us/web/accessibility/aria/roles/index.md
@@ -10,9 +10,11 @@ tags:
 ---
 This page lists reference pages covering all the WAI-ARIA roles discussed on MDN. For a full list of roles, see [Using ARIA: Roles, States, and Properties](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques)
 
-ARIA roles provide semantic meaning to content, allowing screen readers and other tools to present and support interaction with object in a way that is consistent with user expectations of that type of object. ARIA roles can be used to describe elements that don't natively exist in HTML or exist but don't yet have full browser support. By default, semantic elements have a role; `<p>` has the "paragraph" role, `<input type="radio">` has the "radio" role. Non-semantic elements do not have a role; `<div>` and `<span>` without added semantics return *null*. The `role` attribute can provide semantics.
+ARIA roles provide semantic meaning to content, allowing screen readers and other tools to present and support interaction with object in a way that is consistent with user expectations of that type of object. ARIA roles can be used to describe elements that don't natively exist in HTML or exist but don't yet have full browser support.
 
-ARIA roles are HTML attributes. They are added to elements using role="*role type*", where *role type* is the name of a role in the ARIA specification.  Some roles require the inclusion of associated ARIA states or properties; others are only valid in association with other roles.
+By default, many semantic elements in HTML have a role; for example, `<input type="radio">` has the "radio" role. Non-semantic elements in HTML do not have a role; `<div>` and `<span>` without added semantics return *null*. The `role` attribute can provide semantics.
+
+ARIA roles are are added to HTML elements using `role="`*role type*`"`, where *role type* is the name of a role in the ARIA specification.  Some roles require the inclusion of associated ARIA states or properties; others are only valid in association with other roles.
 
 For example, `<ul role="tabpanel">` will be announced as a 'tab panel' by screen readers. However, if the tab panel doesn't have nested tabs, the element with the tabpanel role is not in fact a tab panel and accessibility has actually been negatively impacted.
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11980

Changes:

* Per https://w3c.github.io/html-aria/#el-p, the `<p>` element has no corresponding role. There is no “paragraph” role at all in ARIA 1.1 https://www.w3.org/TR/wai-aria-1.1/ — though there is in ARIA 1.2 https://www.w3.org/TR/wai-aria-1.2/#paragraph; however, the source of truth on allowed roles in HTML is https://w3c.github.io/html-aria — so unless/until that gets updated, it’s not true to state that the `<p>` element has the “paragraph” role.

* Not all semantic elements in HTML have a role. `<audio>`, `<video>`, `<picture>`, `<meter>`, and `<time>` are examples of some that have no role.

* Because ARIA can be used in host languages other than just HTML, the statement _“ARIA roles are HTML attributes”_ isn’t completely accurate. So, refined the wording to make it more accurate.
