### PR TITLE
Explain deprecated

### DIFF
--- a/files/en-us/web/css/word-break/index.md
+++ b/files/en-us/web/css/word-break/index.md
@@ -47,7 +47,7 @@ The `word-break` property is specified as a single keyword chosen from the list 
 
 > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see {{cssxref("overflow-wrap")}}), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
 
-> **Note:**  While `word-break: break-word` is deprecated, when specified, it has the same effect as `word-break: normal` and `overflow-wrap: anywhere`, regardless of the actual value of the {{CSSXref('overflow-wrap')}} property. 
+> **Note:**  While `word-break: break-word` is deprecated it has the same effect, when specified, as `word-break: normal` and `overflow-wrap: anywhere`, regardless of the actual value of the {{CSSXref('overflow-wrap')}} property. 
 
 ## Formal definition
 

--- a/files/en-us/web/css/word-break/index.md
+++ b/files/en-us/web/css/word-break/index.md
@@ -47,6 +47,8 @@ The `word-break` property is specified as a single keyword chosen from the list 
 
 > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see {{cssxref("overflow-wrap")}}), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
 
+> **Note:**  While `word-break: break-word` is deprecated, when specified, it has the same effect as `word-break: normal` and `overflow-wrap: anywhere`, regardless of the actual value of the {{CSSXref('overflow-wrap')}} property. 
+
 ## Formal definition
 
 {{CSSInfo}}

--- a/files/en-us/web/css/word-break/index.md
+++ b/files/en-us/web/css/word-break/index.md
@@ -47,7 +47,7 @@ The `word-break` property is specified as a single keyword chosen from the list 
 
 > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see {{cssxref("overflow-wrap")}}), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
 
-> **Note:**  While `word-break: break-word` is deprecated it has the same effect, when specified, as `word-break: normal` and `overflow-wrap: anywhere`, regardless of the actual value of the {{CSSXref('overflow-wrap')}} property. 
+> **Note:**  While `word-break: break-word` is deprecated, it has the same effect, when specified, as `word-break: normal` and `overflow-wrap: anywhere` — regardless of the actual value of the {{CSSXref('overflow-wrap')}} property. 
 
 ## Formal definition
 


### PR DESCRIPTION
https://drafts.csswg.org/css-text/#word-break-property  - break-word is supported and is in the specification. It's "deprecated" but with an explanation requiring support, so adding that explanation.


- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

