### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
@@ -21,7 +21,7 @@ method.
 ## Syntax
 
 ```js
-void ext.multiDrawArraysWEBGL(mode,
+void ext.multiDrawArraysInstancedWEBGL(mode,
     firstsList, firstsOffset,
     countsList, countsOffset,
     instanceCountsList, instanceCountsOffset,


### PR DESCRIPTION
#### Summary
Fixes a typo.

#### Motivation

I found a typo in an obscure webgl extension I was reading about, might be because the code was copy pasted from the multiDrawArraysWEBGL page, a very similar function.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error