### PR TITLE
Correct broken link anchor to drop targets

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -69,7 +69,7 @@ Each [drag event type](/en-US/docs/Web/API/DragEvent#event_types) has an associa
       <td>
         …a dragged item enters a valid drop target. (See
         <a
-          href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#droptargets"
+          href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#specifying_drop_targets"
           title="Specifying Drop Targets"
           >Specifying Drop Targets</a
         >.)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The anchor inside the link to Drag Operations' Specifying Drop Targets section is not valid.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Correcting the link will help readers more quickly navigate to the information they want to see and will prevent them from being confused when they don't see what they were expecting to see when they clicked on the link.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
