### PR TITLE
A small lexical change

### DIFF
--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
@@ -16,7 +16,7 @@ operator that returns its right-hand side operand when its left-hand side operan
 {{jsxref("null")}} or {{jsxref("undefined")}}, and otherwise returns its left-hand side
 operand.
 
-This can be contrasted with the [logical OR
+This can be seen as a special case of the [logical OR
 (`||`) operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR), which returns the right-hand side operand if the left
 operand is _any_ {{Glossary("falsy")}} value, not only `null` or `undefined`. In other words,
 if you use `||` to provide some default value to another variable


### PR DESCRIPTION
Saying "A can be contrasted to B" may unconsciously suggest a great difference or even opposition between the two.
Saying "A is a special case of B" entails that B is a generalisation of A, suggests that the two are quite similar and invites to spot that key difference that turns an A into a B.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The proposed wording is unambiguous and more descriptive, making the content of the page more digestible.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To make the subject easier to understand.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The lexical field of the word "contrast" may cause resistance to the assimilation of the subject.
[Googling "contrast"](https://www.google.com/search?q=contrast) we get: differ strikingly. "his friend's success contrasted with his own failure"

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
