### PR TITLE
Change some live-sample headings to have better heading text

### DIFF
--- a/files/en-us/web/css/blend-mode/index.md
+++ b/files/en-us/web/css/blend-mode/index.md
@@ -82,7 +82,7 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 
 ## Examples
 
-### normal
+### Example using "normal"
 
 ```html hidden
 <div id="div"></div>
@@ -98,9 +98,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('normal', "300", "350") }}
+{{ EmbedLiveSample('Example using "normal"', "300", "350") }}
 
-### multiply
+### Example using "multiply"
 
 ```html hidden
 <div id="div"></div>
@@ -116,9 +116,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('multiply', "300", "350") }}
+{{ EmbedLiveSample('Example using "multiply"', "300", "350") }}
 
-### screen
+### Example using "screen"
 
 ```html hidden
 <div id="div"></div>
@@ -134,9 +134,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('screen', "300", "350") }}
+{{ EmbedLiveSample('Example using "screen"', "300", "350") }}
 
-### overlay
+### Example using "overlay"
 
 ```html hidden
 <div id="div"></div>
@@ -152,9 +152,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('overlay', "300", "350") }}
+{{ EmbedLiveSample('Example using "overlay"', "300", "350") }}
 
-### darken
+### Example using "darken"
 
 ```html hidden
 <div id="div"></div>
@@ -170,9 +170,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('darken', "300", "350") }}
+{{ EmbedLiveSample('Example using "darken"', "300", "350") }}
 
-### lighten
+### Example using "lighten"
 
 ```html hidden
 <div id="div"></div>
@@ -188,9 +188,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('lighten', "300", "350") }}
+{{ EmbedLiveSample('Example using "lighten"', "300", "350") }}
 
-### color-dodge
+### Example using "color-dodge"
 
 ```html hidden
 <div id="div"></div>
@@ -206,9 +206,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('color-dodge', "300", "350") }}
+{{ EmbedLiveSample('Example using "color-dodge"', "300", "350") }}
 
-### color-burn
+### Example using "color-burn"
 
 ```html hidden
 <div id="div"></div>
@@ -224,9 +224,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('color-burn', "300", "350") }}
+{{ EmbedLiveSample('Example using "color-burn"', "300", "350") }}
 
-### hard-light
+### Example using "hard-light"
 
 ```html hidden
 <div id="div"></div>
@@ -242,9 +242,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('hard-light', "300", "350") }}
+{{ EmbedLiveSample('Example using "hard-light"', "300", "350") }}
 
-### soft-light
+### Example using "soft-light"
 
 ```html hidden
 <div id="div"></div>
@@ -260,9 +260,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('soft-light', "300", "350") }}
+{{ EmbedLiveSample('Example using "soft-light"', "300", "350") }}
 
-### difference
+### Example using "difference"
 
 ```html hidden
 <div id="div"></div>
@@ -278,9 +278,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('difference', "300", "350") }}
+{{ EmbedLiveSample('Example using "difference"', "300", "350") }}
 
-### exclusion
+### Example using "exclusion"
 
 ```html hidden
 <div id="div"></div>
@@ -296,9 +296,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('exclusion', "300", "350") }}
+{{ EmbedLiveSample('Example using "exclusion"', "300", "350") }}
 
-### hue
+### Example using "hue"
 
 ```html hidden
 <div id="div"></div>
@@ -314,9 +314,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('hue', "300", "350") }}
+{{ EmbedLiveSample('Example using "hue"', "300", "350") }}
 
-### saturation
+### Example using "saturation"
 
 ```html hidden
 <div id="div"></div>
@@ -332,9 +332,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('saturation', "300", "350") }}
+{{ EmbedLiveSample('Example using "saturation"', "300", "350") }}
 
-### color
+### Example using "color"
 
 ```html hidden
 <div id="div"></div>
@@ -350,9 +350,9 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('color', "300", "350") }}
+{{ EmbedLiveSample('Example using "color"', "300", "350") }}
 
-### luminosity
+### Example using "luminosity"
 
 ```html hidden
 <div id="div"></div>
