### PR TITLE
Add missing </object> end tag in SVG “Getting started” example

### DIFF
--- a/files/en-us/web/svg/tutorial/getting_started/index.md
+++ b/files/en-us/web/svg/tutorial/getting_started/index.md
@@ -52,7 +52,7 @@ The rendering process involves the following:
   - The SVG file can be referenced with an `object` element:
 
     ```html
-    <object data="image.svg" type="image/svg+xml" />
+    <object data="image.svg" type="image/svg+xml"></object>
     ```
 
   - Likewise an `iframe` element can be used:


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12756

The end tag for the `object` element is required in `text/html` documents; self-closing tags don’t work in `text/html`.