### PR TITLE
Clarifying the behavior of webRequest.filterResponseData

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -46,7 +46,7 @@ This example shows a minimal implementation that passes through the stream data 
 ```js
 let filter = browser.webRequest.filterResponseData(details.requestId);
 filter.ondata = event => {
-  console.log(`filter.ondata received ${e.data.byteLength} bytes`);
+  console.log(`filter.ondata received ${event.data.byteLength} bytes`);
   filter.write(event.data);
 };
 filter.onstop = event => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -41,7 +41,7 @@ A {{WebExtAPIRef("webRequest.StreamFilter")}} object that you can use to monitor
 
 ## Examples
 
-This example shows a minimal implementation that passes through the stream data and closes the filter stream when the stream finishes receiving data. The code would be called from a {{WebExtAPIRef("webRequest")}} event listner and the event listner provides `details`.
+This example shows a minimal implementation that passes through the stream data and closes the filter stream when the stream finishes receiving data. The code would be called from a {{WebExtAPIRef("webRequest")}} event listener and the event listener provides `details`.
 
 ```js
 let filter = browser.webRequest.filterResponseData(details.requestId);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -14,7 +14,7 @@ browser-compat: webextensions.api.webRequest.filterResponseData
 ---
 {{AddonSidebar()}}
 
-Use this function to create a {{WebExtAPIRef("webRequest.StreamFilter")}} object for a request. The stream filter gives the web extension full control over the stream, with the ability to monitor and modify the response. The `webRequest.StreamFilter` must have an `ondata` listener to process the stream — even if it only implements `filter.write(event.data)` to pass through the stream data — and the extension must call `close()` or `disconnect()` when it has finished monitoring the stream.
+Use this function to create a {{WebExtAPIRef("webRequest.StreamFilter")}} object for a request. The stream filter gives the web extension full control over the stream, with the ability to monitor and modify the response. It's the extension's responsibility to write and close or disconnect the stream, as the default behavior is to keep the request open without a response.
 
 You typically call this function from a `webRequest` event listener.
 
