### PR TITLE
Remove polyfill for Array.lastIndexOf()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -7,6 +7,7 @@ tags:
   - JavaScript
   - Method
   - Prototype
+  - Polyfill
 browser-compat: javascript.builtins.Array.lastIndexOf
 ---
 {{JSRef}}

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -7,7 +7,6 @@ tags:
   - JavaScript
   - Method
   - Prototype
-  - Polyfill
 browser-compat: javascript.builtins.Array.lastIndexOf
 ---
 {{JSRef}}
@@ -88,62 +87,6 @@ Note that we have to handle the case `idx == 0` separately here because the
 element will always be found regardless of the `fromIndex` parameter if it is
 the first element of the array. This is different from the
 {{jsxref("Array.prototype.indexOf", "indexOf")}} method.
-
-## Polyfill
-
-`lastIndexOf` was added to the ECMA-262 standard in the 5th edition; as such
-it may not be present in other implementations of the standard. You can work around this
-by inserting the following code at the beginning of your scripts, allowing use of
-`lastIndexOf` in implementations which do not natively support it. This
-algorithm is exactly the one specified in ECMA-262, 5th edition, assuming
-{{jsxref("Object")}}, {{jsxref("TypeError")}}, {{jsxref("Number")}},
-{{jsxref("Math.floor")}}, {{jsxref("Math.abs")}}, and {{jsxref("Math.min")}} have their
-original values.
-
-```js
-// Production steps of ECMA-262, Edition 5, 15.4.4.15
-// Reference: https://es5.github.io/#x15.4.4.15
-if (!Array.prototype.lastIndexOf) {
-  Array.prototype.lastIndexOf = function(searchElement /*, fromIndex*/) {
-    'use strict';
-
-    if (this === void 0 || this === null) {
-      throw new TypeError();
-    }
-
-    var n, k,
-      t = Object(this),
-      len = t.length >>> 0;
-    if (len === 0) {
-      return -1;
-    }
-
-    n = len - 1;
-    if (arguments.length > 1) {
-      n = Number(arguments[1]);
-      if (n != n) {
-        n = 0;
-      }
-      else if (n != 0 && n != (1 / 0) && n != -(1 / 0)) {
-        n = (n > 0 || -1) * Math.floor(Math.abs(n));
-      }
-    }
-
-    for (k = n >= 0 ? Math.min(n, len - 1) : len - Math.abs(n); k >= 0; k--) {
-      if (k in t && t[k] === searchElement) {
-        return k;
-      }
-    }
-    return -1;
-  };
-}
-```
-
-Again, note that this implementation aims for absolute compatibility with
-`lastIndexOf` in Firefox and the SpiderMonkey JavaScript engine, including in
-several cases which are arguably edge cases. If you intend to use this in real-world
-applications, you may be able to calculate `from` with less complicated code
-if you ignore those cases.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removes polyfill for array.lastIndexOf()
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Open-source
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Related to #10072 and #12046
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
