### PR TITLE
Using screen capture - Added compat

### DIFF
--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -333,6 +333,10 @@ If you're performing screen capture within an `<iframe>`, you can request permis
 </iframe>
 ```
 
+## Browser compatibility
+
+{{Compat("api.MediaDevices.getDisplayMedia")}}
+
 ## See also
 
 - [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API)


### PR DESCRIPTION
The screen capture API does not have broader browser support, but that was not obvious from [Using the Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture). I've added compatibility section and included `getDisplayMedia` (the main precondition).

Fixes #13080