### PR TITLE
Add glossary entry for “stringifier”

### DIFF
--- a/files/en-us/glossary/stringifier/index.md
+++ b/files/en-us/glossary/stringifier/index.md
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - Stringifier
 ---
-An {{Glossary("object", "object's")}} stringifier is any {{Glossary("attribute")}} or {{Glossary("method")}} that is defined to provide a textual representation for use when the object is used in situations where a {{Glossary("string")}} is expected e.g. `console.log(anOjbect)`. Objects that don't have any defined stringifer, are usually converted to their {{Glossary("JSON")}} representation in similar situations.
+An {{Glossary("object", "object's")}} stringifier is any {{Glossary("attribute")}} or {{Glossary("method")}} that is defined to provide a textual representation of the object for use in situations where a {{Glossary("string")}} is expected.
 
 ## See also
 - Stringifiers in [Information contained in a WebIDL file](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifier)

--- a/files/en-us/glossary/stringifier/index.md
+++ b/files/en-us/glossary/stringifier/index.md
@@ -9,4 +9,4 @@ tags:
 An {{Glossary("object", "object's")}} stringifier is any {{Glossary("attribute")}} or {{Glossary("method")}} that is defined to provide a textual representation for use when the object is used in situations where a {{Glossary("string")}} is expected e.g. `console.log(anOjbect)`. Objects that don't have any defined stringifer, are usually converted to their {{Glossary("JSON")}} representation in similar situations.
 
 ## See also
-- Stringifiers in [Information contained in a WebIDL file](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifier)}}s)
+- Stringifiers in [Information contained in a WebIDL file](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifier)

