### PR TITLE
Link to reportValidity page

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -439,7 +439,7 @@ email.addEventListener("input", function (event) {
 
 Here we store a reference to the email input, then add an event listener to it that runs the contained code each time the value inside the input is changed.
 
-Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message which is displayed by calling {{domxref("HTMLInputElement#methods","reportValidity()")}}. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
+Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message which is displayed by calling {{domxref("HTMLInputElement.reportValidity","reportValidity()")}}. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
 
 If the `validity.typeMismatch` property returns `false`, we call the `setCustomValidity()` method an empty string. This renders the input valid, so the form will submit.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR adds a link to the newly created page for `reportValidity` to the "Client-side form validation" guide found at the link below.

- https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#implementing_a_customized_error_message

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Previously, the link pointed to a table of `HTMLInputElement` methods because the page for the specific method didn't exist. Since the specific page now exists, the link can point directly to it and save people an extra click.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The new link:
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/reportValidity

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
