### PR TITLE
fix: quad backtick fences

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.md
@@ -67,6 +67,7 @@ const greeting = "I'm a good example";
 const greeting = "I'm a bad example";
 ```
 ````
+
 These will be rendered as:
 
 ```js example-good

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -102,7 +102,7 @@ browser.alarms.create({
 });
 
 browser.alarms.onAlarm.addListener(copy);
-````
+```
 
 Depending on the browser, this may not work. On Firefox, it will not work, and you'll see a message like this in your console:
 

--- a/files/en-us/web/accessibility/architecture/index.md
+++ b/files/en-us/web/accessibility/architecture/index.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-slug: Web/Accessibility/Architecture 
+slug: Web/Accessibility/Architecture
 tags:
   - Accessibility
   - Developing Mozilla
@@ -37,9 +37,9 @@ While it is odd to call non-link objects a link, this was a necessary compromise
 
 Take the following HTML code:
 
-````html
-     <div>Hello<a href="http://www.mozilla.org/access">My link<img src="image.gif">is cool</a>Bye</div>
-````
+```html
+<div>Hello<a href="http://www.mozilla.org/access">My link<img src="image.gif">is cool</a>Bye</div>
+```
 
 Both the {{HTMLElement('a')}} and {{HTMLElement('img')}} are hyperlinks Also, both the {{HTMLElement('div')}} and {{HTMLElement('a')}} are hypertexts So the {{HTMLElement('a')}} is both a hypertext and a hyperlink, because it contains text and is contained within text.
 

--- a/files/en-us/web/accessibility/aria/roles/img_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/img_role/index.md
@@ -95,7 +95,7 @@ If `aria-labelledby` were used, the screen reader would read it. In this case, o
 
 ## Examples
 
-````html
+```html
 <span role="img" aria-label="Rating: 4 out of 5 stars">
     <span>★</span>
     <span>★</span>
@@ -103,7 +103,7 @@ If `aria-labelledby` were used, the screen reader would read it. In this case, o
     <span>★</span>
     <span>☆</span>
 </span>
-````
+```
 
 
 ## Specifications

--- a/files/en-us/web/accessibility/aria/roles/math_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/math_role/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'ARIA: math role'
 slug: Web/Accessibility/ARIA/Roles/math_role
-tags: 
+tags:
   - Accessibility
   - ARIA
   - roles
@@ -32,17 +32,17 @@ If you use image or non-semantic HTML to create an equation, use the `math` role
 
 The above pythagorean theorem is written accessibly as:
 
-````html
+```html
 <div role="math" aria-label="a^{2} + b^{2} = c^{2}">
    a<sup>2</sup> + b<sup>2</sup> = c<sup>2</sup>
 </div>
-````
+```
 
 Had an image been used, the `alt` attribute would be used along with the `math` role:
 
-````html
+```html
 <img src="pythagorean_theorem.gif" alt="a^{2} + b^{2} = c^{2}" role="math">
-````
+```
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/roles/note_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/note_role/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'ARIA: note role'
 slug: Web/Accessibility/ARIA/Roles/note_role
-tags: 
+tags:
   - Accessibility
   - ARIA
   - roles
@@ -23,7 +23,7 @@ The `note` role can be added to parenthetic or ancillary content if no other nat
 
 ## Examples
 
-````html
+```html
 <h1>Madam C. J. Walker</h1>
 <p>Madam C.J. Walker was an African American entrepreneur, philanthropist, and political and social activist.</p>
 <h2>Early Life</p>
@@ -33,7 +33,8 @@ The `note` role can be added to parenthetic or ancillary content if no other nat
 <p role="note" class="hilitebox">At the height of the depression, Madam C. J. Walker trained 20,000 women to sell hair pomade door-to-door</p>
 <h2>Activism and Philanthropy</h2>
 ....
-````
+```
+
 If the above Wikipedia style entry for Madam C.J. Walker, the hilite box `note` could have been a {{HTMLElement('blockquote')}} if it contained a quote or {{HTMLElement('figcaption')}} in a {{HTMLElement('figure')}} if there was an associated image. In this case, as neither of those made sense, the `note` role was added to add semantics to the parenthetic content.
 
 ## Specifications

--- a/files/en-us/web/accessibility/aria/roles/presentation_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/presentation_role/index.md
@@ -24,7 +24,7 @@ When an element has required descendents, such as the various {{HTMLElement('tab
 
 If `presentation` or `none` is applied to a {{HTMLElement('table')}}  element, the descendant {{HTMLElement('caption')}}, {{HTMLElement('thead')}}, {{HTMLElement('tbody')}}, {{HTMLElement('tfoot')}}, {{HTMLElement('tr')}}, {{HTMLElement('th')}}, and {{HTMLElement('td')}} elements inherit the role and are thus not exposed to assistive technologies. But, elements inside of the {{HTMLElement('th')}} and {{HTMLElement('td')}} elements, including nested tables, are exposed to assistive technologies.
 
-````html
+```html
 <ul role="presentation">
   <li>
     <a href="#">Link 1</a>
@@ -36,7 +36,7 @@ If `presentation` or `none` is applied to a {{HTMLElement('table')}}  element, t
     <a href="#">Link 3</a>
   </li>
 </ul>
