### PR TITLE
Normalize a few old Exceptions sections

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -64,17 +64,10 @@ void ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
     scaling of the drawn image. If not specified, the image is not scaled in height when
     drawn. Note that this argument is not included in the 3-argument syntax.
 
-### Exceptions thrown
+### Exceptions
 
-- `INDEX_SIZE_ERR`
-  - : If the canvas or source rectangle width or height is zero.
-- `INVALID_STATE_ERR`
-  - : The image has no image data.
-- `TYPE_MISMATCH_ERR`
-  - : The specified source element isn't supported.
-- `NS_ERROR_NOT_AVAILABLE`
-  - : The image is not loaded yet. Use `.complete === true` and
-    `.onload` to determine when it is ready.
+- `InvalidStateError`
+  - : Thrown if the image has no image data or if the canvas or source rectangle width or height is zero.
 
 ## Examples
 

--- a/files/en-us/web/api/websocket/send/index.md
+++ b/files/en-us/web/api/websocket/send/index.md
@@ -48,12 +48,10 @@ WebSocket.send("Hello server!");
         the buffer, increasing the value of `bufferedAmount` by the requisite
         number of bytes.
 
-### Exceptions thrown
+### Exceptions
 
-- `INVALID_STATE_ERR`
+- `InvalidStateError`
   - : Thrown if {{domxref("WebSocket/readyState", "WebSocket.readyState")}} is `CONNECTING`.
-- `SYNTAX_ERR`
-  - : The data is a string that has unpaired surrogates.
 
 ## Specifications
 

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -34,12 +34,14 @@ var aWebSocket = new WebSocket(url [, protocols]);
 
     If it is omitted, an empty array is used by default, i.e. `[]`.
 
-### Exceptions thrown
+### Exceptions
 
-- `SECURITY_ERR`
-  - : The port to which the connection is being attempted is being blocked.
-- [SyntaxError](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError)
-  - : The URL is invalid.
+- [`SyntaxError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError)
+  - : Thrown if:
+    - parsing of [`url`](#url) fails
+    - [`url`](#url) has a scheme other than `ws` or `wss`
+    - [`url`](#url)  has a [fragment](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#fragment)
+    - any of the values in [`protocols`](#protocols) occur more than once, or otherwise fail to match the requirements for elements that comprise the value of [`Sec-WebSocket-Protocol`](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism#sec-websocket-protocol) fields as defined by the WebSocket Protocol specification
 
 ## Specifications
 
@@ -48,3 +50,7 @@ var aWebSocket = new WebSocket(url [, protocols]);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455.html) (the WebSocket Protocol specification)


### PR DESCRIPTION
This brings a few old Exceptions sections in line with current practice:

- Change “Exceptions thrown” headings to just “Execptions” (these were the only articles in MDN that had “Exceptions thrown” headings)
- Being exception explanations with “Thrown if”
- Replace exception legacy code names with current names; for example, replace `INVALID_STATE_ERR` with `InvalidStateError`
- Drop some exceptions that are not thrown (or no longer thrown) per the current spec
- Make description of when the exception is thrown align with current spec

Relevant spec sections:

- https://html.spec.whatwg.org/multipage/canvas.html#drawing-images:dom-context-2d-drawimage-2
- https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument
- https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-send
- https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-dev
- https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-dev