### PR TITLE
Ff97 @scroll-timeline not released/behind pref

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -557,7 +557,7 @@ It can also be used to specify that the character is selected to be appropriate 
 
 ### Scroll-linked animations
 
-The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} properties allow you to define animations that are linked to container scroll progress (rather than time).
+The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} property allow you to define animations that are linked to container scroll progress (rather than time).
 Once specified, a scroll timeline is associated with a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) by using the `animation-timeline` property.
 For more information see {{bug(1676791)}} and {{bug(1676782)}}
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -554,6 +554,51 @@ It can also be used to specify that the character is selected to be appropriate 
   </tbody>
 </table>
 
+
+### Scroll-linked animations
+
+The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} properties allow you to define animations that are linked to container scroll progress (rather than time).
+Once specified, a scroll timeline is associated with a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) by using the `animation-timeline` property.
+For more information see {{bug(1676791)}} and {{bug(1676782)}}
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.scroll-linked-animations.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
+
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -22,9 +22,6 @@ No notable changes
 - The CSS units `cap` and `ic` are now supported for use with {{cssxref("&lt;length&gt;")}} and {{cssxref("&lt;length-percentage&gt;")}} data types.
   For more information see {{bug(1702924)}} and {{bug(1531223)}}
 
-- The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} property are now supported. This allows you to define an [`AnimationTimeline`](/en-US/docs/Web/API/AnimationTimeline), of which time values are determined by scrolling progress within a scroll container and not by minutes or seconds. Once specified, a scroll timeline is associated with a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) by using the `animation-timeline` property.
-  For more information see {{bug(1676791)}} and {{bug(1676782)}}
-
 - The CSS property `color-adjust` has been renamed to {{cssxref("print-color-adjust")}} to match the relevant specification.
   The `color-adjust` shorthand name is deprecated.
   See {{bug(747595)}} for details.


### PR DESCRIPTION
Part of fixing #12942 

The `@scroll-timeline` and `animation-timeline` support were added behind a preference, which I have updated in https://github.com/mdn/browser-compat-data/pull/14960. As a result this was not shipped in FF97. This removes from release notes and adds to experimental features.

