### PR TITLE
Fix BCD for JS class fields

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -6,6 +6,7 @@ tags:
   - Private
   - JavaScript
   - Language feature
+browser-compat: javascript.classes.private_class_fields
 ---
 {{JsSidebar("Classes")}}
 
@@ -256,11 +257,11 @@ console.log(Derived.publicStaticMethod2());
 
 ## Specifications
 
-{{Specifications("javascript.classes")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("javascript.classes")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -5,6 +5,7 @@ tags:
   - Classes
   - JavaScript
   - Language feature
+browser-compat: javascript.classes.public_class_fields
 ---
 {{JsSidebar("Classes")}}
 
@@ -281,11 +282,11 @@ console.log(instance.msg)
 
 ## Specifications
 
-{{Specifications("javascript.classes")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("javascript.classes")}}
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
The pages for [public](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) and [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) refer to `javascript.classes` for BCD, which means they get the whole BCD for JS classes.

This PR changes them to use a more restrictive BCD query.

**However** this is a bit of a problem for the [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) page, because that page includes stuff about private fields and also private *methods*, which get different BCD values. I'm not sure what's best here:

1. we could split this page into "private fields" and "private methods", but then that's asymmetric with public fields, and could be confusing for readers (since methods are fields AFAIK).
2. we could capture BCD for private methods as a note to the BCD for private fields
3. we could move the BCD for private methods to be a subfeature under the BCD for private fields, then it would appear as an extra row in the table for private fields.

Actually I think I like 3 the best now I've written this out.

<strike>Also, the BCD includes an entry named ["Private class fields 'in'"](https://github.com/mdn/browser-compat-data/blob/a51bcea137986af3b4b240577d08537108b5b47e/javascript/classes.json#L543), but there's no explanation anywhere that I can see of what that means.</strike>oh never mind I found it. But it's not very obvious.

Opinions, @Elchi3 , @queengooborg ?
