### PR TITLE
Update index.md where a sentence is misleading

### DIFF
--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -412,7 +412,7 @@ So there you have it — a rather clever JavaScript-free way to create a togglin
 
 ## Summary
 
-So that rounds off our look at positioning — by now, you should have an idea of how the basic mechanics work, as well as understanding how to start applying these to build some interesting UI features. Don't worry if you didn't get this all immediately — positioning is a fairly advanced topic, and you can always work through the articles again to aid your understanding. The next subject we'll turn to is Flexbox.
+So that rounds off our look at positioning — by now, you should have an idea of how the basic mechanics work, as well as understanding how to start applying these to build some interesting UI features. Don't worry if you didn't get this all immediately — positioning is a fairly advanced topic, and you can always work through the articles again to aid your understanding.
 
 ## In this module
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The sentence "The next subject we'll turn to is Flexbox." removed, because actually this article is just a "see also" article of the [CSS layout module](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout) and there is no subject after it.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It's misleading - maybe this article was at one time before the flexbox article?

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
