### PR TITLE
fix(docs): typo in syntax of `color-mix()`

### DIFF
--- a/files/en-us/web/css/color_value/color-mix()/index.md
+++ b/files/en-us/web/css/color_value/color-mix()/index.md
@@ -27,7 +27,7 @@ color-mix(in srgb, #34c9eb 20%, white);
 
   - : `<colorspace>` is one of `srgb`, `hsl`, `hwb`, `xyz`, `lab`, `lch`. If no colorspace is specified the default is `lch`.
 
-    `[ <color>` is any valid {{cssxref("color_value","color")}}.
+    `<color>` is any valid {{cssxref("color_value","color")}}.
 
     `<percentage>` is the percentage of that color to mix.
 


### PR DESCRIPTION
#### Summary

Fixes a typo found in the syntax of css function `color-mix()`.

#### Motivation

#### Supporting details
 - doc of `color-mix()`: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix()#syntax
 - MDS's CSS value definition syntax: https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax#brackets
 - The to-be-removed `[ ` was added by #3300, and converted from html to md by https://github.com/mdn/content/commit/26f50bdaeb1228f458d21dbdf7dc110387b20daa.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
