### PR TITLE
Fix: Pointing to a new document (HTTP 201 Created) section

### DIFF
--- a/files/en-us/web/http/headers/content-location/index.md
+++ b/files/en-us/web/http/headers/content-location/index.md
@@ -79,7 +79,7 @@ as {{HTTPHeader("Accept-Language")}}.
 Say you're creating a new blog post through a site's API:
 
 ```
-PUT /new/post
+POST /new/post
 Host: example.com
 Content-Type: text/markdown
 
@@ -88,15 +88,16 @@ Content-Type: text/markdown
 I made this through `example.com`'s API. I hope it worked.
 ```
 
-The site returns a generic success message confirming the post was published. The
-server specifies _where_ the new post is with `Content-Location`:
+The site returns the published post in the response body. The server specifies  _where_ the new post is with the `Content-Location` header, indicating that this location refers to the content (the body) of this response:
 
 ```
 HTTP/1.1 201 Created
-Content-Type: text/plain; charset=utf-8
+Content-Type: text/markdown
 Content-Location: /my-first-blog-post
 
-✅ Success!
+# My first blog post
+
+I made this through `example.com`'s API. I hope it worked.
 ```
 
 ### Indicating the URL of a transaction's result


### PR DESCRIPTION
Signed-off-by: Nico Braun <rainbowstack@gmail.com>

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixed 201 content location example

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The documented example seems incorrect.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://httpwg.org/specs/rfc7231.html#header.content-location

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixed #12093 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
