### PR TITLE
Replace some exception legacy code names with current names

### DIFF
--- a/files/en-us/web/api/document/createattribute/index.md
+++ b/files/en-us/web/api/document/createattribute/index.md
@@ -33,8 +33,8 @@ A {{domxref("Attr")}} node.
 
 ### Exceptions
 
-- `INVALID_CHARACTER_ERR` if the parameter contains invalid characters for
-  XML attribute.
+- `InvalidCharacterError`
+  - : Thrown if the [`name`](#name) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
 
 ## Example
 

--- a/files/en-us/web/api/document/createattribute/index.md
+++ b/files/en-us/web/api/document/createattribute/index.md
@@ -33,7 +33,7 @@ A {{domxref("Attr")}} node.
 
 ### Exceptions
 
-- `InvalidCharacterError`
+- `InvalidCharacterError` {{domxref("DOMException")}}
   - : Thrown if the [`name`](#name) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
 
 ## Example

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -30,7 +30,7 @@ piNode = document.createProcessingInstruction(target, data)
 
 ### Exceptions
 
-- `InvalidCharacterError`
+- `InvalidCharacterError` {{domxref("DOMException")}}
 
   - : Thrown if either of the following are true:
 

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -30,12 +30,12 @@ piNode = document.createProcessingInstruction(target, data)
 
 ### Exceptions
 
-- `DOM_INVALID_CHARACTER`
+- `InvalidCharacterError`
 
-  - : Throws if either of the following are true:
+  - : Thrown if either of the following are true:
 
-    - The processing instruction `target` is invalid — it should be a valid _[XML name](https://www.w3.org/TR/REC-xml/#dt-name)_ that doesn't contain "xml", "XML", or any case combination of the two, other than standardized ones such as `<?xml-stylesheet ?>`.
-    - The _closing processing instruction sequence_ (`?>`) is part of the `data`.
+    - The [`target`](#target) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
+    - The _closing processing instruction sequence_ (`?>`) is part of the [`data`](#data) value.
 
 ## Example
 

--- a/files/en-us/web/api/filereader/abort/index.md
+++ b/files/en-us/web/api/filereader/abort/index.md
@@ -22,12 +22,6 @@ the {{domxref("FileReader.readyState","readyState")}} will be `DONE`.
 instanceOfFileReader.abort();
 ```
 
-### Exceptions
-
-- `DOM_FILE_ABORT_ERR`
-  - : Thrown when `abort` is called while no read operation is in progress
-    (that is, the state isn't `LOADING`).
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
This replaces some remaining instances in **Exceptions** sections of legacy code names for DOM exceptions with their current names; for example, `InvalidCharacterError` rather than legacy `INVALID_CHARACTER_ERR`. It also makes other updates:

- Per the current spec, `FileReader»abort()` throws no exceptions
- The `Document»createProcessingInstruction()` `target` parameter can in fact start with `xml`; e.g., `xml-foo` is a valid, non-prohibited XML Name.

Relevant spec citations:

- https://w3c.github.io/FileAPI/#abort
- https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
- https://dom.spec.whatwg.org/#dom-document-createattribute
- https://www.w3.org/TR/xml/#dt-name
- https://www.w3.org/TR/xml/#NT-NameChar