### PR TITLE
fix: MD046 use explicit code fences

### DIFF
--- a/files/en-us/learn/javascript/objects/object-oriented_programming/index.md
+++ b/files/en-us/learn/javascript/objects/object-oriented_programming/index.md
@@ -83,7 +83,7 @@ This constructor takes two parameters so we can initialize the `name` and `teach
 
 Now we have a constructor we can create some professors. Programming languages often use the keyword `new` to signal that a constructor is being called.
 
-```
+```js
 walsh = new Professor('Walsh', 'Psychology')
 lillian = new Professor('Lillian', 'Poetry')
 
@@ -148,7 +148,7 @@ In this case we would say that `Person` is the **superclass** or **parent class*
 
 You might notice that `introduceSelf()` is defined in all three classes. The reason is that while all people want to introduce themselves, the way they do it is different:
 
-```
+```js
 walsh = new Professor('Walsh', 'Psychology')
 walsh.introduceSelf()  // 'My name is Professor Walsh, and I will be your Psychology professor'
 
@@ -158,7 +158,7 @@ summers.introduceSelf() // 'My name is Summers, and I'm in the first year'
 
 We might have a default implementation of `introduceSelf()` for people who aren't students _or_ professors:
 
-```
+```js
 pratt = new Person('Pratt')
 pratt.introduceSelf() // 'My name is Pratt'
 ```
@@ -173,7 +173,7 @@ This is a useful feature because it enables the programmer to change the interna
 
 For example, suppose students are allowed to study archery if they are in the second year or above. We could implement this just by exposing the student's `year` property, and other code could examine that to decide whether the student can take the course:
 
-```
+```js
 if (student.year > 1) {
     // allow the student into the class
 }
@@ -192,7 +192,7 @@ class Student : extends Person
        canStudyArchery() { return this.year < 1 }
 ```
 
-```
+```js
 if (student.canStudyArchery()) {
     // allow the student into the class
 }

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -20,7 +20,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the constructor.
 >
-> ```
+> ```md
 > ---
 > title: NameOfTheConstructor()
 > slug: Web/API/NameOfTheParentInterface/NameOfTheParentInterface

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -20,7 +20,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular event.
 >
-> ```
+> ```md
 > ---
 > title: 'NameOfTheParentInterface: NameOfTheEvent event'
 > slug: Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -17,7 +17,7 @@ tags:
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular interface.
 >
-> ```
+> ```md
 > ---
 > title: NameOfTheAPI API
 > slug: Web/API/NameOfTheAPI_API

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -20,7 +20,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular method.
 >
-> ```
+> ```md
 > ---
 > title: NameOfTheParentInterface.NameOfTheMethod()
 > slug: Web/API/NameOfTheParentInterface/NameOfTheMethod
@@ -45,7 +45,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 >       This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheMethod`.
 >       Note that the name of the method in the slug omits the parenthesis (it ends in `NameOfTheMethod` not `NameOfTheMethod()`).
 > - **tags**
->   - : Always include the following tags: **API**, **Reference**, **Method**,  the _name of the API_ (e.g. **WebVR**), the name of the _parent interface_ (e.g. **IDBIndex**), the name of the method (e.g. **count()**).
+>   - : Always include the following tags: **API**, **Reference**, **Method**,  the _name of the API_ (e.g. **WebVR**), the name of the _parent interface_ (e.g. **IDBIndex**), the name of the method (e.g. **count()**).
 >
 >       Include the following tags as appropriate:
 >       - Technology status: **Experimental** (if the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)), **Deprecated** (if it is [deprecated](/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete)), **Non-standard** if it isn't on a standards track.

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -20,7 +20,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular property.
 >
-> ```
+> ```md
 > ---
 > title: NameOfTheParentInterface.NameOfTheProperty
 > slug: Web/API/NameOfTheParentInterface/NameOfTheProperty

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -19,7 +19,7 @@ browser-compat: css.properties.NameOfTheProperty
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular property.
 >
-> ```
+> ```md
 > ---
 > title: NameOfTheProperty
 > slug: Web/CSS/NameOfTheProperty

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -19,7 +19,7 @@ browser-compat: css.selectors.NameOfTheSelector
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular selector.
 >
-> ```
+> ```md
 > ---
 > title: :NameOfTheSelector
 > slug: Web/CSS/:NameOfTheSelector

--- a/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/glossary_page_template/index.md
@@ -17,7 +17,7 @@ tags:
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular method.
 >
-> ```
+> ```md
 > ---
 > title: Term being defined
 > slug: Glossary/Term_being_defined

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -19,7 +19,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular element.
 >
-> ```
+> ```md
 > ---
 > title: '<NameOfTheElement>: The NameOfTheElement element'
 > slug: Web/HTML/Element/NameOfTheElement

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -19,7 +19,7 @@ browser-compat: path.to.feature.NameOfTheHeader
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular header.
 >
-> ```
+> ```md
 > ---
 > title: NameOfTheHeader
 > slug: Web/HTTP/Headers/NameOfTheHeader

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -19,7 +19,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > The frontmatter at the top of the page is used to define "page metadata".
 > The values should be updated appropriately for the particular element.
 >
-> ```
+> ```md
 > ---
 > title: <NameOfTheElement>
 > slug: Web/SVG/Element/NameOfTheElement

