### PR TITLE
Webdriver conformance changes in Firefox 97

### DIFF
--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -76,8 +76,7 @@ This article provides information about the changes in Firefox 97 that will affe
 ### WebDriver conformance (Marionette)
 
 - `Marionette:Quit` accepts a new boolean parameter, `safeMode`, to restart Firefox in safe mode ({{bug(1144075)}}).
-
-#### Removals
+- Improved stability for `WebDriver:NewSession` and `WebDriver:NewWindow` when waiting for the current or initial document to be loaded ({{bug(1739369)}}, {{bug(1747359)}}).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Here are all the changes for Firefox 97 of the [Marionette component](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&v1=fixed&component=Marionette&v2=verified&product=Testing&f1=cf_status_firefox97&list_id=15981962).

Given that Nicolas already added one of these items to the notes only one more is needed.

CC @juliandescottes 