### PR TITLE
Drop outdated info about Permissions API from Clipboard API doc

### DIFF
--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -17,7 +17,7 @@ tags:
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 
-The **Clipboard API** provides the ability to respond to clipboard commands (cut, copy, and paste) as well as to asynchronously read from and write to the system clipboard. Access to the contents of the clipboard is gated behind the [Permissions API](/en-US/docs/Web/API/Permissions_API): The `clipboard-write` permission is granted automatically to pages when they are in the active tab. The `clipboard-read` permission must be requested, which you can do by trying to read data from the clipboard.
+The **Clipboard API** provides the ability to respond to clipboard commands (cut, copy, and paste) as well as to asynchronously read from and write to the system clipboard.
 
 > **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
@@ -65,5 +65,3 @@ This snippet fetches the text from the clipboard and appends it to the first ele
 
 - [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/image-support-for-async-clipboard/)
-- [Permissions API](/en-US/docs/Web/API/Permissions_API)
-- [Using the Permissions API](/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API)


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12065