### PR TITLE
Change hasOwnProperty to the property accessor

### DIFF
--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -85,7 +85,7 @@ Every object in JavaScript has a built-in property, which is called its **protot
 
 When you try to access a property of an object: if the property can't be found in the object itself, the prototype is searched for the property. If the property still can't be found, then the prototype's prototype is searched, and so on until either the property is found, or the end of the chain is reached, in which case `undefined` is returned.
 
-So when we call `myObject.hasOwnProperty('city')`, the browser:
+So when we call `myObject.city` or `myObject['city']`, the browser:
 
 - looks for `hasOwnProperty` in `myObject`
 - can't find it there, so looks in the prototype object for `myObject`


### PR DESCRIPTION
The example is demonstrating walking prototype chain to resolve a property, not the functionality of `hasOwnProperty`, as currently stated.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
