### PR TITLE
fix: adjust docs typo

### DIFF
--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -145,7 +145,7 @@ Otherwise:
 
 * To not request a popup, omit the _windowFeatures_ parameter.
 * Otherwise:
-   * Specifying any features in the _windowFeatures_ parameter other than `noopener` or `noreferer` has the effect of also requesting a popup.
+   * Specifying any features in the _windowFeatures_ parameter other than `noopener` or `noreferrer` has the effect of also requesting a popup.
    * Otherwise, no popup is requested.
 
 ### Position and size features


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix typo on window interface's open method documentation.

#### Motivation
I am making this changes to avoid disinformation.

#### Metadata

[ ] Adds a new document
[ ] Rewrites (or significantly expands) a document
[x] Fixes a typo, bug, or other error
