### PR TITLE
Fix typo in lab() page

### DIFF
--- a/files/en-us/web/css/color_value/lab()/index.md
+++ b/files/en-us/web/css/color_value/lab()/index.md
@@ -35,7 +35,7 @@ lab(52.2345% 40.1645 59.9971 / .5);
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
-## Specificatiions
+## Specifications
 
 {{Specifications}}
 


### PR DESCRIPTION
Fix a typo in the `lab()` page.