### PR TITLE
Add `sizes` details to the web app manifest `icons` documentation

### DIFF
--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -43,7 +43,7 @@ The `icons` member specifies an array of objects representing image files that c
   },
   {
     "src": "icon/hd_hi.svg",
-    "sizes": "72x72"
+    "sizes": "any"
   }
 ]
 ```
@@ -62,7 +62,11 @@ Image objects may contain the following values:
   <tbody>
     <tr>
       <td><code>sizes</code></td>
-      <td>A string containing space-separated image dimensions.</td>
+      <td>
+        A string containing space-separated image dimensions using the same syntax as the
+        {{ htmlattrxref("link", "sizes") }}
+        attribute.
+      </td>
     </tr>
     <tr>
       <td><code>src</code></td>

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -64,7 +64,7 @@ Image objects may contain the following values:
       <td><code>sizes</code></td>
       <td>
         A string containing space-separated image dimensions using the same syntax as the
-        {{ htmlattrxref("link", "sizes") }}
+        {{ htmlattrxref("sizes", "link") }}
         attribute.
       </td>
     </tr>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add `any` to the SVG `sizes` example and link to more in-depth `sizes` definition.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was trying to find the correct `sizes` value for an manifest SVG icon, and found MDN didn't have the correct information.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
After looking at [the web manifest `icons` documentation](https://w3c.github.io/manifest/#icons-member), I found what I suspected that it uses a standard [image resource](https://www.w3.org/TR/image-resource/#dfn-image-resource) that links to [the `link`s `sizes` attribute definition](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes).
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
