### PR TITLE
template literals: changed explanation about illegal escape sequences

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
@@ -15,8 +15,8 @@ browser-compat: javascript.builtins.String.raw
 The static **`String.raw()`** method
 is a tag function of [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals).
 This is _similar_ to the `r` prefix in Python, or the `@`
-prefix in C# for string literals. (But it is not _identical_; see explanations
-in [this issue](https://bugs.chromium.org/p/v8/issues/detail?id=5016).)
+prefix in C# for string literals. (But it was not _identical_ till ES2018 see 
+[explanations](/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates_and_escape_sequences))
 It's used to get the raw string form of template literals, that is, substitutions (e.g.
 `${foo}`) are processed, but escapes (e.g. `\n`) are not.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
@@ -15,8 +15,7 @@ browser-compat: javascript.builtins.String.raw
 The static **`String.raw()`** method
 is a tag function of [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals).
 This is _similar_ to the `r` prefix in Python, or the `@`
-prefix in C# for string literals. (But it was not _identical_ till ES2018 see 
-[explanations](/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates_and_escape_sequences))
+prefix in C# for string literals.
 It's used to get the raw string form of template literals, that is, substitutions (e.g.
 `${foo}`) are processed, but escapes (e.g. `\n`) are not.
 

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -272,7 +272,7 @@ latex`\unicode`
 
 Tagged templates should allow the embedding of languages (for example [DSLs](https://en.wikipedia.org/wiki/Domain-specific_language), or [LaTeX](https://en.wikipedia.org/wiki/LaTeX)), where other escapes sequences
 are common. The ECMAScript proposal [Template Literal
-Revision](https://tc39.github.io/proposal-template-literal-revision/) (Stage 4, to be integrated in the ECMAScript 2018 standard) removes the
+Revision](https://tc39.github.io/proposal-template-literal-revision/) (integrated in the ECMAScript 2018 standard) removed the
 syntax restriction of ECMAScript escape sequences from tagged templates.
 
 However, illegal escape sequences must still be represented in the “cooked”


### PR DESCRIPTION
#### Summary
Removed link to fixed issue. 
Instead linked to existing explanation.

#### Motivation

#### Supporting details
https://2ality.com/2016/09/template-literal-revision.html
https://github.com/tc39/proposal-template-literal-revision/issues/5
https://github.com/tc39/notes/blob/HEAD/meetings/2017-03/mar-21.md#10ia-template-literal-updates

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
