### PR TITLE
Fix the 'behavior' values description in Window.scroll() doc

### DIFF
--- a/files/en-us/web/api/window/scroll/index.md
+++ b/files/en-us/web/api/window/scroll/index.md
@@ -37,7 +37,7 @@ window.scroll(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Specifies whether the scrolling should animate smoothly (`smooth`), or happen instantly in a single jump (`auto`, the default value).
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12666

Per https://drafts.csswg.org/cssom-view/#changes-from-2013-12-17:

> The `instant` value of scroll-behavior was renamed to `auto`.

Per https://drafts.csswg.org/css-overflow/#propdef-scroll-behavior:

> Value: `auto` | `smooth`

UA requirements: https://drafts.csswg.org/cssom-view/#scrolling