### PR TITLE
Fixes #10817: entire -> entirely

### DIFF
--- a/files/en-us/mdn/contribute/where_is_everything/index.md
+++ b/files/en-us/mdn/contribute/where_is_everything/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{MDNSidebar}}
 
-MDN is a complex project with lots of moving parts. Contributing to the site is easy to begin with, if you have a bit of GitHub knowledge and are starting out on some simple typo fixes or code snippet improvements. However, when you start making more significant contributions such as adding entire new pages, you'll notice that there are quite a few bits of the content that aren't stored in the page sources and instead come from somewhere else.
+MDN is a complex project with lots of moving parts. Contributing to the site is easy to begin with if you have a bit of GitHub knowledge and are starting out on some simple typo fixes or code snippet improvements. However, when you start making more significant contributions such as adding entirely new pages, you'll notice that there are quite a few bits of the content that aren't stored in the page sources and instead come from somewhere else.
 
 This article acts as a quick guide to finding the different repos you need to edit to update the different parts of MDN content.
 


### PR DESCRIPTION
#### Summary

> I think there seems to be a missing comma, between the word "easy" and "to"?

Feel free to correct but looks fine to me without it. We are perhaps trying to say - **easy to begin with**

> I think the comma between the word "with" and the dependent clause marker "if" is not necessary.

Perhaps there for a pause in a long sentence but removed.

> I think the adjective "entire", must be "entirely"? because it modifies the adjective "new".

Modified

#### Motivation
Quick

#### Supporting details
Thanks [iamreynatgithub](https://github.com/iamreynatgithub)

#### Related issues
Fixes #10817

#### Metadata
- [x] Fixes a typo, bug, or other error
