### PR TITLE
Revert "Update “Map” doc to include a Number as a valid Object key (#12918)"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -84,7 +84,7 @@ cases:
       </td>
       <td>
         The keys of an <code>Object</code> must be either a
-        {{jsxref("String")}}, {{jsxref("Number")}}, or a {{jsxref("Symbol")}}.
+        {{jsxref("String")}} or a {{jsxref("Symbol")}}.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
See https://github.com/mdn/content/pull/12918#issuecomment-1036998990. This reverts commit c980d6f084e33cac4d744e5ee0325c01814093bd. That change was wrong; while a key for a `Map` can be a number (or any other primitive, or even a function or object), a key for an `Object` can’t actually be a number. (In fact the point of the table in which this change was made is to contrast (a) the lack of type limitations on `Map` keys with (b) the limitation that `Object` keys can only by strings or symbols.)