### PR TITLE
Ff96 Revert SameSite changes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1748,6 +1748,135 @@ The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP respo
   </tbody>
 </table>
 
+
+### HTTP Set-Cookie: `SameSite=Lax` by default
+
+HTTP cookies (set using [Set-Cookie](/en-US/docs/Web/HTTP/Headers/Set-Cookie) are assumed to implicitly set `SameSite=Lax` if the [SameSite](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) directive is not specified. Previously the default was `SameSite=None`.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+        <code>network.cookie.sameSite.laxByDefault</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### HTTP Set-Cookie: `SameSite=None` require a secure context
+
+HTTP cookies (set using [Set-Cookie](/en-US/docs/Web/HTTP/Headers/Set-Cookie)) that specify the directive [`SameSite=None`](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) require a secure context.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+        <code>network.cookie.sameSite.noneRequiresSecure</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
+### HTTP Set-Cookie: SameSite is schemeful
+
+HTTP cookies sent from the same domain but using different schemes (for example http or https) are now considered to be from different sites with respect to the cookie [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) directive.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>69</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+        <code>network.cookie.sameSite.schemeful</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 ## Developer tools
 
 Mozilla's developer tools are constantly evolving. We experiment with new ideas, add new features, and test them on the Nightly and Developer Edition channels before letting them go through to beta and release. The features below are the current crop of experimental developer tool features.

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -33,11 +33,6 @@ No notable changes
 
 No notable changes.
 
-### HTTP
-
-- Cookies sent from the same domain but using different schemes (for example http or https) are now considered to be from different sites with respect to the cookie [SameSite](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) directive.
-  In addition, cookies are assumed to implicitly set `SameSite=Lax` if the `SameSite` attribute is not specified (previously the default was `SameSite=None`), and cookies with `SameSite=None` require a secure context. ({{bug(1617609)}}).
-
 ### APIs
 
 - {{domxref("navigator.canShare()")}} is now supported on Android, allowing code to check whether {{domxref("navigator.share()")}} will succeed for particular targets.


### PR DESCRIPTION
This reverts the relevant FF96 samesite changes from #10857 that were backed out by https://bugzilla.mozilla.org/show_bug.cgi?id=1750264#c9

It removes the info from release note and adds info into experimental features. Docs themselves were updated in a way such that they are independent of FF implementation of this feature, so do not need update.

Other related docs changes can be tracked in #12224