### PR TITLE
Update code examples index.md

### DIFF
--- a/files/en-us/web/web_components/using_templates_and_slots/index.md
+++ b/files/en-us/web/web_components/using_templates_and_slots/index.md
@@ -50,8 +50,8 @@ customElements.define('my-paragraph',
       let template = document.getElementById('my-paragraph');
       let templateContent = template.content;
 
-      const shadowRoot = this.attachShadow({mode: 'open'})
-        .appendChild(templateContent.cloneNode(true));
+      const shadowRoot = this.attachShadow({mode: 'open'});
+      shadowRoot.appendChild(templateContent.cloneNode(true));
     }
   }
 );
@@ -199,8 +199,8 @@ customElements.define('element-details',
       const template = document
         .getElementById('element-details-template')
         .content;
-      const shadowRoot = this.attachShadow({mode: 'open'})
-        .appendChild(template.cloneNode(true));
+      const shadowRoot = this.attachShadow({mode: 'open'});
+      shadowRoot.appendChild(template.cloneNode(true));
     }
   }
 );


### PR DESCRIPTION
I am sure that the variable name `shadowRoot`  must have result of attachShadow() method which returns ShadowRoot instance, but not result of appendChild() which is Node | DocumentFragment.

This was very confusing, especially when you try to understand something you don`t know


#### Summary
Changed value of `shadowRoot` variable from Node to ShadowRoot

#### Motivation
Allow users to use examples without confusing them

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
