### PR TITLE
Improved code style on JSON.stringify() reference

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -75,7 +75,7 @@ A JSON string representing the given value, or undefined.
   valid JSON values. If any such values are encountered during conversion they are
   either omitted (when found in an object) or changed to {{JSxRef("null")}} (when found
   in an array). `JSON.stringify()` can return `undefined` when
-  passing in "pure" values like `JSON.stringify(function(){})` or
+  passing in "pure" values like `JSON.stringify(function() {})` or
   `JSON.stringify(undefined)`.
 - All {{JSxRef("Symbol")}}-keyed properties will be completely ignored, even when
   using the `replacer` function.
@@ -100,7 +100,7 @@ JSON.stringify([1, 'false', false]);   // '[1,"false",false]'
 JSON.stringify([NaN, null, Infinity]); // '[null,null,null]'
 JSON.stringify({ x: 5 });              // '{"x":5}'
 
-JSON.stringify(new Date(2006, 0, 2, 15, 4, 5))
+JSON.stringify(new Date(2006, 0, 2, 15, 4, 5));
 // '"2006-01-02T15:04:05.000Z"'
 
 JSON.stringify({ x: 5, y: 6 });
@@ -114,7 +114,7 @@ a['baz'] = 'quux';      // a: [ 0: 'foo', 1: 'bar', baz: 'quux' ]
 JSON.stringify(a);
 // '["foo","bar"]'
 
-JSON.stringify({ x: [10, undefined, function(){}, Symbol('')] });
+JSON.stringify({ x: [10, undefined, function() {}, Symbol('')] });
 // '{"x":[10,null,null,null]}'
 
 // Standard data structures


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Improved code style on JavaScript `JSON.stringify()` reference by adding a missing semicolon and adding spaces in empty anonymous functions.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I use the MDN web docs all the time. When I noticed these errors, I wanted to fix them and improve the docs for everyone.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
