### PR TITLE
Fix markdown typo

### DIFF
--- a/files/en-us/learn/server-side/django/home_page/index.md
+++ b/files/en-us/learn/server-side/django/home_page/index.md
@@ -225,7 +225,7 @@ We will use the following code snippet as the base template for the _LocalLibra
 
 > **Note:** We also introduce two additional template tags: `url` and `load static`. These tags will be explained in following sections.
 
-Create a new file ***base_generic.html* **in **/locallibrary/catalog/templates/** and paste the following code to the file:
+Create a new file **base_generic.html** in **/locallibrary/catalog/templates/** and paste the following code to the file:
 
 ```html
 <!DOCTYPE html>
@@ -272,7 +272,7 @@ The base template also references a local css file (**styles.css**) that provide
 
 #### The index template
 
-Create a new HTML file ***index.html* **in **/locallibrary/catalog/templates/** and paste the following code in the file.
+Create a new HTML file **index.html** in **/locallibrary/catalog/templates/** and paste the following code in the file.
 This code extends our base template on the first line, and then replaces the default `content` block for the template.
 
 ```html


### PR DESCRIPTION
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Correct the markdown bold syntax.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was reading this Django Tutorial and found that the text ***base_generic.html* ** looks weird.
Later figured it seems to be a typo which was trying to use markdown bold syntax.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
