### PR TITLE
Fix Math.max() initial value to -Infinity

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.md
@@ -69,7 +69,7 @@ element in a numeric array, by comparing each value:
 var arr = [1,2,3];
 var max = arr.reduce(function(a, b) {
     return Math.max(a, b);
-}, 0);
+}, -Infinity);
 ```
 
 The following function uses {{jsxref("Function.prototype.apply()")}} to get the maximum


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixed the example code of usage with `Array.reduce()`.
The initial value should be `-Infinity` instead of `0`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

`Math.max()` returns `-Infinity` when empty arguments provided.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max#description

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/content/pull/7194

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
