### PR TITLE
Fix case-sensitivity misstatement in “How CSS is structured”

### DIFF
--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -278,7 +278,7 @@ Finally, CSS declaration blocks are paired with _selectors_ to produce _CSS rule
 
 Setting CSS properties to specific values is the primary way of defining layout and styling for a document. The CSS engine calculates which declarations apply to every single element of a page.
 
-> **Warning:** CSS properties and values are case-sensitive. The property and value in each pair are separated by a colon. (`:`)
+CSS properties and values are case-insensitive. The property and value in a property-value pair are separated by a colon (`:`).
 
 **Look up different values of properties listed below. Write CSS rules that apply styling to different HTML elements:**
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12927

https://www.w3.org/TR/css-syntax-3/#style-rules
> Unless otherwise specified, property names are ASCII case-insensitive

https://www.w3.org/TR/css-values/#keywords
> Keywords are identifiers and are interpreted ASCII case-insensitively (i.e., [a-z] and [A-Z] are equivalent).

“keywords” are the main type of CSS value:
https://www.w3.org/TR/css3-values/#component-types

units are also case-insensitive:
https://www.w3.org/TR/css3-values/#dimensions
> Like keywords, unit identifiers are ASCII case-insensitive.

etc.