### PR TITLE
Fix misleading explanation of `:active`

### DIFF
--- a/files/en-us/web/css/_colon_active/index.md
+++ b/files/en-us/web/css/_colon_active/index.md
@@ -21,7 +21,7 @@ a:active {
 }
 ```
 
-The `:active` pseudo-class is commonly used on {{HTMLElement("a")}} and {{HTMLElement("button")}} elements. Other common targets of this pseudo-class include elements that _contain_ an activated element, and form elements that are being activated through their associated {{HTMLElement("label")}}.
+The `:active` pseudo-class is commonly used on {{HTMLElement("a")}} and {{HTMLElement("button")}} elements. Other common targets of this pseudo-class include elements that _contained inside of_ an activated element, and form elements that are being activated through their associated {{HTMLElement("label")}}.
 
 Styles defined by the `:active` pseudo-class will be overridden by any subsequent link-related pseudo-class ({{cssxref(":link")}}, {{cssxref(":hover")}}, or {{cssxref(":visited")}}) that has at least equal specificity. To style links appropriately, put the `:active` rule after all other link-related rules, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`.
 


### PR DESCRIPTION
#### Summary
Misleading explanation of pseudo-class `:active`

#### Motivation
Currently the page states that:

> Other common targets of this pseudo-class include elements that _contain_ an activated element

As I understand an activated element may be `<a>` or `<button>` thus the sentence may be interpreted as this selector `.elem a:active`. I think it should be interpreted as `a:active .elem`. Proposed change is:

> Other common targets of this pseudo-class include elements that _contained inside of_ an activated element

#### Original document
https://developer.mozilla.org/en-US/docs/Web/CSS/:active

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error