### PR TITLE
Fix windows open-web-console keyboard shortcut in “Web Console” doc

### DIFF
--- a/files/en-us/tools/web_console/index.html
+++ b/files/en-us/tools/web_console/index.html
@@ -54,7 +54,7 @@ tags:
 
 <ul>
  <li>Choose <strong>Web Console</strong> from the <strong>Web Developer</strong> submenu in the <strong>Firefox Menu</strong> (or <strong>Tools</strong> menu if you display the menu bar or are on Mac OS X)</li>
- <li>Press the <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> (<kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>K</kbd> on OS X) keyboard shortcut.</li>
+ <li>Press the <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> (<kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>K</kbd> on OS X) keyboard shortcut.</li>
 </ul>
 
 <p>The <a href="/en-US/docs/Tools/Tools_Toolbox">Toolbox</a> appear at the bottom, left, or right of the browser window (depending on your docking settings), with the Web Console activated (it's just called <strong>Console</strong> in the <a href="/en-US/docs/Tools/Tools_Toolbox#toolbar">DevTools toolbar</a>).</p>


### PR DESCRIPTION
Correcting the keyboard shortcut to open the web console on windows.


