### PR TITLE
Move role attribute in “<pre>: The Preformatted Text element”

### DIFF
--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -90,14 +90,13 @@ It is important to provide an alternate description for any images or diagrams c
 
 People experiencing low vision conditions and browsing with the aid of assistive technology such as a screen reader may not understand what the preformatted text characters are representing when they are read out in sequence.
 
-A combination of {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of {{htmlattrxref("id")}}
-and [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes, allows the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
+A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by the [ARIA](/en-US/docs/Web/Accessibility/ARIA) `role` and [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attributes on the `pre` element allow the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
 
 ### Example
 
 ```html
-<figure aria-labelledby="cow-caption">
-  <pre>
+<figure>
+  <pre role="img" aria-label="ASCII COW">
       ___________________________
   &lt; I'm an expert in my field. &gt;
       ---------------------------

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -90,8 +90,8 @@ It is important to provide an alternate description for any images or diagrams c
 
 People experiencing low vision conditions and browsing with the aid of assistive technology such as a screen reader may not understand what the preformatted text characters are representing when they are read out in sequence.
 
-A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of an {{htmlattrxref("id")}}
-and [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes allow the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
+A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of {{htmlattrxref("id")}}
+and [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes, allows the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
 
 ### Example
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -95,7 +95,7 @@ A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}}
 ### Example
 
 ```html
-<figure role="img" aria-labelledby="cow-caption">
+<figure aria-labelledby="cow-caption">
   <pre>
       ___________________________
   &lt; I'm an expert in my field. &gt;

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -90,7 +90,7 @@ It is important to provide an alternate description for any images or diagrams c
 
 People experiencing low vision conditions and browsing with the aid of assistive technology such as a screen reader may not understand what the preformatted text characters are representing when they are read out in sequence.
 
-A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of {{htmlattrxref("id")}}
+A combination of {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of {{htmlattrxref("id")}}
 and [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes, allows the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
 
 ### Example

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -90,7 +90,8 @@ It is important to provide an alternate description for any images or diagrams c
 
 People experiencing low vision conditions and browsing with the aid of assistive technology such as a screen reader may not understand what the preformatted text characters are representing when they are read out in sequence.
 
-A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of an {{htmlattrxref("id")}} and the [ARIA](/en-US/docs/Web/Accessibility/ARIA) `role` and [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes allow the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
+A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by a combination of an {{htmlattrxref("id")}}
+and [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes allow the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
 
 ### Example
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -90,7 +90,7 @@ It is important to provide an alternate description for any images or diagrams c
 
 People experiencing low vision conditions and browsing with the aid of assistive technology such as a screen reader may not understand what the preformatted text characters are representing when they are read out in sequence.
 
-A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by the [ARIA](/en-US/docs/Web/Accessibility/ARIA) `role` and [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attributes on the `pre` element allow the preformatted text to be announced as an image, with the `figcaption` serving as the image's alternate description.
+A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}} elements, supplemented by the [ARIA](/en-US/docs/Web/Accessibility/ARIA) `role` and [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attributes on the `pre` element allow the preformatted ASCII art to be announced as an image with alternative text, and the `figcaption` serving as the image's caption.
 
 ### Example
 


### PR DESCRIPTION
#### Summary
The role attribute was misplaced in the example. And the example reads ascii art chars which it is not supposed to. Verified that it reads more sensibly now:

Voice | Screenreader
--- | ---
 `graphic` ascii cow | NVDA on Windows 11
 `caption` a cow saying ... preformatted text ... | -
 `caption` characters | -
ascii cow `graphic` | Google Talkback on Android 11
 a cow saying ... characters | -
 ascii cow `image` | Orca on Debian 11
 a cow saying ... characters `caption` | -

#### Motivation
| I want to publicly demonstrate my own skills to improve my chances of getting a job.

#### Supporting details
Thanks @9Nish4 for reporting
Thanks @scottaohara for the review and the link https://w3c.github.io/html-aria/#example-8

#### Related issues
Fixes #12361

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
