### PR TITLE
showPicker: Change from date to color picker

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -39,25 +39,25 @@ element.showPicker();
 
 ## Example
 
-Click the button in this example to show a file picker.
+Click the button in this example to show a color picker.
 
 ### HTML
 
 ```html
-<input type="file">
-<button>Show the file picker</button>
+<input type="color">
+<button>Show the color picker</button>
 ```
 
 ### JavaScript
 
 ```js
 const button = document.querySelector("button");
-const fileInput = document.querySelector("input");
+const colorInput = document.querySelector("input");
 
 button.addEventListener("click", () => {
   try {
-    fileInput.showPicker();
-    // A date picker is shown.
+    colorInput.showPicker();
+    // A color picker is shown.
   } catch (error) {
     window.alert(error);
     // Use external library when this fails.

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -39,24 +39,24 @@ element.showPicker();
 
 ## Example
 
-Click the button in this example to show a browser date picker.
+Click the button in this example to show a file picker.
 
 ### HTML
 
 ```html
-<input type="date">
-<button>Show the date picker</button>
+<input type="file">
+<button>Show the file picker</button>
 ```
 
 ### JavaScript
 
 ```js
 const button = document.querySelector("button");
-const dateInput = document.querySelector("input");
+const fileInput = document.querySelector("input");
 
 button.addEventListener("click", () => {
   try {
-    dateInput.showPicker();
+    fileInput.showPicker();
     // A date picker is shown.
   } catch (error) {
     window.alert(error);


### PR DESCRIPTION
#### Summary
Changed example from date to color picker.

#### Motivation
The example is meant to use inside MDN which is delivered in an cross-origin iframe right now.

The spec says:
> If this's relevant settings object's origin is not same origin with this's relevant settings object's top-level origin, and this's type attribute is not in the File Upload state or Color state, then throw a "SecurityError" DOMException.

So the example will **never** work in the live example which makes it a bad live example. Tested with Chrome Canary.

#### Supporting details
https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
