### PR TITLE
Fix redirecting link by jsxref

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -62,7 +62,7 @@ The `Set` [`has`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has) m
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
 - {{jsxref("Set.prototype.values()")}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
-- {{jsxref("Set.prototype.keys()")}}
+- {{jsxref("Set.prototype.values", " Set.prototype.keys()")}}
   - : An alias for {{jsxref("Set.prototype.values()")}}.
 - {{jsxref("Set.prototype.entries()")}}
 


### PR DESCRIPTION
`Set.prototype.keys` is an alias for `Set.prototype.values` and the MDN page redirect.

This fixes a link to `Set.prototype.keys` to link directly to the final page.