### PR TITLE
fix: MD046 use consistent fenced code blocks

### DIFF
--- a/files/en-us/glossary/control_flow/index.md
+++ b/files/en-us/glossary/control_flow/index.md
@@ -8,21 +8,23 @@ tags:
 ---
 The _control flow_ is the order in which the computer executes statements in a script.
 
-Code is run in order from the first line in the file to the last line, unless the computer runs across the (extremely frequent) structures that change the control flow, such as conditionals and loops.
+Code is run in order from the first line in the file to the last line, unless the computer runs across the (extremely frequent) structures that change the control flow, such as conditionals and loops.
 
-For example, imagine a script used to validate user data from a webpage form. The script submits validated data, but if the user, say, leaves a required field empty, the script prompts them to fill it in. To do this, the script uses a {{Glossary("Conditional", "conditional")}} structure or `if...else`, so that different code executes depending on whether the form is complete or not:
+For example, imagine a script used to validate user data from a webpage form. The script submits validated data, but if the user, say, leaves a required field empty, the script prompts them to fill it in. To do this, the script uses a {{Glossary("Conditional", "conditional")}} structure or `if...else`, so that different code executes depending on whether the form is complete or not:
 
-    if (field==empty) {
-        promptUser();
-    } else {
-        submitForm();
-    }
+```js
+if (field==empty) {
+    promptUser();
+} else {
+    submitForm();
+}
+```
 
-A typical script in {{glossary("JavaScript")}} or {{glossary("PHP")}} (and the like) includes many control structures, including conditionals, {{Glossary("Loop", "loops")}} and {{Glossary("Function", "functions")}}. Parts of a script may also be set to execute when {{Glossary("Event", "events")}} occur.
+A typical script in {{glossary("JavaScript")}} or {{glossary("PHP")}} (and the like) includes many control structures, including conditionals, {{Glossary("Loop", "loops")}} and {{Glossary("Function", "functions")}}. Parts of a script may also be set to execute when {{Glossary("Event", "events")}} occur.
 
-For example, the above excerpt might be inside a function that runs when the user clicks the **Submit** button for the form. The function could also include a loop, which iterates through all of the fields in the form, checking each one in turn. Looking back at the code in the `if` and `else` sections, the lines `promptUser` and `submitForm` could also be calls to other functions in the script. As you can see, control structures can dictate complex flows of processing even with only a few lines of code.
+For example, the above excerpt might be inside a function that runs when the user clicks the **Submit** button for the form. The function could also include a loop, which iterates through all of the fields in the form, checking each one in turn. Looking back at the code in the `if` and `else` sections, the lines `promptUser` and `submitForm` could also be calls to other functions in the script. As you can see, control structures can dictate complex flows of processing even with only a few lines of code.
 
-Control flow means that when you read a script, you must not only read from start to finish but also look at program structure and how it affects order of execution.
+Control flow means that when you read a script, you must not only read from start to finish but also look at program structure and how it affects order of execution.
 
 ## See also
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -13,22 +13,28 @@ Note that the idempotence of a method is not guaranteed by the server and some a
 
 `GET /pageX HTTP/1.1` is idempotent. Called several times in a row, the client gets the same results:
 
-    GET /pageX HTTP/1.1
-    GET /pageX HTTP/1.1
-    GET /pageX HTTP/1.1
-    GET /pageX HTTP/1.1
+```
+GET /pageX HTTP/1.1
+GET /pageX HTTP/1.1
+GET /pageX HTTP/1.1
+GET /pageX HTTP/1.1
+```
 
 `POST /add_row HTTP/1.1` is not idempotent; if it is called several times, it adds several rows:
 
-    POST /add_row HTTP/1.1
-    POST /add_row HTTP/1.1   -> Adds a 2nd row
-    POST /add_row HTTP/1.1   -> Adds a 3rd row
+```
+POST /add_row HTTP/1.1
+POST /add_row HTTP/1.1   -> Adds a 2nd row
+POST /add_row HTTP/1.1   -> Adds a 3rd row
+```
 
 `DELETE /idX/delete HTTP/1.1` is idempotent, even if the returned status code may change between requests:
 
-    DELETE /idX/delete HTTP/1.1   -> Returns 200 if idX exists
-    DELETE /idX/delete HTTP/1.1   -> Returns 404 as it just got deleted
-    DELETE /idX/delete HTTP/1.1   -> Returns 404
+```
+DELETE /idX/delete HTTP/1.1   -> Returns 200 if idX exists
+DELETE /idX/delete HTTP/1.1   -> Returns 404 as it just got deleted
+DELETE /idX/delete HTTP/1.1   -> Returns 404
+```
 
 ## See also
 

--- a/files/en-us/glossary/loop/index.md
+++ b/files/en-us/glossary/loop/index.md
@@ -15,9 +15,11 @@ A loop is a sequence of instructions that is continually repeated until a certai
 
 #### Syntax:
 
-    for (statement 1; statement 2; statement 3){
-     execute code block
-    }
+```
+for (statement 1; statement 2; statement 3){
+  execute code block
+}
+```
 
 - Statement 1 is executed once before the code block is run.
 - Statement 2 defines the condition needed to execute the code block.
@@ -42,9 +44,11 @@ For the above example, the syntax is as follows:
 
 #### Syntax:
 
-    while (condition){
-     execute code block
-    }
+```
+while (condition){
+  execute code block
+}
+```
 
 - The code block will continue to loop as long as the condition is true.
 

--- a/files/en-us/glossary/mutable/index.md
+++ b/files/en-us/glossary/mutable/index.md
@@ -16,13 +16,15 @@ A **mutable object** is an object whose state can be modified after it is create
 
 **Strings and Numbers** are **Immutable**. Lets understand this with an example:
 
-    var immutableString = "Hello";
+```js
+var immutableString = "Hello";
 
-    // In the above code, a new object with string value is created.
+// In the above code, a new object with string value is created.
 
-    immutableString = immutableString + "World";
+immutableString = immutableString + "World";
 
-    // We are now appending "World" to the existing value.
+// We are now appending "World" to the existing value.
+```
 
 On appending the "immutableString" with a string value, following events occur:
 

--- a/files/en-us/learn/common_questions/design_for_all_types_of_users/index.md
+++ b/files/en-us/learn/common_questions/design_for_all_types_of_users/index.md
@@ -68,7 +68,9 @@ You can specify font size on a website either through relative units or absolute
 
 Absolute units are not proportionally calculated but refer to a size set in stone, so to speak, and are expressed most of the time in pixels (`px`). For instance, if in your CSS you declare this:
 
-    body { font-size:16px; }
+```css
+body { font-size:16px; }
+```
 
 … you are telling the browser that whatever happens, the font size must be 16 pixels. Modern browsers get around this rule by pretending that you're asking for "16 pixels when the user sets a zoom factor of 100%".
 
@@ -91,40 +93,48 @@ Suppose we wanted a base font size of 16px and an h1 (main heading) at the equiv
 
 Here is the HTML we're using:
 
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Font size experiment</title>
-    </head>
-    <body>
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Font size experiment</title>
+</head>
+<body>
 
-        <h1>This is our main heading
-            <span class="subheading">This is our subheading</span>
-        </h1>
+    <h1>This is our main heading
+        <span class="subheading">This is our subheading</span>
+    </h1>
 
-    </body>
-    </html>
+</body>
+</html>
+```
 
 A percent-based CSS will look like this:
 
-    body { font-size:100%; } /* 100% of the browser's base font size, so in most cases this will render as 16 pixels */
-    h1 { font-size:200%; } /* twice the size of the body, thus 32 pixels */
-    span.subheading { font-size:50%; } /* half the size of the h1, thus 16 pixels to come back to the original size */
+```css
+body { font-size:100%; } /* 100% of the browser's base font size, so in most cases this will render as 16 pixels */
+h1 { font-size:200%; } /* twice the size of the body, thus 32 pixels */
+span.subheading { font-size:50%; } /* half the size of the h1, thus 16 pixels to come back to the original size */
+```
 
 The same problem expressed with ems:
 
-    body { font-size:1em; } /* 1em = 100% of the browser's base font size, so in most cases this will render as 16 pixels */
-    h1 { font-size:2em; } /* twice the size of the body, thus 32 pixels */
-    span.subheading { font-size:0.5em; } /* half the size of the h1, thus 16 pixels to come back to the original size */
+```css
+body { font-size:1em; } /* 1em = 100% of the browser's base font size, so in most cases this will render as 16 pixels */
+h1 { font-size:2em; } /* twice the size of the body, thus 32 pixels */
+span.subheading { font-size:0.5em; } /* half the size of the h1, thus 16 pixels to come back to the original size */
+```
 
 As you can see, the math quickly gets daunting when you have to keep track of the parent, the parent's parent, the parent's parent's parent, and so on. (Most designs are done in pixel-based software, so the math has to be done by the person coding the CSS).
 
 Enter `rem`. This unit is relative to the root element's size and not to any other parent. The CSS can be rewritten thus:
 
-    body { font-size:1em; } /* 1em = 100% of the browser's base font size, so in most cases this will render as 16 pixels */
-    h1 { font-size:2rem; } /* twice the size of the body, thus 32 pixels */
-    span.subheading { font-size:1rem; } /* original size */
+```css
+body { font-size:1em; } /* 1em = 100% of the browser's base font size, so in most cases this will render as 16 pixels */
+h1 { font-size:2rem; } /* twice the size of the body, thus 32 pixels */
+span.subheading { font-size:1rem; } /* original size */
+```
 
 Easier, isn't it? This works as of [Internet Explorer 9 and in every other current browser](https://caniuse.com/#search=rem), so please feel free to use this unit.
 
@@ -149,28 +159,32 @@ Of course the problem doesn't go away when we switch to the Web. The reader's ey
 
 To achieve this, you can specify a size for your text's container. Let's consider this HTML:
 
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Font size experiment</title>
-    </head>
-    <body>
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Font size experiment</title>
+</head>
+<body>
 
-    <div class="container">
-        <h1>This is our main heading
-            <span class="subheading">This is our subheading</span>
-        </h1>
+<div class="container">
+    <h1>This is our main heading
+        <span class="subheading">This is our subheading</span>
+    </h1>
 
-        <p>[lengthy text that spans many lines]</p>
-    </div>
+    <p>[lengthy text that spans many lines]</p>
+</div>
 
-    </body>
-    </html>
+</body>
+</html>
+```
 
 We have a `div` with class `container`. We can style the `div` either to set its width (using the `width` property) or its maximum width so that it never gets too large (using the `max-width` property). If you want an elastic/responsive website, and you don't know what the browser's default width is, you can use the `max-width` property to allow up to 70 characters per line and no more:
 
-    div.container { max-width:70em; }
+```css
+div.container { max-width:70em; }
+```
 
 ### Alternative content for images, audio, and video
 

--- a/files/en-us/learn/css/howto/css_faq/index.md
+++ b/files/en-us/learn/css/howto/css_faq/index.md
@@ -13,7 +13,7 @@ In this article, you'll find some frequently-asked questions (FAQs) about CSS, a
 
 ## Why doesn't my CSS, which is valid, render correctly?
 
