### PR TITLE
Added the order information when using 2 syntax value for background …

### DIFF
--- a/files/en-us/web/css/background-position/index.md
+++ b/files/en-us/web/css/background-position/index.md
@@ -9,6 +9,7 @@ tags:
   - recipe:css-property
 browser-compat: css.properties.background-position
 ---
+
 {{CSSRef}}
 
 The **`background-position`** [CSS](/en-US/docs/Web/CSS) property sets the initial position for each background image. The position is relative to the position layer set by {{cssxref("background-origin")}}.
@@ -68,7 +69,8 @@ The `background-position` property is specified as one or more `<position>` valu
     - One of the keyword values `top`, `left`, `bottom`, `right`. If `left` or `right` are given here, then this defines X and the other given value defines Y. If `top` or `bottom` are given, then this defines Y and the other value defines X.
     - A {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}}. If the other value is `left` or `right`, then this value defines Y, relative to the top edge. If the other value is `top` or `bottom`, then this value defines X, relative to the left edge. If both values are `<length>` or `<percentage>` values, then the first defines X and the second Y.
     - Note that: If one value is `top` or `bottom`, then the other value may not be `top` or `bottom`. If one value is `left` or `right`, then the other value may not be `left` or `right`. This means, e.g., that `top top` and `left right` are not valid.
-    - The default value is `top left` or `0% 0%`.
+    - Order: when pairing keywords, placement is not important as the browser can reorder it, the value `top left` or `left top` will yield the same result. With pairing {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} with a keyword the placement is important, the value defining X should come first followed by Y, the value `right 20px` is not the same as `20px right` the former is valid but the latter is invalid. The value `left 20%` or `20% bottom` is valid as X and Y values are clearly defined and the placement is right.
+    - The default value is `left top` or `0% 0%`.
 
     **3-value syntax:** Two values are keyword values, and the third is the offset for the preceding value:
 
@@ -145,7 +147,7 @@ Each of these three examples uses the {{cssxref("background")}} property to crea
 ```css
 /* Shared among all <div>s */
 div {
-  background-color: #FFEE99;
+  background-color: #ffee99;
   background-repeat: no-repeat;
   width: 300px;
   height: 80px;
@@ -154,19 +156,17 @@ div {
 
 /* These examples use the `background` shorthand property */
 .exampleone {
-  background: url("startransparent.gif") #FFEE99 2.5cm bottom no-repeat;
+  background: url("startransparent.gif") #ffee99 2.5cm bottom no-repeat;
 }
 .exampletwo {
-  background: url("startransparent.gif") #FFEE99 left 4em bottom 1em no-repeat;
+  background: url("startransparent.gif") #ffee99 left 4em bottom 1em no-repeat;
 }
 
 /* Multiple background images: Each image is matched with the
    corresponding position, from first specified to last. */
 .examplethree {
-  background-image:    url("startransparent.gif"),
-                       url("catfront.png");
-  background-position: 0px 0px,
-                       right 3em bottom 2em;
+  background-image: url("startransparent.gif"), url("catfront.png");
+  background-position: 0px 0px, right 3em bottom 2em;
 }
 ```
 
@@ -186,7 +186,5 @@ div {
 
 - {{cssxref("background-position-x")}}
 - {{cssxref("background-position-y")}}
-- {{cssxref("background-position-inline")}}
-- {{cssxref("background-position-block")}}
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
 - {{cssxref("transform-origin")}}


### PR DESCRIPTION
Added more information in regards to the order of pairing values either keyword or a keyword and length in the context of the 2-syntax-value for background position.

This is a fix for  #12008

#### Supporting details
[W3C Candidate Recommendation Draft, 26 July 2021](https://drafts.csswg.org/css-backgrounds/#propdef-background-position)

#### Metadata
- [x] Adds an explanation to the document
