### PR TITLE
Add empty line before inheritance diagram

### DIFF
--- a/files/en-us/web/api/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/index.md
@@ -15,7 +15,9 @@ browser-compat: api.DocumentFragment
 
 The **`DocumentFragment`** interface represents a minimal document object that has no parent.
 
-It is used as a lightweight version of {{domxref("Document")}} that stores a segment of a document structure comprised of nodes just like a standard document. The key difference is due to the fact that the document fragment isn't part of the active document tree structure. Changes made to the fragment don't affect the document (even on {{Glossary("reflow")}}) or incur any performance impact when changes are made.{{InheritanceDiagram}}
+It is used as a lightweight version of {{domxref("Document")}} that stores a segment of a document structure comprised of nodes just like a standard document. The key difference is due to the fact that the document fragment isn't part of the active document tree structure. Changes made to the fragment don't affect the document (even on {{Glossary("reflow")}}) or incur any performance impact when changes are made.
+
+{{InheritanceDiagram}}
 
 ## Constructor
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added an empty line before the inheritance diagram.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
In other documents, there is always an empty line between the text and the `{{InheritanceDiagram}}` macro.

In this document, the inheritance diagram is part of a paragraph. Because of this, the diagram is rendered in a smaller size than it should (https://developer.mozilla.org/en-US/docs/Web/API/documentfragment):

<img width="616" alt="Screenshot 2022-01-31 175731" src="https://user-images.githubusercontent.com/23465488/151816476-67823556-068c-41a0-911f-33a12be2ec63.png">

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
