### PR TITLE
don't use url() in image-set()

### DIFF
--- a/files/en-us/web/css/image/image-set()/index.md
+++ b/files/en-us/web/css/image/image-set()/index.md
@@ -31,7 +31,7 @@ where <image-set-option> = [ <image> | <string> ] <resolution> and
 - `<image>`
   - : The [`<image>`](/en-US/docs/Web/CSS/image) can be any image type except for an image set. The `image-set()` function may not be nested inside another `image-set()` function.
 - `<string>`
-  - : A `url()` to an image.
+  - : An url to an image.
 - `<resolution>`{{optional_inline}}
   - : [`<resolution>`](/en-US/docs/Web/CSS/resolution) units include `x` or `dppx`, for dots per pixel unit, `dpi`, for dots per inch, and `dpcm` for dots per centimeter. Every image within an `image-set()` must have a unique resolution.
 - `type(<string>)`{{optional_inline}}
@@ -61,8 +61,8 @@ There is no inbuilt fallback for `image-set()`; therefore to include a {{cssxref
 .box {
   background-image: url("large-balloons.jpg");
   background-image: image-set(
-    url("large-balloons.avif") type("image/avif"),
-    url("large-balloons.jpg") type("image/jpeg"));
+    "large-balloons.avif" type("image/avif"),
+    "large-balloons.jpg" type("image/jpeg"));
 }
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
You should use strings instead of url() to avoid downloading all the images in the set.

#### Motivation
Performance issue.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
