### PR TITLE
add .catch example in async_function

### DIFF
--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -308,8 +308,10 @@ async function getProcessedData(url) {
   }
   return processDataInWorker(v)
 }
+```
 
-// alternatively, you can chain the promise with .catch
+Alternatively, you can chain the promise with .catch:
+```js
 async function getProcessedData(url) {
   const v = await downloadData(url).catch(e => { 
     return downloadFallbackData(url)
@@ -318,10 +320,10 @@ async function getProcessedData(url) {
 }
 ```
 
-In the second example, notice there is no `await` statement after the
+In the two rewritten versions, notice there is no `await` statement after the
 `return` keyword, although that would be valid too: The return value of an
 async function is implicitly wrapped in {{jsxref("Promise.resolve")}} - if
-it's not already a promise itself (as in this example).
+it's not already a promise itself (as in the examples).
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -310,7 +310,7 @@ async function getProcessedData(url) {
 }
 ```
 
-Alternatively, you can chain the promise with .catch:
+Alternatively, you can chain the promise with `catch()`:
 ```js
 async function getProcessedData(url) {
   const v = await downloadData(url).catch(e => { 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -308,6 +308,14 @@ async function getProcessedData(url) {
   }
   return processDataInWorker(v)
 }
+
+// alternatively, you can chain the promise with .catch
+async function getProcessedData(url) {
+  const v = await downloadData(url).catch(e => { 
+    return downloadFallbackData(url)
+  })
+  return processDataInWorker(v)
+}
 ```
 
 In the second example, notice there is no `await` statement after the


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added an example of chaining a `.catch` instead of using a try/catch. 

#### Motivation
Sometimes people prefer using a `.catch` as it looks a bit cleaner.

#### Supporting details

#### Related issues
Fixes #12098

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
