### PR TITLE
fix small issue where webkitGetGamepads polyfill...

### DIFF
--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -171,7 +171,7 @@ function buttonPressed(b) {
 }
 
 function gameLoop() {
-  var gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : []);
+  var gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
   if (!gamepads) {
     return;
   }


### PR DESCRIPTION
...in the incomplete example does not actually run the webkitGetGamepads after checking. see the two character change I made and it'll all make sense lol

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add parentheses to make a function actually run instead of just setting the variable to the function itself.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Problematic code was on the live webpage so I wanted to quickly fix it.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
