### PR TITLE
Update dump() method documentation

### DIFF
--- a/files/en-us/web/api/window/dump/index.md
+++ b/files/en-us/web/api/window/dump/index.md
@@ -7,10 +7,13 @@ tags:
   - Method
   - Non-standard
   - Window
+browser-compat: api.Window.dump
 ---
 {{ ApiRef() }} {{Non-standard_header}}
 
-**`Window.dump()`** prints messages to the (native) console.
+The **`Window.dump()`** method logs messages to the browser's standard output (`stdout`). If the browser was started from a terminal, output sent to `dump()` will appear in the terminal.
+
+Output from `dump()` is _not_ sent to the browser's developer tools console. To log to the developer tools console, use [`console.log()`](/en-US/docs/Web/API/console/log).
 
 ## Syntax
 
@@ -22,60 +25,13 @@ dump(message);
 
 ### Parameters
 
-- `message` is the string message to log.
-
-## Notes
-
-A common use of `dump()` is to debug JavaScript. The message passed to
-`dump()` is sent to the System Console (Native Console) if the Firefox
-process was started with the `-console` option. If the `-console`
-option was not specified then the output goes to stderr. Output from dump() is not sent
-to the [Browser Console](/en-US/docs/Tools/Browser_Console). Output can be
-sent to the [Browser Console](/en-US/docs/Tools/Browser_Console) using [console.log()](/en-US/docs/Web/API/console/log). Privileged code can also use
-[`Components.utils.reportError`](/en-US/docs/Components.utils.reportError)
-and
-[`nsIConsoleService`](/en-US/docs/XPCOM_Interface_Reference/nsIConsoleService)
-to log messages to the [Error Console](/en-US/docs/Error_Console)/[Browser Console](/en-US/docs/Tools/Browser_Console).
-
-`dump()` is also available to XPCOM components implemented in JavaScript,
-even though {{domxref("window")}} is not the global object in components. It is also
-explicitly made available in [sandboxes](/en-US/docs/Components.utils.Sandbox#Methods_available_on_the_Sandbox_object). However, this use of
-`dump` is not affected by the preference mentioned below -- it will always be
-shown. It is therefore advisable to either check this preference yourself or use a
-debugging preference of your own to make sure you don't send lots of debugging content
-to a user's console when they might not be interested in it at all. Note that
-`dump` output from XPCOM components goes to `stderr`, while
-`dump` called elsewhere will output to `stdout`.
-
-In [Gecko](/en-US/docs/Mozilla/Gecko) `dump()` is **disabled by
-default** – it doesn't do anything but doesn't raise an error either. To see
-the `dump` output you have to enable it by setting the preference
-`browser.dom.window.dump.enabled` to `true`. You can set the
-preference in [about:config](http://kb.mozillazine.org/About:config) or in a
-[user.js file](http://kb.mozillazine.org/User.js_file). Note: this preference
-is not listed in `about:config` by default, you may need to create it
-(right-click the content area -> New -> Boolean).
-
-On Windows, you will need a console to actually see anything. If you don't have one
-already, closing the application and re-opening it with the command line parameter
-`-console` should create the console or use `-attach-console` to
-use the existing console. On other operating systems, it's enough to launch the
-application from a terminal.
-
-To redirect the console output to a file, run firefox _without_ the -console
-option and use the syntax to redirect stderr and stdout to a file, i.e.:
-
-```bash
-firefox > console.txt 2>&1
-```
-
-> **Note:** If you would like the console messages to appear in the console you used to launch
-> the application, you can use the [Gecko Console Redirector](https://github.com/matthewkastor/Redirector).
-> Precompiled binaries are available in the zipped archive <https://github.com/matthewkastor/Redirector/archive/master.zip>
-> under `Redirector-master\Gecko\Console Redirector\bin\Release` Copy all the
-> dll's and the exe to wherever you want. Then run
-> `Console Redirector.exe /?`
+- `message`
+  - : A string containing the message to log.
 
 ## Specifications
 
-This is not part of any specification
+This feature is not part of any specification.
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/workerglobalscope/dump/index.md
+++ b/files/en-us/web/api/workerglobalscope/dump/index.md
@@ -10,50 +10,27 @@ tags:
   - dump
 browser-compat: api.WorkerGlobalScope.dump
 ---
-{{APIRef("Web Workers API")}} {{Deprecated_Header}} {{Non-standard_header}}
+{{APIRef("Web Workers API")}} {{Non-standard_header}}
 
-The **`dump()`** method of the {{domxref("WorkerGlobalScope")}} interface allows you to write a message to stdout — i.e. in your terminal, in Firefox only. This is the same as Firefox's {{domxref("window.dump")}}, but for workers.
+The **`WorkerGlobalScope.dump()`** method logs messages to the browser's standard output (`stdout`). If the browser was started from a terminal, output sent to `dump()` will appear in the terminal. This is the same as {{domxref("Window.dump()")}}, but for workers.
+
+Output from `dump()` is _not_ sent to the browser's developer tools console. To log to the developer tools console, use [`console.log()`](/en-US/docs/Web/API/console/log).
 
 ## Syntax
 
 ```js
-dump('My message\n');
+dump(message);
 ```
 
 ### Parameters
 
-A {{domxref("DOMString")}} containing the message you want to send.
-
-### Returns
-
-{{jsxref('undefined')}}.
-
-## Example
-
-To write an output from your worker to your computer's terminal, you first have to run an instance of Firefox started from your command line/terminal. For example, on Mac OS X you'd run it using something like this (assuming you are inside the `Applications` folder):
-
-```bash
-./Firefox.app/Contents/MacOS/firefox-bin -profile /tmp -no-remote
-```
-
-Now go into `about:config` and enable the `browser.dom.window.dump.enabled` pref.
-
-Next, run a worker containing the following line:
-
-```js
-dump('test\n');
-```
-
-This should result in a "test" message being output to the terminal.
+- `message`
+  - : A string containing the message to log.
 
 ## Specifications
 
-This method does not appear in any specification.
+This feature is not part of any specification.
 
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-{{domxref("WorkerGlobalScope")}}


### PR DESCRIPTION
This updates and cleans the `dump()` method pages, which are Firefox-only and disabled by default. I took out some things I could not verify, including stuff about the `-console` option, which I could not find documented anywhere and which seemed to make no difference.

I filed https://github.com/mdn/browser-compat-data/pull/15014 to update the BCD.