### PR TITLE
Expand link text for core.js polyfills

### DIFF
--- a/files/en-us/web/api/nodelist/entries/index.md
+++ b/files/en-us/web/api/nodelist/entries/index.md
@@ -59,6 +59,6 @@ Array [ 2, <span> ]
 
 ## See also
 
-- A polyfill of `NodeList.prototype.entries` is available in [`core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
+- [Polyfill of `NodeList.prototype.entries` in `core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
 - {{domxref("Node")}}
 - {{domxref("NodeList")}}

--- a/files/en-us/web/api/nodelist/foreach/index.md
+++ b/files/en-us/web/api/nodelist/foreach/index.md
@@ -115,6 +115,6 @@ The above behavior is how many browsers actually implement
 
 ## See also
 
-- A polyfill of `NodeList.prototype.forEach` is available in [`core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
+- [Polyfill of `NodeList.prototype.forEach` in `core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
 - {{domxref("Node")}}
 - {{domxref("NodeList")}}

--- a/files/en-us/web/api/nodelist/keys/index.md
+++ b/files/en-us/web/api/nodelist/keys/index.md
@@ -61,6 +61,6 @@ The result is:
 
 ## See also
 
-- A polyfill of `NodeList.prototype.keys` is available in [`core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
+- [Polyfill of `NodeList.prototype.keys` in `core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
 - {{domxref("Node")}}
 - {{domxref("NodeList")}}

--- a/files/en-us/web/api/nodelist/values/index.md
+++ b/files/en-us/web/api/nodelist/values/index.md
@@ -61,6 +61,6 @@ The result is:
 
 ## See also
 
-- A polyfill of `NodeList.prototype.values` is available in [`core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
+- [Polyfill of `NodeList.prototype.values` in `core-js`](https://github.com/zloirock/core-js#iterable-dom-collections)
 - {{domxref("Node")}}
 - {{domxref("NodeList")}}

--- a/files/en-us/web/api/queuemicrotask/index.md
+++ b/files/en-us/web/api/queuemicrotask/index.md
@@ -116,7 +116,7 @@ if (typeof self.queueMicrotask !== "function") {
 
 ## See also
 
-- A polyfill of `queueMicrotask` is available in [`core-js`](https://github.com/zloirock/core-js#queuemicrotask)
+- [Polyfill of `queueMicrotask` in `core-js`](https://github.com/zloirock/core-js#queuemicrotask)
 - [Using microtasks in
   JavaScript with queueMicrotask()](/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide)
 - [Asynchronous JavaScript](/en-US/docs/Learn/JavaScript/Asynchronous)

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -378,7 +378,7 @@ interval has completed before recursing.
 
 ## See also
 
-- A polyfill of `setInterval` which allows passing arguments to the callback is available in [`core-js`](https://github.com/zloirock/core-js#settimeout-and-setinterval)
+- [Polyfill of `setInterval` which allows passing arguments to the callback in `core-js`](https://github.com/zloirock/core-js#settimeout-and-setinterval)
 - {{domxref("setTimeout")}}
 - {{domxref("clearTimeout")}}
 - {{domxref("clearInterval")}}

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -389,7 +389,7 @@ example](/en-US/docs/Web/API/clearTimeout#example).
 
 ## See also
 
-- A polyfill of `setTimeout` which allows passing arguments to the callback is available in [`core-js`](https://github.com/zloirock/core-js#settimeout-and-setinterval)
+- [Polyfill of `setTimeout` which allows passing arguments to the callback in `core-js`](https://github.com/zloirock/core-js#settimeout-and-setinterval)
 - {{domxref("clearTimeout")}}
 - {{domxref("setInterval()")}}
 - {{domxref("window.requestAnimationFrame")}}

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -125,7 +125,7 @@ const response = await fetch(new URL('http://www.example.com/démonstration.html
 
 ## See also
 
-- A polyfill of `URL` is available in [`core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
+- [Polyfill of `URL` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
 - [URL API](/en-US/docs/Web/API/URL_API)
 - [What is a URL?](/en-US/docs/Learn/Common_questions/What_is_a_URL)
 - Property to obtain a `URL` object: {{domxref("URL")}}.

--- a/files/en-us/web/api/url/tojson/index.md
+++ b/files/en-us/web/api/url/tojson/index.md
@@ -46,4 +46,4 @@ url.toJSON(); // should return the URL as a string
 
 ## See also
 
-- A polyfill of `URL.prototype.toJSON` is available in [`core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
+- [Polyfill of `URL.prototype.toJSON` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -86,5 +86,5 @@ let d = new URL('/en-US/docs', b);                     // =
 
 ## See also
 
-- A polyfill of `URL` is available in [`core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
+- [Polyfill of `URL` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
 - The interface it belongs to: {{domxref("URL")}}.

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -158,6 +158,6 @@ noEquals.toString() // 'foo=&bar=baz'
 
 ## See also
 
-- A polyfill of `URLSearchParams` is available in [`core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
+- [Polyfill of `URLSearchParams` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
 - The {{domxref("URL")}} interface.
 - [Google Developers: Easy URL manipulation with URLSearchParams](https://developers.google.com/web/updates/2016/01/urlsearchparams?hl=en)

--- a/files/en-us/web/api/window/clearimmediate/index.md
+++ b/files/en-us/web/api/window/clearimmediate/index.md
@@ -51,5 +51,5 @@ specification is no longer being worked on.
 
 ## See also
 
-- A polyfill of `clearImmediate` is available in [`core-js`](https://github.com/zloirock/core-js#setimmediate)
+- [Polyfill of `clearImmediate` in `core-js`](https://github.com/zloirock/core-js#setimmediate)
 - {{DOMxRef("Window.setImmediate()")}}

--- a/files/en-us/web/api/window/setimmediate/index.md
+++ b/files/en-us/web/api/window/setimmediate/index.md
@@ -72,7 +72,7 @@ specification is no longer being worked on.
 
 ## See also
 
-- A polyfill of `setImmediate` is available in [`core-js`](https://github.com/zloirock/core-js#setimmediate)
+- [Polyfill of `setImmediate` in `core-js`](https://github.com/zloirock/core-js#setimmediate)
 - {{DOMxRef("Window.clearImmediate()")}}
 - [Microsoft
   `setImmediate` API Demo](http://ie.microsoft.com/testdrive/Performance/setImmediateSorting/Default.html)

--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.md
@@ -54,5 +54,5 @@ try {
 
 ## See also
 
-- A polyfill of `AggregateError` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `AggregateError` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - {{jsxref("Promise.any")}}

--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
@@ -67,6 +67,6 @@ try {
 
 ## See also
 
-- A polyfill of `AggregateError` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `AggregateError` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - {{JSxRef("Error")}}
 - {{JSxRef("Promise.any")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -132,7 +132,7 @@ logIterable(123);
 
 ## See also
 
-- A polyfill of `Array.prototype[@@iterator]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype[@@iterator]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.keys()")}}
 - {{jsxref("Array.prototype.entries()")}}
 - {{jsxref("Array.prototype.forEach()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.md
@@ -92,7 +92,7 @@ console.log(atWay); // Logs: 'green'
 
 ## See also
 
-- A polyfill of `Array.prototype.at` is available in [`core-js`](https://github.com/zloirock/core-js#relative-indexing-method)
+- [Polyfill of `Array.prototype.at` in `core-js`](https://github.com/zloirock/core-js#relative-indexing-method)
 - [A polyfill for the at() method](https://github.com/tc39/proposal-relative-indexing-method#polyfill).
 - {{jsxref("Array.prototype.find()")}} – return a value based on a given test.
 - {{jsxref("Array.prototype.includes()")}} – test whether a value exists in the array.

--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -114,7 +114,7 @@ i32a.copyWithin(0, 2)
 
 ## See also
 
-- A polyfill of `Array.prototype.copyWithin` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.copyWithin` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/array.polyfill.js)
 - {{jsxref("Array")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/entries/index.md
@@ -68,7 +68,7 @@ for (let e of iterator) {
 
 ## See also
 
-- A polyfill of `Array.prototype.entries` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.entries` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.keys()")}}
 - {{jsxref("Array.prototype.values()")}}
 - {{jsxref("Array.prototype.forEach()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -206,7 +206,7 @@ arr.every( (elem, index, arr) => {
 
 ## See also
 
-- A polyfill of `Array.prototype.every` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.every` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.forEach()")}}
 - {{jsxref("Array.prototype.some()")}}
 - {{jsxref("Array.prototype.find()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
@@ -156,6 +156,6 @@ let tempGirls = Array(5).fill("girl",0);
 
 ## See also
 
-- A polyfill of `Array.prototype.fill` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.fill` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array")}}
 - {{jsxref("TypedArray.prototype.fill()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -233,7 +233,7 @@ console.log(deleteWords)
 
 ## See also
 
-- A polyfill of `Array.prototype.filter` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.filter` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.forEach()")}}
 - {{jsxref("Array.prototype.every()")}}
 - {{jsxref("Array.prototype.some()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -208,7 +208,7 @@ array.find(function(value, index) {
 
 ## See also
 
-- A polyfill of `Array.prototype.find` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.find` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.findIndex()")}} – find and return an index
 - {{jsxref("Array.prototype.includes()")}} – test whether a value exists in the array
 - {{jsxref("Array.prototype.filter()")}} – remove all non-matching elements

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -150,6 +150,6 @@ console.log(fruits[index]); // blueberries
 
 ## See also
 
-- A polyfill of `Array.prototype.findIndex` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.findIndex` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.find()")}}
 - {{jsxref("Array.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
@@ -159,7 +159,7 @@ arr5.flat();
 
 ## See also
 
-- A polyfill of `Array.prototype.flat` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.flat` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.flatMap()")}}
 - {{jsxref("Array.prototype.map()")}}
 - {{jsxref("Array.prototype.reduce()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -164,7 +164,7 @@ a.flatMap( (n) =>
 
 ## See also
 
-- A polyfill of `Array.prototype.flatMap` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.flatMap` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.flat()")}}
 - {{jsxref("Array.prototype.map()")}}
 - {{jsxref("Array.prototype.reduce()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -396,7 +396,7 @@ flatten(nested) // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 ## See also
 
-- A polyfill of `Array.prototype.forEach` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.forEach` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.find()")}}
 - {{jsxref("Array.prototype.findIndex()")}}
 - {{jsxref("Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -335,7 +335,7 @@ if (!Array.from) {
 
 ## See also
 
-- A polyfill of `Array.from` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.from` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array")}}
 - {{jsxref("Array.of()")}}
 - {{jsxref("Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
@@ -133,7 +133,7 @@ The example below illustrates `includes()` method called on the function's
 
 ## See also
 
-- A polyfill of `Array.prototype.includes` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.includes` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("TypedArray.prototype.includes()")}}
 - {{jsxref("String.prototype.includes()")}}
 - {{jsxref("Array.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
@@ -212,7 +212,7 @@ if (!Array.prototype.indexOf) {
 
 ## See also
 
-- A polyfill of `Array.prototype.indexOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.indexOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.lastIndexOf()")}}
 - {{jsxref("TypedArray.prototype.indexOf()")}}
 - {{jsxref("String.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/isarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/isarray/index.md
@@ -102,7 +102,7 @@ arr instanceof Array; // false
 
 ## See also
 
-- A polyfill of `Array.isArray` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.isArray` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/array.polyfill.js)
 - {{jsxref("Array")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/keys/index.md
@@ -51,7 +51,7 @@ console.log(denseKeys);  // [0, 1, 2]
 
 ## See also
 
-- A polyfill of `Array.prototype.keys` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.keys` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.values()")}}
 - {{jsxref("Array.prototype.entries()")}}
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -99,6 +99,6 @@ the first element of the array. This is different from the
 
 ## See also
 
-- A polyfill of `Array.prototype.lastIndexOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.lastIndexOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.indexOf()")}}
 - {{jsxref("TypedArray.prototype.lastIndexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -296,7 +296,7 @@ let filteredNumbers = numbers.map(function(num, index) {
 
 ## See also
 
-- A polyfill of `Array.prototype.map` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.map` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.forEach()")}}
 - {{jsxref("Map")}} object
 - {{jsxref("Array.from()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.md
@@ -80,7 +80,7 @@ Array.of(undefined); // [undefined]
 
 ## See also
 
-- A polyfill of `Array.of` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.of` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/array.polyfill.js)
 - {{jsxref("Array")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -563,5 +563,5 @@ if (!Array.prototype.mapUsingReduce) {
 
 ## See also
 
-- A polyfill of `Array.prototype.reduce` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.reduce` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.reduceRight()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -357,5 +357,5 @@ console.log(compose(inc, double)(2)); // 5
 
 ## See also
 
-- A polyfill of `Array.prototype.reduceRight` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.reduceRight` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.reduce()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -182,7 +182,7 @@ getBoolean('true');  // true
 
 ## See also
 
-- A polyfill of `Array.prototype.some` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.some` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.every()")}}
 - {{jsxref("Array.prototype.forEach()")}}
 - {{jsxref("Array.prototype.find()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -305,7 +305,7 @@ Before version 10 (or EcmaScript 2019), sort stability was not guaranteed, meani
 
 ## See also
 
-- A polyfill of `Array.prototype.sort` with modern behavior like stable sort is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.sort` with modern behavior like stable sort in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.reverse()")}}
 - {{jsxref("String.prototype.localeCompare()")}}
 - [About the stability of the algorithm used

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.md
@@ -109,7 +109,7 @@ iterator.next().value;        //  "n"
 
 ## See also
 
-- A polyfill of `Array.prototype.values` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-array)
+- [Polyfill of `Array.prototype.values` in `core-js`](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.keys()")}}
 - {{jsxref("Array.prototype.entries()")}}
 - {{jsxref("Array.prototype.forEach()")}}

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.md
@@ -76,6 +76,6 @@ var view   = new Int32Array(buffer);
 
 ## See also
 
-- A polyfill of `ArrayBuffer` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `ArrayBuffer` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("SharedArrayBuffer")}}

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -64,7 +64,7 @@ const view = new Int32Array(buffer);
 
 ## See also
 
-- A polyfill of `ArrayBuffer` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `ArrayBuffer` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("SharedArrayBuffer")}}
 - [RangeError: invalid array length](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length)

--- a/files/en-us/web/javascript/reference/global_objects/dataview/dataview/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/dataview/index.md
@@ -80,5 +80,5 @@ view.getInt16(1); // 42
 
 ## See also
 
-- A polyfill of `DataView` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `DataView` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/dataview/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/index.md
@@ -142,7 +142,7 @@ view.getInt16(1); // 42
 
 ## See also
 
-- A polyfill of `DataView` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `DataView` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [jDataView](https://github.com/jDataView/jDataView): JavaScript library that polyfills and extends the `DataView` API to all browsers and Node.js.
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("SharedArrayBuffer")}}

--- a/files/en-us/web/javascript/reference/global_objects/date/getyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getyear/index.md
@@ -106,7 +106,7 @@ var year = Xmas.getYear(); // returns 95
 
 ## See also
 
-- A polyfill of `Date.prototype.getYear` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-date)
+- [Polyfill of `Date.prototype.getYear` in `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{jsxref("Date.prototype.getFullYear()")}}
 - {{jsxref("Date.prototype.getUTCFullYear()")}}
 - {{jsxref("Date.prototype.setYear()")}}

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -67,7 +67,7 @@ is larger.
 
 ## See also
 
-- A polyfill of `Date.now` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-date)
+- [Polyfill of `Date.now` in `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{domxref("Performance.now()")}} — provides timestamps with sub-millisecond
   resolution for use in measuring web page performance
 - {{domxref("console.time()")}} / {{domxref("console.timeEnd()")}}

--- a/files/en-us/web/javascript/reference/global_objects/date/setyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setyear/index.md
@@ -68,7 +68,7 @@ theBigDay.setYear(2000);
 
 ## See also
 
-- A polyfill of `Date.prototype.setYear` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-date)
+- [Polyfill of `Date.prototype.setYear` in `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{jsxref("Date.prototype.getFullYear()")}}
 - {{jsxref("Date.prototype.getUTCFullYear()")}}
 - {{jsxref("Date.prototype.setFullYear()")}}

--- a/files/en-us/web/javascript/reference/global_objects/date/togmtstring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/togmtstring/index.md
@@ -58,7 +58,7 @@ console.log(str);               // Mon, 18 Dec 1995 17:28:35 GMT
 
 ## See also
 
-- A polyfill of `Date.prototype.toGMTString` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-date)
+- [Polyfill of `Date.prototype.toGMTString` in `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toTimeString()")}}
 - {{jsxref("Date.prototype.toUTCString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.md
@@ -82,7 +82,7 @@ escape('@*_+-./');    // "@*_+-./"
 
 ## See also
 
-- A polyfill of `escape` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `escape` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("encodeURI")}}
 - {{jsxref("encodeURIComponent")}}
 - {{jsxref("unescape")}}

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -117,7 +117,7 @@ var dv = new Float32Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Float32Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Float32Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -139,7 +139,7 @@ var float32 = new Float32Array(iterable);
 
 ## See also
 
-- A polyfill of `Float32Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Float32Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -117,7 +117,7 @@ var dv = new Float64Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Float64Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Float64Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -139,7 +139,7 @@ var float64 = new Float64Array(iterable);
 
 ## See also
 
-- A polyfill of `Float64Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Float64Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -303,7 +303,7 @@ slice(arguments);
 
 ## See also
 
-- A polyfill of `Function.prototype.bind` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-function)
+- [Polyfill of `Function.prototype.bind` in `core-js`](https://github.com/zloirock/core-js#ecmascript-function)
 - {{jsxref("Function.prototype.apply()")}}
 - {{jsxref("Function.prototype.call()")}}
 - {{jsxref("Functions", "Functions", "", 1)}}

--- a/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
@@ -73,5 +73,5 @@ if (typeof globalThis.setTimeout !== 'function') {
 
 ## See also
 
-- A polyfill of `globalThis` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-globalthis)
+- [Polyfill of `globalThis` in `core-js`](https://github.com/zloirock/core-js#ecmascript-globalthis)
 - {{jsxref("Operators/this", "this")}}

--- a/files/en-us/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/index.md
@@ -139,7 +139,7 @@ var int16 = new Int16Array(iterable);
 
 ## See also
 
-- A polyfill of `Int16Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Int16Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -116,7 +116,7 @@ var dv = new Int16Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Int16Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Int16Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/index.md
@@ -140,7 +140,7 @@ var int32 = new Int32Array(iterable);
 
 ## See also
 
-- A polyfill of `Int32Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Int32Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -113,7 +113,7 @@ var dv = new Int32Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Int32Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Int32Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/index.md
@@ -140,7 +140,7 @@ var int8 = new Int8Array(iterable);
 
 ## See also
 
-- A polyfill of `Int8Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Int8Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
@@ -114,7 +114,7 @@ var dv = new Int8Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Int8Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Int8Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -419,5 +419,5 @@ result of `JSON.stringify` do you need to carefully handle
 
 ## See also
 
-- A polyfill of modern `JSON.stringify` behavior (symbol and well-formed unicode) is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-function)
+- [Polyfill of modern `JSON.stringify` behavior (symbol and well-formed unicode) in `core-js`](https://github.com/zloirock/core-js#ecmascript-function)
 - {{JSxRef("JSON.parse()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/acosh/index.md
@@ -122,7 +122,7 @@ Math.acosh = Math.acosh || function(x) {
 
 ## See also
 
-- A polyfill of `Math.acosh` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.acosh` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.asinh()")}}
 - {{jsxref("Math.atanh()")}}
 - {{jsxref("Math.cosh()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/asinh/index.md
@@ -101,7 +101,7 @@ for details.
 
 ## See also
 
-- A polyfill of `Math.asinh` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.asinh` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.acosh()")}}
 - {{jsxref("Math.atanh()")}}
 - {{jsxref("Math.cosh()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/atanh/index.md
@@ -128,7 +128,7 @@ Math.atanh = Math.atanh || function(x) {
 
 ## See also
 
-- A polyfill of `Math.atanh` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.atanh` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.acosh()")}}
 - {{jsxref("Math.asinh()")}}
 - {{jsxref("Math.cosh()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -116,6 +116,6 @@ Math.cbrt(2);  // 1.2599210498948732
 
 ## See also
 
-- A polyfill of `Math.cbrt` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.cbrt` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.pow()")}}
 - {{jsxref("Math.sqrt()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
@@ -185,6 +185,6 @@ if (!Math.clz32) Math.clz32 = (function(log, LN2){
 
 ## See also
 
-- A polyfill of `Math.clz32` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.clz32` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math")}}
 - {{jsxref("Math.imul")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/cosh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cosh/index.md
@@ -88,7 +88,7 @@ Math.cosh = Math.cosh || function(x) {
 
 ## See also
 
-- A polyfill of `Math.cosh` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.cosh` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.acosh()")}}
 - {{jsxref("Math.asinh()")}}
 - {{jsxref("Math.atanh()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/expm1/index.md
@@ -59,7 +59,7 @@ Math.expm1(1);  // 1.718281828459045
 
 ## See also
 
-- A polyfill of `Math.expm1` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.expm1` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.E")}}
 - {{jsxref("Math.exp()")}}
 - {{jsxref("Math.log()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
@@ -137,5 +137,5 @@ if (!Math.fround) Math.fround = function(arg) {
 
 ## See also
 
-- A polyfill of `Math.fround` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.fround` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.round()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
@@ -169,7 +169,7 @@ if (!Math.hypot) Math.hypot = function () {
 
 ## See also
 
-- A polyfill of `Math.hypot` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.hypot` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.abs()")}}
 - {{jsxref("Math.pow()")}}
 - {{jsxref("Math.sqrt()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/imul/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/imul/index.md
@@ -110,5 +110,5 @@ if (!Math.imul) Math.imul = function(opA, opB) {
 
 ## See also
 
-- A polyfill of `Math.imul` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.imul` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - [Emscripten](https://en.wikipedia.org/wiki/Emscripten)

--- a/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
@@ -103,7 +103,7 @@ Math.log10 = Math.log10 || function(x) {
 
 ## See also
 
-- A polyfill of `Math.log10` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.log10` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.exp()")}}
 - {{jsxref("Math.log()")}}
 - {{jsxref("Math.log1p()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
@@ -98,7 +98,7 @@ Math.log1p(-2); // NaN
 
 ## See also
 
-- A polyfill of `Math.log1p` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.log1p` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.exp()")}}
 - {{jsxref("Math.log()")}}
 - {{jsxref("Math.expm1()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2/index.md
@@ -106,7 +106,7 @@ Math.log2(1024); // 10
 
 ## See also
 
-- A polyfill of `Math.log2` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.log2` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.exp()")}}
 - {{jsxref("Math.log()")}}
 - {{jsxref("Math.log10()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sign/index.md
@@ -72,7 +72,7 @@ Math.sign();      // NaN
 
 ## See also
 
-- A polyfill of `Math.sign` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.sign` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/math.polyfill.js)
 - {{jsxref("Math.abs()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/sinh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sinh/index.md
@@ -88,7 +88,7 @@ Math.sinh(1); // 1.1752011936438014
 
 ## See also
 
-- A polyfill of `Math.sinh` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.sinh` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.acosh()")}}
 - {{jsxref("Math.asinh()")}}
 - {{jsxref("Math.atanh()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/tanh/index.md
@@ -103,7 +103,7 @@ Math.tanh(1);        // 0.7615941559557649
 
 ## See also
 
-- A polyfill of `Math.tanh` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.tanh` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - {{jsxref("Math.acosh()")}}
 - {{jsxref("Math.asinh()")}}
 - {{jsxref("Math.atanh()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/trunc/index.md
@@ -71,7 +71,7 @@ Math.trunc();         // NaN
 
 ## See also
 
-- A polyfill of `Math.trunc` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-math)
+- [Polyfill of `Math.trunc` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/math.polyfill.js)
 - {{jsxref("Math.abs()")}}

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -50,5 +50,5 @@ if (Number.EPSILON === undefined) {
 
 ## See also
 
-- A polyfill of `Number.EPSILON` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.EPSILON` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - The {{jsxref("Number")}} object it belongs to

--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -165,7 +165,7 @@ Number('-Infinity') // -Infinity
 
 ## See also
 
-- A polyfill of modern `Number` behavior (with support binary and octal literals) is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of modern `Number` behavior (with support binary and octal literals) in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - {{jsxref("NaN")}}
 - [Arithmetic operators](/en-US/docs/Web/JavaScript/Reference/Operators#arithmetic_operators)
 - The {{jsxref("Math")}} global object

--- a/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -75,6 +75,6 @@ if (Number.isFinite === undefined) Number.isFinite = function(value) {
 
 ## See also
 
-- A polyfill of `Number.isFinite` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.isFinite` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - The {{jsxref("Number")}} object it belongs to.
 - The global function {{jsxref("isFinite")}}.

--- a/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -74,5 +74,5 @@ Number.isInteger(5.0000000000000001); // true
 
 ## See also
 
-- A polyfill of `Number.isInteger` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.isInteger` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - The {{jsxref("Number")}} object it belongs to.

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
@@ -95,6 +95,6 @@ Number.isNaN = Number.isNaN || function isNaN(input) {
 
 ## See also
 
-- A polyfill of `Number.isNaN` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.isNaN` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - {{jsxref("Number")}}
 - {{jsxref("isNaN", "isNaN()")}}

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -88,7 +88,7 @@ Number.isSafeInteger(3.0);                  // true
 
 ## See also
 
-- A polyfill of `Number.isSafeInteger` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.isSafeInteger` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - The {{jsxref("Number")}} object it belongs to.
 - {{jsxref("Number.MIN_SAFE_INTEGER")}}
 - {{jsxref("Number.MAX_SAFE_INTEGER")}}

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -61,7 +61,7 @@ Number.MAX_SAFE_INTEGER * Number.EPSILON; // 2
 
 ## See also
 
-- A polyfill of `Number.MAX_SAFE_INTEGER` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.MAX_SAFE_INTEGER` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - {{jsxref("Number.MIN_SAFE_INTEGER")}}
 - {{jsxref("Number.isSafeInteger()")}}
 - {{jsxref("BigInt")}}

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -42,7 +42,7 @@ Number.MIN_SAFE_INTEGER // -9007199254740991
 
 ## See also
 
-- A polyfill of `Number.MIN_SAFE_INTEGER` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.MIN_SAFE_INTEGER` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - {{jsxref("Number.MAX_SAFE_INTEGER")}}
 - {{jsxref("Number.isSafeInteger()")}}
 - {{jsxref("BigInt")}}

--- a/files/en-us/web/javascript/reference/global_objects/number/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/number/index.md
@@ -45,7 +45,7 @@ b instanceof Number;         // is false
 
 ## See also
 
-- A polyfill of modern `Number` behavior (with support binary and octal literals) is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of modern `Number` behavior (with support binary and octal literals) in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - {{jsxref("NaN")}}
 - The {{jsxref("Math")}} global object
 - Integers with arbitrary precision: {{jsxref("BigInt")}}

--- a/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -56,7 +56,7 @@ See {{jsxref("parseFloat", "parseFloat()")}} for more detail and examples.
 
 ## See also
 
-- A polyfill of `Number.parseFloat` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.parseFloat` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - - {{jsxref("Number")}}
     - : The object this method belongs to.
 - The global {{jsxref("parseFloat", "parseFloat()")}} method.

--- a/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
@@ -69,6 +69,6 @@ and is part of ECMAScript 2015 (its purpose is modularization of globals). Pleas
 
 ## See also
 
-- A polyfill of `Number.parseInt` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-number)
+- [Polyfill of `Number.parseInt` in `core-js`](https://github.com/zloirock/core-js#ecmascript-number)
 - The {{jsxref("Number")}} object it belongs to.
 - The global {{jsxref("parseInt", "parseInt()")}} method.

--- a/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -80,7 +80,7 @@ console.log(o.gimmeFive); // 5
 
 ## See also
 
-- A polyfill of `Object.prototype.__defineGetter__` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.prototype.__defineGetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.__defineSetter__()")}}
 - {{jsxref("Functions/get", "get")}} operator
 - {{jsxref("Object.defineProperty()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/__definesetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definesetter__/index.md
@@ -96,7 +96,7 @@ console.log(o.anotherValue); // 5
 
 ## See also
 
-- A polyfill of `Object.prototype.__defineSetter__` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.prototype.__defineSetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.__defineGetter__()")}}
 - {{jsxref("Functions/set", "set")}} operator
 - {{jsxref("Object.defineProperty()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
@@ -71,7 +71,7 @@ Object.getOwnPropertyDescriptor(obj, "foo").get;
 
 ## See also
 
-- A polyfill of `Object.prototype.__lookupGetter__` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.prototype.__lookupGetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.__lookupSetter__()")}}
 - {{jsxref("Functions/get", "get")}} operator
 - {{jsxref("Object.getOwnPropertyDescriptor()")}} and

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
@@ -70,7 +70,7 @@ Object.getOwnPropertyDescriptor(obj, 'foo').set;
 
 ## See also
 
-- A polyfill of `Object.prototype.__lookupSetter__` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.prototype.__lookupSetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.__lookupGetter__()")}}
 - {{jsxref("Functions/set", "set")}} operator
 - {{jsxref("Object.getOwnPropertyDescriptor()")}} and

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -250,7 +250,7 @@ console.log(copy);
 
 ## See also
 
-- A polyfill of `Object.assign` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.assign` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.defineProperties()")}}
 - [Enumerability
   and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -367,7 +367,7 @@ o2 = Object.create({p: 42}) */
 
 ## See also
 
-- A polyfill of `Object.create` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.create` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Object.defineProperties()")}}
 - {{jsxref("Object.prototype.isPrototypeOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
@@ -148,7 +148,7 @@ Object.entries(obj).forEach(([key, value]) => console.log(`${key}: ${value}`)); 
 
 ## See also
 
-- A polyfill of `Object.entries` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.entries` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - [Enumerability
   and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.keys()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/fromentries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/fromentries/index.md
@@ -97,7 +97,7 @@ console.log(object2);
 
 ## See also
 
-- A polyfill of `Object.fromEntries` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.fromEntries` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.entries()")}}
 - {{jsxref("Object.keys()")}}
 - {{jsxref("Object.values()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -105,7 +105,7 @@ subclass.prototype = Object.create(
 
 ## See also
 
-- A polyfill of `Object.getOwnPropertyDescriptors` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.getOwnPropertyDescriptors` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.getOwnPropertyDescriptor()")}}
 - {{jsxref("Object.defineProperty()")}}
 - [Polyfill](https://github.com/tc39/proposal-object-getownpropertydescriptors)

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -139,7 +139,7 @@ console.log(nonenum_only);
 
 ## See also
 
-- A polyfill of `Object.getOwnPropertyNames` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.getOwnPropertyNames` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.prototype.hasOwnProperty()")}}
 - {{jsxref("Object.prototype.propertyIsEnumerable()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -65,6 +65,6 @@ console.log(objectSymbols[0]);     // Symbol(a)
 
 ## See also
 
-- A polyfill of `Object.getOwnPropertySymbols` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Object.getOwnPropertySymbols` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Object.getOwnPropertyNames()")}}
 - {{jsxref("Symbol")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -72,7 +72,7 @@ since Opera 10.50.
 
 ## See also
 
-- A polyfill of `Object.getPrototypeOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.getPrototypeOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Object.setPrototypeOf()")}}
 - {{jsxref("Object/proto","Object.prototype.__proto__")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -166,7 +166,7 @@ if (Object.hasOwn(foo, 'prop')) {
 
 ## See also
 
-- A polyfill of `Object.hasOwn` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.hasOwn` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.hasOwnProperty()")}}
 - [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.getOwnPropertyNames()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/is/index.md
@@ -131,7 +131,7 @@ if (!Object.is) {
 
 ## See also
 
-- A polyfill of `Object.is` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.is` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - [Equality
   comparisons and sameness](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness) — a comparison of all three built-in sameness
   facilities

--- a/files/en-us/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/keys/index.md
@@ -148,7 +148,7 @@ For a simple Browser Polyfill, see [Javascript \- Object.keys Browser Compatibil
 
 ## See also
 
-- A polyfill of `Object.keys` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.keys` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - [Enumerability
   and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.prototype.propertyIsEnumerable()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -159,7 +159,7 @@ Object.prototype.toString.call(new Date()); // [object prototype polluted]
 
 ## See also
 
-- A polyfill of `Object.prototype.toString` with `Symbol.toStringTag` support is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.prototype.toString` with `Symbol.toStringTag` support in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.toSource()")}}
 - {{jsxref("Object.prototype.valueOf()")}}
 - {{jsxref("Number.prototype.toString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/values/index.md
@@ -83,7 +83,7 @@ console.log(Object.values('foo')); // ['f', 'o', 'o']
 
 ## See also
 
-- A polyfill of `Object.values` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-object)
+- [Polyfill of `Object.values` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - [Enumerability
   and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.keys()")}}

--- a/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
@@ -108,7 +108,7 @@ console.log(values)
 
 ## See also
 
-- A polyfill of `Promise.allSettled` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `Promise.allSettled` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - [Promises](/en-US/docs/Archive/Add-ons/Techniques/Promises)
 - [Using promises](/en-US/docs/Web/JavaScript/Guide/Using_promises)
 - [Graceful asynchronous

--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -130,7 +130,7 @@ Promise.any([coffee, tea]).then(value => {
 
 ## See also
 
-- A polyfill of `Promise.any` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `Promise.any` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - {{JSxRef("Promise")}}
 - {{JSxRef("Promise.allSettled()")}}
 - {{JSxRef("Promise.all()")}}

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -100,7 +100,7 @@ fetch(myRequest).then(function(response) {
 
 ## See also
 
-- A polyfill of `Promise.prototype.finally` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `Promise.prototype.finally` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - {{jsxref("Promise")}}
 - {{jsxref("Promise.prototype.then()")}}
 - {{jsxref("Promise.prototype.catch()")}}

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -418,7 +418,7 @@ Another simple example using `Promise` and {{domxref("XMLHttpRequest")}} to load
 
 ## See also
 
-- A polyfill of `Promise` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `Promise` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - [Using promises](/en-US/docs/Web/JavaScript/Guide/Using_promises)
 - [Promises/A+ specification](https://promisesaplus.com/)
 - [JavaScript Promises: an introduction](https://web.dev/promises/)

--- a/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
@@ -125,5 +125,5 @@ function myAsyncFunction(url) {
 
 ## See also
 
-- A polyfill of `Promise` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
+- [Polyfill of `Promise` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
 - [Using Promises](/en-US/docs/Web/JavaScript/Guide/Using_promises)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.md
@@ -84,6 +84,6 @@ Reflect.apply(''.charAt, 'ponies', [3])
 
 ## See also
 
-- A polyfill of `Reflect.apply` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.apply` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Function.prototype.apply()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -164,7 +164,7 @@ d.getFullYear()    // 1776
 
 ## See also
 
-- A polyfill of `Reflect.construct` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.construct` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Operators/new", "new")}}
 - [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.md
@@ -93,6 +93,6 @@ if (Reflect.defineProperty(target, property, attributes)) {
 
 ## See also
 
-- A polyfill of `Reflect.defineProperty` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.defineProperty` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.defineProperty()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
@@ -79,7 +79,7 @@ Reflect.deleteProperty(Object.freeze({foo: 1}), 'foo')  // false
 
 ## See also
 
-- A polyfill of `Reflect.deleteProperty` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.deleteProperty` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - [`delete`
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/delete)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
@@ -95,7 +95,7 @@ Reflect.get(obj, 'foo', y) // "3bar"
 
 ## See also
 
-- A polyfill of `Reflect.get` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.get` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - [Property
   accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
@@ -90,6 +90,6 @@ Object.getOwnPropertyDescriptor('foo', 0)
 
 ## See also
 
-- A polyfill of `Reflect.getOwnPropertyDescriptor` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.getOwnPropertyDescriptor` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.getOwnPropertyDescriptor()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
@@ -83,6 +83,6 @@ Reflect.getPrototypeOf(Object('foo'))  // String.prototype
 
 ## See also
 
-- A polyfill of `Reflect.getPrototypeOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.getPrototypeOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.getPrototypeOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/has/index.md
@@ -87,7 +87,7 @@ Reflect.has(c, 'foo') // true
 
 ## See also
 
-- A polyfill of `Reflect.has` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.has` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - [`in`
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/in)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -93,6 +93,6 @@ Object.isExtensible(1)
 
 ## See also
 
-- A polyfill of `Reflect.isExtensible` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.isExtensible` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.isExtensible()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/ownkeys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/ownkeys/index.md
@@ -74,6 +74,6 @@ Reflect.ownKeys(obj)
 
 ## See also
 
-- A polyfill of `Reflect.ownKeys` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.ownKeys` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.getOwnPropertyNames()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -88,6 +88,6 @@ Object.preventExtensions(1)
 
 ## See also
 
-- A polyfill of `Reflect.preventExtensions` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.preventExtensions` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.isExtensible()")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
@@ -87,7 +87,7 @@ Reflect.getOwnPropertyDescriptor(obj, 'undefined')
 
 ## See also
 
-- A polyfill of `Reflect.set` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.set` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - [Property
   accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
@@ -78,6 +78,6 @@ Reflect.setPrototypeOf(target, proto)  // false
 
 ## See also
 
-- A polyfill of `Reflect.setPrototypeOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
+- [Polyfill of `Reflect.setPrototypeOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-reflect)
 - {{jsxref("Reflect")}}
 - {{jsxref("Object.setPrototypeOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -100,7 +100,7 @@ console.log(result.group(3)); // 02
 
 ## See also
 
-- A polyfill of `RegExp.prototype[@@match]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `RegExp.prototype[@@match]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.match()")}}
 - {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
 - {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.md
@@ -100,6 +100,6 @@ console.log(result[1]); // [ "2019-03-07", "2019", "03", "07" ]
 
 ## See also
 
-- A polyfill of `RegExp.prototype[@@matchAll]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `RegExp.prototype[@@matchAll]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{JSxRef("String.prototype.matchAll()")}}
 - {{JSxRef("Symbol.matchAll")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
@@ -115,7 +115,7 @@ console.log(newstr); // ###34567
 
 ## See also
 
-- A polyfill of `RegExp.prototype[@@replace]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `RegExp.prototype[@@replace]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.replace()")}}
 - {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
 - {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
@@ -96,7 +96,7 @@ console.log(result); // 3
 
 ## See also
 
-- A polyfill of `RegExp.prototype[@@search]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `RegExp.prototype[@@search]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.search()")}}
 - {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
 - {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -99,7 +99,7 @@ console.log(result); // ["(2016)", "(01)", "(02)"]
 
 ## See also
 
-- A polyfill of `RegExp.prototype[@@split]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `RegExp.prototype[@@split]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.split()")}}
 - {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
 - {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -66,7 +66,7 @@ console.log(str2.replace(regex2,'')); // Output: bar
 
 ## See also
 
-- A polyfill of `dotAll` `RegExp` flag is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `dotAll` `RegExp` flag in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{JSxRef("RegExp.lastIndex")}}
 - {{JSxRef("RegExp.prototype.global")}}
 - {{JSxRef("RegExp.prototype.hasIndices")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -56,5 +56,5 @@ if (RegExp.prototype.flags === undefined) {
 
 ## See also
 
-- A polyfill of `RegExp.prototype.flags` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `RegExp.prototype.flags` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{JSxRef("RegExp.prototype.source")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -244,7 +244,7 @@ Note that due to web compatibility, `RegExp.$N` will still return an empty strin
 
 ## See also
 
-- A polyfill of many modern `RegExp` features (`dotAll`, `sticky` flags, named capture groups, etc.) is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of many modern `RegExp` features (`dotAll`, `sticky` flags, named capture groups, etc.) in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - [Regular Expressions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) chapter in the [JavaScript Guide](/en-US/docs/Web/JavaScript/Guide)
 - {{jsxref("String.prototype.match()")}}
 - {{jsxref("String.prototype.replace()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -123,7 +123,7 @@ such as user input.
 
 ## See also
 
-- A polyfill of many modern `RegExp` features (`dotAll`, `sticky` flags, named capture groups, etc.) is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of many modern `RegExp` features (`dotAll`, `sticky` flags, named capture groups, etc.) in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - [Regular
   Expressions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) chapter in the [JavaScript
   Guide](/en-US/docs/Web/JavaScript/Guide)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.md
@@ -69,7 +69,7 @@ regex2.test('.\nfoo'); // true - index 2 is the beginning of a line
 
 ## See also
 
-- A polyfill of `sticky` `RegExp` flag is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `sticky` `RegExp` flag in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("RegExp.lastIndex")}}
 - {{JSxRef("RegExp.prototype.dotAll")}}
 - {{JSxRef("RegExp.prototype.global")}}

--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -278,7 +278,7 @@ console.assert(set.size == array.length);
 
 ## See also
 
-- A polyfill of `Set` is available in [`core-js`](https://github.com/zloirock/core-js#set)
+- [Polyfill of `Set` in `core-js`](https://github.com/zloirock/core-js#set)
 - {{jsxref("Map")}}
 - {{jsxref("WeakMap")}}
 - {{jsxref("WeakSet")}}

--- a/files/en-us/web/javascript/reference/global_objects/set/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/set/index.md
@@ -64,5 +64,5 @@ mySet.add(o)
 
 ## See also
 
-- A polyfill of `Set` is available in [`core-js`](https://github.com/zloirock/core-js#set)
+- [Polyfill of `Set` in `core-js`](https://github.com/zloirock/core-js#set)
 - {{jsxref("Set")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/@@iterator/index.md
@@ -69,6 +69,6 @@ for (var v of str) {
 
 ## See also
 
-- A polyfill of `String.prototype[@@iterator]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype[@@iterator]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - [Iteration
   protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/string/anchor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/anchor/index.md
@@ -73,5 +73,5 @@ will output the following HTML:
 
 ## See also
 
-- A polyfill of `String.prototype.anchor` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.anchor` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.link()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.md
@@ -86,7 +86,7 @@ console.log(atWay); // Logs: 't'
 
 ## See also
 
-- A polyfill of `String.prototype.at` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.at` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - [A polyfill for the at() method](https://github.com/tc39/proposal-relative-indexing-method#polyfill).
 - {{jsxref("String.prototype.indexOf()")}}
 - {{jsxref("String.prototype.lastIndexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/big/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/big/index.md
@@ -67,6 +67,6 @@ document.getElementById('yourElemId').style.fontSize = '2em';
 
 ## See also
 
-- A polyfill of `String.prototype.big` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.big` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.fontsize()")}}
 - {{jsxref("String.prototype.small()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/blink/index.md
@@ -61,7 +61,7 @@ console.log(worldString.strike());  // <strike>Hello, world</strike>
 
 ## See also
 
-- A polyfill of `String.prototype.blink` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.blink` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.bold()")}}
 - {{jsxref("String.prototype.italics()")}}
 - {{jsxref("String.prototype.strike()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/bold/index.md
@@ -57,7 +57,7 @@ console.log(worldString.strike());  // <strike>Hello, world</strike>
 
 ## See also
 
-- A polyfill of `String.prototype.bold` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.bold` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.blink()")}}
 - {{jsxref("String.prototype.italics()")}}
 - {{jsxref("String.prototype.strike()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -145,7 +145,7 @@ if (!String.prototype.codePointAt) {
 
 ## See also
 
-- A polyfill of `String.prototype.codePointAt` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.codePointAt` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.fromCodePoint()")}}
 - {{jsxref("String.fromCharCode()")}}
 - {{jsxref("String.prototype.charCodeAt()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
@@ -82,7 +82,7 @@ if (!String.prototype.endsWith) {
 
 ## See also
 
-- A polyfill of `String.prototype.endsWith` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.endsWith` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.startsWith()")}}
 - {{jsxref("String.prototype.includes()")}}
 - {{jsxref("String.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fixed/index.md
@@ -54,7 +54,7 @@ console.log(worldString.fixed()); // "<tt>Hello, world</tt>"
 
 ## See also
 
-- A polyfill of `String.prototype.fixed` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.fixed` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.bold()")}}
 - {{jsxref("String.prototype.italics()")}}
 - {{jsxref("String.prototype.strike()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -77,5 +77,5 @@ document.getElementById('yourElemId').style.color = 'red';
 
 ## See also
 
-- A polyfill of `String.prototype.fontcolor` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.fontcolor` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.fontsize()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -74,6 +74,6 @@ document.getElementById('yourElemId').style.fontSize = '0.7em';
 
 ## See also
 
-- A polyfill of `String.prototype.fontsize` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.fontsize` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.big()")}}
 - {{jsxref("String.prototype.small()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -150,7 +150,7 @@ String.fromCodePoint(0x1F303); // or 127747 in decimal
 
 ## See also
 
-- A polyfill of `String.fromCodePoint` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.fromCodePoint` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.fromCharCode()")}}
 - {{jsxref("String.prototype.charAt()")}}
 - {{jsxref("String.prototype.codePointAt()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
@@ -97,7 +97,7 @@ console.log(str.includes(''))             // true
 
 ## See also
 
-- A polyfill of `String.prototype.includes` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.includes` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("Array.prototype.includes()")}}
 - {{jsxref("TypedArray.prototype.includes()")}}
 - {{jsxref("String.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/italics/index.md
@@ -55,7 +55,7 @@ console.log(worldString.strike());  // <strike>Hello, world</strike>
 
 ## See also
 
-- A polyfill of `String.prototype.italics` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.italics` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.blink()")}}
 - {{jsxref("String.prototype.bold()")}}
 - {{jsxref("String.prototype.strike()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/link/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/link/index.md
@@ -70,5 +70,5 @@ console.log('Click to return to ' + hotText.link(url));
 
 ## See also
 
-- A polyfill of `String.prototype.link` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.link` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.anchor()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -152,7 +152,7 @@ array[1];
 
 ## See also
 
-- A polyfill of `String.prototype.matchAll` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.matchAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.match()")}}
 - [Using regular
   expressions in JavaScript](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)

--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
@@ -66,7 +66,7 @@ A {{jsxref("String")}} of the specified `targetLength` with the
 
 ## See also
 
-- A polyfill of `String.prototype.padEnd` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.padEnd` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.padStart()")}}
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/string.polyfill.js)

--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
@@ -81,7 +81,7 @@ console.log(leftFillNum(num, 5));
 
 ## See also
 
-- A polyfill of `String.prototype.padStart` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.padStart` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.padEnd()")}}
 - [A
   polyfill](https://github.com/behnammodi/polyfill/blob/master/string.polyfill.js)

--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
@@ -111,7 +111,7 @@ String.raw({ raw: 'test' }, 0, 1, 2); // 't0e1s2t'
 
 ## See also
 
-- A polyfill of `String.raw` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.raw` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals)
 - {{jsxref("String")}}
 - [Lexical grammar](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar)

--- a/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md
@@ -117,5 +117,5 @@ if (!String.prototype.repeat) {
 
 ## See also
 
-- A polyfill of `String.prototype.repeat` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.repeat` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.concat()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -134,7 +134,7 @@ This will work:
 
 ## See also
 
-- A polyfill of `String.prototype.replaceAll` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.replaceAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.replace", "String.prototype.replace()")}}
 - {{jsxref("String.prototype.match", "String.prototype.match()")}}
 - {{jsxref("RegExp.prototype.exec", "RegExp.prototype.exec()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/small/index.md
@@ -64,6 +64,6 @@ document.getElementById('yourElemId').style.fontSize = '0.7em';
 
 ## See also
 
-- A polyfill of `String.prototype.small` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.small` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.fontsize()")}}
 - {{jsxref("String.prototype.big()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
@@ -88,7 +88,7 @@ Mathias Bynens](https://github.com/mathiasbynens/String.prototype.startsWith).
 
 ## See also
 
-- A polyfill of `String.prototype.startsWith` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.startsWith` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.endsWith()")}}
 - {{jsxref("String.prototype.includes()")}}
 - {{jsxref("String.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/strike/index.md
@@ -56,7 +56,7 @@ console.log(worldString.strike()); // <strike>Hello, world</strike>
 
 ## See also
 
-- A polyfill of `String.prototype.strike` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.strike` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.blink()")}}
 - {{jsxref("String.prototype.bold()")}}
 - {{jsxref("String.prototype.italics()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/sub/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/sub/index.md
@@ -59,5 +59,5 @@ console.log('This is what a ' + subText.sub() + ' looks like.');
 
 ## See also
 
-- A polyfill of `String.prototype.sub` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.sub` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.sup()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
@@ -112,6 +112,6 @@ console.log(aString.substr(20, 2));  // ''
 
 ## See also
 
-- A polyfill of `String.prototype.substr` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.substr` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.slice()")}}
 - {{jsxref("String.prototype.substring()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/sup/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/sup/index.md
@@ -60,5 +60,5 @@ console.log('This is what a ' + subText.sub() + ' looks like.');
 
 ## See also
 
-- A polyfill of `String.prototype.sup` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.sup` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.sub()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimend/index.md
@@ -68,6 +68,6 @@ console.log(str);        // '   foo'
 
 ## See also
 
-- A polyfill of `String.prototype.trimEnd` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.trimEnd` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.trim()")}}
 - {{jsxref("String.prototype.trimStart()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -105,6 +105,6 @@ ES6:
 
 ## See also
 
-- A polyfill of `String.prototype.trimStart` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `String.prototype.trimStart` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.trim()")}}
 - {{jsxref("String.prototype.trimEnd()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/description/index.md
@@ -48,6 +48,6 @@ Symbol.for('foo').description; // "foo"
 
 ## See also
 
-- A polyfill of `Symbol.prototype.description` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.prototype.description` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{JSxRef("Symbol.prototype.toString()")}}
 - Polyfill: <https://npmjs.com/symbol.prototype.description>

--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -184,7 +184,7 @@ obj[Object(sym)]     // still 1
 
 ## See also
 
-- A polyfill of `Symbol` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Glossary: Symbol data type](/en-US/docs/Glossary/Symbol)
 - {{jsxref("Operators/typeof", "typeof")}}
 - [Data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -80,5 +80,5 @@ x.concat(fakeArray)  // [1, 2, 3, "hello", "world"]
 
 ## See also
 
-- A polyfill of `Symbol.isConcatSpreadable` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.isConcatSpreadable` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Array.prototype.concat()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -89,7 +89,7 @@ nonWellFormedIterable[Symbol.iterator] = () => 1
 
 ## See also
 
-- A polyfill of `Symbol.iterator` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.iterator` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
 - {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
 - {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -53,7 +53,7 @@ re[Symbol.match] = false;
 
 ## See also
 
-- A polyfill of `Symbol.match` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.match` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -60,6 +60,6 @@ See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", 
 
 ## See also
 
-- A polyfill of `Symbol.matchAll` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.matchAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("String.prototype.matchAll()")}}
 - {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -45,7 +45,7 @@ console.log('football'.replace(new CustomReplacer('foo')));
 
 ## See also
 
-- A polyfill of `Symbol.replace` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.replace` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -45,7 +45,7 @@ console.log('foobar'.search(new caseInsensitiveSearch('BaR')));
 
 ## See also
 
-- A polyfill of `Symbol.search` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.search` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.split")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -43,7 +43,7 @@ console.log('Another one bites the dust'.split(new ReverseSplit()));
 
 ## See also
 
-- A polyfill of `Symbol.split` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.split` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/symbol/index.md
@@ -89,5 +89,5 @@ typeof symObj // => "object"
 
 ## See also
 
-- A polyfill of `Symbol` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Glossary: Symbol data type](/en-US/docs/Glossary/Symbol)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -83,5 +83,5 @@ test[Symbol.toStringTag];  // Returns HTMLButtonElement
 
 ## See also
 
-- A polyfill of `Symbol.toStringTag` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [Polyfill of `Symbol.toStringTag` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Object.prototype.toString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/@@iterator/index.md
@@ -64,7 +64,7 @@ console.log(eArr.next().value); // 50
 
 ## See also
 
-- A polyfill of `TypedArray.prototype[@@iterator]` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype[@@iterator]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.md
@@ -85,7 +85,7 @@ console.log(atWay); // Logs: 11
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.at` is available in [`core-js`](https://github.com/zloirock/core-js#relative-indexing-method)
+- [Polyfill of `TypedArray.prototype.at` in `core-js`](https://github.com/zloirock/core-js#relative-indexing-method)
 - [A polyfill for the at() method](https://github.com/tc39/proposal-relative-indexing-method#polyfill).
 - {{jsxref("TypedArray.prototype.find()")}} – return a value based on a given test.
 - {{jsxref("TypedArray.prototype.includes()")}} – test whether a value exists in the array.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -70,5 +70,5 @@ console.log(uint8); // Uint8Array [ 1, 2, 3, 1, 2, 3, 0, 0 ]
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.copyWithin` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.copyWithin` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -66,7 +66,7 @@ console.log(eArr.next().value); // [4, 50]
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.entries` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.entries` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.keys()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -116,6 +116,6 @@ new Uint8Array([12, 54, 18, 130, 44]).every(elem => elem >= 10); // true
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.every` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.every` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.some()")}}
 - {{jsxref("Array.prototype.every()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.md
@@ -90,5 +90,5 @@ if (!Uint8Array.prototype.fill) {
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.fill` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.fill` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("Array.prototype.fill()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -122,7 +122,7 @@ new Uint8Array([12, 5, 8, 130, 44]).filter(elem => elem >= 10);
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.filter` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.filter` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.every()")}}
 - {{jsxref("TypedArray.prototype.some()")}}
 - {{jsxref("Array.prototype.filter()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -123,6 +123,6 @@ console.log(uint8.find(isPrime)); // 5
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.find` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.find` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.findIndex()")}}
 - {{jsxref("TypedArray.prototype.every()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -164,6 +164,6 @@ TypedArray.prototype.findIndex = Array.prototype.findIndex = Array.prototype.fin
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.findIndex` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.findIndex` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.find()")}}
 - {{jsxref("TypedArray.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -121,7 +121,7 @@ new Uint8Array([0, 1, 2, 3]).forEach(logArrayElements);
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.forEach` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.forEach` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.map()")}}
 - {{jsxref("TypedArray.prototype.every()")}}
 - {{jsxref("TypedArray.prototype.some()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
@@ -152,7 +152,7 @@ Uint8Array.from({length: 5}, (v, k) => k);
 
 ## See also
 
-- A polyfill of `TypedArray.from` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.from` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.of()")}}
 - {{jsxref("Array.from()")}}
 - {{jsxref("Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.md
@@ -66,7 +66,7 @@ new Float64Array([NaN]).includes(NaN); // true;
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.includes` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.includes` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("Array.prototype.includes()")}}
 - {{jsxref("String.prototype.includes()")}}
 - {{jsxref("TypedArray.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -338,7 +338,7 @@ const i32 = new Int32Array(new ArrayBuffer(4));
 
 ## See also
 
-- A polyfill of typed arrays is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of typed arrays in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.md
@@ -73,6 +73,6 @@ uint8.indexOf(2, -3); // 0
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.indexOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.indexOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.lastIndexOf()")}}
 - {{jsxref("Array.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
@@ -77,6 +77,6 @@ If you need to support truly obsolete JavaScript engines that don't support
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.join` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.join` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("Array.prototype.join()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -66,7 +66,7 @@ console.log(eArr.next().value); // 4
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.keys` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.keys` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
@@ -76,6 +76,6 @@ uint8.lastIndexOf(2, -1); // 3
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.lastIndexOf` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.lastIndexOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.indexOf()")}}
 - {{jsxref("Array.prototype.lastIndexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -130,6 +130,6 @@ const doubles = numbers.map(function(num) {
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.map` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.map` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.filter()")}}
 - {{jsxref("Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -85,6 +85,6 @@ Int16Array.of(undefined);    // Int16Array [ 0 ]
 
 ## See also
 
-- A polyfill of `TypedArray.of` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.of` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.from()")}}
 - {{jsxref("Array.of()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -116,6 +116,6 @@ same polyfill can be used here: replace `Array.prototype.reduce` with
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.reduce` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.reduce` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.reduceRight()")}}
 - {{jsxref("Array.prototype.reduce()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -116,6 +116,6 @@ var total = new Uint8Array([0, 1, 2, 3]).reduceRight(function(a, b) {
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.reduceRight` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.reduceRight` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.reduce()")}}
 - {{jsxref("Array.prototype.reduceRight()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.md
@@ -52,5 +52,5 @@ console.log(uint8); // Uint8Array [3, 2, 1]
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.reverse` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.reverse` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("Array.prototype.reverse()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -70,7 +70,7 @@ console.log(uint8); // Uint8Array [ 0, 0, 0, 1, 2, 3, 0, 0 ]
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.set` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.set` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("ArrayBuffer")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -108,5 +108,5 @@ If you need to support truly obsolete JavaScript engines that don't support
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.slice` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.slice` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("Array.prototype.slice()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -133,6 +133,6 @@ new Uint8Array([12, 5, 8, 1, 4]).some(elem => elem > 10); // true
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.some` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.some` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("TypedArray.prototype.every()")}}
 - {{jsxref("Array.prototype.some()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -78,5 +78,5 @@ numbers.sort((a, b) => a - b); // compare numbers
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.sort` with modern behavior like stable sort is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.sort` with modern behavior like stable sort in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("Array.prototype.sort()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/subarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/subarray/index.md
@@ -79,7 +79,7 @@ console.log(sub);   // Uint8Array [ 1, 2, 3, 0 ]
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.subarray` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.subarray` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("ArrayBuffer")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -107,7 +107,7 @@ iterator.next().value;        //  "n"
 
 ## See also
 
-- A polyfill of `TypedArray.prototype.values` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `TypedArray.prototype.values` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - {{jsxref("Array.prototype.keys()")}}
 - {{jsxref("Array.prototype.entries()")}}
 - {{jsxref("Array.prototype.forEach()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
@@ -140,7 +140,7 @@ var uint16 = new Uint16Array(iterable);
 
 ## See also
 
-- A polyfill of `Uint16Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint16Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -119,7 +119,7 @@ var uint16 = new Uint16Array(iterable);
 
 ## See also
 
-- A polyfill of `Uint16Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint16Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
@@ -139,7 +139,7 @@ var uint32 = new Uint32Array(iterable);
 
 ## See also
 
-- A polyfill of `Uint32Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint32Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -116,7 +116,7 @@ var dv = new Uint32Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Uint32Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint32Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -140,7 +140,7 @@ var uint8 = new Uint8Array(iterable);
 
 ## See also
 
-- A polyfill of `Uint8Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint8Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -114,7 +114,7 @@ var dv = new Uint8Array([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Uint8Array` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint8Array` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -141,7 +141,7 @@ var uintc8 = new Uint8ClampedArray(iterable);
 
 ## See also
 
-- A polyfill of `Uint8ClampedArray` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint8ClampedArray` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -118,7 +118,7 @@ var dv = new Uint8ClampedArray([1, 2, 3]);
 
 ## See also
 
-- A polyfill of `Uint8ClampedArray` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [Polyfill of `Uint8ClampedArray` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/en-us/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/unescape/index.md
@@ -68,7 +68,7 @@ unescape('%u0107');     // "ć"
 
 ## See also
 
-- A polyfill of `unescape` is available in [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Polyfill of `unescape` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("decodeURI")}}
 - {{jsxref("decodeURIComponent")}}
 - {{jsxref("escape")}}

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -126,7 +126,7 @@ class ClearableWeakMap {
 
 ## See also
 
-- A polyfill of `WeakMap` is available in [`core-js`](https://github.com/zloirock/core-js#weakmap)
+- [Polyfill of `WeakMap` in `core-js`](https://github.com/zloirock/core-js#weakmap)
 - [WeakMap object](/en-US/docs/Web/JavaScript/Guide/Keyed_collections#weakmap_object) in the [Keyed collections](/en-US/docs/Web/JavaScript/Guide/Keyed_collections) guide
 - [Hiding Implementation Details with ECMAScript 6 WeakMaps](https://fitzgeraldnick.com/weblog/53/)
 - {{jsxref("Map")}}

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/weakmap/index.md
@@ -70,7 +70,7 @@ wm1.has(o1); // false
 
 ## See also
 
-- A polyfill of `WeakMap` is available in [`core-js`](https://github.com/zloirock/core-js#weakmap)
+- [Polyfill of `WeakMap` in `core-js`](https://github.com/zloirock/core-js#weakmap)
 - [`WeakMap`
   in the JavaScript guide](/en-US/docs/Web/JavaScript/Guide/Keyed_collections#WeakMap_object)
 - [Hiding Implementation Details with

--- a/files/en-us/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/index.md
@@ -109,7 +109,7 @@ Note that `foo !== bar`. While they are similar objects, _they are not **the sam
 
 ## See also
 
-- A polyfill of `WeakSet` is available in [`core-js`](https://github.com/zloirock/core-js#weakset)
+- [Polyfill of `WeakSet` in `core-js`](https://github.com/zloirock/core-js#weakset)
 - {{jsxref("Map")}}
 - {{jsxref("Set")}}
 - {{jsxref("WeakMap")}}

--- a/files/en-us/web/javascript/reference/global_objects/weakset/weakset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/weakset/index.md
@@ -61,5 +61,5 @@ Note that `foo !== bar`. While they are similar objects, _they are not
 
 ## See also
 
-- A polyfill of `WeakSet` is available in [`core-js`](https://github.com/zloirock/core-js#weakset)
+- [Polyfill of `WeakSet` in `core-js`](https://github.com/zloirock/core-js#weakset)
 - {{jsxref("WeakSet")}}


### PR DESCRIPTION
#### Summary
The link text doesn't capture the link description

#### Motivation
Quick

#### Supporting details
1. Thanks @alattalatta for reporting 
2. Used this command followed by manual review 
```bash
grep -lr '\- A polyfill of' files/en-us/ | xargs perl -pn -i -e 's/- A polyfill of (.*) is available in \[`core-js`\](\(.*\))$/- [Polyfill of $1 in `core-js`]$2/'
```
3. I see these warnings below. Are these false?
![image](https://user-images.githubusercontent.com/2392803/152457770-e5a5c3ad-8aed-4feb-bbda-15830e698b4d.png)

#### Related issues
Fixes #10673

#### Metadata
- [x] Fixes a typo, bug, or other error
