### PR TITLE
Corrections to "Giving each to-do a unique ID"

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
@@ -15,7 +15,7 @@ tags:
 {{LearnSidebar}}
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_Todo_list_beginning","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_components", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}
 
-Now that we have our markup and styles ready we can start developing the required features for our Svelte To-Do list app. In this article we'll be using variables and props to make our app dynamic, allowing us to add and delete todos, mark them as complete, and filter them by status.
+Now that we have our markup and styles ready, we can start developing the required features for our Svelte to-do list app. In this article we'll be using variables and props to make our app dynamic, allowing us to add and delete to-dos, mark them as complete, and filter them by status.
 
 <table>
   <tbody>
@@ -34,7 +34,7 @@ Now that we have our markup and styles ready we can start developing the require
           >.
         </p>
         <p>
-          You'll need a terminal with node + npm installed to compile and build
+          You'll need a terminal with node and npm installed to compile and build
           your app.
         </p>
       </td>
@@ -43,8 +43,8 @@ Now that we have our markup and styles ready we can start developing the require
       <th scope="row">Objective:</th>
       <td>
         Learn and put into practice some basic Svelte concepts, like creating
-        components, passing data using props, render JavaScript expressions into
-        our markup, modify the components state and iterating over lists.
+        components, passing data using props, rendering JavaScript expressions into
+        our markup, modifying the components' state, and iterating over lists.
       </td>
     </tr>
   </tbody>
@@ -54,7 +54,7 @@ Now that we have our markup and styles ready we can start developing the require
 
 ### Git
 
