### PR TITLE
Fix an incorrect literal in GeolocationCoordinates.heading

### DIFF
--- a/files/en-us/web/api/geolocationcoordinates/heading/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/heading/index.md
@@ -15,7 +15,7 @@ browser-compat: api.GeolocationCoordinates.heading
 The **`GeolocationCoordinates.heading`** read-only property is
 a `double` representing the direction in which the device is traveling. This
 value, specified in degrees, indicates how far off from heading due north the device is.
-`Zero` degrees represents true north, and the direction is determined
+`0` degrees represents true north, and the direction is determined
 clockwise (which means that east is `90` degrees and west is `270`
 degrees). If {{domxref("GeolocationCoordinates.speed")}} is `0`,
 `heading` is


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix an incorrect literal `Zero` in GeolocationCoordinates.heading

#### Motivation
The literal `Zero` is never used, `0` should be used instead.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
