### PR TITLE
fix: MD042 empty links

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.md
@@ -80,7 +80,7 @@ Run the application and open your browser to <http://localhost:3000/>. Select th
 
 Currently most *dates* displayed on the site use the default JavaScript format (e.g. _Tue Oct 06 2020 15:49:58 GMT+1100 (AUS Eastern Daylight Time))_. The challenge for this article is to improve the appearance of the date display for `Author` lifespan information (date of death/birth) and for _BookInstance detail_ pages to use the format: Oct 6th, 2016.
 
-> **Note:** You can use the [same approach](#) as we used for the _Book Instance List_ (adding the virtual property for the lifespan to the `Author` model and use [luxon](https://www.npmjs.com/package/luxon) to format the date strings).
+> **Note:** You can use the same approach as we used for the _Book Instance List_ (adding the virtual property for the lifespan to the `Author` model and use [luxon](https://www.npmjs.com/package/luxon) to format the date strings).
 
 To complete this challenge, you must:
 

--- a/files/en-us/web/accessibility/aria/roles/link_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/link_role/index.md
@@ -16,9 +16,9 @@ A `link` widget provides an interactive reference to a resource. The target reso
 
 ## Description
 
-The `link` role is used to identify an element that creates a hyperlink to a resource that is in the application or external. 
+The `link` role is used to identify an element that creates a hyperlink to a resource that is in the application or external.
 
-When not using semantic HTML for its intended purpose, interactive features must be re-implemented. For example, when `role="link"` is added to an element, the <kbd>tab</kbd> key should enable giving focus to the link and the <kbd>enter</kbd> key should execute the link when focused. 
+When not using semantic HTML for its intended purpose, interactive features must be re-implemented. For example, when `role="link"` is added to an element, the <kbd>tab</kbd> key should enable giving focus to the link and the <kbd>enter</kbd> key should execute the link when focused.
 
 Use the {{HTMLattrXRef('tabindex')}} attribute with a value of `0` to ensure the link is in the correct tab focus order.
 
@@ -26,7 +26,7 @@ Use the {{HTMLattrXRef('tabindex')}} attribute with a value of `0` to ensure the
 
 ## Examples
 
-To recreate an accessible link using the `link` role on an element that is not an {{HTMLElement('a')}}, you need to ensure the link receives focus in the correct tab order, that the element looks like a link, and that the "link" behaves like a link. 
+To recreate an accessible link using the `link` role on an element that is not an {{HTMLElement('a')}}, you need to ensure the link receives focus in the correct tab order, that the element looks like a link, and that the "link" behaves like a link.
 
 ```html
 <span data-href="https://mozilla.org" tabindex="0" role="link">
@@ -75,15 +75,15 @@ function navigateLink(e) {
 }
 ```
 
-If the element with `role="link"` receives an <kbd>Enter</kbd> key event, this executes the link, going to the linked page or moving focus to the in page target. 
+If the element with `role="link"` receives an <kbd>Enter</kbd> key event, this executes the link, going to the linked page or moving focus to the in page target.
 
 Optionally, <kbd>Shift</kbd> + <kbd>F10</kbd> opens a context menu for the link.
 
 ## Best practices
 
-The various widget roles are used to define common interactive patterns. Similar to the document-structure roles, some of these roles, including the `link` role, duplicate the semantics of native HTML elements that are well supported, and should not be used. 
+The various widget roles are used to define common interactive patterns. Similar to the document-structure roles, some of these roles, including the `link` role, duplicate the semantics of native HTML elements that are well supported, and should not be used.
 
-Avoid using `link`, which we've included for completeness. The {{HTMLElement('a')}} semantic equivalent with accessible interactivity is available and supported. 
+Avoid using `link`, which we've included for completeness. The {{HTMLElement('a')}} semantic equivalent with accessible interactivity is available and supported.
 
 ### Prefer HTML
 
@@ -102,7 +102,7 @@ Using the {{HTMLElement('a')}} instead.
 - The {{HTMLElement('a')}} element
 - The {{HTMLElement('button')}} element
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
-- [ARIA practices `link` role examples]()
+- [ARIA practices `link` role examples](https://w3c.github.io/aria-practices/examples/link/link.html)
 
 <section id="Quick_links">
 

--- a/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
+++ b/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
@@ -71,7 +71,7 @@ async function fileHash(file) {
   // This gets us an array where each byte of the array buffer becomes one item in the array
   const uint8ViewOfHash = new Uint8Array(hashAsArrayBuffer);
   // We then convert it to a regular array so we can convert each item to hexadecimal strings
-  // Where to characters of 0-9 or a-f represent a number between 0 and 16, containing 4 bits of information, so 2 of them is 8 bits (1 byte). 
+  // Where to characters of 0-9 or a-f represent a number between 0 and 16, containing 4 bits of information, so 2 of them is 8 bits (1 byte).
   const hashAsString = Array.from(uint8ViewOfHash).map(b => b.toString(16).padStart(2, '0')).join('');
 	return hashAsString;
 }
@@ -187,7 +187,7 @@ async function hashTheseFiles(e) {
 
 {{EmbedLiveSample("how-git-stores-files")}}
 
-Notice how it uses the [Encoding API]() to produce the header, which is concatenated with the original ArrayBuffer to produce the string to be hashed.
+Notice how it uses the [Encoding API](/en-US/docs/Web/API/Encoding_API) to produce the header, which is concatenated with the original ArrayBuffer to produce the string to be hashed.
 
 ## How git generates commit hashes
 

--- a/files/en-us/web/api/xpathresult/resulttype/index.md
+++ b/files/en-us/web/api/xpathresult/resulttype/index.md
@@ -26,7 +26,7 @@ var resultType = result.resultType;
 
 ### Return value
 
-An integer value representing the type of the result, as defined by the [type constants](#).
+An integer value representing the type of the result, as defined by the type constants.
 
 ## Constants
 

--- a/files/en-us/web/html/attributes/rel/index.md
+++ b/files/en-us/web/html/attributes/rel/index.md
@@ -88,7 +88,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 - {{htmlattrdef("canonical")}}
   - : Valid for {{htmlelement('link')}}, it defines the preferred URL for the current document, which is useful for search engines.
 - {{htmlattrdef("dns-prefetch")}}
-  - : Relevant for the {{htmlelement('link')}} element both in the {{htmlelement('body')}} and {{htmlelement('head')}}, it tells the browser to preemptively perform DNS resolution for the target resource's origin. Useful for resources the user will likely need, it helps reduce latency and thereby improves performance when the user does access the resources as the browser preemptively performed DNS resolution for the origin of the specified resource. See [dns-prefetch](/en-US/docs/Web/Performance/dns-prefetch) described in resource hints.
+  - : Relevant for the {{htmlelement('link')}} element both in the {{htmlelement('body')}} and {{htmlelement('head')}}, it tells the browser to preemptively perform DNS resolution for the target resource's origin. Useful for resources the user will likely need, it helps reduce latency and thereby improves performance when the user does access the resources as the browser preemptively performed DNS resolution for the origin of the specified resource. See [dns-prefetch](/en-US/docs/Web/Performance/dns-prefetch) described in [resource hints](https://w3c.github.io/resource-hints/).
 - {{htmlattrdef("external")}}
   - : Relevant to {{htmlelement('form')}}, {{htmlelement('a')}}, and {{htmlelement('area')}}, it indicates the referenced document is not part of the current site. This can be used with attribute selectors to style external links in a way that indicates to the user that they will be leaving the current site.
 - {{htmlattrdef("help")}}

--- a/files/en-us/web/html/attributes/rel/index.md
+++ b/files/en-us/web/html/attributes/rel/index.md
@@ -88,7 +88,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 - {{htmlattrdef("canonical")}}
   - : Valid for {{htmlelement('link')}}, it defines the preferred URL for the current document, which is useful for search engines.
 - {{htmlattrdef("dns-prefetch")}}
-  - : Relevant for the {{htmlelement('link')}} element both in the {{htmlelement('body')}} and {{htmlelement('head')}}, it tells the browser to preemptively perform DNS resolution for the target resource's origin. Useful for resources the user will likely need, it helps reduce latency and thereby improves performance when the user does access the resources as the browser preemptively performed DNS resolution for the origin of the specified resource. See [dns-prefetch](/en-US/docs/Web/Performance/dns-prefetch) described in [resource hints]().
+  - : Relevant for the {{htmlelement('link')}} element both in the {{htmlelement('body')}} and {{htmlelement('head')}}, it tells the browser to preemptively perform DNS resolution for the target resource's origin. Useful for resources the user will likely need, it helps reduce latency and thereby improves performance when the user does access the resources as the browser preemptively performed DNS resolution for the origin of the specified resource. See [dns-prefetch](/en-US/docs/Web/Performance/dns-prefetch) described in resource hints.
 - {{htmlattrdef("external")}}
   - : Relevant to {{htmlelement('form')}}, {{htmlelement('a')}}, and {{htmlelement('area')}}, it indicates the referenced document is not part of the current site. This can be used with attribute selectors to style external links in a way that indicates to the user that they will be leaving the current site.
 - {{htmlattrdef("help")}}
@@ -105,7 +105,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 
     If there are multiple `<link rel="icon">`s, the browser uses their [`media`](media) attribute, [`type`](type), and [`sizes`](sizes) attributes to select the most appropriate icon. If several icons are equally appropriate, the last one is used. If the most appropriate icon is later found to be inappropriate, for example because it uses an unsupported format, the browser proceeds to the next-most appropriate, and so on.
 
-    > **Note:** Prior to Firefox 83 the [crossorigin](/en-US/docs/Web/HTML/Attributes/crossorigin) attribute was not supported for `rel="icon"` there is also [an open issue for Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1121645).
+    > **Note:** Prior to Firefox 83 the [crossorigin](/en-US/docs/Web/HTML/Attributes/crossorigin) attribute was not supported for `rel="icon"` there is also [an open issue for Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1121645).
 
     > **Note:** Apple's iOS does not use this link type, nor the [`sizes`](sizes) attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder.
     > Instead it uses the non-standard [`apple-touch-icon`](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4) and [`apple-touch-startup-image`](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6) respectively.


### PR DESCRIPTION
Doesn't fully fix it, as it still trips on some of the text in the macros
```
files/en-us/mdn/structures/page_types/api_reference_page_template/index.md:94:3 MD042/no-empty-links No empty links [Context: "[eventname1]()"]   
files/en-us/mdn/structures/page_types/api_reference_page_template/index.md:96:28 MD042/no-empty-links No empty links [Context: "[oneventname1]()"]
files/en-us/mdn/structures/page_types/api_reference_page_template/index.md:97:3 MD042/no-empty-links No empty links [Context: "[eventname2]()"]   
files/en-us/mdn/structures/page_types/api_reference_page_template/index.md:99:28 MD042/no-empty-links No empty links [Context: "[oneventname2]()"]
files/en-us/mozilla/firefox/releases/49/index.md:73:70 MD042/no-empty-links No empty links [Context: "[@@match]()"]
files/en-us/web/api/mediakeystatusmap/index.md:35:32 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md:64:40 MD042/no-empty-links No empty links [Context: "[fiuv]()"]
files/en-us/web/api/webgl2renderingcontext/index.md:90:91 MD042/no-empty-links No empty links [Context: "[v]()"]
files/en-us/web/api/webgl2renderingcontext/index.md:94:97 MD042/no-empty-links No empty links [Context: "[v]()"]
files/en-us/web/api/webgl2renderingcontext/index.md:111:88 MD042/no-empty-links No empty links [Context: "[fiuv]()"]
files/en-us/web/api/webgl2renderingcontext/index.md:143:98 MD042/no-empty-links No empty links [Context: "[if]()"]
files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md:35:64 MD042/no-empty-links No empty links [Context: "[v]()"]
files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md:39:71 MD042/no-empty-links No empty links [Context: "[fv]()"]
files/en-us/web/api/webglrenderingcontext/index.md:279:88 MD042/no-empty-links No empty links [Context: "[v]()"]
files/en-us/web/api/webglrenderingcontext/index.md:283:95 MD042/no-empty-links No empty links [Context: "[v]()"]
files/en-us/web/api/webglrenderingcontext/uniform/index.md:23:88 MD042/no-empty-links No empty links [Context: "[v]()"]
files/en-us/web/javascript/reference/global_objects/array/index.md:413:60 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/bigint64array/index.md:100:61 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/biguint64array/index.md:100:62 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/float32array/index.md:98:60 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/float64array/index.md:98:60 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/int16array/index.md:98:58 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/int32array/index.md:99:58 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/int8array/index.md:99:57 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/map/index.md:305:44 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md:105:61 MD042/no-empty-links No empty links [Context: "[@@replace]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md:106:60 MD042/no-empty-links No empty links [Context: "[@@search]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md:107:59 MD042/no-empty-links No empty links [Context: "[@@split]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md:120:59 MD042/no-empty-links No empty links [Context: "[@@match]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md:121:60 MD042/no-empty-links No empty links [Context: "[@@search]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md:122:59 MD042/no-empty-links No empty links [Context: "[@@split]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md:101:59 MD042/no-empty-links No empty links [Context: "[@@match]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md:102:61 MD042/no-empty-links No empty links [Context: "[@@replace]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md:103:59 MD042/no-empty-links No empty links [Context: "[@@split]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md:104:59 MD042/no-empty-links No empty links [Context: "[@@match]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md:105:61 MD042/no-empty-links No empty links [Context: "[@@replace]()"]
files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md:106:60 MD042/no-empty-links No empty links [Context: "[@@search]()"]
files/en-us/web/javascript/reference/global_objects/regexp/index.md:100:59 MD042/no-empty-links No empty links [Context: "[@@match]()"]
files/en-us/web/javascript/reference/global_objects/regexp/index.md:102:62 MD042/no-empty-links No empty links [Context: "[@@matchAll]()"]
files/en-us/web/javascript/reference/global_objects/regexp/index.md:104:61 MD042/no-empty-links No empty links [Context: "[@@replace]()"]
files/en-us/web/javascript/reference/global_objects/regexp/index.md:106:60 MD042/no-empty-links No empty links [Context: "[@@search]()"]
files/en-us/web/javascript/reference/global_objects/regexp/index.md:108:59 MD042/no-empty-links No empty links [Context: "[@@split]()"]
files/en-us/web/javascript/reference/global_objects/set/index.md:61:56 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:24:48 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:25:58 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:26:50 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:27:44 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:28:44 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:94:48 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:95:58 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:96:50 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:97:44 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md:98:44 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/symbol/match/index.md:60:47 MD042/no-empty-links No empty links [Context: "[@@match]()"]
files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md:20:134 MD042/no-empty-links No empty links [Context: "[@@matchAll]()"]
files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md:51:98 MD042/no-empty-links No empty links [Context: "[@@matchAll]()"]
files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md:65:50 MD042/no-empty-links No empty links [Context: "[@@matchAll]()"]
files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md:16:73 MD042/no-empty-links No empty links [Context: "[@@replace]()"]
files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md:52:49 MD042/no-empty-links No empty links [Context: "[@@replace]()"]
files/en-us/web/javascript/reference/global_objects/symbol/search/index.md:16:72 MD042/no-empty-links No empty links [Context: "[@@search]()"]
files/en-us/web/javascript/reference/global_objects/symbol/search/index.md:52:48 MD042/no-empty-links No empty links [Context: "[@@search]()"]
files/en-us/web/javascript/reference/global_objects/symbol/split/index.md:16:71 MD042/no-empty-links No empty links [Context: "[@@split]()"]
files/en-us/web/javascript/reference/global_objects/symbol/split/index.md:50:47 MD042/no-empty-links No empty links [Context: "[@@split]()"]
files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md:75:26 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/typedarray/index.md:235:26 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md:75:26 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/uint16array/index.md:99:59 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/uint32array/index.md:98:59 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/uint8array/index.md:99:58 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md:98:65 MD042/no-empty-links No empty links [Context: "[@@iterator]()"]
```