### PR TITLE
ci: use built-in setup-node caching

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v2
         with:
           node-version: "12"
+          cache: yarn
 
       - name: Lint markdown files
         run: |

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -16,20 +16,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v2
         with:
           node-version: "12"
-
-      - name: Cache node_modules
-        uses: actions/cache@v2.1.7
-        id: cached-node_modules
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/pr-check_redirects.yml') }}
+          cache: yarn
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |
           yarn --frozen-lockfile
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -26,20 +26,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v2
         with:
           node-version: "12"
-
-      - name: Cache node_modules
-        uses: actions/cache@v2.1.7
-        id: cached-node_modules
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/pr-test.yml') }}
+          cache: yarn
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |
           yarn --frozen-lockfile
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,20 +15,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v2
         with:
           node-version: "12"
-
-      - name: Cache node_modules
-        uses: actions/cache@v2.1.7
-        id: cached-node_modules
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/preview.yml') }}
+          cache: yarn
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |
           yarn --frozen-lockfile
 


### PR DESCRIPTION
Unpin the setup-node version to the major v2, so it stays up-to-date without dependabot noise. Swap the custom caching with the now built-in support in setup-node in v2