### PR TITLE
Fix link in “HTML guidelines” project docs

### DIFF
--- a/files/en-us/mdn/guidelines/code_guidelines/html/index.md
+++ b/files/en-us/mdn/guidelines/code_guidelines/html/index.md
@@ -71,7 +71,7 @@ Finally, you should always add the viewport meta tag into your HTML {{HTMLElemen
 <meta name="viewport" content="width=device-width">
 ```
 
-See [Using the viewport meta tag to control layout on mobile browsers](/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) for further details.
+See [Using the viewport meta tag to control layout on mobile browsers](/en-US/docs/Web/HTML/Viewport_meta_tag) for further details.
 
 ## General markup coding style
 


### PR DESCRIPTION

#### Summary
Set a new correct URL for "Using the viewport meta tag to control layout on mobile browsers" in this section https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Code_guidelines/HTML#viewport_meta_tag

#### Motivation
Fix broken link


#### Related issues
Fixes #12844

