### PR TITLE
Added spec link for protocol_handlers

### DIFF
--- a/files/en-us/web/manifest/protocol_handlers/index.md
+++ b/files/en-us/web/manifest/protocol_handlers/index.md
@@ -6,8 +6,9 @@ tags:
   - Manifest
   - Web
   - Non-standard
+browser-compat: html.manifest.protocol_handlers
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{Non-standard_Header}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
 <table class="properties">
   <tbody>
@@ -81,8 +82,8 @@ Protocol handlers objects may contain the following values:
 
 ## Specifications
 
-This feature is not part of any specification. It has been proposed to be added to the [Manifest](https://w3c.github.io/manifest/) specification [\[1\]](https://github.com/w3c/manifest/issues/846) [\[2\]](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/URLProtocolHandler/explainer.md).
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("html.manifest.protocol_handlers")}}
+{{Compat}}


### PR DESCRIPTION
#### Summary
The `protocol_handlers` Web App Manifest member didn't have a link to its spec. So I'm fixing this in this PR.

#### Motivation
Other manifest members have similar spec links. See: https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override
So, I'm just making it consistent with that. Plus the BCD data for protocol_handlers already existed, so let's use it here.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

#### Related

I'm also addressing a typo issue on the corresponding BCD data: https://github.com/mdn/browser-compat-data/pull/14592