### PR TITLE
Ensure the innerHeight & innerWidth live samples work

### DIFF
--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -104,7 +104,9 @@ window.addEventListener("resize", resizeListener);
 
 ### Result
 
-Open the {{LiveSampleLink('Demo', 'Demo Link')}} in a new browser window and resize it to see the result.
+{{EmbedLiveSample('Demo')}}
+
+You can also {{LiveSampleLink('Demo', 'view the results of the demo code in a separate page')}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -88,7 +88,9 @@ window.addEventListener("resize", resizeListener);
 
 ### Result
 
-Open the {{LiveSampleLink('Demo', 'Demo Link')}} in a new browser window and resize it to see the result.
+{{EmbedLiveSample('Demo')}}
+
+You can also {{LiveSampleLink('Demo', 'view the results of the demo code in a separate page')}}.
 
 ## Specifications
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/pull/12664 (488e1ee). @himanshugarg

Only after I merged https://github.com/mdn/content/pull/12664 did I remember that `LiveSampleLink` doesn’t work unless you also include `EmbedLiveSample`.