@@ -368,11 +368,11 @@ Changes between blend modes are not interpolated. Any change occurs immediately.
 }
 ```
 
-{{ EmbedLiveSample('luminosity', "300", "350") }}
+{{ EmbedLiveSample('Example using "luminosity"', "300", "350") }}
 
 ### Blend mode comparison
 
-In the following example, we have a `<div>` with two background images set on it — a Firefox logo on top of a linear gradient. Below it we have a provided a `<select>` menu that allows you to change the `background-blend-mode` applied to the `<div>`, allowing you to compare the different blend mode effects.
+In the following example, we have a `<div>` with two background images set on it — a Firefox logo on top of a linear gradient. Below it, we have a provided a `<select>` menu that allows you to change the `background-blend-mode` applied to the `<div>`, allowing you to compare the different blend mode effects.
 
 #### HTML
 

--- a/files/en-us/web/css/text-align/index.md
+++ b/files/en-us/web/css/text-align/index.md
@@ -139,7 +139,7 @@ The inconsistent spacing between words created by justified text can be problema
 
 {{EmbedLiveSample("Centered_text","100%","100%")}}
 
-### Justify
+### Example using "justify"
 
 #### HTML
 
@@ -163,7 +163,7 @@ The inconsistent spacing between words created by justified text can be problema
 
 #### Result
 
-{{EmbedLiveSample("Justify","100%","100%")}}
+{{EmbedLiveSample('Example using "justify"',"100%","100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -53,7 +53,7 @@ text-combine-upright: unset;
 
 ## Examples
 
-### Digits
+### Example using "digits"
 
 The digits value requires less markup than the all value when digits are being combined, but it is currently not very widely supported by browsers.
 
@@ -75,9 +75,9 @@ The digits value requires less markup than the all value when digits are being c
 
 #### Results
 
-{{EmbedLiveSample("Digits", 100, 350, "tate-chu-yoko.png")}}
+{{EmbedLiveSample('Example using "digits"', 100, 350, "tate-chu-yoko.png")}}
 
-### All
+### Example using "all"
 
 The all value requires markup around every piece of horizontal text, but it is currently supported by more browsers than the digits value.
 
@@ -98,7 +98,7 @@ html { writing-mode: vertical-rl; font: 24px serif }
 
 #### Results
 
-{{EmbedLiveSample("All", 250, 300, "text-combine-upright-all.png")}}
+{{EmbedLiveSample('Example using "all"', 250, 300, "text-combine-upright-all.png")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/text-transform/index.md
+++ b/files/en-us/web/css/text-transform/index.md
@@ -83,7 +83,7 @@ Large sections of text set with a `text-transform` value of `uppercase` may be d
 
 ## Examples
 
-### `none`
+### Example using "none"
 
 ```html
 <p>Initial String
@@ -103,9 +103,9 @@ strong { float: right; }
 
 This demonstrates no text transformation.
 
