### PR TITLE
Add missing sections to fullscreen events

### DIFF
--- a/files/en-us/web/api/document/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.md
@@ -20,6 +20,20 @@ To find out whether the `Element` is entering or exiting fullscreen mode, check 
 
 This event is not cancelable.
 
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('fullscreenchange', event => { });
+
+onfullscreenchange = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
 ## Examples
 
 In this example, a handler for the `fullscreenchange` event is added to the {{domxref("Document")}}.

--- a/files/en-us/web/api/document/fullscreenerror_event/index.md
+++ b/files/en-us/web/api/document/fullscreenerror_event/index.md
@@ -20,6 +20,20 @@ For some reasons that switching into fullscreen mode might fail, see [the guide 
 
 This event is not cancelable.
 
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('fullscreenerror', event => { });
+
+onfullscreenerror = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/element/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/element/fullscreenchange_event/index.md
@@ -20,6 +20,20 @@ To find out whether the `Element` is entering or exiting fullscreen mode, check 
 
 This event is not cancelable.
 
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('fullscreenchange', event => { });
+
+onfullscreenchange = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
 ## Examples
 
 In this example, a handler for the `fullscreenchange` event is added to the element whose ID is `fullscreen-div`.

--- a/files/en-us/web/api/element/fullscreenerror_event/index.md
+++ b/files/en-us/web/api/element/fullscreenerror_event/index.md
@@ -20,6 +20,20 @@ For some reasons that switching into fullscreen mode might fail, see [the guide 
 
 This event is not cancelable.
 
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('fullscreenchange', event => { });
+
+onfullscreenchange = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
 ## Examples
 
 ```js


### PR DESCRIPTION
This PR is a follow-up to #12926.  This PR adds the missing "Syntax" and "Event type" sections.  The description section is omitted as I feel there is sufficient explanation in the rest of the page content already.
