### PR TITLE
clarify links are to descriptors, not properties

### DIFF
--- a/files/en-us/web/css/@font-face/size-adjust/index.md
+++ b/files/en-us/web/css/@font-face/size-adjust/index.md
@@ -66,13 +66,14 @@ The `size-adjust` property can help when overriding the metrics of a fallback fo
 
 ## See also
 
-- {{cssxref("@font-face/font-display", "font-display")}}
-- {{cssxref("@font-face/font-family", "font-family")}}
-- {{cssxref("@font-face/font-weight", "font-weight")}}
-- {{cssxref("@font-face/font-style", "font-style")}}
-- {{cssxref("@font-face/font-stretch", "font-stretch")}}
-- {{cssxref("@font-face/font-variant", "font-variant")}}
-- {{cssxref("font-feature-settings", "font-feature-settings")}}
-- {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}
-- {{cssxref("@font-face/src", "src")}}
-- {{cssxref("@font-face/unicode-range", "unicode-range descriptor")}}
+- {{cssxref("@font-face/font-display", "font-display")}} descriptor
+- {{cssxref("@font-face/font-family", "font-family")}} descriptor
+- {{cssxref("@font-face/font-weight", "font-weight")}} descriptor
+- {{cssxref("@font-face/font-style", "font-style")}} descriptor
+- {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor
+- {{cssxref("@font-face/font-variant", "font-variant")}} descriptor
+- {{cssxref("font-feature-settings", "font-feature-settings")}} descriptor
+- {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor
+- {{cssxref("@font-face/src", "src")}} descriptor
+- {{cssxref("@font-face/unicode-range", "unicode-range descriptor")}} descriptor
+- {{cssxref('font-size-adjust')}} property

--- a/files/en-us/web/css/@font-face/size-adjust/index.md
+++ b/files/en-us/web/css/@font-face/size-adjust/index.md
@@ -72,8 +72,8 @@ The `size-adjust` property can help when overriding the metrics of a fallback fo
 - {{cssxref("@font-face/font-style", "font-style")}} descriptor
 - {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor
 - {{cssxref("@font-face/font-variant", "font-variant")}} descriptor
-- {{cssxref("font-feature-settings", "font-feature-settings")}} descriptor
+- {{cssxref("font-feature-settings", "font-feature-settings")}}
 - {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor
 - {{cssxref("@font-face/src", "src")}} descriptor
-- {{cssxref("@font-face/unicode-range", "unicode-range descriptor")}} descriptor
+- {{cssxref("@font-face/unicode-range", "unicode-range")}} descriptor
 - {{cssxref('font-size-adjust')}} property


### PR DESCRIPTION
Many descriptors have associated properties. The "see also" links are to descriptors, not to properties. Removed possible confusion.
Also added link to `font-size-adjust` property which is the property equivalent to this descriptor.
