### PR TITLE
FF98 VR API - make sure deprecation headers applied everywhere

### DIFF
--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -3,7 +3,6 @@ title: Gamepad.displayId
 slug: Web/API/Gamepad/displayId
 tags:
   - API
-  - Experimental
   - Gamepad
   - Property
   - Reference
@@ -24,13 +23,7 @@ A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it r
 >
 > There is no direct replacement for this property. The {{domxref("Gamepad")}} object associated with an {{domxref("XRInputSource")}} can be obtained using the {{domxref("XRInputSource.gamepad")}} property.
 
-## Syntax
-
-```js
-const displayId = gamepadInstance.displayId;
-```
-
-### Value
+## Value
 
 A number representing the associated {{domxref("VRDisplay.displayId")}}. If the number is 0, then the gamepad is not associated with a VR display.
 

--- a/files/en-us/web/api/navigator/activevrdisplays/index.md
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.md
@@ -3,7 +3,7 @@ title: Navigator.activeVRDisplays
 slug: Web/API/Navigator/activeVRDisplays
 tags:
   - API
-  - Experimental
+  - Deprecated
   - HTML DOM
   - Navigator
   - Property
@@ -26,7 +26,7 @@ The **`activeVRDisplays`** read-only property of the
 ## Syntax
 
 ```js
-var myActiveDisplays = navigator.activeVRDisplays;
+navigator.activeVRDisplays
 ```
 
 ### Value

--- a/files/en-us/web/api/navigator/getvrdisplays/index.md
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.md
@@ -3,7 +3,7 @@ title: Navigator.getVRDisplays()
 slug: Web/API/Navigator/getVRDisplays
 tags:
   - API
-  - Experimental
+  - Deprecated
   - HTML DOM
   - Media
   - Method

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.cancelAnimationFrame()
 slug: Web/API/VRDisplay/cancelAnimationFrame
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR
@@ -22,12 +22,12 @@ The **`cancelAnimationFrame()`** method of the {{domxref("VRDisplay")}} interfac
 ## Syntax
 
 ```js
-vrDisplayInstance.cancelAnimationFrame(handle);
+cancelAnimationFrame(handle)
 ```
 
 ### Parameters
 
-- handle
+- `handle`
   - : The handle returned by the {{domxref("VRDisplay.requestAnimationFrame()")}} call that you want to unregister.
 
 ### Return value

--- a/files/en-us/web/api/vrdisplay/capabilities/index.md
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.capabilities
 slug: Web/API/VRDisplay/capabilities
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,13 +19,7 @@ The **`capabilities`** read-only property of the {{domxref("VRDisplay")}} interf
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myCapabilities = vrDisplayInstance.capabilities;
-```
-
-### Value
+## Value
 
 A {{domxref("VRDisplayCapabilities")}} object.
 

--- a/files/en-us/web/api/vrdisplay/depthfar/index.md
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.depthFar
 slug: Web/API/VRDisplay/depthFar
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,17 +21,10 @@ The **`depthFar`** property of the {{domxref("VRDisplay")}} interface gets and s
 
 Generally you should leave the value as is, but you might want to reduce it if you are trying to improve performance on slower computers.
 
-## Syntax
+## Value
 
-```js
-var mydepthFar = vrDisplayInstance.depthFar;
-
-vrDisplayInstance.depthFar = 7500.0;
-```
-
-### Value
-
-A double, representing the z-depth in meters; its initial value is `10000.0`.
+A double, representing the z-depth in meters.
+It initial value is `10000.0`.
 
 ## Examples
 

--- a/files/en-us/web/api/vrdisplay/depthnear/index.md
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.depthNear
 slug: Web/API/VRDisplay/depthNear
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,15 +21,7 @@ The **`depthNear`** property of the {{domxref("VRDisplay")}} interface gets and 
 
 Generally you should leave the value as is, but you might want to increase it if you are trying to improve performance on slower computers, and/or your UI makes sense with the near boundary made further away.
 
-## Syntax
-
-```js
-var mydepthNear = vrDisplayInstance.depthNear;
-
-vrDisplayInstance.depthNear = 1.0;
-```
-
-### Value
+## Value
 
 A double, representing the z-depth in meters; its initial value is `0.01`.
 

--- a/files/en-us/web/api/vrdisplay/displayid/index.md
+++ b/files/en-us/web/api/vrdisplay/displayid/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.displayId
 slug: Web/API/VRDisplay/displayId
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,13 +19,7 @@ The **`displayId`** read-only property of the {{domxref("VRDisplay")}} interface
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myDisplayID = vrDisplayInstance.displayId;
-```
-
-### Value
+## Value
 
 A number representing the ID of the specific `VRDisplay`.
 

--- a/files/en-us/web/api/vrdisplay/displayname/index.md
+++ b/files/en-us/web/api/vrdisplay/displayname/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.displayName
 slug: Web/API/VRDisplay/displayName
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`displayName`** read-only property of the {{domxref("VRDisplay")}} interfa
 
 This will generally be something like "Oculus VR HMD (HMD)" or "Oculus VR HMD (Sensor)".
 
-## Syntax
-
-```js
-var myDisplayName = vrDisplayInstance.displayName;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the human-readable name of the specific VR display.
 

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.md
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.exitPresent()
 slug: Web/API/VRDisplay/exitPresent
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.md
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.getEyeParameters()
 slug: Web/API/VRDisplay/getEyeParameters
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Deprecated
   - Method
   - Reference
@@ -28,7 +28,7 @@ getEyeParameters(whichEye)
 
 ### Parameters
 
-- whichEye
+- `whichEye`
   - : A {{domxref("DOMString")}} representing the eye you want to return the eye parameters for. Available values are `left` and `right` (defined in the [VREye enum](https://w3c.github.io/webvr/spec/1.1/#interface-vreye)).
 
 ### Return value

--- a/files/en-us/web/api/vrdisplay/getframedata/index.md
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.getFrameData()
 slug: Web/API/VRDisplay/getFrameData
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR
@@ -24,12 +24,12 @@ This includes the {{domxref("VRPose")}} and view and projection matrices for the
 ## Syntax
 
 ```js
