### PR TITLE
Clarify CSS path() use in different methods

### DIFF
--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - Web
   - recipe:css-property
@@ -71,7 +70,7 @@ The `clip-path` property is specified as one or a combination of the values list
     - {{cssxref("basic-shape/polygon()","polygon()")}}
       - : Defines a polygon using an SVG fill-rule and a set of vertices.
     - {{cssxref("path()","path()")}}
-      - : Defines a shape using an SVG fill-rule and an SVG path definition.
+      - : Defines a shape using an optional SVG fill-rule and an SVG path definition.
 
 - `<geometry-box>`
 

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -68,9 +68,9 @@ The `clip-path` property is specified as one or a combination of the values list
     - {{cssxref("basic-shape/ellipse()","ellipse()")}}
       - : Defines an ellipse using two radii and a position.
     - {{cssxref("basic-shape/polygon()","polygon()")}}
-      - : Defines a polygon using an SVG fill-rule and a set of vertices.
+      - : Defines a polygon using an SVG filling rule and a set of vertices.
     - {{cssxref("path()","path()")}}
-      - : Defines a shape using an optional SVG fill-rule and an SVG path definition.
+      - : Defines a shape using an optional SVG filling rule and an SVG path definition.
 
 - `<geometry-box>`
 

--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -57,7 +57,7 @@ offset-path: unset;
 
   - : Specifies a [CSS shape](/en-US/docs/Web/CSS/CSS_Shapes/Basic_Shapes) including `circle()`, `ellipse()`, `inset()`, `polygon()`, or `path()`.
 
-    - `path()`
+    - {{cssxref("path()","path()")}}
       - : A path string defined with SVG coordinate syntax.
 
 - `none`
@@ -163,6 +163,7 @@ The top and bottom halves of the scissors would appear in the top left of the ca
 - {{cssxref("offset-distance")}}
 - {{cssxref("offset-rotate")}}
 - [SVG \<path>](/en-US/docs/Web/SVG/Tutorial/Paths)
+- {{cssxref("path()","path()")}}
 
 Other demos:
 

--- a/files/en-us/web/css/path()/index.md
+++ b/files/en-us/web/css/path()/index.md
@@ -28,8 +28,8 @@ path([<'fill-rule'>,]?<string>)
 
 - `<'fill-rule'>`
   - : The filling rule for the interior of the path.
-      Possible values are nonzero or evenodd.
-      The default value is nonzero.
+      Possible values are `nonzero` or `evenodd`.
+      The default value is `nonzero`.
       See [fill-rule](/en-US/docs/Web/SVG/Attribute/fill-rule) for more details.
 - `<string>`
   - : The string is a [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path).

--- a/files/en-us/web/css/path()/index.md
+++ b/files/en-us/web/css/path()/index.md
@@ -10,20 +10,29 @@ browser-compat: css.types.basic-shape.path
 ---
 {{CSSRef}}
 
-The **`path()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) accepts an SVG path string, and is used in CSS Shapes and CSS Motion Path to enable a shape to be drawn.
+The **`path()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) accepts an SVG path string, and is used in [CSS Shapes](/en-US/docs/Web/CSS/CSS_Shapes) and CSS Motion Path to enable a shape to be drawn.
 
 ## Syntax
 
+When used in {{cssxref("offset-path")}} or {{SVGAttr("d")}}:
 ```css
-path( [[<'fill-rule'>,]?<string>)
+path(<string>)
+```
+
+When used in {{cssxref("clip-path")}}:
+```css
+path([<'fill-rule'>,]?<string>)
 ```
 
 ### Parameters
 
 - `<'fill-rule'>`
-  - : The filling rule for the interior of the path. Possible values are nonzero or evenodd. The default value is nonzero. See [fill-rule](/en-US/docs/Web/SVG/Attribute/fill-rule) for more details.
+  - : The filling rule for the interior of the path.
+      Possible values are nonzero or evenodd.
+      The default value is nonzero.
+      See [fill-rule](/en-US/docs/Web/SVG/Attribute/fill-rule) for more details.
 - `<string>`
-  - : The string is a [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path)
+  - : The string is a [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path).
 
 ## Examples
 


### PR DESCRIPTION
This is a follow on to #11597 following engineering feedback in this comment: https://bugzilla.mozilla.org/show_bug.cgi?id=1744599#c6. Essentially `path()` is used slightly differently by offset-path + d and by clip-path. This captures that difference and does some cross linking.