### PR TITLE
Add domrect fromrect

### DIFF
--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -54,3 +54,4 @@ myDOMRect = new DOMRect(0,0,100,100);
 
 - {{domxref("DOMPoint")}}
 - {{domxref("DOMRect")}}
+- {{domxref("DOMRect.fromRect")}}

--- a/files/en-us/web/api/domrect/fromrect/index.md
+++ b/files/en-us/web/api/domrect/fromrect/index.md
@@ -1,0 +1,49 @@
+---
+title: DOMRect.fromRect()
+slug: Web/API/DOMRect/fromRect
+tags:
+  - API
+  - DOM Reference
+  - DOMRect
+  - Experimental
+  - Geometry
+  - Method
+  - Reference
+  - fromRect()
+browser-compat: api.DOMRect.fromRect
+---
+{{APIRef("DOM")}}{{SeeCompatTable}}
+
+The **`fromRect()`** property of the
+{{domxref("DOMRect")}} interface creates a new `DOMRect`
+object with a given location and dimensions.
+
+## Syntax
+
+```js
+var domRect = DOMRect.fromRect(rectangle)
+```
+
+### Parameters
+
+- `rectangle` {{optional_inline}}
+
+  - : An object specifying the location and dimensions of a rectangle. All properties
+    default to `0`. The properties are:
+
+    - `x`: The coordinate of the left side of the rectangle.
+    - `y`: The coordinate of the top side of the rectangle.
+    - `width`: The width of the rectangle.
+    - `height`: The height of the rectangle.
+
+### Return value
+
+An instance of {{domxref("DOMRect")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/domrect/fromrect/index.md
+++ b/files/en-us/web/api/domrect/fromrect/index.md
@@ -21,7 +21,7 @@ object with a given location and dimensions.
 ## Syntax
 
 ```js
-var domRect = DOMRect.fromRect(rectangle)
+fromRect(rectangle)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/domrect/index.md
+++ b/files/en-us/web/api/domrect/index.md
@@ -55,7 +55,7 @@ _`DOMRect` inherits methods from its parent, {{domxref("DOMRectReadOnly")}}._
 
 ## Static methods
 
-- {{domxref("DOMRectReadOnly.fromRect()")}}
+- {{domxref("DOMRect.fromRect()")}}
   - : Creates a new `DOMRect` object with a given location and dimensions.
 
 ## Specifications

--- a/files/en-us/web/api/domrectreadonly/fromrect/index.md
+++ b/files/en-us/web/api/domrectreadonly/fromrect/index.md
@@ -39,7 +39,7 @@ var domRect = DOMRectReadOnly.fromRect(rectangle)
 
 ### Return value
 
-An instance of {{domxref("DOMRect")}}.
+An instance of {{domxref("DOMRectReadOnly")}}.
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary
Added `DOMRect.fromRect()` static method which was missing (it's in the linked spec).

#### Motivation
By chance I found this method was missing.

#### Supporting details
Spec [(Geometry Interfaces Module Level 1 (Geometry Interfaces 1) # dom-domrect-fromrect](https://drafts.fxtf.org/geometry/#dom-domrect-fromrect)

#### Related issues
None

#### Metadata
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
