### PR TITLE
Make markup example in “ARIA: list role” conform to ARIA in HTML spec

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.md
@@ -14,11 +14,11 @@ tags:
 The ARIA `list` role can be used to identify a list of items. It is normally used in conjunction with the `listitem` role, which is used to identify a list item contained inside the list.
 
 ```html
-<section role="list">
+<div role="list">
   <div role="listitem">List item 1</div>
   <div role="listitem">List item 2</div>
   <div role="listitem">List item 3</div>
-</section>
+</div>
 ```
 
 ## Description


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13091. Per https://w3c.github.io/html-aria/#el-section the `section` element can’t have the `list` role. So without this change, the validator reports an error for the existing `<section role="list">` example.