### PR TITLE
fix: MD031 space around code fences

### DIFF
--- a/files/en-us/learn/common_questions/what_are_browser_developer_tools/index.md
+++ b/files/en-us/learn/common_questions/what_are_browser_developer_tools/index.md
@@ -186,9 +186,11 @@ To see what happens, try entering the following snippets of code into the consol
 1.  ```js
     alert('hello!');
     ```
+
 2.  ```js
     document.querySelector('html').style.backgroundColor = 'purple';
     ```
+
 3.  ```js
     const myWordmark = document.createElement('img');
     myWordmark.setAttribute('src','https://blog.mozilla.org/press/wp-content/themes/OneMozilla/img/mozilla-wordmark.png');
@@ -200,9 +202,11 @@ Now try entering the following incorrect versions of the code and see what you g
 1.  ```js
     alert('hello!);
     ```
+
 2.  ```js
     document.cheeseSelector('html').style.backgroundColor = 'purple';
     ```
+
 3.  ```js
     const myWordmark = document.createElement('img');
     myBanana.setAttribute('src','https://blog.mozilla.org/press/wp-content/themes/OneMozilla/img/mozilla-wordmark.png');

--- a/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
@@ -143,6 +143,7 @@ Heading elements allow you to specify that certain parts of your content are hea
 <h3>My subheading</h3>
 <h4>My sub-subheading</h4>
 ```
+
 > **Note:** Anything in HTML between `<!--` and `-->` is a **HTML comment**. The browser ignores comments as it renders the code. In other words, they are not visible on the page - just in the code. HTML comments are a way for you to write helpful notes about your code or logic.
 
 Now try adding a suitable title to your HTML page just above your {{htmlelement("img")}} element.

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -296,6 +296,7 @@ The expression inside the `if( ... )` is the test. This uses the identity operat
 1.  ```js
     let myVariable = document.querySelector('h1');
     ```
+
 2.  ```js
     alert('hello!');
     ```

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.md
@@ -119,7 +119,7 @@ for (let i = 0; i < 100; i++) {
 }
 ```
 
-- `random(x)`, defined earlier in the code, returns a whole number between `0` and `x-1`.
+- `random(x)`, defined earlier in the code, returns a whole number between `0` and `x-1`.
 - `WIDTH` and `HEIGHT` are the width and height of the inner browser window.
 
 You should get the basic idea — we are using a loop to run 100 iterations of this code, each one of which draws a circle in a random position on the page.
@@ -231,6 +231,7 @@ for (initializer; condition; final-expression) {
   // code to run
 }
 ```
+
 Here we have:
 
 1. The keyword `for`, followed by some parentheses.
@@ -378,7 +379,7 @@ console.log(myFavoriteCats);     // "My cats are called Pete, Biggles, and Jasmi
 If you want to exit a loop before all the iterations have been completed, you can use the [break](/en-US/docs/Web/JavaScript/Reference/Statements/break) statement.
 We already met this in the previous article when we looked at [switch statements](/en-US/docs/Learn/JavaScript/Building_blocks/conditionals#switch_statements) — when a case is met in a switch statement that matches the input expression, the `break` statement immediately exits the switch statement and moves on to the code after it.
 
-It's the same with loops — a `break` statement will immediately exit the loop and make the browser move on to any code that follows it.
+It's the same with loops — a `break` statement will immediately exit the loop and make the browser move on to any code that follows it.
 
 Say we wanted to search through an array of contacts and telephone numbers and return just the number we wanted to find?
 First, some simple HTML — a text {{htmlelement("input")}} allowing us to enter a name to search for, a {{htmlelement("button")}} element to submit a search, and a {{htmlelement("p")}} element to display the results in:
@@ -420,7 +421,7 @@ btn.addEventListener('click', () => {
 {{ EmbedLiveSample('Exiting_loops_with_break', '100%', 100) }}
 
 1. First of all, we have some variable definitions — we have an array of contact information, with each item being a string containing a name and phone number separated by a colon.
-2. Next, we attach an event listener to the button (`btn`) so that when it is pressed some code is run to perform the search and return the results.
+2. Next, we attach an event listener to the button (`btn`) so that when it is pressed some code is run to perform the search and return the results.
 3. We store the value entered into the text input in a variable called `searchName`, before then emptying the text input and focusing it again, ready for the next search.
    Note that we also run the [`toLowerCase()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) method on the string, so that searches will be case-insensitive.
 5. Now on to the interesting part, the `for...of` loop:
