### PR TITLE
Specified the definition of screen.width

### DIFF
--- a/files/en-us/web/api/screen/width/index.md
+++ b/files/en-us/web/api/screen/width/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Screen.width
 {{APIRef("CSSOM")}}
 
 The **`Screen.width`** read-only property returns the width of
-the screen in pixels.
+the screen in CSS pixels.
 
 ## Syntax
 


### PR DESCRIPTION
specified that CSS pixels are used in screen.width interface

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I specified which pixels are used in definition

#### Motivation
some people misunderstand the definition and think of screen.width in device pixels


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
