### PR TITLE
note that promise.all preserves order

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -58,7 +58,7 @@ input promises rejecting. In comparison, the promise returned by
 regardless of whether or not one rejects. Consequently, it will always return the final
 result of every promise and function from the input iterable.
 
-NOTE: The order of the promise array is preserved upon completion of this method.
+> **Note:** The order of the promise array is preserved upon completion of this method.
 
 ### Fulfillment
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -58,6 +58,8 @@ input promises rejecting. In comparison, the promise returned by
 regardless of whether or not one rejects. Consequently, it will always return the final
 result of every promise and function from the input iterable.
 
+NOTE: The order of the promise array is preserved upon completion of this method.
+
 ### Fulfillment
 
 The returned promise is fulfilled with an array containing **all** the


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add a note that order is preserved in `promise.all`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I've had to google this a few times and I would like to add it to the MDN docs.

When passing an array of promises, `.all` will resolve them in order. This is guaranteed according to things I've found around the when searching, and having this in MDN docs will be helpful for the broader community.
https://stackoverflow.com/a/28066851
https://www.karltarvas.com/2015/01/21/order-of-resolved-values-in-promise-all.html

This is my first time contributing to MDN and thus am very happy to make any changes to the proposed change. I just want this information added in some capacity.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://stackoverflow.com/a/28066851
https://www.karltarvas.com/2015/01/21/order-of-resolved-values-in-promise-all.html

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
