### PR TITLE
Don't use code formatting for things that aren't identifiers: add ret…

### DIFF
--- a/files/en-us/web/api/broadcastchannel/postmessage/index.md
+++ b/files/en-us/web/api/broadcastchannel/postmessage/index.md
@@ -30,10 +30,12 @@ channel.postMessage(message);
 ### Parameters
 
 - `message`
-  - : Data to be sent to the other window. The data is serialized using
-    {{domxref("Web_Workers_API/Structured_clone_algorithm", "the structured clone
-    algorithm")}}. This means you can pass a broad variety of data objects safely to the
-    destination window without having to serialize them yourself.
+  - : Data to be sent to the other window. The data is serialized using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+    This means you can pass a broad variety of data objects safely to the destination window without having to serialize them yourself.
+
+### Return value
+
+None.
 
 ## Specifications
 


### PR DESCRIPTION
We shouldn't use `domxref` for links to guide pages. Also, this PR adds a "Return value" section to the page.