### PR TITLE
Better wording for `Array.prototype.reduce()` using element at index 0

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -20,7 +20,7 @@ The final result of running the reducer across all elements of the array is a si
 
 The first time that the callback is run there is no "return value of the previous calculation".
 If supplied, an initial value may be used in its place.
-Otherwise array element 0 is used as the initial value and iteration starts from the next element (index 1 instead of index 0).
+Otherwise the array element at index 0 is used as the initial value and iteration starts from the next element (index 1 instead of index 0).
 
 Perhaps the easiest-to-understand case for `reduce()` is to return the sum of all the elements in an array:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The explanation for `Array.prototype.reduce()` using the array element at index 0 at the initial value if the initial value isn't supplied isn't clear. I made the wording clearer on what `Array.prototype.reduce()` does in those situations.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It took about a minute for me to understand what the docs was referring to with the current explanation.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
