### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/webrtc_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/webrtc_api/taking_still_photos/index.md
@@ -43,10 +43,10 @@ We also have an {{HTMLElement("img")}} element into which we will draw the image
 
 ```html
   <canvas id="canvas">
-  </canvas>
-  <div class="output">
-    <img id="photo" alt="The screen capture will appear in this box.">
-  </div>
+    <div class="output">
+      <img id="photo" alt="The screen capture will appear in this box.">
+    </div>
+  </canvas>
 ```
 
 That's all of the relevant HTML. The rest is just some page layout fluff and a bit of text offering a link back to this page.


### PR DESCRIPTION
Error Fix: Moved <canvas> closing tag to encompass <div class="output">.  Without this change the page displays the captured photo twice instead of just once.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
