### PR TITLE
Make clear: Weak etags must not be used in If-Range HTTP header

### DIFF
--- a/files/en-us/web/http/headers/if-range/index.md
+++ b/files/en-us/web/http/headers/if-range/index.md
@@ -48,9 +48,7 @@ If-Range: <etag>
 
 - \<etag>
   - : An entity tag uniquely representing the requested resource. It is a string of ASCII
-    characters placed between double quotes (Like `"675af34563dc-tr34"`). It
-    may be prefixed by `W/` to indicate that the weak comparison algorithm
-    should be used.
+    characters placed between double quotes (Like `"675af34563dc-tr34"`). A weak entity tag (one prefixed by `W/`) must not be used in this header.
 - \<day-name>
   - : One of "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", or "Sun" (case-sensitive).
 - \<day>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12622