### PR TITLE
Fix the String lastIndexOf() & indexOf() docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -7,69 +7,45 @@ tags:
   - Prototype
   - Reference
   - String
+  - indexOf
 browser-compat: javascript.builtins.String.indexOf
 ---
 {{JSRef}}
 
-The **`indexOf()`** method returns the
-index within the calling {{jsxref("String")}} object of the first occurrence of the
-specified value, starting the search at `fromIndex`. Returns
-`-1` if the value is not found.
+The **`indexOf()`** method, given one argument: a substring to search for, searches the entire calling string, and returns the index of the first occurrence of the specified substring. Given a second argument: a number, the method returns the first occurrence of the specified substring at an index greater than or equal to the specified number.
 
 {{EmbedInteractiveExample("pages/js/string-indexof.html")}}
-
-> **Note:** For the Array method, see
-> {{jsxref("Array.prototype.indexOf()")}}.
 
 ## Syntax
 
 ```js
-indexOf(searchValue)
-indexOf(searchValue, fromIndex)
+indexOf(searchString)
+indexOf(searchString, position)
 ```
 
 ### Parameters
 
-- `searchValue`
+- `searchString`
 
-  - : The string value to search for.
+  - : Substring to search for. If the method is called with no arguments, `searchString` [is coerced](https://tc39.github.io/ecma262/#sec-tostring) to "`undefined`". Therefore,`'undefined'.indexOf()` returns `0` — because the substring `undefined` is found at position `0` in the string `undefined`. But `'undefine'.indexOf()`, returns `-1` — because the substring `undefined` is not found in the string `undefine`.
 
-    If no string is explicitly provided, [_searchValue_ will be
-    coerced to "`undefined`"](https://tc39.github.io/ecma262/#sec-tostring), and this value will be searched for in
-    `str`.
+- `position` {{optional_inline}}
 
-    So, for example: `'undefined'.indexOf()` will return `0`, as
-    `undefined` is found at position `0` in the string
-    `undefined`. `'undefine'.indexOf()` however will return
-    `-1`, as `undefined` is not found in the string
-    `undefine`.
+  - : The method returns the index of the first occurrence of the specified substring at a position greater than or equal to `position`, which defaults to `0`. If `position` is greater than the length of the calling string, the method behaves as if no `position` had been specified. If `position` is less than zero, the method behaves as it would if `position` were `0`.
 
-- _`fromIndex`_ {{optional_inline}}
+    - `'hello world hello'.indexOf('o', -5)` returns `4` — because it causes the method to behave as if the second argument were `0`, and the first occurrence of `hello` at a position greater or equal to `0` is at position `4`.
 
-  - : An integer representing the index at which to start the search. Defaults to
-    `0`.
+    - `'hello world hello'.lastIndexOf('world', 12)` returns `-1` — because, while it’s true the substring `world` occurs at index `6`, that position is not greater than or equal to `12`.
 
-    For _`fromIndex`_ values lower than `0`, or greater
-    than `str.length`, the search starts at index `0`
-    and `str.length`, respectively.
-
-    For example, `'hello world'.indexOf('o', -5)` will return
-    `4`, as it starts at position `0`, and `o` is found
-    at position `4`. On the other hand,
-    `'hello world'.indexOf('o', 11)` (and with any `fromIndex`
-    value greater than `11`) will return `-1`, as the search is
-    started at position `11`, a position _after_ the end of the
-    string.
+    - `'hello world hello'.indexOf('o', 99)` returns `-1`— because `99` is greater than the length of `hello world hello`, which causes the method to not search the string at all.
 
 ### Return value
 
-The index of the first occurrence of `searchValue`, or
-**`-1`** if not found.
+The index of the first occurrence of `searchString` found, or `-1` if not found.
 
-An empty string `searchValue` produces strange results. With no
-`fromIndex` value, or any `fromIndex` value
-lower than the string's `length`, the returned value is the same as the
-`fromIndex` value:
+#### Return value when using an empty search string
+
+Searching for an empty search string produces strange results. With no second argument, or with a second argument whose value is less than the calling string's length, the return value is the same as the value of the second argument:
 
 ```js
 'hello world'.indexOf('') // returns 0
@@ -78,9 +54,7 @@ lower than the string's `length`, the returned value is the same as the
 'hello world'.indexOf('', 8) // returns 8
 ```
 
-However, with any `fromIndex` value equal to or greater than the
-string's `length`, the returned value _is_ the string's
-`length`:
+However, with a second argument whose value is greater than or equal to the string's length, the return value is the string's length:
 
 ```js
 'hello world'.indexOf('', 11) // returns 11
@@ -88,15 +62,11 @@ string's `length`, the returned value _is_ the string's
 'hello world'.indexOf('', 22) // returns 11
 ```
 
-In the former instance, JS seems to find an empty string just after the specified index
-value. In the latter instance, JS seems to be finding an empty string at the end of the
-searched string.
+In the former instance, the method behaves as if it found an empty string just after the position specified in the second argument. In the latter instance, the method behaves as if it found an empty string at the end of the calling string.
 
 ## Description
 
-Characters in a string are indexed from left to right. The index of the first character
-is `0`, and the index of the last character of a string called
-`stringName` is `stringName.length - 1`.
+Strings are zero-indexed: The index of a string’s first character is `0`, and the index of a string’s last character is the length of the string minus 1.
 
 ```js
 'Blue Whale'.indexOf('Blue')      // returns  0
@@ -119,20 +89,18 @@ expression returns `-1`:
 
 ### Checking occurrences
 
-Note that `0` doesn't evaluate to `true` and `-1`
-doesn't evaluate to `false`. Therefore, when checking if a specific string
-exists within another string, the correct way to check would be:
+When checking if a specific substring occurs within a string, the correct way to check is test whether the return value is `-1`:
 
 ```js
-'Blue Whale'.indexOf('Blue') !== -1  // true
-'Blue Whale'.indexOf('Bloe') !== -1  // false
+'Blue Whale'.indexOf('Blue') !== -1  // true; found 'Blue' in 'Blue Whale'
+'Blue Whale'.indexOf('Bloe') !== -1  // false; no 'Bloe' in 'Blue Whale'
 ```
 
 ## Examples
 
 ### Using `indexOf()`
 
-The following example uses `indexOf()` to locate values in the string
+The following example uses `indexOf()` to locate substrings in the string
 `"Brave new world"`.
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -31,7 +31,7 @@ indexOf(searchString, position)
 
 - `position` {{optional_inline}}
 
-  - : The method returns the index of the first occurrence of the specified substring at a position greater than or equal to `position`, which defaults to `0`. If `position` is greater than the length of the calling string, the method behaves as if no `position` had been specified. If `position` is less than zero, the method behaves as it would if `position` were `0`.
+  - : The method returns the index of the first occurrence of the specified substring at a position greater than or equal to `position`, which defaults to `0`. If `position` is greater than the length of the calling string, the method doesn’t search the calling string at all. If `position` is less than zero, the method behaves as it would if `position` were `0`.
 
     - `'hello world hello'.indexOf('o', -5)` returns `4` — because it causes the method to behave as if the second argument were `0`, and the first occurrence of `hello` at a position greater or equal to `0` is at position `4`.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -33,7 +33,7 @@ lastIndexOf(searchString, position)
 
 - `position` {{optional_inline}}
 
-  - : The method returns the index of the last occurrence of the specified substring at a position less than or equal to `position`, which defaults to `+Infinity`. If `position` is greater than the length of the calling string, the entire string is searched. If `position` is less than `0`, the behavior is the same as for `0` — that is, the method looks for the specified substring only at index `0`.
+  - : The method returns the index of the last occurrence of the specified substring at a position less than or equal to `position`, which defaults to `+Infinity`. If `position` is greater than the length of the calling string, the method searches the entire string. If `position` is less than `0`, the behavior is the same as for `0` — that is, the method looks for the specified substring only at index `0`.
 
     - `'hello world hello'.lastIndexOf('world', 4)` returns `-1` — because, while the substring `world` does occurs at index `6`, that position is not less than or equal to `4`.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -12,43 +12,42 @@ browser-compat: javascript.builtins.String.lastIndexOf
 ---
 {{JSRef}}
 
-The **`lastIndexOf()`** method returns the index within the
-calling {{jsxref("String")}} object of the last occurrence of the specified value,
-searching backwards from `fromIndex`. Returns `-1` if the value is
-not found.
+The **`lastIndexOf()`** method, given one argument: a substring to search for, searches the entire calling string, and returns the index of the last occurrence of the specified substring. Given a second argument: a number, the method returns the last occurrence of the specified substring at an index less than or equal to the specified number.
 
 {{EmbedInteractiveExample("pages/js/string-lastindexof.html", "shorter")}}
 
 ## Syntax
 
 ```js
-lastIndexOf(searchValue)
-lastIndexOf(searchValue, fromIndex)
+lastIndexOf(searchString)
+lastIndexOf(searchString, position)
 ```
 
 ### Parameters
 
-- `searchValue`
-  - : A string representing the value to search for. If
-    `searchValue` is an empty string, then
-    `fromIndex` is returned.
-- `fromIndex` {{optional_inline}}
-  - : The index of the last character in the string to be considered as the beginning of a
-    match. The default value is `+Infinity`. If
-    `fromIndex >= str.length`, the whole string is
-    searched. If `fromIndex < 0`, the behavior will be the same
-    as if it would be `0`.
+- `searchString`
+
+  - : Substring to search for.
+
+    If the method is called with no arguments, `searchString` [is coerced](https://tc39.github.io/ecma262/#sec-tostring) to "`undefined`". Therefore,`'undefined'.lastIndexOf()` returns `0` — because the substring `undefined` is found at position `0` in the string `undefined`. But `'undefine'.lastIndexOf()`, returns `-1` — because the substring `undefined` is not found in the string `undefine`.
+
+- `position` {{optional_inline}}
+
+  - : The method returns the index of the last occurrence of the specified substring at a position less than or equal to `position`, which defaults to `+Infinity`. If `position` is greater than the length of the calling string, the entire string is searched. If `position` is less than `0`, the behavior is the same as for `0` — that is, the method looks for the specified substring only at index `0`.
+
+    - `'hello world hello'.lastIndexOf('world', 4)` returns `-1` — because, while the substring `world` does occurs at index `6`, that position is not less than or equal to `4`.
+
+    - `'hello world hello'.lastIndexOf('hello', 99)` returns `12` — because the last occurrence of `hello` at a position less than or equal to `99` is at position `12`.
+
+    - `'hello world hello'.lastIndexOf('hello', 0)` and `'hello world hello'.lastIndexOf('hello', -5)` both return `0` — because both cause the method to only look for `hello` at index `0`.
 
 ### Return value
 
-The index of the last occurrence of `searchValue`;
-`-1` if not found.
+The index of the last occurrence of `searchString` found, or `-1` if not found.
 
 ## Description
 
-Characters in a string are indexed from left to right. The index of the first character
-is `0`, and the index of the last character is
-`str.length - 1`.
+Strings are zero-indexed: The index of a string’s first character is `0`, and the index of a string’s last character is the length of the string minus 1.
 
 ```js
 'canal'.lastIndexOf('a');     // returns 3
@@ -60,10 +59,6 @@ is `0`, and the index of the last character is
 'canal'.lastIndexOf('');      // returns 5
 'canal'.lastIndexOf('', 2);   // returns 2
 ```
-
-> **Note:** `'abab'.lastIndexOf('ab', 2)` will return
-> `2` and not `0`, as `fromIndex` limits
-> only the beginning of the match.
 
 ### Case-sensitivity
 
@@ -80,19 +75,15 @@ expression returns `-1`:
 
 The following example uses {{jsxref("String.prototype.indexOf()", "indexOf()")}} and
 `lastIndexOf()` to locate values in the string
-"`Brave new world`".
+"`Brave, Brave New World`".
 
 ```js
-let anyString = 'Brave new world';
+let anyString = 'Brave, Brave New World';
 
-console.log('The index of the first w from the beginning is ' + anyString.indexOf('w'));
-// logs 8
-console.log('The index of the first w from the end is ' + anyString.lastIndexOf('w'));
-// logs 10
-console.log('The index of "new" from the beginning is ' + anyString.indexOf('new'));
-// logs 6
-console.log('The index of "new" from the end is ' + anyString.lastIndexOf('new'));
-// logs 6
+console.log('The index of the first "Brave" is ' + anyString.indexOf('Brave'));
+// logs 0
+console.log('The index of the last "Brave" is ' + anyString.lastIndexOf('Brave'));
+// logs 7
 ```
 
 ## Specifications


### PR DESCRIPTION
The existing wording in the lastIndexOf() doc misled at least one reader (see https://github.com/mdn/content/issues/12351) — because, while for `indexOf()`, it works fine to frame the behavior in terms of searching “from” a particular index (“fromIndex”), that framing doesn’t work well at all for `lastIndexOf()`.

---

So the most important parts of this change are:

- renaming the second argument to “position” rather than “fromIndex”
- removing the wording “searching backwards” from the `lastIndexOf()` doc
- removing mention of “starting” the search at a particular position

The changes to the `indexOf()` doc are less necessary but are somewhat just for preserving consistency/parallelism with the wording needed for the `lastIndexOf()` doc. But the result is wording that’s still just as clear as the existing wording.

Fixes https://github.com/mdn/content/issues/12351