### PR TITLE
Replace arrow functions inside of pre - ES6 code

### DIFF
--- a/files/en-us/glossary/iife/index.md
+++ b/files/en-us/glossary/iife/index.md
@@ -128,7 +128,7 @@ them, we would like them to alert 0 and 1. The following code doesn't work:
 for (var i = 0; i < 2; i++) {
   const button = document.createElement('button');
   button.innerText = 'Button ' + i;
-  button.onclick = () => {
+  button.onclick = function() {
     console.log(i);
   };
   document.body.appendChild(button);
@@ -143,7 +143,7 @@ with the last value 2. To fix this problem before ES6, we could use the IIFE pat
 for (var i = 0; i < 2; i++) {
   const button = document.createElement('button');
   button.innerText = 'Button ' + i;
-  button.onclick = ((copyOfI) => {
+  button.onclick = (function(copyOfI) {
     return () => {
       console.log(copyOfI);
     };
@@ -161,7 +161,7 @@ Using the statement **let**, we could simply do:
 for (let i = 0; i < 2; i++) {
   const button = document.createElement("button");
   button.innerText = 'Button ' + i;
-  button.onclick = () => {
+  button.onclick = function() {
     console.log(i);
   };
   document.body.appendChild(button);


### PR DESCRIPTION
Replaced several instances of arrow function expressions with regular functions using the `function` keyword inside of code specifically described as pre-ES6. This change is especially important as the intention of this section of the article is to showcase the differences between pre-ES6 and modern JavaScript.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To avoid confusion by using features only found in ES6+ inside of described pre-ES6 code.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
n/a
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
