### PR TITLE
Made a <dt> term a link

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/marquee_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/marquee_role/index.md
@@ -28,7 +28,7 @@ The marquee is required to have an accessible name.  Use [`aria-labelledby`](/en
 
   - : Defines when assistive technology should inform the user of updates to content. Elements with the role `marquee` have an implicit [aria-live](https://www.w3.org/TR/wai-aria-1.1/#aria-live) value of `off`, meaning screen readers will not announce changes inside the marquee, even when the user is idle.
 
-- [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or `aria-labelledby`
+- [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
 
   - : The `marquee` is required to have an accessible name.  Use `aria-labelledby` if a visible label is present, otherwise use `aria-label`.
 


### PR DESCRIPTION
should have been a link, but wasn't.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
