### PR TITLE
FF98 Relnote - move createImageBitmap() note from Javascript to WebAPI

### DIFF
--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -25,8 +25,6 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ### JavaScript
 
-- The properties `colorSpaceConversion`, `resizeWidth` and `resizeHeight` can be passed to the method {{domxref("createImageBitmap()")}} using the `options` object ({{bug(1748868)}} and {{bug(1733559)}}).
-
 #### Removals
 
 ### HTTP
@@ -40,6 +38,9 @@ This article provides information about the changes in Firefox 98 that will affe
 ### APIs
 
 #### DOM
+
+- The properties `colorSpaceConversion`, `resizeWidth` and `resizeHeight` can be passed to the method {{domxref("createImageBitmap()")}} using the `options` object ({{bug(1748868)}} and {{bug(1733559)}}).
+
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
A release note was already added for https://bugzilla.mozilla.org/show_bug.cgi?id=1748868 and https://bugzilla.mozilla.org/show_bug.cgi?id=1733559 in #12388 :-)

This just moves it to webAPI section, because it is not AFAIK part of Javascript language