### PR TITLE
NSS releases are documented elsewhere now

### DIFF
--- a/files/en-us/mozilla/projects/nss/nss_releases/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_releases/index.html
@@ -10,13 +10,13 @@ tags:
   - Release Notes
   - Security
 ---
-<p>The current <strong>Stable</strong> release of NSS is 3.66, which was released on <strong>27 May 2021</strong>. (<a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.66_release_notes">NSS 3.66 release notes</a>)</p>
 
-<p>The current <strong>ESR</strong> releases of NSS are 3.44.4 (<a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.44.4_release_notes">NSS 3.44.4 release notes</a>), intended for Firefox ESR 68, which was released on <strong>19 May 2020</strong>, and  3.53.1 <a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.53.1_release_notes">(NSS 3.53.1 release notes)</a>, intended for Firefox ESR 78, which was released on <strong>16 June 2020</strong>.</p>
+<p>New NSS releases are documented on https://firefox-source-docs.mozilla.org/security/nss/releases/index.html</p>
 
 <h2 id="Past_releases">Past releases</h2>
 
 <ul>
+ <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.66_release_notes">NSS 3.66 release notes</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.65_release_notes">NSS 3.65 release notes</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.64_release_notes">NSS 3.64 release notes</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.63.1_release_notes">NSS 3.63.1 release notes</a></li>

--- a/files/en-us/mozilla/projects/nss/nss_releases/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_releases/index.html
@@ -11,7 +11,7 @@ tags:
   - Security
 ---
 
-<p>New NSS releases are documented on https://firefox-source-docs.mozilla.org/security/nss/releases/index.html</p>
+<p>New NSS releases are documented on <a href="https://firefox-source-docs.mozilla.org/security/nss/releases/index.html">Firefox source docs</a></p>
 
 <h2 id="Past_releases">Past releases</h2>
 


### PR DESCRIPTION
The maintenance of the list of releases has moved to firefox source docs