-Clone the github repo (if you haven't already done it) with:
+Clone the GitHub repo (if you haven't already done it) with:
 
 ```bash
 git clone https://github.com/opensas/mdn-svelte-tutorial.git
@@ -80,7 +80,7 @@ To code along with us using the REPL, start at
 
 <https://svelte.dev/repl/c862d964d48d473ca63ab91709a0a5a0?version=3.23.2>
 
-## Working with todos
+## Working with to-dos
 
 Our `Todos.svelte` component is currently just displaying static markup; let's start making it a bit more dynamic. We'll take the tasks information from the markup and store it in a `todos` array. We'll also create two variables to keep track of the total number of tasks and the completed tasks.
 
@@ -110,11 +110,11 @@ The state of our component will be represented by these three top-level variable
     ```
 
 3. Go to the app, and you should see the "2 out of 3 items completed" message as before, but this time the information is coming from the `todos` array.
-4. To prove it, go to that array, and try changing some of the todo object's completed property values, and even add a new todo object. Observe how the numbers in the message are updated appropriately.
+4. To prove it, go to that array, and try changing some of the to-do object's completed property values, and even add a new to-do object. Observe how the numbers in the message are updated appropriately.
 
-## Dynamically generating the todos from the data
+## Dynamically generating the to-dos from the data
 
-At the moment, our displayed todo items are all static. We want to iterate over each item in our `todos` array and render the markup for each task, so let's do that now.
+At the moment, our displayed to-do items are all static. We want to iterate over each item in our `todos` array and render the markup for each task, so let's do that now.
 
 HTML doesn't have a way of expressing logic — like conditionals and loops. Svelte does. In this case we use the [`{#each...}`](https://svelte.dev/docs#each) directive to iterate over the `todos` array. The second parameter, if provided, will contain the index of the current item. Also, a key expression can be provided, which will uniquely identify each item. Svelte will use it to diff the list when data changes, rather than adding or removing items at the end, and it's a good practice to always specify one. Finally, an `:else` block can be provided, which will be rendered when the list is empty.
 
@@ -136,12 +136,12 @@ Let's give it a try.
 
 2. Go back to the app; you'll see something like this:
 
-    ![very simple todo list output created using an each block](01-each-block.png)
+    ![very simple to-do list output created using an each block](01-each-block.png)
 
-3. Now we've seen that this is working, let's generate a complete todo item with each loop of the `{#each}` directive, and inside embed the information from the `todos` array: `id`, `name`, and `completed`. Replace your existing `<ul>` block with the following:
+3. Now that we've seen that this is working, let's generate a complete to-do item with each loop of the `{#each}` directive, and inside embed the information from the `todos` array: `id`, `name`, and `completed`. Replace your existing `<ul>` block with the following:
 
     ```html
-    <!-- Todos -->
+    <!-- To-dos -->
     <ul role="list" class="todo-list stack-large" aria-labelledby="list-heading">
       {#each todos as todo (todo.id)}
         <li class="todo">
@@ -174,7 +174,7 @@ We've turned our static markup into a dynamic template ready to display the task
 
 ## Working with props
 
-With a hardcoded list of todos, our `Todos` component is not very useful. To turn our component into a general purpose To-Do editor we should allow the parent of this component to pass in the list of todos to edit. This would allow us to save them to a web service or local storage and later retrieve them for update. So let's turn the array into a `prop`.
+With a hardcoded list of to-dos, our `Todos` component is not very useful. To turn our component into a general purpose to-do editor, we should allow the parent of this component to pass in the list of to-dos to edit. This would allow us to save them to a web service or local storage and later retrieve them for update. So let's turn the array into a `prop`.
 
 1. In `Todos.svelte`, replace the existing `let todos = ...` block with `export let todos = []`.
 
@@ -189,7 +189,7 @@ With a hardcoded list of todos, our `Todos` component is not very useful. To tur
     So with `export let todos = []`, we are telling Svelte that our `Todos.svelte` component will accept a `todos` attribute, which when omitted will be initialized to an empty array.
 
 2. Have a look at the app, and you'll see the "Nothing to do here!" message. This is because we are currently not passing any value into it from `App.svelte`, so it's using the default value.
-3. Now let's move our todos to `App.svelte` and pass them to the `Todos.svelte` component as a prop. Update `src/App.svelte` as follows:
+3. Now let's move our to-dos to `App.svelte` and pass them to the `Todos.svelte` component as a prop. Update `src/App.svelte` as follows:
 
     ```js
     <script>
@@ -211,9 +211,9 @@ With a hardcoded list of todos, our `Todos` component is not very useful. To tur
     <Todos {todos} />
     ```
 
-At this point your todos should render just like they did before, except that now we're passing them in from the `App.svelte` component.
+At this point your to-dos should render just like they did before, except that now we're passing them in from the `App.svelte` component.
 
-## Toggling and removing todos
+## Toggling and removing to-dos
 
 Let's add some functionality to toggle the task status. Svelte has the `on:eventname` directive for listening to DOM events. Let's add a handler to the `on:click` event of the checkbox input to toggle the completed value.
 
@@ -226,7 +226,7 @@ Let's add some functionality to toggle the task status. Svelte has the `on:event
     />
     ```
 
-2. Next we'll add a function to remove a todo from our `todos` array. At the bottom of the `Todos.svelte` `<script>` section, add the `removeTodo()` function like so:
+2. Next we'll add a function to remove a to-do from our `todos` array. At the bottom of the `Todos.svelte` `<script>` section, add the `removeTodo()` function like so:
 
     ```js
     function removeTodo(todo) {
@@ -248,13 +248,13 @@ Let's add some functionality to toggle the task status. Svelte has the `on:event
 
     In this case you have to specify `on:click={() => removeTodo(todo)}` as the handler. If `removeTodo()` received no params, you could use `on:event={removeTodo}`, but not `on:event={removeTodo()}`. This is not some special Svelte syntax — here we are just using regular JavaScript [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
-Again, this is good progress — at this point, we can now delete tasks. When a todo item's _Delete_ button is pressed, the relevant todo is removed from the `todos` array, and the UI updates to no longer show it. In addition, we can now check the checkboxes, and the completed status of the relevant todos will now update in the todos array.
+Again, this is good progress — at this point, we can now delete tasks. When a to-do item's _Delete_ button is pressed, the relevant to-do is removed from the `todos` array, and the UI updates to no longer show it. In addition, we can now check the checkboxes, and the completed status of the relevant to-dos will now update in the `todos` array.
 
 However, the "x out of y items completed" heading is not being updated. Read on to find out why this is happening and how we can solve it.
 
-## Reactive todos
+## Reactive to-dos
 
-As we've already seen, every time the value of a component top-level variable is modified Svelte knows how to update the UI. In our app, the `todos` array value is updated directly every time a todo is toggled or deleted, and so Svelte will update the DOM automatically.
+As we've already seen, every time the value of a component top-level variable is modified, Svelte knows how to update the UI. In our app, the `todos` array value is updated directly every time a to-do is toggled or deleted, and so Svelte will update the DOM automatically.
 
 The same is not true for `totalTodos` and `completedTodos`, however. In the following code they are assigned a value when the component is instantiated and the script is executed, but after that, their values are not modified:
 
@@ -263,7 +263,7 @@ let totalTodos = todos.length
 let completedTodos = todos.filter(todo => todo.completed).length
 ```
 
-We could recalculate them after toggling and removing todos, but there's an easier way to do it.
+We could recalculate them after toggling and removing to-dos, but there's an easier way to do it.
 
 We can tell Svelte that we want our `totalTodos` and `completedTodos` variables to be reactive by prefixing them with `$:`. Svelte will generate the code to automatically update them whenever data they depend on is changed.
 
@@ -276,15 +276,15 @@ $: totalTodos = todos.length
 $: completedTodos = todos.filter(todo => todo.completed).length
 ```
 
-If you check your app now, you'll see that the heading's numbers are updated when todos are completed or deleted. Nice!
+If you check your app now, you'll see that the heading's numbers are updated when to-dos are completed or deleted. Nice!
 
-Behind the scenes the Svelte compiler will parse and analyze our code to make a dependency tree, then it will generate the JavaScript code to re-evaluate each reactive statement whenever one of their dependencies is updated. Reactivity in Svelte is implemented in a very lightweight and performant way, without using listeners, setters, getters, or any other complex mechanism.
+Behind the scenes the Svelte compiler will parse and analyze our code to make a dependency tree, and then it will generate the JavaScript code to re-evaluate each reactive statement whenever one of their dependencies is updated. Reactivity in Svelte is implemented in a very lightweight and performant way, without using listeners, setters, getters, or any other complex mechanism.
 
-## Adding new todos
+## Adding new to-dos
 
-Now onto the next major task for this article — let's add some functionality for adding new todos.
+Now on to the next major task for this article — let's add some functionality for adding new to-dos.
 
-1. First, we'll create a variable to hold the text of the new todo. Add this declaration to the `<script>` section of `Todos.svelte` file:
+1. First we'll create a variable to hold the text of the new to-do. Add this declaration to the `<script>` section of `Todos.svelte` file:
 
     ```js
     let newTodoName = ''
@@ -319,7 +319,7 @@ Now onto the next major task for this article — let's add some functionality f
     > **Note:** As you may have noticed, reactive statements aren't limited to variable declarations. You can put _any_ JavaScript statement after the `$:` sign.
 
 4. Now try going back to `localhost:5042`, pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd> to open your browser console and typing something into the input field. You should see your entries logged. At this point, you can delete the reactive `console.log()` if you wish.
-5. Next up we'll create a function to add the new todo — `addTodo()` — which will push a new `todo` object onto the `todos` array. Add this to the bottom of your `<script>` block inside `src/components/Todos.svelte`:
+5. Next up we'll create a function to add the new to-do — `addTodo()` — which will push a new `todo` object onto the `todos` array. Add this to the bottom of your `<script>` block inside `src/components/Todos.svelte`:
 
     ```js
     function addTodo() {
@@ -328,7 +328,7 @@ Now onto the next major task for this article — let's add some functionality f
     }
     ```
 
-    > **Note:** For the moment we are just assigning the same `id` to every todo, but don't worry, we will fix that soon.
+    > **Note:** For the moment we are just assigning the same `id` to every to-do, but don't worry, we will fix that soon.
 
 6. Now we want to update our HTML so that we call `addTodo()` whenever the form is submitted. Update the NewTodo form's opening tag like so:
 
@@ -338,11 +338,11 @@ Now onto the next major task for this article — let's add some functionality f
 
     The [`on:eventname`](https://svelte.dev/docs#on_element_event) directive supports adding modifiers to the DOM event with the `|` character. In this case, the `preventDefault` modifier tells Svelte to generate the code to call `event.preventDefault()` before running the handler. Explore the previous link to see what other modifiers are available.
 
-7. If you try adding new todos at this point, the new todos are added to the todos array but our UI is not updated. Remember that in Svelte [reactivity is triggered with assignments](https://svelte.dev/docs#2_Assignments_are_reactive). That means that the `addTodo()` function is executed, the element is added to the `todos` array, but Svelte won't detect that the push method modified the array, so it won't refresh the tasks `<ul>`.
+7. If you try adding new to-dos at this point, the new to-dos are added to the to-dos array, but our UI is not updated. Remember that in Svelte [reactivity is triggered with assignments](https://svelte.dev/docs#2_Assignments_are_reactive). That means that the `addTodo()` function is executed, the element is added to the `todos` array, but Svelte won't detect that the push method modified the array, so it won't refresh the tasks `<ul>`.
 
-    Just adding `todos = todos` to the end of the `addTodo()` function would solve the problem, but it seems strange to have to include that at the end of the function. Instead, we'll take out the `push()` method and use [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) to achieve the same result — we'll assign a value to the `todos` array equal to the `todos` array plus the new object.
+    Just adding `todos = todos` to the end of the `addTodo()` function would solve the problem, but it seems strange to have to include that at the end of the function. Instead, we'll take out the `push()` method and use [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) to achieve the same result: we'll assign a value to the `todos` array equal to the `todos` array plus the new object.
 
-    > **Note:** Array has several mutable operations — [`push()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push), [`pop()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop), [`splice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice), [`shift()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), [`unshift()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift), [`reverse()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse), and [`sort()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort). Using them often causes side effects and bugs that are hard to track. By using the spread syntax instead of `push()` we avoid mutating the array, which is considered a good practice.
+    > **Note:** `Array` has several mutable operations: [`push()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push), [`pop()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop), [`splice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice), [`shift()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), [`unshift()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift), [`reverse()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse), and [`sort()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort). Using them often causes side effects and bugs that are hard to track. By using the spread syntax instead of `push()` we avoid mutating the array, which is considered a good practice.
 
     Update your `addTodo()` function like so:
 
@@ -353,11 +353,11 @@ Now onto the next major task for this article — let's add some functionality f
     }
     ```
 
-## Giving each todo a unique ID
+## Giving each to-do a unique ID
 
-If you try to add new todos in your app now, you'll be able to add a new todo and have it appear in the UI! Once. If you try it a second time, it won't work, and you'll get a console message saying "Error: Cannot have duplicate keys in a keyed each". We need unique IDs for our todos!
+If you try to add new to-dos in your app now, you'll be able to add a new to-do and have it appear in the UI — once. If you try it a second time, it won't work, and you'll get a console message saying "Error: Cannot have duplicate keys in a keyed each". We need unique IDs for our to-dos.
 
-1. Let's declare a `newTodoId` variable calculated from the number of todos plus 1, and make it reactive. Add the following snippet to the `<script>` section:
+1. Let's declare a `newTodoId` variable calculated from the number of to-dos plus 1, and make it reactive. Add the following snippet to the `<script>` section:
 
     ```js
     let newTodoId
@@ -374,7 +374,7 @@ If you try to add new todos in your app now, you'll be able to add a new todo an
 
 2. How does Svelte achieve this? The compiler parses the whole reactive statement, and detects that it depends on the `totalTodos` variable and the `todos` array. So whenever either of them is modified, this code is re-evaluated, updating `newTodoId` accordingly.
 
-    Let's use this in our `addTodo()` function — update it like so:
+    Let's use this in our `addTodo()` function. Update it like so:
 
     ```js
     function addTodo() {
@@ -383,23 +383,23 @@ If you try to add new todos in your app now, you'll be able to add a new todo an
     }
     ```
 
-## Filtering todos by status
+## Filtering to-dos by status
 
-Finally for this article, let's implement the ability to filter our todos by status. We'll create a variable to hold the current filter, and a helper function that will return the filtered todos.
+Finally for this article, let's implement the ability to filter our to-dos by status. We'll create a variable to hold the current filter, and a helper function that will return the filtered to-dos.
 
 1. At the bottom of our `<script>` section add the following:
 
     ```js
     let filter = 'all'
-      const filterTodos = (filter, todos) =>
-        filter === 'active' ? todos.filter(t => !t.completed) :
-        filter === 'completed' ? todos.filter(t => t.completed) :
-        todos
+    const filterTodos = (filter, todos) =>
+      filter === 'active' ? todos.filter(t => !t.completed) :
+      filter === 'completed' ? todos.filter(t => t.completed) :
+      todos
     ```
 
-    We use the `filter` variable to control the active filter: _all_, _active_, or _completed_. Just assigning one of these values to the filter variable will activate the filter and update the list of todos. Let's see how to achieve this.
+    We use the `filter` variable to control the active filter: _all_, _active_, or _completed_. Just assigning one of these values to the filter variable will activate the filter and update the list of to-dos. Let's see how to achieve this.
 
-    The `filterTodos()` function will receive the current filter and the list of todos, and return a new array of todos filtered accordingly.
+    The `filterTodos()` function will receive the current filter and the list of to-dos, and return a new array of to-dos filtered accordingly.
 
 2. Let's update the filter button markup to make it dynamic and update the current filter when the user presses one of the filter buttons. Update it like this:
 
@@ -429,9 +429,9 @@ Finally for this article, let's implement the ability to filter our todos by sta
 
     > **Note:** Svelte provides a shortcut which allows us to shorten `<div class:active={active}>` to `<div class:active>` when the class matches the variable name.
 
-    Something similar happens with `aria-pressed={filter === 'all'}` — when the JavaScript expression passed between curly braces evaluates to a truthy value, the `aria-pressed` attribute will be added to the button.
+    Something similar happens with `aria-pressed={filter === 'all'}`: when the JavaScript expression passed between curly braces evaluates to a truthy value, the `aria-pressed` attribute will be added to the button.
 
-    Whenever we click on a button we update the filter variable by issuing `on:click={()=> filter = 'all'}`. Read on to find out how Svelte reactivity will take care of the rest.
+    Whenever we click on a button, we update the filter variable by issuing `on:click={()=> filter = 'all'}`. Read on to find out how Svelte reactivity will take care of the rest.
 
 3. Now we just need to use the helper function in the `{#each}` loop; update it like this:
 
@@ -442,9 +442,9 @@ Finally for this article, let's implement the ability to filter our todos by sta
     ...
     ```
 
-    After analyzing our code, Svelte detects that our `filterTodos()` function depends on the variables `filter` and `todos`. And, just like with any other dynamic expression embedded in the markup, whenever any of these dependencies change the DOM will be updated accordingly. So whenever `filter` or `todos` changes, the `filterTodos()` function will be re-evaluated and the items inside the loop will be updated.
+    After analyzing our code, Svelte detects that our `filterTodos()` function depends on the variables `filter` and `todos`. And, just like with any other dynamic expression embedded in the markup, whenever any of these dependencies changes, the DOM will be updated accordingly. So whenever `filter` or `todos` changes, the `filterTodos()` function will be re-evaluated and the items inside the loop will be updated.
 
-> **Note:** Reactivity can be tricky sometimes. Svelte recognizes `filter` as a dependency because we are referencing it in the `filterTodos(filter, todo)` expression. `filter` is a top-level variable, so we might be tempted to remove it from the helper function params, and just call it like this — `filterTodos(todo)`. This would work, but now Svelte has no way to find out that `{#each filterTodos(todos)... }` depends on `filter`, and the list of filtered todos won't be updated when the filter changes. Always remember that Svelte analyzes our code to find out dependencies, so it's better to be explicit about it and not rely on the visibility of top-level variables. Besides, it's a good practice to make our code clear and explicit about what information it is using.
+> **Note:** Reactivity can be tricky sometimes. Svelte recognizes `filter` as a dependency because we are referencing it in the `filterTodos(filter, todo)` expression. `filter` is a top-level variable, so we might be tempted to remove it from the helper function params, and just call it like this: `filterTodos(todo)`. This would work, but now Svelte has no way to find out that `{#each filterTodos(todos)... }` depends on `filter`, and the list of filtered to-dos won't be updated when the filter changes. Always remember that Svelte analyzes our code to find out dependencies, so it's better to be explicit about it and not rely on the visibility of top-level variables. Besides, it's a good practice to make our code clear and explicit about what information it is using.
 
 ## The code so far
 
@@ -472,24 +472,24 @@ To see the current state of the code in a REPL, visit:
 
 ## Summary
 
-That will do for now! In this article we already implemented most of our desired functionality. Our app can display, add, and delete todos, toggle their completed status, show how many of them are completed and apply filters.
+That will do for now! In this article we already implemented most of our desired functionality. Our app can display, add, and delete to-dos, toggle their completed status, show how many of them are completed, and apply filters.
 
 To recap, we covered the following topics:
 
-- Creating and using components.
-- Turning static markup into a live template.
-- Embedding JavaScript expressions in our markup.
-- Iterating over lists using the `{#each}` directive.
-- Passing information between components with props.
-- Listening to DOM events.
-- Declaring reactive statements.
-- Basic debugging with `console.log()` and reactive statements.
-- Binding HTML properties with the `bind:property` directive.
-- Triggering reactivity with assignments.
+- Creating and using components
+- Turning static markup into a live template
+- Embedding JavaScript expressions in our markup
+- Iterating over lists using the `{#each}` directive
+- Passing information between components with props
+- Listening to DOM events
+- Declaring reactive statements
+- Basic debugging with `console.log()` and reactive statements
+- Binding HTML properties with the `bind:property` directive
+- Triggering reactivity with assignments
 - Using reactive expressions to filter data
 - Explicitly defining our reactive dependencies
 
-In the next article we will add further functionality, which will allow users to edit todos.
+In the next article we will add further functionality, which will allow users to edit to-dos.
 
 {{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_Todo_list_beginning","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_components", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}
 


### PR DESCRIPTION
Minor grammatical and punctuation corrections. "to-do list" and "to-do" are correct. The text was previously inconsistent and used incorrect variants of these words. This still needs to be corrected in the other texts in the series.