--- a/files/en-us/mozilla/firefox/releases/3/full_page_zoom/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/full_page_zoom/index.md
@@ -14,9 +14,11 @@ Full page zoom (or just fullZoom) is a new feature in [Firefox 3](/en-US/docs/Mo
 
 The following example demonstrates the use for the current focused browser window. This is the typical usage for a Firefox extension.
 
-    var zoom = ZoomManager.getZoomForBrowser(gBrowser.selectedBrowser);
-    ZoomManager.enlarge();
-    ZoomManager.setZoomForBrowser(gBrowser.selectedBrowser, ZoomManager.MIN);
+```js
+var zoom = ZoomManager.getZoomForBrowser(gBrowser.selectedBrowser);
+ZoomManager.enlarge();
+ZoomManager.setZoomForBrowser(gBrowser.selectedBrowser, ZoomManager.MIN);
+```
 
 ### Example (XUL:iframe)
 
@@ -24,11 +26,13 @@ Note: This is probably out of date.
 
 You may use the fullZoom feature for a [XUL:iframe](/en-US/docs/XUL/iframe) as well. However, because an iframe doesn't have a markupDocumentViewer property, we need to get that first:
 
-    var zoom = 1.5;
-    var iframe = document.getElementById("authorFrame");
-    var contViewer = iframe.docShell.contentViewer;
-    var docViewer = contViewer.QueryInterface(Components.interfaces.nsIMarkupDocumentViewer);
-    docViewer.fullZoom = zoom;
+```js
+var zoom = 1.5;
+var iframe = document.getElementById("authorFrame");
+var contViewer = iframe.docShell.contentViewer;
+var docViewer = contViewer.QueryInterface(Components.interfaces.nsIMarkupDocumentViewer);
+docViewer.fullZoom = zoom;
+```
 
 ### References
 

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -124,9 +124,9 @@ _No change._
 - Add badges to [`sdk/ui`](en-US/Add-ons/SDK/High-Level_APIs/ui) buttons ({{bug(994280)}}).
 - Implemented global `require` function to access sdk modules anywhere ({{bug(1070927)}}), using:
 
-<!---->
-
-    var { require } = Cu.import("resource://gre/modules/commonjs/toolkit/require.js", {});
+  ```js
+  var { require } = Cu.import("resource://gre/modules/commonjs/toolkit/require.js", {});
+  ```
 
 #### Details
 

--- a/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
@@ -26,7 +26,9 @@ If your add-on uses {{ ifmethod("nsIChromeFrameMessageManager", "loadFrameScript
 
 Starting in Firefox 9, you should call the new {{ ifmethod("nsIChromeFrameMessageManager", "removeDelayedFrameScript") }} method to stop loading your script in newly-created frames. You do this like this, for example:
 
-    browser.messageManager.removeDelayedFrameScript("chrome://myextension/content/somescript.js");
+```js
+browser.messageManager.removeDelayedFrameScript("chrome://myextension/content/somescript.js");
+```
 
 ## Interface changes
 

--- a/files/en-us/related/project_guidelines/index.md
+++ b/files/en-us/related/project_guidelines/index.md
@@ -53,21 +53,23 @@ If you went through the submission process then you should already have a rough 
 
 Each project will be different, but we'd roughly recommend something like this:
 
-    Landing page
-    |
-    ------Reference
-          |
-          --------Elements
-          |
-          --------Methods
-          |
-          --------Other reference page type(s)?
-    |
-    ------Guides/tutorials
-    |
-    ------Examples
-    |
-    ------Project metadata
+```
+Landing page
+|
+------Reference
+      |
+      --------Elements
+      |
+      --------Methods
+      |
+      --------Other reference page type(s)?
+|
+------Guides/tutorials
+|
+------Examples
+|
+------Project metadata
+```
 
 ### Page templates
 

--- a/files/en-us/web/api/document/xmlencoding/index.md
+++ b/files/en-us/web/api/document/xmlencoding/index.md
@@ -16,13 +16,15 @@ Returns the encoding as determined by the XML declaration. Should be `null` if u
 
 > **Warning:** Do not use this attribute; it has been removed from the DOM Level 4 specification and is no longer supported in Gecko 10.0 {{ geckoRelease("10.0") }}.
 
-If the XML Declaration states:
+If the XML Declaration states:
 
-    <?xml version="1.0" encoding="UTF-16"?>
+```xml
+<?xml version="1.0" encoding="UTF-16"?>
+```
 
 ...the result should be "UTF-16".
 
-However, Firefox 3.0 includes information on endianness (e.g., UTF-16BE for big endian encoding), and while this extra information is removed as of Firefox 3.1b3, Firefox 3.1b3 is still consulting the file's encoding, rather than the XML Declaration as the spec defines it ("An attribute specifying, _as part of the XML declaration_, the encoding of this document.").
+However, Firefox 3.0 includes information on endianness (e.g., UTF-16BE for big endian encoding), and while this extra information is removed as of Firefox 3.1b3, Firefox 3.1b3 is still consulting the file's encoding, rather than the XML Declaration as the spec defines it ("An attribute specifying, _as part of the XML declaration_, the encoding of this document.").
 
 ## Specifications
 

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -59,8 +59,10 @@ To write content to file, create a FileWriter object by calling [`createWriter()
 
 Creates a new `FileWriter` associated with the file that the `FileEntry` represents.
 
-    void createWriter (
-    ) raises (FileException);
+```
+void createWriter (
+) raises (FileException);
+```
 
 #### Parameter
 
@@ -83,8 +85,10 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 Returns a File that represents the current state of the file that this `FileEntry` represents.
 
-    void file (
-    ) raises (FileException);
+```
+void file (
+) raises (FileException);
+```
 
 ##### Parameter
 

--- a/files/en-us/web/api/filesystementrysync/index.md
+++ b/files/en-us/web/api/filesystementrysync/index.md
@@ -27,7 +27,7 @@ This interface includes methods for working with files—including copying, movi
 
 The `FileSystemEntrySync` interface includes methods that you would expect for manipulating files and directories, but it also include a really handy method for getting a URL of the entry: [`toURL()`](#tourl). It also introduces a new URL scheme: `filesystem:`.
 
-You can use the `filesystem:` scheme on Google Chrome to see all the files and folders that are stored in the origin of your app. Just use `filesystem:` scheme for the root directory of the origin of the app. For example, if your app is in [`https://www.html5rocks.com/en/`](https://www.html5rocks.com/en/), open `filesystem:http://www.html5rocks.com/temporary/` in a tab. Chrome shows a read-only list of all the files and folders stored the origin of your app.
+You can use the `filesystem:` scheme on Google Chrome to see all the files and folders that are stored in the origin of your app. Just use `filesystem:` scheme for the root directory of the origin of the app. For example, if your app is in [`https://www.html5rocks.com/en/`](https://www.html5rocks.com/en/), open `filesystem:http://www.html5rocks.com/temporary/` in a tab. Chrome shows a read-only list of all the files and folders stored the origin of your app.
 
 ## Method overview
 
@@ -114,9 +114,9 @@ You can use the `filesystem:` scheme on Google Chrome to see all the files and f
       <td><code>fullpath</code></td>
       <td><code>readonly DOMString</code></td>
       <td>
-        <p>The full absolute path from the root to the entry.</p>
+        <p>The full absolute path from the root to the entry.</p>
         <p>
-          An absolute path is a relative path from the root directory, prepended
+          An absolute path is a relative path from the root directory, prepended
           with a '<code>/</code>'.
         </p>
       </td>
@@ -145,8 +145,10 @@ You can use the `filesystem:` scheme on Google Chrome to see all the files and f
 
 Look up metadata about this entry. \[ todo: specify what kind of metadata ]
 
-    Metadata getMetada ()
-      raises (FileException);
+```
+Metadata getMetada ()
+  raises (FileException);
+```
 
 #### Parameter
 
@@ -167,9 +169,9 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 ### moveTo()
 
-Move an entry to a different location on the file system. Moving a file over an existing file replaces that existing file. Moving a directory over an existing empty directory replaces that directory. \[todo: What if the directory is not empty? ]
+Move an entry to a different location on the file system. Moving a file over an existing file replaces that existing file. Moving a directory over an existing empty directory replaces that directory. \[todo: What if the directory is not empty? ]
 
-\[todo: Verify ] This is the same method for renaming files. You can keep it in the same location and then define the `newName` parameter.
+\[todo: Verify ] This is the same method for renaming files. You can keep it in the same location and then define the `newName` parameter.
 
 You cannot do the following:
 
@@ -178,11 +180,11 @@ You cannot do the following:
 - Move a file to a path occupied by a directory or move a directory to a path occupied by a file
 - Move any element to a path occupied by a directory that is not empty.
 
-<!---->
-
-    FileSystemEntrySync moveTo (
-      in DirectoryEntrySync parent, optional DOMString newName
-    ) raises (FileException);
+```
+FileSystemEntrySync moveTo (
+  in DirectoryEntrySync parent, optional DOMString newName
+) raises (FileException);
+```
 
 #### Parameters
 
@@ -226,7 +228,7 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
         <ul>
           <li>Moving an entry into its parent without changing its name</li>
           <li>
-            Moving a parent directory into one of its child directories. [todo:
+            Moving a parent directory into one of its child directories. [todo:
             verify ]
           </li>
         </ul>
@@ -246,9 +248,11 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 Copy an entry to a different location on the file system. You cannot copy an entry inside itself if it is a directory, nor can you copy it into its parent without providing a new name. Directory copies are always recursive—that is, all contents of the directory are copied. You cannot change this behavior. Files are duplicated.
 
-    void copyTo (
-      in DirectoryEntrySync parent, optional DOMString newName
-    ) raises (FileException);
+```
+void copyTo (
+  in DirectoryEntrySync parent, optional DOMString newName
+) raises (FileException);
+```
 
 #### Parameters
 
@@ -291,7 +295,7 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
         <p>You tried one of the following disallowed operations:</p>
         <ul>
           <li>Moving an entry into its parent without changing its name</li>
-          <li>Moving a parent directory into one of its child directories. </li>
+          <li>Moving a parent directory into one of its child directories.</li>
         </ul>
       </td>
     </tr>
@@ -319,13 +323,15 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 ### toURL()
 
-Returns a URL that can be used to identify this entry. It exposes a new URL scheme—`filesystem:`—that you can use to fill `src` or `href` attributes. For example, if you wanted to display an image and have its [fileEntry](/en-US/docs/Web/API/FileSystemFileEntry), calling `toURL()` gives you the image file's file system URL. You get something like: `filesystem:http://example.com/temporary/lolcat.png.`
+Returns a URL that can be used to identify this entry. It exposes a new URL scheme—`filesystem:`—that you can use to fill `src` or `href` attributes. For example, if you wanted to display an image and have its [fileEntry](/en-US/docs/Web/API/FileSystemFileEntry), calling `toURL()` gives you the image file's file system URL. You get something like: `filesystem:http://example.com/temporary/lolcat.png.`
 
 The file system URL does not expire. Because the method describes a location on disk, the URL is valid for as long as that location exists. You can delete the file and recreate it, and it's all good.
 
 You can supply the `mimeType` to simulate the optional MIME type header associated with HTTP downloads.
 
-    DOMString toURL ();
+```
+DOMString toURL ();
+```
 
 #### Parameter
 
@@ -343,8 +349,10 @@ None
 
 Deletes a file or directory. You cannot delete an empty directory or the root directory of a file system. If you want to remove an empty directory, use [`removeRecursively()`](</en-US/docs/Web/API/DirectoryEntrySync#removerecursively()>) instead.
 
-    void remove (
-    ) raises (FileException);
+```
+void remove (
+) raises (FileException);
+```
 
 #### Parameter
 
@@ -374,7 +382,7 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
       <td><code>INVALID_MODIFICATION_ERR</code></td>
       <td>
         <p>
-          You tried to remove a directory that is not empty. If you want to
+          You tried to remove a directory that is not empty. If you want to
           remove an empty directory, use
           <a href="/en-US/docs/Web/API/DirectoryEntrySync#removerecursively()"
             ><code>removeRecursively()</code></a
@@ -395,9 +403,11 @@ This method can raise a [FileException](/en-US/docs/Web/API/FileException) with 
 
 ### getParent()
 
-Look up the parent [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync) containing the entry. If this entry is the root of its file system, then the parent is itself.
+Look up the parent [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync) containing the entry. If this entry is the root of its file system, then the parent is itself.
 
-    void getParent ();
+```
+void getParent ();
+```
 
 #### Parameter
 
@@ -422,4 +432,4 @@ Specification:{{ spec("http://dev.w3.org/2009/dap/file-system/pub/FileSystem/", 
 
 Reference: [File System API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)
 
-Introduction: [Basic Concepts About the File System API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)
+Introduction: [Basic Concepts About the File System API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)

--- a/files/en-us/web/api/idbcursorsync/index.md
+++ b/files/en-us/web/api/idbcursorsync/index.md
@@ -12,7 +12,7 @@ tags:
 ---
 {{APIRef("IndexedDB")}} {{ draft() }}
 
-> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
+> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
 
 The `IDBCursorSync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) represents a [cursor](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor) for iterating over multiple records in a database. You can have only one instance of `IDBCursorSync` representing a cursor, but you can have an unlimited number of cursors at the same time. Operations are performed on the underlying index or object store. It enables an application to synchronously process all the records in the cursor's range.
 
@@ -155,9 +155,11 @@ The `IDBCursorSync` interface of the [IndexedDB API](/en-US/docs/Web/API/Indexed
 
 Advances the cursor to the next position along its direction, to the item whose key matches the optional `key` parameter. If no key is specified, advance to the immediate next position. Returns false if the cursor has reached the end of its range; otherwise returns true.
 
-    bool continue (
-      in optional any key
-    );
+```
+bool continue (
+  in optional any key
+);
+```
 
 ##### Parameters
 
@@ -168,8 +170,10 @@ Advances the cursor to the next position along its direction, to the item whose 
 
 Deletes the record at the cursor's position, without changing the cursor's position
 
-    void delete (
-    ) raises (DatabaseException);
+```
+void delete (
+) raises (DatabaseException);
+```
 
 ##### Exceptions
 

--- a/files/en-us/web/api/idbdatabasesync/index.md
+++ b/files/en-us/web/api/idbdatabasesync/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{APIRef("IndexedDB")}} {{ draft() }}
 
-> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
+> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
 
 The `DatabaseSync` interface in the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) represents a synchronous [connection to a database](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection).
 
@@ -97,11 +97,13 @@ The `DatabaseSync` interface in the [IndexedDB API](/en-US/docs/Web/API/IndexedD
 
 Creates and returns a new object store with the given name in the connected database.
 
-     IDBObjectStoreSync createObjectStore(
-      in DOMString name,
-      in DOMString keypath,
-      in optional boolean autoIncrement
-    ) raises  (IDBDatabaseException);
+```
+IDBObjectStoreSync createObjectStore(
+  in DOMString name,
+  in DOMString keypath,
+  in optional boolean autoIncrement
+) raises  (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -128,10 +130,12 @@ This method can raise an IDBDatabaseException with the following code:
 
 Opens the object store with the given name in the connected database using the specified mode.
 
-    IDBObjectStoreSync openObjectStore (
-      in DOMString name,
-      in optional unsigned short mode
-    ) raises (IDBDatabaseException);
+```
+IDBObjectStoreSync openObjectStore (
+  in DOMString name,
+  in optional unsigned short mode
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -156,9 +160,11 @@ This method can raise an IDBDatabaseException with the following code:
 
 Destroys an object store with the given name, as well as all indexes that reference that object store.
 
-    void removeObjectStore (
-      in DOMString storeName
-    ) raises (IDBDatabaseException);
+```
+void removeObjectStore (
+  in DOMString storeName
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -180,9 +186,11 @@ This method can raise an IDBDatabaseException with the following code:
 
 Sets the version of the connected database.
 
-    void setVersion (
-      in DOMString version
-    );
+```
+void setVersion (
+  in DOMString version
+);
+```
 
 ##### Parameters
 
@@ -197,10 +205,12 @@ Sets the version of the connected database.
 
 Creates and returns a transaction, acquiring locks on the given database objects, within the specified timeout duration, if possible.
 
-    IDBTransactionSync transaction (
-      in optional DOMStringList storeNames,
-      in optional unsigned int timeout
-    ) raises (IDBDatabaseException);
+```
+IDBTransactionSync transaction (
+  in optional DOMStringList storeNames,
+  in optional unsigned int timeout
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 

--- a/files/en-us/web/api/idbfactorysync/index.md
+++ b/files/en-us/web/api/idbfactorysync/index.md
@@ -11,9 +11,9 @@ tags:
 ---
 {{APIRef("IndexedDB")}} {{ draft() }}
 
-> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
+> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
 
-The `IDBFactorySync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) provide a synchronous means of accessing the capabilities of indexed databases.
+The `IDBFactorySync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) provide a synchronous means of accessing the capabilities of indexed databases.
 
 ## Method overview
 
@@ -40,10 +40,12 @@ The `IDBFactorySync` interface of the [IndexedDB API](/en-US/docs/Web/API/Index
 
 Opens and returns a [connection to a database](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection). Blocks the calling thread until the connection object is ready to return. If there is already a database with the specified name, it uses that one; otherwise, it creates the database using the specified name and description.
 
-    IDBDatabaseSync open (
-      in DOMString name,
-      in DOMString description
-    ) raises (IDBDatabaseException);
+```
+IDBDatabaseSync open (
+  in DOMString name,
+  in DOMString description
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 

--- a/files/en-us/web/api/idbindexsync/index.md
+++ b/files/en-us/web/api/idbindexsync/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{APIRef("IndexedDB")}} {{ draft() }}
 
-> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
+> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
 
 The `IDBIndexSync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) provides synchronous access to an [index](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#index) in a database.
 
@@ -150,10 +150,12 @@ The `IDBIndexSync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedD
 
 Stores the given value into this index, optionally with the specified key. If a record already exists with the given key, an exception is raised.
 
-    any add(
-      in any value,
-      in optional any key
-    ) raises (IDBDatabaseException);
+```
+any add(
+  in any value,
+  in optional any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -176,9 +178,11 @@ This method can raise a IDBDatabaseException with the following code:
 
 Retrieves the value from this index for the record that corresponds to the given key.
 
-    any get (
-      in any key
-    ) raises (IDBDatabaseException);
+```
+any get (
+  in any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -201,9 +205,11 @@ This method can raise an IDBDatabaseException with the following code:
 
 Retrieves and returns the value from this index's referenced object store that corresponds to the given key.
 
-    any getObject (
-      in any key
-    ) raises (IDBDatabaseException);
+```
+any getObject (
+  in any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -226,10 +232,12 @@ This method can raise a IDBDatabaseException with the following code:
 
 Creates a [cursor](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor) over the records of this index. The range of the new cursor matches the specified [key range](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_range); if the key range is not specified or is null, then the range includes all the records.
 
-    void openCursor (
-      in optional IDBKeyRange range,
-      in optional unsigned short direction
-    ) raises (IDBDatabaseException);
+```
+void openCursor (
+  in optional IDBKeyRange range,
+  in optional unsigned short direction
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -253,10 +261,12 @@ This method can raise an IDBDatabaseException with the following code:
 
 Creates a cursor over the records of this index's referenced object store, as arranged by this index. The range of the new cursor matches the specified key range; if the key range is not specified or is null, then the range includes all the records.
 
-    void openObjectCursor (
-      in optional IDBKeyRange range,
-      in optional unsigned short direction
-    ) raises (IDBDatabaseException);
+```
+void openObjectCursor (
+  in optional IDBKeyRange range,
+  in optional unsigned short direction
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -280,9 +290,11 @@ This method can raise an IDBDatabaseException with the following code:
 
 Stores the given value in this index and returns the key for the stored record. If a record already exists with the given key, the record is overwritten.
 
-    any put (
-      in any value,
-      in optional any key) raises (IDBDatabaseException);
+```
+any put (
+  in any value,
+  in optional any key) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -300,9 +312,11 @@ Stores the given value in this index and returns the key for the stored record. 
 
 Removes from this index any records that correspond to the given key.
 
-    void remove (
-      in any key
-    ) raises (IDBDatabaseException);
+```
+void remove (
+  in any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 

--- a/files/en-us/web/api/idbobjectstoresync/index.md
+++ b/files/en-us/web/api/idbobjectstoresync/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 {{ APIRef("IndexedDB") }}
 
-> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
+> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
 
 The `IDBObjectStoreSync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) provides synchronous access to an [object store](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store) of a database.
 
@@ -32,7 +32,7 @@ The `IDBObjectStoreSync` interface of the [IndexedDB API](/en-US/docs/Web/API/In
       <td>
         <a href="/en-US/docs/Web/API/IDBIndexSync"><code>IDBIndexSync</code></a>
         <code
-          ><a href="#createindex">createIndex</a> (in DOMString name, in
+          ><a href="#createindex">createIndex</a> (in DOMString name, in
           DOMString storeName, in DOMString keypath, in optional boolean
           unique);</code
         >
@@ -96,7 +96,7 @@ The `IDBObjectStoreSync` interface of the [IndexedDB API](/en-US/docs/Web/API/In
       <td>
         <code
           >void <a href="#removeindex">removeIndex</a> (in DOMString
-          indexName) raises (<a href="/en-US/docs/Web/API/IDBDatabaseException"
+          indexName) raises (<a href="/en-US/docs/Web/API/IDBDatabaseException"
             >IDBDatabaseException</a
           >);</code
         >
@@ -157,7 +157,7 @@ The `IDBObjectStoreSync` interface of the [IndexedDB API](/en-US/docs/Web/API/In
   </tbody>
 </table>
 
-##  Constants
+## Constants
 
 ### Mode constants
 
@@ -173,10 +173,12 @@ The `IDBObjectStoreSync` interface of the [IndexedDB API](/en-US/docs/Web/API/In
 
 Stores the given value into this object store, optionally with the specified key. If a record already exists with the given key, an exception is raised.
 
-    any add(
-      in any value,
-      in optional any key
-    ) raises (IDBDatabaseException);
+```
+any add(
+  in any value,
+  in optional any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -203,11 +205,13 @@ This method can raise a IDBDatabaseException with the following codes:
 
 Creates and returns a new index with the given name in the connected database.
 
-     IDBIndexSync createIndex (
-        in DOMString name,
-        in DOMString keypath,
-        in optional boolean unique
-     );
+```
+IDBIndexSync createIndex (
+  in DOMString name,
+  in DOMString keypath,
+  in optional boolean unique
+);
+```
 
 ##### Parameters
 
@@ -227,9 +231,11 @@ Creates and returns a new index with the given name in the connected database.
 
 Retrieves and returns the value from this object store for the record that corresponds to the given key.
 
-    any get (
-      in any key
-    ) raises (IDBDatabaseException);
+```
+any get (
+  in any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -254,10 +260,12 @@ This method can raise a IDBDatabaseException with the following codes:
 
 Creates a [cursor](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor) over the records of this object store. The range of the new cursor matches the specified [key range](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_range); if the key range is not specified or is null, then the range includes all the records.
 
-    CursorSync openCursor (
-      in optional KeyRange range,
-      in optional unsigned short direction
-    ) raises (DatabaseException);
+```
+CursorSync openCursor (
+  in optional KeyRange range,
+  in optional unsigned short direction
+) raises (DatabaseException);
+```
 
 ##### Parameters
 
@@ -282,9 +290,11 @@ This method can raise a DatabaseException with the following code:
 
 Opens the index with the given name, using the mode of the current transaction.
 
-     IDBIndexSync openIndex (
-       in DOMString name
-     ) raises  (IDBDatabaseException);
+```
+IDBIndexSync openIndex (
+  in DOMString name
+) raises  (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -307,10 +317,12 @@ This method can raise an IDBDatabaseException with the following code:
 
 Stores the given value in this object store and returns the key for the stored record. If a record already exists with the given key, it is overwritten.
 
-    any put (
-      in any value,
-      in optional any key
-    ) raises (IDBDatabaseException);
+```
+any put (
+  in any value,
+  in optional any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -339,9 +351,11 @@ This method can raise an IDBDatabaseException with the following codes:
 
 Removes from this object store any records that correspond to the given key.
 
-    void remove (
-      in any key
-    ) raises (IDBDatabaseException);
+```
+void remove (
+  in any key
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 
@@ -363,9 +377,11 @@ This method can raise a IDBDatabaseException with the following code:
 
 Destroys an index with the given name.
 
-      void removeIndex (
-        in DOMString indexName
-      ) raises (IDBDatabaseException);
+```
+void removeIndex (
+  in DOMString indexName
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 

--- a/files/en-us/web/api/idbtransactionsync/index.md
+++ b/files/en-us/web/api/idbtransactionsync/index.md
@@ -11,9 +11,9 @@ tags:
 ---
 {{APIRef("IndexedDB")}}{{ draft() }}
 
-> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
+> **Warning:** The synchronous version of the IndexedDB API was originally intended for use only with [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.
 
-The `IDBTransactionSync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) provides a synchronous [transaction](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction) on a database. When an application creates an IDBTransactionSync object, it blocks until the browser is able to reserve the require database objects.
+The `IDBTransactionSync` interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) provides a synchronous [transaction](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction) on a database. When an application creates an IDBTransactionSync object, it blocks until the browser is able to reserve the require database objects.
 
 ## Method overview
 
@@ -101,8 +101,10 @@ The `IDBTransactionSync` interface of the [IndexedDB API](/en-US/docs/Web/API/I
 
 Call this method to signal a need to cancel the effects of the operations performed by this transaction. When this method is called, the browser ignores all the changes performed to the objects of this database since this transaction was created.
 
-    void abort(
-    ) raises (IDBDatabaseException);
+```
+void abort(
+) raises (IDBDatabaseException);
+```
 
 ##### Exceptions
 
@@ -115,8 +117,10 @@ This method can raise an IDBDatabaseException with the following code:
 
 Call this method to signal that the transaction has completed normally and satisfactorily. When this method is called, the browser durably stores all the changes performed to the objects of the database since this transaction was created.
 
-    void commit(
-    ) raises (IDBDatabaseException);
+```
+void commit(
+) raises (IDBDatabaseException);
+```
 
 ##### Exceptions
 
@@ -131,9 +135,11 @@ This method can raise an IDBDatabaseException with the following codes:
 
 Returns an [object store](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store) that has already been added to the scope of this transaction.
 
-    IDBObjectStoreSync objectStore(
-      in DOMString name
-    ) raises (IDBDatabaseException);
+```
+IDBObjectStoreSync objectStore(
+  in DOMString name
+) raises (IDBDatabaseException);
+```
 
 ##### Parameters
 

--- a/files/en-us/web/api/messageport/index.md
+++ b/files/en-us/web/api/messageport/index.md
@@ -53,25 +53,27 @@ When the IFrame has loaded, we register an {{domxref("MessagePort.onmessage","on
 
 When a message is received back from the IFrame, the `onMessage` function outputs the message to a paragraph.
 
-    var channel = new MessageChannel();
-    var output = document.querySelector('.output');
-    var iframe = document.querySelector('iframe');
+```js
+var channel = new MessageChannel();
+var output = document.querySelector('.output');
+var iframe = document.querySelector('iframe');
 
-    // Wait for the iframe to load
-    iframe.addEventListener("load", onLoad);
+// Wait for the iframe to load
+iframe.addEventListener("load", onLoad);
 
-    function onLoad() {
-      // Listen for messages on port1
-      channel.port1.onmessage = onMessage;
+function onLoad() {
+  // Listen for messages on port1
+  channel.port1.onmessage = onMessage;
 
-      // Transfer port2 to the iframe
-      iframe.contentWindow.postMessage('Hello from the main page!', '*', [channel.port2]);
-    }
+  // Transfer port2 to the iframe
+  iframe.contentWindow.postMessage('Hello from the main page!', '*', [channel.port2]);
+}
 
-    // Handle messages received on port1
-    function onMessage(e) {
-      output.innerHTML = e.data;
-    }
+// Handle messages received on port1
+function onMessage(e) {
+  output.innerHTML = e.data;
+}
+```
 
 For a full working example, see our [channel messaging basic demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-basic) on Github ([run it live too](https://mdn.github.io/dom-examples/channel-messaging-basic/)).
 

--- a/files/en-us/web/api/mousescrollevent/index.md
+++ b/files/en-us/web/api/mousescrollevent/index.md
@@ -21,23 +21,25 @@ The **`MouseScrollEvent`** interface represents events that occur due to the use
 
 ## Method overview
 
-    void initMouseScrollEvent(
-      in DOMString typeArg,
-      in boolean canBubbleArg,
-      in boolean cancelableArg,
-      in nsIDOMAbstractView viewArg,
-      in long detailArg,
-      in long screenXArg,
-      in long screenYArg,
-      in long clientXArg,
-      in long clientYArg,
-      in boolean ctrlKeyArg,
-      in boolean altKeyArg,
-      in boolean shiftKeyArg,
-      in boolean metaKeyArg,
-      in unsigned short buttonArg,
-      in nsIDOMEventTarget relatedTargetArg,
-      in long axis);
+```
+void initMouseScrollEvent(
+  in DOMString typeArg,
+  in boolean canBubbleArg,
+  in boolean cancelableArg,
+  in nsIDOMAbstractView viewArg,
+  in long detailArg,
+  in long screenXArg,
+  in long screenYArg,
+  in long clientXArg,
+  in long clientYArg,
+  in boolean ctrlKeyArg,
+  in boolean altKeyArg,
+  in boolean shiftKeyArg,
+  in boolean metaKeyArg,
+  in unsigned short buttonArg,
+  in nsIDOMEventTarget relatedTargetArg,
+  in long axis);
+```
 
 ## Attributes
 

--- a/files/en-us/web/api/mssitemodeevent/index.md
+++ b/files/en-us/web/api/mssitemodeevent/index.md
@@ -151,10 +151,12 @@ Although this event inherits from the [Event](/en-US/docs/Web/API/Event) object,
 
 ## Example
 
-    declare var MSSiteModeEvent: {
-        prototype: MSSiteModeEvent;
-        new(): MSSiteModeEvent;
-    }
+```
+declare var MSSiteModeEvent: {
+    prototype: MSSiteModeEvent;
+    new(): MSSiteModeEvent;
+}
+```
 
 ## See also
 

--- a/files/en-us/web/api/mutationevent/index.md
+++ b/files/en-us/web/api/mutationevent/index.md
@@ -59,9 +59,11 @@ The following is a list of all mutation events, as defined in [DOM Level 3 Event
 
 You can register a listener for mutation events using {{DOMxRef("EventTarget.addEventListener()")}} as follows:
 
-    element.addEventListener("DOMNodeInserted", function (event) {
-      // ...
-    }, false);
+```js
+element.addEventListener("DOMNodeInserted", function (event) {
+  // ...
+}, false);
+```
 
 The event object is passed to the listener in a `MutationEvent` (see [its definition in the specification](https://www.w3.org/TR/DOM-Level-3-Events/#events-MutationEvent)) for most events, and {{DOMxRef("MutationNameEvent")}} for `DOMAttributeNameChanged` and `DOMElementNameChanged`.
 

--- a/files/en-us/web/api/stylesheet/media/index.md
+++ b/files/en-us/web/api/stylesheet/media/index.md
@@ -14,39 +14,41 @@ The **`media`** property of the {{domxref("StyleSheet")}} interface specifies th
 
 ## Example
 
-    <!doctype html>
-    <html>
-    <head>
-    <link rel="stylesheet" href="document.css" type="text/css" media="screen" />
-    <style rel="stylesheet" type="text/css" media="screen, print">
-    body  { background-color: snow; }
-    </style>
-    </head>
-    <body>
+```html
+<!doctype html>
+<html>
+<head>
+<link rel="stylesheet" href="document.css" type="text/css" media="screen" />
+<style rel="stylesheet" type="text/css" media="screen, print">
+body  { background-color: snow; }
+</style>
+</head>
+<body>
 
-    <script>
-    for (var iSheetIndex = 0; iSheetIndex < document.styleSheets.length; iSheetIndex++)
-     {
-      console.log('document.styleSheets[' + String(iSheetIndex) + '].media: ' +
-       JSON.stringify(document.styleSheets[iSheetIndex].media));
-      if (iSheetIndex === 0)
-        document.styleSheets[iSheetIndex].media.appendMedium('handheld');
-      if (iSheetIndex === 1)
-        document.styleSheets[iSheetIndex].media.deleteMedium('print');
-      console.log('document.styleSheets[' + String(iSheetIndex) + '].media: ' +
-       JSON.stringify(document.styleSheets[iSheetIndex].media));
-     }
-    /*
-    will log:
-    document.styleSheets[0].media: {"0":"screen"}
-    document.styleSheets[0].media: {"0":"screen","1":"handheld"}
-    document.styleSheets[1].media: {"0":"screen","1":"print"}
-    document.styleSheets[1].media: {"0":"screen"}
-    */
-    </script>
+<script>
+for (var iSheetIndex = 0; iSheetIndex < document.styleSheets.length; iSheetIndex++)
+  {
+  console.log('document.styleSheets[' + String(iSheetIndex) + '].media: ' +
+    JSON.stringify(document.styleSheets[iSheetIndex].media));
+  if (iSheetIndex === 0)
+    document.styleSheets[iSheetIndex].media.appendMedium('handheld');
+  if (iSheetIndex === 1)
+    document.styleSheets[iSheetIndex].media.deleteMedium('print');
+  console.log('document.styleSheets[' + String(iSheetIndex) + '].media: ' +
+    JSON.stringify(document.styleSheets[iSheetIndex].media));
+  }
+/*
+will log:
+document.styleSheets[0].media: {"0":"screen"}
+document.styleSheets[0].media: {"0":"screen","1":"handheld"}
+document.styleSheets[1].media: {"0":"screen","1":"print"}
+document.styleSheets[1].media: {"0":"screen"}
+*/
+</script>
 
-    </body>
-    </html>
+</body>
+</html>
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/svgrect/the__x__property/index.md
+++ b/files/en-us/web/api/svgrect/the__x__property/index.md
@@ -2,7 +2,7 @@
 title: The 'X' property
 slug: Web/API/SVGRect/The__X__property
 ---
-The [x](https://svgwg.org/svg2-draft/geometry.html#XProperty) property describes the horizontal coordinate of the position of the element.
+The [x](https://svgwg.org/svg2-draft/geometry.html#XProperty) property describes the horizontal coordinate of the position of the element.
 
 ## Usage context
 
@@ -18,7 +18,7 @@ The [x](https://svgwg.org/svg2-draft/geometry.html#XProperty) property describ
       <td>Value</td>
       <td>
         <a href="https://www.w3.org/TR/css3-values/#lengths">&#x3C;length></a
-        > | <a href="https://www.w3.org/TR/css3-values/#percentages"
+        > | <a href="https://www.w3.org/TR/css3-values/#percentages"
           >&#x3C;percentage></a
         >
       </td>
@@ -30,14 +30,14 @@ The [x](https://svgwg.org/svg2-draft/geometry.html#XProperty) property describ
     <tr>
       <td>Applies to</td>
       <td>
-        {{ SVGElement("mask") }} , ‘<a
+        {{ SVGElement("mask") }} , ‘<a
           href="https://svgwg.org/svg2-draft/struct.html#SVGElement"
           >svg</a
-        >’, ‘<a href="https://svgwg.org/svg2-draft/shapes.html#RectElement"
+        >’, ‘<a href="https://svgwg.org/svg2-draft/shapes.html#RectElement"
           >rect</a
-        >’, ‘<a href="https://svgwg.org/svg2-draft/embedded.html#ImageElement"
+        >’, ‘<a href="https://svgwg.org/svg2-draft/embedded.html#ImageElement"
           >image</a
-        >’, ‘<a
+        >’, ‘<a
           href="https://svgwg.org/svg2-draft/embedded.html#ForeignObjectElement"
           >foreignObject</a
         >’
@@ -50,7 +50,7 @@ The [x](https://svgwg.org/svg2-draft/geometry.html#XProperty) property describ
     <tr>
       <td>Percentages</td>
       <td>
-        refer to the size of the current viewport (see <a
+        refer to the size of the current viewport (see <a
           href="https://svgwg.org/svg2-draft/coords.html#Units"
           >Units</a
         >)
@@ -73,11 +73,12 @@ The [x](https://svgwg.org/svg2-draft/geometry.html#XProperty) property describ
 
 ## Simple usage
 
-A \<coordinate> is a length in the user coordinate system that is the given distance from the origin of the user coordinate system along the relevant axis (the x-axis for X coordinates, the y-axis for Y coordinates). Its syntax is the same as that for [\<length>](https://www.w3.org/TR/SVG11/types.html#DataTypeLength)
+A \<coordinate> is a length in the user coordinate system that is the given distance from the origin of the user coordinate system along the relevant axis (the x-axis for X coordinates, the y-axis for Y coordinates). Its syntax is the same as that for [\<length>](https://www.w3.org/TR/SVG11/types.html#DataTypeLength)
 
-    // Rect draws a rectangle with upper left-hand corner at x,y, with width w, and height h, with optional style
-    // Standard Reference: http://www.w3.org/TR/SVG11/shapes.html#RectElement
-
-         func (svg *SVG) Rect(x float64, y float64, w float64, h float64, s ...string) {
-                 svg.printf(`<rect %s %s`, dim(x, y, w, h, svg.Decimals), endstyle(s, emptyclose))
-    }
+```js
+// Rect draws a rectangle with upper left-hand corner at x,y, with width w, and height h, with optional style
+// Standard Reference: http://www.w3.org/TR/SVG11/shapes.html#RectElement
+func (svg *SVG) Rect(x float64, y float64, w float64, h float64, s ...string) {
+  svg.printf(`<rect %s %s`, dim(x, y, w, h, svg.Decimals), endstyle(s, emptyclose))
+}
+```

--- a/files/en-us/web/api/touch/msmanipulationviewsenabled/index.md
+++ b/files/en-us/web/api/touch/msmanipulationviewsenabled/index.md
@@ -20,9 +20,11 @@ Returns _true_ if manipulation features are support available, such as _touch pa
 
 Using a JSON file:
 
-    {
-    msManipulationViewsEnabled: true,
-    }
+```json
+{
+  "msManipulationViewsEnabled": true,
+}
+```
 
 ## See also
 

--- a/files/en-us/web/api/webxr_device_api/performance/index.md
+++ b/files/en-us/web/api/webxr_device_api/performance/index.md
@@ -56,40 +56,44 @@ While an individual vector or matrix doesn't occupy an inordinate amount of memo
 
 Consider the following
 
-    function drawScene(gl, view, programInfo, buffers, texture, deltaTime) {
-      ...
-      for (object in scene) {
-        let vertexList = ...
-        let normalMatrix = mat4.create();
-        let modelViewMatrix = mat4.create();
-        let objectMatrix = mat4.
+```js
+function drawScene(gl, view, programInfo, buffers, texture, deltaTime) {
+  ...
+  for (object in scene) {
+    let vertexList = ...
+    let normalMatrix = mat4.create();
+    let modelViewMatrix = mat4.create();
+    let objectMatrix = mat4.
 
-        // Apply rotation updates to the object if needed
+    // Apply rotation updates to the object if needed
 
-        mat4.rotate(
-      }
-    }
+    mat4.rotate(
+  }
+}
+```
 
 This renders a scene. But it's inefficient, because it allocates as local variables a number of things, including at least two matrices, an array of vertices, and more. That means that for every frame, the JavaScript runtime has to allocate memory for those and set them up—possibly triggering garbage collection—and then when each interaction of the loop is completed, the memory is released.
 
 A simple change can optimize this significantly:
 
-    const vertexList = ...
-    const normalMatrix = mat4.create();
-    const modelViewMatrix = mat4.create();
+```js
+const vertexList = ...
+const normalMatrix = mat4.create();
+const modelViewMatrix = mat4.create();
 
-    function drawScene(gl, view, programInfo, buffers, texture, deltaTime) {
-      ...
-      for (object in scene) {
-        ...
-      }
-    }
+function drawScene(gl, view, programInfo, buffers, texture, deltaTime) {
+  ...
+  for (object in scene) {
+    ...
+  }
+}
+```
 
 Now, instead of allocating variables every loop iteration, we're using global constants(or class member constants). This has multiple benefits:
 
 - The memory allocated for each value or structure will not need to be reallocated every frame. This reduces the potential for triggering garbage collection, and optimizes memory use.
 - You can't accidentally delete the objects that contain your vectors and matrices, since they're constants.
-- You can, however, still replace the *contents* of each of these objects, so they're reusable.
+- You can, however, still replace the *contents* of each of these objects, so they're reusable.
 
 You're now protected from several possible coding mistakes, and your entire animation will be smoother and more performant as well.
 

--- a/files/en-us/web/api/xsltprocessor/xsl_transformations_in_mozilla_faq/index.md
+++ b/files/en-us/web/api/xsltprocessor/xsl_transformations_in_mozilla_faq/index.md
@@ -7,7 +7,7 @@ tags:
 ---
 ## Why isn't my stylesheet applied?
 
-Make sure the mime type for both source and stylesheet are set to an XML mimetype, namely `text/xml` or `application/xml`. The XSLT namespace is `http://www.w3.org/1999/XSL/Transform`. Use the \<?xml-stylesheet ?> processing instruction instead of the non-standard xml:stylesheet. The most common cause is the MIME type handling. To find out which MIME type your server sends, look at Page Info, use extensions like [LiveHTTPHeaders](http://livehttpheaders.mozdev.org/) or a download manager like `wget`. Mozilla won't load XSLT stylesheets from a different domain for security reasons.
+Make sure the mime type for both source and stylesheet are set to an XML mimetype, namely `text/xml` or `application/xml`. The XSLT namespace is `http://www.w3.org/1999/XSL/Transform`. Use the \<?xml-stylesheet ?> processing instruction instead of the non-standard xml:stylesheet. The most common cause is the MIME type handling. To find out which MIME type your server sends, look at Page Info, use extensions like [LiveHTTPHeaders](http://livehttpheaders.mozdev.org/) or a download manager like `wget`. Mozilla won't load XSLT stylesheets from a different domain for security reasons.
 
 > **Note:** Starting in {{Gecko("7.0") }}, both `text/xsl` and `application/xslt+xml` are supported MIME types for XSLT media stylesheets.
 
@@ -25,23 +25,27 @@ This is actually pretty close to the question above. And in short, no. Disabling
 
 Just like for XHTML, `document.write` is not supported during XSLT transformations. Sadly, current builds don't error, but just give unexpected results, like crashes ({{ Bug(202765) }}). In most cases, there is no need to actually use it, though. If you need platform dependent code or stylesheets, just do
 
-          <xsl:if test="system-property('xsl:vendor')='Transformiix'">
-            <!-- Mozilla specific markup -->
-          </xsl:if>
-          <xsl:if test="system-property('xsl:vendor')='Microsoft'">
-            <!-- IE specific markup -->
-          </xsl:if>
+```xml
+<xsl:if test="system-property('xsl:vendor')='Transformiix'">
+  <!-- Mozilla specific markup -->
+</xsl:if>
+<xsl:if test="system-property('xsl:vendor')='Microsoft'">
+  <!-- IE specific markup -->
+</xsl:if>
+```
 
 Check system-properties.xml for the properties of your favorite system. MSXML has an additional property.
 
-          <xsl:if xmlns:msxsl="urn:schemas-microsoft-com:xslt"
-                  test="system-property('msxsl:version')=3">
-            <!-- MSXML3 specific markup -->
-          </xsl:if>
+```xml
+<xsl:if xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+        test="system-property('msxsl:version')=3">
+  <!-- MSXML3 specific markup -->
+</xsl:if>
+```
 
 ## What about `media="print"`?
 
-When printing a document, Mozilla tries to render the page on paper as closely to what you see as possible. This includes stuff like text entered into textfields and other dynamic changes. This is achieved by printing the current DOM tree. Having XSLT stylesheet specific to particular `media` would require to retransform the original XML source, which counteracts the expectations of the user. Thus, using `media` in \<?xml-stylesheet ?> is strongly discouraged. Future builds might only load an XSLT stylesheet if `media` is not specified, or if the specified `media` include `screen`.
+When printing a document, Mozilla tries to render the page on paper as closely to what you see as possible. This includes stuff like text entered into textfields and other dynamic changes. This is achieved by printing the current DOM tree. Having XSLT stylesheet specific to particular `media` would require to retransform the original XML source, which counteracts the expectations of the user. Thus, using `media` in \<?xml-stylesheet ?> is strongly discouraged. Future builds might only load an XSLT stylesheet if `media` is not specified, or if the specified `media` include `screen`.
 This does not affect CSS stylesheets loaded from the generated DOM, those honor media just like in pages without XSLT.
 
 ## How do I do `transformNode`?
@@ -50,7 +54,7 @@ There is `transformToDocument` and `transformToFragment` starting with Mozilla 1
 
 ## Why does Internet Explorer require a different XSLT namespace than Mozilla?
 
-IE up to version 6 required a deprecated namespace of a XSLT working draft, please update to Mozilla ;-), IE6+ or MSXML3+, as it is fixed there. As the differences between XSLT1.0 and the IE implementation of that WD are significant, we offer no legacy support.
+IE up to version 6 required a deprecated namespace of a XSLT working draft, please update to Mozilla ;-), IE6+ or MSXML3+, as it is fixed there. As the differences between XSLT1.0 and the IE implementation of that WD are significant, we offer no legacy support.
 
 ## How do I build the standalone version of TransforMiiX?
 

--- a/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
+++ b/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
@@ -28,11 +28,11 @@ The properties defined by the specification are:
 - {{cssxref("column-fill")}}
 - {{cssxref("column-gap")}}
 
-By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
+By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
 
 ## Defining columns
 
-To create a multicol container you must use at least one of the `column-*` properties, these being `column-count` and `column-width`.
+To create a multicol container you must use at least one of the `column-*` properties, these being `column-count` and `column-width`.
 
 ### The `column-count` property
 
@@ -42,7 +42,7 @@ In the below example we use the `column-count` property to create three columns 
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
 
-In the above example the content is wrapped in paragraph `p` tags with default styling.  Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new Block Formatting Context (BFC) which means margins on child elements do not collapse with any margin on the container.
+In the above example the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new Block Formatting Context (BFC) which means margins on child elements do not collapse with any margin on the container.
 
 ### The `column-width` property
 
@@ -56,7 +56,7 @@ In the below example we use the `column-width` property with a value of 200px. W
 
 ### Using `column-count` and `column-width` together
 
-If you specify both properties on a multicol container then `column-count` will act as a maximum number of columns. Therefore the behavior as described for column-width will happen, until the number of columns in column-count is reached. After this point no more columns will be drawn, and the extra space is distributed evenly between the existing columns, even if there is enough room for more columns of the specified `column-width`  size.
+If you specify both properties on a multicol container then `column-count` will act as a maximum number of columns. Therefore the behavior as described for column-width will happen, until the number of columns in column-count is reached. After this point no more columns will be drawn, and the extra space is distributed evenly between the existing columns, even if there is enough room for more columns of the specified `column-width` size.
 
 When using both properties together you may get fewer columns than specified in the value for `column-count`.
 
@@ -70,21 +70,27 @@ You can use the `columns`shorthand to set `column-count` and `column-width`. If 
 
 This CSS would give the same result as example 1, `column-count` set to 3.
 
-    .container {
-      columns: 3;
-    }
+```css
+.container {
+  columns: 3;
+}
+```
 
 This CSS would give the same result as example 2, with `column-width` of 200px.
 
-    .container {
-      columns: 200px;
-    }
+```css
+.container {
+  columns: 200px;
+}
+```
 
 This CSS would give the same result as example 3, with both `column-count` and `column-width` set.
 
-    .container {
-      columns: 2 200px;
-    }
+```css
+.container {
+  columns: 2 200px;
+}
+```
 
 ## Next Steps
 

--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -27,11 +27,13 @@ The items typically display inline with a separator to indicate a hierarchy betw
 >
 > [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/breadcrumb-navigation--download.html)
 
-> **Note:** The example above uses two selectors to insert content before every `li` except the first one. This could also be achieved using one selector only:
+> **Note:** The example above uses two selectors to insert content before every `li` except the first one. This could also be achieved using one selector only:
 >
->     .breadcrumb li:not(:first-child)::before {
->       content: "→";
->     }
+> ```css
+> .breadcrumb li:not(:first-child)::before {
+>   content: "→";
+> }
+> ```
 >
 > This solution uses a more complex selector, but requires less rules. Feel free to choose the solution that you prefer.
 

--- a/files/en-us/web/css/string/index.md
+++ b/files/en-us/web/css/string/index.md
@@ -32,24 +32,26 @@ However, to get new lines, you must also set the {{cssxref("white-space")}} prop
 
 ### Examples of valid strings
 
-    /* Simple strings */
-    "This string is demarcated by double quotes."
-    'This string is demarcated by single quotes.'
+```css
+/* Simple strings */
+"This string is demarcated by double quotes."
+'This string is demarcated by single quotes.'
 
-    /* Character escaping */
-    "This is a string with \" an escaped double quote."
-    "This string also has \22 an escaped double quote."
-    'This is a string with \' an escaped single quote.'
-    'This string also has \27 an escaped single quote.'
-    "This is a string with \\ an escaped backslash."
+/* Character escaping */
+"This is a string with \" an escaped double quote."
+"This string also has \22 an escaped double quote."
+'This is a string with \' an escaped single quote.'
+'This string also has \27 an escaped single quote.'
+"This is a string with \\ an escaped backslash."
 
-    /* New line in a string */
-    "This string has a \Aline break in it."
+/* New line in a string */
+"This string has a \Aline break in it."
 
-    /* String spanning two lines of code (these two strings will have identical output) */
-    "A really long \
-    awesome string"
-    "A really long awesome string"
+/* String spanning two lines of code (these two strings will have identical output) */
+"A really long \
+awesome string"
+"A really long awesome string"
+```
 
 ## Specifications
 

--- a/files/en-us/web/exslt/exsl/node-set/index.md
+++ b/files/en-us/web/exslt/exsl/node-set/index.md
@@ -14,7 +14,9 @@ You can also use `exsl:node-set()` to turn strings into text nodes.
 
 ## Syntax
 
-    exsl:node-set(object)
+```
+exsl:node-set(object)
+```
 
 ### Parameters
 

--- a/files/en-us/web/exslt/math/min/index.md
+++ b/files/en-us/web/exslt/math/min/index.md
@@ -15,7 +15,9 @@ To compute the minimum value of the node-set, the node set is sorted into ascend
 
 ## Syntax
 
-    math:min(nodeSet)
+```
+math:min(nodeSet)
+```
 
 ### Parameters
 

--- a/files/en-us/web/guide/html/content_categories/index.md
+++ b/files/en-us/web/guide/html/content_categories/index.md
@@ -142,11 +142,15 @@ If an element has a transparent content model, then its contents must be structu
 
 For example, the {{HTMLElement("del")}} and {{HTMLELement("ins")}} elements are transparent:
 
-    <p>We hold these truths to be <del><em>sacred &amp; undeniable</em></del> <ins>self-evident</ins>.</p>
+```html
+<p>We hold these truths to be <del><em>sacred &amp; undeniable</em></del> <ins>self-evident</ins>.</p>
+```
 
 If those elements were removed, this fragment would still be valid HTML (if not correct English).
 
-    <p>We hold these truths to be <em>sacred &amp; undeniable</em> self-evident.</p>
+```html
+<p>We hold these truths to be <em>sacred &amp; undeniable</em> self-evident.</p>
+```
 
 ## Other content models
 

--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -1509,10 +1509,12 @@ Some content attributes (e.g. `required`, `readonly`, `disabled`) are called [bo
 
 HTML5 defines restrictions on the allowed values of boolean attributes: If the attribute is present, its value must either be the empty string (equivalently, the attribute may have an unassigned value), or a value that is an ASCII case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace. The following examples are valid ways to mark up a boolean attribute:
 
-    <div itemscope> This is valid HTML but invalid XML. </div>
-    <div itemscope=itemscope> This is also valid HTML but invalid XML. </div>
-    <div itemscope=""> This is valid HTML and also valid XML. </div>
-    <div itemscope="itemscope"> This is also valid HTML and XML, but perhaps a bit verbose. </div>
+```html
+<div itemscope> This is valid HTML but invalid XML. </div>
+<div itemscope=itemscope> This is also valid HTML but invalid XML. </div>
+<div itemscope=""> This is valid HTML and also valid XML. </div>
+<div itemscope="itemscope"> This is also valid HTML and XML, but perhaps a bit verbose. </div>
+```
 
 To be clear, the values "`true`" and "`false`" are not allowed on boolean attributes. To represent a false value, the attribute has to be omitted altogether. This restriction clears up some common misunderstandings: With `checked="false"` for example, the element's `checked` attribute would be interpreted as **true** because the attribute is present.
 

--- a/files/en-us/web/html/element/basefont/index.md
+++ b/files/en-us/web/html/element/basefont/index.md
@@ -45,7 +45,9 @@ This element implements the {{domxref("HTMLBaseFontElement")}} interface.
 
 ## Example
 
-    <basefont color="#FF0000" face="Helvetica" size="+2" />
+```html
+<basefont color="#FF0000" face="Helvetica" size="+2" />
+```
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/translate/index.md
+++ b/files/en-us/web/html/global_attributes/translate/index.md
@@ -24,9 +24,11 @@ Although not all browsers recognize this attribute, it is respected by automatic
 
 In this example, the `translate` attribute is used to ask translation tools not to translate the company's brand name in the footer.
 
-    <footer>
-      <small>© 2020 <span translate="no">BrandName</span></small>
-    </footer>
+```html
+<footer>
+  <small>© 2020 <span translate="no">BrandName</span></small>
+</footer>
+```
 
 ## Specifications
 

--- a/files/en-us/web/html/viewport_meta_tag/index.md
+++ b/files/en-us/web/html/viewport_meta_tag/index.md
@@ -30,7 +30,9 @@ Learn more about viewports in different mobile browsers in [A Tale of Two Viewpo
 
 A typical mobile-optimized site contains something like the following:
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
 
 The `width` property controls the size of the viewport. It can be set to a specific number of pixels like `width=600` or to the special value `device-width`, which is the width of the screen in CSS pixels at a scale of 100%. (There are corresponding `height` and `device-height` values, which may be useful for pages with elements that change size or position based on the viewport height.)
 
@@ -56,17 +58,23 @@ Sites can set their viewport to a specific size. For example, the definition `"w
 
 For pages that set an initial or maximum scale, this means the `width` property actually translates into a _minimum_ viewport width. For example, if your layout needs at least 500 pixels of width then you can use the following markup. When the screen is more than 500 pixels wide, the browser will expand the viewport (rather than zoom in) to fit the screen:
 
-    <meta name="viewport" content="width=500, initial-scale=1">
+```html
+<meta name="viewport" content="width=500, initial-scale=1">
+```
 
 Other [attributes](/en-US/docs/Web/HTML/Element/meta#Attributes) that are available are `minimum-scale`, `maximum-scale`, and `user-scalable`. These properties affect the initial scale and width, as well as limiting changes in zoom level.
 
 Not all mobile browsers handle orientation changes in the same way. For example, Mobile Safari often just zooms the page when changing from portrait to landscape, instead of laying out the page as it would if originally loaded in landscape. If web developers want their scale settings to remain consistent when switching orientations on the iPhone, they must add a `maximum-scale` value to prevent this zooming, which has the sometimes-unwanted side effect of preventing users from zooming in:
 
-    <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+```html
+<meta name="viewport" content="initial-scale=1, maximum-scale=1">
+```
 
 Suppress the small zoom applied by many smartphones by setting the initial scale and minimum-scale values to 0.86. The result is horizontal scroll is suppressed in any orientation and the user can zoom in if they want to.
 
-    <meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86">
+```html
+<meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86">
+```
 
 ## Common viewport sizes for mobile and tablet devices
 

--- a/files/en-us/web/http/public_key_pinning/index.md
+++ b/files/en-us/web/http/public_key_pinning/index.md
@@ -48,7 +48,7 @@ First you need to extract the public key information from your certificate or ke
 
 The following commands will help you extract the Base64 encoded information from a key file, a certificate signing request, or a certificate.
 
-```
+```bash
 openssl rsa -in my-rsa-key-file.key -outform der -pubout | openssl dgst -sha256 -binary | openssl enc -base64
 
 openssl ec -in my-ecc-key-file.key -outform der -pubout | openssl dgst -sha256 -binary | openssl enc -base64
@@ -60,7 +60,7 @@ openssl x509 -in my-certificate.crt -pubkey -noout | openssl pkey -pubin -outfor
 
 The following command will extract the Base64 encoded information for a website.
 
-```
+```bash
 openssl s_client -servername www.example.com -connect www.example.com:443 | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
 ```
 
@@ -122,7 +122,7 @@ server.modules += ( "mod_setenv" )
 
 Add the following line to the Web.config file to send the `Public-Key-Pins` header:
 
-```
+```xml
 <system.webServer>
   ...
 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.statements.async_function
 ---
 {{jsSidebar("Statements")}}
 
-An async function is a function declared with the `async` keyword, and the `await` keyword is permitted within it. The `async` and `await` keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains.
+An async function is a function declared with the `async` keyword, and the `await` keyword is permitted within it. The `async` and `await` keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains.
 
 Async functions may also be defined {{jsxref("Operators/async_function", "as
   expressions", "", 1)}}.
@@ -33,7 +33,7 @@ async function name([param[, param[, ...param]]]) {
 - `param`
   - : The name of an argument to be passed to the function.
 - `statements`
-  - : The statements comprising the body of the function.  The `await`
+  - : The statements comprising the body of the function. The `await`
     mechanism may be used.
 
 ### Return value
@@ -44,7 +44,7 @@ function.
 
 ## Description
 
-Async functions can contain zero or more {{jsxref("Operators/await", "await")}} expressions. Await expressions make promise-returning functions behave as though they're synchronous by suspending execution until the returned promise is fulfilled or rejected. The resolved value of the promise is treated as the return value of the await expression. Use of `async` and `await` enables the use of ordinary `try` / `catch` blocks around asynchronous code.
+Async functions can contain zero or more {{jsxref("Operators/await", "await")}} expressions. Await expressions make promise-returning functions behave as though they're synchronous by suspending execution until the returned promise is fulfilled or rejected. The resolved value of the promise is treated as the return value of the await expression. Use of `async` and `await` enables the use of ordinary `try` / `catch` blocks around asynchronous code.
 
 > **Note:** The `await` keyword is only valid inside async functions within regular JavaScript code. If you use it outside of an async function's body, you will get a {{jsxref("SyntaxError")}}.
 >
@@ -52,7 +52,7 @@ Async functions can contain zero or more {{jsxref("Operators/await", "await")}}
 
 > **Note:** The purpose of `async`/`await` is to simplify the syntax
 > necessary to consume promise-based APIs. The behavior
-> of `async`/`await` is similar to combining [generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) and
+> of `async`/`await` is similar to combining [generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) and
 > promises.
 
 Async functions always return a promise. If the return value of an async function is
@@ -126,7 +126,7 @@ callback. In this way a promise chain is progressively constructed with each ree
 step through the function. The return value forms the final link in the chain.
 
 In the following example, we successively await two promises. Progress moves through
-function `foo` in three stages.
+function `foo` in three stages.
 
 1.  The first line of the body of function `foo` is executed synchronously,
     with the await expression configured with the pending promise. Progress through
@@ -158,16 +158,16 @@ constructed in stages as control is successively yielded from and returned to th
 function. As a result, we must be mindful of error handling behavior when dealing with
 concurrent asynchronous operations.
 
-For example, in the following code an unhandled promise rejection error will be thrown,
+For example, in the following code an unhandled promise rejection error will be thrown,
 even if a `.catch` handler has been configured further along the promise
-chain. This is because `p2` will not be "wired into" the promise chain until
+chain. This is because `p2` will not be "wired into" the promise chain until
 control returns from `p1`.
 
 ```js
 async function foo() {
    const p1 = new Promise((resolve) => setTimeout(() => resolve('1'), 1000))
    const p2 = new Promise((_,reject) => setTimeout(() => reject('2'), 500))
-   const results = [await p1, await p2] // Do not do this! Use Promise.all or Promise.allSettled instead.
+   const results = [await p1, await p2] // Do not do this! Use Promise.all or Promise.allSettled instead.
 }
 foo().catch(() => {}) // Attempt to swallow all errors...
 ```
@@ -263,18 +263,18 @@ However, the `await` calls still run in series, which means the second
 the fastest timer is processed after the slowest.
 
 If you wish to safely perform two or more jobs in parallel, you must await a call
-to [`Promise.all`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all),
+to [`Promise.all`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all),
 or
 [`Promise.allSettled`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled).
 
-> **Warning:** The functions `concurrentStart` and `concurrentPromise`
+> **Warning:** The functions `concurrentStart` and `concurrentPromise`
 > are not functionally equivalent.
 >
-> In `concurrentStart`, if promise `fast` rejects before promise
+> In `concurrentStart`, if promise `fast` rejects before promise
 > `slow` is fulfilled, then an unhandled promise rejection error will be
 > raised, regardless of whether the caller has configured a catch clause.
 >
-> In `concurrentPromise`, `Promise.all` wires up the promise
+> In `concurrentPromise`, `Promise.all` wires up the promise
 > chain in one go, meaning that the operation will fail-fast regardless of the order of
 > rejection of the promises, and the error will always occur within the configured
 > promise chain, enabling it to be caught in the normal way.
@@ -311,6 +311,7 @@ async function getProcessedData(url) {
 ```
 
 Alternatively, you can chain the promise with `catch()`:
+
 ```js
 async function getProcessedData(url) {
   const v = await downloadData(url).catch(e => { 

--- a/files/en-us/web/svg/attribute/systemlanguage/index.md
+++ b/files/en-us/web/svg/attribute/systemlanguage/index.md
@@ -84,7 +84,9 @@ The prefix rule allows the use of prefix tags if this is the case.
 
 Multiple languages may be listed for content that is intended for multiple audiences. For example, content that is presented simultaneously in the original Maori and English versions, would call for:
 
-    <text systemLanguage="mi, en"><!-- content goes here --></text>
+```html
+<text systemLanguage="mi, en"><!-- content goes here --></text>
+```
 
 However, just because multiple languages are present within the object on which the `systemLanguage` test attribute is placed, this does not mean that it is intended for multiple linguistic audiences. An example would be a beginner's language primer, such as "A First Lesson in Latin," which is clearly intended to be used by an English-literate audience. In this case, the attribute should only include `en`.
 

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -136,7 +136,7 @@ SVG makes use of a number of data types. This article lists these types along wi
 ## Integer
 
 *   \<integer>
-    *   : An \<integer> is specified as an optional sign character (`+` or `-`) followed by one or more digits `0` to `9`:
+    *   : An \<integer> is specified as an optional sign character (`+` or `-`) followed by one or more digits `0` to `9`:
 
         ```
         integer ::= [+-]? [0-9]+
@@ -169,13 +169,13 @@ SVG makes use of a number of data types. This article lists these types along wi
 
         SVG makes extensive use of *IRI* references, both absolute and relative, to other objects. For example, to fill a rectangle with a linear gradient, you first define a {{SVGElement("linearGradient")}} element and give it an ID, as in:
 
-        ```
+        ```html
         <linearGradient xml:id="MyGradient">...</linearGradient>
         ```
 
         You then reference the linear gradient as the value of the {{SVGAttr("fill")}} attribute for the rectangle, as in the following example:
 
-        ```
+        ```html
         <rect fill="url(#MyGradient)"/>
         ```
 

--- a/files/en-us/web/svg/scripting/index.md
+++ b/files/en-us/web/svg/scripting/index.md
@@ -20,44 +20,44 @@ When writing drag and drop code, sometimes you'll find that text on the page get
 
 The methods `addEventListener()` and `removeEventListener()` are very useful when writing interactive SVG. You can pass an object that implements the `handleEvent` interface as the second parameter to these methods.
 
-    function myRect(x,y,w,h,message){
-    this.message=message
+```js
+function myRect(x, y, w, h, message) {
+  this.message=message
 
-<!---->
+  this.rect=document.createElementNS("http://www.w3.org/2000/svg","rect")
+  this.rect.setAttributeNS(null,"x",x)
+  this.rect.setAttributeNS(null,"y",y)
+  this.rect.setAttributeNS(null,"width",w)
+  this.rect.setAttributeNS(null,"height",h)
+  document.documentElement.appendChild(this.rect)
 
-     this.rect=document.createElementNS("http://www.w3.org/2000/svg","rect")
-     this.rect.setAttributeNS(null,"x",x)
-     this.rect.setAttributeNS(null,"y",y)
-     this.rect.setAttributeNS(null,"width",w)
-     this.rect.setAttributeNS(null,"height",h)
-     document.documentElement.appendChild(this.rect)
+  this.rect.addEventListener("click",this,false)
 
-<!---->
-
-     this.rect.addEventListener("click",this,false)
-
-<!---->
-
-     this.handleEvent= function(evt){
-       switch (evt.type){
-        case "click":
-         alert(this.message)
-         break;
-        }
-       }
-      }
+  this.handleEvent= function(evt){
+    switch (evt.type){
+    case "click":
+      alert(this.message)
+      break;
+    }
+  }
+}
+```
 
 ### Inter-document scripting: referencing embedded SVG
 
 When using SVG within HTML, Adobe's SVG Viewer 3.0 automatically includes a window property called `svgDocument` that points to the SVG document. This is not the case for Mozilla's native SVG implementation; therefore, using `window.svgDocument` does not work in Mozilla. Instead, you can use
 
-    var svgDoc=document.embeds["name_of_svg"].getSVGDocument();
+```js
+var svgDoc=document.embeds["name_of_svg"].getSVGDocument();
+```
 
 to get a reference to an embedded SVG document instead.
 
 The best way to get access to the {{domxref("Document")}} representing an SVG document is to look at {{domxref("HTMLIFrameElement.contentDocument")}} (if the document is presented in an {{HTMLElement("iframe")}}) or {{domxref("HTMLObjectElement.contentDocument")}} (if the document is presented in an {{HTMLElement("object")}} element), like this:
 
-    var svgDoc = document.getElementById("iframe_element").contentDocument;
+```js
+var svgDoc = document.getElementById("iframe_element").contentDocument;
+```
 
 In addition, the {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("object")}} elements offer a method, `getSVGDocument()`, which returns the {{domxref("XMLDocument")}} representing the element's embedded SVG or `null` if the element doesn't represent an SVG document.
 

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -57,7 +57,7 @@ To use a gradient, we have to reference it from an object's `fill` or `stroke` a
 
 The `<linearGradient>` element also takes several other attributes, which specify the size and appearance of the gradient. The orientation of the gradient is controlled by two points, designated by the attributes `x1`, `x2`, `y1`, and `y2`. These attributes define a line along which the gradient travels. The gradient defaults to a horizontal orientation, but it can be rotated by changing these. Gradient2 in the above example is designed to create a vertical gradient.
 
-```
+```html
 <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
 ```
 

--- a/files/en-us/web/svg/tutorial/positions/index.md
+++ b/files/en-us/web/svg/tutorial/positions/index.md
@@ -27,7 +27,9 @@ Note that this is slightly different than the way you're taught to graph as a ki
 
 The element
 
-    <rect x="0" y="0" width="100" height="100" />
+```html
+<rect x="0" y="0" width="100" height="100" />
+```
 
 defines a rectangle from the upper left corner, that spans from there 100px to the right and to the bottom.
 
@@ -37,11 +39,15 @@ In the most basic case one pixel in an SVG document maps to one pixel on the out
 
 Without further specification, one user unit equals one screen unit. To explicitly change this behavior, there are several possibilities in SVG. We start with the `svg` root element:
 
-    <svg width="100" height="100">
+```html
+<svg width="100" height="100">
+```
 
 The above element defines a simple SVG canvas with 100x100px. One user unit equals one screen unit.
 
-    <svg width="200" height="200" viewBox="0 0 100 100">
+```html
+<svg width="200" height="200" viewBox="0 0 100 100">
+```
 
 The whole SVG canvas here is 200px by 200px in size. However, the `viewBox` attribute defines the portion of that canvas to display. These 200x200 pixels display an area that starts at user unit (0,0) and spans 100x100 user units to the right and to the bottom. This effectively zooms in on the 100x100 unit area and enlarges the image to double size.
 

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -13,7 +13,7 @@ When SVG was specified, support for web fonts was not widespread in browsers. Si
 
 > **Note:** SVG Fonts are currently supported only in Safari and Android Browser.
 >
-> Internet Explorer [hasn't considered implementing this](http://blogs.msdn.com/b/ie/archive/2010/08/04/html5-modernized-fourth-ie9-platform-preview-available-for-developers.aspx), the functionality has been [removed from Chrome 38](https://www.chromestatus.com/feature/5930075908210688) (and Opera 25) and Firefox has [postponed its implementation indefinitely](https://bugzilla.mozilla.org/show_bug.cgi?id=119490) to concentrate on [WOFF](/en-US/docs/Web/Guide/WOFF). Other tools however like the [Adobe SVG Viewer](http://www.adobe.com/svg/viewer/install/) plugin, Batik and parts of Inkscape support SVG font embedding.
+> Internet Explorer [hasn't considered implementing this](http://blogs.msdn.com/b/ie/archive/2010/08/04/html5-modernized-fourth-ie9-platform-preview-available-for-developers.aspx), the functionality has been [removed from Chrome 38](https://www.chromestatus.com/feature/5930075908210688) (and Opera 25) and Firefox has [postponed its implementation indefinitely](https://bugzilla.mozilla.org/show_bug.cgi?id=119490) to concentrate on [WOFF](/en-US/docs/Web/Guide/WOFF). Other tools however like the [Adobe SVG Viewer](http://www.adobe.com/svg/viewer/install/) plugin, Batik and parts of Inkscape support SVG font embedding.
 
 The base for defining an SVG font is the {{ SVGElement("font") }} element.
 
@@ -21,20 +21,22 @@ The base for defining an SVG font is the {{ SVGElement("font") }} element.
 
 There are some ingredients required for embedding a font in SVG. Let's show an example declaration (the one [from the specification](https://www.w3.org/TR/SVG/fonts.html#FontElement)), and explain the details.
 
-    <font id="Font1" horiz-adv-x="1000">
-      <font-face font-family="Super Sans" font-weight="bold" font-style="normal"
-          units-per-em="1000" cap-height="600" x-height="400"
-          ascent="700" descent="300"
-          alphabetic="0" mathematical="350" ideographic="400" hanging="500">
-        <font-face-src>
-          <font-face-name name="Super Sans Bold"/>
-        </font-face-src>
-      </font-face>
-      <missing-glyph><path d="M0,0h200v200h-200z"/></missing-glyph>
-      <glyph unicode="!" horiz-adv-x="300"><!-- Outline of exclam. pt. glyph --></glyph>
-      <glyph unicode="@"><!-- Outline of @ glyph --></glyph>
-      <!-- more glyphs -->
-    </font>
+```html
+<font id="Font1" horiz-adv-x="1000">
+  <font-face font-family="Super Sans" font-weight="bold" font-style="normal"
+      units-per-em="1000" cap-height="600" x-height="400"
+      ascent="700" descent="300"
+      alphabetic="0" mathematical="350" ideographic="400" hanging="500">
+    <font-face-src>
+      <font-face-name name="Super Sans Bold"/>
+    </font-face-src>
+  </font-face>
+  <missing-glyph><path d="M0,0h200v200h-200z"/></missing-glyph>
+  <glyph unicode="!" horiz-adv-x="300"><!-- Outline of exclam. pt. glyph --></glyph>
+  <glyph unicode="@"><!-- Outline of @ glyph --></glyph>
+  <!-- more glyphs -->
+</font>
+```
 
 We start with the {{ SVGElement("font") }} element. This bears an id attribute, to enable it to be referenced via a URI (see below). The `horiz-adv-x` attribute determines how wide a character is on average compared to the path definitions of the single glyphs. The value `1000` sets a reasonable value to work with. There are several accompanying attributes that help further define the basic glyph-box layout.
 
@@ -48,18 +50,22 @@ The actual glyphs are then defined by {{ SVGElement("glyph") }} elements. The mo
 
 There are two further elements that can be defined inside `font`: {{ SVGElement("hkern") }} and {{ SVGElement("vkern") }}. Each carries references to at least two characters (attributes `u1` and `u2`) and an attribute `k` that determines how much the distance between those characters should be decreased. The below example instructs user agents to place the "A" and "V" characters closer together the standard distance between characters.
 
-    <hkern u1="A" u2="V" k="20" />
+```html
+<hkern u1="A" u2="V" k="20" />
+```
 
 ## Referencing a font
 
 When you have put together your font declaration as described above, you can just use a simple `font-family` attribute to actually apply the font to some SVG text:
 
-    <font>
-      <font-face font-family="Super Sans" />
-      <!-- and so on -->
-    </font>
+```html
+<font>
+  <font-face font-family="Super Sans" />
+  <!-- and so on -->
+</font>
 
-    <text font-family="Super Sans">My text uses Super Sans</text>
+<text font-family="Super Sans">My text uses Super Sans</text>
+```
 
 However, you are free to combine several methods for great freedom of how and where to define the font.
 
@@ -67,29 +73,33 @@ However, you are free to combine several methods for great freedom of how and wh
 
 You can use `@font-face` to reference remote (and not so remote) fonts:
 
-    <font id="Super_Sans">
-      <!-- and so on -->
-    </font>
+```html
+<font id="Super_Sans">
+  <!-- and so on -->
+</font>
 
-    <style type="text/css">
-    @font-face {
-      font-family: "Super Sans";
-      src: url(#Super_Sans);
-    }
-    </style>
+<style type="text/css">
+@font-face {
+  font-family: "Super Sans";
+  src: url(#Super_Sans);
+}
+</style>
 
-    <text font-family="Super Sans">My text uses Super Sans</text>
+<text font-family="Super Sans">My text uses Super Sans</text>
+```
 
 ### Option: reference a remote font
 
 The above mentioned `font-face-uri` element allows you to reference an external font, hence allowing greater re-usability:
 
-    <font>
-      <font-face font-family="Super Sans">
-        <font-face-src>
-          <font-face-uri xlink:href="fonts.svg#Super_Sans" />
-        </font-face-src>
-      </font-face>
-    </font>
+```html
+<font>
+  <font-face font-family="Super Sans">
+    <font-face-src>
+      <font-face-uri xlink:href="fonts.svg#Super_Sans" />
+    </font-face-src>
+  </font-face>
+</font>
+```
 
 {{ PreviousNext("Web/SVG/Tutorial/Filter_effects", "Web/SVG/Tutorial/SVG_Image_Tag") }}

--- a/files/en-us/web/webdriver/commands/getelementproperty/index.md
+++ b/files/en-us/web/webdriver/commands/getelementproperty/index.md
@@ -38,25 +38,29 @@ The _Get Element Property_ [command](/en-US/docs/Web/WebDriver/Commands) of the 
 
 Python:
 
-    import urllib
+```python
+import urllib
 
-    from selenium import webdriver
+from selenium import webdriver
 
-    def inline(doc):
-        return "data:text/html;charset=utf-8,{}".format(urllib.quote(doc))
+def inline(doc):
+    return "data:text/html;charset=utf-8,{}".format(urllib.quote(doc))
 
-    session = webdriver.Firefox()
-    session.get(inline("<input value=foo>"))
-    textbox = driver.find_element_by_tag_name("input")
-    textbox.send_keys("bar")
+session = webdriver.Firefox()
+session.get(inline("<input value=foo>"))
+textbox = driver.find_element_by_tag_name("input")
+textbox.send_keys("bar")
 
-    print(text_box.get_attribute("value"))
-    print(text_box.get_property("value"))
+print(text_box.get_attribute("value"))
+print(text_box.get_property("value"))
+```
 
 Output:
 
-    foo
-    bar
+```
+foo
+bar
+```
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/errors/insecurecertificate/index.md
+++ b/files/en-us/web/webdriver/errors/insecurecertificate/index.md
@@ -17,18 +17,22 @@ WebDriver does offer an [`acceptInsecureCerts` capability](/en-US/docs/Web/WebDr
 
 This is what will happen when navigating to a domain that has a self-signed TLS certificate using the Python client:
 
-    from selenium import webdriver
-    from selenium.common import exceptions
+```python
+from selenium import webdriver
+from selenium.common import exceptions
 
-    session = webdriver.Firefox()
-    try:
-        session.get("https://self-signed.badssl.com/")
-    except exceptions.InsecureCertificateException as e:
-        print("Hit insecure cert on {}".format(session.current_url)
+session = webdriver.Firefox()
+try:
+    session.get("https://self-signed.badssl.com/")
+except exceptions.InsecureCertificateException as e:
+    print("Hit insecure cert on {}".format(session.current_url)
+```
 
 Output:
 
-    Hit an insecure cert on https://self-signed.badssl.com/
+```
+Hit an insecure cert on https://self-signed.badssl.com/
+```
 
 ## See also
 

--- a/files/en-us/web/webdriver/errors/unknownmethod/index.md
+++ b/files/en-us/web/webdriver/errors/unknownmethod/index.md
@@ -15,18 +15,24 @@ WebDriver provides a largely REST-ish API and not all endpoints in this API has 
 
 The New Session command provides a `POST` request endpoint which lets you create new WebDriver sessions:
 
-    % curl -d '{}' http://localhost:4444/session
-    {"sessionId":"d4605710-5a4e-4d64-a52a-778bb0c31e00","value":{"XULappId":"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}","acceptSslCerts":false,"appBuildId":"20160913030425","browserName":"firefox","browserVersion":"51.0a1","command_id":1,"platform":"LINUX","platformName":"linux","platformVersion":"4.9.0-1-amd64","processId":17474,"proxy":{},"raisesAccessibilityExceptions":false,"rotatable":false,"specificationLevel":0,"takesElementScreenshot":true,"takesScreenshot":true,"version":"51.0a1"}}
+```bash
+% curl -d '{}' http://localhost:4444/session
+{"sessionId":"d4605710-5a4e-4d64-a52a-778bb0c31e00","value":{"XULappId":"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}","acceptSslCerts":false,"appBuildId":"20160913030425","browserName":"firefox","browserVersion":"51.0a1","command_id":1,"platform":"LINUX","platformName":"linux","platformVersion":"4.9.0-1-amd64","processId":17474,"proxy":{},"raisesAccessibilityExceptions":false,"rotatable":false,"specificationLevel":0,"takesElementScreenshot":true,"takesScreenshot":true,"version":"51.0a1"}}
+```
 
 It also implements the `DELETE` method for ending a session:
 
-    % curl -X DELETE http://localhost:4444/session/d4605710-5a4e-4d64-a52a-778bb0c31e00
-    {}
+```bash
+% curl -X DELETE http://localhost:4444/session/d4605710-5a4e-4d64-a52a-778bb0c31e00
+{}
+```
 
 But it does not, for example, provide a `GET` method, and this will consequently return an unknown method error:
 
-    % curl http://localhost:4444/session/650f9df3-740e-314c-958d-307e41752fae
-    {"value":{"error":"unknown command","message":"GET /session/650f9df3-740e-314c-958d-307e41752fae did not match a known command","stacktrace":""}}%
+```bash
+% curl http://localhost:4444/session/650f9df3-740e-314c-958d-307e41752fae
+{"value":{"error":"unknown command","message":"GET /session/650f9df3-740e-314c-958d-307e41752fae did not match a known command","stacktrace":""}}%
+```
 
 ## See also
 

--- a/files/en-us/web/webdriver/index.md
+++ b/files/en-us/web/webdriver/index.md
@@ -22,29 +22,33 @@ So what does WebDriver let you do and what does it look like? Since WebDriver is
 
 But using a popular client written in Python, your interaction with WebDriver might look like this:
 
-    from selenium import webdriver
-    from selenium.webdriver.common.by import By
-    from selenium.webdriver.common.keys import Keys
-    from selenium.webdriver.support.ui import WebDriverWait
-    from selenium.webdriver.support.expected_conditions import presence_of_element_located
+```python
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support.expected_conditions import presence_of_element_located
 
 
 
-    with webdriver.Firefox() as driver:
+with webdriver.Firefox() as driver:
 
-        wait = WebDriverWait(driver, 10)
-        driver.get("http://google.com/ncr")
-        driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN)
+    wait = WebDriverWait(driver, 10)
+    driver.get("http://google.com/ncr")
+    driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN)
 
-        wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>a")))
+    wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>a")))
 
-        results = driver.find_elements_by_css_selector("h3>a")
-        for i, result in results.iteritems():
-            print(f"#{i}: {result.text} ({result.get_property('href')})")
+    results = driver.find_elements_by_css_selector("h3>a")
+    for i, result in results.iteritems():
+        print(f"#{i}: {result.text} ({result.get_property('href')})")
+```
 
 This might produce output akin to this:
 
-    #1 Cheese - Wikipedia (https://en.wikipedia.org/wiki/Cheese)
+```
+#1 Cheese - Wikipedia (https://en.wikipedia.org/wiki/Cheese)
+```
 
 ## Reference
 


### PR DESCRIPTION
This pass cleans up the remaining ones flagged running with
```
  "MD046": {
    "style": "fenced"
  }
```