### PR TITLE
fix: function introduction: arguments by reference

### DIFF
--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -46,7 +46,7 @@ The parameters of a function call are the function's _arguments_. Arguments may 
 (in the case of [primitive values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#primitive_values))
 or _by reference_ (in the case of [objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#objects)).
 This means that if a function reassigns a primitive type parameter, the value won't change outside the function. In the case of
-an object type parameter, if it's properties are mutated, the change will impact outside of the function.
+an object type parameter, if its properties are mutated, the change will impact outside of the function.
 See the following example:
 
 ```js

--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -46,7 +46,7 @@ The parameters of a function call are the function's _arguments_. Arguments may 
 (in the case of [primitive values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#primitive_values))
 or _by reference_ (in the case of [objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#objects)).
 This means that if a function reassigns a primitive type parameter, the value won't change outside the function. In the case of
-an object type parameter, if it's reassigned or mutated, the change will impact outside of the function.
+an object type parameter, if it's properties are mutated, the change will impact outside of the function.
 See the following example:
 
 ```js


### PR DESCRIPTION
#### Summary
Fixed the introduction on functions, stating the object property change is visible outside the function (previously, the documentation also suggested that a reassigned argument with be visible outside, which is not true).

#### Motivation
Fixing an inproper explanation what changes to the function arguments do.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
