### PR TITLE
Minor orthographic correction in Image functions

### DIFF
--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -188,11 +188,11 @@ These functions may be used wherever an {{cssxref("&lt;image&gt;")}} is valid as
   - : Linear gradients transition colors progressively along an imaginary line.
 - {{cssxref("gradient/radial-gradient()","radial-gradient()")}}
   - : Radial gradients transition colors progressively from a center point (origin).
-- {{cssxref("gradient/repeating-linear-gradient()","repeating-linear-gradiant()")}}
+- {{cssxref("gradient/repeating-linear-gradient()","repeating-linear-gradient()")}}
   - : Is similar to `linear-gradient()` and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container.
 - {{cssxref("gradient/repeating-radial-gradient()","repeating-radial-gradient()")}}
   - : Is similar to `radial-gradient()` and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container.
-- {{cssxref("gradient/repeating-conic-gradient()","repeat-conic-gradiant()")}}
+- {{cssxref("gradient/repeating-conic-gradient()","repeating-conic-gradient()")}}
   - : Is similar to `conic-gradient()` and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container.
 - {{cssxref("cross-fade()")}}
   - : Can be used to blend two or more images at a defined transparency.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I corrected a minor orthographic error in the Image functions section with the names of the repeating-linear-gradient and repeating-conic-gradient functions.

#### Motivation
While searching information about all CSS functions these typos caused me confusion, until I realized these weren't the correct names. Fixing this will avoid the confusion for future readers.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