-Browsers use the `DOCTYPE` declaration to choose whether to show the document using a mode that is more compatible  with Web standards or with old browser bugs. Using a correct and modern `DOCTYPE` declaration at the start of your HTML will improve browser standards compliance.
+Browsers use the `DOCTYPE` declaration to choose whether to show the document using a mode that is more compatible with Web standards or with old browser bugs. Using a correct and modern `DOCTYPE` declaration at the start of your HTML will improve browser standards compliance.
 
 Modern browsers have two main rendering modes:
 
@@ -24,20 +24,30 @@ Gecko-based browsers, have a third _[Almost Standards Mode](/en-US/docs/Mozilla/
 
 This is a list of the most commonly used `DOCTYPE` declarations that will trigger Standards or Almost Standards mode:
 
-    <!DOCTYPE html> /* This is the HTML5 doctype. Given that each modern browser uses an HTML5
-                       parser, this is the recommended doctype */
+```html
+<!DOCTYPE html> /* This is the HTML5 doctype. Given that each modern browser uses an HTML5
+                    parser, this is the recommended doctype */
+```
 
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-    "http://www.w3.org/TR/html4/loose.dtd">
+```html
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+```
 
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-    "http://www.w3.org/TR/html4/strict.dtd">
+```html
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+"http://www.w3.org/TR/html4/strict.dtd">
+```
 
-    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+```html
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+```
 
-    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+```html
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+```
 
 When at all possible, you should just use the HTML5 doctype.
 
@@ -61,7 +71,7 @@ It is generally recommended to use classes as much as possible, and to use ids o
 - Classes allow you to style multiple elements, therefore they can lead to shorter stylesheets, rather than having to write out the same styling information in multiple rules that use id selectors. Shorter stylesheets are more performant.
 - Class selectors have lower [specificity](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance#specificity) than id selectors, so are easier to override if needed.
 
-> **Note:** See [Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors) for more information.
+> **Note:** See [Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors) for more information.
 
 ## How do I restore the default value of a property?
 
@@ -89,14 +99,16 @@ CSS does not exactly allow one style to be defined in terms of another. However,
 
 HTML elements can be assigned multiple classes by listing the classes in the `class` attribute, with a blank space to separate them.
 
-    <style type="text/css">
-    .news { background: black; color: white; }
-    .today { font-weight: bold; }
-    </style>
+```html
+<style type="text/css">
+.news { background: black; color: white; }
+.today { font-weight: bold; }
+</style>
 
-    <div class="news today">
-    ... content of today's news ...
-    </div>
+<div class="news today">
+... content of today's news ...
+</div>
+```
 
 If the same property is declared in both rules, the conflict is resolved first through specificity, then according to the order of the CSS declarations. The order of classes in the `class` attribute is not relevant.
 
@@ -108,13 +120,17 @@ Style rules that are syntactically correct may not apply in certain situations. 
 
 The way CSS styles are applied to HTML elements depends also on the elements hierarchy. It is important to remember that a rule applied to a descendent overrides the style of the parent, in spite of any specificity or priority of CSS rules.
 
-    .news { color: black; }
-    .corpName { font-weight: bold; color: red; }
+```css
+.news { color: black; }
+.corpName { font-weight: bold; color: red; }
+```
 
-    <!-- news item text is black, but corporate name is red and in bold -->
-    <div class="news">
-       (Reuters) <span class="corpName">General Electric</span> (GE.NYS) announced on Thursday...
-    </div>
+```html
+<!-- news item text is black, but corporate name is red and in bold -->
+<div class="news">
+    (Reuters) <span class="corpName">General Electric</span> (GE.NYS) announced on Thursday...
+</div>
+```
 
 In case of complex HTML hierarchies, if a rule seems to be ignored, check if the element is inside another element with a different style.
 
@@ -122,17 +138,21 @@ In case of complex HTML hierarchies, if a rule seems to be ignored, check if the
 
 In CSS stylesheets, order **is** important. If you define a rule and then you re-define the same rule, the last definition is used.
 
-    #stockTicker { font-weight: bold; }
-    .stockSymbol { color: red; }
-    /*  other rules             */
-    /*  other rules             */
-    /*  other rules             */
-    .stockSymbol { font-weight: normal; }
+```css
+#stockTicker { font-weight: bold; }
+.stockSymbol { color: red; }
+/*  other rules             */
+/*  other rules             */
+/*  other rules             */
+.stockSymbol { font-weight: normal; }
+```
 
-    <!-- most text is in bold, except "GE", which is red and not bold -->
-    <div id="stockTicker">
-       NYS: <span class="stockSymbol">GE</span> +1.0 ...
-    </div>
+```html
+<!-- most text is in bold, except "GE", which is red and not bold -->
+<div id="stockTicker">
+    NYS: <span class="stockSymbol">GE</span> +1.0 ...
+</div>
+```
 
 To avoid this kind of error, try to define rules only once for a certain selector, and group all rules belonging to that selector.
 
@@ -140,32 +160,42 @@ To avoid this kind of error, try to define rules only once for a certain selecto
 
 Using shorthand properties for defining style rules is good because it uses a very compact syntax. Using shorthand with only some attributes is possible and correct, but it must be remembered that undeclared attributes are automatically reset to their default values. This means that a previous rule for a single attribute could be implicitly overridden.
 
-    #stockTicker { font-size: 12px; font-family: Verdana; font-weight: bold; }
-    .stockSymbol { font: 14px Arial; color: red; }
+```css
+#stockTicker { font-size: 12px; font-family: Verdana; font-weight: bold; }
+.stockSymbol { font: 14px Arial; color: red; }
+```
 
-    <div id="stockTicker">
-       NYS: <span class="stockSymbol">GE</span> +1.0 ...
-    </div>
+```html
+<div id="stockTicker">
+    NYS: <span class="stockSymbol">GE</span> +1.0 ...
+</div>
+```
 
 In the previous example the problem occurred on rules belonging to different elements, but it could happen also for the same element, because rule order **is** important.
 
-    #stockTicker {
-       font-weight: bold;
-       font: 12px Verdana;  /* font-weight is now set to normal */
-    }
+```css
+#stockTicker {
+    font-weight: bold;
+    font: 12px Verdana;  /* font-weight is now set to normal */
+}
+```
 
 ### Use of the `*` selector
 
 The `*` wildcard selector refers to any element, and it has to be used with particular care.
 
-    body * { font-weight: normal; }
-    #stockTicker { font: 12px Verdana; }
-    .corpName { font-weight: bold; }
-    .stockUp { color: red; }
+```css
+body * { font-weight: normal; }
+#stockTicker { font: 12px Verdana; }
+.corpName { font-weight: bold; }
+.stockUp { color: red; }
+```
 
-    <div id="section">
-       NYS: <span class="corpName"><span class="stockUp">GE</span></span> +1.0 ...
-    </div>
+```html
+<div id="section">
+    NYS: <span class="corpName"><span class="stockUp">GE</span></span> +1.0 ...
+</div>
+```
 
 In this example the `body *` selector applies the rule to all elements inside body, at any hierarchy level, including the `.stockUp` class. So `font-weight: bold;` applied to the `.corpName` class is overridden by `font-weight: normal;` applied to all elements in the body.
 
@@ -175,11 +205,15 @@ The use of the \* selector should be minimized as it is a slow selector, especia
 
 When multiple rules apply to a certain element, the rule chosen depends on its style [specificity](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance#specificity). Inline style (in HTML `style` attributes) has the highest specificity and will override any selectors, followed by ID selectors, then class selectors, and eventually element selectors. The text color of the below {{htmlelement("div")}} will therefore be red.
 
-    div { color: black; }
-    #orange { color: orange; }
-    .green { color: green; }
+```css
+div { color: black; }
+#orange { color: orange; }
+.green { color: green; }
+```
 
-    <div id="orange" class="green" style="color: red;">This is red</div>
+```html
+<div id="orange" class="green" style="color: red;">This is red</div>
+```
 
 The rules are more complicated when the selector has multiple parts. More detailed information about how selector specificity is calculated can be found in the [CSS 2.1 Specification chapter 6.4.3](https://www.w3.org/TR/CSS21/cascade.html#specificity).
 

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -56,14 +56,16 @@ Your video editing software probably has a feature to reduce file size. If not, 
 
 Order video source from smallest to largest. For example, given video compressions in three different formats at 10MB, 12MB, and 13MB, declare the smallest first and the largest last:
 
-    <video width="400" height="300" controls="controls">
-      <!-- WebM: 10 MB -->
-      <source src="video.webm" type="video/webm" />
-      <!-- MPEG-4/H.264: 12 MB -->
-      <source src="video.mp4" type="video/mp4" />
-      <!-- Ogg/Theora: 13 MB -->
-      <source src="video.ogv" type="video/ogv" />
-    </video>
+```html
+<video width="400" height="300" controls="controls">
+  <!-- WebM: 10 MB -->
+  <source src="video.webm" type="video/webm" />
+  <!-- MPEG-4/H.264: 12 MB -->
+  <source src="video.mp4" type="video/mp4" />
+  <!-- Ogg/Theora: 13 MB -->
+  <source src="video.ogv" type="video/ogv" />
+</video>
+```
 
 The browser downloads the first format it understands. The goal is to offer smaller versions ahead of larger versions. With the smallest version, make sure that the most compressed video still looks good. There are some compression algorithms that can make video look (bad) like an animated GIF. While a 128 Kb video may seem like it could provide a better user experience than a 10 MB download, a grainy GIF-like video may reflect poorly on the brand or project.
 
@@ -73,7 +75,9 @@ See [CanIUse.com](https://caniuse.com/#search=video) for current browser support
 
 To ensure that a looping background video autoplays, you must add several attributes to the video tag: `autoplay`, `muted`, and `playsinline.`
 
-    <video autoplay="" loop="" muted="true" playsinline="" src="backgroundvideo.mp4">
+```html
+<video autoplay="" loop="" muted="true" playsinline="" src="backgroundvideo.mp4">
+```
 
 While the `loop` and `autoplay` make sense for a looping and autoplaying video, the `muted` attribute is required for autoplay in mobile browsers.
 
@@ -83,17 +87,21 @@ While the `loop` and `autoplay` make sense for a looping and autoplaying video, 
 
 For hero-video or other video without audio, removing audio is smart.
 
-    <video autoplay="" loop="" muted="true" playsinline="" id="hero-video">
-      <source src="banner_video.webm"
-              type='video/webm; codecs="vp8, vorbis"'>
-      <source src="web_banner.mp4" type="video/mp4">
-    </video>
+```html
+<video autoplay="" loop="" muted="true" playsinline="" id="hero-video">
+  <source src="banner_video.webm"
+          type='video/webm; codecs="vp8, vorbis"'>
+  <source src="web_banner.mp4" type="video/mp4">
+</video>
+```
 
 This hero-video code (above) is common to conference websites and corporate home pages. It includes a video that is auto-playing, looping, and muted. There are no controls, so there is no way to hear audio. The audio is often empty, but still present, and still using bandwidth. There is no reason to serve audio with video that is always muted. **Removing audio can save 20% of the bandwidth.**
 
 Depending on your choice of software, you might be able to remove audio during export and compression. If not, a free utility called [FFmpeg](https://www.ffmpeg.org/) can do it for you. This is the FFmpeg command string to remove audio:
 
-    ffmpeg -i original.mp4 -an -c:v copy audioFreeVersion.mp4
+```
+ffmpeg -i original.mp4 -an -c:v copy audioFreeVersion.mp4
+```
 
 ### Video preload
 

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -18,7 +18,9 @@ APIs that use match patterns usually accept a list of match patterns, and will p
 
 All match patterns are specified as strings. Apart from the special [`<all_urls>`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#%3call_urls%3e) pattern, match patterns consist of three parts: _scheme_, _host_, and _path_. The scheme and host are separated by `://`.
 
-    <scheme>://<host><path>
+```
+<scheme>://<host><path>
+```
 
 ### scheme
 

--- a/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
@@ -22,15 +22,19 @@ It should be noted that the value of the `priority` attribute follows UNIX conve
 
 To change the priority of an HTTP request, you need access to the [nsIChannel](/en-US/docs/XPCOM_Interface_Reference/nsIChannel) that the request is being made on. If you do not have an existing channel, then you can create one as follows:
 
-    var ios = Components.classes["@mozilla.org/network/io-service;1"]
-                        .getService(Components.interfaces.nsIIOService);
-    var ch = ios.newChannel("https://www.example.com/", null, null);
+```js
+var ios = Components.classes["@mozilla.org/network/io-service;1"]
+                    .getService(Components.interfaces.nsIIOService);
+var ch = ios.newChannel("https://www.example.com/", null, null);
+```
 
 Once you have an [nsIChannel](/en-US/docs/XPCOM_Interface_Reference/nsIChannel), you can access the priority as follows:
 
-    if (ch instanceof Components.interfaces.nsISupportsPriority) {
-      ch.priority = Components.interfaces.nsISupportsPriority.PRIORITY_LOWEST;
-    }
+```js
+if (ch instanceof Components.interfaces.nsISupportsPriority) {
+  ch.priority = Components.interfaces.nsISupportsPriority.PRIORITY_LOWEST;
+}
+```
 
 For convenience, the interface defines several standard priority values that you can use, ranging from `PRIORITY_HIGHEST` to `PRIORITY_LOWEST`.
 
@@ -38,12 +42,14 @@ For convenience, the interface defines several standard priority values that you
 
 If you are programming in [JavaScript](/en-US/docs/Web/JavaScript), you will probably want to use [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest), a much higher level abstraction of an HTTP request. You can access the `channel` member of an [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) once you have called the `open` method on it, as follows:
 
-    var req = new XMLHttpRequest();
-    req.open("GET", "https://www.example.com", false);
-    if (req.channel instanceof Components.interfaces.nsISupportsPriority) {
-      req.channel.priority = Components.interfaces.nsISupportsPriority.PRIORITY_LOWEST;
-    }
-    req.send(null);
+```js
+var req = new XMLHttpRequest();
+req.open("GET", "https://www.example.com", false);
+if (req.channel instanceof Components.interfaces.nsISupportsPriority) {
+  req.channel.priority = Components.interfaces.nsISupportsPriority.PRIORITY_LOWEST;
+}
+req.send(null);
+```
 
 > **Note:** This example uses a synchronous [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest), which you should not use in practice.
 
@@ -51,9 +57,11 @@ If you are programming in [JavaScript](/en-US/docs/Web/JavaScript), you will pro
 
 [nsISupportsPriority](/en-US/docs/nsISupportsPriority#adjustPriority) includes a convenience method named `adjustPriority`. You should use this if you want to alter the priority of a request by a certain amount. For example, if you would like to make a request have slightly higher priority than it currently has, you could do the following:
 
-    // assuming we already have a nsIChannel from above
-    if (ch instanceof Components.interfaces.nsISupportsPriority) {
-      ch.adjustPriority(-1);
-    }
+```js
+// assuming we already have a nsIChannel from above
+if (ch instanceof Components.interfaces.nsISupportsPriority) {
+  ch.adjustPriority(-1);
+}
+```
 
 Remember that lower numbers mean higher priority, so adjusting by a negative number will serve to increase the request's priority.

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -28,15 +28,17 @@ If you want to create subdirectories, you have to create each child directory in
 
 #### Example
 
-The `getFile()` method returns a `FileEntrySync`, which represents a file in the file system.  The following creates an empty file called `seekrits.txt` in the root directory.
+The `getFile()` method returns a `FileEntrySync`, which represents a file in the file system. The following creates an empty file called `seekrits.txt` in the root directory.
 
 ```js
 var fileEntry = fs.root.getFile('seekrits.txt', {create: true});
 ```
 
-The `getDirectory()` method returns a `DirectoryEntrySync`, which represents a file in the file system. The following creates a new directory called `superseekrit` in the root directory.
+The `getDirectory()` method returns a `DirectoryEntrySync`, which represents a file in the file system. The following creates a new directory called `superseekrit` in the root directory.
 
-    var dirEntry = fs.root.getDirectory('superseekrit', {create: true});
+```js
+var dirEntry = fs.root.getDirectory('superseekrit', {create: true});
+```
 
 ## Method overview
 
@@ -116,7 +118,7 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 ### getFile()
 
-Depending on how you've set the `options` parameter, the method either creates a file or looks up an existing file.
+Depending on how you've set the `options` parameter, the method either creates a file or looks up an existing file.
 
     void getFile (
       in DOMString path, in optional Flags options
@@ -127,7 +129,7 @@ Depending on how you've set the `options` parameter, the method either creates
 - path
   - : Either an absolute path or a relative path from the directory to the file to be looked up or created. You cannot create a file whose immediate parent does not exist. Create the parent directory first.
 - options
-  - : An object literal describing the behavior of the method. If the file does not exist, it is created.
+  - : An object literal describing the behavior of the method. If the file does not exist, it is created.
 
 <table class="no-markdown">
   <thead>
@@ -334,8 +336,8 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 ## See also
 
-Specification: {{ spec("http://dev.w3.org/2009/dap/file-system/pub/FileSystem/", "File API: Directories and System Specification", "WD") }}
+Specification: {{ spec("http://dev.w3.org/2009/dap/file-system/pub/FileSystem/", "File API: Directories and System Specification", "WD") }}
 
 Reference: [File System API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)
 
-Introduction: [Basic Concepts About the File System API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)
+Introduction: [Basic Concepts About the File System API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)

--- a/files/en-us/web/api/element/insertadjacentelement/index.md
+++ b/files/en-us/web/api/element/insertadjacentelement/index.md
@@ -56,13 +56,15 @@ The element that was inserted, or `null`, if the insertion failed.
 
 ### Visualization of position names
 
-    <!-- beforebegin -->
-    <p>
-      <!-- afterbegin -->
-      foo
-      <!-- beforeend -->
-    </p>
-    <!-- afterend -->
+```html
+<!-- beforebegin -->
+<p>
+  <!-- afterbegin -->
+  foo
+  <!-- beforeend -->
+</p>
+<!-- afterend -->
+```
 
 > **Note:** The `beforebegin` and
 > `afterend` positions work only if the node is in a tree and has an element

--- a/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.md
@@ -17,40 +17,50 @@ The drag processing described in this document use the {{domxref("DataTransfer")
 
 ## Setting and getting with indices
 
-The {{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} method allows you to add multiple items during a {{event("dragstart")}} event. This function similarly to {{domxref("DataTransfer.setData","setData()")}}
+The {{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} method allows you to add multiple items during a {{event("dragstart")}} event. This function similarly to {{domxref("DataTransfer.setData","setData()")}}
 
-    var dt = event.dataTransfer;
-    dt.mozSetDataAt("text/plain", "Data to drag", 0);
-    dt.mozSetDataAt("text/plain", "Second data to drag", 1);
+```js
+var dt = event.dataTransfer;
+dt.mozSetDataAt("text/plain", "Data to drag", 0);
+dt.mozSetDataAt("text/plain", "Second data to drag", 1);
+```
 
 This example adds two items to be dragged. The last argument specifies the index of the item to add. You should add them in order starting with 0 as you cannot add items at positions farther than the last item, however you can replace existing items by using indices you have already added. Using 0 as the index is equivalent to calling {{domxref("DataTransfer.setData","setData()")}}.
 
 You can clear an item using the {{domxref("DataTransfer.mozClearDataAt","mozClearDataAt()")}} method.
 
-    event.dataTransfer.mozClearDataAt("text/plain", 1);
+```js
+event.dataTransfer.mozClearDataAt("text/plain", 1);
+```
 
 Caution: removing the last format for a particular index will remove that item entirely, shifting the remaining items down, so the later items will have different indices. For example:
 
-    var dt = event.dataTransfer;
-    dt.mozSetDataAt("text/uri-list", "URL1", 0);
-    dt.mozSetDataAt("text/plain",    "URL1", 0);
-    dt.mozSetDataAt("text/uri-list", "URL2", 1);
-    dt.mozSetDataAt("text/plain",    "URL2", 1);
-    dt.mozSetDataAt("text/uri-list", "URL3", 2);
-    dt.mozSetDataAt("text/plain",    "URL3", 2);
-    // [item1] data=URL1, index=0
-    // [item2] data=URL2, index=1
-    // [item3] data=URL3, index=2
+```js
+var dt = event.dataTransfer;
+dt.mozSetDataAt("text/uri-list", "URL1", 0);
+dt.mozSetDataAt("text/plain",    "URL1", 0);
+dt.mozSetDataAt("text/uri-list", "URL2", 1);
+dt.mozSetDataAt("text/plain",    "URL2", 1);
+dt.mozSetDataAt("text/uri-list", "URL3", 2);
+dt.mozSetDataAt("text/plain",    "URL3", 2);
+// [item1] data=URL1, index=0
+// [item2] data=URL2, index=1
+// [item3] data=URL3, index=2
+```
 
 After you added three items in two different formats,
 
-    dt.mozClearDataAt("text/uri-list", 1);
-    dt.mozClearDataAt("text/plain", 1);
+```js
+dt.mozClearDataAt("text/uri-list", 1);
+dt.mozClearDataAt("text/plain", 1);
+```
 
 You've removed the second item clearing all types, then the old third item becomes new second item, and its index decreases.
 
-    // [item1] data=URL1, index=0
-    // [item2] data=URL3, index=1
+```js
+// [item1] data=URL1, index=0
+// [item2] data=URL3, index=1
+```
 
 Fortunately, you don't normally need to clear items often; it's more common to just add the items only when you know they are needed.
 
@@ -62,23 +72,29 @@ To just take the first item being dropped, use the {{domxref("DataTransfer.getDa
 
 However, use the {{domxref("DataTransfer.mozGetDataAt","mozGetDataAt()")}} method to retrieve a specific item from the data transfer. The following example retrieves a set of files being dragged and adds them to an array.
 
-    function onDrop(event)
-    {
-      var files = [];
-      var dt = event.dataTransfer;
-      for (var i = 0; i < dt.mozItemCount; i++)
-        files.push(dt.mozGetDataAt("application/x-moz-file", i));
-    }
+```js
+function onDrop(event)
+{
+  var files = [];
+  var dt = event.dataTransfer;
+  for (var i = 0; i < dt.mozItemCount; i++)
+    files.push(dt.mozGetDataAt("application/x-moz-file", i));
+}
+```
 
 You may also wish to check if the desired format exists using the {{domxref("DataTransfer.mozTypesAt","mozTypesAt")}} method. As with the {{domxref("DataTransfer.types","types")}} property, it returns a list of strings of the types for an item. {{domxref("DataTransfer.types","types ")}} property is equivalent to retrieving the list of types for the item at index 0.
 
-    var types = event.dataTransfer.mozTypesAt(1);
+```js
+var types = event.dataTransfer.mozTypesAt(1);
+```
 
 ## Dragging Non-String Data
 
 The additional methods described above are also not restricted to string data; you can specify any type of data. For example, files are dragged using the [application/x-moz-file](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#file) type stored as [nsIFile](/en-US/docs/XPCOM_Interface_Reference/nsIFile) objects. As the {{domxref("DataTransfer.setData","setData()")}} method only supports strings, it cannot be used to specify files for dragging in this manner. Instead the {{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} method must be used.
 
-    dt.mozSetDataAt("application/x-moz-file", file, 0);
+```js
+dt.mozSetDataAt("application/x-moz-file", file, 0);
+```
 
 By using this method, you can file objects, although you do not necessarily need to support multiple items. Thus, you should pass 0 as the index.
 
@@ -88,54 +104,56 @@ Similarly, you will need to retrieve the file object or objects using the {{domx
 
 The following example provides a box where the lists of items and formats dropped on it are displayed.
 
-    <html>
-    <head>
-    <script>
+```html
+<html>
+<head>
+<script>
 
-    function dodrop(event)
-    {
-      var dt = event.dataTransfer;
-      var count = dt.mozItemCount;
-      output("Items: " + count + "\n");
+function dodrop(event)
+{
+  var dt = event.dataTransfer;
+  var count = dt.mozItemCount;
+  output("Items: " + count + "\n");
 
-      for (var i = 0; i < count; i++) {
-        output(" Item " + i + ":\n");
-        var types = dt.mozTypesAt(i);
-        for (var t = 0; t < types.length; t++) {
-          output("  " + types[t] + ": ");
-          try {
-            var data = dt.mozGetDataAt(types[t], i);
-            output("(" + (typeof data) + ") : <" + data + " >\n");
-          } catch (ex) {
-            output("<<error>>\n");
-            dump(ex);
-          }
-        }
+  for (var i = 0; i < count; i++) {
+    output(" Item " + i + ":\n");
+    var types = dt.mozTypesAt(i);
+    for (var t = 0; t < types.length; t++) {
+      output("  " + types[t] + ": ");
+      try {
+        var data = dt.mozGetDataAt(types[t], i);
+        output("(" + (typeof data) + ") : <" + data + " >\n");
+      } catch (ex) {
+        output("<<error>>\n");
+        dump(ex);
       }
     }
+  }
+}
 
-    function output(text)
-    {
-      document.getElementById("output").textContent += text;
-      dump(text);
-    }
+function output(text)
+{
+  document.getElementById("output").textContent += text;
+  dump(text);
+}
 
-    </script>
-    </head>
-    <body>
+</script>
+</head>
+<body>
 
-    <div id="output" style="min-height: 100px; white-space: pre; border: 1px solid black;"
-         ondragenter="document.getElementById('output').textContent = ''; event.stopPropagation(); event.preventDefault();"
-         ondragover="event.stopPropagation(); event.preventDefault();"
-         ondrop="event.stopPropagation(); event.preventDefault(); dodrop(event);">
+<div id="output" style="min-height: 100px; white-space: pre; border: 1px solid black;"
+      ondragenter="document.getElementById('output').textContent = ''; event.stopPropagation(); event.preventDefault();"
+      ondragover="event.stopPropagation(); event.preventDefault();"
+      ondrop="event.stopPropagation(); event.preventDefault(); dodrop(event);">
 
-    <div>
+<div>
 
-     Fix</div>
-    </div>
+  Fix</div>
+</div>
 
-    </body>
-    </html>
+</body>
+</html>
+```
 
 This example cancels both the `{{event("dragenter")}}` and `{{event("dragover")}}` events by calling the {{domxref("Event.preventDefault","preventDefault()")}}. method. This allows a drop to occur on that element.
 

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -319,12 +319,16 @@ For example, this line in the HTTP headers will enable use of a camera for the d
 and any embedded {{HTMLElement("iframe")}} elements that are loaded from the same
 origin:
 
-    Feature-Policy: camera 'self'
+```
+Feature-Policy: camera 'self'
+```
 
 This will request access to the microphone for the current origin and the specific
 origin https\://developer.mozilla.org:
 
-    Feature-Policy: microphone 'self' https://developer.mozilla.org
+```
+Feature-Policy: microphone 'self' https://developer.mozilla.org
+```
 
 If you're using `getUserMedia()` within an `<iframe>`, you
 can request permission just for that frame, which is clearly more secure than requesting

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -40,19 +40,25 @@ window.scrollBy(options)
 
 To scroll down one page:
 
-    window.scrollBy(0, window.innerHeight);
+```js
+window.scrollBy(0, window.innerHeight);
+```
 
 To scroll up:
 
-    window.scrollBy(0, -window.innerHeight);
+```js
+window.scrollBy(0, -window.innerHeight);
+```
 
 Using `options`:
 
-    window.scrollBy({
-      top: 100,
-      left: 100,
-      behavior: 'smooth'
-    });
+```js
+window.scrollBy({
+  top: 100,
+  left: 100,
+  behavior: 'smooth'
+});
+```
 
 ## Notes
 

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -1139,8 +1139,8 @@ In this example we provide a `<div>` and a text input. Entering a valid color in
 
 ```css
 div {
-  width: 100%;
-  height: 200px;
+  width: 100%;
+  height: 200px;
 }
 ```
 
@@ -1181,91 +1181,99 @@ inputElem.addEventListener('change', () => {
 
 This example shows the many ways in which a single color can be created with the various RGB color syntaxes.
 
-    /* These syntax variations all specify the same color: a fully opaque hot pink. */
+```css
+/* These syntax variations all specify the same color: a fully opaque hot pink. */
 
-    /* Hexadecimal syntax */
-    #f09
-    #F09
-    #ff0099
-    #FF0099
+/* Hexadecimal syntax */
+#f09
+#F09
+#ff0099
+#FF0099
 
-    /* Functional syntax */
-    rgb(255,0,153)
-    rgb(255, 0, 153)
-    rgb(255, 0, 153.0)
-    rgb(100%,0%,60%)
-    rgb(100%, 0%, 60%)
-    rgb(100%, 0, 60%) /* ERROR! Don't mix numbers and percentages. */
-    rgb(255 0 153)
+/* Functional syntax */
+rgb(255,0,153)
+rgb(255, 0, 153)
+rgb(255, 0, 153.0)
+rgb(100%,0%,60%)
+rgb(100%, 0%, 60%)
+rgb(100%, 0, 60%) /* ERROR! Don't mix numbers and percentages. */
+rgb(255 0 153)
 
-    /* Hexadecimal syntax with alpha value */
-    #f09f
-    #F09F
-    #ff0099ff
-    #FF0099FF
+/* Hexadecimal syntax with alpha value */
+#f09f
+#F09F
+#ff0099ff
+#FF0099FF
 
-    /* Functional syntax with alpha value */
-    rgb(255, 0, 153, 1)
-    rgb(255, 0, 153, 100%)
+/* Functional syntax with alpha value */
+rgb(255, 0, 153, 1)
+rgb(255, 0, 153, 100%)
 
-    /* Whitespace syntax */
-    rgb(255 0 153 / 1)
-    rgb(255 0 153 / 100%)
+/* Whitespace syntax */
+rgb(255 0 153 / 1)
+rgb(255 0 153 / 100%)
 
-    /* Functional syntax with floats value */
-    rgb(255, 0, 153.6, 1)
-    rgb(2.55e2, 0e0, 1.53e2, 1e2%)
+/* Functional syntax with floats value */
+rgb(255, 0, 153.6, 1)
+rgb(2.55e2, 0e0, 1.53e2, 1e2%)
+```
 
 ### RGB transparency variations
 
-    /* Hexadecimal syntax */
-    #3a30                    /*   0% opaque green */
-    #3A3F                    /* full opaque green */
-    #33aa3300                /*   0% opaque green */
-    #33AA3380                /*  50% opaque green */
+```css
+/* Hexadecimal syntax */
+#3a30                    /*   0% opaque green */
+#3A3F                    /* full opaque green */
+#33aa3300                /*   0% opaque green */
+#33AA3380                /*  50% opaque green */
 
-    /* Functional syntax */
-    rgba(51, 170, 51, .1)    /*  10% opaque green */
-    rgba(51, 170, 51, .4)    /*  40% opaque green */
-    rgba(51, 170, 51, .7)    /*  70% opaque green */
-    rgba(51, 170, 51,  1)    /* full opaque green */
+/* Functional syntax */
+rgba(51, 170, 51, .1)    /*  10% opaque green */
+rgba(51, 170, 51, .4)    /*  40% opaque green */
+rgba(51, 170, 51, .7)    /*  70% opaque green */
+rgba(51, 170, 51,  1)    /* full opaque green */
 
-    /* Whitespace syntax */
-    rgba(51 170 51 / 0.4)    /*  40% opaque green */
-    rgba(51 170 51 / 40%)    /*  40% opaque green */
+/* Whitespace syntax */
+rgba(51 170 51 / 0.4)    /*  40% opaque green */
+rgba(51 170 51 / 40%)    /*  40% opaque green */
 
-    /* Functional syntax with floats value */
-    rgba(51, 170, 51.6, 1)
-    rgba(5.1e1, 1.7e2, 5.1e1, 1e2%)
+/* Functional syntax with floats value */
+rgba(51, 170, 51.6, 1)
+rgba(5.1e1, 1.7e2, 5.1e1, 1e2%)
+```
 
 ### HSL syntax variations
 
-    /* These examples all specify the same color: a lavender. */
-    hsl(270,60%,70%)
-    hsl(270, 60%, 70%)
-    hsl(270 60% 70%)
-    hsl(270deg, 60%, 70%)
-    hsl(4.71239rad, 60%, 70%)
-    hsl(.75turn, 60%, 70%)
+```css
+/* These examples all specify the same color: a lavender. */
+hsl(270,60%,70%)
+hsl(270, 60%, 70%)
+hsl(270 60% 70%)
+hsl(270deg, 60%, 70%)
+hsl(4.71239rad, 60%, 70%)
+hsl(.75turn, 60%, 70%)
 
-    /* These examples all specify the same color: a lavender that is 15% opaque. */
-    hsl(270, 60%, 50%, .15)
-    hsl(270, 60%, 50%, 15%)
-    hsl(270 60% 50% / .15)
-    hsl(270 60% 50% / 15%)
+/* These examples all specify the same color: a lavender that is 15% opaque. */
+hsl(270, 60%, 50%, .15)
+hsl(270, 60%, 50%, 15%)
+hsl(270 60% 50% / .15)
+hsl(270 60% 50% / 15%)
+```
 
 ### HWB syntax variations
 
-    /* These examples all specify varying shades of a lime green. */
-    hwb(90 10% 10%)
-    hwb(90 50% 10%)
-    hwb(90deg 10% 10%)
-    hwb(1.5708rad 60% 0%)
-    hwb(.25turn 0% 40%)
+```css
+/* These examples all specify varying shades of a lime green. */
+hwb(90 10% 10%)
+hwb(90 50% 10%)
+hwb(90deg 10% 10%)
+hwb(1.5708rad 60% 0%)
+hwb(.25turn 0% 40%)
 
-    /* Same lime green but with an alpha value */
-    hwb(90 10% 10% / 0.5)
-    hwb(90 10% 10% / 50%)
+/* Same lime green but with an alpha value */
+hwb(90 10% 10% / 0.5)
+hwb(90 10% 10% / 50%)
+```
 
 ### Fully saturated colors
 
@@ -1436,16 +1444,18 @@ This example shows the many ways in which a single color can be created with the
 
 ### HSL transparency variations
 
-    hsla(240, 100%, 50%, .05)     /*   5% opaque blue */
-    hsla(240, 100%, 50%, .4)      /*  40% opaque blue */
-    hsla(240, 100%, 50%, .7)      /*  70% opaque blue */
-    hsla(240, 100%, 50%, 1)       /* full opaque blue */
+```css
+hsla(240, 100%, 50%, .05)     /*   5% opaque blue */
+hsla(240, 100%, 50%, .4)      /*  40% opaque blue */
+hsla(240, 100%, 50%, .7)      /*  70% opaque blue */
+hsla(240, 100%, 50%, 1)       /* full opaque blue */
 
-    /* Whitespace syntax */
-    hsla(240 100% 50% / .05)      /*   5% opaque blue */
+/* Whitespace syntax */
+hsla(240 100% 50% / .05)      /*   5% opaque blue */
 
-    /* Percentage value for alpha */
-    hsla(240 100% 50% / 5%)       /*   5% opaque blue */
+/* Percentage value for alpha */
+hsla(240 100% 50% / 5%)       /*   5% opaque blue */
+```
 
 ## Specifications
 

--- a/files/en-us/web/guide/writing_forward-compatible_websites/index.md
+++ b/files/en-us/web/guide/writing_forward-compatible_websites/index.md
@@ -19,7 +19,9 @@ This is especially important for intranets and other non-public websites; if we 
 
 When an event handler content attribute (`onclick`, `onmouseover`, and so forth) is used on HTML element, all name lookup in the attribute first happens on the element itself, then on the element's form if the element is a form control, then on the document, and then on the window (where the global variables you have defined are). For example, if you have this markup:
 
-    <div onclick="alert(ownerDocument)">Click me</div>
+```html
+<div onclick="alert(ownerDocument)">Click me</div>
+```
 
 then clicking on the text alerts the `ownerDocument` of the `div`. This happens even if there is a `var ownerDocument` declared in global scope.
 
@@ -27,12 +29,14 @@ What this means is that any time you access a global variable in an event handle
 
 To avoid this, fully qualify global variable access using "window.", like so:
 
-    <script>
-      function localName() {
-        alert('Function localName has been called');
-      }
-    </script>
-    <div onclick="window.localName()">Clicking me should show an alert<div>
+```html
+<script>
+  function localName() {
+    alert('Function localName has been called');
+  }
+</script>
+<div onclick="window.localName()">Clicking me should show an alert<div>
+```
 
 ### Don't concatenate scripts you don't control
 
@@ -94,12 +98,14 @@ Make sure to test what happens in a browser that doesn't implement the feature y
 
 Vendor-prefixed features can change behavior in future releases.  Once a browser has shipped a feature unprefixed, however, you can use the prefixed version to target old releases by making sure to always use the unprefixed version of the feature when available.  A good example, for a browser vendor using the `-vnd` CSS prefix that has shipped an unprefixed implementation of the `make-it-pretty` property, with a behavior for the value `"sometimes"` that differs from the prefixed version:
 
-    <style>
-      .pretty-element {
-        -vnd-make-it-pretty: sometimes;
-        make-it-pretty: sometimes;
-      }
-    </style>
+```html
+<style>
+  .pretty-element {
+    -vnd-make-it-pretty: sometimes;
+    make-it-pretty: sometimes;
+  }
+</style>
+```
 
 The order of the declarations in the rule above is important: the unprefixed one needs to come last.
 

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -45,35 +45,39 @@ with other directives.
 
 ## Syntax
 
-    Content-Security-Policy: report-to <json-field-value>;
+```
+Content-Security-Policy: report-to <json-field-value>;
+```
 
 ## Examples
 
 See {{HTTPHeader("Content-Security-Policy-Report-Only")}} for more information and
 examples.
 
-    Report-To: { "group": "csp-endpoint",
-                 "max_age": 10886400,
-                 "endpoints": [
-                   { "url": "https://example.com/csp-reports" }
-                 ] },
-               { "group": "hpkp-endpoint",
-                 "max_age": 10886400,
-                 "endpoints": [
-                   { "url": "https://example.com/hpkp-reports" }
-                 ] }
-    Content-Security-Policy: ...; report-to csp-endpoint
+```
+Report-To: { "group": "csp-endpoint",
+              "max_age": 10886400,
+              "endpoints": [
+                { "url": "https://example.com/csp-reports" }
+              ] },
+            { "group": "hpkp-endpoint",
+              "max_age": 10886400,
+              "endpoints": [
+                { "url": "https://example.com/hpkp-reports" }
+              ] }
+Content-Security-Policy: ...; report-to csp-endpoint
+```
 
-<!---->
+```
+Report-To: { "group": "endpoint-1",
+              "max_age": 10886400,
+              "endpoints": [
+                { "url": "https://example.com/reports" },
+                { "url": "https://backup.com/reports" }
+              ] }
 
-    Report-To: { "group": "endpoint-1",
-                 "max_age": 10886400,
-                 "endpoints": [
-                   { "url": "https://example.com/reports" },
-                   { "url": "https://backup.com/reports" }
-                 ] }
-
-    Content-Security-Policy: ...; report-to endpoint-1
+Content-Security-Policy: ...; report-to endpoint-1
+```
 
 ## Specifications
 

--- a/files/en-us/web/mathml/authoring/index.md
+++ b/files/en-us/web/mathml/authoring/index.md
@@ -173,7 +173,9 @@ In a Web environment, the most obvious method to convert a simple syntax into a 
 
 [TeXZilla](https://github.com/fred-wang/TeXZilla) has an [\<x-tex>](https://github.com/fred-wang/x-tex) custom element, that can be used to write things like
 
-    <x-tex>\frac{x^2}{a^2} + \frac{y^2}{b^2} = 1</x-tex>
+```
+<x-tex>\frac{x^2}{a^2} + \frac{y^2}{b^2} = 1</x-tex>
+```
 
 and get it automatically converted into MathML. This is still a work-in-progress, but could be improved in the future thanks to Web Components and shadow DOM. Alternatively, you can use the more traditional [Javascript parsing of expressions at load time](https://github.com/fred-wang/TeXZilla/wiki/Advanced-Usages#parsing-tex-expressions-in-your-web-page) as all the other tools in this section do.
 

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -14,7 +14,9 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<angle>
     *   : Angles are specified in one of two ways. When used in the value of a property in a stylesheet, an \<angle> is defined as follows:
 
-            angle ::= number (~"deg" | ~"grad" | ~"rad")?
+        ```
+        angle ::= number (~"deg" | ~"grad" | ~"rad")?
+        ```
 
         where `deg` indicates degrees, `grad` indicates grads and `rad` indicates radians.
 
@@ -33,7 +35,9 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<anything>
     *   : The basic type \<anything> is a sequence of zero or more characters. Specifically:
 
-            anything ::= Char*
+        ```
+        anything ::= Char*
+        ```
 
         where [Char](https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Char) is the production for a character, as defined in XML 1.0 , section 2.2.
 
@@ -42,19 +46,21 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<clock-value>
     *   : Clock values have the same syntax as in [SMIL Animation](https://www.w3.org/TR/2001/REC-smil-animation-20010904/) specification. The grammar for clock values is repeated here:
 
-            Clock-val         ::= Full-clock-val | Partial-clock-val
-                                  | Timecount-val
-            Full-clock-val    ::= Hours ":" Minutes ":" Seconds ("." Fraction)?
-            Partial-clock-val ::= Minutes ":" Seconds ("." Fraction)?
-            Timecount-val     ::= Timecount ("." Fraction)? (Metric)?
-            Metric            ::= "h" | "min" | "s" | "ms"
-            Hours             ::= DIGIT+; any positive number
-            Minutes           ::= 2DIGIT; range from 00 to 59
-            Seconds           ::= 2DIGIT; range from 00 to 59
-            Fraction          ::= DIGIT+
-            Timecount         ::= DIGIT+
-            2DIGIT            ::= DIGIT DIGIT
-            DIGIT             ::= [0-9]
+        ```
+        Clock-val         ::= Full-clock-val | Partial-clock-val
+                              | Timecount-val
+        Full-clock-val    ::= Hours ":" Minutes ":" Seconds ("." Fraction)?
+        Partial-clock-val ::= Minutes ":" Seconds ("." Fraction)?
+        Timecount-val     ::= Timecount ("." Fraction)? (Metric)?
+        Metric            ::= "h" | "min" | "s" | "ms"
+        Hours             ::= DIGIT+; any positive number
+        Minutes           ::= 2DIGIT; range from 00 to 59
+        Seconds           ::= 2DIGIT; range from 00 to 59
+        Fraction          ::= DIGIT+
+        Timecount         ::= DIGIT+
+        2DIGIT            ::= DIGIT DIGIT
+        DIGIT             ::= [0-9]
+        ```
 
         For `Timecount` values, the default metric suffix is "`s`" (for seconds). No embedded white space is allowed in clock values, although leading and trailing white space characters will be ignored.
 
@@ -91,11 +97,13 @@ SVG makes use of a number of data types. This article lists these types along wi
 
         The format of an RGB value in hexadecimal notation is a "`#`" immediately followed by either three or six hexadecimal characters. The three-digit RGB notation (`#rgb`) is converted into six-digit form (`#rrggbb`) by replicating digits, not by adding zeros. For example, `#fb0` expands to `#ffbb00`. This ensures that white (`#ffffff`) can be specified with the short notation (`#fff`) and removes any dependencies on the color depth of the display. The format of an RGB value in the functional notation is an RGB start-function, followed by a comma-separated list of three numerical values (either three integer values or three percentage values) followed by "`)`". An RGB start-function is the case-insensitive string "`rgb(`", for example "`RGB(`" or "`rGb(`". For compatibility, the all-lowercase form "`rgb(`" is preferred. The integer value `255` corresponds to `100%`, and to `F` or `FF` in the hexadecimal notation: `rgb(255,255,255)` = `rgb(100%,100%,100%)` = `#FFF`. White space characters are allowed around the numerical values. All RGB colors are specified in the sRGB color space. Using sRGB provides an unambiguous and objectively measurable definition of the color, which can be related to international standards.
 
-            color    ::= "#" hexdigit hexdigit hexdigit (hexdigit hexdigit hexdigit)?
-                         | "rgb("integer, integer, integer")"
-                         | "rgb("integer "%", integer "%", integer "%)"
-                         | color-keyword
-            hexdigit ::= [0-9A-Fa-f]
+        ```
+        color    ::= "#" hexdigit hexdigit hexdigit (hexdigit hexdigit hexdigit)?
+                      | "rgb("integer, integer, integer")"
+                      | "rgb("integer "%", integer "%", integer "%)"
+                      | color-keyword
+        hexdigit ::= [0-9A-Fa-f]
+        ```
 
         where `color-keyword` matches (case insensitively) one of the color keywords listed in [CSS Color Module Level 3](https://www.w3.org/TR/css3-color/), or one of the system color keywords listed in [User preferences for colors](https://www.w3.org/TR/2008/REC-CSS2-20080411/ui.html#system-colors) (CSS2, section 18.2).
 
@@ -128,7 +136,9 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<integer>
     *   : An \<integer> is specified as an optional sign character (`+` or `-`) followed by one or more digits `0` to `9`:
 
-            integer ::= [+-]? [0-9]+
+        ```
+        integer ::= [+-]? [0-9]+
+        ```
 
         If the sign character is not present, the number is non-negative.
 
@@ -143,21 +153,29 @@ SVG makes use of a number of data types. This article lists these types along wi
 
         On the Internet, resources are identified using *IRI*s (Internationalized Resource Identifiers). For example, an SVG file called `someDrawing.svg` located at <http://example.com> might have the following *IRI*:
 
-            http://example.com/someDrawing.svg
+        ```
+        http://example.com/someDrawing.svg
+        ```
 
         An *IRI* can also address a particular element within an XML document by including an *IRI* fragment identifier as part of the *IRI*. An *IRI* which includes an *IRI* fragment identifier consists of an optional base *IRI*, followed by a "`#`" character, followed by the *IRI* fragment identifier. For example, the following *IRI* can be used to specify the element whose ID is "`Lamppost`" within file `someDrawing.svg`:
 
-            http://example.com/someDrawing.svg#Lamppost
+        ```
+        http://example.com/someDrawing.svg#Lamppost
+        ```
 
         *IRI*s are used in the {{SVGAttr("xlink:href")}} attribute. Some attributes allow both *IRI*s and text strings as content. To disambiguate a text string from a relative IRI, the functional notation \<FuncIRI> is used. This is an *IRI* delimited with a functional notation. Note: For historical reasons, the delimiters are "`url(`" and "`)`", for compatibility with the CSS specifications. The *FuncIRI* form is used in presentation attributes .
 
         SVG makes extensive use of *IRI* references, both absolute and relative, to other objects. For example, to fill a rectangle with a linear gradient, you first define a {{SVGElement("linearGradient")}} element and give it an ID, as in:
 
-            <linearGradient xml:id="MyGradient">...</linearGradient>
+        ```
+        <linearGradient xml:id="MyGradient">...</linearGradient>
+        ```
 
         You then reference the linear gradient as the value of the {{SVGAttr("fill")}} attribute for the rectangle, as in the following example:
 
-            <rect fill="url(#MyGradient)"/>
+        ```
+        <rect fill="url(#MyGradient)"/>
+        ```
 
         SVG supports two types of *IRI* references:
 
@@ -171,7 +189,9 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<length>
     *   : A length is a distance measurement, given as a number along with a unit. Lengths are specified in one of two ways. When used in a stylesheet, a \<length> is defined as follows:
 
-            length ::= number (~"em" | ~"ex" | ~"px" | ~"in" | ~"cm" | ~"mm" | ~"pt" | ~"pc")?
+        ```
+        length ::= number (~"em" | ~"ex" | ~"px" | ~"in" | ~"cm" | ~"mm" | ~"pt" | ~"pc")?
+        ```
 
         [See the CSS2 specification](https://www.w3.org/TR/2008/REC-CSS2-20080411/syndata.html#length-units) for the meanings of the unit identifiers.
 
@@ -179,7 +199,9 @@ SVG makes use of a number of data types. This article lists these types along wi
 
         When lengths are used in an SVG attribute, a \<length> is instead defined as follows:
 
-            length ::= number ("em" | "ex" | "px" | "in" | "cm" | "mm" | "pt" | "pc" | "%")?
+        ```
+        length ::= number ("em" | "ex" | "px" | "in" | "cm" | "mm" | "pt" | "pc" | "%")?
+        ```
 
         The unit identifiers in such \<length> values must be in lower case.
 
@@ -199,8 +221,10 @@ SVG makes use of a number of data types. This article lists these types along wi
 
         The following is a template for an EBNF grammar describing the \<list-of-*T*s> syntax:
 
-            list-of-Ts ::= T
-                           | T, list-of-Ts
+        ```
+        list-of-Ts ::= T
+                        | T, list-of-Ts
+        ```
 
         Within the SVG DOM, values of a \<list-of-*T*s> type are represented by an interface specific for the particular type *T*. For example, a \<list-of-lengths> is represented in the SVG DOM using an {{domxref("SVGLengthList")}} or {{domxref("SVGAnimatedLengthList")}} object.
 
@@ -209,22 +233,28 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<name>
     *   : A name, which is a string where a few characters of syntactic significance are disallowed.
 
-            name  ::= [^,()#x20#x9#xD#xA] /* any char except ",", "(", ")" or wsp */
+        ```
+        name  ::= [^,()#x20#x9#xD#xA] /* any char except ",", "(", ")" or wsp */
+        ```
 
 ## Number
 
 *   \<number>
     *   : Real numbers are specified in one of two ways. When used in a stylesheet, a \<number> is defined as follows:
 
-            number ::= integer
-                       | [+-]? [0-9]* "." [0-9]+
+        ```
+        number ::= integer
+                    | [+-]? [0-9]* "." [0-9]+
+        ```
 
         This syntax is the same as the definition in CSS (CSS2, section 4.3.1).
 
         When used in an SVG attribute, a \<number> is defined differently, to allow numbers with large magnitudes to be specified more concisely:
 
-            number ::= integer ([Ee] integer)?
-                       | [+-]? [0-9]* "." [0-9]+ ([Ee] integer)?
+        ```
+        number ::= integer ([Ee] integer)?
+                    | [+-]? [0-9]* "." [0-9]+ ([Ee] integer)?
+        ```
 
         Within the SVG DOM, a \<number> is represented as a float, {{domxref("SVGNumber")}} or a {{domxref("SVGAnimatedNumber")}}.
 
@@ -233,8 +263,10 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<number-optional-number>
     *   : A pair of \<number>s, where the second \<number> is optional.
 
-            number-optional-number ::= number
-                                       | number, number
+        ```
+        number-optional-number ::= number
+                                    | number, number
+        ```
 
         In the SVG DOM, a \<number-optional-number> is represented using a pair of {{domxref("SVGAnimatedInteger")}} or {{domxref("SVGAnimatedNumber")}} objects.
 
@@ -255,7 +287,9 @@ SVG makes use of a number of data types. This article lists these types along wi
 *   \<percentage>
     *   : Percentages are specified as a number followed by a "`%`" character:
 
-            percentage ::= number "%"
+        ```
+        percentage ::= number "%"
+        ```
 
         Note that the definition of \<number> depends on whether the percentage is specified in a stylesheet or in an attribute that is not also a presentation attribute.
 

--- a/files/en-us/web/svg/tutorial/getting_started/index.md
+++ b/files/en-us/web/svg/tutorial/getting_started/index.md
@@ -51,10 +51,16 @@ The rendering process involves the following:
     *   If the HTML is HTML5, and the browser is a conforming HTML5 browser, the SVG can also be directly embedded. However, there may be syntax changes necessary to conform to the HTML5 specification.
     *   The SVG file can be referenced with an `object` element:
 
-                    <object data="image.svg" type="image/svg+xml" />
+        ```html
+        <object data="image.svg" type="image/svg+xml" />
+        ```
+
     *   Likewise an `iframe` element can be used:
 
-                    <iframe src="image.svg"></iframe>
+        ```html
+        <iframe src="image.svg"></iframe>
+        ```
+
     *   An `img` element can theoretically be used too. However, this technique doesn't work in Firefox before 4.0.
     *   Finally, SVG can be created dynamically with JavaScript and injected into the HTML DOM. With this method, replacement technologies can be implemented for browsers which normally can't process SVG.
 
@@ -70,15 +76,18 @@ Due to the potentially massive size SVG files can reach when used for some appli
 ### A word on Webservers
 
 Now that you have an idea of how to create basic SVG files, the next stage is to upload them to a Webserver. There are some gotchas at this stage though. For normal SVG files, servers should send the HTTP headers:
-
-    Content-Type: image/svg+xml
-    Vary: Accept-Encoding
+```
+Content-Type: image/svg+xml
+Vary: Accept-Encoding
+```
 
 For gzip-compressed SVG files, servers should send the HTTP headers:
 
-    Content-Type: image/svg+xml
-    Content-Encoding: gzip
-    Vary: Accept-Encoding
+```
+Content-Type: image/svg+xml
+Content-Encoding: gzip
+Vary: Accept-Encoding
+```
 
 You can check that your server is sending the correct HTTP headers with your SVG files by using the [Network Monitor panel](/en-US/docs/Tools/Network_Monitor#headers) or a site such as [websniffer.cc](https://websniffer.cc/). Submit the URL of one of your SVG files and look at the HTTP response headers. If you find that your server is not sending the headers with the values given above, then you should contact your Web host. If you have problems convincing them to correctly configure their servers for SVG, there may be ways to do it yourself. See the [server configuration page](https://www.w3.org/services/svg-server/) on the w3.org for a range of simple solutions.
 

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -10,7 +10,7 @@ tags:
 
 Perhaps more exciting than just fills and strokes is the fact that you can also create and apply gradients as either fills or strokes.
 
-There are two types of gradients: linear and radial. You **must** give the gradient an `id` attribute; otherwise it can't be referenced by other elements inside the file.  Gradients are defined in a defs section as opposed to on a shape itself to promote reusability.
+There are two types of gradients: linear and radial. You **must** give the gradient an `id` attribute; otherwise it can't be referenced by other elements inside the file. Gradients are defined in a defs section as opposed to on a shape itself to promote reusability.
 
 ## Linear Gradient
 
@@ -47,25 +47,31 @@ Linear gradients change along a straight line. To insert one, you create a {{SVG
 
 {{ EmbedLiveSample('Linear_Gradient','120','280') }}
 
-Above is an example of a linear gradient being applied to a `<rect>` element. Inside the linear gradient are several {{SVGElement('stop')}} nodes. These nodes tell the gradient what color it should be at certain positions by specifying an `offset` attribute for the position, and a `stop-color` attribute. This can be assigned directly or through CSS. The two methods have been intermixed for the purposes of this example. For instance, this one tells the gradient to start at the color red, change to transparent-black in the middle, and end at the color blue. You can insert as many stop colors as you like to create a blend that's as beautiful or hideous as you need, but the offsets should always increase from 0% (or 0 if you want to drop the % sign) to 100% (or 1). Duplicate values will use the stop that is assigned furthest down the XML tree. Also, like with fill and stroke, you can specify a `stop-opacity` attribute to set the opacity at that position (again, in FF3 you can also use rgba values to do this).
+Above is an example of a linear gradient being applied to a `<rect>` element. Inside the linear gradient are several {{SVGElement('stop')}} nodes. These nodes tell the gradient what color it should be at certain positions by specifying an `offset` attribute for the position, and a `stop-color` attribute. This can be assigned directly or through CSS. The two methods have been intermixed for the purposes of this example. For instance, this one tells the gradient to start at the color red, change to transparent-black in the middle, and end at the color blue. You can insert as many stop colors as you like to create a blend that's as beautiful or hideous as you need, but the offsets should always increase from 0% (or 0 if you want to drop the % sign) to 100% (or 1). Duplicate values will use the stop that is assigned furthest down the XML tree. Also, like with fill and stroke, you can specify a `stop-opacity` attribute to set the opacity at that position (again, in FF3 you can also use rgba values to do this).
 
-     <stop offset="100%" stop-color="yellow" stop-opacity="0.5"/>
+```
+<stop offset="100%" stop-color="yellow" stop-opacity="0.5"/>
+```
 
 To use a gradient, we have to reference it from an object's `fill` or `stroke` attributes. This is done the same way you reference elements in CSS, using a `url`. In this case, the url is just a reference to our gradient, which I've given the creative ID, "Gradient". To attach it, set the `fill` to `url(#Gradient)`, and voila! Our object is now multicolored. You can do the same with `stroke`.
 
 The `<linearGradient>` element also takes several other attributes, which specify the size and appearance of the gradient. The orientation of the gradient is controlled by two points, designated by the attributes `x1`, `x2`, `y1`, and `y2`. These attributes define a line along which the gradient travels. The gradient defaults to a horizontal orientation, but it can be rotated by changing these. Gradient2 in the above example is designed to create a vertical gradient.
 
-     <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
+```
+<linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
+```
 
 > **Note:** You can also use the `xlink:href` attribute on gradients too. When it is used, attributes and stops from one gradient can be included on another. In the above example, you wouldn't have to recreate all the stops in Gradient2.
 >
->      <linearGradient id="Gradient1">
->        <stop id="stop1" offset="0%"/>
->        <stop id="stop2" offset="50%"/>
->        <stop id="stop3" offset="100%"/>
->      </linearGradient>
->      <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1"
->         xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Gradient1"/>
+> ```html
+> <linearGradient id="Gradient1">
+>   <stop id="stop1" offset="0%"/>
+>   <stop id="stop2" offset="50%"/>
+>   <stop id="stop3" offset="100%"/>
+> </linearGradient>
+> <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1"
+>    xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Gradient1"/>
+> ```
 >
 > I've included the xlink namespace here directly on the node, although usually you would define it at the top of your document. More on that when we [talk about images](/en-US/docs/Web/SVG/Tutorial/Other_content_in_SVG).
 
@@ -140,34 +146,34 @@ Both linear and radial gradients also take a few other attributes to describe tr
 <?xml version="1.0" standalone="no"?>
 
 <svg width="220" height="220" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-      <radialGradient id="GradientPad"
-            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
-            spreadMethod="pad">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
-      <radialGradient id="GradientRepeat"
-            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
-            spreadMethod="repeat">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
-      <radialGradient id="GradientReflect"
-            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
-            spreadMethod="reflect">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
-  </defs>
+  <defs>
+      <radialGradient id="GradientPad"
+            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
+            spreadMethod="pad">
+        <stop offset="0%" stop-color="red"/>
+        <stop offset="100%" stop-color="blue"/>
+      </radialGradient>
+      <radialGradient id="GradientRepeat"
+            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
+            spreadMethod="repeat">
+        <stop offset="0%" stop-color="red"/>
+        <stop offset="100%" stop-color="blue"/>
+      </radialGradient>
+      <radialGradient id="GradientReflect"
+            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
+            spreadMethod="reflect">
+        <stop offset="0%" stop-color="red"/>
+        <stop offset="100%" stop-color="blue"/>
+      </radialGradient>
+  </defs>
 
-  <rect x="10" y="10" rx="15" ry="15" width="100" height="100" fill="url(#GradientPad)"/>
-  <rect x="10" y="120" rx="15" ry="15" width="100" height="100" fill="url(#GradientRepeat)"/>
-  <rect x="120" y="120" rx="15" ry="15" width="100" height="100" fill="url(#GradientReflect)"/>
+  <rect x="10" y="10" rx="15" ry="15" width="100" height="100" fill="url(#GradientPad)"/>
+  <rect x="10" y="120" rx="15" ry="15" width="100" height="100" fill="url(#GradientRepeat)"/>
+  <rect x="120" y="120" rx="15" ry="15" width="100" height="100" fill="url(#GradientReflect)"/>
 
-  <text x="15" y="30" fill="white" font-family="sans-serif" font-size="12pt">Pad</text>
-  <text x="15" y="140" fill="white" font-family="sans-serif" font-size="12pt">Repeat</text>
-  <text x="125" y="140" fill="white" font-family="sans-serif" font-size="12pt">Reflect</text>
+  <text x="15" y="30" fill="white" font-family="sans-serif" font-size="12pt">Pad</text>
+  <text x="15" y="140" fill="white" font-family="sans-serif" font-size="12pt">Repeat</text>
+  <text x="125" y="140" fill="white" font-family="sans-serif" font-size="12pt">Reflect</text>
 
 </svg>
 ```
@@ -176,7 +182,9 @@ Both linear and radial gradients also take a few other attributes to describe tr
 
 Both gradients also have an attribute named `gradientUnits`, which describes the unit system you're going to use when you describe the size or orientation of the gradient. There are two possible values to use here: `userSpaceOnUse` or `objectBoundingBox`. `objectBoundingBox` is the default, so that's what has been shown so far. It essentially scales the gradient to the size of your object, so you only have to specify coordinates in values from zero to one, and they're scaled to the size of your object automatically for you. `userSpaceOnUse` essentially takes in absolute units. So you have to know where your object is, and place the gradient at the same place. The radialGradient above would be rewritten:
 
-     <radialGradient id="Gradient" cx="60" cy="60" r="50" fx="35" fy="35" gradientUnits="userSpaceOnUse">
+```html
+<radialGradient id="Gradient" cx="60" cy="60" r="50" fx="35" fy="35" gradientUnits="userSpaceOnUse">
+```
 
 You can also then apply another transformation to the gradient by using the `gradientTransform` attribute, but since we haven't [introduced transforms](/en-US/docs/Web/SVG/Tutorial/Basic_Transformations) yet, I'll leave that for later.
 

--- a/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.md
+++ b/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.md
@@ -13,16 +13,20 @@ The **`acceptInsecureCerts` capability** communicates whether expired or invalid
 
 Using the `acceptInsecureCerts` capability you can bypass, or implicitly trust, TLS certificates that the certificate service in the browser does not trust:
 
-    from selenium import webdriver
-    from selenium.common import exceptions
+```python
+from selenium import webdriver
+from selenium.common import exceptions
 
-    session = webdriver.Firefox(capabilities={"acceptInsecureCerts": True})
-    session.get("https://self-signed.badssl.com/")
-    print(session.current_url)
+session = webdriver.Firefox(capabilities={"acceptInsecureCerts": True})
+session.get("https://self-signed.badssl.com/")
+print(session.current_url)
+```
 
 Output:
 
-    https://self-signed.badssl.com/
+```
+https://self-signed.badssl.com/
+```
 
 ## See also
 

--- a/files/en-us/web/webdriver/errors/scripttimeout/index.md
+++ b/files/en-us/web/webdriver/errors/scripttimeout/index.md
@@ -33,7 +33,9 @@ except exceptions.ScriptTimeoutException as e:
 
 Output:
 
-    ScriptTimeoutException: Timed out after 35000 ms
+```
+ScriptTimeoutException: Timed out after 35000 ms
+```
 
 However, it is possible to _extend_ the session’s default script timeout by using capabilities if you have a script that you expect will take longer:
 
@@ -51,7 +53,9 @@ print("finished successfully")
 
 Output:
 
-    finished successfully
+```
+finished successfully
+```
 
 ## See also
 

--- a/files/en-us/web/webdriver/errors/unknowncommand/index.md
+++ b/files/en-us/web/webdriver/errors/unknowncommand/index.md
@@ -13,16 +13,18 @@ The **unknown command** error is a [WebDriver error](/en-US/docs/Web/WebDriver/E
 
 The `/session/{session id}/foo` endpoint does not exist, and will return an unknown command error with a [`404 Not Found`](/en-US/docs/Web/HTTP/Status/404) HTTP status code:
 
-    % curl -i -d '{}' http://localhost:4444/session/foo
-    HTTP/1.1 404 Not Found
-    Connection: close
-    Content-Type: application/json; charset=utf-8
-    Cache-Control: no-cache
-    Content-Length: 113
-    Date: Fri, 30 Mar 2018 15:30:51 GMT
+```
+% curl -i -d '{}' http://localhost:4444/session/foo
+HTTP/1.1 404 Not Found
+Connection: close
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-cache
+Content-Length: 113
+Date: Fri, 30 Mar 2018 15:30:51 GMT
 
-    {"value":{"error":"unknown command","message":"POST /session/asd did not match a known command","stacktrace":""}}
+{"value":{"error":"unknown command","message":"POST /session/asd did not match a known command","stacktrace":""}}
 
+```
 ## See also
 
 - [List of WebDriver errors](/en-US/docs/Web/WebDriver/Errors)

--- a/files/en-us/web/xml/xml_introduction/index.md
+++ b/files/en-us/web/xml/xml_introduction/index.md
@@ -86,13 +86,15 @@ Like HTML, XML offers methods (called entities) for referring to some special re
 
 Even though there are only 5 declared entities, more can be added using the document's [Document Type Definition](/en-US/docs/Glossary/Doctype). For example, to create a new `&warning;` entity, you can do this:
 
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE body [
-      <!ENTITY warning "Warning: Something bad happened... please refresh and try again.">
-    ]>
-    <body>
-      <message> &warning; </message>
-    </body>
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE body [
+  <!ENTITY warning "Warning: Something bad happened... please refresh and try again.">
+]>
+<body>
+  <message> &warning; </message>
+</body>
+```
 
 You can also use numeric character references to specify special characters; for example, \&#xA9; is the "©" symbol.
 
@@ -102,11 +104,15 @@ XML is usually used for descriptive purposes, but there are ways to display XML 
 
 One way to style XML output is to specify [CSS](/en-US/docs/Web/CSS) to apply to the document using the `xml-stylesheet` processing instruction.
 
-    <?xml-stylesheet type="text/css" href="stylesheet.css"?>
+```xml
+<?xml-stylesheet type="text/css" href="stylesheet.css"?>
+```
 
 There is also another more powerful way to display XML: the **Extensible Stylesheet Language Transformations** ([XSLT](/en-US/docs/Web/XSLT)) which can be used to transform XML into other languages such as HTML. This makes XML incredibly versatile.
 
-    <?xml-stylesheet type="text/xsl" href="transform.xsl"?>
+```xml
+<?xml-stylesheet type="text/xsl" href="transform.xsl"?>
+```
 
 ## Recommendations
 

--- a/files/en-us/web/xpath/functions/current/index.md
+++ b/files/en-us/web/xpath/functions/current/index.md
@@ -11,7 +11,9 @@ The `current` function can be used to get the context node in an XSLT instructio
 
 ### Syntax
 
-    current()
+```
+current()
+```
 
 ### Returns
 
@@ -23,33 +25,41 @@ This function is an XSLT-specific addition to XPath. It is not a part of the cor
 
 For an outermost expression (an expression not occurring within another expression), the current node is always the same as the context node (which will be returned by the `.` or `self` syntax). The following two are semantically equivalent.
 
-    <xsl:value-of select="current()"/>
+```xml
+<xsl:value-of select="current()"/>
+```
 
-<!---->
-
-    <xsl:value-of select="."/>
+```xml
+<xsl:value-of select="."/>
+```
 
 In an inner expression (e.g. in square brackets), the current node is still the same as it would have been in an outermost expression. Thus within all of the following three expressions the `current` function (not the entire expressions) returns the same node. Moreover, the latter two are semantically equivalent.
 
-    <xsl:value-of select="current()"/>
+```xml
+<xsl:value-of select="current()"/>
+  ```
 
-<!---->
+```xml
+<xsl:value-of select="foo/bar[current() = X]"/>
+```
 
-    <xsl:value-of select="foo/bar[current() = X]"/>
-
-<!---->
-
-    <xsl:variable name="current" select="current()"/>
-    <xsl:value-of select="foo/bar[$current = X]"/>
+```xml
+<xsl:variable name="current" select="current()"/>
+<xsl:value-of select="foo/bar[$current = X]"/>
+```
 
 And the next code is also semantically equivalent to the latter two, since the `.` occurs in an outermost expression.
 
-    <xsl:variable name="current" select="."/>
-    <xsl:value-of select="foo/bar[$current = X]"/>
+```xml
+<xsl:variable name="current" select="."/>
+<xsl:value-of select="foo/bar[$current = X]"/>
+```
 
 But the `.` always relate to the narrowest context. Thus in
 
-    <xsl:value-of select="foo/bar[. = X]"/>
+```xml
+<xsl:value-of select="foo/bar[. = X]"/>
+```
 
 the `.` returns the `bar` node, which may be different from the current node.
 

--- a/files/en-us/web/xpath/functions/name/index.md
+++ b/files/en-us/web/xpath/functions/name/index.md
@@ -11,7 +11,9 @@ The `name` function returns a string representing the QName of the first node in
 
 ### Syntax
 
-    name( [node-set] )
+```
+name( [node-set] )
+```
 
 ### Arguments
 

--- a/files/en-us/web/xpath/functions/translate/index.md
+++ b/files/en-us/web/xpath/functions/translate/index.md
@@ -11,7 +11,9 @@ The `translate` function evaluates a string and a set of characters to translate
 
 ### Syntax
 
-    translate(string, abc, XYZ)
+```
+translate(string, abc, XYZ)
+```
 
 ### Arguments
 

--- a/files/en-us/web/xslt/element/copy/index.md
+++ b/files/en-us/web/xslt/element/copy/index.md
@@ -13,9 +13,11 @@ The `<xsl:copy>` element transfers a shallow copy (the node and any associated n
 
 ### Syntax
 
-    <xsl:copy use-attribute-sets=LIST-OF-NAMES>
-    	TEMPLATE
-    </xsl:copy>
+```xml
+<xsl:copy use-attribute-sets=LIST-OF-NAMES>
+  TEMPLATE
+</xsl:copy>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/decimal-format/index.md
+++ b/files/en-us/web/xslt/element/decimal-format/index.md
@@ -13,18 +13,20 @@ The `<xsl:decimal-format>` element defines the characters and symbols that are t
 
 ### Syntax
 
-    <xsl:decimal-format
-    	name=NAME
-    	decimal-separator=CHARACTER
-    	grouping-separator=CHARACTER
-    	infinity=STRING
-    	minus-sign=CHARACTER
-    	NaN=STRING
-    	percent=CHARACTER
-    	per-mille=CHARACTER
-    	zero-digit=CHARACTER
-    	digit=CHARACTER
-    	pattern-separator=CHARACTER />
+```xml
+<xsl:decimal-format
+  name=NAME
+  decimal-separator=CHARACTER
+  grouping-separator=CHARACTER
+  infinity=STRING
+  minus-sign=CHARACTER
+  NaN=STRING
+  percent=CHARACTER
+  per-mille=CHARACTER
+  zero-digit=CHARACTER
+  digit=CHARACTER
+  pattern-separator=CHARACTER />
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/element/index.md
+++ b/files/en-us/web/xslt/element/element/index.md
@@ -12,9 +12,11 @@ The `<xsl:element>` element creates an element in the output document.
 
 ### Syntax
 
-    <xsl:element name=NAME namespace=URI use-attribute-sets=LIST-OF-NAMES >
-    	TEMPLATE
-    </xsl:element>
+```xml
+<xsl:element name=NAME namespace=URI use-attribute-sets=LIST-OF-NAMES >
+  TEMPLATE
+</xsl:element>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/for-each/index.md
+++ b/files/en-us/web/xslt/element/for-each/index.md
@@ -14,10 +14,12 @@ The `<xsl:for-each>` element selects a set of nodes and processes each of them i
 
 ### Syntax
 
-    <xsl:for-each select=EXPRESSION>
-    	<xsl:sort> [optional]
-    	TEMPLATE
-    </xsl:for-each>
+```xml
+<xsl:for-each select=EXPRESSION>
+  <xsl:sort> [optional]
+  TEMPLATE
+</xsl:for-each>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/namespace-alias/index.md
+++ b/files/en-us/web/xslt/element/namespace-alias/index.md
@@ -13,7 +13,9 @@ The `<xsl:namespace-alias>` element is a rarely used device that maps a namespac
 
 ### Syntax
 
-    <xsl:namespace-alias stylesheet-prefix=NAME result-prefix=NAME />
+```xml
+<xsl:namespace-alias stylesheet-prefix=NAME result-prefix=NAME />
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/otherwise/index.md
+++ b/files/en-us/web/xslt/element/otherwise/index.md
@@ -13,9 +13,11 @@ The `<xsl:otherwise>` element is used to define the action that should be taken 
 
 ### Syntax
 
-    <xsl:otherwise>
-    	TEMPLATE
-    </xsl:otherwise>
+```xml
+<xsl:otherwise>
+  TEMPLATE
+</xsl:otherwise>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/param/index.md
+++ b/files/en-us/web/xslt/element/param/index.md
@@ -13,9 +13,11 @@ The `<xsl:param>` element establishes a parameter by name and, optionally, a def
 
 ### Syntax
 
-    <xsl:param name=NAME select=EXPRESSION>
-    	TEMPLATE
-    </xsl:param>
+```xml
+<xsl:param name=NAME select=EXPRESSION>
+  TEMPLATE
+</xsl:param>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/sort/index.md
+++ b/files/en-us/web/xslt/element/sort/index.md
@@ -13,12 +13,14 @@ The `<xsl:sort>` element defines a sort key for nodes selected by `<xsl:apply-te
 
 ### Syntax
 
-    <xsl:sort
-    	select=EXPRESSION
-    	order="ascending" | "descending"
-    	case-order="upper-first" | "lower-first"
-    	lang=XML:LANG-CODE
-    	data-type="text" | "number" />
+```xml
+<xsl:sort
+  select=EXPRESSION
+  order="ascending" | "descending"
+  case-order="upper-first" | "lower-first"
+  lang=XML:LANG-CODE
+  data-type="text" | "number" />
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/variable/index.md
+++ b/files/en-us/web/xslt/element/variable/index.md
@@ -13,9 +13,11 @@ The `<xsl:variable>` element declares a global or local variable in a stylesheet
 
 ### Syntax
 
-    <xsl:variable name=NAME select=EXPRESSION >
-    	TEMPLATE
-    </xsl:variable>
+```xml
+<xsl:variable name=NAME select=EXPRESSION >
+  TEMPLATE
+</xsl:variable>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/when/index.md
+++ b/files/en-us/web/xslt/element/when/index.md
@@ -13,9 +13,11 @@ The `<xsl:when>` element always appears within an `<xsl:choose>` element, acting
 
 ### Syntax
 
-    <xsl:when test=EXPRESSION>
-    	TEMPLATE
-    </xsl:when>
+```xml
+<xsl:when test=EXPRESSION>
+  TEMPLATE
+</xsl:when>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/element/with-param/index.md
+++ b/files/en-us/web/xslt/element/with-param/index.md
@@ -13,9 +13,11 @@ The `<xsl:with-param>` element sets the value of a parameter to be passed into a
 
 ### Syntax
 
-    <xsl:with-param name=NAME select=EXPRESSION>
-    	TEMPLATE
-    </xsl:with-param>
+```xml
+<xsl:with-param name=NAME select=EXPRESSION>
+  TEMPLATE
+</xsl:with-param>
+```
 
 ### Required Attributes
 

--- a/files/en-us/web/xslt/pi_parameters/index.md
+++ b/files/en-us/web/xslt/pi_parameters/index.md
@@ -12,7 +12,7 @@ To solve this two new PIs are implemented in [Firefox 2](/en-US/Firefox_2) (see 
 
 The following document passes the two parameters "color" and "size" to the stylesheet "style.xsl".
 
-```plain
+```xml
 <?xslt-param name="color" value="blue"?>
 <?xslt-param name="size" select="2"?>
 <?xml-stylesheet type="text/xsl" href="style.xsl"?>
@@ -55,19 +55,27 @@ Note that `value="..."` is not strictly equal to `select="'...'"` since the valu
 
 Set the parameter 'color' to the string 'red':
 
-    <?xslt-param name="color" value="red"?>
+```xml
+<?xslt-param name="color" value="red"?>
+```
 
 Set the parameter 'columns' to the number 2:
 
-    <?xslt-param name="columns" select="2"?>
+```xml
+<?xslt-param name="columns" select="2"?>
+```
 
 Set the parameter 'books' to a nodeset containing all `<book>` elements in the null namespace:
 
-    <?xslt-param name="books" select="//book"?>
+```xml
+<?xslt-param name="books" select="//book"?>
+```
 
 Set the parameter 'show-toc' to boolean `true`:
 
-     <?xslt-param name="show-toc" select="true()"?>
+```xml
+<?xslt-param name="show-toc" select="true()"?>
+```
 
 ##### The select attribute context
 
@@ -103,9 +111,10 @@ If **namespace** is missing, the PI is ignored. If **namespace** is empty, the p
 
 Set the parameter 'books' to a nodeset containing all `<book>` elements in the 'http\://www\.example.org/myNamespace' namespace:
 
-    <?xslt-param-namespace prefix="my" namespace="http://www.example.org/myNamespace"?>
-    <?xslt-param name="books" select="//my:book"?>
-
+```xml
+<?xslt-param-namespace prefix="my" namespace="http://www.example.org/myNamespace"?>
+<?xslt-param name="books" select="//my:book"?>
+```
 ### Supported versions
 
 Supported as of Firefox 2.0.0.1. The **value** attribute is supported in Firefox 2, but the **select** attribute crashes for some expressions in the 2.0 release.


### PR DESCRIPTION
Set the following in a local config and cleaned up some of the flagged issues
```
  "MD046": {
    "style": "fenced"
  },
``` 