### PR TITLE
Fix the Math.pow() summary

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
@@ -11,7 +11,6 @@ browser-compat: javascript.builtins.Math.pow
 {{JSRef}}
 
 The **`Math.pow()`** function, given two arguments, _base_ and _exponent_, returns `base`<sup>`exponent`</sup>.
-`base` to the `exponent` power, as in
 
 {{EmbedInteractiveExample("pages/js/math-pow.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
@@ -10,9 +10,8 @@ browser-compat: javascript.builtins.Math.pow
 ---
 {{JSRef}}
 
-The **`Math.pow()`** function returns the
+The **`Math.pow()`** function, given two arguments, _base_ and _exponent_, returns `base`<sup>`exponent`</sup>.
 `base` to the `exponent` power, as in
-`base^exponent` (in math notation, not in JavaScript).
 
 {{EmbedInteractiveExample("pages/js/math-pow.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.pow
 
 The **`Math.pow()`** function returns the
 `base` to the `exponent` power, as in
-`base^exponent`.
+`base^exponent` (in math notation, not in JavaScript).
 
 {{EmbedInteractiveExample("pages/js/math-pow.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Math.pow
 ---
 {{JSRef}}
 
-The **`Math.pow()`** function, given two arguments, _base_ and _exponent_, returns `base`<sup>`exponent`</sup>.
+The **`Math.pow()`** static method, given two arguments, _base_ and _exponent_, returns `base`<sup>`exponent`</sup>.
 
 {{EmbedInteractiveExample("pages/js/math-pow.html")}}
 


### PR DESCRIPTION
Just to be specific here because someone not related with math notation can understand that you can do, for example, 2^0 in JS natively. And this work with unexpected result, because a caret  operator is the bitwise XOR operator.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I understand this not in a good wait in a first time. I think is just a little change that can save time to others. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
