### PR TITLE
chore: inline disable only MD011 issue

### DIFF
--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -249,6 +249,7 @@ The following table summarizes the available traps available to `Proxy` objects.
           </dd>
           <dt>Inherited property access</dt>
           <dd>
+            <!-- markdownlint-disable-next-line MD011 -->
             <code>Object.create(<var>proxy</var>)[foo]</code
             ><br />{{jsxref("Reflect.get()")}}
           </dd>
@@ -285,7 +286,7 @@ The following table summarizes the available traps available to `Proxy` objects.
           </dd>
           <dt>Inherited property assignment</dt>
           <dd>
-            <code>Object.create(<var>proxy</var>)[foo] = bar</code
+            <code>Object.create[<var>proxy</var>](foo) = bar</code
             ><br />{{jsxref("Reflect.set()")}}
           </dd>
         </dl>

--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -286,7 +286,8 @@ The following table summarizes the available traps available to `Proxy` objects.
           </dd>
           <dt>Inherited property assignment</dt>
           <dd>
-            <code>Object.create[<var>proxy</var>](foo) = bar</code
+            <!-- markdownlint-disable-next-line MD011 -->
+            <code>Object.create(<var>proxy</var>)[foo] = bar</code
             ><br />{{jsxref("Reflect.set()")}}
           </dd>
         </dl>


### PR DESCRIPTION
There is only one instance that this rule is flagging. Since Markdownlint doesn't try and work around mixed HTML/MD syntax it is unlikely a case that would be resolved upstream, so disabling inline seems best