### PR TITLE
Remove “concurrency” from Web/JavaScript/EventLoop title & text

### DIFF
--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -1,5 +1,5 @@
 ---
-title: Concurrency model and the event loop
+title: The event loop
 slug: Web/JavaScript/EventLoop
 tags:
   - Advanced
@@ -13,7 +13,7 @@ tags:
 ---
 {{JsSidebar("Advanced")}}
 
-JavaScript has a concurrency model based on an **event loop**, which is responsible for executing the code, collecting and processing events, and executing queued sub-tasks. This model is quite different from models in other languages like C and Java.
+JavaScript has a runtime model based on an **event loop**, which is responsible for executing the code, collecting and processing events, and executing queued sub-tasks. This model is quite different from models in other languages like C and Java.
 
 ## Runtime concepts
 
@@ -148,7 +148,7 @@ A web worker or a cross-origin `iframe` has its own stack, heap, and message que
 
 A very interesting property of the event loop model is that JavaScript, unlike a lot of other languages, never blocks. Handling I/O is typically performed via events and callbacks, so when the application is waiting for an [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) query to return or an [XHR](/en-US/docs/Web/API/XMLHttpRequest) request to return, it can still process other things like user input.
 
-Legacy exceptions exist like `alert` or synchronous XHR, but it is considered good practice to avoid them. Beware: [exceptions to the exception do exist](http://stackoverflow.com/questions/2734025/is-javascript-guaranteed-to-be-single-threaded/2734311#2734311) (but are usually implementation bugs, rather than anything else).
+Legacy exceptions exist like `alert` or synchronous XHR, but it is considered good practice to avoid them. Beware: [exceptions to the exception do exist](https://stackoverflow.com/questions/2734025/is-javascript-guaranteed-to-be-single-threaded/2734311#2734311) (but are usually implementation bugs, rather than anything else).
 
 ## See also
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12352