### PR TITLE
Remove experimental tag from AnimationEvent docs

### DIFF
--- a/files/en-us/web/api/animationevent/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/animationevent/index.md
@@ -6,12 +6,11 @@ tags:
   - AnimationEvent
   - CSSOM
   - Constructor
-  - Experimental
   - Reference
   - Web Animations
 browser-compat: api.AnimationEvent.AnimationEvent
 ---
-{{APIRef("Web Animations")}}{{SeeCompatTable}}
+{{APIRef("Web Animations API")}}
 
 The **`AnimationEvent()`** constructor returns a newly created
 {{domxref("AnimationEvent")}}, representing an event in relation with an animation.

--- a/files/en-us/web/api/animationevent/animationname/index.md
+++ b/files/en-us/web/api/animationevent/animationname/index.md
@@ -5,13 +5,12 @@ tags:
   - API
   - AnimationEvent
   - CSSOM
-  - Experimental
   - Property
   - Reference
   - Web Animations
 browser-compat: api.AnimationEvent.animationName
 ---
-{{SeeCompatTable}}{{ apiref("Web Animations API") }}
+{{APIRef("Web Animations API")}}
 
 The **`AnimationEvent.animationName`** read-only property is a
 {{domxref("DOMString")}} containing the value of the {{cssxref("animation-name")}} CSS

--- a/files/en-us/web/api/animationevent/elapsedtime/index.md
+++ b/files/en-us/web/api/animationevent/elapsedtime/index.md
@@ -5,13 +5,12 @@ tags:
   - API
   - AnimationEvent
   - CSSOM
-  - Experimental
   - Property
   - Reference
   - Web Animations
 browser-compat: api.AnimationEvent.elapsedTime
 ---
-{{SeeCompatTable}}{{ apiref("Web Animations API") }}
+{{APIRef("Web Animations API")}}
 
 The **`AnimationEvent.elapsedTime`** read-only property is a
 `float` giving the amount of time the animation has been running, in seconds,

--- a/files/en-us/web/api/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/index.md
@@ -3,13 +3,12 @@ title: AnimationEvent
 slug: Web/API/AnimationEvent
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - Web Animations
 browser-compat: api.AnimationEvent
 ---
-{{SeeCompatTable}}{{APIRef("Web Animations API")}}
+{{APIRef("Web Animations API")}}
 
 The **`AnimationEvent`** interface represents events providing information related to [animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations).
 

--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -6,13 +6,12 @@ tags:
   - AnimationEvent
   - CSS
   - CSSOM
-  - Experimental
   - Property
   - Reference
   - Web Animations
 browser-compat: api.AnimationEvent.pseudoElement
 ---
-{{SeeCompatTable}}{{ apiref("Web Animations API") }}
+{{APIRef("Web Animations API")}}
 
 ## Summary
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove `Experimental` tags and `{{SeeCompatTable}}` macro from `AnimationEvent` docs.

#### Motivation
They aren't considered experimental now by compat data.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
