### PR TITLE
Update “let” doc where statements about TDZ are misleading

### DIFF
--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -206,7 +206,7 @@ declaration, the variable is initialized with a value of
 
 > **Note:** This differs from {{jsxref("Statements/var", "var", "var_hoisting")}} variables,
 > which will return a value of `undefined` even if they are accessed before they
-> are declared. That means you can read/write `var` even before they are declared but not `let`.
+> are declared.
 
 The variable is said to be in a "temporal dead zone" (TDZ) from the start of the block
 until the declaration has completed.

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -205,7 +205,7 @@ declaration, the variable is initialized with a value of
 {{jsxref("ReferenceError")}}.
 
 > **Note:** This differs from {{jsxref("Statements/var", "var", "var_hoisting")}} variables,
-> which will return a value of `undefined` even if they are accessed before they
+> which will return a value of `undefined` if they are accessed before they
 > are declared.
 
 The variable is said to be in a "temporal dead zone" (TDZ) from the start of the block

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -198,18 +198,18 @@ switch(x) {
 
 ### Temporal dead zone (TDZ)
 
-`let` variables cannot be read/written until they have been fully
-initialized, which happens when they are declared (if no initial value is specified on
+`let` variables cannot be read/written until they have been
+declared. If no initial value is specified on
 declaration, the variable is initialized with a value of
-`undefined`). Accessing the variable before the initialization results in a
+`undefined`. Accessing the variable before the declaration results in a
 {{jsxref("ReferenceError")}}.
 
 > **Note:** This differs from {{jsxref("Statements/var", "var", "var_hoisting")}} variables,
-> which will return a value of `undefined` if they are accessed before they
-> are declared.
+> which will return a value of `undefined` even if they are accessed before they
+> are declared. That means you can read/write `var` even before they are declared but not `let`.
 
 The variable is said to be in a "temporal dead zone" (TDZ) from the start of the block
-until the initialization has completed.
+until the declaration has completed.
 
 ```js example-bad
 { // TDZ starts at beginning of scope


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Improved TDZ concept of "let". 
1) It said "let variables cannot be read/written until they have been fully initialized" which is wrong. "let" can be read/written even before initialization if it is declared in the code.
2) "let" variable is in the TDZ from the start of the block until the declaration. After declaration, we can read/write it.

#### Motivation
MDN is my favorite website for references and guides. I noticed this mistake and want to help improve it so that other developers don't get confused and learn the right concepts from the right place :)


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
