### PR TITLE
Fix typos in HTMLInputElement.stepDown()

### DIFF
--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -88,8 +88,7 @@ invoking the `stepDown()` method will return a value that does match the form
 controls constraints.
 
 If the form control is non time, date, or numeric in nature, and therefore does not
-support the `step` attribute (see the list of supported input types in the
-table above), or if the `step` value is set to `any`, an
+support the `step` attribute (see the list of supported input types above), or if the `step` value is set to `any`, an
 `InvalidStateError` exception is thrown.
 
 - {{domxref("HTMLInputElement.stepDown()")}}
@@ -117,14 +116,14 @@ element.stepDown( [ stepDecrement ] );
 
   - : The optional  `stepDecrement` parameter is a numeric value.  If no parameter is passed, _stepDecrement_ defaults to 1.
 
-    If the value is a float, the value will increment as if
+    If the value is a float, the value will decrement as if
     [`Math.floor(stepDecrement)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor)
     was passed. If the value is negative, the value will be incremented instead of
     decremented.
 
 ## Example
 
-Click the button in this example to increment the {{HTMLElement("input/number",
+Click the button in this example to decrement the {{HTMLElement("input/number",
   "number")}} input type:
 
 ### HTML
@@ -136,7 +135,7 @@ Click the button in this example to increment the {{HTMLElement("input/number",
   </label>
 </p>
 <p>
-  <label>Enter how many values of step you would like to increment by or leave it blank:
+  <label>Enter how many values of step you would like to decrement by or leave it blank:
    <input type="number" step="1" id="decrementer" min="-2" max="15">
   </label>
 </p>
@@ -156,7 +155,7 @@ function stepondown() {
   let input = document.getElementById('theNumber');
   let val = document.getElementById('decrementer').value;
 
-  if (val) {  /* increment with a parameter */
+  if (val) {  /* decrement with a parameter */
     input.stepDown(val);
   } else {    /* or without a parameter. Try it with 0, 5, -2, etc. */
     input.stepDown();
@@ -178,9 +177,9 @@ input:invalid {
 
 Note if you don't pass a parameter to the `stepDown()` method, it defaults
 to 1. Any other value is a multiplier of the `step` attribute value, which in
-this case is 5. If we pass 4 as the stepDecrement, the input will stepDown by
-`4 * 5`, or `20`. If the parameter is 0, the number will not be
-decremented. The stepDown() method will not allow the input to go out of range, in this
+this case is 5. If we pass `4` as the _`stepDecrement`_, the input will `stepDown` by
+`4 * 5`, or `20`. If the parameter is `0`, the number will not be
+decremented. The `stepDown()` method will not allow the input to go out of range, in this
 case stopping when it reaches 0 and rounding down and floats that are passed as a
 parameter.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
HTMLInputElement.stepDown() has several problems.
- Some "increment(s)" might be a mistake of "decrement(s)"
- There is no table mentioned in line 91-92
- Mark some literals as \`...\`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
