### PR TITLE
Fix typo in CSP connect-src doc

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -26,7 +26,7 @@ loaded using script interfaces. The APIs that are restricted are:
 - {{domxref("Navigator.sendBeacon()")}}.
 
 > **Note:** `connect-src 'self'` does not resolve to websocket
-> schemas in all browsers, more info in this [issue](https://github.com/w3c/webappsec-csp/issues/7).
+> schemes in all browsers, more info in this [issue](https://github.com/w3c/webappsec-csp/issues/7).
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix possible typo when referring to websocket schemes. I believe it should read as websocket schemes as in http/https/wss not schemas

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
