### PR TITLE
For clarity, make variable name in example match doc’d param name

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -518,9 +518,9 @@ const triple = x => 3 * x
 const quadruple = x => 4 * x
 
 // Function composition enabling pipe functionality
-const pipe = (...functions) => input => functions.reduce(
+const pipe = (...functions) => initialValue => functions.reduce(
     (acc, fn) => fn(acc),
-    input
+    initialValue
 )
 
 // Composed functions for multiplication of specific values


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12549