### PR TITLE
fix first wildcard example

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -217,7 +217,7 @@ string.
 
 ```js
 // A wildcard at the end of a pattern
-const pattern = new URLPattern('/books/', 'https://example.com');
+const pattern = new URLPattern('/books/*', 'https://example.com');
 console.log(pattern.test('https://example.com/books/123')); // true
 console.log(pattern.test('https://example.com/books')); // false
 console.log(pattern.test('https://example.com/books/')); // true


### PR DESCRIPTION
#### Summary

I found and added a missing `*` in one of `URLPattern`'s wildcard examples.

#### Metadata

This PR…

- [x] Fixes a typo, bug, or other error
