### PR TITLE
Fix the polyfill of Math.fround.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
@@ -109,21 +109,42 @@ Math.fround = Math.fround || (function (array) {
 Supporting older browsers is slower, but also possible:
 
 ```js
-if (!Math.fround) Math.fround = function(arg) {
-  arg = Number(arg);
-  // Return early for ±0 and NaN.
-  if (!arg) return arg;
-  var sign = arg < 0 ? -1 : 1;
-  if (sign < 0) arg = -arg;
-  // Compute the exponent (8 bits, signed).
-  var exp = Math.floor(Math.log(arg) / Math.LN2);
-  var powexp = Math.pow(2, Math.max(-126, Math.min(exp, 127)));
-  // Handle subnormals: leading digit is zero if exponent bits are all zero.
-  var leading = exp < -127 ? 0 : 1;
-  // Compute 23 bits of mantissa, inverted to round toward zero.
-  var mantissa = Math.round((leading - arg / powexp) * 0x800000);
-  if (mantissa <= -0x800000) return sign * Infinity;
-  return sign * powexp * (leading - mantissa / 0x800000);
+if (!Math.fround) Math.fround = function(v) {
+  v = Number(v);
+  if (!v)
+    return v;
+  var isNegative = v < 0;
+  var av = isNegative ? -v : v;
+  var absResult;
+  if (av >= 3.4028235677973366e38) { // also handles the case av === Infinity
+    absResult = Infinity;
+  } else if (av >= 1.1754943508222875e-38) { // threshold for normal representations
+    var e = Math.floor(Math.log(av) / 0.6931471805599453); // Math.LN2
+    var twoPowE = Math.pow(2, e);
+    var significand = av / twoPowE;
+    /* Because of loss of precision in its computation (Math.log is not
+     * guaranteed to return the best approximation), e might be 1 up or down,
+     * which causes twoPowE and significand to be a factor 2 up or down.
+     * We now adjust that so that significand is really in the range [1.0, 2.0).
+     */
+    if (significand < 1) {
+      twoPowE = twoPowE / 2;
+      significand = significand * 2;
+    } else if (significand >= 2) {
+      twoPowE = twoPowE * 2;
+      significand = significand / 2;
+    };
+    // Round the significand to 23 bits of fractional part, and multiply back by twoPowE
+    // Break ties to even
+    // The constant is (min positive double value) / (1.0 / 2**23)
+    absResult = ((significand * 4.144523e-317) / 4.144523e-317) * twoPowE;
+  } else {
+    // Round the value to a multiple of the smallest Float ULP
+    // Break ties to even
+    // The constant is (min positive double value) / (min positive float value)
+    absResult = (av * 3.5257702653609953e-279) / 3.5257702653609953e-279;
+  };
+  return isNegative ? -absResult : absResult;
 };
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
@@ -93,61 +93,6 @@ Math.fround('abc'); // NaN
 Math.fround(NaN); // NaN
 ```
 
-## Polyfill
-
-This can be emulated with the following function, if {{jsxref("Float32Array")}} are
-supported:
-
-```js
-Math.fround = Math.fround || (function (array) {
-  return function(x) {
-    return array[0] = x, array[0];
-  };
-})(new Float32Array(1));
-```
-
-Supporting older browsers is slower, but also possible:
-
-```js
-if (!Math.fround) Math.fround = function(v) {
-  v = Number(v);
-  if (!v)
-    return v;
-  var isNegative = v < 0;
-  var av = isNegative ? -v : v;
-  var absResult;
-  if (av >= 3.4028235677973366e38) { // also handles the case av === Infinity
-    absResult = Infinity;
-  } else if (av >= 1.1754943508222875e-38) { // threshold for normal representations
-    var e = Math.floor(Math.log(av) / 0.6931471805599453); // Math.LN2
-    var twoPowE = Math.pow(2, e);
-    var significand = av / twoPowE;
-    /* Because of loss of precision in its computation (Math.log is not
-     * guaranteed to return the best approximation), e might be 1 up or down,
-     * which causes twoPowE and significand to be a factor 2 up or down.
-     * We now adjust that so that significand is really in the range [1.0, 2.0).
-     */
-    if (significand < 1) {
-      twoPowE = twoPowE / 2;
-      significand = significand * 2;
-    } else if (significand >= 2) {
-      twoPowE = twoPowE * 2;
-      significand = significand / 2;
-    };
-    // Round the significand to 23 bits of fractional part, and multiply back by twoPowE
-    // Break ties to even
-    // The constant is (min positive double value) / (1.0 / 2**23)
-    absResult = ((significand * 4.144523e-317) / 4.144523e-317) * twoPowE;
-  } else {
-    // Round the value to a multiple of the smallest Float ULP
-    // Break ties to even
-    // The constant is (min positive double value) / (min positive float value)
-    absResult = (av * 3.5257702653609953e-279) / 3.5257702653609953e-279;
-  };
-  return isNegative ? -absResult : absResult;
-};
-```
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
#### Summary

Fix the polyfill of `Math.fround` that does not rely on `Float32Array`.

#### Motivation

As shown here:
https://gist.github.com/shicks/7a97ec6b3f10212e60a89a7f6d2d097d?permalink_comment_id=4048135#gistcomment-4048135
the old polyfill was incorrect, because it was breaking ties *upwards* when rounding. The spec of `fround` requires to break ties to *even* instead.

The new polyfill correctly breaks ties to even, even at the critical points of transitioning from subnormal to normal forms, and from finite to infinity.

To perform ties-to-even, the code relies on the natural rounding that will happen when getting into the subnormal forms of (64-bit) `number`s.

In addition, the new polyfill does not assume that `Math.log` will always return the best approximation. The spec of `Math.log` explicitly says that it may not return the best approximation.

#### Supporting details

* The gist with the old polyfill, with the test cases that break, and the new implementation: https://gist.github.com/shicks/7a97ec6b3f10212e60a89a7f6d2d097d?permalink_comment_id=4048135#gistcomment-4048135
* The new polyfill is the one used by Scala.js. In the Scala.js codebase, it is written as a JS AST [here](https://github.com/scala-js/scala-js/blob/5e5880af2f61751a3f02584dc42fffd57e521e0e/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala#L200-L302). Its tests are [here](https://github.com/scala-js/scala-js/blob/5e5880af2f61751a3f02584dc42fffd57e521e0e/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala#L61-L204)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
