### PR TITLE
media.textTracks returns object, not array

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.md
@@ -39,7 +39,7 @@ existing ones removed.
 See {{SectionOnPage("/en-US/docs/Web/API/TextTrackList", "Event handlers")}} to learn
 more about watching for changes to a media element's track list.
 
-### Value
+## Value
 
 A {{DOMxRef("TextTrackList")}} object representing the list of text tracks included in the media element. The list of tracks can be accessed using `textTracks[n]` to get the *n*th text track from the object’s list of text tracks, or using the `textTracks`.[`getTrackById()`](/en-US/docs/Web/API/TextTrackList/getTrackById)
 method.

--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.md
@@ -39,18 +39,9 @@ existing ones removed.
 See {{SectionOnPage("/en-US/docs/Web/API/TextTrackList", "Event handlers")}} to learn
 more about watching for changes to a media element's track list.
 
-## Syntax
-
-```js
-var textTracks = mediaElement.textTracks;
-```
-
 ### Value
 
-A {{DOMxRef("TextTrackList")}} object representing the list of text tracks included in
-the media element. The list of tracks can be accessed using array notation, or using the
-object's
-[`getTrackById()`](/en-US/docs/Web/API/VideoTrackList/getTrackById)
+A {{DOMxRef("TextTrackList")}} object representing the list of text tracks included in the media element. The list of tracks can be accessed using `textTracks[n]` to get the *n*th text track from the object’s list of text tracks, or using the `textTracks`.[`getTrackById()`](/en-US/docs/Web/API/TextTrackList/getTrackById)
 method.
 
 Each track is represented by a {{DOMxRef("TextTrack")}} object which provides

--- a/files/en-us/web/api/texttracklist/index.md
+++ b/files/en-us/web/api/texttracklist/index.md
@@ -18,7 +18,13 @@ browser-compat: api.TextTrackList
 
 The **`TextTrackList`** interface is used to represent a list of the text tracks defined by the {{HTMLElement("track")}} element, with each track represented by a separate {{domxref("textTrack")}} object in the list.
 
-Retrieve an instance of this object with {{domxref('HTMLMediaElement.textTracks')}}. The individual tracks can be accessed using array syntax or functions such as {{jsxref("Array.forEach", "forEach()")}} for example.
+Retrieve an instance of this object with the {{domxref('HTMLMediaElement.textTracks', 'textTracks')}} property of an {{domxref('HTMLMediaElement')}} object.
+
+For a given {{domxref('HTMLMediaElement')}} object _media_, the individual tracks can be accessed using:
+
+- `media.TextTracks[n]`, to get the *n*th text track from the object’s list of text tracks
+
+- the `media.textTracks`.[`getTrackById()`](/en-US/docs/Web/API/TextTrackList/getTrackById) method
 
 ## Properties
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11974