### PR TITLE
Changed var to const

### DIFF
--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -17,7 +17,7 @@ The **`AbortController()`** constructor creates a new {{domxref("AbortController
 ## Syntax
 
 ```js
-var controller = new AbortController();
+const controller = new AbortController();
 ```
 
 ### Parameters
@@ -33,11 +33,11 @@ We first create a controller using the {{domxref("AbortController.AbortControlle
 When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 
 ```js
-var controller = new AbortController();
-var signal = controller.signal;
+const controller = new AbortController();
+const signal = controller.signal;
 
-var downloadBtn = document.querySelector('.download');
-var abortBtn = document.querySelector('.abort');
+const downloadBtn = document.querySelector('.download');
+const abortBtn = document.querySelector('.abort');
 
 downloadBtn.addEventListener('click', fetchVideo);
 


### PR DESCRIPTION
#### Summary
Changed `var` to `const`.

#### Motivation
Using `var` in the example might encourage new developers to use it when it's not required, instead of using `let` and `const` when they are more applicable.

#### Metadata

- [x ] Fixes a typo, bug, or other error
