### PR TITLE
Fixes #1463: Adds optional argument to Syntax

### DIFF
--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -29,6 +29,7 @@ The `mark()'s` stores its data internally as
 
 ```js
 performance.mark(name);
+performance.mark(measureName, markOptions)
 ```
 
 ### Arguments
@@ -38,6 +39,14 @@ performance.mark(name);
     `name` given to this method already exists in the
     {{domxref("PerformanceTiming")}} interface, {{jsxref("SyntaxError")}} is
     thrown.
+
+- `markOptions` {{optional_inline}}
+  - : An object for specifying a timestamp and additional metadata for the mark.
+
+      - `detail`
+        - : Arbitrary metadata to include in the mark.
+      - `startTime`
+        - : {{domxref("DOMHighResTimeStamp")}} to be used as the mark time.
 
 ### Return value
 

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -46,7 +46,7 @@ performance.mark(measureName, markOptions)
       - `detail`
         - : Arbitrary metadata to include in the mark.
       - `startTime`
-        - : {{domxref("DOMHighResTimeStamp")}} to be used as the mark time.
+        - : {{domxref("DOMHighResTimeStamp")}} to use as the mark time.
 
 ### Return value
 


### PR DESCRIPTION
#### Summary
Adds optional second argument

#### Motivation
Low hanging :mango:

#### Supporting details
1. Borrows content/style from https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure
2. W3 spec - https://www.w3.org/TR/user-timing/#mark-method

#### Related issues
Fixes #1463

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
