### PR TITLE
index.md: Remove erroneous monospacing

### DIFF
--- a/files/en-us/web/api/rtcrtpsender/dtmf/index.md
+++ b/files/en-us/web/api/rtcrtpsender/dtmf/index.md
@@ -19,7 +19,7 @@ The read-only **`dtmf`** property on the
 **{{domxref("RTCRtpSender")}}** interface returns a
 {{domxref("RTCDTMFSender")}} object which can be used to send {{Glossary("DTMF")}} tones
 over the {{domxref("RTCPeerConnection")}} . See [Using DTMF](/en-US/docs/Web/API/WebRTC_API/Using_DTMF) for details on how to
-make use of th`e` returned `RTCDTMFSender` object.
+make use of the returned `RTCDTMFSender` object.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes monospace formatting from the letter `e` in the word 'the'.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
