### PR TITLE
Add info about SVGPoint replacements

### DIFF
--- a/files/en-us/web/api/svgpoint/index.md
+++ b/files/en-us/web/api/svgpoint/index.md
@@ -6,9 +6,13 @@ tags:
   - DOM
   - NeedsContent
   - SVG
+  - deprecated
 browser-compat: api.SVGPoint
 ---
 {{APIRef("SVG")}}{{Deprecated_header}}
+
+> **Warning:** `SVGPoint` is deprecated. 
+> Use {{domxref("DOMPoint")}} or {{domxref("DOMPointReadOnly")}} instead.
 
 An `SVGPoint` represents a 2D or 3D point in the SVG coordinate system.
 


### PR DESCRIPTION
[SVGPoint](https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint) is deprecated, but the replacement is not documented. According to BCD this appears to be equivalent DOM point as per https://github.com/mdn/browser-compat-data/pull/10538

It is useful to list alternatives, if they exist and are known.

Fixes #12570

