### PR TITLE
Lowercase Array.p.reduce() slug (for consistency w/ other Array methods)

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -1,6 +1,6 @@
 ---
 title: Array.prototype.reduce()
-slug: Web/JavaScript/Reference/Global_Objects/Array/Reduce
+slug: Web/JavaScript/Reference/Global_Objects/Array/reduce
 tags:
   - Array
   - Array method


### PR DESCRIPTION
This changes the slug for the `Array.prototype.reduce()` article to `Web/JavaScript/Reference/Global_Objects/Array/reduce`, for consistency with slugs for all other `Array` methods — in particular, `reduceRight()`: `Web/JavaScript/Reference/Global_Objects/Array/reduceRight`

Below are the results of ripgrepping `Global_Objects/Array` slugs.

As can be seen in the results, the `Array.prototype.reduce()` article is the only one that doesn’t have a lowercase slug — other than the `Array()` constructor article, whose slug should not be lowercased.

```
slug: Web/JavaScript/Reference/Global_Objects/Array/@@iterator
slug: Web/JavaScript/Reference/Global_Objects/Array/@@species
slug: Web/JavaScript/Reference/Global_Objects/Array/@@unscopables
slug: Web/JavaScript/Reference/Global_Objects/Array/Array
slug: Web/JavaScript/Reference/Global_Objects/Array/Reduce
slug: Web/JavaScript/Reference/Global_Objects/Array/at
slug: Web/JavaScript/Reference/Global_Objects/Array/concat
slug: Web/JavaScript/Reference/Global_Objects/Array/copyWithin
slug: Web/JavaScript/Reference/Global_Objects/Array/entries
slug: Web/JavaScript/Reference/Global_Objects/Array/every
slug: Web/JavaScript/Reference/Global_Objects/Array/fill
slug: Web/JavaScript/Reference/Global_Objects/Array/filter
slug: Web/JavaScript/Reference/Global_Objects/Array/find
slug: Web/JavaScript/Reference/Global_Objects/Array/findIndex
slug: Web/JavaScript/Reference/Global_Objects/Array/flat
slug: Web/JavaScript/Reference/Global_Objects/Array/flatMap
slug: Web/JavaScript/Reference/Global_Objects/Array/forEach
slug: Web/JavaScript/Reference/Global_Objects/Array/from
slug: Web/JavaScript/Reference/Global_Objects/Array/includes
slug: Web/JavaScript/Reference/Global_Objects/Array/indexOf
slug: Web/JavaScript/Reference/Global_Objects/Array/isArray
slug: Web/JavaScript/Reference/Global_Objects/Array/join
slug: Web/JavaScript/Reference/Global_Objects/Array/keys
slug: Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
slug: Web/JavaScript/Reference/Global_Objects/Array/length
slug: Web/JavaScript/Reference/Global_Objects/Array/map
slug: Web/JavaScript/Reference/Global_Objects/Array/of
slug: Web/JavaScript/Reference/Global_Objects/Array/pop
slug: Web/JavaScript/Reference/Global_Objects/Array/push
slug: Web/JavaScript/Reference/Global_Objects/Array/reduceRight
slug: Web/JavaScript/Reference/Global_Objects/Array/reverse
slug: Web/JavaScript/Reference/Global_Objects/Array/shift
slug: Web/JavaScript/Reference/Global_Objects/Array/slice
slug: Web/JavaScript/Reference/Global_Objects/Array/some
slug: Web/JavaScript/Reference/Global_Objects/Array/sort
slug: Web/JavaScript/Reference/Global_Objects/Array/splice
slug: Web/JavaScript/Reference/Global_Objects/Array/toLocaleString
slug: Web/JavaScript/Reference/Global_Objects/Array/toSource
slug: Web/JavaScript/Reference/Global_Objects/Array/toString
slug: Web/JavaScript/Reference/Global_Objects/Array/unshift
slug: Web/JavaScript/Reference/Global_Objects/Array/values
```