-````
+```
 
 Because the `presentation` role was applied to the {{HTMLElement('ul')}} element, every child {{HTMLElement('li')}} element inherits the `presentation` role. This is because ARIA requires the `listitem` elements to have a parent `list` element. While the {{HTMLElement('li')}}  elements, in this case, are not exposed to assistive technologies, descendants of those required elements are exposed. If we had nested a list within one of those {{HTMLElement('li')}}'s, they would be visible to assistive technologies. For elements with no required children, any elements nested inside the element with `role="presentation"` or `role="none"` preserve their semantics.  In this case, the {{HTMLElement('a')}} elements contained inside of those {{HTMLElement('li')}} elements are exposed.
 

--- a/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'ARIA: tooltip role'
 slug: Web/Accessibility/ARIA/Roles/tooltip_role
-tags: 
+tags:
   - Accessibility
   - ARIA
   - roles
@@ -38,7 +38,7 @@ The accessible name of a tooltip can come from the contents, or from an [`aria-l
 
 * The element that serves as the tooltip container has `role="tooltip"` set.
 * The element that triggers the tooltip references the tooltip element with [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby).
-  
+
 ### Keyboard interactions
 
 - <kbd>Escape</kbd>
@@ -73,11 +73,11 @@ The tooltip should appear on focus or when the element is hovered on, without ke
     <li>Unique to this website</li>
   </ul>
 </div>
+```
 
-````
 The tooltip can be instantiated with CSS. Change the class name with JavaScript to a class that hides the tooltip if the user hits the <kbd>Escape</kbd> key.
 
-````css
+```css
 [role=tooltip],
 .hidetooltip.hidetooltip.hidetooltip + [role=tooltip] {
   visibility: hidden;
@@ -95,7 +95,8 @@ The tooltip can be instantiated with CSS. Change the class name with JavaScript 
 [aria-describedby]:focus + [role=tooltip] {
  visibility: visible;
 }
-````
+```
+
 The above hides the tooltip with CSS in the default state or if the hidetooltip class has been added with JavaScript (when the user hit <kbd>Escape</kbd>), with high specificity to ensure the tooltip doesn't show. When the owning element receives focus, it gets positioned relatively and the tooltip becomes visible.
 
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -142,7 +142,7 @@ The output might look like:
 ```plain
 before: Uint8ClampedArray(4) [ 1, 127, 255, 1 ]
 after: Uint8ClampedArray(4) [ 255, 255, 255, 1 ]
-````
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/characterdata/data/index.md
+++ b/files/en-us/web/api/characterdata/data/index.md
@@ -39,7 +39,7 @@ output.value = comment.data;
 
 ```html
 <span>Result: </span>Not set.
-````
+```
 
 ```js
 let span = document.getElementsByTagName("span")[0];

--- a/files/en-us/web/api/event/composed/index.md
+++ b/files/en-us/web/api/event/composed/index.md
@@ -93,7 +93,7 @@ Whereas the `<closed-shadow>` element's composed path is a follows:
 
 ```plain
 Array [ closed-shadow, body, html, HTMLDocument https://mdn.github.io/web-components-examples/composed-composed-path/, Window ]
-````
+```
 
 In the second case, the event listeners only propagate as far as the
 `<closed-shadow>` element itself, but not to the nodes inside the

--- a/files/en-us/web/api/event/initevent/index.md
+++ b/files/en-us/web/api/event/initevent/index.md
@@ -60,7 +60,7 @@ elem.addEventListener('click', function (e) {
 }, false);
 
 elem.dispatchEvent(event);
-````
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/navigator/setappbadge/index.md
+++ b/files/en-us/web/api/navigator/setappbadge/index.md
@@ -18,7 +18,7 @@ The **`setAppBadge()`** method of the {{domxref("Navigator")}} interface a badge
 
 ```js
 let promise = Navigator.setAppBadge(contents);
-````
+```
 
 ### Parameters
 

--- a/files/en-us/web/http/cors/errors/index.md
+++ b/files/en-us/web/http/cors/errors/index.md
@@ -33,7 +33,7 @@ The text of the error message will be something similar to the following:
 Cross-Origin Request Blocked: The Same Origin Policy disallows
 reading the remote resource at https://some-url-here. (Reason:
 additional information here).
-````
+```
 
 > **Note:** For security reasons, specifics about what went wrong with a CORS request _are not available to JavaScript code_. All the code knows is that an error occurred. The only way to determine what specifically went wrong is to look at the browser's console for details.
 

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -18,7 +18,7 @@ When used, those functions only accept non-spoofable, typed values created by Tr
 
 ```
 Content-Security-Policy: require-trusted-types-for 'script';
-````
+```
 
 - `'script'`
   - : Disallows using strings with DOM XSS injection sink functions, and requires matching types created by Trusted Type policies.

--- a/files/en-us/web/http/methods/delete/index.md
+++ b/files/en-us/web/http/methods/delete/index.md
@@ -79,7 +79,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
     <h1>File deleted.</h1>
   </body>
 </html>
-````
+```
 
 ## Specifications
 


### PR DESCRIPTION
Some unbalanced that affect IDE highlighting.
Left a few for the nested code fences