### PR TITLE
fix: MD038 replace explicit space padding with quotes

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -42,7 +42,7 @@ The final selectors we will look at are called combinators, because they combine
 
 ## Descendant combinator
 
-The **descendant combinator** — typically represented by a single space (` `) character — combines two selectors such that elements matched by the second selector are selected if they have an ancestor (parent, parent's parent, parent's parent's parent, etc) element matching the first selector. Selectors that utilize a descendant combinator are called *descendant selectors*.
+The **descendant combinator** — typically represented by a single space (" ") character — combines two selectors such that elements matched by the second selector are selected if they have an ancestor (parent, parent's parent, parent's parent's parent, etc) element matching the first selector. Selectors that utilize a descendant combinator are called *descendant selectors*.
 
 ```css
 body article p
@@ -54,7 +54,7 @@ In the example below, we are matching only the `<p>` element which is inside an 
 
 ## Child combinator
 
-The **child combinator** (`>`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the direct children of elements matched by the first. Descendant elements further down the hierarchy don't match. For example, to select only `<p>` elements that are direct children of `<article>` elements:
+The **child combinator** (`>`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the direct children of elements matched by the first. Descendant elements further down the hierarchy don't match. For example, to select only `<p>` elements that are direct children of `<article>` elements:
 
 ```css
 article > p
@@ -106,7 +106,7 @@ It is often better to create a simple class and apply that to the element in que
 
 ## Test your skills!
 
-We have covered a lot in this article, but can you remember the most important information? You can find some further tests to verify that you've retained this information before you move on — see [Test your skills: Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Selectors_Tasks).
+We have covered a lot in this article, but can you remember the most important information? You can find some further tests to verify that you've retained this information before you move on — see [Test your skills: Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Selectors_Tasks).
 
 ## Moving on
 

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.md
@@ -237,14 +237,14 @@ To create definition lists in MDN authors write a modified form of a GFM unorder
 
 - The GFM `<ul>` contains any number of top-level GFM `<li>` elements.
 - Each of these top-level GFM `<li>` elements must contain, as its final element, one GFM `<ul>` element.
-- This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with `: ` (a colon followed by a space). This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
+- This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with ": " (a colon followed by a space). This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
 
 Each of these top-level GFM `<li>` elements will be transformed into a
 `<dt>`/`<dd>` pair, as follows:
 
 - The top-level GFM `<li>` element will be parsed as a GFM `<li>` element
   and its internal contents will comprise the contents of the `<dt>`, except for the final nested `<ul>`, which will not be included in the `<dt>`.
-- The `<li>` element in the final nested `<ul>` will be parsed as a GFM `<li>` element and its internal contents will comprise the contents of the `<dd>`, except for the leading `: `, which will be discarded.
+- The `<li>` element in the final nested `<ul>` will be parsed as a GFM `<li>` element and its internal contents will comprise the contents of the `<dd>`, except for the leading ": ", which will be discarded.
 
 For example, this is a `<dl>`:
 

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -51,7 +51,7 @@ tags:
 ## Combinators
 
 - [Descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator)
-  - : The ` ` (space) combinator selects nodes that are descendants of the first element.  
+  - : The " " (space) combinator selects nodes that are descendants of the first element.  
     **Syntax:** `A B`  
     **Example:** `div span` will match all {{HTMLElement("span")}} elements that are inside a {{HTMLElement("div")}} element.  
 

--- a/files/en-us/web/css/descendant_combinator/index.md
+++ b/files/en-us/web/css/descendant_combinator/index.md
@@ -10,7 +10,7 @@ browser-compat: css.selectors.descendant
 ---
 {{CSSRef("Selectors")}}
 
-The **descendant combinator** — typically represented by a single space (` `) character — combines two selectors such that elements matched by the second selector are selected if they have an ancestor (parent, parent's parent, parent's parent's parent, etc) element matching the first selector. Selectors that utilize a descendant combinator are called _descendant selectors_.
+The **descendant combinator** — typically represented by a single space (" ") character — combines two selectors such that elements matched by the second selector are selected if they have an ancestor (parent, parent's parent, parent's parent's parent, etc) element matching the first selector. Selectors that utilize a descendant combinator are called _descendant selectors_.
 
 ```css
 /* List items that are descendants of the "my-things" list */

--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -26,7 +26,7 @@ The following list of selector types increases by specificity:
 2.  [Class selectors](/en-US/docs/Web/CSS/Class_selectors) (e.g., `.example`), attributes selectors (e.g., `[type="radio"]`) and pseudo-classes (e.g., `:hover`).
 3.  [ID selectors](/en-US/docs/Web/CSS/ID_selectors) (e.g., `#example`).
 
-Universal selector ({{CSSxRef("Universal_selectors", "*")}}), combinators ({{CSSxRef("Adjacent_sibling_combinator", "+")}}, {{CSSxRef("Child_combinator", "&gt;")}}, {{CSSxRef("General_sibling_combinator", "~")}}, ['` `'](/en-US/docs/Web/CSS/Descendant_combinator), {{CSSxRef("Column_combinator", "||")}}) and negation pseudo-class ({{CSSxRef(":not", ":not()")}}) have no effect on specificity. (The selectors declared _inside_ `:not()` do, however.)
+Universal selector ({{CSSxRef("Universal_selectors", "*")}}), combinators ({{CSSxRef("Adjacent_sibling_combinator", "+")}}, {{CSSxRef("Child_combinator", "&gt;")}}, {{CSSxRef("General_sibling_combinator", "~")}}, [" "](/en-US/docs/Web/CSS/Descendant_combinator), {{CSSxRef("Column_combinator", "||")}}) and negation pseudo-class ({{CSSxRef(":not", ":not()")}}) have no effect on specificity. (The selectors declared _inside_ `:not()` do, however.)
 
 For more information, visit: ["Specificity" in "Cascade and inheritance"](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance#Specificity_2), you can also visit: <https://specifishity.com>
 

--- a/files/en-us/web/html/element/hgroup/index.md
+++ b/files/en-us/web/html/element/hgroup/index.md
@@ -88,13 +88,13 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 The `<hgroup>` element allows the primary heading for a document section to be grouped with any secondary headings—such as subheadings or alternative titles—to form a _multi-level_ heading.
 
-In other words, the `<hgroup>` element prevents any of its secondary [`<h1>–<h6>`](/en-US/docs/Web/HTML/Element/Heading_Elements) children from creating separate sections of their own in the outline—as those [`<h1>–<h6>`](/en-US/docs/Web/HTML/Element/Heading_Elements) elements otherwise normally would if they were not children of any `<hgroup>`.
+In other words, the `<hgroup>` element prevents any of its secondary [`<h1>–<h6>`](/en-US/docs/Web/HTML/Element/Heading_Elements) children from creating separate sections of their own in the outline—as those [`<h1>–<h6>`](/en-US/docs/Web/HTML/Element/Heading_Elements) elements otherwise normally would if they were not children of any `<hgroup>`.
 
 So in the abstract outline produced by the [HTML outline algorithm defined in the HTML specification](/en-US/docs/Web/HTML/Element/Heading_Elements#the_html5_outline_algorithm), the `<hgroup>` as a whole forms a single logical heading, with the entire set of [`<h1>–<h6>`](/en-US/docs/Web/HTML/Element/Heading_Elements) children of the `<hgroup>` going into the outline as one _multi-level_ unit, to comprise that single logical heading in the abstract outline.
 
 To produce any (non-abstract) _rendered_ view of such an outline, some choice must be made in the design of the rendering tool about how to render `<hgroup>` headings in such a way as to convey their multi-level nature. There are a variety of ways an `<hgroup>` might be shown in a rendered outline; for example:
 
-- an `<hgroup>` might be shown in a rendered outline in with a colon character and space (“`: `”) or other such punctuation after the primary heading and before the first secondary heading (and with the same or similar punctuation before any other secondary headings
+- an `<hgroup>` might be shown in a rendered outline in with a colon character and space (": ") or other such punctuation after the primary heading and before the first secondary heading (and with the same or similar punctuation before any other secondary headings
 - an `<hgroup>` might be shown in a rendered outline in with the primary heading followed by parentheses around the secondary heading(s)
 
 Consider the following HTML document:

--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
@@ -36,7 +36,7 @@ padEnd(targetLength, padString)
     `padString` is too long to stay within
     `targetLength`, it will be truncated: for left-to-right
     languages the left-most part and for right-to-left languages the right-most will be
-    applied. The default value for this parameter is "` `"
+    applied. The default value for this parameter is " "
     (`U+0020`).
 
 ### Return value
@@ -50,7 +50,7 @@ A {{jsxref("String")}} of the specified `targetLength` with the
 ### Using padEnd
 
 ```js
-'abc'.padEnd(10);          // "abc       "
+'abc'.padEnd(10);          // "abc       "
 'abc'.padEnd(10, "foo");   // "abcfoofoof"
 'abc'.padEnd(6, "123456"); // "abc123"
 'abc'.padEnd(1);           // "abc"


### PR DESCRIPTION
These were the last things flagged by MD038 because leading/trailing space gets collapsed down, so swapped to plain double quoting