### PR TITLE
FF98 WebVR API - release note and experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -983,6 +983,50 @@ With this feature enabled, Firefox supports [JPEG XL](https://jpeg.org/jpegxl/) 
   </tbody>
 </table>
 
+### WebVR API
+
+#### WebVR API (Disabled)
+
+The deprecated [WebVR API](/en-US/docs/Web/API/WebVR_API) is on the path for removal.
+It is disabled by default on all builds {{bug(1750902)}}.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version removed</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.vr.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
+
 ### HTML DOM API
 
 #### HTMLMediaElement method: setSinkId()

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -47,7 +47,11 @@ This article provides information about the changes in Firefox 98 that will affe
 
 #### Media, WebRTC, and Web Audio
 
+
 #### Removals
+
+- The deprecated [WebVR API](/en-US/docs/Web/API/WebVR_API) is now disabled by default on all builds (previously it was enabled on Windows, macOS, and all nightly/dev builds).
+  It can be re-enabled in `about:config` using by setting `dom.vr.enabled` to `true`. {{bug(1750902)}}.
 
 ### WebAssembly
 


### PR DESCRIPTION
This adds release note and experimental features updates to indicate removal of Web VR API (behind preference) from FF98. 

This is part of #12582