### PR TITLE
Correcting multiple errors in wholeText doc

### DIFF
--- a/files/en-us/web/api/text/wholetext/index.md
+++ b/files/en-us/web/api/text/wholetext/index.md
@@ -36,12 +36,12 @@ const para = document.getElementsByTagname("p")[0]; // Reads the paragraph
 para.removeChild(para.childNodes[1]); // Delete the strong element
 ```
 
-Now you end up with "Through-hiking is great! However, casting a ballot is tricky." with two nodes before the hyperlink:
+Now you end up with _"Through-hiking is great! However, casting a ballot is tricky."_, with two nodes before the hyperlink:
 
 1. `Through-hiking is great!  `
 2. ` However, `
 
-To get those two nodes at once, you would call `para.childNodes[0].wholeText`
+To get those two nodes at once, you would call `para.childNodes[0].wholeText`:
 
 ```js
 console.log( "'" + para.childNodes[0].wholeText + "'" ); // 'Through-hiking is great!   However, '

--- a/files/en-us/web/api/text/wholetext/index.md
+++ b/files/en-us/web/api/text/wholetext/index.md
@@ -36,32 +36,15 @@ const para = document.getElementsByTagname("p")[0]; // Reads the paragraph
 para.removeChild(para.childNodes[1]); // Delete the strong element
 ```
 
-Later, you want to rephrase things to, "Through-hiking is great, but casting a ballot is tricky." _while preserving the hyperlink_.
+Now you end up with "Through-hiking is great! However, casting a ballot is tricky." with two nodes before the hyperlink:
 
-But, when you removed the `<strong>` element, the two text nodes on each part of the removed element, weren't merged into a single one: you have two consecutive `Text` nodes, one with `'Through-hiking is great!  '`, immediately followed by `' However, '`.
+1. `Through-hiking is great!  `
+2. ` However, `
 
-So, if you do this:
+To get those two nodes at once, you would call `para.childNodes[0].wholeText`
 
-```js example-bad
-para.firstChild.data = "Through-hiking is great, but ";
-```
-
-you'll end replacing  the first `Text` node only and you'll get:
-
-```html
-<p>Through-hiking is great, but However, <a href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a  ballot</a> is tricky.</p>
-```
-
-To treat all those adjacent text nodes as a single one, you use `wholeText`.
-
-```js example-good
-para.firstChild.wholeText == "Through-hiking is great, but ";
-```
-
-and you end with:
-
-```html
-<p>Through-hiking is great, but <a href="https://en.wikipedia.org/wiki/Absentee_ballot">casting a  ballot</a> is tricky.</p>
+```js
+console.log( "'" + para.childNodes[0].wholeText + "'" ); // 'Through-hiking is great!   However, '
 ```
 
 ## Specifications


### PR DESCRIPTION
First, the example calls `getElementBytagname` instead of `getElementByTagName`
Second, the original author of this example seemed to have ignored that `wholeText` is a read-only property so one cannot assign a value to it.
Third, when the author, in his/her example, assigned a value, he/she used a comparison operator `==` which would only yield true or false.

See the [codepen example](https://codepen.io/jdeguest/pen/OJxdRqm) I created to illustrate this.

I changed the example to something more simple.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
