### PR TITLE
Minor update: remove support note

### DIFF
--- a/files/en-us/web/css/font-stretch/index.md
+++ b/files/en-us/web/css/font-stretch/index.md
@@ -147,8 +147,6 @@ The table below demonstrates the effect of supplying various different percentag
 
 ### Setting font stretch percentages
 
-> **Note:** This example will only work in browsers that support `<percentage>` values.
-
 {{EmbedGHLiveSample("css-examples/variable-fonts/font-stretch.html", '100%', 950)}}
 
 ## Specifications


### PR DESCRIPTION
Removed note about only working in supportive browsers b/c the only browser that doesn't support the feature is IE.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error