### PR TITLE
Replace {{jsxref("String")}} with "string" in String.prototype.replace()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -41,12 +41,12 @@ replace(substr, replacerFunction)
     `newSubstr` or the value returned by the specified
     `replacerFunction`.
 - `substr`
-  - : A {{jsxref("String")}} that is to be replaced by `newSubstr`.
+  - : A string that is to be replaced by `newSubstr`.
     It is treated as a literal string and is _not_ interpreted as a regular
     expression. Only the first occurrence will be replaced.
 - `newSubstr` (replacement)
 
-  - : The {{jsxref("String")}} that replaces the substring specified by the specified
+  - : The string that replaces the substring specified by the specified
     `regexp` or `substr` parameter. A number
     of special replacement patterns are supported; see the "[Specifying a string as a parameter](#specifying_a_string_as_a_parameter)"
     section below.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{jsxref("String")}} with "string".

#### Motivation
The function takes string primitive rather than String wrapper object.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
