### PR TITLE
Update `Intl.DateTimeFormat` calendars to match supported list

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -51,10 +51,15 @@ new Intl.DateTimeFormat(locales, options)
         "`telu`", "`thai`", "`tibt`".
     - `ca`
       - : Calendar. Possible values include: "`buddhist`",
-        "`chinese`", "`coptic`", "`ethiopia`",
-        "`ethiopic`", "`gregory`", "`hebrew`",
-        "`indian`", "`islamic`", "`iso8601`",
-        "`japanese`", "`persian`", "`roc`".
+        "`chinese`", "`coptic`", "`dangi`", 
+        "`ethioaa`", "`ethiopic`", "`gregory`", 
+        "`hebrew`", "`indian`", "`islamic`", 
+        "`islamic-umalqura`", "`islamic-tbla`", "`islamic-civil`", 
+        "`islamic-rgsa`", "`iso8601`", "`japanese`", 
+        "`persian`", "`roc`", "`islamicc`".
+
+        > **Warning:** The `islamicc` calendar key has been deprecated. Please use `islamic-civil`.
+
     - `hc`
       - : Hour cycle. Possible values include: "`h11`",
         "`h12`", "`h23`", "`h24`".
@@ -93,10 +98,15 @@ new Intl.DateTimeFormat(locales, options)
 
     - `calendar`
       - : Calendar. Possible values include: "`buddhist`",
-        "`chinese`", " `coptic`", "`ethiopia`",
-        "`ethiopic`", "`gregory`", " `hebrew`",
-        "`indian`", "`islamic`", "`iso8601`", "
-        `japanese`", "`persian`", "`roc`".
+        "`chinese`", "`coptic`", "`dangi`", 
+        "`ethioaa`", "`ethiopic`", "`gregory`", 
+        "`hebrew`", "`indian`", "`islamic`", 
+        "`islamic-umalqura`", "`islamic-tbla`", "`islamic-civil`", 
+        "`islamic-rgsa`", "`iso8601`", "`japanese`", 
+        "`persian`", "`roc`", "`islamicc`".
+
+        > **Warning:** The `islamicc` calendar key has been deprecated. Please use `islamic-civil`.
+
     - `dayPeriod`
 
       - : The formatting style used for day periods like "in the morning", "am", "noon", "n" etc. Possible values include:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

This PR corrects the list of supported calendars to match the actual supported calendar list, which is here:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar

Not sure why DateTimeFormat's docs have an incorrect list, but the list in the Locale docs (linked above) is correct. 

Note that in addition to being incomplete, the current content also has a typo: there's no `ethiopia` calendar. The correct name is `ethioaa`, with two a's and no p. This PR fixes this typo too.

#### Motivation

The current list of calendars is inaccurate and inconsistent with other MDN docs. 

#### Supporting details

Here's a repro showing that the list of calendars in this PR is actually supported in the latest versions of Firefox, Chrome, and Safari:

```js
calendars = [
  "buddhist", 
  "chinese", 
  "coptic", 
  "dangi", 
  "ethioaa", 
  "ethiopic", 
  "gregory", 
  "hebrew", 
  "indian", 
  "islamic", 
  "islamic-umalqura", 
  "islamic-tbla", 
  "islamic-civil", 
  "islamic-rgsa", 
  "iso8601", 
  "japanese", 
  "persian", 
  "roc", 
  "islamicc"
];
// using `calendar` option
calendars.forEach(calendar => console.log(`${calendar} option: ${new Intl.DateTimeFormat('en-US', { calendar }).format(new Date())}`));
// using calendar inside locale
calendars.forEach(calendar => console.log(`${calendar} in locale: ${new Intl.DateTimeFormat(`en-US-u-ca-${calendar}`).format(new Date())}`));
```
#### Related issues

mdn/translated-content#4012 (similar typo in French localized docs for `Date.prototype.toLocaleString` / `Date.prototype.toLocaleDateString`)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
