### PR TITLE
Fix formatting of dl in splice() page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -35,7 +35,7 @@ splice(start, deleteCount, item1, item2, itemN)
   - : The index at which to start changing the array.
 
     If greater than the length of the array, `start` will be set to the length of the array.
-    In this case, no element will be deleted but the method will behave as an adding function, adding as many elements as items \[n\*] provided.
+    In this case, no element will be deleted but the method will behave as an adding function, adding as many elements as items provided.
 
     If negative, it will begin that many elements from the end of the array.
     (In this case, the origin `-1`, meaning `-n` is the index of the `n`th last element, and is therefore equivalent to the index of `array.length - n`.)
@@ -52,7 +52,8 @@ splice(start, deleteCount, item1, item2, itemN)
 
 - `item1, item2, ...` {{optional_inline}}
   - : The elements to add to the array, beginning from `start`.
-  - If you do not specify any elements, `splice()` will only remove elements from the array.
+
+    If you do not specify any elements, `splice()` will only remove elements from the array.
 
 ### Return value
 


### PR DESCRIPTION
The `<dl>` formatting in the page for `splice()` was broken.