### PR TITLE
Move inheritance diagram to intro

### DIFF
--- a/files/en-us/web/api/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/index.md
@@ -17,6 +17,8 @@ An `AnalyserNode` has exactly one input and one output. The node works even if t
 
 ![Without modifying the audio stream, the node allows to get the frequency and time-domain data associated to it, using a FFT.](fttaudiodata_en.svg)
 
+{{InheritanceDiagram}}
+
 <table class="properties">
   <tbody>
     <tr>
@@ -41,12 +43,6 @@ An `AnalyserNode` has exactly one input and one output. The node works even if t
     </tr>
   </tbody>
 </table>
-
-## Inheritance
-
-This interface inherits from the following parent interfaces:
-
-{{InheritanceDiagram}}
 
 ## Constructor
 

--- a/files/en-us/web/api/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/index.md
@@ -18,6 +18,8 @@ The **`PeriodicSyncEvent`** interface of the {{domxref('Web Periodic Background 
 
 An instance of this event is passed to the {{domxref('ServiceWorkerGlobalScope.onperiodicsync')}} handler. This happens periodically, at an interval greater than or equal to that set in the {{domxref('PeriodicSyncManager.register()')}} method. Other implementation-specific factors such as the user's engagement with the site decide the actual interval.
 
+{{InheritanceDiagram}}
+
 ## Constructor
 
 - {{domxref("PeriodicSyncEvent.PeriodicSyncEvent()")}}
@@ -31,8 +33,6 @@ An instance of this event is passed to the {{domxref('ServiceWorkerGlobalScope.o
 ## Methods
 
 Inherits methods from its parent {{domxref('ExtendableEvent')}}.
-
-{{InheritanceDiagram}}
 
 ## Examples
 

--- a/files/en-us/web/api/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/index.md
@@ -13,10 +13,6 @@ browser-compat: api.WebGLContextEvent
 
 The **WebContextEvent** interface is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and is an interface for an event that is generated in response to a status change to the WebGL rendering context.
 
-## Inheritance
-
-_This interface inherits properties and methods from its parent interface, {{domxref("Event")}}._
-
 {{InheritanceDiagram}}
 
 ## Properties


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Moved some inheritance diagrams to the section before the first second level heading.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
These are the only md files where the inheritance diagram is placed in a separate section. Other documents contain their inheritance diagrams inside the intro.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
