### PR TITLE
Rewrite description array.prototype.reduce

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -77,24 +77,34 @@ The value that results from running the “reducer” callback function to compl
 
 ## Description
 
-The ECMAScript spec describes the behavior of `reduce()` as follows:
+`reduce` takes two arguments, a callback function and an optional initial value.
+`reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.
 
-> *callbackfn* should be a function that takes four arguments. `reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.
->
-> *callbackfn* is called with four arguments:
->
-> - the *previousValue* (value from the previous call to *callbackfn*)
-> - the *currentValue* (value of the current element)
-> - the *currentIndex*, and
-> - the object being traversed
-> The first time that callback is called, the *previousValue* and *currentValue* can be one of two values:
-> - If an *initialValue* was supplied in the call to `reduce`, then *previousValue* will be equal to *initialValue* and *currentValue* will be equal to the first value in the array.
-> - If no *initialValue* was supplied, then *previousValue* will be equal to the first value in the array and *currentValue* will be equal to the second.
-> It is a {{jsxref("TypeError")}} if the array contains no elements and *initialValue* is not provided.
->
-> `reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to *callbackfn*.
->
-> The range of elements processed by `reduce` is set before the first call to *callbackfn*. Elements that are appended to the array after the call to `reduce` begins will not be visited by *callbackfn*. If existing elements of the array are changed, their value as passed to *callbackfn* will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.
+`reduce` returns whatever is returned from the callback on the final iteration.
+
+### When to not use reduce()
+
+Recursive functions like `reduce` can be powerful, but sometimes difficult to understand,
+especially for less experienced JavaScript developers.
+If code becomes clearer when using other array methods,
+developers must weigh the readability tradeoff against the other benefits
+of using reduce.
+In cases where reduce is the best choice, documentation and semantic variable
+naming can help mitigate readability drawnbacks.
+
+### Behavior during array mutations
+
+`reduce` does not mutate the array it is used on, however it is possible for code inside the callback to mutate
+the array.
+
+If elements are appended to the array after `reduce` begins to iterate over the array, the appended
+elememts are not visited by *callbackfn*.
+
+If existing elements of the array are changed, their value as passed to *callbackfn* will be the value at the time `reduce` visits them.
+
+Elements that are deleted after the call to `reduce` begins and before being visited are not visited.
+
+### Edge cases
 
 If the array only has one element (regardless of position) and no *initialValue* is provided, or if *initialValue* is provided but the array is empty, the solo value will be returned _without_ calling _`callbackFn`._
 
@@ -118,6 +128,8 @@ const getMax = (a, b) => Math.max(a, b);
 
 [      ].reduce(getMax);     // TypeError
 ```
+
+## Examples
 
 ### How reduce() works without an initial value
 
@@ -272,8 +284,6 @@ The callback would be invoked five times, with the arguments and return values i
 </table>
 
 The value returned by `reduce()` in this case would be `95`.
-
-## Examples
 
 ### Sum all the values of an array
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -78,7 +78,9 @@ The value that results from running the “reducer” callback function to compl
 ## Description
 
 `reduce` takes two arguments, a callback function and an optional initial value.
