### PR TITLE
Correct broken link anchor to drag effects

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -243,7 +243,7 @@ function dragstart_handler(ev) {
 
 For more details, see:
 
-- [Drag Effects](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#drageffects "Drag Effects")
+- [Drag Effects](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#drag_effects "Drag Effects")
 
 ### Define a _drop zone_
 


### PR DESCRIPTION
The link to the "Drag Effects" section of the "Drag Operations" page is missing an underscore.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The anchor inside the link to Drag Operations' Drag Effects section is not valid.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Correcting the link will help readers more quickly navigate to the information they want to see and will prevent them from being confused when they don't see what they were expecting to see when they clicked on the link.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
