### PR TITLE
Cut misleading intro from CSSStyleSheet»insertRule() Exceptions

### DIFF
--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -48,7 +48,7 @@ stylesheet.insertRule(rule [, index])
 
 The newly inserted rule's index within the stylesheet's rule-list.
 
-### Exceptions
+### Restrictions
 
 CSS has some intuitive and not-so-intuitive restrictions affecting where rules can be
 inserted. Violating them will raise an exception.

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -48,10 +48,8 @@ stylesheet.insertRule(rule [, index])
 
 The newly inserted rule's index within the stylesheet's rule-list.
 
-### Restrictions
+### Exceptions
 
-CSS has some intuitive and not-so-intuitive restrictions affecting where rules can be
-inserted. Violating them will raise an exception.
 
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `index` > `{{domxref("CSSRuleList", "", "", "1")}}.length`.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I have no hard feeling against using "exceptions" but the section's intro and the link anchor in the header of the page are both using "restrictions".

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Fix incorrect anchor link.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
NA.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
NA.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
