### PR TITLE
Fix links for the `readystatechange` event

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -69,7 +69,7 @@ Each line is terminated by both carriage return and line feed characters
 
 ## Example
 
-This example examines the headers in the request's {{event("readystatechange")}} event
+This example examines the headers in the request's {{domxref("XMLHttpRequest/readystatechange_event", "readystatechange")}} event
 handler, {{domxref("XMLHttpRequest.onreadystatechange")}}. The code shows how to obtain
 the raw header string, as well as how to convert it into an array of individual headers
 and then how to take that array and create a mapping of header names to their values.

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
@@ -53,7 +53,7 @@ response.
 
 ## Example
 
-In this example, a request is created and sent, and a {{Event("readystatechange")}}
+In this example, a request is created and sent, and a {{domxref("XMLHttpRequest/readystatechange_event", "readystatechange")}}
 handler is established to look for the {{DOMxRef("XMLHttpRequest.readyState",
   "readyState")}} to indicate that the headers have been received; when that is the case,
 the value of the {{httpheader("Content-Type")}} header is fetched. If the

--- a/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.md
+++ b/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.md
@@ -16,7 +16,7 @@ browser-compat: api.XMLHttpRequest.onreadystatechange
 An [event handler](/en-US/docs/Web/Events/Event_handlers) that is called whenever the `readyState`
 attribute changes. The callback is called from the user interface thread. The
 **`XMLHttpRequest.onreadystatechange`** property contains the
-event handler to be called when the {{domxref("Document/readystatechange_event",
+event handler to be called when the {{domxref("XMLHttpRequest/readystatechange_event",
   "readystatechange")}} event is fired, that is every time the
 {{domxref("XMLHttpRequest.readyState", "readyState")}} property of the
 {{domxref("XMLHttpRequest")}} changes.

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -49,7 +49,7 @@ response so far while the request is still in the `LOADING`
 
 This example presents a function, `load()`, which loads and processes a page
 from the server. It works by creating an {{domxref("XMLHttpRequest")}} object and
-creating a listener for {{event("readystatechange")}} events such that when
+creating a listener for {{domxref("XMLHttpRequest/readystatechange_event", "readystatechange")}} events such that when
 `readyState` changes to `DONE` (4), the `response` is
 obtained and passed into the callback function provided to `load()`.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
These articles have links to `readystatechange` event, but they link to the event of Document interface. It should link to the event of XMLHttpRequest (but the page isn't created yet).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
