### PR TITLE
Fix automatic semicolon insertion info in “Lexical grammar” doc

### DIFF
--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -483,7 +483,6 @@ tag `string text ${expression} string text`
 
 Some [JavaScript statements](/en-US/docs/Web/JavaScript/Reference/Statements) must be terminated with semicolons and are therefore affected by automatic semicolon insertion (ASI):
 
-- Empty statement
 - `let`, `const`, variable statement
 - `import`, `export`, module declaration
 - Expression statement


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In the [specification referenced](https://tc39.es/ecma262/#sec-rules-of-automatic-semicolon-insertion),  it says
> However, there is an additional overriding condition on the preceding rules: a semicolon is never inserted automatically if the semicolon would then be parsed as an empty statement [...].

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
