### PR TITLE
FF98 registerProtocolHandler allows sftp, ftp, ftps schemes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -37,6 +37,8 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ### APIs
 
+- {{domxref("navigator.registerProtocolHandler()")}} can now register protocol handlers for the `ftp`, `sftp`, and `ftps` schemes ({{bug(1705202)}}).
+
 #### DOM
 
 - The properties `colorSpaceConversion`, `resizeWidth` and `resizeHeight` can be passed to the method {{domxref("createImageBitmap()")}} using the `options` object ({{bug(1748868)}} and {{bug(1733559)}}).

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.md
@@ -78,6 +78,8 @@ For example, `web+burger`, as shown in the {{anch("Example")}} below.
 Otherwise, the scheme must be one of the following:
 
 - `bitcoin`
+- `ftp`
+- `ftps`
 - `geo`
 - `im`
 - `irc`
@@ -89,6 +91,7 @@ Otherwise, the scheme must be one of the following:
 - `news`
 - `nntp`
 - `openpgp4fpr`
+- `sftp`
 - `sip`
 - `sms`
 - `smsto`


### PR DESCRIPTION
FF98 (https://bugzilla.mozilla.org/show_bug.cgi?id=1705202) adds support for `ftp`, `ftps`, `sftp` protocol handlers in [Navigator.registerProtocolHandler()](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler). This adds those items to the safelist doc and also adds a release note.

This is part of #12581