### PR TITLE
Example for handling break or return in iterable 

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -51,6 +51,9 @@ const asyncIterable = {
         }
 
         return Promise.resolve({ done: true });
+      },
+      return() {
+        // return will be called if the consumer called `break` or `return` early in the loop.
       }
     };
   }

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -54,6 +54,7 @@ const asyncIterable = {
       },
       return() {
         // return will be called if the consumer called `break` or `return` early in the loop.
+        return { done: true }
       }
     };
   }

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -53,7 +53,7 @@ const asyncIterable = {
         return Promise.resolve({ done: true });
       },
       return() {
-        // return will be called if the consumer called `break` or `return` early in the loop.
+        // return will be called if the consumer called 'break' or 'return' early in the loop.
         return { done: true }
       }
     };

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -53,7 +53,7 @@ const asyncIterable = {
         return Promise.resolve({ done: true });
       },
       return() {
-        // return will be called if the consumer called 'break' or 'return' early in the loop.
+        // This will be reached if the consumer called 'break' or 'return' early in the loop.
         return { done: true }
       }
     };


### PR DESCRIPTION
#### Summary
Changed the example of the explicitly implemented async iterable protocol to include the return() method, so that it's showed how to handle if a consumer `break`s or `return`s early when iterating.

#### Motivation
I spent a lot of time trying to figure out how to do this when implementing an async iterator in my [Postgres.js](https://github.com/porsager/postgres) library. It was nowhere to be found on mdn, so thought at least a little addition to the code example could help others, until a more thorough description is made.

#### Supporting details
I found the solution by looking at other code where this was implemented. Can't find it currently.

This PR…
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error