### PR TITLE
Add nav links to CSS Learn

### DIFF
--- a/files/en-us/learn/css/building_blocks/a_cool_looking_box/index.md
+++ b/files/en-us/learn/css/building_blocks/a_cool_looking_box/index.md
@@ -13,6 +13,7 @@ tags:
   - effects
 ---
 {{LearnSidebar}}
+{{PreviousMenu("Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper", "Learn/CSS/Building_blocks")}}
 
 In this assessment, you'll get some more practice in creating cool-looking boxes by trying to create an eye-catching box.
 
@@ -85,3 +86,5 @@ If you would like your work assessed, or are stuck and want to ask for help:
     - Details of what you have already tried, and what you would like us to do, e.g. if you are stuck and need help, or want an assessment.
     - A link to the example you want assessed or need help with, in an online shareable editor (as mentioned in step 1 above). This is a good practice to get into — it's very hard to help someone with a coding problem if you can't see their code.
     - A link to the actual task or assessment page, so we can find the question you want help with.
+
+{{PreviousMenu("Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.md
+++ b/files/en-us/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.md
@@ -16,6 +16,7 @@ tags:
   - paper
 ---
 {{LearnSidebar}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Fundamental_CSS_comprehension", "Learn/CSS/Building_blocks/A_cool_looking_box", "Learn/CSS/Building_blocks")}}
 
 If you want to make the right impression, writing a letter on nice letterheaded paper can be a really good start. In this assessment we'll challenge you to create an online template to achieve such a look.
 
@@ -94,3 +95,5 @@ If you would like your work assessed, or are stuck and want to ask for help:
     - Details of what you have already tried, and what you would like us to do, e.g. if you are stuck and need help, or want an assessment.
     - A link to the example you want assessed or need help with, in an online shareable editor (as mentioned in step 1 above). This is a good practice to get into — it's very hard to help someone with a coding problem if you can't see their code.
     - A link to the actual task or assessment page, so we can find the question you want help with.
+
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Fundamental_CSS_comprehension", "Learn/CSS/Building_blocks/A_cool_looking_box", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/fundamental_css_comprehension/index.md
+++ b/files/en-us/learn/css/building_blocks/fundamental_css_comprehension/index.md
@@ -14,6 +14,7 @@ tags:
   - rules
 ---
 {{LearnSidebar}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper", "Learn/CSS/Building_blocks")}}
 
 You've covered a lot in this module, so it must feel good to have reached the end! The final step before you move on is to attempt the assessment for the module — this involves a number of related exercises that must be completed in order to create the final design — a business card/gamer card/social media profile.
 
@@ -107,3 +108,5 @@ If you would like your work assessed, or are stuck and want to ask for help:
     - Details of what you have already tried, and what you would like us to do, e.g. if you are stuck and need help, or want an assessment.
     - A link to the example you want assessed or need help with, in an online shareable editor (as mentioned in step 1 above). This is a good practice to get into — it's very hard to help someone with a coding problem if you can't see their code.
     - A link to the actual task or assessment page, so we can find the question you want help with.
+
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/organizing/index.md
+++ b/files/en-us/learn/css/building_blocks/organizing/index.md
@@ -14,7 +14,7 @@ tags:
   - pre-processor
   - styleguide
 ---
-{{LearnSidebar}}{{PreviousMenu("Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks/Fundamental_CSS_comprehension", "Learn/CSS/Building_blocks")}}
 
 As you start to work on larger stylesheets and big projects you will discover that maintaining a huge CSS file can be challenging. In this article we will take a brief look at some best practices for writing your CSS to make it easily maintainable, and some of the solutions you will find in use by others to help improve maintainability.
 
@@ -390,7 +390,7 @@ To learn more about layout in CSS, see the [Learn CSS Layout](/en-US/docs/Learn/
 
 You should also now have the skills to explore the rest of the [MDN CSS](/en-US/docs/Web/CSS) material. You can look up properties and values, explore our [CSS Cookbook](/en-US/docs/Web/CSS/Layout_cookbook) for patterns to use, or continue reading in some of the specific guides, such as our [Guide to CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout).
 
-{{PreviousMenu("Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks/Fundamental_CSS_comprehension", "Learn/CSS/Building_blocks")}}
 
 ## In this module
 

--- a/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.md
+++ b/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Test Your Skills: Fundamental layout comprehension'
+title: 'Fundamental layout comprehension'
 slug: Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension
 tags:
   - Assessment
@@ -9,6 +9,7 @@ tags:
   - Learn
 ---
 {{LearnSidebar}}
+{{PreviousMenu("Learn/CSS/CSS_layout/Supporting_Older_Browsers", "Learn/CSS/CSS_layout")}}
 
 If you have worked through this module then you will have already covered the basics of what you need to know to do CSS layout today, and to work with older CSS as well. This task will test some of your knowledge by way of developing a simple webpage layout using a variety of techniques.
 
@@ -66,6 +67,9 @@ If you would like your work assessed, or are stuck and want to ask for help:
     - Details of what you have already tried, and what you would like us to do, e.g. if you are stuck and need help, or want an assessment.
     - A link to the example you want assessed or need help with, in an online shareable editor (as mentioned in step 1 above). This is a good practice to get into — it's very hard to help someone with a coding problem if you can't see their code.
     - A link to the actual task or assessment page, so we can find the question you want help with.
+
+{{PreviousMenu("Learn/CSS/CSS_layout/Supporting_Older_Browsers", "Learn/CSS/CSS_layout")}}
+
 
 ## In this module
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11962.

This PR adds next/previous/menu links for the pages identified in https://github.com/mdn/content/issues/11962 as lacking them. I also renamed "Test Your Skills: Fundamental layout comprehension", to just "Fundamental layout comprehension", because we don't use "Test Your Skills:" for assessments.
