### PR TITLE
Add note about onBeforeRequest unavailability

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -30,6 +30,8 @@ From Firefox 52 onwards, instead of returning `BlockingResponse`, the listener c
 
 If you use `"blocking"`, you must have the ["webRequestBlocking" API permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions) in your manifest.json.
 
+Be aware that you can not run webRequest.onBeforeRequest in  a content script, you must use a background script, see [web Extension API's](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#webextension_apis) for the list of content script supported API's.
+
 ## Syntax
 
 ```js


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added that webRequest.onBeforeRequest is not avaliable in content scripts.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I spent two hours trying to do this, and stumbled across the answer on a random stack overflow, seems pertinent.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://stackoverflow.com/questions/40996014/typeerror-api-is-undefined-in-content-script-or-why-cant-i-do-this-in-a-cont
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
