### PR TITLE
Fixes #12406: restores text from a deleted file

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -41,7 +41,12 @@ rtpTransceiver = RTCPeerConnection.addTransceiver(trackOrKind, init);
   - : An object that conforms to the {{domxref("RTCRtpTransceiverInit")}} dictionary which
     provides any options that you may wish to specify when creating the new transceiver.
     Possible values are:
-    {{page("/en-US/docs/Web/API/RTCRtpTransceiverInit", "Properties")}}
+    - `direction` {{optional_inline}}
+      - : The new transceiver's preferred directionality. This value is used to initialize the new {{domxref("RTCRtpTransceiver")}} object's {{domxref("RTCRtpTransceiver.direction")}} property.
+    - `sendEncodings` {{optional_inline}}
+      - : A list of encodings to allow when sending RTP media from the {{domxref("RTCRtpSender")}}. Each entry is of type {{domxref("RTCRtpEncodingParameters")}}.
+    - `streams` {{optional_inline}}
+      - : A list of {{domxref("MediaStream")}} objects to add to the transceiver's{{domxref("RTCRtpReceiver")}}; when the remote peer's {{domxref("RTCPeerConnection")}}'s {{event("track")}} event occurs, these are the streams that will be specified by that event.
 
 ### Exceptions
 

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -46,7 +46,7 @@ rtpTransceiver = RTCPeerConnection.addTransceiver(trackOrKind, init);
     - `sendEncodings` {{optional_inline}}
       - : A list of encodings to allow when sending RTP media from the {{domxref("RTCRtpSender")}}. Each entry is of type {{domxref("RTCRtpEncodingParameters")}}.
     - `streams` {{optional_inline}}
-      - : A list of {{domxref("MediaStream")}} objects to add to the transceiver's{{domxref("RTCRtpReceiver")}}; when the remote peer's {{domxref("RTCPeerConnection")}}'s {{event("track")}} event occurs, these are the streams that will be specified by that event.
+      - : A list of {{domxref("MediaStream")}} objects to add to the transceiver's {{domxref("RTCRtpReceiver")}}; when the remote peer's {{domxref("RTCPeerConnection")}}'s {{event("track")}} event occurs, these are the streams that will be specified by that event.
 
 ### Exceptions
 


### PR DESCRIPTION
#### Summary
The page macro fetched text from a deleted page. Restored text from there. See #9773

#### Motivation
quick

#### Supporting details
Thanks @joeycarr for reporting.

#### Related issues
Fixes #12406

#### Metadata
- [x] Fixes a typo, bug, or other error
