### PR TITLE
Array.find() - confusing use of "returns value"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Array.find
 ---
 {{JSRef}}
 
-The `find()` method returns the value of the first
+The `find()` method returns the first
 element in the provided array that satisfies the provided testing function. If no
 values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
@@ -63,14 +63,16 @@ find(function(element, index, array) { /* ... */ }, thisArg)
     - `array` {{optional_inline}}
       - : The array that `find` was called on.
 
+    The callback must return a [truthy](/en-US/docs/Glossary/Truthy) value to indicate a matching element has been found.
+
 - `thisArg` {{optional_inline}}
   - : Object to use as {{jsxref("Operators/this", "this")}} inside
     `callbackFn`.
 
 ### Return value
 
-The **value** of the **first element** in the array that
-satisfies the provided testing function. Otherwise, {{jsxref("undefined")}} is returned.
+The first element in the array that satisfies the provided testing function.
+Otherwise, {{jsxref("undefined")}} is returned.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -13,23 +13,17 @@ browser-compat: javascript.builtins.Array.find
 ---
 {{JSRef}}
 
-The `find()` method returns the first
-element in the provided array that satisfies the provided testing function. If no
-values satisfy the testing function, {{jsxref("undefined")}} is returned.
+The `find()` method returns the first element in the provided array that satisfies the provided testing function.
+If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 {{EmbedInteractiveExample("pages/js/array-find.html","shorter")}}
 
-- If you need the **index** of the found element in the array, use
-  {{jsxref("Array.findIndex", "findIndex()")}}.
-- If you need to find the **index of a value**, use
-  {{jsxref("Array.prototype.indexOf()")}}. (It’s similar to {{jsxref("Array.findIndex",
-    "findIndex()")}}, but checks each element for equality with the value instead of using
-  a testing function.)
-- If you need to find if a value **exists** in an array, use
-  {{jsxref("Array.prototype.includes()")}}. Again, it checks each element for equality
-  with the value instead of using a testing function.
-- If you need to find if any element satisfies the provided testing function, use
-  {{jsxref("Array.prototype.some()")}}.
+- If you need the **index** of the found element in the array, use {{jsxref("Array.findIndex", "findIndex()")}}.
+- If you need to find the **index of a value**, use {{jsxref("Array.prototype.indexOf()")}}.
+  (It’s similar to {{jsxref("Array.findIndex", "findIndex()")}}, but checks each element for equality with the value instead of using a testing function.)
+- If you need to find if a value **exists** in an array, use {{jsxref("Array.prototype.includes()")}}.
+  Again, it checks each element for equality with the value instead of using a testing function.
+- If you need to find if any element satisfies the provided testing function, use {{jsxref("Array.prototype.some()")}}.
 
 ## Syntax
 
@@ -66,8 +60,7 @@ find(function(element, index, array) { /* ... */ }, thisArg)
     The callback must return a [truthy](/en-US/docs/Glossary/Truthy) value to indicate a matching element has been found.
 
 - `thisArg` {{optional_inline}}
-  - : Object to use as {{jsxref("Operators/this", "this")}} inside
-    `callbackFn`.
+  - : Object to use as {{jsxref("Operators/this", "this")}} inside `callbackFn`.
 
 ### Return value
 
@@ -76,33 +69,22 @@ Otherwise, {{jsxref("undefined")}} is returned.
 
 ## Description
 
-The `find` method executes the `callbackFn` function
-once for each index of the array until the `callbackFn` returns a [truthy](/en-US/docs/Glossary/Truthy) value. If so, `find`
-immediately returns the value of that element. Otherwise, `find` returns
-{{jsxref("undefined")}}.
+The `find` method executes the `callbackFn` function once for each index of the array until the `callbackFn` returns a [truthy](/en-US/docs/Glossary/Truthy) value.
+If so, `find` immediately returns the value of that element. Otherwise, `find` returns {{jsxref("undefined")}}.
 
-`callbackFn` is invoked for _every_ index of the array, not
-just those with assigned values. This means it may be less efficient for sparse arrays,
-compared to methods that only visit assigned values.
+`callbackFn` is invoked for _every_ index of the array, not just those with assigned values.
+This means it may be less efficient for sparse arrays, compared to methods that only visit assigned values.
 
-If a `thisArg` parameter is provided to `find`, it
-will be used as the `this` value inside each invocation of the
-`callbackFn`. If it is not provided, then {{jsxref("undefined")}} is
-used.
+If a `thisArg` parameter is provided to `find`, it will be used as the `this` value inside each invocation of the `callbackFn`.
+If it is not provided, then {{jsxref("undefined")}} is used.
 
-The `find` method does not mutate the array on which it is called, but the
-function provided to `callbackFn` can. If so, the elements processed
-by `find` are set _before_ the first invocation of
-`callbackFn`. Therefore:
+The `find` method does not mutate the array on which it is called, but the function provided to `callbackFn` can.
+If so, the elements processed by `find` are set _before_ the first invocation of `callbackFn`.
+Therefore:
 
-- `callbackFn` will not visit any elements added to the array
-  after the call to `find` begins.
-- Elements which are assigned to indexes already visited, or to indexes
-  outside the range, will not be visited by `callbackFn`.
-- If an existing, yet-unvisited element of the array is changed by
-  `callbackFn`, its value passed to the
-  `callbackFn` will be the value at the time `find`
-  visits that element's index.
+- `callbackFn` will not visit any elements added to the array after the call to `find` begins.
+- Elements which are assigned to indexes already visited, or to indexes outside the range, will not be visited by `callbackFn`.
+- If an existing, yet-unvisited element of the array is changed by `callbackFn`, its value passed to the `callbackFn` will be the value at the time `find` visits that element's index.
 - Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.
 
 > **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
@@ -142,8 +124,7 @@ console.log(result) // { name: 'cherries', quantity: 5 }
 
 ### Find a prime number in an array
 
-The following example finds an element in the array that is a prime number (or returns
-{{jsxref("undefined")}} if there is no prime number):
+The following example finds an element in the array that is a prime number (or returns {{jsxref("undefined")}} if there is no prime number):
 
 ```js
 function isPrime(element, index, array) {


### PR DESCRIPTION
Fixes #12643

Array.find gets the first element that matches a test, not the "value" of the first element. Or to be more precise, the use of "value" there is confusing, because it implies that perhaps the element returned is a copy, whereas it is actually the actual element. 

NOTE: This is two commits. The first is the content changes. The second only affects layout, and can be ignored.