### PR TITLE
Remove the experimental tag from Selection api documentation

### DIFF
--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -3,13 +3,12 @@ title: Selection
 slug: Web/API/Selection
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - Selection
 browser-compat: api.Selection
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 A **`Selection`** object represents the range of text selected by the user or the current position of the caret. To obtain a `Selection` object for examination or manipulation, call {{DOMxRef("window.getSelection()")}}.
 


### PR DESCRIPTION
It seems to be in every browser starting from ie 9, so there's no need for it to be called "experimental"

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Remove the experimental tag

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It seems to be in every browser starting from ie 9, so there's no need for it to be called "experimental"

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
