### PR TITLE
adds decoder, changes encoder

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -64,11 +64,15 @@ Another possible solution without utilizing the now deprecated 'unescape' and 'e
 
 ```js
 function b64EncodeUnicode(str) {
-    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
-        return String.fromCharCode('0x' + p1);
-    }));
-}
- b64EncodeUnicode('✓ à la mode'); // "4pyTIMOgIGxhIG1vZGU="
+    return btoa(encodeURIComponent(str));
+};
+
+function UnicodeDecodeB64(str) {
+    return decodeURIComponent(atob(str));
+};
+
+b64EncodeUnicode("✓ à la mode"); // "JUUyJTlDJTkzJTIwJUMzJUEwJTIwbGElMjBtb2Rl"
+UnicodeDecodeB64("JUUyJTlDJTkzJTIwJUMzJUEwJTIwbGElMjBtb2Rl"); // "✓ à la mode"
 ```
 
 ### Solution #2 – rewriting `atob()` and `btoa()` using `TypedArray`s and UTF-8


### PR DESCRIPTION
#### Summary
The current encoder didn't have a corresponding decoder. Perhaps a decoder wasn't possible(?). As the encoder removed a % sign in an intermediate step possibly to make it compatible with another decoder.

#### Motivation
quick

#### Supporting details
Thanks [JounQin](https://github.com/JounQin) for reporting

#### Related issues
Fixes #9970

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
