### PR TITLE
fix(svg-element-fetile): self closing tag

### DIFF
--- a/files/en-us/web/svg/element/fetile/index.md
+++ b/files/en-us/web/svg/element/fetile/index.md
@@ -46,7 +46,6 @@ This element implements the {{domxref("SVGFETileElement")}} interface.
     <filter id="tile" x="0" y="0" width="100%" height="100%">
       <feTile in="SourceGraphic" x="50" y="50"
           width="100" height="100" />
-      <feTile/>
     </filter>
   </defs>
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Typo on feTile tags. Is both self closing and explicitely closing.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Despite this does not generate any undesirable behaviour, it's proper notation should be self-closing instead of both.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
