### PR TITLE
fix: change "error string" to "empty string"

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -1328,7 +1328,7 @@ function validate(input) {
 }
 ```
 
-The last line, setting the custom validity message to the error string is vital. If the user makes an error, and the validity is set, it will fail to submit, even if all of the values are valid, until the message is `null`.
+The last line, setting the custom validity message to the empty string is vital. If the user makes an error, and the validity is set, it will fail to submit, even if all of the values are valid, until the message is `null`.
 
 #### Custom validation error example
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changing "error string" to "empty string" in the text.

#### Motivation
"Error string" doesn't make much sense in this context, and "empty string" better fits both the code, and the textual context around

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Link to the page: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
Screenshot of the text with issue:
![image](https://user-images.githubusercontent.com/11510394/150699220-b7bed7a1-d0fe-449c-9930-0b4149732a0d.png)


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