-vrDisplayInstance.getFrameData(frameData);
+getFrameData(frameData)
 ```
 
 ### Parameters
 
-- frameData
+- `frameData`
   - : The {{domxref("VRFrameData")}} object you want to populate.
 
 ### Return value

--- a/files/en-us/web/api/vrdisplay/getimmediatepose/index.md
+++ b/files/en-us/web/api/vrdisplay/getimmediatepose/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.getImmediatePose()
 slug: Web/API/VRDisplay/getImmediatePose
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Deprecated
   - Reference
@@ -14,7 +14,7 @@ tags:
   - getImmediatePose()
 browser-compat: api.VRDisplay.getImmediatePose
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}
 
 The **`getImmediatePose()`** method of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRPose")}} object defining the current pose of the `VRDisplay`, with no prediction applied.
 
@@ -23,7 +23,7 @@ The **`getImmediatePose()`** method of the {{domxref("VRDisplay")}} interface re
 ## Syntax
 
 ```js
-var myImmediatePose = vrDisplayInstance.getImmediatePose();
+getImmediatePose()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplay/getlayers/index.md
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.getLayers()
 slug: Web/API/VRDisplay/getLayers
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Deprecated
   - Method
   - Reference
@@ -23,7 +23,7 @@ The **`getLayers()`** method of the {{domxref("VRDisplay")}} interface returns t
 ## Syntax
 
 ```js
-var myLayers = vrDisplayInstance.getLayers();
+getLayers()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplay/getpose/index.md
+++ b/files/en-us/web/api/vrdisplay/getpose/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRDisplay/getPose
 tags:
   - API
   - Deprecated
-  - Experimental
   - Method
   - Reference
   - VR
@@ -25,7 +24,7 @@ The **`getPose()`** method of the {{domxref("VRDisplay")}} interface returns a {
 ## Syntax
 
 ```js
-var myPose = vrDisplayInstance.getPose();
+getPose()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplay/hardwareunitid/index.md
+++ b/files/en-us/web/api/vrdisplay/hardwareunitid/index.md
@@ -3,7 +3,6 @@ title: VRDisplay.hardwareUnitId
 slug: Web/API/VRDisplay/hardwareUnitId
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -14,19 +13,13 @@ tags:
   - hardwareUnitId
 browser-compat: api.VRDisplay.hardwareUnitId
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{APIRef("WebVR API")}}{{deprecated_header}}
 
 The **`hardwareUnitId`** read-only property of the {{domxref("VRDisplay")}} interface returns the distinct hardware ID for the overall hardware unit that this `VRDevice` is a part of. All devices that are part of the same physical piece of hardware will have the same `hardwareUnitId`.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var hardwareID = VRDevice.hardwareUnitId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the ID of the overall hardware unit.
 

--- a/files/en-us/web/api/vrdisplay/isconnected/index.md
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRDisplay/isConnected
 tags:
   - API
   - Deprecated
-  - Experimental
   - Property
   - Reference
   - VR
@@ -20,13 +19,7 @@ The **`isConnected`** read-only property of the {{domxref("VRDisplay")}} interfa
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var isItConnected = vrDisplayInstance.isConnected;
-```
-
-### Value
+## Value
 
 A boolean value; `true` means the display is connected; `false` means it isn't.
 

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.md
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.isPresenting
 slug: Web/API/VRDisplay/isPresenting
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,13 +19,7 @@ The **`isPresenting`** read-only property of the {{domxref("VRDisplay")}} interf
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var isItPresenting = vrDisplayInstance.isPresenting;
-```
-
-### Value
+## Value
 
 A boolean value; `true` means the display is presenting; `false` means it isn't.
 

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.requestAnimationFrame()
 slug: Web/API/VRDisplay/requestAnimationFrame
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR
@@ -25,12 +25,12 @@ The **`requestAnimationFrame()`** method of the {{domxref("VRDisplay")}} interfa
 ## Syntax
 
 ```js
-var handle = vrDisplayInstance.requestAnimationFrame(callback);
+requestAnimationFrame(callback)
 ```
 
 ### Parameters
 
-- callback
+- `callback`
   - : A callback function that will be called every time a new frame of the `VRDisplay` presentation is rendered.
 
 ### Return value

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.md
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.requestPresent()
 slug: Web/API/VRDisplay/requestPresent
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR

--- a/files/en-us/web/api/vrdisplay/resetpose/index.md
+++ b/files/en-us/web/api/vrdisplay/resetpose/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRDisplay/resetPose
 tags:
   - API
   - Deprecated
-  - Experimental
   - Method
   - Reference
   - VR
@@ -27,7 +26,7 @@ The VRDisplay's reported roll and pitch do not change when `resetPose()` is call
 ## Syntax
 
 ```js
-vrDisplayInstance.resetPose();
+resetPose()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.md
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.md
@@ -3,7 +3,6 @@ title: VRDisplay.stageParameters
 slug: Web/API/VRDisplay/stageParameters
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -20,13 +19,7 @@ The **`stageParameters`** read-only property of the {{domxref("VRDisplay")}} int
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myStageParameters = vrDisplayInstance.stageParameters;
-```
-
-### Value
+## Value
 
 {{domxref("VRStageParameters")}} object containing the `VRDisplay`'s room-scale parameters, or `null` if the `VRDisplay` is not capable of supporting room-scale experiences.
 

--- a/files/en-us/web/api/vrdisplay/submitframe/index.md
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.md
@@ -3,7 +3,7 @@ title: VRDisplay.submitFrame()
 slug: Web/API/VRDisplay/submitFrame
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Method
   - Reference
   - VR