@@ -474,10 +475,10 @@ Here's the output:
 
 {{ EmbedLiveSample('Skipping_iterations_with_continue', '100%', 100) }}
 
-1. In this case, the input should be a number (`num`). The `for` loop is given a counter starting at 1 (as we are not interested in 0 in this case), an exit condition that says the loop will stop when the counter becomes bigger than the input `num`, and an iterator that adds 1 to the counter each time.
-2. Inside the loop, we find the square root of each number using [Math.sqrt(i)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt), then check whether the square root is an integer by testing whether it is the same as itself when it has been rounded down to the nearest integer (this is what [Math.floor()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor) does to the number it is passed).
+1. In this case, the input should be a number (`num`). The `for` loop is given a counter starting at 1 (as we are not interested in 0 in this case), an exit condition that says the loop will stop when the counter becomes bigger than the input `num`, and an iterator that adds 1 to the counter each time.
+2. Inside the loop, we find the square root of each number using [Math.sqrt(i)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt), then check whether the square root is an integer by testing whether it is the same as itself when it has been rounded down to the nearest integer (this is what [Math.floor()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor) does to the number it is passed).
 3. If the square root and the rounded down square root do not equal one another (`!==`), it means that the square root is not an integer, so we are not interested in it. In such a case, we use the `continue` statement to skip on to the next loop iteration without recording the number anywhere.
