### PR TITLE
Fixes #3797: detached -> transferable

### DIFF
--- a/files/en-us/web/api/audiodata/clone/index.md
+++ b/files/en-us/web/api/audiodata/clone/index.md
@@ -30,7 +30,7 @@ The cloned {{domxref("AudioData")}} object.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the `AudioData` object has been {{domxref("Transferable","transferred")}}.
+  - : Thrown if the `AudioData` object has been {{Glossary("Transferable Objects","transferred")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/messageport/postmessage/index.md
+++ b/files/en-us/web/api/messageport/postmessage/index.md
@@ -34,7 +34,7 @@ port.postMessage(message, transferList);
   - : The message you want to send through the channel. This can be of any basic data
     type. Multiple data items can be sent as an array.
 - transferList {{optional_inline}}
-  - : {{domxref("Transferable")}} objects to be transferred — these objects have their
+  - : {{Glossary("Transferable Objects")}} to be transferred — these objects have their
     ownership transferred to the receiving browsing context, so are no longer usable by
     the sending browsing context.
 

--- a/files/en-us/web/api/videoframe/clone/index.md
+++ b/files/en-us/web/api/videoframe/clone/index.md
@@ -30,7 +30,7 @@ The cloned {{domxref("VideoData")}} object.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the `VideoFrame` object has been {{domxref("Transferable","transferred", "", "true")}}.
+  - : Thrown if the `VideoFrame` object has been {{Glossary("Transferable Objects","transferred")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -35,7 +35,7 @@ worker.postMessage(message, [transfer]);
 
 - _transfer_ {{optional_inline}}
 
-  - : An optional [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.
+  - : An optional [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of {{Glossary("Transferable Objects")}} to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.
 
     Transferable objects are instances of classes like {{jsxref("ArrayBuffer")}}, {{domxref("MessagePort")}} or {{domxref("ImageBitmap")}} objects that can be transferred. `null` is not an acceptable value for `transfer`.
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.SharedArrayBuffer
 ---
 {{JSRef}}
 
-The **`SharedArrayBuffer`** object is used to represent a generic, fixed-length raw binary data buffer, similar to the {{jsxref("ArrayBuffer")}} object, but in a way that they can be used to create views on shared memory. Unlike an `ArrayBuffer`, a `SharedArrayBuffer` cannot become detached.
+The **`SharedArrayBuffer`** object is used to represent a generic, fixed-length raw binary data buffer, similar to the {{jsxref("ArrayBuffer")}} object, but in a way that they can be used to create views on shared memory. A `SharedArrayBuffer` is not a {{Glossary("Transferable Objects", "Transferable Object")}}, unlike an `ArrayBuffer` which is transferable.
 
 ## Description
 


### PR DESCRIPTION
#### Summary
1. The doc uses the term `detached` where we could use `transferable` which is well documented on MDN. 
2. Also fixed macro flaws for transferable objects.

#### Motivation

> I want to publicly demonstrate my own skills to improve my chances of getting a job.

#### Supporting details
Thanks @myshov for reporting

#### Related issues
Fixes #3797

#### Metadata
- [x] Fixes a typo, bug, or other error