-`reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.
+`reduce` calls the callback, as a function, once for each element in the array whenever
+an initial value is provided, in ascending order. If no initial value is provided,
+`reduce` calls the callback once for each element in the array after the first element.
 
 `reduce` returns whatever is returned from the callback on the final iteration.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -97,8 +97,8 @@ naming can help mitigate readability drawbacks.
 `reduce` does not mutate the array it is used on, however it is possible for code inside the callback to mutate
 the array.
 
-If elements are appended to the array after `reduce` begins to iterate over the array, the appended
-elememts are not visited by *callbackfn*.
+If elements are appended to the array after `reduce()` begins to iterate over the array, the callback
+function does not iterate over the appended elements.
 
 If existing elements of the array are changed, their values as passed to the callback function will be the values at the time `reduce()` iterates over the elements.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -80,7 +80,7 @@ The value that results from running the “reducer” callback function to compl
 The `reduce()` method takes two arguments: a callback function and an optional initial value.
 If an initial value is provided, `reduce()` calls the "reducer" callback function on each element in the array, in order. If no initial value is provided, `reduce()` calls the callback function on each element in the array after the first element.
 
-`reduce` returns whatever is returned from the callback on the final iteration.
+`reduce()` returns the value that is returned from the callback function on the final iteration of the array.
 
 ### When to not use reduce()
 
@@ -94,13 +94,11 @@ naming can help mitigate readability drawbacks.
 
 ### Behavior during array mutations
 
-`reduce` does not mutate the array it is used on, however it is possible for code inside the callback to mutate
-the array. Here is what happens if a mutation occurs:
+The `reduce()` method itself does not mutate the array it is used on. However, it is possible for code inside the callback function to mutate the array. These are the possible scenarios of array mutations and how `reduce()` behaves in these scenarios:
 
-- If elements are appended to the array after `reduce()` begins to iterate over the array, the callback
-function does not iterate over the appended elements.
+- If elements are appended to the array _after_ `reduce()` begins to iterate over the array, the callback function does not iterate over the appended elements.
 - If existing elements of the array are changed, their values as passed to the callback function will be the values at the time `reduce()` iterates over the elements.
-- Elements that are deleted after the call to `reduce()` begins and before being iterated over are not visited.
+- Array elements that are deleted _after_ the call to `reduce()` begins _and_ before being iterated over are not visited by `reduce()`.
 
 ### Edge cases
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -95,14 +95,12 @@ naming can help mitigate readability drawbacks.
 ### Behavior during array mutations
 
 `reduce` does not mutate the array it is used on, however it is possible for code inside the callback to mutate
-the array.
+the array. Here is what happens if a mutation occurs:
 
-If elements are appended to the array after `reduce()` begins to iterate over the array, the callback
+- If elements are appended to the array after `reduce()` begins to iterate over the array, the callback
 function does not iterate over the appended elements.
-
-If existing elements of the array are changed, their values as passed to the callback function will be the values at the time `reduce()` iterates over the elements.
-
-Elements that are deleted after the call to `reduce()` begins and before being iterated over are not visited.
+- If existing elements of the array are changed, their values as passed to the callback function will be the values at the time `reduce()` iterates over the elements.
+- Elements that are deleted after the call to `reduce()` begins and before being iterated over are not visited.
 
 ### Edge cases
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -97,7 +97,7 @@ naming can help mitigate readability drawbacks.
 The `reduce()` method itself does not mutate the array it is used on. However, it is possible for code inside the callback function to mutate the array. These are the possible scenarios of array mutations and how `reduce()` behaves in these scenarios:
 
 - If elements are appended to the array _after_ `reduce()` begins to iterate over the array, the callback function does not iterate over the appended elements.
-- If existing elements of the array are changed, their values as passed to the callback function will be the values at the time `reduce()` iterates over the elements.
+- If existing elements of the array do get changed, the values passed to the callback function will be the values from the time that reduce() was first called on the array.
 - Array elements that are deleted _after_ the call to `reduce()` begins _and_ before being iterated over are not visited by `reduce()`.
 
 ### Edge cases

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -77,22 +77,20 @@ The value that results from running the “reducer” callback function to compl
 
 ## Description
 
-`reduce` takes two arguments, a callback function and an optional initial value.
-`reduce` calls the callback, as a function, once for each element in the array whenever
-an initial value is provided, in ascending order. If no initial value is provided,
-`reduce` calls the callback once for each element in the array after the first element.
+The `reduce()` method takes two arguments: a callback function and an optional initial value.
+If an initial value is provided, `reduce()` calls the "reducer" callback function on each element in the array, in order. If no initial value is provided, `reduce()` calls the callback function on each element in the array after the first element.
 
 `reduce` returns whatever is returned from the callback on the final iteration.
 
 ### When to not use reduce()
 
-Recursive functions like `reduce` can be powerful, but sometimes difficult to understand,
+Recursive functions like `reduce()` can be powerful but sometimes difficult to understand,
 especially for less experienced JavaScript developers.
 If code becomes clearer when using other array methods,
 developers must weigh the readability tradeoff against the other benefits
-of using reduce.
-In cases where reduce is the best choice, documentation and semantic variable
-naming can help mitigate readability drawnbacks.
+of using `reduce()`.
+In cases where `reduce()` is the best choice, documentation and semantic variable
+naming can help mitigate readability drawbacks.
 
 ### Behavior during array mutations
 
@@ -102,9 +100,9 @@ the array.
 If elements are appended to the array after `reduce` begins to iterate over the array, the appended
 elememts are not visited by *callbackfn*.
 
-If existing elements of the array are changed, their value as passed to *callbackfn* will be the value at the time `reduce` visits them.
+If existing elements of the array are changed, their values as passed to the callback function will be the values at the time `reduce()` iterates over the elements.
 
-Elements that are deleted after the call to `reduce` begins and before being visited are not visited.
+Elements that are deleted after the call to `reduce()` begins and before being iterated over are not visited.
 
 ### Edge cases
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The quote from ECMA spec had a lot of redundant information that was covered in the Parameters section.
This removes redundant information and attempts to provide prose instead of pure specification.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Reduce is very tricky for new developers. My aim is to make it easier to digest the information without sugar-coating or hiding the complexities. This follows my previous work here https://github.com/mdn/interactive-examples/pull/1996

#### Supporting details

Prior work by other contributors: https://github.com/mdn/content/pull/10555

Comment by @wbamberg  https://github.com/mdn/content/pull/10555: 
> I would love to replace that big quote from the spec

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Closes #12947 
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

### Changes

- Remove redundant information
- Categorize spec info about edge cases and mutations. 
- Give guidance about when to not use reduce.
- Organize examples - Moved 2 spec examples down to go with the rest of the examples.

### Open questions

Do we want to have the "when not to use" section? I saw something similar exists for [Array.prototype.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)

How's the ordering here?