### PR TITLE
FF97 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -512,46 +512,6 @@ The {{cssxref("math-style")}} property indicates whether MathML equations should
   </tbody>
 </table>
 
-### @layer rule and layer() function
-
-The [`@layer`](en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which allows declaration of styles and can be imported via the [`@import`](/en-US/docs/Web/CSS/@import) rule using the `layer()` function. (See {{bug(1699217)}} for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>94</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>94</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>94</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>94</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.cascade-layers.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Property: hyphenate-character
 
 The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break.
@@ -1305,6 +1265,53 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
   </tbody>
 </table>
 
+#### ElementInternals: Form associated custom element methods and properties
+
+New {{domxref("ElementInternals")}} properties and methods that allow a custom elements to interact with a form:
+
+- property: {{domxref("ElementInternals.form","form")}} gets the form associated with the element
+- property: {{domxref("ElementInternals.labels","labels")}} gets the list of labels associated with the element
+- property: {{domxref("ElementInternals.willValidate", "willValidate")}} checks if a custom form element will be validated.
+- method: {{domxref("ElementInternals.setFormValue()","setFormValue()")}} set the sanitized value and user-entered data, if needed.
+
+See these bugs for details: {{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556365)}}, {{bug(1556449)}}.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>95</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>95</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>95</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>95</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.webcomponents.formAssociatedCustomElement.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Payment Request API
 
 #### Primary payment handling
@@ -1696,132 +1703,6 @@ The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP respo
       <th>Preference name</th>
       <td colspan="2">
         <code>privacy.clearsitedata.cache.enabled</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### HTTP Set-Cookie: `SameSite=Lax` by default
-
-HTTP cookies (set using [Set-Cookie](/en-US/docs/Web/HTTP/Headers/Set-Cookie) are assumed to implicitly set `SameSite=Lax` if the [SameSite](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) directive is not specified. Previously the default was `SameSite=None`.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">
-        <code>network.cookie.sameSite.laxByDefault</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### HTTP Set-Cookie: `SameSite=None` require a secure context
-
-HTTP cookies (set using [Set-Cookie](/en-US/docs/Web/HTTP/Headers/Set-Cookie)) that specify the directive [`SameSite=None`](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) require a secure context.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">
-        <code>network.cookie.sameSite.noneRequiresSecure</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### HTTP Set-Cookie: SameSite is schemeful
-
-HTTP cookies sent from the same domain but using different schemes (for example http or https) are now considered to be from different sites with respect to the cookie [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) directive.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>69</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">
-        <code>network.cookie.sameSite.schemeful</code>
       </td>
     </tr>
   </tbody>

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 96 that will affect developers. Firefox 96 was released on January 11, 2022.
+This article provides information about the changes in Firefox 96 that affect developers. Firefox 96 was released on January 11, 2022.
 
 ## Changes for web developers
 
@@ -32,6 +32,11 @@ No notable changes
 ### JavaScript
 
 No notable changes.
+
+### HTTP
+
+- Cookies sent from the same domain but using different schemes (for example http or https) are now considered to be from different sites with respect to the cookie [SameSite](/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) directive.
+  In addition, cookies are assumed to implicitly set `SameSite=Lax` if the `SameSite` attribute is not specified (previously the default was `SameSite=None`), and cookies with `SameSite=None` require a secure context. ({{bug(1617609)}}).
 
 ### APIs
 

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -21,12 +21,18 @@ No notable changes
 
 - The CSS units `cap` and `ic` are now supported for use with {{cssxref("&lt;length&gt;")}} and {{cssxref("&lt;length-percentage&gt;")}} data types.
   For more information see {{bug(1702924)}} and {{bug(1531223)}}
+
 - The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} property are now supported. This allows you to define an [`AnimationTimeline`](/en-US/docs/Web/API/AnimationTimeline), of which time values are determined by scrolling progress within a scroll container and not by minutes or seconds. Once specified, a scroll timeline is associated with a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) by using the `animation-timeline` property.
   For more information see {{bug(1676791)}} and {{bug(1676782)}}
