### PR TITLE
Improve .map examples: syntax and consistency

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -121,10 +121,9 @@ The following code takes an array of numbers and creates a new array containing 
 square roots of the numbers in the first array.
 
 ```js
-let numbers = [1, 4, 9]
-let roots = numbers.map(function(num) {
-    return Math.sqrt(num)
-})
+const numbers = [1, 4, 9];
+const roots = numbers.map((num) => Math.sqrt(num));
+
 // roots is now     [1, 2, 3]
 // numbers is still [1, 4, 9]
 ```
@@ -135,15 +134,12 @@ The following code takes an array of objects and creates a new array containing 
 newly reformatted objects.
 
 ```js
-let kvArray = [{key: 1, value: 10},
-               {key: 2, value: 20},
-               {key: 3, value: 30}]
+const kvArray = [{ key: 1, value: 10 },
+                 { key: 2, value: 20 },
+                 { key: 3, value: 30 }];
 
-let reformattedArray = kvArray.map(obj => {
-   let rObj = {}
-   rObj[obj.key] = obj.value
-   return rObj
-})
+const reformattedArray = kvArray.map(({ key, value}) => ({ [key]: value }));
+
 // reformattedArray is now [{1: 10}, {2: 20}, {3: 30}],
 
 // kvArray is still:
@@ -159,10 +155,8 @@ argument is used with it. The argument will automatically be assigned from each 
 of the array as `map` loops through the original array.
 
 ```js
-let numbers = [1, 4, 9]
-let doubles = numbers.map(function(num) {
-  return num * 2
-})
+const numbers = [1, 4, 9];
+const doubles = numbers.map((num) => num * 2);
 
 // doubles is now   [2, 8, 18]
 // numbers is still [1, 4, 9]
@@ -174,11 +168,10 @@ This example shows how to use map on a {{jsxref("String")}} to get an array of b
 the ASCII encoding representing the character values:
 
 ```js
-let map = Array.prototype.map
-let a = map.call('Hello World', function(x) {
-  return x.charCodeAt(0)
-})
-// a now equals [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]
+const map = Array.prototype.map;
+const charCodes = map.call('Hello World', (x) => x.charCodeAt(0));
+
+// charCodes now equals [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]
 ```
 
 ### Using map generically querySelectorAll
@@ -190,10 +183,8 @@ This example shows how to iterate through a collection of objects collected by
 In this case, we return all the selected `option`s' values on the screen:
 
 ```js
-let elems = document.querySelectorAll('select option:checked')
-let values = Array.prototype.map.call(elems, function(obj) {
-  return obj.value
-})
+const elems = document.querySelectorAll('select option:checked');
+const values = Array.prototype.map.call(elems, ({ value }) => value);
 ```
 
 An easier way would be the {{jsxref("Array.from()")}} method.
@@ -209,7 +200,7 @@ additional optional arguments. These habits may lead to confusing behaviors.
 Consider:
 
 ```js
-["1", "2", "3"].map(parseInt)
+['1', '2', '3'].map(parseInt);
 ```
 
 While one might expect `[1, 2, 3]`, the actual result is
@@ -230,44 +221,41 @@ Here is a concise example of the iteration steps:
 
 ```js
 // parseInt(string, radix) -> map(parseInt(value, index))
-/*  first iteration  (index is 0): */ parseInt("1", 0)  // 1
-/*  second iteration (index is 1): */ parseInt("2", 1)  // NaN
-/*  third iteration  (index is 2): */ parseInt("3", 2)  // NaN
+/*  first iteration  (index is 0): */ parseInt("1", 0);  // 1
+/*  second iteration (index is 1): */ parseInt("2", 1);  // NaN
+/*  third iteration  (index is 2): */ parseInt("3", 2);  // NaN
 ```
 
 Then let's talk about solutions.
 
 ```js
-function returnInt(element) {
-  return parseInt(element, 10)
-}
+const returnInt = (element) => parseInt(element, 10);
 
 ['1', '2', '3'].map(returnInt); // [1, 2, 3]
 // Actual result is an array of numbers (as expected)
 
 // Same as above, but using the concise arrow function syntax
-['1', '2', '3'].map( str => parseInt(str) )
+['1', '2', '3'].map((str) => parseInt(str)); // [1, 2, 3]
 
 // A simpler way to achieve the above, while avoiding the "gotcha":
-['1', '2', '3'].map(Number)  // [1, 2, 3]
+['1', '2', '3'].map(Number); // [1, 2, 3]
 
 // But unlike parseInt(), Number() will also return a float or (resolved) exponential notation:
-['1.1', '2.2e2', '3e300'].map(Number)  // [1.1, 220, 3e+300]
+['1.1', '2.2e2', '3e300'].map(Number); // [1.1, 220, 3e+300]
 
 // For comparison, if we use parseInt() on the array above:
-['1.1', '2.2e2', '3e300'].map( str => parseInt(str) ) // [1, 2, 3]
+['1.1', '2.2e2', '3e300'].map((str) => parseInt(str)); // [1, 2, 3]
 ```
 
 One alternative output of the map method being called with {{jsxref("parseInt")}} as a
 parameter runs as follows:
 
 ```js
-let xs = ['10', '10', '10']
+const strings = ['10', '10', '10'];
+const numbers = strings.map(parseInt);
 
-xs = xs.map(parseInt)
-
-console.log(xs)
-// Actual result of 10,NaN,2 may be unexpected based on the above description.
+console.log(numbers);
+// Actual result of [10, NaN, 2] may be unexpected based on the above description.
 ```
 
 ### Mapped array contains undefined
@@ -275,12 +263,13 @@ console.log(xs)
 When {{jsxref("undefined")}} or nothing is returned:
 
 ```js
-let numbers = [1, 2, 3, 4]
-let filteredNumbers = numbers.map(function(num, index) {
+const numbers = [1, 2, 3, 4];
+const filteredNumbers = numbers.map((num, index) => {
   if (index < 3) {
-     return num
+    return num;
   }
-})
+});
+
 // index goes from 0, so the filterNumbers are 1,2,3 and undefined.
 // filteredNumbers is [1, 2, 3, undefined]
 // numbers is still [1, 2, 3, 4]


### PR DESCRIPTION
### **Summary**

- Change `let` to `const` where possible
- Use one-line arrow functions is possible
- Improve code indentation and alignment, fix other style consistency issues

### **Motivation**

Improving code examples.

### **Metadata**

- [ ]  Adds a new document
- [ ]  Rewrites (or significantly expands) a document
- [x]  Fixes a typo, bug, or other error