### PR TITLE
Updating Windows Prerequisites with a link to Mozilla Build.

### DIFF
--- a/files/en-us/mozilla/projects/nss/building/index.html
+++ b/files/en-us/mozilla/projects/nss/building/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h3 id="Windows">Windows</h3>
 
-<p>NSS compilation on Windows uses the same shared build system as Mozilla Firefox. You must first install the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows Prerequisites</a>, including <strong>MozillaBuild</strong>.</p>
+<p>NSS compilation on Windows uses the same shared build system as Mozilla Firefox. You must first install the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows Prerequisites</a>, including <a href="https://wiki.mozilla.org/MozillaBuild">MozillaBuild</a>.</p>
 
 <p>You can also build NSS on the Windows Subsystem for Linux, but the resulting binaries aren't usable by other Windows applications.</p>
 


### PR DESCRIPTION
#### Summary
Unfortunately, the link to Windows Prerequisites does not work, so I propose adding also a link to MozillaBuild wiki-page. 

Thanks.