--- a/files/en-us/glossary/stringifier/index.md
+++ b/files/en-us/glossary/stringifier/index.md
@@ -1,0 +1,12 @@
+---
+title: Stringifier
+slug: Glossary/Stringifier
+tags:
+  - CodingScripting
+  - Glossary
+  - Stringifier
+---
+An {{Glossary("object", "object's")}} stringifier is any {{Glossary("attribute")}} or {{Glossary("method")}} that is defined to provide a textual representation for use when the object is used in situations where a {{Glossary("string")}} is expected e.g. `console.log(anOjbect)`. Objects that don't have any defined stringifer, are usually converted to their {{Glossary("JSON")}} representation in similar situations.
+
+## See also
+- Stringifiers in [Information contained in a WebIDL file](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifier)}}s)

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -15,7 +15,7 @@ browser-compat: api.CSSKeywordValue
 
 The **`CSSKeywordValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) creates an object to represent CSS keywords and other identifiers.
 
-The interface instance name is a stringifier meaning that when used anywhere a string is expected it will return the value of `CSSKeyword.value`.
+The interface instance name is a {{Glossary("stringifier")}} meaning that when used anywhere a string is expected it will return the value of `CSSKeyword.value`.
 
 ## Constructor
 

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -14,7 +14,7 @@ browser-compat: api.CSSTransformComponent.toString
 ---
 {{APIRef("CSS Typed OM")}}
 
-The **`toString()`** method of the {{domxref("CSSTransformComponent")}} interface is a stringifier returning a [CSS Transforms](/en-US/docs/Web/CSS/CSS_Transforms) function.
+The **`toString()`** method of the {{domxref("CSSTransformComponent")}} interface is a {{Glossary("stringifier")}} returning a [CSS Transforms](/en-US/docs/Web/CSS/CSS_Transforms) function.
 
 ## Syntax
 

--- a/files/en-us/web/api/domtokenlist/index.md
+++ b/files/en-us/web/api/domtokenlist/index.md
@@ -17,7 +17,7 @@ A `DOMTokenList` is indexed beginning with `0` as with JavaScript {{jsxref("Arra
 - {{domxref("DOMTokenList.length")}} {{ReadOnlyInline}}
   - : Is an `integer` representing the number of objects stored in the object.
 - {{domxref("DOMTokenList.value")}}
-  - : A stringifier property that returns the value of the list as a string.
+  - : A {{Glossary("stringifier")}} property that returns the value of the list as a string.
 
 ## Methods
 

--- a/files/en-us/web/api/domtokenlist/value/index.md
+++ b/files/en-us/web/api/domtokenlist/value/index.md
@@ -9,7 +9,7 @@ browser-compat: api.DOMTokenList.value
 {{APIRef("DOM")}}
 
 The **`value`** property of the {{domxref("DOMTokenList")}}
-interface is a stringifier that returns the value of the list serialized as a
+interface is a {{Glossary("stringifier")}} that returns the value of the list serialized as a
 string, or clears and sets the list to the given value.
 
 ## Value

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -51,7 +51,7 @@ const fetchResponsePromise = fetch(resource [, init])
 
   - : This defines the resource that you wish to fetch. This can either be:
 
-    - A string or any other object with a [stringifier](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers) — including a {{domxref("URL")}} object — that provides the URL of the resource you want to fetch.
+    - A string or any other object with a {{Glossary("stringifier")}} — including a {{domxref("URL")}} object — that provides the URL of the resource you want to fetch.
     - A {{domxref("Request")}} object.
 
 - `init` {{optional_inline}}

--- a/files/en-us/web/api/htmlanchorelement/href/index.md
+++ b/files/en-us/web/api/htmlanchorelement/href/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLAnchorElement.href
 {{ApiRef("HTML DOM")}}
 
 The **`HTMLAnchorElement.href`** property is a
-stringifier that returns a {{domxref("USVString")}} containing the whole URL, and allows
+{{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole URL, and allows
 the href to be updated.
 
 ## Syntax

--- a/files/en-us/web/api/htmlanchorelement/tostring/index.md
+++ b/files/en-us/web/api/htmlanchorelement/tostring/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLAnchorElement.toString
 ---
 {{ApiRef("URL API")}}
 
-The **`HTMLAnchorElement.toString()`** stringifier
+The **`HTMLAnchorElement.toString()`** {{Glossary("stringifier")}}
 method returns a {{domxref("USVString")}} containing the whole URL. It is a read-only
 version of {{domxref("HTMLAnchorElement.href")}}.
 

--- a/files/en-us/web/api/htmlareaelement/href/index.md
+++ b/files/en-us/web/api/htmlareaelement/href/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLAreaElement.href
 {{ApiRef("HTML DOM")}}
 
 The **`HTMLAreaElement.href`** property is a
-stringifier that returns a {{domxref("USVString")}} containing the whole URL, and allows
+{{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole URL, and allows
 the href to be updated.
 
 ## Syntax

--- a/files/en-us/web/api/htmlareaelement/tostring/index.md
+++ b/files/en-us/web/api/htmlareaelement/tostring/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLAreaElement.toString
 ---
 {{ApiRef("URL API")}}
 
-The **`HTMLAreaElement.toString()`** stringifier
+The **`HTMLAreaElement.toString()`** {{Glossary("stringifier")}}
 method returns a {{domxref("USVString")}} containing the whole URL. It is a read-only
 version of {{domxref("HTMLAreaElement.href")}}.
 

--- a/files/en-us/web/api/location/href/index.md
+++ b/files/en-us/web/api/location/href/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Location.href
 {{ApiRef("Location")}}
 
 The **`href`** property of the {{domxref("Location")}}
-interface is a stringifier that returns a {{domxref("USVString")}} containing the whole
+interface is a {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole
 URL, and allows the href to be updated.
 
 Setting the value of `href` _navigates_ to the provided URL. If you

--- a/files/en-us/web/api/location/index.md
+++ b/files/en-us/web/api/location/index.md
@@ -66,7 +66,7 @@ document.body.addEventListener('click', function (evt) {
 - {{domxref("Location.ancestorOrigins")}}
   - : Is a static {{domxref("DOMStringList")}} containing, in reverse order, the origins of all ancestor browsing contexts of the document associated with the given `Location` object.
 - {{domxref("Location.href")}}
-  - : Is a stringifier that returns a {{domxref("USVString")}} containing the entire URL. If changed, the associated document navigates to the new page. It can be set from a different origin than the associated document.
+  - : Is a {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the entire URL. If changed, the associated document navigates to the new page. It can be set from a different origin than the associated document.
 - {{domxref("Location.protocol")}}
   - : Is a {{domxref("USVString")}} containing the protocol scheme of the URL, including the final `':'`.
 - {{domxref("Location.host")}}

--- a/files/en-us/web/api/location/tostring/index.md
+++ b/files/en-us/web/api/location/tostring/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Location.toString
 ---
 {{ApiRef("Location")}}
 
-The **`toString()`** stringifier method of the
+The **`toString()`** {{Glossary("stringifier")}} method of the
 {{domxref("Location")}} interface returns a {{domxref("USVString")}} containing the
 whole URL. It is a read-only version of {{domxref("Location.href")}}.
 

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -18,7 +18,7 @@ The **`MediaList`** interface represents the media queries of a stylesheet, e.g.
 ## Properties
 
 - {{domxref("MediaList.mediaText")}}
-  - : A stringifier that returns a {{domxref("DOMString")}} representing the `MediaList` as text, and also allows you to set a new `MediaList`.
+  - : A {{Glossary("stringifier")}} that returns a {{domxref("DOMString")}} representing the `MediaList` as text, and also allows you to set a new `MediaList`.
 - {{domxref("MediaList.length")}} {{readonlyInline}}
   - : Returns the number of media queries in the `MediaList`.
 

--- a/files/en-us/web/api/medialist/mediatext/index.md
+++ b/files/en-us/web/api/medialist/mediatext/index.md
@@ -13,7 +13,7 @@ browser-compat: api.MediaList.mediaText
 {{APIRef("CSSOM")}}
 
 The **`mediaText`** property of the {{domxref("MediaList")}}
-interface is a stringifier that returns a {{domxref("DOMString")}} representing the
+interface is a {{Glossary("stringifier")}} that returns a {{domxref("DOMString")}} representing the
 `MediaList` as text, and also allows you to set a new `MediaList`.
 
 ## Syntax

--- a/files/en-us/web/api/range/tostring/index.md
+++ b/files/en-us/web/api/range/tostring/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Range.toString
 ---
 {{ApiRef("DOM")}}
 
-The **`Range.toString()`** method is a stringifier returning
+The **`Range.toString()`** method is a {{Glossary("stringifier")}} returning
 the text of the {{domxref("Range")}}.
 
 Alerting the contents of a {{domxref("Range")}} makes an implicit

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -43,7 +43,7 @@ If a browser doesn't yet support the {{domxref("URL.URL", "URL()")}} constructor
 - {{domxref("URL.hostname", "hostname")}}
   - : A {{domxref("USVString")}} containing the domain of the URL.
 - {{domxref("URL.href", "href")}}
-  - : A stringifier that returns a {{domxref("USVString")}} containing the whole URL.
+  - : A {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole URL.
 - {{domxref("URL.origin", "origin")}} {{readonlyInline}}
   - : Returns a {{domxref("USVString")}} containing the origin of the URL, that is its scheme, its domain and its port.
 - {{domxref("URL.password", "password")}}

--- a/files/en-us/web/api/url/tostring/index.md
+++ b/files/en-us/web/api/url/tostring/index.md
@@ -12,7 +12,7 @@ browser-compat: api.URL.toString
 ---
 {{ApiRef("URL API")}}
 
-The **`URL.toString()`** stringifier method returns a
+The **`URL.toString()`** {{Glossary("stringifier")}} method returns a
 {{domxref("USVString")}} containing the whole URL. It is effectively a read-only version
 of {{domxref("URL.href")}}.
 

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -29,7 +29,7 @@ const url = new URL(url [, base])
 ### Parameters
 
 - `url`
-  - : A {{domxref("USVString")}} or any other object with a [stringifier](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers) — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
+  - : A {{domxref("USVString")}} or any other object with a {{Glossary("stringifier")}} — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
     If `url` is a relative URL, `base` is
     required, and will be used as the base URL. If `url` is an
     absolute URL, a given `base` will be ignored.

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -11,7 +11,7 @@ browser-compat: api.WorkerLocation.toString
 ---
 {{ApiRef("WorkerLocation")}}
 
-The **`toString()`** stringifier method of a {{domxref("WorkerLocation")}} object returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker’s location. It is a synonym for {{domxref("WorkerLocation.href")}}.
+The **`toString()`** {{Glossary("stringifier")}} method of a {{domxref("WorkerLocation")}} object returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker’s location. It is a synonym for {{domxref("WorkerLocation.href")}}.
 
 ## Syntax
 


### PR DESCRIPTION
#### Summary
Adds a glossary entry for `stringifier`

#### Motivation
Low hanging :mango: due to another existing PR

#### Supporting details
1. See https://github.com/mdn/content/pull/1670#pullrequestreview-575288862
2. [Stringifiers](https://webidl.spec.whatwg.org/#idl-stringifiers)

#### Related issues
Fixes #1928

#### Metadata
- [x] Adds a new document