### PR TITLE
Element.scroll event: Fix broken resize event link

### DIFF
--- a/files/en-us/web/api/element/scroll_event/index.md
+++ b/files/en-us/web/api/element/scroll_event/index.md
@@ -70,7 +70,7 @@ window.addEventListener('scroll', function(e) {
 });
 ```
 
-> **Note:** You can find more examples on the {{domxref("Document/resize_event", "resize")}} event page.
+> **Note:** You can find more examples on the {{domxref("Window/resize_event", "resize")}} event page.
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary

The link is broken, update it to the same target as on the document/scroll_event/index.md page, where the same link does work.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
