### PR TITLE
Correcting grammar in the comments section

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -733,7 +733,7 @@ To write an HTML comment, wrap it in the special markers `<!--` and `-->`. For e
 <!-- <p>I am!</p> -->
 ```
 
-As you can see below, only the first paragraph displays in the live output.
+As you can see below, only the first paragraph is displayed in the live output.
 
 {{ EmbedLiveSample('HTML_comments', 700, 100, "", "") }}
 


### PR DESCRIPTION

#### Summary
Changing the incorrect usage from `only the first paragraph displays` to `only the first paragraph is displayed`

#### Motivation
The changes correct the grammar.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


