### PR TITLE
Updates for Values in the CSS height

### DIFF
--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -56,8 +56,10 @@ height: unset;
   - : The intrinsic preferred height.
 - `min-content`
   - : The intrinsic minimum height.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
-  - : Uses the fit-content formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, <length-percentage>))`.
+- `fit-content`
+  - : Box will use the available space, but never more than `max-content`
+- {{cssxref("&lt;clamp()&gt;")}}
+  - : Enables selecting a middle value within a range of values between a defined minimum and maximum
 
 ## Accessibility concerns
 

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -58,7 +58,7 @@ height: unset;
   - : The intrinsic minimum height.
 - `fit-content`
   - : Box will use the available space, but never more than `max-content`
-- {{cssxref("&lt;clamp()&gt;")}}
+- {{cssxref("clamp()")}}
   - : Enables selecting a middle value within a range of values between a defined minimum and maximum
 
 ## Accessibility concerns

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -58,6 +58,8 @@ height: unset;
   - : The intrinsic minimum height.
 - `fit-content`
   - : Box will use the available space, but never more than `max-content`
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
+  - : Uses the fit-content formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, <length-percentage>))`
 - {{cssxref("clamp()")}}
   - : Enables selecting a middle value within a range of values between a defined minimum and maximum
 


### PR DESCRIPTION
#### Summary
Removed misleading part where it looks like you can use `fit-content` function as a value.
Add adding `clamp()` function although not sure if it would format correct link to the docs.

#### Motivation
It was misleading and hard to understand why I can't use `fit-content()`

#### Supporting details

https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()
https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content
https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content()

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
