### PR TITLE
Fix a property name in the See also section

### DIFF
--- a/files/en-us/web/css/offset-anchor/index.md
+++ b/files/en-us/web/css/offset-anchor/index.md
@@ -143,5 +143,5 @@ section {
 
 - {{cssxref("offset")}}
 - {{cssxref("offset-distance")}}
-- {{cssxref("offset-rotation")}}
+- {{cssxref("offset-rotate")}}
 - [SVG `<path>`](/en-US/docs/Web/SVG/Tutorial/Paths)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix a property name in the See also section. "offset-rotation" should be "offset-rotate".

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
