### PR TITLE
“Angular todo list” doc: mention notes file not used right away

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -91,7 +91,7 @@ export interface Item {
 }
 ```
 
-You won't use this file until [later](/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component#add_logic_to_itemcomponent) but it is a good time to know and record your knowledge of what an item is. The `Item` `interface` creates an `item` object model so that your application will understand what an `item` is. For this to-do list, an `item` is an object that has a description and can be done.
+You won't use this file until [later](/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component#add_logic_to_itemcomponent), but it is a good time to know and record your knowledge of what an `item` is. The `Item` `interface` creates an `item` object model so that your application will understand what an `item` is. For this to-do list, an `item` is an object that has a description and can be done.
 
 ## Add logic to AppComponent
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -91,12 +91,11 @@ export interface Item {
 }
 ```
 
-The `Item` `interface` creates an `item` object model so that your application understands what an `item` is.
-For this to-do list, an `item` is an object that has a description and can be done.
+You won't use this file until [later](/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component#add_logic_to_itemcomponent) but it is a good time to know and record your knowledge of what an item is. The `Item` `interface` creates an `item` object model so that your application will understand what an `item` is. For this to-do list, an `item` is an object that has a description and can be done.
 
 ## Add logic to AppComponent
 
-Now that your application knows what an `item` is, you can give it some items by adding them to the TypeScript file, `app.component.ts`.
+Now that you know what an `item` is, you can give your application some items by adding them to the TypeScript file, `app.component.ts`.
 In `app.component.ts`, replace the contents with the following:
 
 ```js


### PR DESCRIPTION
#### Summary
An interface file `item.ts` is defined but used on this page. Added justification.

#### Motivation
Low hanging :mango:

#### Supporting details
Tested it works without the file:
![image](https://user-images.githubusercontent.com/2392803/150661463-06fa4cb9-0278-45ef-8513-d5d65347008e.png)

#### Related issues
Fixes #12050

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
