### PR TITLE
Improve section: spread syntax only for iterators

### DIFF
--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -295,29 +295,26 @@ let mergedObj2 = merge ({}, obj1, obj2);
 // Object { 0: {}, 1: { foo: 'bar', x: 42 }, 2: { foo: 'baz', y: 13 } }
 ```
 
-In the above example, the spread syntax does not work as one might expect: it spreads
-an _array_ of arguments into the object literal, due to the rest parameter.
+In the above example, the spread syntax does not work as one might expect: it spreads an _array_ of arguments into the object literal, due to the rest parameter.
 
 ### Only for iterables
 
-Objects themselves are not iterable, but they become iterable when used in an Array, or
-with iterating functions such as `map()`, `reduce()`, and
-`assign()`. When merging 2 objects together with the spread operator, it is
-assumed another iterating function is used when the merging occurs.
+Spread syntax (other than in the case of spread properties) can only be applied to [iterable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator)
+objects like {{jsxref("Array"), or with iterating functions such as `map()`, `reduce()`, and `assign()`.
 
-Spread syntax (other than in the case of spread properties) can be applied only to [iterable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator)
-objects:
+Many objects are not iterable, including {{JSxRef("Object")}}:
 
 ```js
 let obj = {'key1': 'value1'};
 let array = [...obj]; // TypeError: obj is not iterable
 ```
 
+To use spread syntax with these objects you will need to provide an iterator function.
+
 ### Spread with many values
 
-When using spread syntax for function calls, be aware of the possibility of exceeding
-the JavaScript engine's argument length limit. See {{jsxref("Function.prototype.apply",
-   "apply()")}} for more details.
+When using spread syntax for function calls, be aware of the possibility of exceeding the JavaScript engine's argument length limit.
+See {{jsxref("Function.prototype.apply", "apply()")}} for more details.
 
 ## Specifications
 
@@ -329,6 +326,5 @@ the JavaScript engine's argument length limit. See {{jsxref("Function.prototype.
 
 ## See also
 
-- {{jsxref("Functions/rest_parameters", "Rest parameters", "", 1)}} (also
-  ‘`...`’)
+- {{jsxref("Functions/rest_parameters", "Rest parameters", "", 1)}} (also ‘`...`’)
 - {{jsxref("Function.prototype.apply()")}} (also ‘`...`’)

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -309,7 +309,7 @@ let obj = {'key1': 'value1'};
 let array = [...obj]; // TypeError: obj is not iterable
 ```
 
-To use spread syntax with these objects you will need to provide an iterator function.
+To use spread syntax with these objects, you will need to provide an iterator function.
 
 ### Spread with many values
 

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -300,7 +300,7 @@ In the above example, the spread syntax does not work as one might expect: it sp
 ### Only for iterables
 
 Spread syntax (other than in the case of spread properties) can only be applied to [iterable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator)
-objects like {{jsxref("Array"), or with iterating functions such as `map()`, `reduce()`, and `assign()`.
+objects like {{jsxref("Array")}}, or with iterating functions such as `map()`, `reduce()`, and `assign()`.
 
 Many objects are not iterable, including {{JSxRef("Object")}}:
 


### PR DESCRIPTION
Fixes #13079

Fixes gibberish sentence about iterating objects. 