### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -396,7 +396,7 @@ When no pages are using the current version, the new worker activates and become
 
 ### Deleting old caches
 
-You also get an `activate` event. This is a generally used to do stuff that would have broken the previous version while it was still running, for example getting rid of old caches. This is also useful for removing data that is no longer needed to avoid filling up too much disk space — each browser has a hard limit on the amount of cache storage that a given service worker can use. The browser does its best to manage disk space, but it may delete the Cache storage for an origin.  The browser will generally delete all of the data for an origin or none of the data for an origin.
+You also get an `activate` event. This is generally used to do stuff that would have broken the previous version while it was still running, for example getting rid of old caches. This is also useful for removing data that is no longer needed to avoid filling up too much disk space — each browser has a hard limit on the amount of cache storage that a given service worker can use. The browser does its best to manage disk space, but it may delete the Cache storage for an origin.  The browser will generally delete all of the data for an origin or none of the data for an origin.
 
 Promises passed into `waitUntil()` will block other events until completion, so you can rest assured that your clean-up operation will have completed by the time you get your first `fetch` event on the new service worker.
 


### PR DESCRIPTION
#### Summary
Fixing a tiny typo on the using a service workers index.md document.

#### Motivation
To improve documents, even with fixing a tiny typo.

#### Supporting details

#### Related issues

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

