### PR TITLE
CSS counter() - remove note about type-or-unit

### DIFF
--- a/files/en-us/web/css/counter()/index.md
+++ b/files/en-us/web/css/counter()/index.md
@@ -11,7 +11,8 @@ browser-compat: css.types.counter
 ---
 {{CSSRef}}
 
-The **`counter()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a string representing the current value of the named counter, if there is one. It is generally used with [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements), but can be used, theoretically, anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
+The **`counter()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a string representing the current value of the named counter, if there is one.
+It is generally used in the {{CSSxRef("content")}} property of [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements), but can theoretically be used anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
 
 ```css
 /* Simple usage */
@@ -21,11 +22,9 @@ counter(countername);
 counter(countername, upper-roman)
 ```
 
-A [counter](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) has no visible effect by itself. The `counter()` function (and {{cssxref("counters()")}} function) is what makes it useful by returning developer defined strings (or images).
+A [counter](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) has no visible effect by itself.
+The `counter()` function (and {{cssxref("counters()")}} function) is what makes it useful by returning developer defined strings (or images).
 
-> **Note:** The `counter()` function can be used with any CSS property, but support for properties other than {{CSSxRef("content")}} is experimental, and support for the type-or-unit parameter is sparse.
->
-> Check the [Browser compatibility table](#browser_compatibility) carefully before using this in production.
 
 ## Syntax
 

--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -20,6 +20,13 @@ You can define your own named counters, and you can also manipulate the `list-it
 
 ## Using counters
 
+To use a counter it must first be initialized to a value with the {{cssxref("counter-reset")}} property.
+The counter's value can then be increased or decreased using {{cssxref("counter-increment")}} property.
+The current value of a counter is displayed using the {{cssxref("counter()")}} or {{cssxref("counters()")}} function, typically within a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) {{CSSxRef("content")}} property.
+
+Note that counters can only be set, reset, or incremented in elements that generate boxes.
+For example, if an element is set to `display: none` then any counter operation on that element will be ignored.
+
 ### Manipulating a counter's value
 
 To use a CSS counter, it must first be initialized to a value with the {{cssxref("counter-reset")}} property.


### PR DESCRIPTION
This originates from the discussion here: https://github.com/mdn/content/discussions/11959

In [`counter()`]( https://developer.mozilla.org/en-US/docs/Web/CSS/counter()) this note appears to be a copy paste error
![image](https://user-images.githubusercontent.com/5368500/151899038-328b1341-6fa0-47e1-83c2-fb8c210de9d7.png)

More precisely, the `type-or-unit` does not exist on this method in the spec and there is no compatibility information to show. You should be able to use this wherever a string is used, but you are expected to use this, as shown, in the `content` property. I have removed the note and added text to this effect.