### PR TITLE
Use w3c link to Web Share Target API

### DIFF
--- a/files/en-us/web/api/web_share_api/index.md
+++ b/files/en-us/web/api/web_share_api/index.md
@@ -18,7 +18,7 @@ The **Web Share API** provides a mechanism for sharing text, links, files, and o
 
 > **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
-> **Note:** This API should not be confused with the [Web Share Target API](/en-US/docs/Web/API/Web_Share_Target_API), which allows a website to specify itself as a share target.
+> **Note:** This API should not be confused with the [Web Share Target API](https://w3c.github.io/web-share-target/), which allows a website to specify itself as a share target.
 
 ## Concepts and usage
 


### PR DESCRIPTION

#### Summary

The link was a 404. 

Until there is an MDN page on it, we can refer to the standard draft document (external URL), instead.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Want fewer dead links.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
