### PR TITLE
Document that Request() calls with init replace any existing options

### DIFF
--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -70,6 +70,17 @@ var myRequest = new Request(input[, init]);
       value of the request (e.g.,
       `sha256-BpfBw7ivV8q2jLiT13fxDYAe2tJllusRSZ273h2nFSE=`).
 
+    If you construct a new `Request` from an existing `Request`, any options you set in the _init_ object for the new request replace any corresponding options set in the existing `Request`. For example:
+
+       ```js
+       const oldRequest = new Request('https://github.com/mdn/content/issues/12959',
+         { headers: { 'From': 'webmaster@example.org'}});
+       oldRequest.headers.get("From"); // "webmaster@example.org"
+       const newRequest = new Request(oldRequest,
+         { headers: { 'From': 'developer@example.org'}});
+       newRequest.headers.get('From') // "developer@example.org"
+       ```
+
 ## Errors
 
 <table class="no-markdown">

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -70,7 +70,7 @@ var myRequest = new Request(input[, init]);
       value of the request (e.g.,
       `sha256-BpfBw7ivV8q2jLiT13fxDYAe2tJllusRSZ273h2nFSE=`).
 
-    If you construct a new `Request` from an existing `Request`, any options you set in the _init_ object for the new request replace any corresponding options set in the existing `Request`. For example:
+    If you construct a new `Request` from an existing `Request`, any options you set in the _init_ object for the new request replace any corresponding options set in the original `Request`. For example:
 
        ```js
        const oldRequest = new Request('https://github.com/mdn/content/issues/12959',


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12959

Per step 32, substep 2 of https://fetch.spec.whatwg.org/#dom-request, If you construct a new `Request` from an existing `Request`, any options you set in the _init_ object for the new request replace any corresponding options previously set in the existing `Request`.