### PR TITLE
Clarify call-by-value

### DIFF
--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -38,9 +38,9 @@ The function `square` takes one parameter, called `number`. The function consist
 return number * number;
 ```
 
-Primitive parameters (such as a number) are passed to functions **by value**; the value is passed to the function, but if the function changes the value of the parameter, **this change is not reflected globally or in the calling function**.
+Parameters (such as a number or an object reference) are passed to functions **by value**; the value is passed to the function, but if the function changes the value of the parameter, **this change is not reflected globally or in the calling function**.
 
-If you pass an object (i.e., a non-primitive value, such as {{jsxref("Array")}} or a user-defined object) as a parameter and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
+If you pass an reference (i.e., to a non-primitive value, such as {{jsxref("Array")}} or a user-defined object) as a parameter and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
 
 ```js
 function myFunc(theObject) {

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -38,9 +38,9 @@ The function `square` takes one parameter, called `number`. The function consist
 return number * number;
 ```
 
-Parameters are passed to functions **by value**; the value is passed to the function, but if the function then changes the value of the parameter, **the change is not reflected globally or in the calling code**.
+Parameters are passed to functions **by value** — so if the code within the body of a function assigns a completely new value to a parameter that was passed to the function, **the change is not reflected globally or in the code which called that function**.
 
-If as a parameter you pass a reference — which will necessarily be a reference to an object of some kind — and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
+However, when you pass an object as a parameter, if the function changes the object's properties, that change is visible outside the function, as shown in the following example:
 
 ```js
 function myFunc(theObject) {

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -38,9 +38,9 @@ The function `square` takes one parameter, called `number`. The function consist
 return number * number;
 ```
 
-Parameters (such as a number or an object reference) are passed to functions **by value**; the value is passed to the function, but if the function changes the value of the parameter, **this change is not reflected globally or in the calling function**.
+Parameters are passed to functions **by value**; the value is passed to the function, but if the function then changes the value of the parameter, **the change is not reflected globally or in the caller**.
 
-If you pass a reference (i.e., to a non-primitive value, such as {{jsxref("Array")}} or a user-defined object) as a parameter and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
+If as a parameter you pass a reference — which will necessarily be a reference to an object of some kind — and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
 
 ```js
 function myFunc(theObject) {

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -38,7 +38,7 @@ The function `square` takes one parameter, called `number`. The function consist
 return number * number;
 ```
 
-Parameters are passed to functions **by value**; the value is passed to the function, but if the function then changes the value of the parameter, **the change is not reflected globally or in the caller**.
+Parameters are passed to functions **by value**; the value is passed to the function, but if the function then changes the value of the parameter, **the change is not reflected globally or in the calling code**.
 
 If as a parameter you pass a reference — which will necessarily be a reference to an object of some kind — and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
 

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -40,7 +40,7 @@ return number * number;
 
 Parameters (such as a number or an object reference) are passed to functions **by value**; the value is passed to the function, but if the function changes the value of the parameter, **this change is not reflected globally or in the calling function**.
 
-If you pass an reference (i.e., to a non-primitive value, such as {{jsxref("Array")}} or a user-defined object) as a parameter and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
+If you pass a reference (i.e., to a non-primitive value, such as {{jsxref("Array")}} or a user-defined object) as a parameter and the function changes the object's properties, that change is visible outside the function, as shown in the following example:
 
 ```js
 function myFunc(theObject) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The wording in Javascript/Guide/Functions confusingly implies that only primitives are passed by value, then apparently contrasts this with changing a property of an object via a passed reference.

Fix the wording so these are clearly orthogonal concerns.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

MDN has been [cited](https://news.ycombinator.com/item?id=16234789) for getting Javascript parameter passing wrong.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [X] Rewords a misleading explanation

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
