### PR TITLE
Adding "unsigned" to message length

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -235,7 +235,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 On the application side, you use standard input to receive messages and standard output to send them.
 
-Each message is serialized using JSON, UTF-8 encoded and is preceded with a 32-bit value containing the message length in native byte order.
+Each message is serialized using JSON, UTF-8 encoded and is preceded with an unsigned 32-bit value containing the message length in native byte order.
 
 The maximum size of a single message from the application is 1 MB. The maximum size of a message sent to the application is 4 GB.
 


### PR DESCRIPTION
This change clarifies that the message length value should be unsigned. While this may be deduced from the overall context and code example, I think stating this explicitly will avoid inadvertent errors from attempting to use a signed variable instead of an unsigned variable.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This changes the native app message description to explicitly state that the length value is unsigned. While this fact may be apparent from the overall context and sample code, I think that explicitly stating this will reduce the likelihood of inadvertently using a signed variable instead of an unsigned one.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

To ensure that it is clear to someone reading the documentation that they should expect an unsigned value for the message length.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

e.g., https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/extensions/api/messaging/native_message_process_host.cc;l=191;drc=bb733b33b305d7bb1eb4b6553e470cc3afc5bf51

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
