### PR TITLE
Add reportValidity to example and to explanation

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -430,6 +430,7 @@ const email = document.getElementById("mail");
 email.addEventListener("input", function (event) {
   if (email.validity.typeMismatch) {
     email.setCustomValidity("I am expecting an e-mail address!");
+    email.reportValidity();
   } else {
     email.setCustomValidity("");
   }
@@ -438,7 +439,7 @@ email.addEventListener("input", function (event) {
 
 Here we store a reference to the email input, then add an event listener to it that runs the contained code each time the value inside the input is changed.
 
-Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
+Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message which is displayed by calling {{domxref("HTMLInputElement#methods","reportValidity()")}}. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
 
 If the `validity.typeMismatch` property returns `false`, we call the `setCustomValidity()` method an empty string. This renders the input valid, so the form will submit.
 


### PR DESCRIPTION
#### Summary
This PR adds ```reportValidity``` to the "Implementing a customized error message" Form Validation code sample in order for it to work as described, as mentioned in #12110. It also adds a brief explanation.

#### Motivation
The guide in the issue did not work as intended which might confuse some people. Both the code snippet and the explanation now work as described.

#### Supporting details
Curiously, the MDN page for this does not exist (it should be at the very bottom of the table found at the link below):
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#methods

The WHATWG spec that references the method used can be found at the following link:
- https://html.spec.whatwg.org/multipage/input.html#htmlinputelement

#### Related issues
Fixes #12110

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
