### PR TITLE
Add small missing space

### DIFF
--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -31,7 +31,7 @@ For users, the experience of a seemingly-native PWA is more comfortable and conv
 
 ## What browsers support installation?
 
-Installation is supported by Chrome for Android and Android WebView version 31 and later, Opera for Android 32 onward, Samsung Internet from version 4 onward, and Firefox for Android[version 58](/en-US/docs/Mozilla/Firefox/Releases/58) and later.
+Installation is supported by Chrome for Android and Android WebView version 31 and later, Opera for Android 32 onward, Samsung Internet from version 4 onward, and Firefox for Android [version 58](/en-US/docs/Mozilla/Firefox/Releases/58) and later.
 
 Safari on iOS is a little different. Some parts of the PWA ecosystem are supported, while others are not. iOS 13 introduced a much more comparable install experience, which is also described here.
 


### PR DESCRIPTION
#### Summary
I found 2 words that didn't have a space between them. It seemed like they were supposed to, so I added that :)

#### Motivation
Just makes it easier to read.

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error