@@ -24,7 +24,7 @@ The frame should subsequently be rendered using the {{domxref("VRPose")}} and ma
 ## Syntax
 
 ```js
-vrDisplayInstance.submitFrame();
+submitFrame()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.md
@@ -3,7 +3,7 @@ title: VRDisplayCapabilities.canPresent
 slug: Web/API/VRDisplayCapabilities/canPresent
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`canPresent`** read-only property of the {{domxref("VRDisplayCapabilities"
 
 This is useful for identifying "magic window" devices that are capable of 6DoF tracking but for which {{domxref("VRDisplay.requestPresent()")}} is not meaningful. If `canPresent` is `false`, calls to {{domxref("VRDisplay.requestPresent()")}} will fail, and {{domxref("VRDisplay.getEyeParameters()")}} will return `null`.
 
-## Syntax
-
-```js
-var canIPresent = vrDisplayCapabilitiesInstance.canPresent;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.md
@@ -3,7 +3,7 @@ title: VRDisplayCapabilities.hasExternalDisplay
 slug: Web/API/VRDisplayCapabilities/hasExternalDisplay
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`hasExternalDisplay`** read-only property of the {{domxref("VRDisplayCapab
 
 > **Note:** If presenting VR content would obscure other content on the device, this will return `false`, in which case the application should not attempt to mirror VR content or update non-VR UI because that content will not be visible.
 
-## Syntax
-
-```js
-var hasAnExternalDisplay = vrDisplayCapabilitiesInstance.hasExternalDisplay;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRDisplayCapabilities/hasOrientation
 tags:
   - API
   - Deprecated
-  - Experimental
   - Property
   - Reference
   - VR
@@ -20,13 +19,7 @@ The **`hasOrientation`** read-only property of the {{domxref("VRDisplayCapabilit
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var hasItGotOrientation = vrDisplayCapabilitiesInstance.hasOrientation;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.md
@@ -3,7 +3,7 @@ title: VRDisplayCapabilities.hasPosition
 slug: Web/API/VRDisplayCapabilities/hasPosition
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,13 +19,7 @@ The **`hasPosition`** read-only property of the {{domxref("VRDisplayCapabilities
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var hasItGotPosition = vrDisplayCapabilitiesInstance.hasPosition;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.md
@@ -3,7 +3,7 @@ title: VRDisplayCapabilities
 slug: Web/API/VRDisplayCapabilities
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Interface
   - Reference
   - VR
@@ -22,15 +22,15 @@ This interface is accessible through the {{domxref("VRDisplay.capabilities")}} p
 
 ## Properties
 
-- {{domxref("VRDisplayCapabilities.canPresent")}} {{readonlyInline}}
+- {{domxref("VRDisplayCapabilities.canPresent")}} {{deprecated_inline}}{{readonlyInline}} 
   - : Returns a boolean value stating whether the VR display is capable of presenting content (e.g. through an HMD).
-- {{domxref("VRDisplayCapabilities.hasExternalDisplay")}} {{readonlyInline}}
+- {{domxref("VRDisplayCapabilities.hasExternalDisplay")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns a boolean value stating whether the VR display is separate from the device's primary display.
-- {{domxref("VRDisplayCapabilities.hasOrientation")}} {{deprecated_inline}} {{readonlyInline}}
+- {{domxref("VRDisplayCapabilities.hasOrientation")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns a boolean value stating whether the VR display can track and return orientation information.
-- {{domxref("VRDisplayCapabilities.hasPosition")}} {{readonlyInline}}
+- {{domxref("VRDisplayCapabilities.hasPosition")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns a boolean value stating whether the VR display can track and return position information.
-- {{domxref("VRDisplayCapabilities.maxLayers")}} {{readonlyInline}}
+- {{domxref("VRDisplayCapabilities.maxLayers")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns a number indicating the maximum number of {{domxref("VRLayerInit")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("VRDisplay.requestPresent()")}} can accept.)
 
 ## Examples

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.md
@@ -3,7 +3,7 @@ title: VRDisplayCapabilities.maxLayers
 slug: Web/API/VRDisplayCapabilities/maxLayers
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,13 +19,7 @@ The **`maxLayers`** read-only property of the {{domxref("VRDisplayCapabilities")
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var maximumLayers = vrDisplayCapabilitiesInstance.maxLayers;
-```
-
-### Value
+## Value
 
 A number, which must be 1 if {{domxref("VRDisplayCapabilities.canPresent")}} is `true`, or 0 otherwise.
 

--- a/files/en-us/web/api/vrdisplayevent/display/index.md
+++ b/files/en-us/web/api/vrdisplayevent/display/index.md
@@ -3,7 +3,6 @@ title: VRDisplayEvent.display
 slug: Web/API/VRDisplayEvent/display
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -20,13 +19,7 @@ The **`display`** read-only property of the {{domxref("VRDisplayEvent")}} interf
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myDisplay = vrDisplayEventInstance.display;
-```
-
-### Value
+## Value
 
 A {{domxref("VRDisplay")}} object.
 

--- a/files/en-us/web/api/vrdisplayevent/index.md
+++ b/files/en-us/web/api/vrdisplayevent/index.md
@@ -3,7 +3,6 @@ title: VRDisplayEvent
 slug: Web/API/VRDisplayEvent
 tags:
   - API
-  - Experimental
   - Deprecated
   - Interface
   - Reference
@@ -21,16 +20,16 @@ The **`VRDisplayEvent`** interface of the [WebVR API](/en-US/docs/Web/API/WebVR_
 
 ## Constructor
 
-- {{domxref("VRDisplayEvent.VRDisplayEvent()")}}
+- {{domxref("VRDisplayEvent.VRDisplayEvent()")}} {{deprecated_inline}}
   - : Creates a `VRDisplayEvent` object instance.
 
 ## Properties
 
 _`VRDisplayEvent` also inherits properties from its parent object, {{domxref("Event")}}._
 
-- {{domxref("VRDisplayEvent.display")}} {{readonlyInline}}
+- {{domxref("VRDisplayEvent.display")}} {{deprecated_inline}}{{readonlyInline}}
   - : The {{domxref("VRDisplay")}} associated with this event.
-- {{domxref("VRDisplayEvent.reason")}} {{readonlyInline}}
+- {{domxref("VRDisplayEvent.reason")}} {{deprecated_inline}}{{readonlyInline}}
   - : A human-readable reason why the event was fired.
 
 ## Examples

--- a/files/en-us/web/api/vrdisplayevent/reason/index.md
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.md
@@ -3,7 +3,7 @@ title: VRDisplayEvent.reason
 slug: Web/API/VRDisplayEvent/reason
 tags:
   - API
-  - Experimental
+
   - Deprecated
   - Property
   - Reference
@@ -20,13 +20,7 @@ The **`reason`** read-only property of the {{domxref("VRDisplayEvent")}} interfa
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myReason = vrDisplayEventInstance.reason;
-```
-
-### Value
+## Value
 
 A string representing the reason why the event was fired. The available reasons are defined in the [`VRDisplayEventReason`](https://w3c.github.io/webvr/spec/1.1/#interface-vrdisplayeventreason) enum, and are as follows:
 

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.md
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.md
@@ -4,7 +4,7 @@ slug: Web/API/VRDisplayEvent/VRDisplayEvent
 tags:
   - API
   - Constructor
-  - Experimental
+  - Deprecated
   - Reference
   - VR
   - VRDisplayEvent

--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.md
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VREyeParameters/fieldOfView
 tags:
   - API
   - Deprecated
-  - Experimental
   - Property
   - Reference
   - VR
@@ -20,13 +19,7 @@ The **`fieldOfView`** read-only property of the {{domxref("VREyeParameters")}} i
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myFOV = eyeParametersInstance.fieldOfView;
-```
-
-### Value
+## Value
 
 A {{domxref("VRFieldOfView")}} object.
 

--- a/files/en-us/web/api/vreyeparameters/index.md
+++ b/files/en-us/web/api/vreyeparameters/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters
 slug: Web/API/VREyeParameters
 tags:
   - API
-  - Experimental
   - Deprecated
   - Landing
   - Reference

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.md
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters.maximumFieldOfView
 slug: Web/API/VREyeParameters/maximumFieldOfView
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -20,13 +19,7 @@ The **`maximumFieldOfView`** read-only property of the {{domxref("VREyeParameter
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var maxFOV = myEyeParameters.maximumFieldOfView;
-```
-
-### Value
+## Value
 
 A {{domxref("VRFieldOfView")}} object.
 

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.md
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.md
@@ -3,7 +3,7 @@ title: VREyeParameters.minimumFieldOfView
 slug: Web/API/VREyeParameters/minimumFieldOfView
 tags:
   - API
-  - Experimental
+
   - Deprecated
   - Property
   - Reference
@@ -20,13 +20,7 @@ The **`minimumFieldOfView`** read-only property of the {{domxref("VREyeParameter
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var minFOV = myEyeParameters.minimumFieldOfView;
-```
-
-### Value
+## Value
 
 A {{domxref("VRFieldOfView")}} object.
 

--- a/files/en-us/web/api/vreyeparameters/offset/index.md
+++ b/files/en-us/web/api/vreyeparameters/offset/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters.offset
 slug: Web/API/VREyeParameters/offset
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -22,13 +21,7 @@ The **`offset`** read-only property of the {{domxref("VREyeParameters")}} interf
 
 This value should represent half the user’s interpupillary distance (IPD), but may also represent the distance from the center point of the headset to the center point of the lens for the given eye.
 
-## Syntax
-
-```js
-var myOffset = eyeParametersInstance.offset;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} representing a vector describing the offset from the center point between the users eyes to the center of the eye in meters.
 

--- a/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.md
+++ b/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters.recommendedFieldOfView
 slug: Web/API/VREyeParameters/recommendedFieldOfView
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -14,19 +13,13 @@ tags:
   - recommendedFieldOfView
 browser-compat: api.VREyeParameters.recommendedFieldOfView
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}
 
 The **`recommendedFieldOfView`** read-only property of the {{domxref("VREyeParameters")}} interface describes the recommended field of view for the current eye — ideally based on user calibration.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var recFOV = myEyeParameters.recommendedFieldOfView;
-```
-
-### Value
+## Value
 
 A {{domxref("VRFieldOfView")}} object.
 

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.md
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters.renderHeight
 slug: Web/API/VREyeParameters/renderHeight
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -22,13 +21,7 @@ The **`renderHeight`** read-only property of the {{domxref("VREyeParameters")}} 
 
 This is already in device pixel units, so there's no need to multiply by [Window.devicePixelRatio](/en-US/docs/Web/API/Window/devicePixelRatio) before setting to [HTMLCanvasElement.height.](/en-US/docs/Web/API/HTMLCanvasElement/height)
 
-## Syntax
-
-```js
-var myRenderHeight = eyeParametersInstance.renderHeight;
-```
-
-### Value
+## Value
 
 A number, representing the height in pixels.
 

--- a/files/en-us/web/api/vreyeparameters/renderrect/index.md
+++ b/files/en-us/web/api/vreyeparameters/renderrect/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters.renderRect
 slug: Web/API/VREyeParameters/renderRect
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -14,19 +13,13 @@ tags:
   - renderRect
 browser-compat: api.VREyeParameters.renderRect
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}
 
 The **`renderRect`** read-only property of the {{domxref("VREyeParameters")}} interface _specifies_ the viewport of a canvas into which visuals for the current eye should be rendered.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myRenderRect = MyEyeParameters.renderRect;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMRect")}} object.
 

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.md
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.md
@@ -3,7 +3,6 @@ title: VREyeParameters.renderWidth
 slug: Web/API/VREyeParameters/renderWidth
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -22,13 +21,7 @@ The **`renderWidth`** read-only property of the {{domxref("VREyeParameters")}} i
 
 This is already in device pixel units, so there's no need to multiply by [Window.devicePixelRatio](/en-US/docs/Web/API/Window/devicePixelRatio) before setting to [HTMLCanvasElement.width.](/en-US/docs/Web/API/HTMLCanvasElement/width)
 
-## Syntax
-
-```js
-var myRenderWidth = eyeParametersInstance.renderWidth;
-```
-
-### Value
+## Value
 
 A number, representing the width in pixels.
 

--- a/files/en-us/web/api/vrframedata/index.md
+++ b/files/en-us/web/api/vrframedata/index.md
@@ -3,7 +3,7 @@ title: VRFrameData
 slug: Web/API/VRFrameData
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Interface
   - Reference
   - VR
@@ -20,22 +20,22 @@ The **`VRFrameData`** interface of the [WebVR API](/en-US/docs/Web/API/WebVR_API
 
 ## Constructor
 
-- {{domxref("VRFrameData.VRFrameData()")}}
+- {{domxref("VRFrameData.VRFrameData()")}} {{deprecated_inline}}
   - : Creates a `VRFrameData` object instance.
 
 ## Properties
 
-- {{domxref("VRFrameData.leftProjectionMatrix")}} {{readonlyInline}}
+- {{domxref("VRFrameData.leftProjectionMatrix")}} {{deprecated_inline}}{{readonlyInline}}
   - : A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.
-- {{domxref("VRFrameData.leftViewMatrix")}} {{readonlyInline}}
+- {{domxref("VRFrameData.leftViewMatrix")}} {{deprecated_inline}}{{readonlyInline}}
   - : A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.
-- {{domxref("VRFrameData.pose")}} {{readonlyInline}}
+- {{domxref("VRFrameData.pose")}} {{deprecated_inline}}{{readonlyInline}}
   - : The {{domxref("VRPose")}} of the {{domxref("VRDisplay")}} at the current {{domxref("VRFrameData.timestamp")}}.
-- {{domxref("VRFrameData.rightProjectionMatrix")}} {{readonlyInline}}
+- {{domxref("VRFrameData.rightProjectionMatrix")}} {{deprecated_inline}}{{readonlyInline}}
   - : A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.
-- {{domxref("VRFrameData.rightViewMatrix")}} {{readonlyInline}}
+- {{domxref("VRFrameData.rightViewMatrix")}} {{deprecated_inline}}{{readonlyInline}}
   - : A {{jsxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.
-- {{domxref("VRFrameData.timestamp")}} {{readonlyInline}}
+- {{domxref("VRFrameData.timestamp")}} {{deprecated_inline}}{{readonlyInline}}
   - : A constantly increasing timestamp value representing the time a frame update occurred.
 
 ## Examples

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.md
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.md
@@ -3,7 +3,7 @@ title: VRFrameData.leftProjectionMatrix
 slug: Web/API/VRFrameData/leftProjectionMatrix
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -25,11 +25,7 @@ This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.
 
 ## Syntax
 
-```js
-var myLPM = vrFrameDataInstance.leftProjectionMatrix;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} object.
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.md
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.md
@@ -3,7 +3,7 @@ title: VRFrameData.leftViewMatrix
 slug: Web/API/VRFrameData/leftViewMatrix
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -23,13 +23,7 @@ This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.
 
 > **Warning:** It is highly recommended that applications use this matrix when rendering.
 
-## Syntax
-
-```js
-var myLVM = vrFrameDataInstance.leftViewMatrix;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} object.
 

--- a/files/en-us/web/api/vrframedata/pose/index.md
+++ b/files/en-us/web/api/vrframedata/pose/index.md
@@ -3,7 +3,7 @@ title: VRFrameData.pose
 slug: Web/API/VRFrameData/pose
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,13 +19,8 @@ The **`pose`** read-only property of the {{domxref("VRFrameData")}} interface re
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
 
-```js
-var myPose = vrFrameDataInstance.pose;
-```
-
-### Value
+## Value
 
 A {{domxref("VRPose")}} object.
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.md
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.md
@@ -3,7 +3,7 @@ title: VRFrameData.rightProjectionMatrix
 slug: Web/API/VRFrameData/rightProjectionMatrix
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -23,13 +23,7 @@ This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.
 
 > **Warning:** It is highly recommended that applications use this matrix without modification. Failure to use this projection matrix when rendering may cause the presented frame to be distorted or badly aligned, resulting in varying degrees of user discomfort.
 
-## Syntax
-
-```js
-var myRPM = vrFrameDataInstance.rightProjectionMatrix;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} object.
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.md
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.md
@@ -3,7 +3,7 @@ title: VRFrameData.rightViewMatrix
 slug: Web/API/VRFrameData/rightViewMatrix
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -23,13 +23,7 @@ This value may be passed directly to WebGL’s {{domxref("WebGLRenderingContext.
 
 > **Warning:** It is highly recommended that applications use this matrix when rendering.
 
-## Syntax
-
-```js
-var myRVM = vrFrameDataInstance.rightViewMatrix;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}} object.
 

--- a/files/en-us/web/api/vrframedata/timestamp/index.md
+++ b/files/en-us/web/api/vrframedata/timestamp/index.md
@@ -3,7 +3,7 @@ title: VRFrameData.timestamp
 slug: Web/API/VRFrameData/timestamp
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -23,13 +23,7 @@ Timestamps are useful for determining if position state data has been updated fr
 
 The timestamp starts at 0 the first time {{domxref("VRDisplay.getFrameData()")}} is invoked for a given {{domxref("VRDisplay")}}.
 
-## Syntax
-
-```js
-var myTimestamp = vrFrameDataInstance.timestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object.
 

--- a/files/en-us/web/api/vrframedata/vrframedata/index.md
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.md
@@ -4,7 +4,7 @@ slug: Web/API/VRFrameData/VRFrameData
 tags:
   - API
   - Constructor
-  - Experimental
+  - Deprecated
   - Reference
   - VR
   - VRFrameData
@@ -21,7 +21,7 @@ The **`VRFrameData()`** constructor creates a {{domxref("VRFrameData")}} object 
 ## Syntax
 
 ```js
-var myFrameData = new VRFrameData();
+new VRFrameData()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrlayerinit/index.md
+++ b/files/en-us/web/api/vrlayerinit/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRLayerInit
 tags:
   - API
   - Dictionary
-  - Experimental
   - Deprecated
   - Interface
   - Reference
@@ -23,11 +22,11 @@ You can retrieve `VRLayerInit` objects using {{domxref("VRDisplay.getLayers()")}
 
 ## Properties
 
-- {{domxref("VRLayerInit.leftBounds")}}
+- {{domxref("VRLayerInit.leftBounds")}} {{deprecated_inline}}
   - : Defines the left texture bounds of the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.
-- {{domxref("VRLayerInit.rightBounds")}}
+- {{domxref("VRLayerInit.rightBounds")}} {{deprecated_inline}}
   - : Defines the right texture bounds of the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.
-- {{domxref("VRLayerInit.source")}}
+- {{domxref("VRLayerInit.source")}} {{deprecated_inline}}
   - : Defines the canvas whose contents will be presented by the {{domxref("VRDisplay")}} when {{domxref("VRDisplay.submitFrame()")}} is called.
 
 ## Examples

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.md
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.md
@@ -3,7 +3,6 @@ title: VRLayerInit.leftBounds
 slug: Web/API/VRLayerInit/leftBounds
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -19,16 +18,9 @@ The **`leftBounds`** property of the {{domxref("VRLayerInit")}} interface (dicti
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
+## Value
 
-```js
-var myVRLayerInit = { };
-myVRLayerInit.leftBounds = [0.0, 0.0, 0.5, 1.0];
-```
-
-### Value
-
-An array of four floating point values, which can take values from 0.0–1.0:
+An array of four floating point values, which can take values from 0.0–1.0.
 
 - The left offset of the bounds.
 - The top offset of the bounds.

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.md
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.md
@@ -3,7 +3,6 @@ title: VRLayerInit.rightBounds
 slug: Web/API/VRLayerInit/rightBounds
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -19,14 +18,7 @@ The **`rightBounds`** property of the {{domxref("VRLayerInit")}} interface (dict
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myVRLayerInit = { };
-myVRLayerInit.rightBounds = [0.5, 0.0, 0.5, 1.0];
-```
-
-### Value
+## Value
 
 An array of four floating point values, which can take values from 0.0–1.0:
 

--- a/files/en-us/web/api/vrlayerinit/source/index.md
+++ b/files/en-us/web/api/vrlayerinit/source/index.md
@@ -3,7 +3,6 @@ title: VRLayerInit.source
 slug: Web/API/VRLayerInit/source
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -19,14 +18,7 @@ The **`source`** property of the {{domxref("VRLayerInit")}} interface (dictionar
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myVRLayerInit = { };
-myVRLayerInit.source = myCanvas;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}} object.
 

--- a/files/en-us/web/api/vrpose/angularacceleration/index.md
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.md
@@ -3,7 +3,7 @@ title: VRPose.angularAcceleration
 slug: Web/API/VRPose/angularAcceleration
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`angularAcceleration`** read-only property of the {{domxref("VRPose")}} in
 
 In other words, the current acceleration of the sensor's rotation around the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myAngularAcceleration = VRPose.angularAcceleration;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide angular acceleration information.
 

--- a/files/en-us/web/api/vrpose/angularvelocity/index.md
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.md
@@ -3,7 +3,7 @@ title: VRPose.angularVelocity
 slug: Web/API/VRPose/angularVelocity
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`angularVelocity`** read-only property of the {{domxref("VRPose")}} interf
 
 In other words, the current velocity at which the sensor is rotating around the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myAngularVelocity = VRPose.angularVelocity;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide angular velocity information.
 

--- a/files/en-us/web/api/vrpose/hasorientation/index.md
+++ b/files/en-us/web/api/vrpose/hasorientation/index.md
@@ -3,7 +3,6 @@ title: VRPose.hasOrientation
 slug: Web/API/VRPose/hasOrientation
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -14,19 +13,13 @@ tags:
   - hasOrientation
 browser-compat: api.VRPose.hasOrientation
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}
 
 The **`hasOrientation`** read-only property of the {{domxref("VRPose")}} interface returns a boolean indicating whether the {{domxref("VRPose.orientation")}} property is valid (i.e. if the hardware is currently registering a valid orientation). If it is `false`, the orientation property will return `null`.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myHasOrientation = VRPositionState.hasOrientation;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/vrpose/hasposition/index.md
+++ b/files/en-us/web/api/vrpose/hasposition/index.md
@@ -3,7 +3,6 @@ title: VRPose.hasPosition
 slug: Web/API/VRPose/hasPosition
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -14,19 +13,13 @@ tags:
   - hasPosition
 browser-compat: api.VRPose.hasPosition
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}
 
 The **`hasPosition`** read-only property of the {{domxref("VRPose")}} interface returns a boolean indicating whether the {{domxref("VRPose.position")}} property is valid (i.e. if the hardware is currently registering a valid position). If it is `false`, the `position` property will return `null`.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myHasPosition = VRPositionState.hasPosition;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/vrpose/index.md
+++ b/files/en-us/web/api/vrpose/index.md
@@ -3,7 +3,7 @@ title: VRPose
 slug: Web/API/VRPose
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Landing
   - Reference
   - VR
@@ -22,22 +22,22 @@ This interface is accessible through the {{domxref("VRDisplay.getPose()")}} and�
 
 ## Properties
 
-- {{domxref("VRPose.position")}} {{readonlyInline}}
+- {{domxref("VRPose.position")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the position of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}} as a 3D vector
-- {{domxref("VRPose.linearVelocity")}} {{readonlyInline}}
+- {{domxref("VRPose.linearVelocity")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the linear velocity of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second.
-- {{domxref("VRPose.linearAcceleration")}} {{readonlyInline}}
+- {{domxref("VRPose.linearAcceleration")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the linear acceleration of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second per second.
-- {{domxref("VRPose.orientation")}} {{readonlyInline}}
+- {{domxref("VRPose.orientation")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the orientation of the sensor at the current {{domxref("VRPose.timestamp")}}, as a quarternion value.
-- {{domxref("VRPose.angularVelocity")}} {{readonlyInline}}
+- {{domxref("VRPose.angularVelocity")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the angular velocity of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in radians per second.
-- {{domxref("VRPose.angularAcceleration")}} {{readonlyInline}}
+- {{domxref("VRPose.angularAcceleration")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the angular acceleration of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second per second.
 
 ### Obsolete properties
 
-- {{domxref("VRPose.timeStamp")}} {{readonlyInline}} {{deprecated_inline}}
+- {{domxref("VRPose.timeStamp")}} {{deprecated_inline}}{{readonlyInline}}
   - : Returns the current time stamp of the system — a monotonically increasing value useful for determining if position data has been updated, and what order updates have occurred in. **This version of `timestamp` has been removed from the spec — instead, timestamps are now returned when {{domxref("VRDisplay.getFrameData()")}} is called — see {{domxref("VRFrameData.timestamp")}}.**
 
 ## Examples

--- a/files/en-us/web/api/vrpose/linearacceleration/index.md
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.md
@@ -3,7 +3,7 @@ title: VRPose.linearAcceleration
 slug: Web/API/VRPose/linearAcceleration
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`linearAcceleration`** read-only property of the {{domxref("VRPose")}} int
 
 In other words, the current acceleration of the sensor, along the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myLinearAcceleration = VRPose.linearAcceleration;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide linear acceleration data.
 

--- a/files/en-us/web/api/vrpose/linearvelocity/index.md
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.md
@@ -3,7 +3,7 @@ title: VRPose.linearVelocity
 slug: Web/API/VRPose/linearVelocity
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -21,13 +21,7 @@ The **`linearVelocity`** read-only property of the {{domxref("VRPose")}} interfa
 
 In other words, the current velocity at which the sensor is moving along the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myLinearVelocity = VRPose.linearVelocity;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide linear velocity data.
 

--- a/files/en-us/web/api/vrpose/orientation/index.md
+++ b/files/en-us/web/api/vrpose/orientation/index.md
@@ -3,7 +3,7 @@ title: VRPose.orientation
 slug: Web/API/VRPose/orientation
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Orientation
   - Property
   - Reference
@@ -28,13 +28,7 @@ The value is a {{jsxref("Float32Array")}}, made up of the following values:
 
 The orientation yaw (rotation around the y axis) is relative to the initial yaw of the sensor when it was first read or the yaw of the sensor at the point that {{domxref("VRDisplay.resetPose()")}} was last called.
 
-## Syntax
-
-```js
-var myOrientation = VRPose.orientation;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide orientation data.
 

--- a/files/en-us/web/api/vrpose/position/index.md
+++ b/files/en-us/web/api/vrpose/position/index.md
@@ -3,7 +3,7 @@ title: VRPose.position
 slug: Web/API/VRPose/position
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Position
   - Property
   - Reference
@@ -29,13 +29,7 @@ Positions are measured in meters from an origin point — this point is either t
 
 > **Note:** By default, all positions are given as a sitting space position. Transforming this point with {{domxref("VRStageParameters.sittingToStandingTransform")}} — when you are working with a room display for example — converts this to a standing space position.
 
-## Syntax
-
-```js
-var myPosition = VRPose.position;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or null if the VR sensor is not able to provide position data.
 

--- a/files/en-us/web/api/vrpose/timestamp/index.md
+++ b/files/en-us/web/api/vrpose/timestamp/index.md
@@ -3,7 +3,6 @@ title: VRPose.timestamp
 slug: Web/API/VRPose/timeStamp
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -14,7 +13,7 @@ tags:
   - timeStamp
 browser-compat: api.VRPose.timestamp
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}
 
 The **`timestamp`** read-only property of the {{domxref("VRPose")}} interface returns the current time stamp of the system — a monotonically increasing value representing the time since the current app was started.
 
@@ -24,13 +23,7 @@ This property is useful for determining if position data has been updated, and w
 
 > **Warning:** This version of `timestamp` has been removed from the spec — instead, timestamps are returned when {{domxref("VRDisplay.getFrameData()")}} is called — see {{domxref("VRFrameData.timestamp")}}.
 
-## Syntax
-
-```js
-var myTimeStamp = VRPose.timestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the timestamp, in seconds.
 

--- a/files/en-us/web/api/vrstageparameters/index.md
+++ b/files/en-us/web/api/vrstageparameters/index.md
@@ -3,7 +3,6 @@ title: VRStageParameters
 slug: Web/API/VRStageParameters
 tags:
   - API
-  - Experimental
   - Deprecated
   - Interface
   - Reference
@@ -23,11 +22,11 @@ This interface is accessible through the {{domxref("VRDisplay.stageParameters")}
 
 ## Properties
 
-- {{domxref("VRStageParameters.sittingToStandingTransform")}} {{readonlyInline}}
+- {{domxref("VRStageParameters.sittingToStandingTransform")}} {{deprecated_inline}}{{readonlyInline}}
   - : Contains a matrix that transforms the sitting-space view matrices of {{domxref("VRFrameData")}} to standing-space.
-- {{domxref("VRStageParameters.sizeX")}} {{readonlyInline}}
+- {{domxref("VRStageParameters.sizeX")}} {{deprecated_inline}}{{readonlyInline}}
   - : *Returns the w*idth of the play-area bounds in meters.
-- {{domxref("VRStageParameters.sizeY")}} {{readonlyInline}}
+- {{domxref("VRStageParameters.sizeY")}} {{deprecated_inline}}{{readonlyInline}}
   - : _Returns the depth_ of the play-area bounds in meters.
 
 ## Examples

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.md
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.md
@@ -3,7 +3,6 @@ title: VRStageParameters.sittingToStandingTransform
 slug: Web/API/VRStageParameters/sittingToStandingTransform
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -22,13 +21,7 @@ The **`sittingToStandingTransform`** read-only property of the {{domxref("VRStag
 
 Basically, this can be passed into your WebGL code to transform the rendered view from a sitting to standing view.
 
-## Syntax
-
-```js
-var myTransform = vrStageParametersInstance.sittingToStandingTransform;
-```
-
-### Value
+## Value
 
 A 16-element {{jsxref("Float32Array")}} containing the components of a 4×4 transform matrix.
 

--- a/files/en-us/web/api/vrstageparameters/sizex/index.md
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.md
@@ -3,7 +3,7 @@ title: VRStageParameters.sizeX
 slug: Web/API/VRStageParameters/sizeX
 tags:
   - API
-  - Experimental
+
   - Deprecated
   - Property
   - Reference
@@ -22,13 +22,7 @@ The **`sizeX`** read-only property of the {{domxref("VRStageParameters")}} inter
 
 The bounds are defined as an axis-aligned rectangle on the floor, for safety purposes. Content should not require the user to move beyond these bounds; however, it is possible for the user to ignore the bounds resulting in position values outside of this rectangle. The center of the rectangle is at (0,0,0) in standing-space coordinates.
 
-## Syntax
-
-```js
-var mySizeX = vrStageParametersInstance.sizeX;
-```
-
-### Value
+## Value
 
 A float representing the width in meters.
 

--- a/files/en-us/web/api/vrstageparameters/sizey/index.md
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.md
@@ -3,7 +3,6 @@ title: VRStageParameters.sizeY
 slug: Web/API/VRStageParameters/sizeY
 tags:
   - API
-  - Experimental
   - Deprecated
   - Property
   - Reference
@@ -22,13 +21,7 @@ The **`sizeY`** read-only property of the {{domxref("VRStageParameters")}} inter
 
 The bounds are defined as an axis-aligned rectangle on the floor, for safety purposes. Content should not require the user to move beyond these bounds; however, it is possible for the user to ignore the bounds resulting in position values outside of this rectangle. The center of the rectangle is at (0,0,0) in standing-space coordinates.
 
-## Syntax
-
-```js
-var mySizeY = vrStageParametersInstance.sizeY;
-```
-
-### Value
+## Value
 
 A float representing the depth in meters.
 

--- a/files/en-us/web/api/window/onvrdisplayactivate/index.md
+++ b/files/en-us/web/api/window/onvrdisplayactivate/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Window/onvrdisplayactivate
 tags:
   - API
   - Event Handler
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR
@@ -19,9 +19,7 @@ browser-compat: api.Window.onvrdisplayactivate
 
 The **`onvrdisplayactivate`** property of the
 {{domxref("Window")}} interface represents an event handler that will run when a display
-is able to be presented to (when the {{event("vrdisplayactivate")}} event fires), for
-example if an HMD has been moved to bring it out of standby, or woken up by being put
-on.
+is able to be presented to (when the {{event("vrdisplayactivate")}} event fires), for example if an HMD has been moved to bring it out of standby, or woken up by being put on.
 
 > **Note:** This event handler was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 

--- a/files/en-us/web/api/window/onvrdisplayblur/index.md
+++ b/files/en-us/web/api/window/onvrdisplayblur/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Window/onvrdisplayblur
 tags:
   - API
   - Event Handler
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/window/onvrdisplayconnect/index.md
+++ b/files/en-us/web/api/window/onvrdisplayconnect/index.md
@@ -3,7 +3,7 @@ title: Window.onvrdisplayconnect
 slug: Web/API/Window/onvrdisplayconnect
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/window/onvrdisplaydeactivate/index.md
+++ b/files/en-us/web/api/window/onvrdisplaydeactivate/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Window/onvrdisplaydeactivate
 tags:
   - API
   - Event Handler
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/window/onvrdisplaydisconnect/index.md
+++ b/files/en-us/web/api/window/onvrdisplaydisconnect/index.md
@@ -3,7 +3,7 @@ title: Window.onvrdisplaydisconnect
 slug: Web/API/Window/onvrdisplaydisconnect
 tags:
   - API
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/window/onvrdisplayfocus/index.md
+++ b/files/en-us/web/api/window/onvrdisplayfocus/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Window/onvrdisplayfocus
 tags:
   - API
   - Event Handler
-  - Experimental
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/window/onvrdisplaypresentchange/index.md
+++ b/files/en-us/web/api/window/onvrdisplaypresentchange/index.md
@@ -3,7 +3,6 @@ title: Window.onvrdisplaypresentchange
 slug: Web/API/Window/onvrdisplaypresentchange
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - VR


### PR DESCRIPTION
Makes sure VR API has correct deprecation tag and header. 
Also fixed up some property syntax sections while here.

This is part of #12582 