### PR TITLE
chore: Disable whitespace trimming in MD files and fix MD009

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -9,9 +9,9 @@ tags:
 ---
 {{AddonSidebar()}}
 
-> **Note:** This article discusses building cross-browser extensions for manifest v2. At the time of writing (December 2021), manifest v3 is being introduced by the major browser vendors. Manifest v3 is likely to change the way cross-browser extension development is undertaken. However, work on Manifest v3 is not complete. The major browser vendors are collaborating (with community members) to ease the development of a cross-browser extension in the [W3C WebExtensions Community Group](https://github.com/w3c/webextensions). 
+> **Note:** This article discusses building cross-browser extensions for manifest v2. At the time of writing (December 2021), manifest v3 is being introduced by the major browser vendors. Manifest v3 is likely to change the way cross-browser extension development is undertaken. However, work on Manifest v3 is not complete. The major browser vendors are collaborating (with community members) to ease the development of a cross-browser extension in the [W3C WebExtensions Community Group](https://github.com/w3c/webextensions).
 
-The introduction of the browser extensions API created a uniform landscape for the development of browser extensions. However, there are differences in the API implementations and the scope of coverage among the browsers that use the extensions API (the major ones being Chrome, Edge, Firefox, Opera, and Safari). 
+The introduction of the browser extensions API created a uniform landscape for the development of browser extensions. However, there are differences in the API implementations and the scope of coverage among the browsers that use the extensions API (the major ones being Chrome, Edge, Firefox, Opera, and Safari).
 
 Maximizing the reach of your browser extension means developing it for at least two browsers, possibly more. This article looks at six of the main challenges faced when creating a cross-browser extension and suggests how to address these challenges.
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -105,7 +105,7 @@ The {{domxref("HTMLElement")}} property {{DOMxRef("HTMLElement.inert")}} is a {{
 
 ### Layout for input type="search"
 
-Layout for `input type="search"` has been updated. This causes a search field to have a clear icon once someone starts typing in it, to match other browser implementations. (See {{bug(558594)}} for more details)
+Layout for `input type="search"` has been updated. This causes a search field to have a clear icon once someone starts typing in it, to match other browser implementations. (See {{bug(558594)}} for more details)
 
 <table>
   <thead>
@@ -555,7 +555,7 @@ The [`@layer`](en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which a
 ### Property: hyphenate-character
 
 The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break.
-It can also be used to specify that the character is selected to be appropriate for the language conventions of the affected content. 
+It can also be used to specify that the character is selected to be appropriate for the language conventions of the affected content.
 (See {{bug(1746187)}} for more details.)
 
 <table>
@@ -1147,7 +1147,7 @@ The [Clipboard.read()](/en-US/docs/Web/API/Clipboard/read) method of the {{domxr
 
 #### HTML Sanitizer API
 
-The {{domxref('HTML Sanitizer API')}} allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document’s DOM. Default elements within each configuration property (those to be sanitized) are still under consideration. Due to this the config parameter has not been implemented (see {{domxref('Sanitizer.sanitizer()', 'the constructor')}}) for more information. See {{bug('1673309')}} for more details.
+The {{domxref('HTML Sanitizer API')}} allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document’s DOM. Default elements within each configuration property (those to be sanitized) are still under consideration. Due to this the config parameter has not been implemented (see {{domxref('Sanitizer.sanitizer()', 'the constructor')}}) for more information. See {{bug('1673309')}} for more details.
 
 <table>
   <thead>
@@ -1878,7 +1878,7 @@ The Network Monitor displays information for [server-sent](/en-US/docs/Web/API/S
 
 ### CSS browser compatibility tooltips
 
-The CSS Rules View can display browser compatibility tooltips next to any CSS properties that have known issues. For more information see: [Examine and edit HTML > Browser Compat Warnings](/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#browser_compat_warnings).
+The CSS Rules View can display browser compatibility tooltips next to any CSS properties that have known issues. For more information see: [Examine and edit HTML > Browser Compat Warnings](/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#browser_compat_warnings).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -32,14 +32,14 @@ Firefox 18 was released on January 8, 2013. This article lists key changes that 
 - {{domxref("BlobBuilder", "MozBlobBuilder")}} is removed. Developers need to use {{domxref("Blob")}} constructor for creating a `Blob` object. ({{bug("744907")}})
 - The {{event("visibilitychange")}} event and the [Page Visibility API](/en-US/docs/Web/API/Page_Visibility_API) has been unprefixed ({{bug("812086")}}).
 - {{domxref("TextDecoder")}} and {{domxref("TextEncoder")}} have been added. Note that the implementation and spec of these evolved and have been changed in Firefox 19 ({{bug("764234")}}).
-- ` HTMLMediaElement.src` has been separate in two properties: the standard `src` property, dealing with {{domxref("DOMString")}}, and the prefixed `mozSrcObject` property, dealing with [media streams](/en-US/docs/Web/API/Media_Streams_API) ({{bug("792665")}}).
+- `HTMLMediaElement.src` has been separate in two properties: the standard `src` property, dealing with {{domxref("DOMString")}}, and the prefixed `mozSrcObject` property, dealing with [media streams](/en-US/docs/Web/API/Media_Streams_API) ({{bug("792665")}}).
 - Support for [transferable objects.](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#passing_data_by_transferring_.c2.a0ownership_%28transferable_objects%29)
 - The {{domxref("Screen.lockOrientation()")}} method now supports an `Array` of {{domxref("DOMString")}} as argument ({{bug("784549")}}.
 
 ### JavaScript
 
 - Harmony's (ECMAScript 2015) [Direct Proxies](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) have been landed ({{bug("703537")}}). Warning: the implementation contains a couple of known bugs, missing features and misalignments with the current state of the spec. Do not rely on it for production code.
-- The ECMAScript 2015 `contains()` method is now implemented on strings. This is unfortunately not compatible with Mootools 1.2, which expects different behavior from `contains()` on strings but does not ensure it. Newer versions of Mootools fix this issue; sites should upgrade their Mootools version to something newer than 1.2.
+- The ECMAScript 2015 `contains()` method is now implemented on strings. This is unfortunately not compatible with Mootools 1.2, which expects different behavior from `contains()` on strings but does not ensure it. Newer versions of Mootools fix this issue; sites should upgrade their Mootools version to something newer than 1.2.
 
 ### WebGL
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/index.md
+++ b/files/en-us/web/accessibility/aria/aria_techniques/index.md
@@ -143,7 +143,7 @@ The techniques below describe each composite role as well as their required and 
 
 - [`aria-dropeffect`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-dropeffect) {{deprecated_inline}}
 - [`aria-grabbed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-grabbed) {{deprecated_inline}}
- 
+
 ### Relationship attributes
 
 - [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant)

--- a/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
@@ -14,7 +14,7 @@ The global `aria-describedby` attribute identifies the element (or elements) tha
 
 ## Description
 
-The `aria-describedby` attribute lists the {{HTMLattrxref('id')}}s of the elements that describe the object. It is used to establish a relationship between widgets or groups and the text that describes them. 
+The `aria-describedby` attribute lists the {{HTMLattrxref('id')}}s of the elements that describe the object. It is used to establish a relationship between widgets or groups and the text that describes them.
 
 The `aria-describedby` attribute is not limited to form controls. It can also be used to associate static text with widgets, groups of elements, regions that have a heading, definitions, and more. The `aria-describedby` attribute can be used with semantic HTML elements and with elements that have an ARIA [`role`](/en-US/docs/Web/Accessibility/ARIA/Roles/).
 
@@ -39,7 +39,7 @@ The `aria-describedby` property is appropriate when the associated content conta
 ## Values
 
 - ID reference list
-  - : The `id` or space-separated list of elements IDs that describe the current element. 
+  - : The `id` or space-separated list of elements IDs that describe the current element.
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -10,13 +10,13 @@ tags:
   - Reference
 ---
 
-The `aria-labelledby` attribute identifies the element (or elements) that labels the element it is applied to. 
+The `aria-labelledby` attribute identifies the element (or elements) that labels the element it is applied to.
 
 ## Description
 
-The `aria-labelledby` property enables authors to reference other elements on the page to define an accessible name. This is useful when using elements that don't have native support for associating elements to provide an accessible name. 
+The `aria-labelledby` property enables authors to reference other elements on the page to define an accessible name. This is useful when using elements that don't have native support for associating elements to provide an accessible name.
 
-Some elements get their [accessible name](/en-US/docs/Glossary/Accessible_Name) from their inner content. For example, the accessible name for a {{HTMLElement('button')}}, {{HTMLElement('a')}}, or {{HTMLElement('td')}} comes from the text between the opening and closing tags. Other elements, such as form {{HTMLElement('textarea')}}, {{HTMLElement('fieldset')}}, and {{HTMLElement('table')}} get their accessible name from the content of associated elements; for these elements, the accessible name comes from the {{HTMLElement('label')}} with a `for` attribute, {{HTMLElement('legend')}}, and {{HTMLElement('caption')}} respectively. 
+Some elements get their [accessible name](/en-US/docs/Glossary/Accessible_Name) from their inner content. For example, the accessible name for a {{HTMLElement('button')}}, {{HTMLElement('a')}}, or {{HTMLElement('td')}} comes from the text between the opening and closing tags. Other elements, such as form {{HTMLElement('textarea')}}, {{HTMLElement('fieldset')}}, and {{HTMLElement('table')}} get their accessible name from the content of associated elements; for these elements, the accessible name comes from the {{HTMLElement('label')}} with a `for` attribute, {{HTMLElement('legend')}}, and {{HTMLElement('caption')}} respectively.
 
 All interactive elements must have an accessible name. `aria-labelledby` can be used to reference another element to define its accessible name, when an element's accessible name needs to use content from elsewhere in the DOM.
 
@@ -58,8 +58,8 @@ Fortunately, the HTML {{HTMLElement('input')}} with `type="checkbox"` works with
    <span id="color">Yellow</span>
    ```
 
-In this example, that accessible name is "Yellow". 
-   
+   In this example, that accessible name is "Yellow".
+
 2. The `aria-labelledby` property takes as value an id reference list, which means you can combine more than one element into a single accessible name. You can include the {{htmlattrxref('id')}} of the element itself to reference its own content.
 
    ```html
@@ -69,18 +69,18 @@ In this example, that accessible name is "Yellow".
    </p>
    ```
 
-In this example, the accessible name is "read more 13 ARIA attributes you need to know".
-   
+    In this example, the accessible name is "read more 13 ARIA attributes you need to know".
+
 3. The `aria-labelledby` property value order matters. When more than one element is referenced by `aria-labelledby`, the content from each referenced element is combined in the order that they are referenced in the `aria-labelledby` value. Had we written `aria-labelledby="attr rm13">`, the accessible name would have been "13 ARIA attributes you need to know read more".
-       
+
 4. The `aria-labelledby` property ignores repeated `id`s in its value. If an element is referenced more than one time, only the first reference is processed. `aria-labelledby="attr attr rm13 rm13">` is treated as `aria-labelledby="attr rm13">`
 
 5. The `aria-labelledby` property value can include content from elements that aren't even visible. While you should provide assistive technology users with the same content and all other users, you can include content from elements with the HTML {{htmlattrxref('hidden')}} attribute, CSS [`display: none`](/en-US/docs/Web/CSS/display), and CSS [`visibility: hidden`](/en-US/docs/Web/CSS/visibility) in the calculated name string.
-   
+
 6. The `aria-labelledby` property incorporates the value of input elements. If the value references an `<input>`, the current value of the form control is included in the calculated name string, changing if the value is updated.
-   
+
 7. The `aria-labelledby` property cannot be chained. If an element with `aria-labelledby` references another element that also has `aria-labelledby`, the `aria-labelledby` attribute on the referenced element is ignored.
-   
+
 > **Warning:** Because calculating the name of an element with `aria-labelledby` can be complex and reference hidden content, testing with assistive technologies to ensure the expected name is presented to users is very important.
 
 ## Values
@@ -96,7 +96,7 @@ The `aria-labelledby` attribute is **NOT** supported in [`code`](/en-US/docs/Web
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-labelledby","ARIA: aria-labelledby Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-owns/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-owns/index.md
@@ -10,17 +10,17 @@ tags:
   - Reference
 ---
 
-The `aria-owns` attribute identifies an element (or elements) in order to define a visual, functional, or contextual relationship between a parent and its child elements when the DOM hierarchy cannot be used to represent the relationship. 
+The `aria-owns` attribute identifies an element (or elements) in order to define a visual, functional, or contextual relationship between a parent and its child elements when the DOM hierarchy cannot be used to represent the relationship.
 
 ## Description
 
-Every element is the parent, sibling, or child of another element. The document object, made up of HTML elements and text nodes, is the basis of the DOM tree. The Accessibility Object Model (<abbr>AOM</abbr>) relies on a well-built DOM to enable assistive technologies to relay meaningful information about a document's contents to users. 
+Every element is the parent, sibling, or child of another element. The document object, made up of HTML elements and text nodes, is the basis of the DOM tree. The Accessibility Object Model (<abbr>AOM</abbr>) relies on a well-built DOM to enable assistive technologies to relay meaningful information about a document's contents to users.
 
 There are circumstances where the layout that appears on screen may differ from the underlying DOM structure due to the ability of JavaScript to alter content and CSS to alter layout. When this is the case, the `aria-owns` attribute can be used to recreate a meaningful relationship for assistive technology that consumes the DOM.
 
-When elements appear to be related visually but are not associated in the DOM, the `aria-owns` attribute enables creating the relationship that appears on screen in the accessibility layer for use by assistive technology. The **only** reason to include `aria-owns` is to expose a parent/child contextual relationship to assistive technology when the DOM's construction can't provide that relationship. 
+When elements appear to be related visually but are not associated in the DOM, the `aria-owns` attribute enables creating the relationship that appears on screen in the accessibility layer for use by assistive technology. The **only** reason to include `aria-owns` is to expose a parent/child contextual relationship to assistive technology when the DOM's construction can't provide that relationship.
 
-An "owning element" is any DOM ancestor of an element. If an element visually, functionally, or contextually appears to "own" (be an ancestor of) an element, but isn't actually an ancestor the element in the DOM, include the `aria-owns` to create that relationship. Add the attribute to the owning element with reference to the non-child owned element (or elements) to tell assistive technology that an element should be treated as a child. 
+An "owning element" is any DOM ancestor of an element. If an element visually, functionally, or contextually appears to "own" (be an ancestor of) an element, but isn't actually an ancestor the element in the DOM, include the `aria-owns` to create that relationship. Add the attribute to the owning element with reference to the non-child owned element (or elements) to tell assistive technology that an element should be treated as a child.
 
 Referencing the ID of one or more elements allows any element to "own" any other element with an `aria-owns` declaration. The value of the `aria-owns` attribute is a space-separated ID reference list that references the IDs of one or more elements in the document.
 
@@ -28,24 +28,24 @@ Referencing the ID of one or more elements allows any element to "own" any other
 
 Do not use `aria-owns` as a replacement for the DOM hierarchy. If the relationship is represented in the DOM, do not use `aria-owns`.
 
-A child element is owned by it's DOM parent by default: in this case, `aria-owns` should not be used. Avoid using the `aria-owns` attribute to rearrange existing child elements into a different order. 
+A child element is owned by it's DOM parent by default: in this case, `aria-owns` should not be used. Avoid using the `aria-owns` attribute to rearrange existing child elements into a different order.
 
-When using `aria-owns`, make sure you [manage focus order](https://css-tricks.com/focus-management-and-inert/). Ensure the visual focus order matches this assistive technology reading order. 
+When using `aria-owns`, make sure you [manage focus order](https://css-tricks.com/focus-management-and-inert/). Ensure the visual focus order matches this assistive technology reading order.
 
 An example of when to use `aria-owns` includes pop-up sub-menus that visually appear positioned near a parent menu, but cannot be nested in the DOM within the parent menu because it would affect the visual presentation. In this case, use `aria-owns` to present the sub-menu as a child of the parent menu to a screen reader.
 
-> **Note:** The `aria-owns` attribute should only be used when the parent/child relationship cannot be determined from the DOM. 
+> **Note:** The `aria-owns` attribute should only be used when the parent/child relationship cannot be determined from the DOM.
 
 If an element has both `aria-owns` and DOM children, the order of the child elements:
 
- 1. The actual DOM children first, 
- 2. Then the elements referenced in `aria-owns`. 
- 
-This order can be changed by including the ID references to the actual DOM children in the `aria-owns` value. 
+1. The actual DOM children first,
+2. Then the elements referenced in `aria-owns`.
 
-The {{CSSXRef('order')}} property, part of flex or grid layouts, can be used to change the order of flex and grid items making them appear in a different order from their order in the source document, creating a divergence of the logical order of elements. While it may be tempting to order the accessibility layer to match order changes created with the CSS {{CSSXref('order')}} property, avoiding both the `order` property and the `aria-owns` attribute is the best option. 
+This order can be changed by including the ID references to the actual DOM children in the `aria-owns` value.
 
-Make sure your owned elements have only one owner. Do not specify the `id` of an element in more than one other element's `aria-owns` attribute. An element can have only one owner. 
+The {{CSSXRef('order')}} property, part of flex or grid layouts, can be used to change the order of flex and grid items making them appear in a different order from their order in the source document, creating a divergence of the logical order of elements. While it may be tempting to order the accessibility layer to match order changes created with the CSS {{CSSXref('order')}} property, avoiding both the `order` property and the `aria-owns` attribute is the best option.
+
+Make sure your owned elements have only one owner. Do not specify the `id` of an element in more than one other element's `aria-owns` attribute. An element can have only one owner.
 
 > **Warning:** At the time of this writing, [`aria-owns` is not supported](https://a11ysupport.io/tech/aria/aria-owns_attribute) on MacOS and iOS with VoiceOver.
 
@@ -56,11 +56,11 @@ Make sure your owned elements have only one owner. Do not specify the `id` of an
 
 ## Associated roles
 
-Used in **ALL** roles. 
+Used in **ALL** roles.
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-owns","ARIA: aria-owns Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
@@ -16,7 +16,7 @@ The `aria-placeholder` attribute defines a short hint (a word or short phrase) i
 
 A placeholder is text that appears in the form control when it has no value set. The HTML [`placeholder`](/en-US/docs/Web/HTML/Element/input#attr-placeholder) attribute enables providing a sample value or a brief description of the expected format for several HTML {{HTMLElement('input')}} types and {{HTMLElement('textarea')}}.
 
-If you are creating a `textbox` using any other element, `placeholder` is not supported. That is where `aria-placeholder` comes into play. The `aria-placeholder` attribute can be used to defines a short hint to help the user understand what type of data is expected when a non-semantic form control has no value. 
+If you are creating a `textbox` using any other element, `placeholder` is not supported. That is where `aria-placeholder` comes into play. The `aria-placeholder` attribute can be used to defines a short hint to help the user understand what type of data is expected when a non-semantic form control has no value.
 
 ```html
 <p id="date-of-birth">Birthday</span>
@@ -27,18 +27,18 @@ The placeholder hint should be shown to the user whenever the control's value is
 
 > **Note:** ARIA is only modify the accessibility tree for an element and therefore how assistive technology presents the content to your users. ARIA doesn't change anything about an elements function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior.
 
-The `aria-placeholder` is used in addition to, not instead of, a label. They have different purposes and different functionality. A label explains what kind of information is expected. Placeholder text provides a hint about the expected value. 
+The `aria-placeholder` is used in addition to, not instead of, a label. They have different purposes and different functionality. A label explains what kind of information is expected. Placeholder text provides a hint about the expected value.
 
 > **Warning:** Using a placeholder instead of a visible label harms accessibility and usability for many users including older users and users with cognitive, mobility, fine motor skill and vision impairments. Labels are better: they are always visible and they provide for a larger hit region to focus on the control. Placeholders have several drawbacks: they disappear when the control has any value including just white space, they can confuse users into thinking the value is pre-filled, and the default color has insufficient contrast.
 
-> **Note:** Placeholders should only be used to show an example of the type of data that should be entered into a form; they don't replace a proper label. 
+> **Note:** Placeholders should only be used to show an example of the type of data that should be entered into a form; they don't replace a proper label.
 
 ## Values
 
 - `<string>`
-  - : The word or short phrase to display in a control when the control has no value. 
+  - : The word or short phrase to display in a control when the control has no value.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaPlaceholder")}}
   - : The  [`ariaPlaceholder`](/en-US/docs/Web/API/Element/ariaPlaceholder) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-placeholder` attribute.
@@ -47,24 +47,24 @@ The `aria-placeholder` is used in addition to, not instead of, a label. They hav
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role)
 
-Inherited into roles: 
+Inherited into roles:
 
 - [`searchbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role)
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-placeholder","ARIA: aria-placeholder Attribute")}}  | {{Spec2('ARIA')}} |
 
 ## See Also
 
 - [HTML `placeholder` attribute](/en-US/docs/Web/HTML/Element/input#attr-placeholder)
-- [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) 
+- [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
 
 <section id="Quick_links">

--- a/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
@@ -10,36 +10,36 @@ tags:
   - Reference
 ---
 
-Used in ARIA live regions, the global `aria-relevant` attribute indicates what notifications the user agent will trigger when the [accessibility tree](/en-US/docs/Glossary/Accessibility_tree) within a live region is modified. 
+Used in ARIA live regions, the global `aria-relevant` attribute indicates what notifications the user agent will trigger when the [accessibility tree](/en-US/docs/Glossary/Accessibility_tree) within a live region is modified.
 
 ## Description
 
 [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) are areas of a web page that are updated when user's attention may be elsewhere. When an update is outside of the user's keyboard focus, assistive technologies such as screen readers use a live region area to report updates to the user.
 
-Examples of live regions include news marquees, stock tickers, chat windows, and score boards. These update without user interaction. Some updates are important for the user to know about. They're relevant. Others are not. The `aria-relevant` is used to describe what types of changes have occurred to an [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) region, and which are relevant and should be announced. 
+Examples of live regions include news marquees, stock tickers, chat windows, and score boards. These update without user interaction. Some updates are important for the user to know about. They're relevant. Others are not. The `aria-relevant` is used to describe what types of changes have occurred to an [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) region, and which are relevant and should be announced.
 
-The value is a space-separated list of change types, including `additions`, `removals`, and `text`, with a shorthand `all` meaning all three. 
+The value is a space-separated list of change types, including `additions`, `removals`, and `text`, with a shorthand `all` meaning all three.
 
-When `aria-relevant` is not defined, the value is inherited from the nearest ancestor with a defined value. Inherited values are not additive; the value provided on a descendant element completely overrides any inherited value from an ancestor element. When a live region doesn't have an `aria-relevant` attribute set and has no ancestor with it set, it defaults to `additions text`, because generally text modifications and node additions are relevant, but node removals are not. 
+When `aria-relevant` is not defined, the value is inherited from the nearest ancestor with a defined value. Inherited values are not additive; the value provided on a descendant element completely overrides any inherited value from an ancestor element. When a live region doesn't have an `aria-relevant` attribute set and has no ancestor with it set, it defaults to `additions text`, because generally text modifications and node additions are relevant, but node removals are not.
 
-While not a supported value, if the value of `none` makes the most sense, it should not be a live region. 
+While not a supported value, if the value of `none` makes the most sense, it should not be a live region.
 
 The values of `removals` and `all` should be used sparingly. For example, when a goal happens in the World Cup, the new score (the addition) is important, the old value (the removal) is not. Assistive technologies only need to be informed of content removal when its removal represents an important change, such as a when a player is taken out of the game.
 
 ## Values
 
-- `additions`	
+- `additions`
   - : Element nodes are added to the accessibility tree within the live region.
-- `all`	
+- `all`
   - : Shorthand for `additions removals text`.
-- `removals`	
+- `removals`
   - : Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.
 - `text`
   - : Text content or a text alternative is added to any descendant in the accessibility tree of the live region.
-- `additions text` (default)	
-  - : Element nodes are added to the accessibility tree within the live region AND text content or a text alternative is added to any descendant in the accessibility tree of the live region. 
+- `additions text` (default)
+  - : Element nodes are added to the accessibility tree within the live region AND text content or a text alternative is added to any descendant in the accessibility tree of the live region.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRelevant")}}
   - : The  [`ariaRelevant`](/en-US/docs/Web/API/Element/ariaRelevant) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-relevant` attribute.
@@ -48,11 +48,11 @@ The values of `removals` and `all` should be used sparingly. For example, when a
 
 ## Associated roles
 
-Used in **ALL** roles. 
+Used in **ALL** roles.
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-relevant","ARIA: aria-relevant Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
@@ -14,11 +14,11 @@ The `aria-required` attribute indicates that user input is required on the eleme
 
 ## Description
 
-When a semantic HTML {{htmlelement("input")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}} must have a value, it should have the {{ htmlattrxref("required", "input") }} attribute applied to it. The HTML `required` attribute disables submitting the form unless the required form controls have valid values, while ensuring those navigating with the aid of assistive technologies understand which semantic form controls need valid content. 
+When a semantic HTML {{htmlelement("input")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}} must have a value, it should have the {{ htmlattrxref("required", "input") }} attribute applied to it. The HTML `required` attribute disables submitting the form unless the required form controls have valid values, while ensuring those navigating with the aid of assistive technologies understand which semantic form controls need valid content.
 
-When form controls are created using non-semantic elements, such as a {{HTMLElement('div')}} with a [role](/en-US/docs/Web/Accessibility/ARIA/Roles/) of [`checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role), the `aria-required` attribute should be included, with a value of `true`, to indicate to assistive technologies that user input is required on the element for the form to be submittable. The `aria-required` attribute can be used with HTML form elements; it is not limited to elements that have an ARIA role assigned. 
+When form controls are created using non-semantic elements, such as a {{HTMLElement('div')}} with a [role](/en-US/docs/Web/Accessibility/ARIA/Roles/) of [`checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role), the `aria-required` attribute should be included, with a value of `true`, to indicate to assistive technologies that user input is required on the element for the form to be submittable. The `aria-required` attribute can be used with HTML form elements; it is not limited to elements that have an ARIA role assigned.
 
-Similar to the HTML `required` attribute set on semantic HTML form controls, the `aria-required` attribute explicitly conveys to assistive technologies that the element is required before a form may be submitted. The `required` attribute on a semantic HTML form control will prevent the form control from being submitted if no value is present — providing native error messaging in some browsers if a required value is invalid when the user attempts to submit the form. The `aria-required` attribute, like all ARIA states and properties, has no impact on element functionality. Functionality and behavior must be added in with JavaScript. 
+Similar to the HTML `required` attribute set on semantic HTML form controls, the `aria-required` attribute explicitly conveys to assistive technologies that the element is required before a form may be submitted. The `required` attribute on a semantic HTML form control will prevent the form control from being submitted if no value is present — providing native error messaging in some browsers if a required value is invalid when the user attempts to submit the form. The `aria-required` attribute, like all ARIA states and properties, has no impact on element functionality. Functionality and behavior must be added in with JavaScript.
 
 > **Note:** ARIA only modifies the accessibility tree, modifying how assistive technology presents content to users. ARIA does not change anything about an element's function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior, focus, and ARIA states.
 
@@ -26,7 +26,7 @@ The CSS {{CSSXRef(':required')}} and {{CSSXRef(':optional')}} pseudoclasses matc
 
 If a form contains both required and optional form elements, the required elements should be indicated visually using a treatment that does not rely solely on color to convey meaning. Typically, descriptive text and/or an icon are used.
 
-> **Note:** Which elements are required should be apparent to all users. Ensure the visual presentation indicates the form control is required in a consistent, visible manner, remembering that color is not enough to convey information. 
+> **Note:** Which elements are required should be apparent to all users. Ensure the visual presentation indicates the form control is required in a consistent, visible manner, remembering that color is not enough to convey information.
 
 ## Examples
 
@@ -53,7 +53,7 @@ This could be written semantically, without the need for JavaScript:
 - `false`
   - : The element is not required.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRequired")}}
   - : The  [`ariaRequired`](/en-US/docs/Web/API/Element/ariaRequired) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-required` attribute.
@@ -62,7 +62,7 @@ This could be written semantically, without the need for JavaScript:
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)
 - [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role)
@@ -83,14 +83,14 @@ Inherits into roles:
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-required","ARIA: aria-required Attribute")}}  | {{Spec2('ARIA')}} |
 
 ## See Also
 
 - HTML {{ htmlattrxref("required", "input") }} attribute
-- [`:optional` pseudoclass](/en-US/docs/Web/CSS/:optional) 
+- [`:optional` pseudoclass](/en-US/docs/Web/CSS/:optional)
 - [`:required` pseudoclass](/en-US/docs/Web/CSS/:required)
 - [`aria-invalid` attribute](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid)
 - [MDN Understanding WCAG, Guideline 3.3 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#guideline_3.3_%e2%80%94_input_assistance_help_users_avoid_and_correct_mistakes)

--- a/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
@@ -28,7 +28,7 @@ When there are no semantic or ARIA widget roles that correspond to the interacti
 
 ATs may customize and localize the names of ARIA roles. If you are using `aria-roledescription` to change how the role name is presented to the user, remember to handle localization. The value should be translated when a page is localized.
 
-Changing how the role is presented to the user has no impact on the functionality of the element. For example, if an element has a role of [`region`](/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) or [`button`](/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)  when AT provides functions for navigating to the next region or button, if you set the `aria-roledescription` to `continent` and `escape` respectively, the AT will still allow those functions to navigate to regions and buttons. 
+Changing how the role is presented to the user has no impact on the functionality of the element. For example, if an element has a role of [`region`](/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) or [`button`](/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)  when AT provides functions for navigating to the next region or button, if you set the `aria-roledescription` to `continent` and `escape` respectively, the AT will still allow those functions to navigate to regions and buttons.
 
 Again, avoid using `aria-roledescription`. In this example, `escape` has no relevant meaning to the user, but `button` with "escape" as a label does.  
 
@@ -47,14 +47,14 @@ The following example shows the use of `aria-roledescription` to indicate that a
 </div>
 ```
 
-In the previous examples, a screen reader user may hear "Quarterly Report, slide" rather than the less precise "Quarterly Report, article". 
+In the previous examples, a screen reader user may hear "Quarterly Report, slide" rather than the less precise "Quarterly Report, article".
 
 ## Values
 
 - `<string>`
   - : A non-empty string, an unconstrained value type,containing more than just white space.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRoleDescription")}}
   - : The  [`ariaRoleDescription`](/en-US/docs/Web/API/Element/ariaRoleDescription) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-roledescription` attribute.
@@ -63,11 +63,11 @@ In the previous examples, a screen reader user may hear "Quarterly Report, slide
 
 ## Associated roles
 
-Supported by all roles and by all base markup elements except for `role="generic"`. 
+Supported by all roles and by all base markup elements except for `role="generic"`.
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-roledescription","ARIA: aria-roledescription Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
@@ -10,13 +10,13 @@ tags:
   - Reference
 ---
 
-The `aria-rowcount` attribute defines the total number of rows in a table, grid, or treegrid. 
+The `aria-rowcount` attribute defines the total number of rows in a table, grid, or treegrid.
 
 ## Description
 
-Some tables have hundreds, even millions, of rows. Even for tables with fewer rows, loading only a subsection of rows may be a design requirement, improve performance, or improve user experience. When only a subset of rows are loaded, you do need to let all users know that only a subset of the data is being displayed. The `aria-rowcount` attribute is used to define the total number of rows in a table, grid, or treegrid. 
+Some tables have hundreds, even millions, of rows. Even for tables with fewer rows, loading only a subsection of rows may be a design requirement, improve performance, or improve user experience. When only a subset of rows are loaded, you do need to let all users know that only a subset of the data is being displayed. The `aria-rowcount` attribute is used to define the total number of rows in a table, grid, or treegrid.
 
-Included on the {{HTMLElement('table')}} element or on an element with a role of [`table`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role), the value is the number of rows in the full table, as an integer. If the total number of rows is not known, include `aria-rowcount="-1"`, which tells the browser to not count the total number of rows. 
+Included on the {{HTMLElement('table')}} element or on an element with a role of [`table`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role), the value is the number of rows in the full table, as an integer. If the total number of rows is not known, include `aria-rowcount="-1"`, which tells the browser to not count the total number of rows.
 
 If all of the rows are loaded and in the DOM, you don't need to include `aria-rowcount` as browsers automatically count the total number of rows. However, if the rows aren't all present in the DOM at any time, this attribute is needed to provide the number of rows when the full table size is known and to tell the browser to not automatically count the rows when the total number of rows is not known.  
 
@@ -52,13 +52,13 @@ The following example shows a grid with 24 rows, of which the first row and rows
   </div>
 </div>
 ```
-    
+
 ## Values
 
 - `<integer>`
   - : The number of rows in the full table or `-1` is the table size is not known.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRowCount")}}
   - : The  [`ariaRowCount`](/en-US/docs/Web/API/Element/ariaRowCount) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowcount` attribute.
@@ -67,7 +67,7 @@ The following example shows a grid with 24 rows, of which the first row and rows
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`table`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role)
 
@@ -78,7 +78,7 @@ Inherited into roles:
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-rowcount","ARIA: aria-rowcount Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
@@ -14,9 +14,9 @@ The `aria-rowindex` attribute defines an element's position with respect to the 
 
 ## Description
 
-Some tables have many, many rows. Loading only a subsection of rows may be done as a design requirement, to improve performance, or to improve user experience. 
+Some tables have many, many rows. Loading only a subsection of rows may be done as a design requirement, to improve performance, or to improve user experience.
 
-When only a subset of rows are loaded, you do need to let all users know which subsets of rows are being displayed. The `aria-rowindex` attribute is used to define the cell or row's row index or position with respect to the total number of rows within a table, grid, or treegrid. 
+When only a subset of rows are loaded, you do need to let all users know which subsets of rows are being displayed. The `aria-rowindex` attribute is used to define the cell or row's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
 Included on the {{HTMLElement('tr')}} element or on an element with a role of [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role), or directly on the {{HTMLElement('td')}}, {{HTMLElement('th')}}, or element with role of [`cell`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role) or [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role), the value is the row's position with respect to the full table.
 
@@ -26,11 +26,11 @@ If all of the rows are loaded and in the DOM, you don't need to include `aria-ro
 
 If the table with only a subset of rows has a cell that spans more than one row, both the row and cell need to have the `aria-rowspan`  set. If a cell spans more than one row－when a cell role includes the `aria-rowspan` attribute or HTML cell has a `rowspan` attribute set to a value greater than 1－include the row's `aria-rowindex` value on the spanning cell in addition to the appropriate row spanning attribute. The value should be the row index of the row where the span starts.
 
-> **Note**: The `aria-rowindex` must be added to each row, but is optional on the cells, except for cells that span rows: the `aria-rowindex` attribute is required on all spanning cells. 
+> **Note**: The `aria-rowindex` must be added to each row, but is optional on the cells, except for cells that span rows: the `aria-rowindex` attribute is required on all spanning cells.
 
 ## Examples
 
-The following example shows a grid with 24 rows, of which the first row and rows 7 through 10 are displayed to the user. The last "position" cell spans column 9 and 10. 
+The following example shows a grid with 24 rows, of which the first row and rows 7 through 10 are displayed to the user. The last "position" cell spans column 9 and 10.
 
 ```html
 <div role="grid" aria-rowcount="24">
@@ -66,14 +66,14 @@ The following example shows a grid with 24 rows, of which the first row and rows
 </div>
 ```
 
-Note both  `aria-rowspan` and `aria-rowindex` are present on the Goalkeeper cell, which spans two rows. 
+Note both  `aria-rowspan` and `aria-rowindex` are present on the Goalkeeper cell, which spans two rows.
 
 ## Values
 
 - `<integer>`
   - : An integer greater than or equal to 1, greater than the `aria-rowindex` of the previous row, if any, and less than or equal to the value of [`aria-rowcount`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-rowcount).
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRowIndex")}}
   - : The  [`ariaRowIndex`](/en-US/docs/Web/API/Element/ariaRowIndex) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindex` attribute.
@@ -82,7 +82,7 @@ Note both  `aria-rowspan` and `aria-rowindex` are present on the Goalkeeper cell
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`cell`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role)
 - [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role)
@@ -95,8 +95,8 @@ Inherited into roles:
 
 ## Specifications
 
-| Specification | Status | 
-| ------------- | ------  |
+| Specification | Status |
+| ------------- | ------ |
 | {{SpecName("ARIA","#aria-rowindex","ARIA: aria-rowindex Attribute")}}  | {{Spec2('ARIA')}} |
 
 ## See Also
@@ -105,7 +105,7 @@ Inherited into roles:
 -  [`aria-rowcount`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-rowcount)
 -  [`aria-rowspan`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-rowspan)
 -  [`aria-colindex`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-colindex)
--  The [`rowspan`](/en-US/docs/Web/HTML/Element/td#attr-rowspan) attribute on {{HTMLElement('td')}} 
+-  The [`rowspan`](/en-US/docs/Web/HTML/Element/td#attr-rowspan) attribute on {{HTMLElement('td')}}
 
 <section id="Quick_links">
 <strong><a href="/en-US/docs/Web/Accessibility/ARIA/Attributes">WAI-ARIA states and properties</a></strong>

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 ---
 
-The `aria-rowindextext` attribute defines a human-readable text alternative of `aria-rowindex`. 
+The `aria-rowindextext` attribute defines a human-readable text alternative of `aria-rowindex`.
 
 ## Description
 
@@ -25,7 +25,7 @@ The `aria-rowindextext` is added to each {{HTMLElement('row')}} or to elements w
 - `<string>`
   - The human readable text alternative of the numeric [`aria-spanindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-spanindex)
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRowIndexText")}}
   - : The  [`ariaRowIndexText`](/en-US/docs/Web/API/Element/ariaRowIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindextext` attribute.
@@ -34,7 +34,7 @@ The `aria-rowindextext` is added to each {{HTMLElement('row')}} or to elements w
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`cell`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role)
 - [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role)
@@ -47,7 +47,7 @@ Inherited into roles:
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-rowindextext","ARIA: aria-rowindextext Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
@@ -10,11 +10,11 @@ tags:
   - Reference
 ---
 
-The `aria-rowspan` attribute defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid. 
+The `aria-rowspan` attribute defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
 ## Description
 
-Similar to the `rowspan` attribute of the {{HTMLElement('td')}} and {{HTMLElement('th')}} elements, but for cells and gridcells which are not contained in a native table, the `aria-rowspan` attribute defines the number of rows spanned by a `cell` or `gridcell` within a `table`, `grid`, or `treegrid`. 
+Similar to the `rowspan` attribute of the {{HTMLElement('td')}} and {{HTMLElement('th')}} elements, but for cells and gridcells which are not contained in a native table, the `aria-rowspan` attribute defines the number of rows spanned by a `cell` or `gridcell` within a `table`, `grid`, or `treegrid`.
 
 This attribute is intended for cells and gridcells which are **not** part of an HTML {{HTMLElement('table')}}. When a cell is nested in a semantic `<table>`, the `rowspan` attribute should be used when a <td> or <th> spans more than one row. If both are present, `rowspan` takes precedence over `aria-rowspan`. But, like all ARIA attributes, `aria-rowspan` only impacts the accessibility tree. It doesn't change your layout.
 
@@ -27,7 +27,7 @@ The value of `aria-rowspan` is an integer greater than or equal to 0 and less th
 - `<integer>`
   - : An integer greater than or equal to `0` and less than would cause a cell to overlap the next cell in the same column.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaRowSpan")}}
   - : The  [`ariaRowSpan`](/en-US/docs/Web/API/Element/ariaRowSpan) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowspan` attribute.
@@ -36,7 +36,7 @@ The value of `aria-rowspan` is an integer greater than or equal to 0 and less th
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`cell`](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role)
 
@@ -47,13 +47,13 @@ Inherited into roles:
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-rowspan","ARIA: aria-rowspan Attribute")}}  | {{Spec2('ARIA')}} |
 
 ## See Also
 
--  The [`rowspan`](/en-US/docs/Web/HTML/Element/td#attr-rowspan) attribute on {{HTMLElement('td')}} 
+-  The [`rowspan`](/en-US/docs/Web/HTML/Element/td#attr-rowspan) attribute on {{HTMLElement('td')}}
 -  [`aria-rowindex`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-rowindex)
 -  [`aria-colspan`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-colspan)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
@@ -10,21 +10,21 @@ tags:
   - Reference
 ---
 
-The `aria-selected` attribute indicates the current "selected" state of various widgets. 
+The `aria-selected` attribute indicates the current "selected" state of various widgets.
 
 ## Description
 
-The `aria-selected` attribute indicates the current "selected" state for [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role), [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/Option_role), [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/Row_role) and [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_role) roles. 
+The `aria-selected` attribute indicates the current "selected" state for [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role), [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/Option_role), [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/Row_role) and [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_role) roles.
 
 This attribute is used to indicate which elements within single-selection and multiple-selection composite widgets are selected. If more than one element is selectable at a time, include `aria-multiselectable="true"` on the grid, listbox, tablist, or other owning role, while including `aria-selected` only on the selectable cells, options, and tabs.
 
 For other roles, the currently selected state is set with [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current), or possibly [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) or [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed), depending on the role.
 
-Widgets that support both `aria-selected` and `aria-current` at the same time have different meanings for each. For example, `aria-current="page"` can be used in a navigation tree to indicate which page is currently displayed, while `aria-selected="true"` indicates which page will be displayed if the user activates the `treeitem`. 
+Widgets that support both `aria-selected` and `aria-current` at the same time have different meanings for each. For example, `aria-current="page"` can be used in a navigation tree to indicate which page is currently displayed, while `aria-selected="true"` indicates which page will be displayed if the user activates the `treeitem`.
 
 ### Grid
 
-Setting `aria-selected="false"` on a focusable gridcell indicates the cell is selectable. If the grid allows more than one gridcell to be selected at a time, set `aria-multiselectable="true"` on the element with role [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role). Setting `aria-selected` on a column or row header gridcell does not propagate the state to other cells in the column or row. 
+Setting `aria-selected="false"` on a focusable gridcell indicates the cell is selectable. If the grid allows more than one gridcell to be selected at a time, set `aria-multiselectable="true"` on the element with role [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role). Setting `aria-selected` on a column or row header gridcell does not propagate the state to other cells in the column or row.
 
 ### Option
 
@@ -34,7 +34,7 @@ Don't specify both `aria-selected` and `aria-checked` on `option` elements conta
 
 ### Row
 
-The `aria-selected` attribute is supported on `row` but not `column`. If a grid supports selection, when a cell or row is selected, the selected element has `aria-selected="true"` set. 
+The `aria-selected` attribute is supported on `row` but not `column`. If a grid supports selection, when a cell or row is selected, the selected element has `aria-selected="true"` set.
 
 If the grid supports column selection and a column is selected, all cells in the column have `aria-selected` set to `true`.
 
@@ -44,7 +44,7 @@ In a tablist, `aria-selected` is used on a tab to indicate the currently-display
 
 The selected [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) in a [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) should have has its `aria-selected="true"` set. All inactive tabs in the tablist should have `aria-selected="false"` set.Setting the state only impacts the accessibility tree: make sure to style the active tab in a way that visual indicates it's selected state. The default value for `aria-selected` on a `tab` role is `false`.
 
-If more than one tab is selectable at a time, include `aria-multiselectable` on the `tablist`. 
+If more than one tab is selectable at a time, include `aria-multiselectable` on the `tablist`.
 
 ## Examples
 
@@ -90,7 +90,7 @@ In this `tablist` example, the first `tab` is selected:
 - `undefined` (default)
   - : The element is not selectable.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaSelected")}}
   - : The  [`ariaSelected`](/en-US/docs/Web/API/Element/ariaSelected) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-selected` attribute.
@@ -99,7 +99,7 @@ In this `tablist` example, the first `tab` is selected:
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role)
 - [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/option_role)
@@ -114,7 +114,7 @@ Inherited into roles:
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-selected","ARIA: aria-selected Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
@@ -14,9 +14,9 @@ The `aria-setsize` attribute defines the number of items in the current set of l
 
 ## Description
 
-Browsers automatically calculate the set size and position for each item in a group of items, like the number of {{HTMLelement('li')}}s in a list, buttons in a same-named group of [radio buttons](/en-US/docs/Web/HTML/Element/input/radio), and {{HTMLelement('option')}}}s in a {{HTMLelement('select')}}. Assistive technologies, like screen readers, take advantage of this state management to report set sizes to the user. 
+Browsers automatically calculate the set size and position for each item in a group of items, like the number of {{HTMLelement('li')}}s in a list, buttons in a same-named group of [radio buttons](/en-US/docs/Web/HTML/Element/input/radio), and {{HTMLelement('option')}}}s in a {{HTMLelement('select')}}. Assistive technologies, like screen readers, take advantage of this state management to report set sizes to the user.
 
-When the DOM is not complete, the browser calculation of the number of items in a set can be incorrect. When only a subset of items, such as list items, are loaded into the DOM, the browser calculates the number of items based only on those present. The `aria-setsize` attribute should be used to override the browser's incorrect count. It defines the number of items in the current set of listitems or treeitems had the entire set been loaded. 
+When the DOM is not complete, the browser calculation of the number of items in a set can be incorrect. When only a subset of items, such as list items, are loaded into the DOM, the browser calculates the number of items based only on those present. The `aria-setsize` attribute should be used to override the browser's incorrect count. It defines the number of items in the current set of listitems or treeitems had the entire set been loaded.
 
 `aria-setsize` attribute is set on each item, rather than on any containing element. The value is the same for each item: an integer reflecting number of items in the complete set, or `-1` if the set size is unknown. If all the items are present in the DOM, the browser can calculate the set size and the position of each item, making both `aria-setsize` and `aria-posinset` unnecessary.
 
@@ -24,7 +24,7 @@ Elements with the `aria-setsize` generally have the  [`aria-posinset`](/en-US/do
 
 For example, in a page's comments section, When comments in are not all in the DOM, such as when comments are paginated, the level, total number of comments, and position of each comment should be set with ARIA. The hierarchical level of comments can be indicated with [`aria-level`](en-US/docs/Web/Accessibility/aria/Attributes/aria-level). Group positional information is indicated with `aria-posinset` and `aria-setsize`.
 
-When a feed has a static number of articles, `aria-setsize` can be added to each article element with the value being either the total number of articles loaded or the total number in the feed. The value chosen depends on which value is most helpful to users. If the number of articles is extremely large, indefinite, or changes often, `aria-setsize="-1"` can be set to communicate the size of the set is unknown. 
+When a feed has a static number of articles, `aria-setsize` can be added to each article element with the value being either the total number of articles loaded or the total number in the feed. The value chosen depends on which value is most helpful to users. If the number of articles is extremely large, indefinite, or changes often, `aria-setsize="-1"` can be set to communicate the size of the set is unknown.
 
 In a [`listbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role), when the complete set of available options is not present in the DOM due to dynamic loading on scroll, both `aria-setsize` and `aria-posinset` can be set on each [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/option_role).
 
@@ -53,7 +53,7 @@ To orient the user, assistive technologies would list the bananas above as "item
 - `<integer>`
   - : The number of items in the full set or `-1` is the set size is unknown.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaSetSize")}}
   - : The  [`ariaSetSize`](/en-US/docs/Web/API/Element/ariaSetSize) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-setsize` attribute.
@@ -84,7 +84,7 @@ Inherits into roles:
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-setsize","ARIA: aria-setsize Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
@@ -14,7 +14,7 @@ The `aria-sort` attribute indicates if items in a table or grid are sorted in as
 
 ## Description
 
-If a grid or table provides sort functionality, the `aria-sort` attribute should be set to either `ascending` or `descending` (or `other`) on the header cell element for the sorted column or row. 
+If a grid or table provides sort functionality, the `aria-sort` attribute should be set to either `ascending` or `descending` (or `other`) on the header cell element for the sorted column or row.
 
 The `aria-sort` attribute is only set on the currently sorted column or row.  Set `aria-sort="ascending"` to indicate the data cells in the column or row are sorted in ascending order. If the sort order is reversed, toggle the value to `aria-sort="descending"`. When a different column or row becomes sorted, the single `aria-sort` attribute is moved to the header cell for the newly sorted column or row with the appropriate value for the sort order.
 
@@ -63,14 +63,14 @@ We provided instructions in the caption for assistive technology who may not see
 
 - `ascending`
   - : Items are sorted in ascending order by this column.
-- `descending`	
+- `descending`
   - : Items are sorted in descending order by this column.
 - `none` (default)
   - : There is no defined sort applied to the column.
-- `other`	
+- `other`
   - : A sorting algorithm other than ascending or descending has been applied.
 
-## ARIAMixin API 
+## ARIAMixin API
 
 - {{domxref("Element.ariaSort")}}
   - : The  [`ariaSort`](/en-US/docs/Web/API/Element/ariaSort) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-sort` attribute.
@@ -79,14 +79,14 @@ We provided instructions in the caption for assistive technology who may not see
 
 ## Associated roles
 
-Used in roles: 
+Used in roles:
 
 - [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role)
 - [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role)
 
 ## Specifications
 
-| Specification | Status | 
+| Specification | Status |
 | ------------- | ------  |
 | {{SpecName("ARIA","#aria-sort","ARIA: aria-sort Attribute")}}  | {{Spec2('ARIA')}} |
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
@@ -16,7 +16,7 @@ The `aria-valuemax` attribute defines the maximum allowed value for a range widg
 
 The `aria-valuemax` attribute defines the maximum value allowed for range widgets. It is similar to the `max` attribute of {{HTMLElement('progress')}}, {{HTMLElement('meter')}}, and {{HTMLElement('input')}} of type [`range`](en-US/docs/Web/HTML/Element/input/range), [`number`](en-US/docs/Web/HTML/Element/input/number) and all the date-time types.
 
-When creating a range type role, including [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role), [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role), [`slider`](/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role), and [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role) on a non-semantic element, the `aria-valuemax` enables defining a maximum that is more than the minimum value  and is a required attribute of `slider`, `scrollbar` and `spinbutton`. 
+When creating a range type role, including [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role), [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role), [`slider`](/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role), and [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role) on a non-semantic element, the `aria-valuemax` enables defining a maximum that is more than the minimum value  and is a required attribute of `slider`, `scrollbar` and `spinbutton`.
 
 Declaring the minimum and maximum values allows assistive technologies to convey the size of the range to users. The minimum value is defined with [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin).
 
@@ -47,7 +47,7 @@ The code below shows a simple slider with a maximum value of 9.
 
 Used in roles:
 
-- [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role) 
+- [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role) (required)
 - [`separator`](/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role)
 - [`slider`](/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role) (required)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
@@ -14,11 +14,11 @@ The `aria-valuetext` attribute defines the human readable text alternative of `a
 
 ## Description
 
-Numbers — even percentages — aren't always user-friendly. Assistive technologies present [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) as numeric values. If a progress bar is at 8%, what does that mean? `aria-valuetext` provides a way of presenting the current value in a more user-friendly, human-understandable way. For example, a battery meter value might be conveyed as `aria-valuetext="8% (34 minutes) remaining"`.
+Numbers — even percentages — aren't always user-friendly. Assistive technologies present [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) as numeric values. If a progress bar is at 8%, what does that mean? `aria-valuetext` provides a way of presenting the current value in a more user-friendly, human-understandable way. For example, a battery meter value might be conveyed as `aria-valuetext="8% (34 minutes) remaining"`.
 
 The `aria-valuetext` attribute is used with the `aria-valuenow` attribute, not instead of it, unless that value is not known.
 
-`aria-valuetext` is only needed when the numeric value of `aria-valuenow` is not meaningful. For example, a range's values are numeric but may be used for non-numeric values, such as college class level. The values of `aria-valuenow` for a 4-year college could range from 1 through 4, which indicate the position of each value in the value space. In this case, the `aria-valuetext` could be one of the strings: "first year", "sophomore", "junior", and "senior". 
+`aria-valuetext` is only needed when the numeric value of `aria-valuenow` is not meaningful. For example, a range's values are numeric but may be used for non-numeric values, such as college class level. The values of `aria-valuenow` for a 4-year college could range from 1 through 4, which indicate the position of each value in the value space. In this case, the `aria-valuetext` could be one of the strings: "first year", "sophomore", "junior", and "senior".
 
 If the numeric value is meaningful, such as a spinner with `aria-valuenow="3"` for how many pizza slices you want to order, `aria-valuetext` is not needed.
 

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -16,23 +16,23 @@ The `alert` role is for important, and usually time-sensitive, information. The 
 
 ## Description
 
-The `alert` role is used to communicate an important and usually time-sensitive message to the user. When this role is added to an element, the browser will send out an accessible alert event to assistive technology products which can then notify the user. 
+The `alert` role is used to communicate an important and usually time-sensitive message to the user. When this role is added to an element, the browser will send out an accessible alert event to assistive technology products which can then notify the user.
 
 The alert role should only be used for information that requires the user's immediate attention, for example:
 
-- An invalid value was entered into a form field 
+- An invalid value was entered into a form field
 - The user's login session is about to expire
 - The connection to the server was lost so local changes will not be saved
 
-The `alert` role should only be used for static text content. The element with the `alert` role does not have to be able to receive focus, as screen readers (speech or braille) will automatically announce the updated content regardless of where keyboard focus when the role is added. 
+The `alert` role should only be used for static text content. The element with the `alert` role does not have to be able to receive focus, as screen readers (speech or braille) will automatically announce the updated content regardless of where keyboard focus when the role is added.
 
 The `alert` role is added to the node containing an alert message, **not** the element causing the alert to be triggered. Alerts are [assertive live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). Setting `role="alert"` is equivalent to setting [`aria-live="assertive"`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-live) and [`aria-atomic="true"`](/en-US/docs/Web/Accessibility/aria/Attributes/aria-atomic). As they don't receive focus, focus does not need to be managed and no user interaction should be required.
 
-> **Warning:** Because of its intrusive nature, the `alert` role must be used sparingly and only in situations where the user's immediate attention is required. 
+> **Warning:** Because of its intrusive nature, the `alert` role must be used sparingly and only in situations where the user's immediate attention is required.
 
 The [`alert`](https://www.w3.org/TR/wai-aria-1.1/#alert) role is of the five [live region](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) roles. Dynamic changes that are less urgent should use a less aggressive method, such as including `aria-live="polite"` or using an other live region role like [`status`](/en-US/docs/Web/Accessibility/ARIA/Roles/status_role). If the user is expected to close the alert, then the [`alertdialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) role should be used instead.
 
-The most important thing to know about the `alert` role is that it's for dynamic content. It is perfect for situations such as when a user fills out a form and JavaScript is used to add an error message - the alert would immediately read out the message. It should not be used on HTML that the user hasn't interacted with. For example, if a page loads with multiple visible alerts scattered throughout, no alert would be read as they were not dynamically triggered.
+The most important thing to know about the `alert` role is that it's for dynamic content. It is perfect for situations such as when a user fills out a form and JavaScript is used to add an error message - the alert would immediately read out the message. It should not be used on HTML that the user hasn't interacted with. For example, if a page loads with multiple visible alerts scattered throughout, no alert would be read as they were not dynamically triggered.
 
 If an element has `role="alert"` and `display: none;` set, when the [`display`](/en-US/docs/Web/CSS/CSS_Display) value is changed with CSS or JavaScript, it automatically triggers the screen reader to read out the content.
 
@@ -55,19 +55,19 @@ btn.addEventListener('click', triggerAlert);
 
 function triggerAlert() {
   var alertEl = document.querySelector('.alert');
-  alertEl.setAttribute("role", "alert");
+  alertEl.setAttribute("role", "alert");
 }
 ```
 
-As the `alert` role reads out content that has changed, bring the user's attention to it immediately, it should not be used for static content nor used regularly. Alerts, by definition, are disruptive. Several alerts at once, and unnecessary alerts, create bad user experiences.
+As the `alert` role reads out content that has changed, bring the user's attention to it immediately, it should not be used for static content nor used regularly. Alerts, by definition, are disruptive. Several alerts at once, and unnecessary alerts, create bad user experiences.
 
 ## Examples
 
-Following are four ways of creating alerts: 
+Following are four ways of creating alerts:
 
 ### Example 1: Adding the role in the HTML code
 
-Here, the alert role is added directly into the HTML source code. When the element finishes loading the screen reader will be notified of the alert. 
+Here, the alert role is added directly into the HTML source code. When the element finishes loading the screen reader will be notified of the alert.
 
 ```html
 <h2 role="alert">Your form could not be submitted because of 3 validation errors.</h2>
@@ -89,7 +89,7 @@ document.body.appendChild(myAlert);
 
 ### Example 3: Adding alert role to an existing element
 
-Sometimes it is useful to add an `alert` role to an element that is already visible on the page rather than creating a new element. This allows the developer to reiterate information that has become more relevant or urgent to the user. For example, a form control may have instructions about the expected value. If a different value is entered, `role="alert"` can be added to the instruction text so that the screen reader announces it as an alert. 
+Sometimes it is useful to add an `alert` role to an element that is already visible on the page rather than creating a new element. This allows the developer to reiterate information that has become more relevant or urgent to the user. For example, a form control may have instructions about the expected value. If a different value is entered, `role="alert"` can be added to the instruction text so that the screen reader announces it as an alert.
 
 ```html
 <p id="formInstruction">You must select at least 3 options</p>
@@ -102,7 +102,7 @@ document.getElementById("formInstruction").setAttribute("role", "alert");
 
 ### Example 4: Making an element with an alert role visible
 
-If an element already has `role="alert"` and is initially hidden using CSS, making it visible will cause the alert to fire as if it was just added to the page. This means that an existing alert can be "reused" multiple times. 
+If an element already has `role="alert"` and is initially hidden using CSS, making it visible will cause the alert to fire as if it was just added to the page. This means that an existing alert can be "reused" multiple times.
 
 ```css
 .hidden {

--- a/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -17,13 +17,13 @@ The **alertdialog** role is to be used on modal alert dialogs that interrupt a u
 
 The `alertdialog` role is used to notify users of urgent information that demands the user's immediate attention. Including `role="alertdialog"` on the element containing the dialog helps assistive technology identify the content as being grouped and separated from the rest of the page content.  Examples include error messages that require confirmation and other action confirmation prompts.  
 
-As the name implies, `alertdialog` is a mashup of the [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) roles. `alertdialog` is a type of `dialog` with similar use cases as `alert`, but for when a user response is required.
+As the name implies, `alertdialog` is a mashup of the [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) roles. `alertdialog` is a type of `dialog` with similar use cases as `alert`, but for when a user response is required.
 
 > **Note:** The `alertdialog` role should only be used for alert messages that have associated interactive controls. If an alert dialog only contains static content and has no interactive controls at all, use [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) instead.
 
 Being a type of dialog, the [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) role's states, properties, and keyboard focus requirements are applicable to the `alertdialog` role as well.
 
-Because of its urgent nature, interrupting the user's workflow, alert dialogs must always be [modal](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal). 
+Because of its urgent nature, interrupting the user's workflow, alert dialogs must always be [modal](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal).
 
 The alert dialog must have at least one focusable control — such as Confirm, Close, and Cancel — and focus must be moved to that control when the alert dialog appears. Alertdialogs can have additional interactive controls such as text fields and checkboxes.
 
@@ -89,10 +89,10 @@ The code snippet above shows how to mark up an alert dialog that only provides a
 
 ## See Also
 
-  * [The `dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
-  * [The `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
+  * [The `dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
+  * [The `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
   * [`aria-modal` attribute](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal)
-  * [`Window.alert()`](/en-US/docs/Web/API/Window/alert) 
+  * [`Window.alert()`](/en-US/docs/Web/API/Window/alert)
   * [`Window.prompt()`](/en-US/docs/Web/API/Window/prompt)
 
 <section id="Quick_links">

--- a/files/en-us/web/accessibility/aria/roles/button_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.md
@@ -14,9 +14,9 @@ The `button` role is for clickable elements that trigger a response when activat
 
 ## Description
 
-The button role identifies an element as a button to assistive technology such as screen readers. A button is a widget used to perform actions such as submitting a form, opening a dialog, canceling an action, or performing a command such as inserting a new record or displaying information. Adding `role="button"` tells assistive technology that the element is a button but provides no button functionality. Use {{HTMLElement("button")}} or {{HTMLElement("input")}} with `type="button"` instead. 
+The button role identifies an element as a button to assistive technology such as screen readers. A button is a widget used to perform actions such as submitting a form, opening a dialog, canceling an action, or performing a command such as inserting a new record or displaying information. Adding `role="button"` tells assistive technology that the element is a button but provides no button functionality. Use {{HTMLElement("button")}} or {{HTMLElement("input")}} with `type="button"` instead.
 
-This `button` role can be used in combination with the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute to [create toggle buttons](#toggle_buttons).
+This `button` role can be used in combination with the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute to [create toggle buttons](#toggle_buttons).
 
 ```html
 <div id="saveChanges" tabindex="0" role="button" aria-pressed="false">Save</div>
@@ -30,9 +30,9 @@ The above example creates a focusable button, but requires JavaScript and CSS to
 
 > **Note:** If using `role="button"` instead of the semantic `<button>` or `<input type="button">` elements, you will need to make the element focusable and define event handlers for {{event("click")}} and {{event("keydown")}} events. This includes handling the <kbd>Enter</kbd> and <kbd>Space</kbd> keypresses in order to process all forms of user input. See [the official WAI-ARIA example code](https://www.w3.org/TR/wai-aria-practices/examples/button/button.html).
 
-In addition to the ordinary button widget, `role="button"` should be included when creating a toggle button or menu button using a non-button element. 
+In addition to the ordinary button widget, `role="button"` should be included when creating a toggle button or menu button using a non-button element.
 
-A toggle button is a two-state button that can be either off (not pressed) or on (pressed). The [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute values of `true` or `false` identify a button as a toggle button. 
+A toggle button is a two-state button that can be either off (not pressed) or on (pressed). The [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute values of `true` or `false` identify a button as a toggle button.
 
 A menu button is a button that controls a menu and has an [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) property attribute set to either `menu` or `true`.
 
@@ -41,19 +41,19 @@ A menu button is a button that controls a menu and has an [`aria-haspopup`](/en-
 - [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed)
   - : The `aria-pressed`  attribute defines the button as a toggle button. The value describes the state of the button. The values include `aria-pressed="false"` when a button is not currently pressed, `aria-pressed="true"` to indicate a button is currently pressed, and `aria-pressed="mixed"` if the button is considered to be partially pressed. If the attribute is omitted or set to its default value of `aria-pressed="undefined"`, the element does not support being pressed.  
 - [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
-  - : If the button controls a grouping of other elements, the `aria-expanded` state indicates whether the controlled grouping is currently expanded or collapsed.  If the button has `aria-expanded="false"` set, the grouping is not currently expanded; If the button has `aria-expanded="true"` set, it is currently expanded; if the button has `aria-expanded="undefined"` set or the attribute is omitted, it is not expandable.
+  - : If the button controls a grouping of other elements, the `aria-expanded` state indicates whether the controlled grouping is currently expanded or collapsed. If the button has `aria-expanded="false"` set, the grouping is not currently expanded; If the button has `aria-expanded="true"` set, it is currently expanded; if the button has `aria-expanded="undefined"` set or the attribute is omitted, it is not expandable.
 
 ### Basic buttons
 
-Buttons should always have an accessible name. For most buttons, this name will be the same as the text inside the button, between the opening and closing tags. In some cases, for example buttons represented by icons, the accessible name may be provided from the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes.
+Buttons should always have an accessible name. For most buttons, this name will be the same as the text inside the button, between the opening and closing tags. In some cases, for example buttons represented by icons, the accessible name may be provided from the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes.
 
 ### Toggle buttons
 
-A toggle button typically has two states: pressed and not pressed. A third mixed state is available for toggle buttons that control other elements, such as other toggle buttons or checkboxes, which do not all share the same value.  Whether an element is a toggle button or not can be indicated with the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute in addition to the `button` role (if the element is not already a native button element):
+A toggle button typically has two states: pressed and not pressed. A third mixed state is available for toggle buttons that control other elements, such as other toggle buttons or checkboxes, which do not all share the same value. Whether an element is a toggle button or not can be indicated with the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute in addition to the `button` role (if the element is not already a native button element):
 
 - If `aria-pressed` is not used, or is set to the "undefined" state, the button is not a toggle button.
-- If `aria-pressed="false"` is used the button is a toggle button that is currently not pressed.
-- If `aria-pressed="true"` is used the button is a toggle button that is currently pressed.
+- If `aria-pressed="false"` is used the button is a toggle button that is currently not pressed.
+- If `aria-pressed="true"` is used the button is a toggle button that is currently pressed.
 - if `aria-pressed="mixed"` is used, the button is considered to be partially pressed.
 
 As an example, the mute button on an audio player labeled "mute" could indicate that sound is muted by setting the `aria-pressed` state true. The label of a toggle button should not change when its state changes. In our example the label remains "Mute" with a screen reader reading "Mute toggle button pressed" or "Mute toggle button not pressed" depending on the value of `aria-pressed`. If the design were to call for the button label to change from "Mute" to "Unmute," a toggle button would not be appropriate, so the `aria-pressed` attribute would be omitted.
@@ -71,18 +71,18 @@ Following button activation, focus is set depending on the type of action the bu
 
 #### Required event handlers
 
-Buttons can be operated by mouse, touch, and keyboard users. For native HTML `<button>` elements, the button's `onclick` event fires for mouse clicks and when the user presses <kbd>Space</kbd> or <kbd>Enter</kbd> while the button has focus. But if another tag is used to create a button, the `onclick` event only fires when clicked by the mouse cursor, even if `role="button"` is used. Because of this, separate key event handlers must be added to the element so that the button is be triggered when the <kbd>Space</kbd> or <kbd>Enter</kbd> key is pressed.
+Buttons can be operated by mouse, touch, and keyboard users. For native HTML `<button>` elements, the button's `onclick` event fires for mouse clicks and when the user presses <kbd>Space</kbd> or <kbd>Enter</kbd> while the button has focus. But if another tag is used to create a button, the `onclick` event only fires when clicked by the mouse cursor, even if `role="button"` is used. Because of this, separate key event handlers must be added to the element so that the button is be triggered when the <kbd>Space</kbd> or <kbd>Enter</kbd> key is pressed.
 
 - `onclick`
   - : Handles the event raised when the button is activated using a mouse click or touch event.
 - `onKeyDown`
-  - : Handles the event raised when the button is activated using the Enter or Space key on the keyboard. (Note not the [deprecated onKeyPress](/en-US/docs/Web/API/Document/keypress_event))
+  - : Handles the event raised when the button is activated using the Enter or Space key on the keyboard. (Note not the [deprecated onKeyPress](/en-US/docs/Web/API/Document/keypress_event))
 
 ## Examples
 
 ### Basic button example
 
-In this example, a span element has been given the `button` role. Because a `<span>` element is used, the `tabindex` attribute is required to make the button focusable and part of the page's tab order. The included CSS style is provided to make the `<span>` element look like a button, and to provide visual cues when the button has focus.
+In this example, a span element has been given the `button` role. Because a `<span>` element is used, the `tabindex` attribute is required to make the button focusable and part of the page's tab order. The included CSS style is provided to make the `<span>` element look like a button, and to provide visual cues when the button has focus.
 
 The `handleBtnClick` and `handleBtnKeyDown` event handlers perform the button's action when activated using a mouse click or the <kbd>Space</kbd> or <kbd>Enter</kbd> key. In this case, the action is to add a new name to the list of names.
 
@@ -102,9 +102,9 @@ Try the example by adding a name to the text box. The button will cause the name
 
 ```css
 [role="button"] {
-  padding: 2px;
-  background-color: navy;
-  color: white;
+  padding: 2px;
+  background-color: navy;
+  color: white;
   cursor: default;
 }
 [role="button"]:hover,
@@ -152,7 +152,7 @@ function handleCommand(event) {
 
 ### Toggle button example
 
-In this snippet a {{HTMLElement("span")}} element is converted to a toggle button using the `button` role and the `aria-pressed` attribute. When the button is activated, the `aria-pressed` value switches states; changing from `true` to `false` and back again.
+In this snippet a {{HTMLElement("span")}} element is converted to a toggle button using the `button` role and the `aria-pressed` attribute. When the button is activated, the `aria-pressed` value switches states; changing from `true` to `false` and back again.
 
 #### HTML
 
@@ -168,7 +168,7 @@ In this snippet a {{HTMLElement("span")}} element is converted to a toggle butto
 </span>
 
 <audio id="audio" src="https://soundbible.com/mp3/Tyrannosaurus%20Rex%20Roar-SoundBible.com-807702404.mp3">
-  Your browser does not support the `audio` element.
+  Your browser does not support the `audio` element.
 </audio>
 ```
 
@@ -177,14 +177,14 @@ In this snippet a {{HTMLElement("span")}} element is converted to a toggle butto
 ```css
 button,
 [role="button"] {
-    padding: 3px;
-    border: 2px solid transparent;
+    padding: 3px;
+    border: 2px solid transparent;
 }
 
 button:active,
 button:focus,
 [role="button"][aria-pressed="true"] {
-    border: 2px solid #000;
+    border: 2px solid #000;
 }
 ```
 
@@ -192,24 +192,24 @@ button:focus,
 
 ```js
 function handleBtnClick(event) {
-  toggleButton(event.target);
+  toggleButton(event.target);
 }
 
 function handleBtnKeyDown(event) {
-  // Check to see if space or enter were pressed
-  if (event.key === " " || event.key === "Enter" || event.key === "Spacebar") { // "Spacebar" for IE11 support
+  // Check to see if space or enter were pressed
+  if (event.key === " " || event.key === "Enter" || event.key === "Spacebar") { // "Spacebar" for IE11 support
     // Prevent the default action to stop scrolling when space is pressed
-    event.preventDefault();
-    toggleButton(event.target);
-  }
+    event.preventDefault();
+    toggleButton(event.target);
+  }
 }
 
 function toggleButton(element) {
   var audio = document.getElementById('audio');
-  // Check to see if the button is pressed
-  var pressed = (element.getAttribute("aria-pressed") === "true");
-  // Change aria-pressed to the opposite state
-  element.setAttribute("aria-pressed", !pressed);
+  // Check to see if the button is pressed
+  var pressed = (element.getAttribute("aria-pressed") === "true");
+  // Change aria-pressed to the opposite state
+  element.setAttribute("aria-pressed", !pressed);
   // toggle the play state of the audio file
   if(pressed) {
      audio.pause();
@@ -225,15 +225,15 @@ function toggleButton(element) {
 
 ## Accessibility concerns
 
-Buttons are interactive controls and thus focusable. If the `button` role is added to an element that is not focusable by itself (such as `<span>`, `<div>` or `<p>`) then, the `tabindex` attribute has to be used to make the button focusable.
+Buttons are interactive controls and thus focusable. If the `button` role is added to an element that is not focusable by itself (such as `<span>`, `<div>` or `<p>`) then, the `tabindex` attribute has to be used to make the button focusable.
 
 > **Warning:** Be careful when marking up links with the button role. Buttons are expected to be triggered using the <kbd>Space</kbd> or <kbd>Enter</kbd> key, while links are expected to be triggered using the <kbd>Enter</kbd> key. In other words, when links are used to behave like buttons, adding `role="button"` alone is not sufficient. It will also be necessary to add a key event handler that listens for the <kbd>Space</kbd> key in order to be consistent with native buttons.
 
-When the `button` role is used, screen readers announce the element as a button, generally saying "click" followed by the button's accessible name. The accessible name is either the content of the element or the value of an `aria-label` or element referenced by an  `aria-labelledby` attribute, or description, if included.
+When the `button` role is used, screen readers announce the element as a button, generally saying "click" followed by the button's accessible name. The accessible name is either the content of the element or the value of an `aria-label` or element referenced by an `aria-labelledby` attribute, or description, if included.
 
 ## Best practices
 
-If a link performs the action of a button, giving the element `role="button"` helps assistive technology users understand the function of the element. However, a better solution is to adjust the visual design so it matches the function and ARIA role.  Where possible, it is recommended to use native HTML buttons (`<button>`, `<input type="button">`,  `<input type="submit">`, `<input type="reset">` and `<input type="image">`) rather than the `button` role, as native HTML buttons are supported by all user agents and assistive technology and provide keyboard and focus requirements by default, without need for additional customization.
+If a link performs the action of a button, giving the element `role="button"` helps assistive technology users understand the function of the element. However, a better solution is to adjust the visual design so it matches the function and ARIA role. Where possible, it is recommended to use native HTML buttons (`<button>`, `<input type="button">`, `<input type="submit">`, `<input type="reset">` and `<input type="image">`) rather than the `button` role, as native HTML buttons are supported by all user agents and assistive technology and provide keyboard and focus requirements by default, without need for additional customization.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/roles/meter_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/meter_role/index.md
@@ -7,9 +7,9 @@ tags:
   - Meter
   - Web Development
 ---
-The `meter` role is used to identify an element being used as a meter.
+The `meter` role is used to identify an element being used as a meter.
 
-> **Note:** Where possible, it is recommended that you use a native {{HTMLElement("meter")}} element rather than the `meter` role, as native elements are more widely supported by user agents and assistive technology. 
+> **Note:** Where possible, it is recommended that you use a native {{HTMLElement("meter")}} element rather than the `meter` role, as native elements are more widely supported by user agents and assistive technology.
 
 ## Description
 
@@ -22,13 +22,13 @@ Each element with `role="meter"` must also have one of the following:
 
 ### Associated ARIA roles, states, and properties
 
-- [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) 
+- [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow)
   - : Set to a decimal value between `aria-valuemin` and `aria-valuemax` indicating the current value of the meter.
-- [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) 
+- [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext)
   - : Assistive technologies often present the value of `aria-valuenow` as a percentage. If this would not be accurate use this property to make the meter value understandable.
-- [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) 
+- [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin)
   - : Set to a decimal value representing the minimum value, and less than `aria-valuemax`.
-- [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) 
+- [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax)
   - : Set to a decimal value representing the maximum value, and greater than `aria-valuemin`.
 
 It is recommended to use a native {{HTMLElement("meter")}} element rather than the `meter` role. User agents provide a stylize widget for the {{HTMLElement("meter")}} element based on the current `value` as it relates to the `min` and `max` values. When using non-semantic elements, all features of the native semantic element need to be recreated with ARIA attributes, JavaScript and CSS.
@@ -62,7 +62,7 @@ In the above scenario, when the `aria-valuenow` value updates, the width of the 
 | -------------------------------------------------------- | ---------------------------- |
 | {{SpecName("ARIA 1.2","#meter","meter")}} | {{Spec2('ARIA 1.2')}} |
 
-## See also 
+## See also
 
 - {{HTMLElement('meter')}}
 - {{HTMLElement('progress')}}

--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -60,7 +60,7 @@ The `role` attribute only adds semantics; all of the functionality that comes na
 </fieldset>
 ```
 
-The native HTML radio ([`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio))  form control had two states ("checked" or "not checked"). Similarly, an element with `role="radio"`  can expose two states through the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute: `true` and `false`. The value of `mixed` correlates to the  `indeterminate` value of HTML `checked` attribute, meaning neither checked nor unchecked. While `mixed` is valid on both radios and checkboxes, it is rarely useful for a radio button. 
+The native HTML radio ([`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)) form control had two states ("checked" or "not checked"). Similarly, an element with `role="radio"` can expose two states through the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute: `true` and `false`. The value of `mixed` correlates to the  `indeterminate` value of HTML `checked` attribute, meaning neither checked nor unchecked. While `mixed` is valid on both radios and checkboxes, it is rarely useful for a radio button.
 
 If a radio button is checked, the radio element has `aria-checked` set to `true`. If it is not checked, it has `aria-checked` set to `false`.
 
@@ -68,7 +68,7 @@ Each radio button element has role `radio`. The radio role should always be nest
 
 Each radio element is labelled by its content, has a visible label referenced by `aria-labelledby`, or has a label specified with `aria-label`. The containing radiogroup element should either have a visible label referenced by `aria-labelledby` or a label specified with `aria-label`. If elements providing additional information about either the radio group or each radio button are present, those elements should be referenced by the radiogroup element or radio elements with the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) property.
 
-As `radio` is an interactive control; it must be focusable and keyboard accessible. If the role is applied to a non-focusable element, use the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute to change this. The expected keyboard shortcut for activating a radio is the <kbd>Space</kbd> key. Use JavaScript to toggle the `aria-checked` attribute to `true` when a radio becomes checked while ensuing that all the other radio roles in the group are set to  `aria-checked="false"`.
+As `radio` is an interactive control; it must be focusable and keyboard accessible. If the role is applied to a non-focusable element, use the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute to change this. The expected keyboard shortcut for activating a radio is the <kbd>Space</kbd> key. Use JavaScript to toggle the `aria-checked` attribute to `true` when a radio becomes checked while ensuing that all the other radio roles in the group are set to `aria-checked="false"`.
 
 If any of the radio roles in a group has `aria-required="true"` set, it is as if all of the radios in the group had the attribute making the selection of one of the radios in the radiogroup being required to be valid;  though not necessarily the one that has the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute set.
 
@@ -252,7 +252,7 @@ No JavaScript (or even CSS) would be needed had we used semantic HTML element wi
 
 ## Best practices
 
-The first rule of ARIA is: if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding an ARIA role, state or property to make it accessible. As such, it is recommended to use the native [HTML radio](/en-US/docs/Web/HTML/Element/input/radio) using form controls instead of recreating a radio's functionality with JavaScript and ARIA.
+The first rule of ARIA is: if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding an ARIA role, state or property to make it accessible. As such, it is recommended to use the native [HTML radio](/en-US/docs/Web/HTML/Element/input/radio) using form controls instead of recreating a radio's functionality with JavaScript and ARIA.
 
 ## See also
 

--- a/files/en-us/web/accessibility/aria/roles/tab_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tab_role/index.md
@@ -28,7 +28,7 @@ When elements with the `tab` role are selected or active they should have their 
   - : boolean
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
   - : `id` of element with `tabpanel` role
-- {{htmlattrxref("id")}} 
+- {{htmlattrxref("id")}}
   - : content
 
 ### Keyboard interaction

--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -27,7 +27,7 @@ abort(reason)
 
 - `reason`
   - : The reason why the operation was aborted, which can be any JavaScript value.
-    If not specified, the reason is set to "AbortError" {{domxref("DOMException")}}. 
+    If not specified, the reason is set to "AbortError" {{domxref("DOMException")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/abortsignal/abort/index.md
+++ b/files/en-us/web/api/abortsignal/abort/index.md
@@ -36,7 +36,7 @@ abort(reason)
 
 - `reason`
   - : The reason why the operation was aborted, which can be any JavaScript value.
-    If not specified, the reason is set to "AbortError" {{domxref("DOMException")}}. 
+    If not specified, the reason is set to "AbortError" {{domxref("DOMException")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -32,7 +32,7 @@ throwIfAborted()
 
 The examples below come from the specification.
 
-### Aborting a polling operation 
+### Aborting a polling operation
 
 This example demonstrates how you can use `throwIfAborted()` to abort a polling operation.
 
@@ -104,7 +104,7 @@ controller.abort();
 ```
 
 APIs that do not return promises might react in a similar manner.
-In some cases it may make sense to absorb the signal. 
+In some cases it may make sense to absorb the signal.
 
 ## Specifications
 

--- a/files/en-us/web/api/clients/claim/index.md
+++ b/files/en-us/web/api/clients/claim/index.md
@@ -14,11 +14,11 @@ browser-compat: api.Clients.claim
 ---
 {{APIRef("Service Worker Clients")}}
 
-The **`claim()`** method of the {{domxref("Clients")}} interface allows an active service worker to set itself as the {{domxref("ServiceWorkerContainer.controller", "controller")}} for all clients within its {{domxref("ServiceWorkerRegistration.scope", "scope")}}. 
-This triggers a "`controllerchange`" event on {{domxref("ServiceWorkerContainer","navigator.serviceWorker")}} in any clients that become controlled by this service worker.
+The **`claim()`** method of the {{domxref("Clients")}} interface allows an active service worker to set itself as the {{domxref("ServiceWorkerContainer.controller", "controller")}} for all clients within its {{domxref("ServiceWorkerRegistration.scope", "scope")}}.
+This triggers a "`controllerchange`" event on {{domxref("ServiceWorkerContainer","navigator.serviceWorker")}} in any clients that become controlled by this service worker.
 
 When a service worker is initially registered, pages won't use it until they next
-load. The `claim()` method causes those pages to be controlled immediately.
+load. The `claim()` method causes those pages to be controlled immediately.
 Be aware that this results in your service worker controlling pages that loaded
 regularly over the network, or possibly via a different service worker.
 
@@ -38,11 +38,11 @@ A {{jsxref("Promise")}} that resolves to `undefined`.
 
 ## Example
 
-The following example uses `claim()` inside service worker's "`activate`" event listener so that clients loaded in the same scope do not need to be reloaded before their fetches will go through this service worker.
+The following example uses `claim()` inside service worker's "`activate`" event listener so that clients loaded in the same scope do not need to be reloaded before their fetches will go through this service worker.
 
 ```js
 self.addEventListener('activate', event => {
-  event.waitUntil(clients.claim());
+  event.waitUntil(clients.claim());
 });
 ```
 

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -13,7 +13,7 @@ browser-compat: api.HTMLInputElement.showPicker
 {{ APIRef("HTML DOM") }}
 
 The **`HTMLInputElement.showPicker()`** method shows a browser picker to the
-user. 
+user.
 
 A browser picker is shown when the element is one of these types: `"date"`,
 `"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`. It

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -47,7 +47,7 @@ navigator.mediaSession.setActionHandler(type, callback)
     - `seekto`
       - : Moves the playback position to the specified time within the media.
         The time to which to seek is specified in the `seekTime` property passed to the callback.
-        If you intend to perform multiple `seekto` operations in rapid succession, you can also specify the `fastSeek` property passed to the callback with a value of `true`. 
+        If you intend to perform multiple `seekto` operations in rapid succession, you can also specify the `fastSeek` property passed to the callback with a value of `true`.
         This lets the browser know it can take steps to optimize repeated operations, and is likely to result in improved performance.
     - `skipad`
       - : Skips past the currently playing advertisement or commercial.
@@ -59,15 +59,15 @@ navigator.mediaSession.setActionHandler(type, callback)
     - `action`
       - : A {{domxref("DOMString")}} representing the action type. This property allows a single callback to handle multiple action types.
     - `fastSeek` {{optional_inline}}
-      - : An `{{anch("seekto")}}` action may *optionally* include this property, which is a Boolean value indicating whether or not to perform a "fast" seek.
+      - : An `{{anch("seekto")}}` action may *optionally* include this property, which is a Boolean value indicating whether or not to perform a "fast" seek.
         A "fast" seek is a seek being performed in a rapid sequence, such as when fast-forwarding or reversing through the media, rapidly skipping through it.
         This property can be used to indicate that you should use the shortest possible method to seek the media.
-        `fastSeek` is not included on the final action in the seek sequence in this situation.
+        `fastSeek` is not included on the final action in the seek sequence in this situation.
     - `seekOffset` {{optional_inline}}
-      - : If the `action` is either `{{anch("seekforward")}}` or `{{anch("seekbackward")}}` and this property is present, it is a floating point value which indicates the number of seconds to move the play position forward or backward.
+      - : If the `action` is either `{{anch("seekforward")}}` or `{{anch("seekbackward")}}` and this property is present, it is a floating point value which indicates the number of seconds to move the play position forward or backward.
         If this property isn't present, those actions should choose a reasonable default distance to skip forward or backward (such as 7 or 10 seconds).
     - `seekTime` {{optional_inline}}
-      - : If the `action` is `{{anch("seekto")}}`, this property must be present and must be a floating-point value indicating the absolute time within the media to move the playback position to, where 0 indicates the beginning of the media. This property is not present for other action types.
+      - : If the `action` is `{{anch("seekto")}}`, this property must be present and must be a floating-point value indicating the absolute time within the media to move the playback position to, where 0 indicates the beginning of the media. This property is not present for other action types.
 
 ### Return value
 
@@ -183,19 +183,19 @@ navigator.mediaSession.setActionHandler("seekforward", handleSeek);
 navigator.mediaSession.setActionHandler("seekbackward", handleSeek);
 
 function handleSeek(details) {
-  switch(details.action) {
-    case "seekforward":
-      audio.currentTime = Math.min(audio.currentTime + skipTime,
-              audio.duration);
-      break;
-    case "seekbackward":
-      audio.currentTime = Math.max(audio.currentTime - skipTime, 0);
-      break;
-  }
+  switch(details.action) {
+    case "seekforward":
+      audio.currentTime = Math.min(audio.currentTime + skipTime,
+              audio.duration);
+      break;
+    case "seekbackward":
+      audio.currentTime = Math.max(audio.currentTime - skipTime, 0);
+      break;
+  }
 }
 ```
 
-Here, the `handleSeek()` function handles both `seekbackward` and `seekforward` actions.
+Here, the `handleSeek()` function handles both `seekbackward` and `seekforward` actions.
 
 ## Specifications
 

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -90,7 +90,7 @@ The returned _measure_ will have the following property values:
 
 - `TypeError` {{domxref("DOMException")}}
   - : This can be thrown in any case where the start, end or duration might be ambiguous:
-    
+
     - Both `endMark` and `MeasureOptions` are specified.
     - `MeasureOptions` is specified without either `start` and `end` members.
     - `MeasureOptions` is specified with all of `start`, `end`, and `duration` members (which might then be inconsistent).

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -167,7 +167,7 @@ This can be used together with {{CSSxRef("list-style-type")}} and {{CSSxRef("lis
     - `inline-block`
 
       - : The element generates a block element box that will be flowed with surrounding content as if it were a single inline box (behaving much like a replaced element would).
-      
+
         It is equivalent to `inline flow-root`.
 
     - `inline-table`

--- a/files/en-us/web/css/inherit/index.md
+++ b/files/en-us/web/css/inherit/index.md
@@ -18,7 +18,7 @@ browser-compat: css.types.global_keywords.inherit
 
 The **`inherit`** CSS keyword causes the element for which it is specified to take the [computed value](/en-US/docs/Web/CSS/computed_value) of the property from its parent element. It can be applied to any CSS property, including the CSS shorthand {{cssxref("all")}}.
 
-For [inherited properties](/en-US/docs/Web/CSS/inheritance#Inherited_properties), this reinforces the default behavior, and is only needed to override another rule. 
+For [inherited properties](/en-US/docs/Web/CSS/inheritance#Inherited_properties), this reinforces the default behavior, and is only needed to override another rule.
 
 Inheritance is always from the parent element in the document tree, even when the parent element is not the containing block.
 

--- a/files/en-us/web/css/path()/index.md
+++ b/files/en-us/web/css/path()/index.md
@@ -23,7 +23,7 @@ path( [[<'fill-rule'>,]?<string>)
 - `<'fill-rule'>`
   - : The filling rule for the interior of the path. Possible values are nonzero or evenodd. The default value is nonzero. See [fill-rule](/en-US/docs/Web/SVG/Attribute/fill-rule) for more details.
 - `<string>`
-  - : The string is a [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path) 
+  - : The string is a [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path)
 
 ## Examples
 
@@ -65,7 +65,7 @@ html,body,svg { height:100% }
 </svg>
 ```
 
-#### Result 
+#### Result
 
 {{EmbedLiveSample('Modify the value of the SVG path d attribute', '100%', 200)}}
 

--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -82,7 +82,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 > **Note:** Unlike the {{htmlelement("meter")}} element, the minimum value is always 0, and the `min` attribute is not allowed for the `<progress>` element.
 
-> **Note:** The {{cssxref(":indeterminate")}} pseudo-class can be used to match against indeterminate progress bars. To change the progress bar to indeterminate after giving it a value you must remove the value attribute with {{domxref("Element.removeAttribute", "element.removeAttribute('value')")}}.
+> **Note:** The {{cssxref(":indeterminate")}} pseudo-class can be used to match against indeterminate progress bars. To change the progress bar to indeterminate after giving it a value you must remove the value attribute with {{domxref("Element.removeAttribute", "element.removeAttribute('value')")}}.
 
 ## Examples
 
@@ -116,7 +116,7 @@ In most cases you should provide an accessible label when using `<progress>`. Wh
   <label for="progress-bar">Uploading Document</label>
   <progress id="progress-bar" value="70" max="100">
 ```
-    
+
 ### Describing a particular region
 
 If the `<progress>` element is describing the loading progress of a section of a page, use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) to point to the status, and set [`aria-busy="true"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria_busy ) on the section that is being updated, removing the `aria-busy` attribute when it has finished loading.

--- a/files/en-us/web/http/headers/alt-svc/index.md
+++ b/files/en-us/web/http/headers/alt-svc/index.md
@@ -10,7 +10,7 @@ browser-compat: http.headers.Alt-Svc
 ---
 {{HTTPSidebar}}
 
-The {{HTTPHeader("Alt-Svc")}} HTTP header allows a server to indicate that another network location (the "alternative service") can be treated as authoritative for that origin when making future requests. 
+The {{HTTPHeader("Alt-Svc")}} HTTP header allows a server to indicate that another network location (the "alternative service") can be treated as authoritative for that origin when making future requests.
 
 Doing so allows new protocol versions to be advertised without affecting in-flight requests, and can also help servers manage traffic. Using an alternative service is not visible to the end user; it does not change the URL or the origin of the request, and does not introduce extra round trips.
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -101,7 +101,7 @@ The [UA client hints](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints)
   - : User agent's underlying operation system/platform.
 - {{HTTPHeader("Sec-CH-UA-Platform-Version")}} {{experimental_inline}}
   - : User agent's underlying operation system version.
- 
+
 ### Device client hints
 
 - {{HTTPHeader("Content-DPR")}} {{deprecated_inline}}{{experimental_inline}}
@@ -289,7 +289,7 @@ _Learn more about CORS [here](CORS)._
   - : Allows sites to opt in to reporting and/or enforcement of Certificate Transparency requirements, which prevents the use of misissued certificates for that site from going unnoticed. When a site enables the Expect-CT header, they are requesting that Chrome check that any certificate for that site appears in public CT logs.
 - {{HTTPHeader("Feature-Policy")}}
   - : Provides a mechanism to allow and deny the use of browser features in its own frame, and in iframes that it embeds.
-- {{HTTPHeader("Origin-Isolation")}} {{experimental_inline}}
+- {{HTTPHeader("Origin-Isolation")}} {{experimental_inline}}
   - : Provides a mechanism to allow web applications to isolate their origins.
 - {{HTTPHeader("Strict-Transport-Security")}} ({{Glossary("HSTS")}})
   - : Force communication using HTTPS instead of HTTP.

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -65,7 +65,7 @@ The `Origin` header value may be `null` in a number of cases, including (non-exh
 
 - Origins whose scheme is not one of `http`, `https`, `ftp`, `ws`, `wss`, or `gopher` (including `blob`, `file` and `data`).
 - Cross-origin images and media data, including that in `<img>`, `<video>` and `<audio>` elements.
-- Documents created programmatically using `createDocument()`, generated from a `data:` url, or that do not have a creator browsing context. 
+- Documents created programmatically using `createDocument()`, generated from a `data:` url, or that do not have a creator browsing context.
 - Redirects across origins.
 - iframes with a sandbox attribute that doesn’t contain the value `allow-same-origin`.
 - Responses that are network errors.

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Bitness
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Bitness`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the "bitness" of the user-agent's underlying CPU architecture. 
+The **`Sec-CH-UA-Bitness`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the "bitness" of the user-agent's underlying CPU architecture.
 This is the size in bits of an integer or memory address—typically 64 or 32 bits.
 
 This might be used by a server, for example, to select and offer the correct binary format of an executable for a user to download.

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Platform-Version
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the version of the operating system on which the user agent is running. 
+The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the version of the operating system on which the user agent is running.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Sec-CH-UA-Platform
 ---
 {{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
 
-The **`Sec-CH-UA-Platform`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the platform or operating system on which the user agent is running. 
+The **`Sec-CH-UA-Platform`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the platform or operating system on which the user agent is running.
 For example: "Windows" or "Android".
 
 `Sec-CH-UA-Platform` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints).

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -71,7 +71,7 @@ Sec-CH-UA: "<brand>";v="<significant version>", ...
 `Sec-CH-UA` is a [low entropy hint](/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints).
 Unless explicitly blocked by a user agent policy, it will be sent in all requests (without the server having to opt in by sending {{HTTPHeader("Accept-CH")}}).
 
-Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below. 
+Strings from Chromium, Chrome, Edge, and Opera desktop browsers are shown below.
 Note that they all share the "Chromium" brand, but have an additional brand indicating their origin.
 They also have an intentionally incorrect brand string, which may appear in any position and have different text.
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -55,7 +55,7 @@ The redirect could be exploited to direct visitors to a malicious site instead o
 The HTTP Strict Transport Security header informs the browser that it should never load a site using HTTP and should automatically convert all attempts to access the site using HTTP to HTTPS requests instead.
 
 > **Note:** The `Strict-Transport-Security` header is **ignored** by the browser when your site is accessed using HTTP;
-> this is because an attacker may intercept HTTP connections and inject the header or remove it. 
+> this is because an attacker may intercept HTTP connections and inject the header or remove it.
 > When your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the `Strict-Transport-Security` header.
 
 ### An example scenario

--- a/files/en-us/web/http/status/101/index.md
+++ b/files/en-us/web/http/status/101/index.md
@@ -10,8 +10,8 @@ tags:
 ---
 {{HTTPSidebar}}
 
-The HTTP **`101 Switching Protocols`** response code indicates
-a protocol to which the server switches. 
+The HTTP **`101 Switching Protocols`** response code indicates
+a protocol to which the server switches.
 The protocol is specified in the {{HTTPHeader("Upgrade")}} request header received from a client.
 
 The server includes in this response an {{HTTPHeader("Upgrade")}} response header to

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -47,8 +47,8 @@ The `screenshots` member defines an array of screenshots intended to showcase th
 
 The `label` member is a string that serves as an accessible name for the screenshots. It can also serve as alternative text for the screenshots.
 
-The `platform` member is also a string that can define the distribution platform for which the specific screenshots should apply to. If not 
-defined, user agents can use the screenshot's aspect ratio for displaying. 
+The `platform` member is also a string that can define the distribution platform for which the specific screenshots should apply to. If not
+defined, user agents can use the screenshot's aspect ratio for displaying.
 
 The `platform` member can be set to one of the following _general purpose_ values :
 

--- a/files/en-us/web/privacy/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/index.md
@@ -50,7 +50,7 @@ Cookies:
 
 DOM Storage:
 
-- [localStorage](/en-US/docs/Web/API/Web_Storage_API): [`Window.localStorage`](/en-US/docs/Web/API/Window/localStorage): read and write attempts throw a `SecurityError` exception.  Prior to Firefox 70: [`Window.localStorage`](/en-US/docs/Web/API/Window/localStorage) is `null`. Thus, attempts to read and write using this object will throw a `TypeError` exception.
+- [localStorage](/en-US/docs/Web/API/Web_Storage_API): [`Window.localStorage`](/en-US/docs/Web/API/Window/localStorage): read and write attempts throw a `SecurityError` exception. Prior to Firefox 70: [`Window.localStorage`](/en-US/docs/Web/API/Window/localStorage) is `null`. Thus, attempts to read and write using this object will throw a `TypeError` exception.
 - [sessionStorage](/en-US/docs/Web/API/Web_Storage_API): read and write attempts are permitted.
 - [IndexedDB](/en-US/docs/Web/API/IndexedDB_API): attempting to access the IndexedDB factory object throws a `SecurityError` exception.
 
@@ -101,7 +101,7 @@ Third-party storage access may be granted to resources that have been classified
 
 ### Scope of storage access
 
-When storage access is granted, it is scoped to the site of the opener document or subdomains of that origin. Access that is granted on the subdomain of an origin does extend to the top-level origin. As an example, if a resource from `tracker.example` is granted storage access on `foo.example.com`, then `tracker.example` will be able to access its cookies on `bar.foo.example.com` and on `example.com`. 
+When storage access is granted, it is scoped to the site of the opener document or subdomains of that origin. Access that is granted on the subdomain of an origin does extend to the top-level origin. As an example, if a resource from `tracker.example` is granted storage access on `foo.example.com`, then `tracker.example` will be able to access its cookies on `bar.foo.example.com` and on `example.com`.
 
 When storage access is granted to `tracker.example` on `example.com`, all resources loaded from `tracker.example` on any top-level document loaded from `example.com` are immediately given storage access. This includes all resources loaded in the main context of the page, embedded `<iframe>`s, and resources loaded within embedded `<iframe>`s. Storage access is not extended to other resources loaded on `example.com` (e.g. `other-tracker.example`), nor to other first parties on which `tracker.example` is embedded (e.g. `example.org`).
 
@@ -119,9 +119,9 @@ Consider the following embedding scenarios on a top-level page loaded from `exam
 
 ### Storage access expiration
 
-The storage access grant expires after 30 days. Domains classified as tracking resources may be granted third-party storage access on multiple first parties, and the storage permission for each party expires independently. The above heuristics will also serve to extend the lifetime of a third-party storage permission on origins that have already been granted access.  Each time the heuristic is activated, or a success call to the Storage Access API is made, the pre-existing storage access expiration will be extended by 30 days, counting from the time the previous access was granted.
+The storage access grant expires after 30 days. Domains classified as tracking resources may be granted third-party storage access on multiple first parties, and the storage permission for each party expires independently. The above heuristics will also serve to extend the lifetime of a third-party storage permission on origins that have already been granted access. Each time the heuristic is activated, or a success call to the Storage Access API is made, the pre-existing storage access expiration will be extended by 30 days, counting from the time the previous access was granted.
 
-Please note that in the future we expect to make changes to how long storage access will remain valid for.  As mentioned before, the way to know that you will be able to use storage as a third-party going forward will be using the Storage Access API.
+Please note that in the future we expect to make changes to how long storage access will remain valid for. As mentioned before, the way to know that you will be able to use storage as a third-party going forward will be using the Storage Access API.
 
 ## Debugging
 

--- a/files/en-us/web/svg/attribute/presentation/index.md
+++ b/files/en-us/web/svg/attribute/presentation/index.md
@@ -22,7 +22,7 @@ SVG presentation attributes are CSS properties that can be used as attributes on
 *   [color-profile](#attr-color-profile)
 *   [color-rendering](#attr-color-rendering)
 *   [cursor](#attr-cursor)
-*   [d](#attr-d) 
+*   [d](#attr-d)
 *   [direction](#attr-direction)
 *   [display](#attr-display)
 *   [dominant-baseline](#attr-dominant-baseline)
@@ -136,13 +136,13 @@ SVG presentation attributes are CSS properties that can be used as attributes on
     *   : It indicates how to determine what side of a path is inside a shape.
         *Value*: **`nonzero`**|`evenodd`|`inherit`; *Animatable*: **Yes**
 *   {{SVGAttr('filter')}}
-    *   : It defines the filter effects defined by the {{SVGElement('filter')}} element that shall be applied to its element.
+    *   : It defines the filter effects defined by the {{SVGElement('filter')}} element that shall be applied to its element.
         *Value*: [\<FuncIRI>](/en-US/docs/Web/SVG/Content_type#funciri)|**`none`**|`inherit`; *Animatable*: **Yes**
 *   {{SVGAttr('flood-color')}}
-    *   : It indicates what color to use to flood the current filter primitive subregion defined through the {{SVGElement('feFlood')}} or {{SVGElement('feDropShadow')}} element.
+    *   : It indicates what color to use to flood the current filter primitive subregion defined through the {{SVGElement('feFlood')}} or {{SVGElement('feDropShadow')}} element.
         *Value*: [\<color>](/en-US/docs/Web/SVG/Content_type#color); *Animatable*: **Yes**
 *   {{SVGAttr('flood-opacity')}}
-    *   : It indicates the opacity value to use across the current filter primitive subregion defined through the {{SVGElement('feFlood')}} or {{SVGElement('feDropShadow')}} element.
+    *   : It indicates the opacity value to use across the current filter primitive subregion defined through the {{SVGElement('feFlood')}} or {{SVGElement('feDropShadow')}} element.
         *Value*: [\<number>](/en-US/docs/Web/SVG/Content_type#number)|[\<percentage>](/en-US/docs/Web/SVG/Content_type#percentage); *Animatable*: **Yes**
 *   {{SVGAttr('font-family')}}
     *   : It indicates which font family will be used to render the text of the element.
@@ -181,7 +181,7 @@ SVG presentation attributes are CSS properties that can be used as attributes on
     *   : It controls spacing between text characters.
         *Value*: **`normal`**|[\<length>](/en-US/docs/Web/SVG/Content_type#length)|`inherit`; *Animatable*: **Yes**
 *   {{SVGAttr('lighting-color')}}
-    *   : It defines the color of the light source for filter primitives elements {{SVGElement('feDiffuseLighting')}} and {{SVGElement('feSpecularLighting')}}.
+    *   : It defines the color of the light source for filter primitives elements {{SVGElement('feDiffuseLighting')}} and {{SVGElement('feSpecularLighting')}}.
         *Value*: [\<color>](/en-US/docs/Web/SVG/Content_type#color); *Animatable*: **Yes**
 *   {{SVGAttr('marker-end')}}
     *   : It defines the arrowhead or polymarker that will be drawn at the final vertex of the given {{SVGElement('path')}} element or basic shape.
@@ -205,7 +205,7 @@ SVG presentation attributes are CSS properties that can be used as attributes on
     *   : Defines whether or when an element may be the target of a mouse event.
         *Value*: `bounding-box`|**`visiblePainted`**|`visibleFil`|`visibleStroke`|`visible` |`painted`|`fill`|`stroke`|`all`|`none`; *Animatable*: **Yes**
 *   {{SVGAttr('shape-rendering')}}
-    *   : Hints about what tradeoffs to make as the browser renders {{SVGElement('path')}} element or basic shapes.
+    *   : Hints about what tradeoffs to make as the browser renders {{SVGElement('path')}} element or basic shapes.
         *Value*: **`auto`**|`optimizeSpeed`|`crispEdges`|`geometricPrecision` |`inherit`; *Animatable*: **Yes**
 *   {{SVGAttr('solid-color')}}
     *   : -


### PR DESCRIPTION
Double space at the end of files is used to create a BR tag. MD009 will smartly leave those instances, but trim any others.
Noticed a few places cleaning up other stuff that appeared to be using this style, so safer to disable for now.