### PR TITLE
Fix error in example

### DIFF
--- a/files/en-us/web/api/event/cancelable/index.md
+++ b/files/en-us/web/api/event/cancelable/index.md
@@ -17,10 +17,10 @@ If the event is _not_ cancelable, then its `cancelable` property will be
 
 Most browser-native events that can be canceled are the ones that result from the user
 interacting with the page. Canceling the {{domxref("Element/click_event", "click")}},
-{{domxref("Document/scroll_event", "scroll")}}, or
+{{domxref("Document/wheel_event", "wheel")}}, or
 {{domxref("Window/beforeunload_event", "beforeunload")}} events would prevent the user
-from clicking on something, scrolling the page, or navigating away from the page,
-respectively.
+from clicking on something, scrolling the page with the mouse wheel, or
+navigating away from the page, respectively.
 
 [Synthetic events](/en-US/docs/Web/API/Event/Event) created by other JavaScript
 code define if they can be canceled when they are created.


### PR DESCRIPTION
#### Summary

Fixed an error in the `Event.cancelable` property description example. Replaced the `scroll` event with the `wheel` event in the example.

#### Motivation

The example says that canceling the `scroll` event would prevent the user from scrolling the page. This is incorrect because the `scroll` event can't be canceled.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