-{{ EmbedLiveSample('none', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "none"', '100%', '100px') }}
 
-### capitalize (General)
+### Example using "capitalize" (general)
 
 ```html
 <p>Initial String
@@ -125,9 +125,9 @@ strong { float: right; }
 
 This demonstrates text capitalization.
 
-{{ EmbedLiveSample('capitalize_General', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "capitalize" (general)', '100%', '100px') }}
 
-### capitalize (Punctuation)
+### Example using "capitalize" (punctuation)
 
 ```html
 <p>Initial String
@@ -147,9 +147,9 @@ strong { float: right; }
 
 This demonstrates how initial punctuations of a word are ignored. The keyword target the first letter, that is the first Unicode character part of the Letter or Number general category.
 
-{{ EmbedLiveSample('capitalize_Punctuation', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "capitalize" (punctuation)', '100%', '100px') }}
 
-### capitalize (Symbols)
+### Example using "capitalize" (Symbols)
 
 ```html
 <p>Initial String
@@ -169,9 +169,9 @@ strong { float: right; }
 
 This demonstrates how initial symbols are ignored. The keyword target the first letter, that is the first Unicode character part of the Letter or Number general category.
 
-{{ EmbedLiveSample('capitalize_Symbols', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "capitalize" (symbols)', '100%', '100px') }}
 
-### capitalize (Dutch ij digraph)
+### Example using "capitalize" (Dutch ij digraph)
 
 ```html
 <p>Initial String
@@ -191,9 +191,9 @@ strong { float: right; }
 
 This demonstrates how the Dutch _ij_ digraph must be handled like one single letter.
 
-{{ EmbedLiveSample('capitalize_Dutch_ij_digraph', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "capitalize" (Dutch ij digraph)', '100%', '100px') }}
 
-### uppercase (General)
+### Example using "uppercase" (general)
 
 ```html
 <p>Initial String
@@ -213,9 +213,9 @@ strong { float: right; }
 
 This demonstrates transforming the text to uppercase.
 
-{{ EmbedLiveSample('uppercase_General', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "uppercase" (general)', '100%', '100px') }}
 
-### uppercase (Greek Vowels)
+### Example using "uppercase" (Greek vowels)
 
 ```html
 <p>Initial String
@@ -235,9 +235,9 @@ strong { float: right; }
 
 This demonstrates how Greek vowels except disjunctive _eta_ should have no accent, and the accent on the first vowel of a vowel pair becomes a diaeresis on the second vowel.
 
-{{ EmbedLiveSample('uppercase_Greek_Vowels', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "uppercase" (Greek vowels)', '100%', '100px') }}
 
-### lowercase (General)
+### Example using "lowercase" (general)
 
 ```html
 <p>Initial String
@@ -257,9 +257,9 @@ strong { float: right; }
 
 This demonstrates transforming the text to lowercase.
 
-{{ EmbedLiveSample('lowercase_General', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "lowercase" (general)', '100%', '100px') }}
 
-### lowercase (Greek Σ)
+### Example using "lowercase" (Greek Σ)
 
 ```html
 <p>Initial String
@@ -279,9 +279,9 @@ strong { float: right; }
 
 This demonstrates how the Greek character sigma (`Σ`) is transformed into the regular lowercase sigma (`σ`) or the word-final variant (`ς`), according the context.
 
-{{ EmbedLiveSample('lowercase_Greek_Σ', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "lowercase" (Greek Σ)', '100%', '100px') }}
 
-### lowercase (Lithuanian)
+### Example using "lowercase" (Lithuanian)
 
 ```html
 <p>Initial String
@@ -301,9 +301,9 @@ strong { float: right; }
 
 This demonstrates how the Lithuanian letters `Ĩ` and `J́` retain their dot when transformed to lowercase.
 
-{{ EmbedLiveSample('lowercase_Lithuanian', '100%', '100px') }}
+{{ EmbedLiveSample('Example using "lowercase" (Lithuanian)', '100%', '100px') }}
 
-### full-width (General)
+### Example using "full-width" (general)
 
 ```html
 <p>Initial String
@@ -321,11 +321,11 @@ span {
 strong { width: 100%; float: right; }
 ```
 
-Some characters exists in two formats, normal width and a full-width, with different Unicode code points. The full-width version is used to mix them smoothly with Asian ideographic characters.
+Some characters exist in two formats: normal width and a full-width, with different Unicode code points. The full-width version is used to mix them smoothly with Asian ideographic characters.
 
-{{ EmbedLiveSample('full-width_General', '100%', '175px') }}
+{{ EmbedLiveSample('Example using "full-width" (general)', '100%', '175px') }}
 
-### full-width (Japanese half-width katakana)
+### Example using "full-width" (Japanese half-width katakana)
 
 ```html
 <p>Initial String
@@ -345,9 +345,9 @@ strong { width: 100%; float: right; }
 
 The Japanese half-width katakana was used to represent katakana in 8-bit character codes. Unlike regular (full-width) katakana characters, a letter with dakuten (voiced sound mark) is represented as two code points, the body of letter and dakuten. The `full-width` combines these into a single code point when converting these characters into full-width.
 
-{{ EmbedLiveSample('full-width_Japanese_half-width_katakana', '100%', '175px') }}
+{{ EmbedLiveSample('Example using "full-width" (Japanese half-width katakana)', '100%', '175px') }}
 
-### full-size-kana
+### Example using "full-size-kana"
 
 ```html
 <p>ァィゥェ ォヵㇰヶ ㇱㇲッㇳ ㇴㇵㇶㇷ ㇸㇹㇺャ ュョㇻㇼ ㇽㇾㇿヮ</p>
@@ -361,7 +361,7 @@ p:nth-of-type(2) {
 }
 ```
 
-{{ EmbedLiveSample('full-size-kana', '100%', '175px') }}
+{{ EmbedLiveSample('Example using "full-size-kana"', '100%', '175px') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -89,7 +89,7 @@ p.goldie {
 
 {{EmbedLiveSample('Default_width', '500px', '64px')}}
 
-### Pixels and ems
+### Example using pixels and ems
 
 ```css
 .px_length {
@@ -112,9 +112,9 @@ p.goldie {
 <div class="em_length">Width measured in em</div>
 ```
 
-{{EmbedLiveSample('Pixels_and_ems', '500px', '64px')}}
+{{EmbedLiveSample('Example using pixels and ems', '500px', '64px')}}
 
-### Percentage
+### Example with percentage
 
 ```css
 .percent {
@@ -128,9 +128,9 @@ p.goldie {
 <div class="percent">Width in percentage</div>
 ```
 
-{{EmbedLiveSample('Percentage', '500px', '64px')}}
+{{EmbedLiveSample('Example using percentage', '500px', '64px')}}
 
-### max-content
+### Example using "max-content"
 
 ```css
 p.maxgreen {
@@ -146,9 +146,9 @@ p.maxgreen {
 <p class="maxgreen">The Mozilla community produces a lot of great software.</p>
 ```
 
-{{EmbedLiveSample('max-content', '500px', '64px')}}
+{{EmbedLiveSample('Example using "max-content"', '500px', '64px')}}
 
-### min-content
+### Example using "min-content"
 
 ```css
 p.minblue {
@@ -163,7 +163,7 @@ p.minblue {
 <p class="minblue">The Mozilla community produces a lot of great software.</p>
 ```
 
-{{EmbedLiveSample('min-content', '500px', '155px')}}
+{{EmbedLiveSample('Example using "min-content"', '500px', '155px')}}
 
 ## Specifications
 

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -116,7 +116,7 @@ The HTML specification doesn't define where the baseline of a `<textarea>` is, s
 
 ### Controlling whether a textarea is resizable
 
-In most browsers, `<textarea>`s are resizable — you'll notice the drag handle in the right hand corner, which can be used to alter the size of the element on the page. This is controlled by the {{ cssxref("resize") }} CSS property — resizing is enabled by default, but you can explicitly disable it using a `resize` value of `none`:
+In most browsers, `<textarea>`s are resizable — you'll notice the drag handle in the right-hand corner, which can be used to alter the size of the element on the page. This is controlled by the {{ cssxref("resize") }} CSS property — resizing is enabled by default, but you can explicitly disable it using a `resize` value of `none`:
 
 ```html
 textarea {
@@ -142,7 +142,7 @@ textarea:valid {
 
 ### Basic example
 
-The following example show a very simple textarea, with a set numbers of rows and columns and some default content.
+The following example shows a very simple textarea, with a set numbers of rows and columns and some default content.
 
 ```html
 <textarea name="textarea"
@@ -151,7 +151,7 @@ The following example show a very simple textarea, with a set numbers of rows an
 
 {{ EmbedLiveSample('Basic_example','600','150') }}
 
-### Min and max length
+### Example using "minlength" and "maxlength"
 
 This example has a minimum and maximum number of characters — of 10 and 20 respectively. Try it and see.
 
@@ -161,11 +161,11 @@ This example has a minimum and maximum number of characters — of 10 and 20 res
    minlength="10" maxlength="20">Write something here</textarea>
 ```
 
-{{ EmbedLiveSample('Min_and_max_length','600','80') }}
+{{ EmbedLiveSample('Example using "minlength" and "maxlength"','600','80') }}
 
 Note that `minlength` doesn't stop the user from removing characters so that the number entered goes past the minimum, but it does make the value entered into the `<textarea>` invalid. Also note that even if you have a `minlength` value set (3, for example), an empty `<textarea>` is still considered valid unless you also have the `required` attribute set.
 
-### Placeholder
+### Example using "placeholder"
 
 This example has a placeholder set. Notice how it disappears when you start typing into the box.
 
@@ -175,7 +175,7 @@ This example has a placeholder set. Notice how it disappears when you start typi
    placeholder="Comment text."></textarea>
 ```
 
-{{ EmbedLiveSample('Placeholder','600','80') }}
+{{ EmbedLiveSample('Example using "placeholder"','600','80') }}
 
 > **Note:** Placeholders should only be used to show an example of the type of data that should be entered into a form; they are _not_ a substitute for a proper {{HTMLElement("label")}} element tied to the input. See {{SectionOnPage("/en-US/docs/Web/HTML/Element/input", "Labels and placeholders")}} for a full explanation.
 


### PR DESCRIPTION
This changes takes some headings for examples that have live samples and that are of this form:

> ### multiply

... and changes them to this form:

> ### Example using "multiply"

That ensures those headings get more-descriptive and more-helpful anchors/fragments of the form `foo#example_using_multiply` — and it also ensures that the live-sample behavior for those won’t break after https://github.com/mdn/yari/pull/5190 lands, and all `dt` elements have generated IDs (in which case that `foo#multiply` anchor will take readers to the actual definition for the `multiply` term, rather than to an example).