### PR TITLE
Fix a comment of counter-reset property

### DIFF
--- a/files/en-us/web/css/counter-reset/index.md
+++ b/files/en-us/web/css/counter-reset/index.md
@@ -104,8 +104,8 @@ h1 {
 h1 {
   counter-reset: reversed(chapter) reversed(section) 1 page;
   /* Sets the reversed flag on the chapter and section counters.
-     Sets the chapter and page counters to 0,
-     and the section counter to 1 */
+     Sets the chapter to the number of elements, the section counter to 1,
+     and the page counters to 0*/
 }
 ```
 

--- a/files/en-us/web/css/counter-set/index.md
+++ b/files/en-us/web/css/counter-set/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.counter-set
 ---
 {{CSSRef}}
 
-The **`counter-set`** [CSS](/en-US/docs/Web/CSS) property sets a [CSS counter](/en-US/docs/Web/Guide/CSS/Counters) to a given value. It manipulates the value of existing counters, and will only create new counters if there isn't already a counter of the given name on the element.
+The **`counter-set`** [CSS](/en-US/docs/Web/CSS) property sets a [CSS counter](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) to a given value. It manipulates the value of existing counters, and will only create new counters if there isn't already a counter of the given name on the element.
 
 > **Note:** The counter's value can be incremented or decremented using the {{cssxref("counter-increment")}} CSS property.
 
@@ -81,9 +81,9 @@ h1 {
 
 ## See also
 
-- [Using CSS Counters](/en-US/docs/Web/CSS/Counters)
+- [Using CSS Counters](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters)
 - {{cssxref("counter-increment")}}
 - {{cssxref("counter-reset")}}
 - {{cssxref("@counter-style")}}
-- {{cssxref("counter")}} and {{cssxref("counters")}} functions
+- {{cssxref("counter()")}} and {{cssxref("counters()")}} functions
 - {{cssxref("content")}} property

--- a/files/en-us/web/css/counter-set/index.md
+++ b/files/en-us/web/css/counter-set/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.counter-set
 ---
 {{CSSRef}}
 
-The **`counter-set`** [CSS](/en-US/docs/Web/CSS) property sets a [CSS counter](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) to a given value. It manipulates the value of existing counters, and will only create new counters if there isn't already a counter of the given name on the element.
+The **`counter-set`** [CSS](/en-US/docs/Web/CSS) property sets a [CSS counter](/en-US/docs/Web/Guide/CSS/Counters) to a given value. It manipulates the value of existing counters, and will only create new counters if there isn't already a counter of the given name on the element.
 
 > **Note:** The counter's value can be incremented or decremented using the {{cssxref("counter-increment")}} CSS property.
 
@@ -81,9 +81,9 @@ h1 {
 
 ## See also
 
-- [Using CSS Counters](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters)
+- [Using CSS Counters](/en-US/docs/Web/CSS/Counters)
 - {{cssxref("counter-increment")}}
 - {{cssxref("counter-reset")}}
 - {{cssxref("@counter-style")}}
-- {{cssxref("counter()")}} and {{cssxref("counters()")}} functions
+- {{cssxref("counter")}} and {{cssxref("counters")}} functions
 - {{cssxref("content")}} property


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix a comment of counter-reset property

#### Motivation
In the example, the reversed counter 'chapter' should be reset to the number of elements, rather than zero.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
