### PR TITLE
Fix method descriptions in <input> element article

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -889,9 +889,9 @@ The following non-standard attributes are also available on some browsers. As a 
 The following methods are provided by the {{domxref("HTMLInputElement")}} interface which represents `<input>` elements in the DOM. Also available are those methods specified by the parent interfaces, {{domxref("HTMLElement")}}, {{domxref("Element")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}.
 
 - {{domxref("HTMLInputElement.checkValidity", "checkValidity()")}}
-  - : Returns `true` if the element's value passes validity checks; otherwise, returns `false`.
+  - : Returns `true` if the element's value passes validity checks; otherwise, returns `false` and fires an {{domxref("HTMLInputElement.invalid_event", "invalid")}} event at the element.
 - {{domxref("HTMLFormElement.reportValidity", "reportValidity()")}}
-  - : Immediately runs the validity check on the element, triggering the document to fire the {{domxref("HTMLInputElement.invalid_event", "invalid")}} event at the element if the value isn't valid.
+  - : Returns `true` if the element's value passes validity checks; otherwise, returns `false`, fires an {{domxref("HTMLInputElement.invalid_event", "invalid")}} event at the element, and (if the event isn't canceled) reports the problem to the user.
 - {{domxref("HTMLInputElement.select", "select()")}}
   - : Selects the entire content of the `<input>` element, if the element's content is selectable. For elements with no selectable text content (such as a visual color picker or calendar date input), this method does nothing.
 - {{domxref("HTMLInputElement.setCustomValidity", "setCustomValidity()")}}

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -889,9 +889,9 @@ The following non-standard attributes are also available on some browsers. As a 
 The following methods are provided by the {{domxref("HTMLInputElement")}} interface which represents `<input>` elements in the DOM. Also available are those methods specified by the parent interfaces, {{domxref("HTMLElement")}}, {{domxref("Element")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}.
 
 - {{domxref("HTMLInputElement.checkValidity", "checkValidity()")}}
-  - : Immediately runs the validity check on the element, triggering the document to fire the {{domxref("HTMLInputElement.invalid_event", "invalid")}} event at the element if the value isn't valid.
-- {{domxref("HTMLFormElement.reportValidity", "reportValidity()")}}
   - : Returns `true` if the element's value passes validity checks; otherwise, returns `false`.
+- {{domxref("HTMLFormElement.reportValidity", "reportValidity()")}}
+  - : Immediately runs the validity check on the element, triggering the document to fire the {{domxref("HTMLInputElement.invalid_event", "invalid")}} event at the element if the value isn't valid.
 - {{domxref("HTMLInputElement.select", "select()")}}
   - : Selects the entire content of the `<input>` element, if the element's content is selectable. For elements with no selectable text content (such as a visual color picker or calendar date input), this method does nothing.
 - {{domxref("HTMLInputElement.setCustomValidity", "setCustomValidity()")}}


### PR DESCRIPTION
#### Summary
Somehow the short descriptions of those two methods got reversed on this summary page. Changed to make the detail pages and the observed behavior of the methods.

#### Motivation
Correction

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

