### PR TITLE
Remove incorrect options.signDisplay value for Intl.NumberFormat

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -132,7 +132,6 @@ new Intl.NumberFormat(locales, options)
         - "`auto`" sign display for negative numbers only
         - "`exceptZero`" sign display for positive and negative
           numbers, but not zero
-        - "`negative`" sign display for negative numbers only, excluding negative zero.
         - "`never`" never display sign
 
     - `style`


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The options of the `signDisplay` property in `options` parameter are not correct. Value `negative` is not supported.

Run
```
console.log(new Intl.NumberFormat("en-US", { maximumFractionDigits: 0, minimumFractionDigits: 0, signDisplay: 'negative' }).format(-0.2))
```
Error
```
Error: Value negative out of range for Intl.NumberFormat options property signDisplay
```

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