+
 - The CSS property `color-adjust` has been renamed to {{cssxref("print-color-adjust")}} to match the relevant specification.
   The `color-adjust` shorthand name is deprecated.
   See {{bug(747595)}} for details.
-- CSS cascade layers are now available by default. The [`@layer`](en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which allows declaration of styles and can be imported via the [`@import`](/en-US/docs/Web/CSS/@import) rule using the `layer()` function. (See {{bug(1699217)}} for more details.)
+
+- CSS cascade layers are now available by default. The [`@layer`](en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which allows declaration of styles and can be imported via the [`@import`](/en-US/docs/Web/CSS/@import) rule using the `layer()` function. See {{bug(1699217)}} for more details.
+
+- The CSS [`scrollbar-gutter`](/en-US/docs/Web/CSS/scrollbar-gutter) property is now supported. This gives developers control over reserved space for the scrollbar, preventing unwanted layout changes as the content grows.
+  See {{bug(1715112)}} for more details.
 
 
 ### JavaScript

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -76,7 +76,8 @@ This article provides information about the changes in Firefox 97 that will affe
 ### WebDriver conformance (Marionette)
 
 - `Marionette:Quit` accepts a new boolean parameter, `safeMode`, to restart Firefox in safe mode ({{bug(1144075)}}).
-- Improved stability for `WebDriver:NewSession` and `WebDriver:NewWindow` when waiting for the current or initial document to be loaded ({{bug(1739369)}}, {{bug(1747359)}}).
+
+#### Removals
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -7,33 +7,31 @@ tags:
   - Mozilla
   - Release
 ---
-{{FirefoxSidebar}}{{draft}}
+{{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 97 that will affect developers. Firefox 97 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta), and will ship on [February 8, 2022](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 97 that affect developers. Firefox 97 was released on February 8, 2022.
 
 ## Changes for web developers
 
-### Developer Tools
-
 ### HTML
 
-#### Removals
+No notable changes
 
 ### CSS
 
 - The CSS units `cap` and `ic` are now supported for use with {{cssxref("&lt;length&gt;")}} and {{cssxref("&lt;length-percentage&gt;")}} data types.
-  For more information see {{bug(1702924)}} and {{bug(1531223)}}.
+  For more information see {{bug(1702924)}} and {{bug(1531223)}}
 - The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} property are now supported. This allows you to define an [`AnimationTimeline`](/en-US/docs/Web/API/AnimationTimeline), of which time values are determined by scrolling progress within a scroll container and not by minutes or seconds. Once specified, a scroll timeline is associated with a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) by using the `animation-timeline` property.
   For more information see {{bug(1676791)}} and {{bug(1676782)}}
 - The CSS property `color-adjust` has been renamed to {{cssxref("print-color-adjust")}} to match the relevant specification.
   The `color-adjust` shorthand name is deprecated.
   See {{bug(747595)}} for details.
+- CSS cascade layers are now available by default. The [`@layer`](en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which allows declaration of styles and can be imported via the [`@import`](/en-US/docs/Web/CSS/@import) rule using the `layer()` function. (See {{bug(1699217)}} for more details.)
 
-#### Removals
 
 ### JavaScript
 
-#### Removals
+No notable changes
 
 ### SVG
 
@@ -46,15 +44,11 @@ This article provides information about the changes in Firefox 97 that will affe
   This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/docs/Web/API/SVGPathElement), `SVGAnimatedPathData`.
   (See {{bug(1388931)}} for more details.)
 
-### HTTP
-
-#### Removals
-
-### Security
-
-#### Removals
 
 ### APIs
+
+- `AnimationFrameProvider` is now available in a [`DedicatedWorkerGlobalScope`](/en-US/docs/Web/API/DedicatedWorkerGlobalScope). This means the [`requestAnimationFrame`](/en-US/docs/Web/API/window/requestAnimationFrame) and [`cancelAnimationFrame`](/en-US/docs/Web/API/Window/cancelAnimationFrame) methods can be used within a dedicated worker.
+  (See {{bug(1388931)}} for more details.)
 
 #### DOM
 
@@ -65,28 +59,17 @@ This article provides information about the changes in Firefox 97 that will affe
 - The convenience method {{domxref("AbortSignal.throwIfAborted()")}} can be used to check if a signal has been aborted, and if so throw the {{domxref("AbortSignal.reason()")}}.
   This makes it easier for developers to handle abort signals in code where you can't simply pass the signal to an abortable method. ({{bug(1745372)}}).
 
-#### Media, WebRTC, and Web Audio
-
-#### Removals
-
-### WebAssembly
-
-#### Removals
 
 ### WebDriver conformance (Marionette)
 
 - `Marionette:Quit` accepts a new boolean parameter, `safeMode`, to restart Firefox in safe mode ({{bug(1144075)}}).
-
-#### Removals
+- Improved stability for `WebDriver:NewSession` and `WebDriver:NewWindow` when waiting for the current or initial document to be loaded ({{bug(1739369)}}, {{bug(1747359)}}).
 
 ## Changes for add-on developers
 
 - `cookieStoreId` in {{WebExtAPIRef("tabs.query")}} supports an array of strings. This enables queries to match tabs against more than one cookie store ID ({{bug(1730931)}}).
 - `cookieStoreId` added to {{WebExtAPIRef("contentScripts.register")}}. This enables extensions to register container-specific content scripts ({{bug(1470651)}}).
 
-#### Removals
-
-### Other
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{FirefoxSidebar}}{{draft}}
 
-This article provides information about the changes in Firefox 98 that will affect developers. Firefox 98 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly), and will ship on [March 8, 2022](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 98 that will affect developers. Firefox 98 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta), and will ship on [March 8, 2022](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 
 ## Changes for web developers
 
@@ -40,10 +40,6 @@ This article provides information about the changes in Firefox 98 that will affe
 ### APIs
 
 #### DOM
-
-- {{domxref("ElementInternals")}} now has new form-associated custom element methods and properties that allow custom elements to interact with a form.
-  These include the {{domxref("ElementInternals.form","form")}}, {{domxref("ElementInternals.labels","labels")}} and {{domxref("ElementInternals.willValidate", "willValidate")}} properties, and the {{domxref("ElementInternals.setFormValue()","setFormValue()")}} method.
-  ({{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556365)}}, {{bug(1556449)}}).
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -1,0 +1,62 @@
+---
+title: Firefox 99 for developers
+slug: Mozilla/Firefox/Releases/99
+tags:
+  - '99'
+  - Firefox
+  - Mozilla
+  - Release
+---
+{{FirefoxSidebar}}{{draft}}
+
+This article provides information about the changes in Firefox 99 that will affect developers. Firefox 99 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly), and will ship on [April 5, 2022](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+
+## Changes for web developers
+
+### Developer Tools
+
+### HTML
+
+#### Removals
+
+### CSS
+
+#### Removals
+
+### JavaScript
+
+#### Removals
+
+### HTTP
+
+#### Removals
+
+### Security
+
+#### Removals
+
+### APIs
+
+#### DOM
+
+#### Media, WebRTC, and Web Audio
+
+#### Removals
+
+### WebAssembly
+
+#### Removals
+
+### WebDriver conformance (Marionette)
+
+#### Removals
+
+## Changes for add-on developers
+
+#### Removals
+
+### Other
+
+## Older versions
+
+{{Firefox_for_developers(98)}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Release notes for Firefox 97

* Tidies up
* Moves cascade layers from experimental to 97
* Adds animation frame provider
* Adds rel note file for 99
* Moves 98 from beta to release version

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
