### PR TITLE
fix: prevent caching of SSE streams

### DIFF
--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -67,7 +67,7 @@ The {{Glossary("PHP")}} code for the example we're using here follows:
 
 ```php
 date_default_timezone_set("America/New_York");
-header("Cache-Control: no-cache");
+header("Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0");
 header("Content-Type: text/event-stream");
 
 $counter = rand(1, 10);

--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -67,7 +67,7 @@ The {{Glossary("PHP")}} code for the example we're using here follows:
 
 ```php
 date_default_timezone_set("America/New_York");
-header("Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0");
+header("Cache-Control: no-store");
 header("Content-Type: text/event-stream");
 
 $counter = rand(1, 10);


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`no-cache` allows proxy servers to store the response, which is unwanted when using SSE.
This patch ensures that the stream is never cached. 

#### Motivation
Use current best practices.

#### Supporting details
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_storing

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
