### PR TITLE
Make the ARIA spec URL in SpecData be the current spec URL

### DIFF
--- a/files/jsondata/SpecData.json
+++ b/files/jsondata/SpecData.json
@@ -15,6 +15,11 @@
     "status": "CR"
   },
   "ARIA": {
+    "name": "Accessible Rich Internet Applications (WAI-ARIA)",
+    "url": "https://w3c.github.io/aria/",
+    "status": "Living"
+  },
+  "ARIA 1.1": {
     "name": "Accessible Rich Internet Applications (WAI-ARIA) 1.1",
     "url": "https://www.w3.org/TR/wai-aria-1.1/",
     "status": "REC"


### PR DESCRIPTION
The practice we’ve been following in general for spec URLs is to use the URL for whatever the current spec is — that is, the URL for the “Living” spec (aka “Editor’s Draft”).

So this change brings the ARIA spec URL in line with that practice — while adding an “ARIA 1.1” spec reference (for the latest W3C Rec).

See https://github.com/mdn/content/pull/12940 for an example of a problem that’s caused by the fact our existing docs reference the (now-obsolete and no longer maintained or updated) ARIA 1.1 Rec rather than the current (actively maintained) ARIA spec.