### PR TITLE
Error in a comment of Date»setDate

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/setdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setdate/index.md
@@ -54,9 +54,9 @@ const theBigDay = new Date(1962, 6, 7, 12); // noon of 1962-07-07 (7th of July 1
 theBigDay.setDate(24);  // 1962-07-24 (24th of July 1962)
 theBigDay.setDate(32);  // 1962-08-01 (1st of August 1962)
 theBigDay.setDate(22);  // 1962-08-22 (22nd of August 1962)
-theBigDay.setDate(0);   // 1962-07-31 (30th of June 1962)
+theBigDay.setDate(0);   // 1962-06-30 (30th of June 1962)
 theBigDay.setDate(98);  // 1962-10-06 (6th of October 1962)
-theBigDay.setDate(-50); // 1962-08-11 (11th of August 1962)
+theBigDay.setDate(-50); // 1962-05-11 (11th of May 1962)
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/date/setdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setdate/index.md
@@ -54,7 +54,7 @@ const theBigDay = new Date(1962, 6, 7, 12); // noon of 1962-07-07 (7th of July 1
 theBigDay.setDate(24);  // 1962-07-24 (24th of July 1962)
 theBigDay.setDate(32);  // 1962-08-01 (1st of August 1962)
 theBigDay.setDate(22);  // 1962-08-22 (22nd of August 1962)
-theBigDay.setDate(0);   // 1962-07-31 (31st of July 1962)
+theBigDay.setDate(0);   // 1962-07-31 (30th of June 1962)
 theBigDay.setDate(98);  // 1962-10-06 (6th of October 1962)
 theBigDay.setDate(-50); // 1962-08-11 (11th of August 1962)
 ```


### PR DESCRIPTION
setDate(0) sets to the last day of previous month
setDate(-50) sets the date a few months back

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fixed mistake in an example usage of Date.setDate(0) and Date.setDate(-50). 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It's contradicting the information above, the function truly seems to return dates in the past.

-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
