### PR TITLE
Note: browsers don’t set Response»body to null for no-body responses

### DIFF
--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -16,7 +16,9 @@ The **`body`** read-only property of the {{domxref("Response")}} interface is a 
 
 ## Value
 
-A {{domxref("ReadableStream")}}, or [`null`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) for any response that has no body.
+A {{domxref("ReadableStream")}}, or else [`null`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) for any `Response` object [constructed](/en-US/docs/Web/API/Response/Response) with a null [`body`](/en-US/docs/Web/API/Response/Response#body) property, or for any actual [HTTP response](/en-US/docs/Web/HTTP/Messages#http_responses) that has no [body](/en-US/docs/Web/HTTP/Messages#body_2).
+
+> **Note:** Current browsers don’t actually conform to the spec requirement to set the `body` property to `null` for responses with no body (for example, responses to [`HEAD`](/en-US/docs/Web/HTTP/Methods/HEAD) requests, or [`204 No Content`](/en-US/docs/Web/HTTP/Status/204) responses).
 
 ## Example
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/issues/12862. See https://github.com/mdn/content/issues/12862#issuecomment-1034609833 and https://matrixlogs.bakkot.com/WHATWG/2022-02-10#L0

cc @jespertheend