### PR TITLE
Document that Response»body can be null

### DIFF
--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -16,7 +16,7 @@ The **`body`** read-only property of the {{domxref("Response")}} interface is a 
 
 ## Value
 
-A {{domxref("ReadableStream")}}.
+A {{domxref("ReadableStream")}}, or [`null`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) for any response that has no body.
 
 ## Example
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12862. It’s possible for a response to have no body; a common case is HTTP 204 “No Content” responses (which, for example, some servers send in response to CORS preflight `OPTIONS` requests).

And at https://fetch.spec.whatwg.org/#ref-for-dom-body-body, the WebIDL for `Response`»`body` looks like this:

```
readonly attribute ReadableStream? body;
```

Per https://webidl.spec.whatwg.org/#idl-nullable-type, the "`?`" annotation there means that the `ReadableStream` type is nullable.