### PR TITLE
Fix 12658: Only link to assessment at the end of the module

### DIFF
--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -787,12 +787,6 @@ window.addEventListener("load", drawOutput);
 
 {{ EmbedLiveSample('Active_learning_Playing_with_styling_text', 700, 800) }}
 
-## Test your skills!
-
-You've reached the end of this article, but can you remember the most important information going forward? You can find an assessment to verify that you've retained this information at the end of the module — see [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage).
-
-This assessment tests all the knowledge discussed in this module, so you might want to read the other articles before moving on to it.
-
 ## Summary
 
 We hoped you enjoyed playing with text in this article! The next article will provide you with all you need to know about styling HTML lists.
@@ -801,7 +795,7 @@ We hoped you enjoyed playing with text in this article! The next article will pr
 
 ## In this module
 
-- [Fundamental text and font styling](/en-US/docs/Learn/CSS/Styling_text/Fundamentals)
+- **Fundamental text and font styling**
 - [Styling lists](/en-US/docs/Learn/CSS/Styling_text/Styling_lists)
 - [Styling links](/en-US/docs/Learn/CSS/Styling_text/Styling_links)
 - [Web fonts](/en-US/docs/Learn/CSS/Styling_text/Web_fonts)

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -454,12 +454,6 @@ Let's explain what's going on here, focusing on the most interesting parts:
 
 > **Note:** You may have noticed that the list items in the HTML are all put on the same line as each other. This is done because spaces/line breaks in between inline block elements create spaces on the page, just like the spaces in between words; however, such spaces would break our horizontal navigation menu layout. So we've removed them. You can find more information about this problem (and solutions) at [Fighting the space between inline block elements](https://css-tricks.com/fighting-the-space-between-inline-block-elements/).
 
-## Test your skills!
-
-You've reached the end of this article, and already did some skill testing in our Active Learning sections, but can you remember the most important information going forward? You can find an assessment to verify that you've retained this information at the end of the module — see [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage).
-
-This assessment tests all the knowledge discussed in this module, so you might want to read the next article before moving on to it.
-
 ## Summary
 
 We hope this article has provided you with all you'll need to know about links — for now! The final article in our Styling text module details how to use custom fonts on your websites (or web fonts, as they are better known).

--- a/files/en-us/learn/css/styling_text/styling_lists/index.md
+++ b/files/en-us/learn/css/styling_text/styling_lists/index.md
@@ -385,12 +385,6 @@ CSS counters provide advanced tools for customizing list counting and styling, b
 - {{cssxref("counter-increment")}}
 - {{cssxref("counter-reset")}}
 
-## Test your skills!
-
-You've reached the end of this article, but can you remember the most important information going forward? You can find an assessment to verify that you've retained this information at the end of the module — see [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage).
-
-This assessment tests all the knowledge discussed in this module, so you might want to read the other articles before moving on to it.
-
 ## Summary
 
 Lists are relatively easy to get the hang of styling once you know a few associated basic principles and specific properties. In the next article we'll move on to link styling techniques.
@@ -400,7 +394,7 @@ Lists are relatively easy to get the hang of styling once you know a few associa
 ## In this module
 
 - [Fundamental text and font styling](/en-US/docs/Learn/CSS/Styling_text/Fundamentals)
-- [Styling lists](/en-US/docs/Learn/CSS/Styling_text/Styling_lists)
+- **Styling lists**
 - [Styling links](/en-US/docs/Learn/CSS/Styling_text/Styling_links)
 - [Web fonts](/en-US/docs/Learn/CSS/Styling_text/Web_fonts)
 - [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage)

--- a/files/en-us/learn/css/styling_text/typesetting_a_homepage/index.md
+++ b/files/en-us/learn/css/styling_text/typesetting_a_homepage/index.md
@@ -111,4 +111,4 @@ If you would like your work assessed, or are stuck and want to ask for help:
 - [Styling lists](/en-US/docs/Learn/CSS/Styling_text/Styling_lists)
 - [Styling links](/en-US/docs/Learn/CSS/Styling_text/Styling_links)
 - [Web fonts](/en-US/docs/Learn/CSS/Styling_text/Web_fonts)
-- [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage)
+- **Typesetting a community school homepage**

--- a/files/en-us/learn/css/styling_text/web_fonts/index.md
+++ b/files/en-us/learn/css/styling_text/web_fonts/index.md
@@ -213,7 +213,7 @@ There is a newer font technology available in browsers called variable fonts. Th
 
 ## Test your skills!
 
-You've reached the end of this article, and already did some skill testing in our Active Learning sections, but can you remember the most important information going forward? You can find an assessment to verify that you've retained this information at the end of the module — see [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage).
+You've reached the end of this module, and already did some skill testing in our Active Learning sections, but can you remember the most important information going forward? You can find an assessment to verify that you've retained this information at the end of the module — see [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage).
 
 ## Summary
 
@@ -226,5 +226,5 @@ Now that you have worked through our articles on text styling fundamentals, it's
 - [Fundamental text and font styling](/en-US/docs/Learn/CSS/Styling_text/Fundamentals)
 - [Styling lists](/en-US/docs/Learn/CSS/Styling_text/Styling_lists)
 - [Styling links](/en-US/docs/Learn/CSS/Styling_text/Styling_links)
-- [Web fonts](/en-US/docs/Learn/CSS/Styling_text/Web_fonts)
+- **Web fonts**
 - [Typesetting a community school homepage](/en-US/docs/Learn/CSS/Styling_text/Typesetting_a_homepage)


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12658.

We shouldn't expect people to complete assessments on material we haven't taught yet.