### PR TITLE
Update “Map” doc to include a Number as a valid Object key

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -84,7 +84,7 @@ cases:
       </td>
       <td>
         The keys of an <code>Object</code> must be either a
-        {{jsxref("String")}} or a {{jsxref("Symbol")}}.
+        {{jsxref("String")}}, {{jsxref("Number")}}, or a {{jsxref("Symbol")}}.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The Map document compares Maps to Objects in a table.

I updated the info on an Object's keys to include Number as a valid key type.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
JavaScript keys can either be of type String, Number, or Symbol.

When an integer Number is used as a key on an Object, JavaScript will keep it of type Number.

When a floating-point Number is used as a key on an Object, JavaScript will convert the Number to its equivalent String and use the resultant String as the key instead.

Despite the conversion of floating-point Numbers to Strings, you can still access a JavaScript object with either the integer or floating-point Number you used to create the Object using the bracket-notation.

```
const myObject = {
12: "first",
123.4: "second",
};
>> { 12: "first", "123.4": "second" }

console.log(myObject[12]);
>> first

console.log(myObject[123.4]);
>> second
```

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
