### PR TITLE
content_scripts: Remove link to long-resolved Firefox expando bug

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -35,8 +35,6 @@ Content scripts can only access [a small subset of the WebExtension APIs](#webex
 >
 > Because these restrictions include addons.mozilla.org, users may attempt to use your extension immediately after installation—only to find that it doesn't work! You may want to add an appropriate warning, or an [onboarding page](https://extensionworkshop.com/documentation/develop/onboard-upboard-offboard-users/) to move users away from `addons.mozilla.org`.
 
-> **Note:** Values added to the global scope of a content script with `let foo` or `window.foo = "bar"` may disappear due to bug [1408996](https://bugzilla.mozilla.org/show_bug.cgi?id=1408996).
-
 ## Loading content scripts
 
 You can load a content script into a web page in one of three ways:


### PR DESCRIPTION
Bug 1408996 was resolved by bug 1514050 which was released in Firefox 67.0 on May 21, 2019.

#### Motivation
Firefox 67 is no longer supported on release on ESR channels so the warning is just a distraction.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1408996#c37
https://bugzilla.mozilla.org/show_bug.cgi?id=1514050#c5
https://wiki.mozilla.org/Release_Management/Calendar#Past_branch_dates

#### Metadata
- [x] Fixes a typo, bug, or other error