### PR TITLE
Fix issue 11328: digest algorithm parameter may be an object

### DIFF
--- a/files/en-us/web/api/subtlecrypto/digest/index.md
+++ b/files/en-us/web/api/subtlecrypto/digest/index.md
@@ -29,21 +29,21 @@ const digest = crypto.subtle.digest(algorithm, data);
 
 ### Parameters
 
-- `algorithm` is a {{domxref("DOMString")}} defining the hash
-  function to use. Supported values are:
+- `algorithm`
+  - : This may be a string or an object with a single property `name` that is a string. The string names the hash function to use. Supported values are:
 
-  - `SHA-1` (but don't use this in cryptographic applications)
-  - `SHA-256`
-  - `SHA-384`
-  - `SHA-512`.
+    - `"SHA-1"` (but don't use this in cryptographic applications)
+    - `"SHA-256"`
+    - `"SHA-384"`
+    - `"SHA-512"`.
 
-- `data` is an {{jsxref("ArrayBuffer")}} or
-  {{domxref("ArrayBufferView")}} containing the data to be digested.
+- `data`
+  - : An {{jsxref("ArrayBuffer")}} or {{domxref("ArrayBufferView")}} containing the data to be digested.
 
 ### Return value
 
-- `digest` is a {{jsxref("Promise")}} that fulfills with an
-  {{jsxref("ArrayBuffer")}} containing the digest.
+- `digest`
+  - : {{jsxref("Promise")}} that fulfills with an {{jsxref("ArrayBuffer")}} containing the digest.
 
 ## Supported algorithms
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11328 : the `algorithm` parameter to [`digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) may be an object.