@@ -40,6 +40,21 @@ var filter = browser.webRequest.filterResponseData(
 A {{WebExtAPIRef("webRequest.StreamFilter")}} object that you can use to monitor and modify the response.
 
 ## Examples
+
+This example shows a minimal implementation that passes through the stream data and closes the filter stream when the stream finishes receiving data.
+
+```js
+var filter = browser.webRequest.filterResponseData(details.requestId);
+filter.ondata = event => {
+  console.log(`filter.ondata received ${e.data.byteLength} bytes`);
+  filter.write(event.data);
+};
+filter.onstop = event => {
+  // The extension should always call filter.close() or filter.disconnect()
+  // after creating the StreamFilter, otherwise the response is kept alive forever.
+  filter.close();
+};
+```
 
 This example, taken from the [http-response](https://github.com/mdn/webextensions-examples/tree/master/http-response) example extension, creates a filter in {{WebExtAPIRef("webRequest.onBeforeRequest")}} and uses it, to modify the first chunk of the response:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -14,7 +14,9 @@ browser-compat: webextensions.api.webRequest.filterResponseData
 ---
 {{AddonSidebar()}}
 
-Use this function to create a {{WebExtAPIRef("webRequest.StreamFilter")}} object for a request. Then use the stream filter to monitor and modify the response. You'd typically call this function from a `webRequest` event listener.
+Use this function to create a {{WebExtAPIRef("webRequest.StreamFilter")}} object for a request. The stream filter gives the web extension full control over the stream, with the ability to monitor and modify the response. The `webRequest.StreamFilter` must have an `ondata` listener to process the stream — even if it only implements `filter.write(event.data)` to pass through the stream data — and the extension must call `close()` or `disconnect()` when it has finished monitoring the stream.
+
+You typically call this function from a `webRequest` event listener.
 
 Firefox uses an optimized byte cache for script requests. This optimized byte cache overrides the normal request caching. Data from this cache is not available in a form useful to extensions. If your extension needs to filter scripts, create your filter in {{WebExtAPIRef("webRequest.onBeforeRequest")}}. Doing this ensures that the filter is created prior to the attempt to load from cache, thereby avoiding the optimized cache.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -41,10 +41,10 @@ A {{WebExtAPIRef("webRequest.StreamFilter")}} object that you can use to monitor
 
 ## Examples
 
-This example shows a minimal implementation that passes through the stream data and closes the filter stream when the stream finishes receiving data.
+This example shows a minimal implementation that passes through the stream data and closes the filter stream when the stream finishes receiving data. The code would be called from a {{WebExtAPIRef("webRequest")}} event listner and the event listner provides `details`.
 
 ```js
-var filter = browser.webRequest.filterResponseData(details.requestId);
+let filter = browser.webRequest.filterResponseData(details.requestId);
 filter.ondata = event => {
   console.log(`filter.ondata received ${e.data.byteLength} bytes`);
   filter.write(event.data);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -18,12 +18,12 @@ A `StreamFilter` is an object you use to monitor and modify HTTP responses.
 
 To create a `StreamFilter`, call {{WebExtAPIRef("webRequest.filterResponseData()")}}, passing the ID of the web request you want to filter.
 
-You can think of the stream filter as sitting between the networking stack and the browser's rendering engine. The filter is passed HTTP response data as it's received from the network. It can examine and modify the data before passing it along to the rendering engine, where it is parsed and rendered. Therefore, the stream filter gives the web extension full control over the stream. It must have an `ondata` listener to process the stream, even if it only implements `filter.write(event.data)` to pass through the stream data.
+You can think of the stream filter as sitting between the networking stack and the browser's rendering engine. The filter is passed HTTP response data as it's received from the network. It can examine and modify the data before passing it along to the rendering engine, where it is parsed and rendered. The filter has full control over the response body, and the default behavior without any listeners or write calls is to have a stream without content that never closes.
 
 The filter generates four different events:
 
 - {{WebEXTAPIRef("webRequest.StreamFilter.onstart", "onstart")}} when the filter is about to start receiving response data.
-- {{WebEXTAPIRef("webRequest.StreamFilter.ondata", "ondata")}} when some response data has been received by the filter and is available to be examined or modified. This event should always be implemented.
+- {{WebEXTAPIRef("webRequest.StreamFilter.ondata", "ondata")}} when some response data has been received by the filter and is available to be examined or modified. 
 - {{WebEXTAPIRef("webRequest.StreamFilter.onstop", "onstop")}} when the filter has finished receiving response data.
 - {{WebEXTAPIRef("webRequest.StreamFilter.onerror", "onerror")}} if an error has occurred in initializing and operating the filter.
 
@@ -39,9 +39,9 @@ Note that the request is blocked during the execution of any event listeners.
 
 The filter provides a {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}} function. At any time from the `onstart` event onwards you can use this function to write data to the output stream.
 
-If you assign listeners to any of the filter's events, then all the response data passed to the rendering engine will be supplied through calls you make to `write()`: so if you add a listener but don't call `write()`, then the rendered page will be blank.
+If you assign listeners to any of the filter's events, all the response data passed to the rendering engine is supplied through calls you make to `write()`. So, if you add a listener and don't call `write()` the rendered page is blank.
 
-Once you have finished interacting with the response you call either of the following:
+Once you have finished interacting with the response, call either of the following:
 
 - {{WebEXTAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}: This disconnects the filter from the request, so the rest of the response is processed normally.
 - {{WebEXTAPIRef("webRequest.StreamFilter.close()", "close()")}}: This closes the request, so no additional response data will be processed.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -14,16 +14,16 @@ browser-compat: webextensions.api.webRequest.StreamFilter
 ---
 {{AddonSidebar()}}
 
-A `StreamFilter` is an object you can use to monitor and modify HTTP responses.
+A `StreamFilter` is an object you use to monitor and modify HTTP responses.
 
-To create a `StreamFilter`, call {{WebExtAPIRef("webRequest.filterResponseData()")}}, passing it the ID of the web request that you want to filter.
+To create a `StreamFilter`, call {{WebExtAPIRef("webRequest.filterResponseData()")}}, passing the ID of the web request you want to filter.
 
-You can imagine the stream filter sitting between the networking stack and browser's rendering engine. The filter is passed HTTP response data as it is received from the network, and can examine and modify the data before passing it along to the rendering engine, where it will be parsed and rendered.
+You can think of the stream filter as sitting between the networking stack and the browser's rendering engine. The filter is passed HTTP response data as it's received from the network. It can examine and modify the data before passing it along to the rendering engine, where it is parsed and rendered. Therefore, the stream filter gives the web extension full control over the stream. It must have an `ondata` listener to process the stream, even if it only implements `filter.write(event.data)` to pass through the stream data.
 
 The filter generates four different events:
 
 - {{WebEXTAPIRef("webRequest.StreamFilter.onstart", "onstart")}} when the filter is about to start receiving response data.
-- {{WebEXTAPIRef("webRequest.StreamFilter.ondata", "ondata")}} when some response data has been received by the filter and is available to be examined or modified.
+- {{WebEXTAPIRef("webRequest.StreamFilter.ondata", "ondata")}} when some response data has been received by the filter and is available to be examined or modified. This event should always be implemented.
 - {{WebEXTAPIRef("webRequest.StreamFilter.onstop", "onstop")}} when the filter has finished receiving response data.
 - {{WebEXTAPIRef("webRequest.StreamFilter.onerror", "onerror")}} if an error has occurred in initializing and operating the filter.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -23,7 +23,7 @@ You can think of the stream filter as sitting between the networking stack and t
 The filter generates four different events:
 
 - {{WebEXTAPIRef("webRequest.StreamFilter.onstart", "onstart")}} when the filter is about to start receiving response data.
-- {{WebEXTAPIRef("webRequest.StreamFilter.ondata", "ondata")}} when some response data has been received by the filter and is available to be examined or modified. 
+- {{WebEXTAPIRef("webRequest.StreamFilter.ondata", "ondata")}} when some response data has been received by the filter and is available to be examined or modified.
 - {{WebEXTAPIRef("webRequest.StreamFilter.onstop", "onstop")}} when the filter has finished receiving response data.
 - {{WebEXTAPIRef("webRequest.StreamFilter.onerror", "onerror")}} if an error has occurred in initializing and operating the filter.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -15,9 +15,11 @@ browser-compat: webextensions.api.webRequest.StreamFilter.ondata
 ---
 {{AddonSidebar()}}
 
-An event handler that will be called repeatedly when response data is available. The handler is passed an `event` object which contains a `data` property, which contains a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
+An event handler that is called repeatedly when response data is available. The handler is passed an `event` object containing a `data` property, which includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
 
-To decode the data use either {{domxref("TextDecoder")}} or {{domxref("Blob")}}.
+To decode the data, use either {{domxref("TextDecoder")}} or {{domxref("Blob")}}.
+
+Without an `ondata` listener, you don't receive the original response body, and the output stream is empty unless {{WebEXTAPIRef("webRequest.StreamFilter.write", "write")}} is called.
 
 ## WebExtension Examples
 


### PR DESCRIPTION
#### Summary
Provides clarification that the stream filter gives the an extension complete control over web request data, and must, at a minimum, implement an event to pass through the stream data.

#### Motivation
To clarify the behavior of stream data following Bug [1738877](https://bugzilla.mozilla.org/show_bug.cgi?id=1738877) Warn on badly used browser.webRequest.filterResponseData.

#### Metadata
This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
