### PR TITLE
replace {{event}} macro with more specific {{domxref}}

### DIFF
--- a/files/en-us/web/api/geolocationcoordinates/longitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/longitude/index.md
@@ -77,7 +77,7 @@ established by calling {{domxref("EventTarget.addEventListener", "addEventListen
 on the {{HTMLElement("button")}} element. When the user clicks the button, we'll fetch
 and display the location information.
 
-Upon receiving a {{event("click")}} event, we call
+Upon receiving a {{domxref("Element/click_event", "click")}} event, we call
 {{domxref("Geolocation.getCurrentPosition", "getCurrentPosition()")}} to request the
 device's current position. This is an asynchronous request, so we provide a callback
 which receives as in put a {{domxref("GeolocationPosition")}} object describing the


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{event("click")}} with {{domxref("Element/click_event", "click")}} because {{event}} is ambiguous.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
