### PR TITLE
Streams: fix closed getters

### DIFF
--- a/files/en-us/web/api/readablestreambyobreader/closed/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.md
@@ -15,8 +15,8 @@ browser-compat: api.ReadableStreamBYOBReader.closed
 
 The **`closed`** read-only property
 of the {{domxref("ReadableStreamBYOBReader")}} interface returns a
-{{jsxref("Promise")}} that fulfills when the stream closes or the reader's lock
-is released, or rejects if the stream throws an error. This property enables you
+{{jsxref("Promise")}} that fulfills when the stream closes, or rejects if the
+stream throws an error or the reader's lock is released. This property enables you
 to write code that responds to an end to the streaming process.
 
 ## Syntax

--- a/files/en-us/web/api/readablestreambyobreader/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/index.md
@@ -23,7 +23,7 @@ The `ReadableStreamBYOBReader` interface of the [Streams API](/en-US/docs/Web/AP
 ## Properties
 
 - {{domxref("ReadableStreamBYOBReader.closed")}} {{readonlyInline}}
-  - : Returns a {{jsxref("Promise")}} that fulfills when the stream closes or the reader's lock is released, or rejects if the stream throws an error. This property enables you to write code that responds to an end to the streaming process.
+  - : Returns a {{jsxref("Promise")}} that fulfills when the stream closes, or rejects if the stream throws an error or the reader's lock is released. This property enables you to write code that responds to an end to the streaming process.
 
 ## Methods
 

--- a/files/en-us/web/api/readablestreamdefaultreader/closed/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/closed/index.md
@@ -14,8 +14,8 @@ browser-compat: api.ReadableStreamDefaultReader.closed
 
 The **`closed`** read-only property of the
 {{domxref("ReadableStreamDefaultReader")}} interface returns a
-{{jsxref("Promise")}} that fulfills when the stream closes or the reader's lock
-is released, or rejects if the stream throws an error. This property enables you
+{{jsxref("Promise")}} that fulfills when the stream closes, or rejects if the
+stream throws an error or the reader's lock is released. This property enables you
 to write code that responds to an end to the streaming process.
 
 ## Syntax

--- a/files/en-us/web/api/readablestreamdefaultreader/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.md
@@ -22,7 +22,7 @@ The **`ReadableStreamDefaultReader`** interface of the [Streams API](/en-US/docs
 ## Properties
 
 - {{domxref("ReadableStreamDefaultReader.closed")}} {{readonlyInline}}
-  - : Returns a {{jsxref("Promise")}} that fulfills when the stream closes or the reader's lock is released, or rejects if the stream throws an error. This property enables you to write code that responds to an end to the streaming process.
+  - : Returns a {{jsxref("Promise")}} that fulfills when the stream closes, or rejects if the stream throws an error or the reader's lock is released. This property enables you to write code that responds to an end to the streaming process.
 
 ## Methods
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
@@ -15,8 +15,8 @@ browser-compat: api.WritableStreamDefaultWriter.closed
 
 The **`closed`** read-only property of the
 {{domxref("WritableStreamDefaultWriter")}} interface returns a promise that fulfills if
-the stream becomes closed or the writer's lock is released, or rejects if the stream
-errors.
+the stream becomes closed, or rejects if the stream errors or the writer's lock is
+released.
 
 ## Syntax
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
@@ -14,9 +14,9 @@ browser-compat: api.WritableStreamDefaultWriter.closed
 {{SeeCompatTable}}{{APIRef("Streams")}}
 
 The **`closed`** read-only property of the
-{{domxref("WritableStreamDefaultWriter")}} interface returns a promise that fulfills if
-the stream becomes closed, or rejects if the stream errors or the writer's lock is
-released.
+{{domxref("WritableStreamDefaultWriter")}} interface returns a
+{{jsxref("Promise")}} that fulfills if the stream becomes closed, or rejects if
+the stream errors or the writer's lock is released.
 
 ## Syntax
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -23,7 +23,7 @@ The **`WritableStreamDefaultWriter`** interface of the [Streams API](/en-US/docs
 ## Properties
 
 - {{domxref("WritableStreamDefaultWriter.closed")}}{{readonlyinline}}
-  - : Allows you to write code that responds to an end to the streaming process. Returns a promise that fulfills if the stream becomes closed or the writer's lock is released, or rejects if the stream errors.
+  - : Allows you to write code that responds to an end to the streaming process. Returns a promise that fulfills if the stream becomes closed, or rejects if the stream errors or the writer's lock is released.
 - {{domxref("WritableStreamDefaultWriter.desiredSize")}}{{readonlyinline}}
   - : Returns the desired size required to fill the stream's internal queue.
 - {{domxref("WritableStreamDefaultWriter.ready")}}{{readonlyinline}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The documentation for the `closed` getters of `ReadableStreamBYOBReader`, `ReadableStreamDefaultReader` and `WritableStreamDefaultWriter` claim that they *resolve* when the reader/writer's lock is released. In reality, they *reject* when the lock is released.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The current documentation is incorrect, and may give developers the wrong expectation when using these getters.

#### Supporting details
The [official specification for `ReadableStreamDefaultReader`](https://streams.spec.whatwg.org/#default-reader-prototype) says:
> `await reader.closed`
>
> Returns a promise that will be fulfilled when the stream becomes closed, or rejected if the stream ever errors or the reader’s lock is [released](https://streams.spec.whatwg.org/#release-a-lock) before the stream finishes closing.

A similar wording can be found in the specification of [`ReadableStreamBYOBReader`](https://streams.spec.whatwg.org/#byob-reader-prototype) and [`WritableStreamDefaultWriter`](https://streams.spec.whatwg.org/#default-writer-prototype).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
This was initially discovered in https://github.com/nodejs/node/issues/41858#issuecomment-1030651366, as Node's docs contain the same mistake.

The specification itself also had this mistake, but this was fixed in 2018: https://github.com/whatwg/streams/pull/914. It's possible that the MDN docs were written using the (incorrect) specification from before that change.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
