### PR TITLE
Remove grid- prefixes from *-gap in Glossary/Gutters

### DIFF
--- a/files/en-us/glossary/gutters/index.md
+++ b/files/en-us/glossary/gutters/index.md
@@ -52,7 +52,7 @@ In the example below we have a three-column and two-row track grid, with 20-pixe
 
 In terms of grid sizing, gaps act as if they were a regular grid track however nothing can be placed into the gap. The gap acts as if the grid line at that location has gained extra size, so any grid item placed after that line begins at the end of the gap.
 
-The `*-gap` properties are not the only thing that can cause tracks to space out. Margins, padding or the use of the space distribution properties in [Box Alignment](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout) can all contribute to the visible gap – therefore the `*-gap` properties should not be seen as equal to the "gutter size" unless you know that your design has not introduced any additional space with one of these methods.
+The `row-gap` and `column-gap` properties are not the only things that can cause tracks to space out. Margins, padding, or the use of the space distribution properties in [Box Alignment](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout) can all contribute to the visible gap – therefore the `row-gap` and `column-gap` properties should not be seen as equal to the "gutter size" unless you know that your design has not introduced any additional space with one of these methods.
 
 ## See also
 

--- a/files/en-us/glossary/gutters/index.md
+++ b/files/en-us/glossary/gutters/index.md
@@ -31,7 +31,7 @@ In the example below we have a three-column and two-row track grid, with 20-pixe
 ```css
 .wrapper {
   display: grid;
-  grid-template-columns: repeat(3,1.2fr);
+  grid-template-columns: repeat(3, 1.2fr);
   grid-auto-rows: 45%;
   column-gap: 20px;
   row-gap: 20px;

--- a/files/en-us/glossary/gutters/index.md
+++ b/files/en-us/glossary/gutters/index.md
@@ -33,8 +33,8 @@ In the example below we have a three-column and two-row track grid, with 20-pixe
   display: grid;
   grid-template-columns: repeat(3,1.2fr);
   grid-auto-rows: 45%;
-  grid-column-gap: 20px;
-  grid-row-gap: 20px;
+  column-gap: 20px;
+  row-gap: 20px;
 }
 ```
 
@@ -48,11 +48,11 @@ In the example below we have a three-column and two-row track grid, with 20-pixe
 </div>
 ```
 
-{{ EmbedLiveSample('Example', '300', '280') }}
+{{EmbedLiveSample('Example', '300', '280')}}
 
 In terms of grid sizing, gaps act as if they were a regular grid track however nothing can be placed into the gap. The gap acts as if the grid line at that location has gained extra size, so any grid item placed after that line begins at the end of the gap.
 
-The grid-gap properties are not the only thing that can cause tracks to space out. Margins, padding or the use of the space distribution properties in [Box Alignment](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout) can all contribute to the visible gap – therefore the grid-gap properties should not be seen as equal to “the gutter size” unless you know that your design has not introduced any additional space with one of these methods.
+The `*-gap` properties are not the only thing that can cause tracks to space out. Margins, padding or the use of the space distribution properties in [Box Alignment](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout) can all contribute to the visible gap – therefore the `*-gap` properties should not be seen as equal to the "gutter size" unless you know that your design has not introduced any additional space with one of these methods.
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation

The main purpose of this PR is to remove "obsolete" `grid-` prefixes from `*-gap` properties (e.g. `grid-row-gap` should now be `row-gap`).

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
