### PR TITLE
fix: MD032 space around lists

### DIFF
--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -76,6 +76,7 @@ console.log(original.byteLength);  // 0
 ## Supported objects
 
 The items that can be _transferred_ are:
+
 - {{jsxref("ArrayBuffer")}}
 - {{domxref("MessagePort")}}
 - {{domxref("ReadableStream")}}

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -12,6 +12,7 @@ This state is sometimes used as a mechanism for ensuring that a web API can only
 For example, scripts cannot arbitrarily launch a popup that requires _transient activation_ ⁠—it must be triggered from a UI element's event handler.
 
 Examples of APIs that require _transient activation_ are:
+
 - {{domxref("MediaDevices.selectAudioOutput()")}}
 
 > **Note:** Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs.

--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
@@ -123,6 +123,7 @@ if (browserType.endsWith('zilla')) {
 ## Extracting a substring from a string
 
 You can extract a substring from a string using the {{jsxref("String.prototype.slice()", "slice()")}} method. You pass it:
+
 * the index at which to start extracting
 * the index at which to stop extracting. This is exclusive, meaning that the character at this index is not included in the extracted substring.
 

--- a/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.md
+++ b/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.md
@@ -109,6 +109,7 @@ Create a definition for an `EvilCircle` class. It should inherit from `Shape` us
 #### EvilCircle constructor
 
 The constructor for `EvilCircle` should:
+
 - be passed just `x`, `y` arguments
 - pass the `x`, `y` arguments up to the `Shape` superclass along with values for `velX` and `velY` hardcoded to 20. You should do this with code like `super(x, y, 20, 20);`
 - set `color` to `white` and `size` to `10`.

--- a/files/en-us/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/en-us/learn/javascript/objects/classes_in_javascript/index.md
@@ -59,6 +59,7 @@ class Person {
 ```
 
 This declares a class called `Person`, with:
+
 * a `name` property.
 * a constructor that takes a `name` parameter that is used to initialize the new object's `name` property
 * an `introduceSelf()` method that can refer to the object's properties using `this`.
@@ -68,6 +69,7 @@ The `name;` declaration is optional: you could omit it, and the line `this.name 
 You could also initialize the property to a default value when you declare it, with a line like `name = '';`.
 
 The constructor is defined using the {{jsxref("Classes/constructor", "constructor")}} keyword. Just like a [constructor outside a class definition](/en-US/docs/Learn/JavaScript/Objects/Basics#introducing_constructors), it will:
+
 * create a new object
 * bind `this` to the new object, so you can refer to `this` in your constructor code
 * run the code in the constructor

--- a/files/en-us/learn/javascript/objects/json/index.md
+++ b/files/en-us/learn/javascript/objects/json/index.md
@@ -215,6 +215,7 @@ async function populate() {
 To obtain the JSON, we use an API called [Fetch](/en-US/docs/Web/API/Fetch_API). This API allows us to make network requests to retrieve resources from a server via JavaScript (e.g. images, text, JSON, even HTML snippets), meaning that we can update small sections of content without having to reload the entire page.
 
 In our function, the first four lines use the Fetch API to fetch the JSON from the server:
+
 * we declare the `requestURL` variable to store the GitHub URL
 * we use the URL to initialize a new {{domxref("Request")}} object.
 * we make the network request using the {{domxref("fetch", "fetch()")}} function, and this returns a {{domxref("Response")}} object

--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -86,6 +86,7 @@ Every object in JavaScript has a built-in property, which is called its **protot
 When you try to access a property of an object: if the property can't be found in the object itself, the prototype is searched for the property. If the property still can't be found, then the prototype's prototype is searched, and so on until either the property is found, or the end of the chain is reached, in which case `undefined` is returned.
 
 So when we call `myObject.hasOwnProperty('city')`, the browser:
+
 * looks for `hasOwnProperty` in `myObject`
 * can't find it there, so looks in the prototype object for `myObject`
 * finds it there, and calls it.
@@ -189,6 +190,7 @@ Person.prototype.constructor = Person;
 ```
 
 Here we create:
+
 * an object `personPrototype`, which has a `greet()` method
 * a `Person()` constructor function which initializes the name of the person to create.
 

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 > browser-compat: path.to.feature.NameOfTheConstructor
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**()**.
@@ -63,6 +64,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.md
@@ -36,6 +36,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 > browser-compat: path.to.feature.NameOfTheEventHandler
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**.**_NameOfTheEventHandler_.
@@ -64,6 +65,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > browser-compat: path.to.feature.NameOfTheEvent_event
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as "_NameOfTheParentInterface_**:** _NameOfTheEvent_ **event**".
@@ -62,6 +63,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -31,6 +31,7 @@ tags:
 >   - Non-standard
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       This is the name of the API followed by the text "API": _NameOfTheAPI_ **API**.
@@ -54,6 +55,7 @@ tags:
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -35,6 +35,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 > browser-compat: path.to.feature.NameOfTheMethod
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**.**_NameOfTheMethod_**()**.
@@ -64,6 +65,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -35,6 +35,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 > browser-compat: path.to.feature.NameOfTheProperty
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**.**_NameOfTheProperty_.
@@ -63,6 +64,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -33,6 +33,7 @@ browser-compat: css.properties.NameOfTheProperty
 > browser-compat: css.properties.NameOfTheProperty
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page. Format as _NameOfTheProperty.
 >       For example, the [`background-color`](/en-US/docs/Web/CSS/background-color) property has a title of _background-color_.
@@ -59,6 +60,7 @@ browser-compat: css.properties.NameOfTheProperty
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you can remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -33,6 +33,7 @@ browser-compat: css.selectors.NameOfTheSelector
 > browser-compat: css.selectors.NameOfTheSelector
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page. Format as _:NameOfTheSelector_.
 >       For example, the [`:hover`](/en-US/docs/Web/CSS/:hover) selector has a title of _:hover_.
@@ -59,6 +60,7 @@ browser-compat: css.selectors.NameOfTheSelector
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you can remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
@@ -26,6 +26,7 @@ tags:
 >   - The term
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as: `Term being defined`.
@@ -34,6 +35,7 @@ tags:
 >       This will be formatted as snake case of the title: `Glossary/Term_being_defined`.
 > - **tags**
 >   - : Always include the following tags: **Glossary**, _Term being defined_.
+>
 > ---
 > _Remember to remove this whole explanatory note before publishing_
 

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > browser-compat: html.elements.NameOfTheElement
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as `'<NameOfTheElement>: Description of element's purpose'`.
@@ -62,6 +63,7 @@ browser-compat: path.to.feature.NameOfTheElement
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -35,6 +35,7 @@ browser-compat: path.to.feature.NameOfTheHeader
 > browser-compat: path.to.feature.NameOfTheHeader
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page. Format as _NameOfTheHeader_. For example, the [Cache-Control](/en-US/docs/Web/HTTP/Headers/Cache-Control) header has a _title_ of `Cache-Control`.
 > - **slug**
@@ -59,6 +60,7 @@ browser-compat: path.to.feature.NameOfTheHeader
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the header is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the header you are documenting is not experimental, you can remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > browser-compat: svg.elements.NameOfTheElement
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as **<**_NameOfTheElement_**>**.
@@ -61,6 +62,7 @@ browser-compat: path.to.feature.NameOfTheElement
 >
 > A number of macro calls appear at the top of the content section (immediately below the page frontmatter).
 > You should update or delete them according to the advice below:
+>
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)).
 >   If the technology you are documenting is not experimental, you should remove this.
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -63,6 +63,7 @@ Here we use {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}} to
 The `{urls: ["<all_urls>"]}` [pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) means we will intercept HTTP requests to all URLs.
 
 To test it out:
+
 - [Install the extension](https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/)
 - Open the [Browser Console](https://firefox-source-docs.mozilla.org/devtools-user/browser_console/) (use <kbd>Ctrl + Shift + J</kbd>)
 - Enable *Show Content Messages* in the menu:

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1311,6 +1311,7 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
 #### ElementInternals: Form associated custom element methods and properties
 
 New {{domxref("ElementInternals")}} properties and methods that allow a custom elements to interact with a form:
+
 - property: {{domxref("ElementInternals.form","form")}} gets the form associated with the element
 - property: {{domxref("ElementInternals.labels","labels")}} gets the list of labels associated with the element
 - property: {{domxref("ElementInternals.willValidate", "willValidate")}} checks if a custom form element will be validated.

--- a/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
@@ -50,6 +50,7 @@ If an autocomplete list value is automatically accepted when the field loses foc
 ## Associated roles
 
 Used in roles:
+
 - [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) role
 - [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role) role
 - inherits from [`searchbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role) role

--- a/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
@@ -46,6 +46,7 @@ A few rules to remember:
 > **Note:** Do NOT use `aria-brailleroledescription` to replicate `aria-roledescription`. Only include this attribute when `aria-roledescription` does not provide an adequate braille representation.
 
 The `aria-brailleroledescription` value will not be exposed to the braille user if:
+
 - The value is empty or contains only whitespace characters or the empty Braille pattern: dots-0 (U+2800).
 - The element to which the attribute is applied has an explicit or implicit WAI-ARIA role where `aria-brailleroledescription` is prohibited, including the `generic` role.
 - The element to which the attribute is applied does not have a valid `aria-roledescription`.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -68,9 +68,11 @@ See related [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/
 ## Associated roles
 
 Used in roles:
+
  - [`cell`](/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_role)
 
 Inherits into roles:
+
  - [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_role)
  - [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_role)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
@@ -147,9 +147,11 @@ If we had used a {{HTMLElement('table')}} and semantic table elements our markup
 ## Associated roles
 
 Used in roles:
+
  - [`cell`](/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_role)
 
 Inherits into roles:
+
  - [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_role)
  - [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_role)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -91,6 +91,7 @@ If you used just CSS to style the disabled state using an attribute selector, th
 ## Associated roles
 
 Used in roles:
+
 - [`application`](/en-US/docs/Web/Accessibility/ARIA/roles/application_role)
 - [`button`](/en-US/docs/Web/Accessibility/ARIA/roles/button_role)
 - [`composite`](/en-US/docs/Web/Accessibility/ARIA/roles/composite_role)
@@ -104,6 +105,7 @@ Used in roles:
 - [`tab`](/en-US/docs/Web/Accessibility/ARIA/roles/tab_role)
 
 Inherits into roles:
+
 - [`checkbox`](/en-US/docs/Web/Accessibility/ARIA/roles/checkbox_role)
 - [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/roles/columnheader_role)
 - [`combobox`](/en-US/docs/Web/Accessibility/ARIA/roles/combobox_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
@@ -47,6 +47,7 @@ If the non-changeable value shouldn't be able to receive focus, use [`aria-disab
 ## Associated roles
 
 Used in roles:
+
 - [`checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)
 - [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role)
 - [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role)
@@ -58,6 +59,7 @@ Used in roles:
 - [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role)
 
 Inherited into roles:
+
 - [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role)
 - [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role)
 - [`searchbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
@@ -46,6 +46,7 @@ The code below shows a simple slider with a maximum value of 9.
 ## Associated roles
 
 Used in roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role) 
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role) (required)
 - [`separator`](/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role)
@@ -53,6 +54,7 @@ Used in roles:
 - [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role) (required)
 
 Inherited into roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`progressbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
@@ -39,6 +39,7 @@ The maximum value is defined with [`aria-valuemax`](/en-US/docs/Web/Accessibilit
 ## Associated roles
 
 Used in roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role)
 - [`separator`](/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role)
@@ -46,6 +47,7 @@ Used in roles:
 - [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role)
 
 Inherited into roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`progressbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -106,6 +106,7 @@ If we employ native HTML semantics with {{HTMLElement('input')}} we get styles a
 ## Associated roles
 
 Used in roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role)
 - [`separator`](/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role)
@@ -113,6 +114,7 @@ Used in roles:
 - [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role)
 
 Inherited into roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`progressbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
@@ -39,11 +39,13 @@ When both the `aria-valuetext` and `aria-valuenow` are included, the `aria-value
 ## Associated roles
 
 Used in roles:
+
 - [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role)
 - [`separator`](/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role)
 - [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role)
 
 Inherited into roles:
+
 - [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`progressbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role)

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -128,6 +128,7 @@ Assistive technology products should do the following:
 - Screen readers should announce the element as a checkbox, and optionally provide instructions on how to activate it.
 
 People implementing checkboxes should do the following:
+
 - Ensure that the checkbox can be reached and interacted with by both keyboard controls and clicks
 - Keep the `aria-checked` attribute up to date following user interactions
 - Provide styles that indicate when the checkbox has focus

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -15,6 +15,7 @@ Common targets are {{domxref("Element")}}, or its children, {{domxref("Document"
 but the target may be any object that supports events (such as {{domxref("XMLHttpRequest")}}).
 
 > **Note:** The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
+>
 > - It allows adding more than one handler for an event. This is particularly
 >   useful for libraries, JavaScript modules, or any other kind of
 >   code that needs to work well with other libraries or extensions.

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -34,6 +34,7 @@ eyeDropper.open({ signal: abortController.signal });
 A {{jsxref("Promise")}} that eventually resolves when the user selects a pixel color from the screen.
 
 The promise resolves to an object with the following property:
+
 - `sRGBHex`
   - : A string representing the selected color, in hexadecimal sRGB format (`#aabbcc`).
 

--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -22,12 +22,13 @@ The configuration options parameter allows you to specify the allowed and dis-al
 The most common use-case - preventing XSS - is handled by the default configuration.
 Creating a {{domxref('Sanitizer.Sanitizer')}} with a custom configuration is necessary only to handle additional, application-specific use cases.
 
-The API has three main methods for sanitizing data.
-- {{domxref('Element.setHTML()')}} parses and sanitizes a string of HTML and immediately inserts it into the DOM as a child of the current element.
+The API has three main methods for sanitizing data:
+
+1. {{domxref('Element.setHTML()')}} parses and sanitizes a string of HTML and immediately inserts it into the DOM as a child of the current element.
   This is essentially "safe" version of {{domxref('Element.innerHTML')}}, and should be used instead of `innerHTML` when inserting untrusted data.
-- {{domxref('Sanitizer.sanitizeFor()')}} parses and sanitizes a string of HTML for later insertion into the DOM.
+2. {{domxref('Sanitizer.sanitizeFor()')}} parses and sanitizes a string of HTML for later insertion into the DOM.
   This might be used when the target element for the string is not always ready/available for update.
-- {{domxref('Sanitizer.sanitize()')}} sanitizes data that is in a {{domxref('Document')}} or {{domxref('DocumentFragment')}}.
+3. {{domxref('Sanitizer.sanitize()')}} sanitizes data that is in a {{domxref('Document')}} or {{domxref('DocumentFragment')}}.
   It might be used, for example, to sanitize a {{domxref('Document')}} instance in a frame.
 
 
@@ -109,7 +110,7 @@ console.log(sanitizedDiv.innerHTML)
 // At some point later ...
 
 // Get the element to update. This must be a div to match our sanitizeFor() context.
-// Set its content to be the children of our sanitized element. 
+// Set its content to be the children of our sanitized element.
 document.querySelector("div#target").replaceChildren(sanitizedDiv.children);
 ```
 
@@ -117,7 +118,7 @@ document.querySelector("div#target").replaceChildren(sanitizedDiv.children);
 > but you must remember to use the correct context when the string is applied:
 >
 > ```js
-> const unsanitized_string = "abc <script>alert(1)</script> def"; 
+> const unsanitized_string = "abc <script>alert(1)</script> def";
 > let sanitizedString = new Sanitizer().sanitizeFor("div", unsanitized_string).innerHTML;
 > ```
 

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -30,6 +30,7 @@ const capabilitiesPromise = imageCaptureObj.getPhotoCapabilities()
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with an object containing the following properties:
+
 - `redEyeReduction`
   - : Returns one of `"never"`, `"always"`, or `"controllable"`. The `"controllable"` value means the device's red-eye reduction is controllable by the user.
 - `imageHeight`

--- a/files/en-us/web/api/svg_api/index.md
+++ b/files/en-us/web/api/svg_api/index.md
@@ -14,6 +14,7 @@ tags:
 SVG provides elements for circles, rectangles, and simple and complex curves. The elements' attribute values specify how these must be drawn. The **SVG API** is the subset of the **DOM** connecting these SVG elements and their attribute values to scripts or programming languages by representing them in memory. The SVG API thus provides methods that allow programmatic access to the SVG elements and their attribute values.
 
 The SVG API is a set of interfaces that have been categorized into the following broad categories:
+
 1. [The element interfaces](#svg_element_interfaces) provide access to the properties of SVG elements and methods to manipulate them.
 2. [The static data type](#svg_data_type_interfaces) interfaces provide access to element attribute values and methods to manipulate them.
 3. For attributes that can be animated, the [animated data type interfaces](#svg_data_type_interfaces) provide read only access to the current animated value of an attribute.

--- a/files/en-us/web/api/xrcompositionlayer/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/index.md
@@ -20,6 +20,7 @@ browser-compat: api.XRCompositionLayer
 The **`XRCompositionLayer`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) is a base class that defines a set of common properties and behaviors for WebXR layer types. It is not constructable on its own.
 
 Several layer types inherit from `XRCompositionLayer`:
+
 - {{domxref("XREquirectLayer")}}
 - {{domxref("XRCubeLayer")}}
 - {{domxref("XRCylinderLayer")}}

--- a/files/en-us/web/api/xrcylinderlayer/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/index.md
@@ -21,7 +21,8 @@ The **`XRCylinderLayer`** interface of the [WebXR Device API](/en-US/docs/Web/AP
 
 `XRCylinderLayer` requires the `layers` feature to be enabled for the {{domxref("XRSession")}}. You can request it in {{domxref("XRSystem.requestSession()")}}.
 
-To create a new `XRCylinderLayer`, call either
+To create a new `XRCylinderLayer`, call either:
+
 - {{domxref("XRWebGLBinding.createCylinderLayer()")}} for a WebGL opaque texture layer, or
 - {{domxref("XRMediaBinding.createCylinderLayer()")}} for an HTML {{HTMLElement("video")}} playback layer.
 

--- a/files/en-us/web/api/xrequirectlayer/index.md
+++ b/files/en-us/web/api/xrequirectlayer/index.md
@@ -21,7 +21,8 @@ The **`XREquirectLayer`** interface of the [WebXR Device API](/en-US/docs/Web/AP
 
 `XREquirectLayer` requires the `layers` feature to be enabled for the {{domxref("XRSession")}}. You can request it in {{domxref("XRSystem.requestSession()")}}.
 
-To create a new `XREquirectLayer`, call either
+To create a new `XREquirectLayer`, call either:
+
 - {{domxref("XRWebGLBinding.createEquirectLayer()")}} for a WebGL opaque texture layer, or
 - {{domxref("XRMediaBinding.createEquirectLayer()")}} for an HTML {{HTMLElement("video")}} playback layer.
 

--- a/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
@@ -21,6 +21,7 @@ It is most useful for low-contrast textures such as background images, but less 
 ## Value
 
 A number between 0 and 1.
+
 - The minimum amount of foveation is indicated by 0 (full resolution).
 - The maximum amount of foveation is indicated by 1 (the edges render at lower resolution).
 

--- a/files/en-us/web/api/xrquadlayer/index.md
+++ b/files/en-us/web/api/xrquadlayer/index.md
@@ -21,7 +21,8 @@ The **`XRQuadLayer`** interface of the [WebXR Device API](/en-US/docs/Web/API/We
 
 `XRQuadLayer` requires the `layers` feature to be enabled for the {{domxref("XRSession")}}. You can request it in {{domxref("XRSystem.requestSession()")}}.
 
-To create a new `XRQuadLayer`, call either
+To create a new `XRQuadLayer`, call either:
+
 - {{domxref("XRWebGLBinding.createQuadLayer()")}} for a WebGL opaque texture quad layer, or
 - {{domxref("XRMediaBinding.createQuadLayer()")}} for an HTML {{HTMLElement("video")}} playback quad layer.
 

--- a/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
@@ -41,6 +41,7 @@ A {{domxref("XRWebGLSubImage")}} object.
 ### Exceptions
 
 A {{jsxref("TypeError")}} is thrown,
+
   - if `layer` is not in the [session's `layer` array](/en-US/docs/Web/API/XRSession/updateRenderState#setting_the_layers_array).
   - if `layer` is a {{domxref("XRProjectionLayer")}}.
   - if the layer's [`layout`](/en-US/docs/Web/API/XRCompositionLayer/layout) property is `default`.

--- a/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
@@ -34,6 +34,7 @@ A {{domxref("XRWebGLSubImage")}} object.
 ### Exceptions
 
 A {{jsxref("TypeError")}} is thrown,
+
   - if `layer` is not in the [session's `layer` array](/en-US/docs/Web/API/XRSession/updateRenderState#setting_the_layers_array).
 
 ## Examples

--- a/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
@@ -22,6 +22,7 @@ It is most useful for low contrast textures, such as background images but less 
 ## Value
 
 A number between 0 and 1.
+
 - The minium amount of foveation is indicated by 0 (full resolution).
 - The maximum amount of foveation is indicated by 1 (the edges render at lower resolution).
 

--- a/files/en-us/web/api/xsltprocessor/basic_example/index.md
+++ b/files/en-us/web/api/xsltprocessor/basic_example/index.md
@@ -52,6 +52,7 @@ The example above has two templates - one that matches the root node and one tha
 The template that matches the root node outputs the article's title and then says to process all templates (via `apply-templates`) that match `Author` nodes which are children of the `Authors` node.
 
 To try out the example:
+
 1. Create a directory in your file system and inside it create the files **example.xml** and **example.xsl** listed above
 1. [Start a local server](/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server#running_a_simple_local_http_server) in the directory containing the files.
    This allows you to browse the files in the directory as though they were hosted on the internet.

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -55,12 +55,14 @@ The `Origin` header is similar to the {{HTTPHeader("Referer")}} header, but does
 It is used to provide the "security context" for the origin request, except in cases where the origin information would be sensitive or unnecessary.
 
 Broadly speaking, user agents add the {{httpheader("Origin")}} request header to:
+
 - {{Glossary("CORS", "cross origin")}} requests.
 - [same-origin](/en-US/docs/Web/Security/Same-origin_policy) requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).
 
 There are some exceptions to the above rules; for example, if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in [no-cors mode](/en-US/docs/Web/API/Request/mode#value), the `Origin` header will not be added.
 
 The `Origin` header value may be `null` in a number of cases, including (non-exhaustively):
+
 - Origins whose scheme is not one of `http`, `https`, `ftp`, `ws`, `wss`, or `gopher` (including `blob`, `file` and `data`).
 - Cross-origin images and media data, including that in `<img>`, `<video>` and `<audio>` elements.
 - Documents created programmatically using `createDocument()`, generated from a `data:` url, or that do not have a creator browsing context. 

--- a/files/en-us/web/privacy/state_partitioning/index.md
+++ b/files/en-us/web/privacy/state_partitioning/index.md
@@ -251,6 +251,7 @@ State Partitioning mechanism in Firefox and it does not rely on temporary
 heuristics.
 
 Features disabled by the pref include:
+
 - [Storage access heuristics](#storage_access_heuristics): Unpartitioned storage
   access can only be aquired via the Storage Access API.
 - Automatic storage access grants:


### PR DESCRIPTION
Shouldn't affect rendering. Adjusted a few that didn't match the `:` trailing pattern leading into a list