### PR TITLE
Finish conversion of AudioScheduledSourceNode ended event page

### DIFF
--- a/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.md
@@ -22,6 +22,20 @@ This event occurs when a {{domxref("AudioScheduledSourceNode")}} has stopped pla
 
 This event is not cancelable and does not bubble.
 
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('ended', event => { });
+
+onended = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
 ## Examples
 
 In this simple example, an event listener for the `ended` event is set up to enable a "Start" button in the user interface when the node stops playing:
@@ -32,7 +46,7 @@ node.addEventListener('ended', () => {
 })
 ```
 
-You can also set up the event handler using the {{domxref("AudioScheduledSourceNode.onended")}} property:
+You can also set up the event handler using the `onended` property:
 
 ```js
 node.onended = function() {

--- a/files/en-us/web/api/audioscheduledsourcenode/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/index.md
@@ -14,7 +14,7 @@ browser-compat: api.AudioScheduledSourceNode
 ---
 {{APIRef("Web Audio API")}}
 
-The `AudioScheduledSourceNode` interface—part of the Web Audio API—is a parent interface for several types of audio source node interfaces which share the ability to be started and stopped, optionally at specified times. Specifically, this interface defines the {{domxref("AudioScheduledSourceNode.start", "start()")}} and {{domxref("AudioScheduledSourceNode.stop", "stop()")}} methods, as well as the {{domxref("AudioScheduledSourceNode.onended", "onended")}} event handler.
+The `AudioScheduledSourceNode` interface—part of the Web Audio API—is a parent interface for several types of audio source node interfaces which share the ability to be started and stopped, optionally at specified times. Specifically, this interface defines the {{domxref("AudioScheduledSourceNode.start", "start()")}} and {{domxref("AudioScheduledSourceNode.stop", "stop()")}} methods, as well as the {{domxref("AudioScheduledSourceNode.ended_event", "ended")}} event.
 
 > **Note:** You can't create an `AudioScheduledSourceNode` object directly. Instead, use the interface which extends it, such as {{domxref("AudioBufferSourceNode")}}, {{domxref("OscillatorNode")}}, and {{domxref("ConstantSourceNode")}}.
 
@@ -41,7 +41,6 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 - [`ended`](/en-US/docs/Web/API/AudioScheduledSourceNode/ended_event)
   - : Fired when the source node has stopped playing, either because it's reached a predetermined stop time, the full duration of the audio has been performed, or because the entire buffer has been played.
-    Also available using the [`onended`](/en-US/docs/Web/API/AudioScheduledSourceNode/onended) event handler property.
 
 ## Specifications
 

--- a/files/en-us/web/api/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/index.md
@@ -44,13 +44,13 @@ _Inherits properties from its parent interface, {{domxref("AudioScheduledSourceN
 - {{domxref("ConstantSourceNode.offset", "offset")}}
   - : An {{domxref("AudioParam")}} which specifies the value that this source continuously outputs. The default value is 1.0.
 
-### Event handlers
+### Events
 
-_Inherits event handlers from its parent interface, {{domxref("AudioScheduledSourceNode")}}._
+_Inherits events from its parent interface, {{domxref("AudioScheduledSourceNode")}}._
 
-> **Note:** Some browsers' implementations of this event handler are part of the  {{domxref("AudioScheduledSourceNode")}} interface.
+> **Note:** Some browsers' implementations of these events are part of the  {{domxref("AudioScheduledSourceNode")}} interface.
 
-- {{domxref("AudioScheduledSourceNode.onended()","onended")}}
+- {{domxref("AudioScheduledSourceNode.ended_event","ended")}}
   - : Fired whenever the {{domxref('ConstantSourceNode')}} data has stopped playing.
 
 ## Methods


### PR DESCRIPTION
This PR completes the conversion of the `ended` event of the `AudioScheduledSourceNode` API by performing two operations:
- Adds the missing sections to the event's page
- Removes all links to the former event handler page
