### PR TITLE
Update webidl link from MDN to Firefox Source docs

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -29,7 +29,7 @@ WebIDL can be found in multiple locations:
 
 WebIDL is defined in [its specification](https://heycam.github.io/webidl/). But it has been designed to be extended to convey more information, and browser vendors have done so:
 
-- For Gecko, MDN has the [documentation](/en-US/docs/Mozilla/WebIDL_bindings) of its dialectal WebIDL.
+- For Gecko, Mozilla created the [documentation](https://firefox-source-docs.mozilla.org/dom/webIdlBindings/index.html) of its dialectal WebIDL.
 - For Chromium, Google also created a [document](https://www.chromium.org/blink/webidl) to describe its extensions.
 - For WebCore, Apple also made available a [page](https://trac.webkit.org/wiki/WebKitIDL) for its dialect.
 


### PR DESCRIPTION
Fixes #12728 