### PR TITLE
Fixes #2104: adds requested text

### DIFF
--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -14,7 +14,7 @@ browser-compat: api.URLSearchParams.entries
 The **`entries()`** method of the
 {{domxref("URLSearchParams")}} interface returns an
 {{jsxref("Iteration_protocols",'iterator')}} allowing iteration through all key/value
-pairs contained in this object. The key and value of each pair are
+pairs contained in this object. The iterator returns key/value pairs in the same order as they appear in the query string. The key and value of each pair are
 {{domxref("USVString")}} objects.
 
 {{availableinworkers}}

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -15,7 +15,7 @@ browser-compat: api.URLSearchParams
 
 The **`URLSearchParams`** interface defines utility methods to work with the query string of a URL.
 
-An object implementing `URLSearchParams` can directly be used in a {{jsxref("Statements/for...of", "for...of")}} structure, for example the following two lines are equivalent:
+An object implementing `URLSearchParams` can directly be used in a {{jsxref("Statements/for...of", "for...of")}} structure to iterate over key/value pairs in the same order as they appear in the query string, for example the following two lines are equivalent:
 
 ```js
 for (const [key, value] of mySearchParams) {}
@@ -36,7 +36,7 @@ for (const [key, value] of mySearchParams.entries()) {}
 - {{domxref("URLSearchParams.delete()")}}
   - : Deletes the given search parameter, and its associated value, from the list of all search parameters.
 - {{domxref("URLSearchParams.entries()")}}
-  - : Returns an {{jsxref("Iteration_protocols","iterator")}} allowing iteration through all key/value pairs contained in this object.
+  - : Returns an {{jsxref("Iteration_protocols","iterator")}} allowing iteration through all key/value pairs contained in this object in the same order as they appear in the query string.
 - {{domxref("URLSearchParams.forEach()")}}
   - : Allows iteration through all values contained in this object via a callback function.
 - {{domxref("URLSearchParams.get()")}}


### PR DESCRIPTION
#### Summary

> -   An example highlighting get returns the first value (poosibly added to the get() method page as well)

Appears highlighted in the last example, in `get()`'s brief and on its own page.

> -   Text explaining order is preserved

Added in this PR

> -   A round trip example

Now present. See last gotcha. Thanks @verhovsky 

#### Motivation
Low hanging :mango:

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #2104

#### Metadata
- [x] Fixes a typo, bug, or other error