-4. If the square root is an integer, we skip past the `if` block entirely, so the `continue` statement is not executed; instead, we concatenate the current `i` value plus a space on to the end of the paragraph content.
+4. If the square root is an integer, we skip past the `if` block entirely, so the `continue` statement is not executed; instead, we concatenate the current `i` value plus a space on to the end of the paragraph content.
 
 > **Note:** You can view the [full source code on GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/loops/integer-squares.html) too (also [see it running live](https://mdn.github.io/learning-area/javascript/building-blocks/loops/integer-squares.html)).
 
@@ -562,7 +563,7 @@ console.log(myFavoriteCats);     // "My cats are called Pete, Biggles, and Jasmi
 
 > **Note:** Again, this works just the same as expected — have a look at it [running live on GitHub](https://mdn.github.io/learning-area/javascript/building-blocks/loops/do-while.html) (also view the [full source code](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/loops/do-while.html)).
 
-> **Warning:** With while and do...while — as with all loops — you must make sure that the initializer is incremented or, depending on the case, decremented, so the condition eventually becomes false.
+> **Warning:** With while and do...while — as with all loops — you must make sure that the initializer is incremented or, depending on the case, decremented, so the condition eventually becomes false.
 > If not, the loop will go on forever, and either the browser will force it to stop, or it will crash. This is called an **infinite loop**.
 
 ## Active learning: Launch countdown
@@ -766,7 +767,7 @@ If you get really stuck, press "Show solution" to see a solution.
 <h2>Live output</h2>
 <div class="output" style="height: 100px;overflow: auto;">
   <p class="admitted">Admit: </p>
-  <p class="refused">Refuse: </p>
+  <p class="refused">Refuse: </p>
 </div>
 
 <h2>Editable code</h2>

--- a/files/en-us/learn/server-side/django/generic_views/index.md
+++ b/files/en-us/learn/server-side/django/generic_views/index.md
@@ -184,13 +184,14 @@ Each iteration populates the `book` template variable with information for the c
 ```
 
 You might also use the `{% empty %}` template tag to define what happens if the book list is empty (although our template chooses to use a conditional instead):
+
 ```html
 <ul>
   {% for book in book_list %}
     <li> <!-- code here get information from each book item --> </li>
   {% empty %}
     <p>There are no books in the library.</p>
-  {% endfor %}
+  {% endfor %}
 </ul>
 ```
 

--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.md
@@ -193,6 +193,7 @@ The following steps show how you can use NPM to download a package, save it into
     ```
 
 3.  Now install Express in the `myapp` directory and save it in the dependencies list of your **package.json** file
+
 4.  ```bash
     npm install express
     ```

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -327,6 +327,7 @@ Let's work through an exercise — in this example we will use a Fetch polyfill 
     ```
 
 4.  Inside the original {{htmlelement("script")}}, add the following code:
+
 5.  ```js
     var myImage = document.querySelector('.my-image');
 

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 > browser-compat: path.to.feature.NameOfTheConstructor
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**()**.

--- a/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.md
@@ -36,6 +36,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 > browser-compat: path.to.feature.NameOfTheEventHandler
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**.**_NameOfTheEventHandler_.

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > browser-compat: path.to.feature.NameOfTheEvent_event
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as "_NameOfTheParentInterface_**:** _NameOfTheEvent_ **event**".

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -31,6 +31,7 @@ tags:
 >   - Non-standard
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       This is the name of the API followed by the text "API": _NameOfTheAPI_ **API**.

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -35,6 +35,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 > browser-compat: path.to.feature.NameOfTheMethod
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**.**_NameOfTheMethod_**()**.

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -35,6 +35,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 > browser-compat: path.to.feature.NameOfTheProperty
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as _NameOfTheParentInterface_**.**_NameOfTheProperty_.

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -33,6 +33,7 @@ browser-compat: css.properties.NameOfTheProperty
 > browser-compat: css.properties.NameOfTheProperty
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page. Format as _NameOfTheProperty.
 >       For example, the [`background-color`](/en-US/docs/Web/CSS/background-color) property has a title of _background-color_.

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -33,6 +33,7 @@ browser-compat: css.selectors.NameOfTheSelector
 > browser-compat: css.selectors.NameOfTheSelector
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page. Format as _:NameOfTheSelector_.
 >       For example, the [`:hover`](/en-US/docs/Web/CSS/:hover) selector has a title of _:hover_.

--- a/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
@@ -26,6 +26,7 @@ tags:
 >   - The term
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as: `Term being defined`.

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > browser-compat: html.elements.NameOfTheElement
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as `'<NameOfTheElement>: Description of element's purpose'`.

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -35,6 +35,7 @@ browser-compat: path.to.feature.NameOfTheHeader
 > browser-compat: path.to.feature.NameOfTheHeader
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page. Format as _NameOfTheHeader_. For example, the [Cache-Control](/en-US/docs/Web/HTTP/Headers/Cache-Control) header has a _title_ of `Cache-Control`.
 > - **slug**

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -34,6 +34,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > browser-compat: svg.elements.NameOfTheElement
 > ---
 > ```
+>
 > - **title**
 >   - : Title heading displayed at top of page.
 >       Format as **<**_NameOfTheElement_**>**.

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
@@ -76,9 +76,11 @@ The only mandatory key is `default_icon`.
 There are two ways to specify a page action: with or without a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups).
 
 - **Without a popup:** When the user clicks the button, an event is dispatched to the extension, which the extension listens for using [`pageAction.onClicked`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked "Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup."):
+
 - ```js
   browser.pageAction.onClicked.addListener(handleClick);
   ```
+
 - **With a popup:** the `click` event is not dispatched. Instead, the popup appears when the user clicks the button. The user then interacts with the popup. When the user clicks outside of the popup, it closes automatically. See the [Popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups) article for more details on creating and managing popups.
 
 Note that your extension can have just one page action.

--- a/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
@@ -35,6 +35,7 @@ Using only the accessible name, e.g., from content or via `aria-label` is almost
   <img alt="3 out of 5 stars" src="three_stars.png">
 </button>
 ```
+
 A braille display may display "btn \**\*" in Braille rather than the more verbose "btn gra 3 out of 5 stars".
 
 ## Values

--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -22,6 +22,7 @@ The `mixed` value is not supported on [`radio`](/en-US/docs/Web/Accessibility/AR
 <span role="checkbox" id="checkBoxInput" aria-checked="false" tabindex="0" aria-labelledby="chk15-label"></span> 
 <label id="chk15-label">Subscribe to the newsletter</label>
 ```
+
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
 
 The `tabindex` attribute is required to enable focus. JavaScript is required to toggle the `aria-checked` state. And, if this checkbox is part of a submittable form, more JavaScript is required to set a name and a value.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
@@ -132,6 +132,7 @@ The following is an example of part of a bowling tournament league scoring sprea
         <span role="cell">18</span>  
       ...
 ```
+
 If we had used a {{HTMLElement('table')}} and semantic table elements our markup would have been less verbose and accessible by default.
 
 ## Values

--- a/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
@@ -60,6 +60,7 @@ The breadcrumb for the "current page" should have `aria-current="page"` set on i
   </ol>
 </nav>
 ```
+
 If the element representing the current page in the breadcrumb was not a link, the `aria-current` is optional.
 
 ## Values

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -43,6 +43,7 @@ While adding `disabled` to an HTML form control causes `:disabled` user-agent st
   opacity: 0.5;
 }
 ```
+
 > **Note:** If you are using CSS's [`pointer-events: none;`](/en-US/docs/Web/CSS/pointer-events) to make an element non-clickable, make sure you disable interactivity with JavaScript as well. `pointer-events: none;` prevents mouse clicks, but does not prevent the element from being activated via the keyboard.
 
 ```js

--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -87,6 +87,7 @@ The `aria-keyshortcuts` attribute is very similar to the [problematic](https://w
 <strong><u>S</u></strong>tress reliever!</p>
 <button accesskey="s">Stress reliever</button>
 ```
+
 In this example, we ensured the presence of the shortcut was known to sited users a well by highlighting the non-modifier character.
 
 While the goal of the `accesskey` attribute matches the intention of `aria-keyshortcuts` and to do so natively, `accesskey` is rife with issues. Because of these issues, it is generally advised not to use accesskeys for most general-purpose websites and web apps.

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -23,6 +23,7 @@ In cases where an interactive element has no accessible name, or an accessible n
   <svg aria-hidden="true" focusable="false" width="17" height="17" xmlns="http://www.w3.org/2000/svg"><path d="m.967 14.217 5.8-5.906-5.765-5.89L3.094.26l5.783 5.888L14.66.26l2.092 2.162-5.766 5.889 5.801 5.906-2.092 2.162-5.818-5.924-5.818 5.924-2.092-2.162Z" fill="#000"/></svg>
 </button>
 ```
+
 > **Note:** `aria-label` is intended for use on interactive elements, or elements made to be interactive via other ARIA declarations, when there is no appropriate text visible in the DOM that could be referenced as a label
 
 Most content has an accessible name generated from its immediate wrapping element's text content. Accessible names can also be created by certain attributes or associated elements.

--- a/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
@@ -29,6 +29,7 @@ The `aria-level` attribute is a required attribute of the [`heading`](/en-US/doc
 ```html
 <div role="heading" aria-level="3">Heading for this sub section</div>
 ```
+
 Opt for using the {{htmlelement('h1')}} thru {{htmlelement('h6')}} elements instead.
 
 ### Within `treegrid` role

--- a/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
@@ -29,6 +29,7 @@ The following example shows a listbox with four element options out of the 118 i
   <li role="option" aria-setsize="118" aria-posinset="19">Potassium</li>
 </ul>
 ```
+
 The value of each `aria-posinset` is an integer greater than or equal to `1`, and less than or equal to the size of the set when that size is known.
 
 > **Note:** When using `aria-posinset` you must also include  value for [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize), which is the size of the entire set. If the size of the entire set is unknown, set `aria-setsize="-1"`.

--- a/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
@@ -36,6 +36,7 @@ The attribute should be added to the form-control role. If the user needs to fil
 <div id="tbLabel">Email Address (required)</>
 <div role="textbox" contenteditable aria-labelledby="tblabel" aria-required="true" id="email1"></div>
 ```
+
 In this example, JavaScript must be used to prevent the containing form from being sumbmitted if the textbox has no content.
 
 This could be written semantically, without the need for JavaScript:

--- a/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
@@ -54,6 +54,7 @@ This table loads with the last name column sorted in ascending order.
   ... <!-- the <tbody> -->
 </table>
 ```
+
 If the user clicks on the last name button, [`aria-pressed="true"`](/en-us/web/accessibility/aria/attributes/aria-pressed) would be added to the {{HTMLElement('button')}} element and the `aria-sort` value would be toggled to `"descending"` with JavaScript. If the user clicks on a different header button, the `aria-sort` button would be removed `aria-sort` from the last name header to be placed on the clicked button's {{HTMLElement('th')}} parent.
 
 We provided instructions in the caption for assistive technology who may not see the down arrows that we would add with CSS targeting the  `th[aria-sort="ascending"]` and `th[aria-sort="descending"]` seletors.

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -39,6 +39,7 @@ If an element has `role="alert"` and `display: none;` set, when the [`display`](
 ```html
 <p role="alert" style="display: none;">This alert will trigger when the element becomes visible.</p>
 ```
+
 While triggering an alert via CSS alone is possible, it is better to rely on JavaScript because it has more browser/screen reader support and is often more appropriate as part of a larger user interaction, such as inside an event handler or form validation.
 
 With JavaScript, developers control the adding and removing of alerts as appropriate.
@@ -93,6 +94,7 @@ Sometimes it is useful to add an `alert` role to an element that is already visi
 ```html
 <p id="formInstruction">You must select at least 3 options</p>
 ```
+
 ```js
 // When the user tries to submit the form with less than 3 checkboxes selected:
 document.getElementById("formInstruction").setAttribute("role", "alert");
@@ -107,9 +109,11 @@ If an element already has `role="alert"` and is initially hidden using CSS, maki
   display:none;
 }
 ```
+
 ```html
 <p id="expirationWarning" role="alert" class="hidden">Your log in session will expire in 2 minutes</p>
 ```
+
 ```js
 // removing the 'hidden' class makes the element visible, which will make the screen reader announce the alert:
 document.getElementById("expirationWarning").classList.remove('hidden'); 

--- a/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -49,6 +49,7 @@ The `alertdialog` must have an accessible name, defined with [`aria-labelledby`]
   </div>
 </div>
 ```
+
 The code snippet above shows how to mark up an alert dialog that only provides a message and an OK button.
 
 ### Example 2: Confirmation dialog with two options

--- a/files/en-us/web/accessibility/aria/roles/img_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/img_role/index.md
@@ -86,6 +86,7 @@ Another example where this might be suitable is when using ASCII emoji combinati
   </p>
 </div>
 ```
+
 If `aria-labelledby` were used, the screen reader would read it. In this case, only the contents of the `aria-label` are announced to screen reader users, hiding the jibberish of the characters without the need for descendant ARIA to hide things, but also hiding potential content that may be part of the image.
 
 ### Associated WAI-ARIA Roles, States, and Properties

--- a/files/en-us/web/accessibility/aria/roles/separator_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/separator_role/index.md
@@ -29,6 +29,7 @@ A non-focusable separator is a static structural element that can be used to hel
 <h2>Two years later, my second post</h2>
   ....
 ```
+
 In the example, an image creates a visual separator between two blog posts. The author could have used a semantic thematic break {{HTMLElement('hr')}} element and styled it with CSS to make it blue (and not have to change the image when they change the blog's theme), or the author could have encompassed each post in the semantic {{HTMLElement('article')}} element, or both.
 
 ```html

--- a/files/en-us/web/accessibility/aria/roles/term_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/term_role/index.md
@@ -49,7 +49,9 @@ Including better semantics, the above could also be written:
   <dfn role="term">Mansplaining</dfn>, <span role="definition">a portmanteau of "man" and "explain", is the patronizing act of explaining without being asked to do so, to someone already learned on the topic, often after someone has already explained it</span>. 
 </p>
 ```
+
 or without any ARIA (but possibly not how you want it presented)
+
 ```html
 <dl>
   <dt>Mansplaining</dt>

--- a/files/en-us/web/api/angle_instanced_arrays/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/index.md
@@ -40,6 +40,7 @@ This extension exposes three new methods.
 
 The following example shows how to draw a given geometry multiple times with a single draw call.
 > **Warning:** The following is educational, not production level code. It should generally be avoided to construct data / buffers within the rendering loop or right before use.
+
 ```js
 // enable the extension
 const ext = gl.getExtension('ANGLE_instanced_arrays');

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -117,6 +117,7 @@ affixScriptToHead("myScript2.js", function () { alert("The script \"myScript2.js
 {{domxref("HTMLScriptElement.supports()")}} provides a unified mechanism for checking whether a browser supports particular types of scripts.
 
 The example below shows how to check for module support, using the existance of the `noModule` attribute as a fallback.
+
 ```js
 function checkModuleSupport() {
   if ('supports' in HTMLScriptElement) {

--- a/files/en-us/web/api/treewalker/index.md
+++ b/files/en-us/web/api/treewalker/index.md
@@ -55,6 +55,7 @@ _This interface doesn't inherit any method._
   - : Moves the current {{domxref("Node")}} to the first _visible_ ancestor node in the document order, and returns the found node. It also moves the current node to this one. If no such node exists, or if it is before that the _root node_ defined at the object construction, returns `null` and the current node is not changed.
 - {{domxref("TreeWalker.firstChild()")}}
   - : Moves the current {{domxref("Node")}} to the first _visible_ child of the current node, and returns the found child. It also moves the current node to this child. If no such child exists, returns `null` and the current node is not changed. Note that the node returned by `firstChild()` is dependent on the value of `whatToShow` set during instantiation of the `TreeWalker` object. Assuming the following HTML tree, and if you set the `whatToShow` to `NodeFilter.SHOW_ALL` a call to `firstChild()` will return a `Text` node and not an `HTMLDivElement` ojbect.
+
   ```html
   <!DOCTYPE html>
   <html>
@@ -64,6 +65,7 @@ _This interface doesn't inherit any method._
     </body>
   </html>
   ```
+
   ```js
   let walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ALL);
   let node = walker.firstChild(); // nodeName: "#text"
@@ -71,6 +73,7 @@ _This interface doesn't inherit any method._
   let walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
   let node = walker.firstChild(); // nodeName: "DIV"
   ```
+
   The same applies to `nextSibling()`, `previousSibling()`, `firstChild()` and `lastChild()`
 - {{domxref("TreeWalker.lastChild()")}}
   - : Moves the current {{domxref("Node")}} to the last _visible_ child of the current node, and returns the found child. It also moves the current node to this child. If no such child exists, `null` is returned and the current node is not changed.

--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -46,6 +46,7 @@ h3::before {
   counter-increment: section; /* Increment the value of section counter by 1 */
 }
 ```
+
 You can specify the value to increment or decrement the counter after the counter name, using a positive or negative number.
 
 The counter's name must not be `none`, `inherit`, or `initial`; otherwise the declaration is ignored.

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -29,6 +29,7 @@ It is also relatively "privacy-preserving", in that it is up to the client to de
 There is a small set of [low entropy client hint headers](#low_entropy_hints) that may be sent by a client event if not requested.
 
 > **Note:** Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) attribute.
+>
 > ```html
 > <meta http-equiv="Accept-CH" content="Width, Downlink, Sec-CH-UA">
 > ```

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -405,6 +405,7 @@ Access-Control-Expose-Headers: X-My-Custom-Header, X-Another-Custom-Header
 ### Access-Control-Max-Age
 
 The {{HTTPHeader("Access-Control-Max-Age")}} header indicates how long the results of a preflight request can be cached. For an example of a preflight request, see the above examples.
+
 ```
 Access-Control-Max-Age: <delta-seconds>
 ```

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -75,6 +75,7 @@ The `Origin` header value may be `null` in a number of cases, including (non-exh
 ```http
 Origin: https://developer.mozilla.org
 ```
+
 ```http
 Origin: http://developer.mozilla.org:80
 ```

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -68,6 +68,7 @@ instance ensuring that the user is not served a lower-quality image from the cac
 ### With `Save-Data: on`
 
 Request:
+
 ```
 GET /image.jpg HTTP/1.0
 Host: example.com

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -60,6 +60,7 @@ Sec-CH-UA-Mobile: ?0
 ```
 
 A browser on a mobile device would usually send requests with the following header:
+
 ```http
 Sec-CH-UA-Mobile: ?1
 ```

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -79,12 +79,15 @@ They also have an intentionally incorrect brand string, which may appear in any 
 ```http
 Sec-CH-UA: "(Not(A:Brand";v="8", "Chromium";v="98"
 ```
+
 ```http
 Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
 ```
+
 ```http
 Sec-CH-UA: " Not A;Brand";v="99", "Chromium";v="96", "Microsoft Edge";v="96"
 ```
+
 ```http
 Sec-CH-UA: "Opera";v="81", " Not;A Brand";v="99", "Chromium";v="95"
 ```

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -93,6 +93,7 @@ This blocks access to pages or subdomains that can only be served over HTTP.
 ```http
 Strict-Transport-Security: max-age=31536000; includeSubDomains
 ```
+
 If a `max-age` of 1 year is acceptable for a domain, however, two years is the recommended value as explained on <https://hstspreload.org>.
 
 In the following example, `max-age` is set to 2 years, and is suffixed with `preload`, which is necessary for inclusion in most major web browsers' HSTS preload lists, like Chromium, Edge, and Firefox.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -45,6 +45,7 @@ The client is expected to select the most secure of the challenges it understand
 
 At least one challenge must be specified.
 Multiple challenges may be specified, comma-separated, in a single header, or in individual headers:
+
 ```http
 // Challenges specified in single header
 WWW-Authenticate: challenge1, ..., challengeN

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
@@ -198,9 +198,11 @@ Here's a non-exhaustive list of built-in methods and operators that might cause 
 
 - {{jsxref("Operators/Unary_negation", "- (unary negation)")}}
   - : Consider the following example:
+
       ```js
       let stoppingForce = obj.mass * -obj.velocity;
       ```
+
       If `obj.velocity` is `0` (or computes to `0`), a `-0` is introduced at that place and propagates out into `stoppingForce`.
 - {{jsxref("Math.atan2")}}, {{jsxref("Math.ceil")}}, {{jsxref("Math.pow")}}, {{jsxref("Math.round")}}
   - : In some cases,it's possible for a `-0` to be introduced into an expression as a return value of these methods even when no `-0` exists as one of the parameters. For example, using {{jsxref("Math.pow")}} to raise {{jsxref("Infinity", "-Infinity")}} to the power of any negative, odd exponent evaluates to `-0`. Refer to the documentation for the individual methods.

--- a/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
@@ -83,6 +83,7 @@ let obj = {
 
 // SyntaxError: invalid regular expression flag "W"
 ```
+
 An expression containing two slashes is interpreted as a regular expression literal.
 Most likely the intent was to create a string literal, using single or double quotes as shown below:
 

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -50,15 +50,18 @@ Note the following when working with the `get` syntax:
   change: literal getter and setter functions must now have exactly zero or one
   arguments](https://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/) for more information);
 - It must not appear in an object literal with another `get` e.g. the following is forbidden
+
   ```js example-bad
-  { 
-    get x() { }, get x() { } 
+  {
+    get x() { }, get x() { }
   }
   ```
+
 - It must not appear with a data entry for the same property e.g. the following is forbidden
+
   ```js example-bad
-  { 
-    x: ..., get x() { } 
+  {
+    x: ..., get x() { }
   }
   ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -295,12 +295,14 @@ Shallow copy using [spread sequence](/en-US/docs/Web/JavaScript/Reference/Operat
 let shallowCopySpread = [...fruits]
 // ["Strawberry", "Mango"]
 ```
+
 Shallow copy using {{jsxref("Array.slice()")}}:
 
 ```js
 let shallowCopySlice = fruits.slice()
 // ["Strawberry", "Mango"]
 ```
+
 Shallow copy using {{jsxref("Array.from()")}}:
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -68,10 +68,12 @@ Intl.supportedValuesOf("calendar").forEach(function(calendar) {
    // "buddhist", "chinese", "coptic", "dangi", ...
 });
 ```
+
 > **Note:** The array returned for calendar values will always include the value "gregory" (gregorian).
 
 
 The other values are all obtained in the same way:
+
 ```js
 Intl.supportedValuesOf("collation").forEach(function(collation) {
    // "big5han", "compat", "dict", "emoji", ...

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -335,9 +335,11 @@ drawChart({
 ```
 
 > **Note:** In the function signature for **`drawChart`** above, the destructured left-hand side is assigned to an empty object literal on the right-hand side:
+>
 > ```js
 > {size = 'big', coords = {x: 0, y: 0}, radius = 25} = {}
 > ```
+>
 > You could have also written the function without the right-hand side assignment.
 > However, if you leave out the right-hand side assignment, the function will look for at least one argument to be supplied when invoked, whereas in its current form, you can call **`drawChart()`** without supplying any parameters.
 > The current design is useful if you want to be able to call the function without supplying any parameters. The other can be useful when you want to ensure an object is passed to the function.


### PR DESCRIPTION
There is also a newer option to skip the spacing inside lists, but that wasn't used here