### PR TITLE
Add reportValidity page for HTMLInputElement

### DIFF
--- a/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
@@ -1,0 +1,41 @@
+---
+title: HTMLInputElement.reportValidity()
+slug: Web/API/HTMLInputElement/reportValidity
+tags:
+  - API
+  - HTML DOM
+  - HTMLInputElement
+  - Method
+  - NeedsExample
+  - Reference
+  - reportValidity
+  - reportValidity()
+browser-compat: api.HTMLInputElement.reportValidity
+---
+{{APIRef("HTML DOM")}}
+
+The **`HTMLInputElement.reportValidity()`** method performs the same validity checking steps as the {{domxref("HTMLInputElement/checkValidity", "checkValidity()")}} method. If the value is invalid, this method also fires the {{domxref("HTMLInputElement/invalid_event", "invalid")}} event on the element, and (if the event isn't canceled) reports the problem to the user.
+
+## Syntax
+
+```js
+element.reportValidity();
+```
+
+### Return value
+
+Returns `true` if the element's value has no validity problems; otherwise, returns `false`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Learn: Client-side form validation](/en-US/docs/Learn/Forms/Form_validation)
+- [Guide: Constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation)
+- [Constraint validation API](/en-US/docs/Web/API/Constraint_validation)

--- a/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLInputElement.reportValidity
 ---
 {{APIRef("HTML DOM")}}
 
-The **`HTMLInputElement.reportValidity()`** method performs the same validity checking steps as the {{domxref("HTMLInputElement/checkValidity", "checkValidity()")}} method. If the value is invalid, this method also fires the {{domxref("HTMLInputElement/invalid_event", "invalid")}} event on the element, and (if the event isn't canceled) reports the problem to the user.
+The **`reportValidity()`** method of the {{domxref('HTMLInputElement')}} interface performs the same validity checking steps as the {{domxref("HTMLInputElement.checkValidity", "checkValidity()")}} method. If the value is invalid, this method also fires the {{domxref("HTMLInputElement.invalid_event", "invalid")}} event on the element, and (if the event isn't canceled) reports the problem to the user.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR introduces a page describing the `reportValidity` method of `HTMLInputElement`.
I will also create an issue with `w3c/browser-specs` to make sure the specification is included .

#### Motivation
This page is missing. It is the last method of all the `HTMLInputElement` methods to not have its own page.

#### Supporting details
- https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity-dev
- https://html.spec.whatwg.org/multipage/input.html#htmlinputelement

#### Related issues
Fixes #12422

#### Metadata
This PR…

- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
