### PR TITLE
Undeprecate Battery Status API

### DIFF
--- a/files/en-us/web/api/battery_status_api/index.md
+++ b/files/en-us/web/api/battery_status_api/index.md
@@ -9,11 +9,10 @@ tags:
   - Battery Status API
   - Guide
   - Mobile
-  - Deprecated
   - Overview
 browser-compat: api.BatteryManager
 ---
-{{DefaultAPISidebar("Battery API")}}{{deprecated_header}}
+{{DefaultAPISidebar("Battery API")}}
 
 The **Battery Status API**, more often referred to as the **Battery API**, provides information about the system's battery charge level and lets you be notified by events that are sent when the battery level or charging status change. This can be used to adjust your app's resource usage to reduce battery drain when the battery is low, or to save changes before the battery runs out in order to prevent data loss.
 

--- a/files/en-us/web/api/batterymanager/charging/index.md
+++ b/files/en-us/web/api/batterymanager/charging/index.md
@@ -4,11 +4,10 @@ slug: Web/API/BatteryManager/charging
 tags:
   - API
   - Property
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.charging
 ---
-{{deprecated_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 The **`BatteryManager.charging`** property is a Boolean value indicating whether or not the device's battery is currently being charged. When its value changes, the [`chargingchange`](/en-US/docs/Web/API/BatteryManager/chargingchange_event) event is fired.
 

--- a/files/en-us/web/api/batterymanager/chargingchange_event/index.md
+++ b/files/en-us/web/api/batterymanager/chargingchange_event/index.md
@@ -4,12 +4,9 @@ slug: Web/API/BatteryManager/chargingchange_event
 tags:
   - API
   - Event
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.chargingchange_event
 ---
-{{deprecated_header}}
-
 {{APIRef("Battery API")}}
 
 The **`chargingchange`** event of the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) is fired when the battery {{domxref("BatteryManager.charging","charging")}} property is updated.

--- a/files/en-us/web/api/batterymanager/chargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.md
@@ -4,12 +4,9 @@ slug: Web/API/BatteryManager/chargingTime
 tags:
   - API
   - Property
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.chargingTime
 ---
-{{deprecated_header}}
-
 {{APIRef("Battery API")}}
 
 The **`BatteryManager.chargingTime`** property indicates the amount of time, in seconds, that remain until the battery is fully charged or `0` if the battery is already fully charged. If the battery is currently

--- a/files/en-us/web/api/batterymanager/chargingtimechange_event/index.md
+++ b/files/en-us/web/api/batterymanager/chargingtimechange_event/index.md
@@ -4,12 +4,9 @@ slug: Web/API/BatteryManager/chargingtimechange_event
 tags:
   - API
   - Event
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.chargingtimechange_event
 ---
-{{deprecated_header}}
-
 {{APIRef("Battery API")}}
 
 The **`chargingtimechange`** event of the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) is fired when the battery {{domxref("BatteryManager.chargingTime","chargingTime")}} is updated.

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.md
@@ -4,11 +4,10 @@ slug: Web/API/BatteryManager/dischargingTime
 tags:
   - API
   - Property
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.dischargingTime
 ---
-{{deprecated_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 The **`BatteryManager.dischargingTime`** property indicates the amount of time, in seconds, that remains until the battery is fully
 discharged,

--- a/files/en-us/web/api/batterymanager/dischargingtimechange_event/index.md
+++ b/files/en-us/web/api/batterymanager/dischargingtimechange_event/index.md
@@ -4,12 +4,9 @@ slug: Web/API/BatteryManager/dischargingtimechange_event
 tags:
   - API
   - Event
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.dischargingtimechange_event
 ---
-{{deprecated_header}}
-
 {{APIRef("Battery API")}}
 
 The **`dischargingtimechange`** event of the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) is fired when the battery {{domxref("BatteryManager.dischargingTime","dischargingTime")}} is updated.

--- a/files/en-us/web/api/batterymanager/index.md
+++ b/files/en-us/web/api/batterymanager/index.md
@@ -6,11 +6,10 @@ tags:
   - Battery API
   - Device API
   - Interface
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager
 ---
-{{APIRef}}{{deprecated_header}}
+{{APIRef}}
 
 The `BatteryManager` interface of the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) provides information about the system's battery charge level. The {{domxref("navigator.getBattery()")}} method returns a promise that resolves with a `BatteryManager` interface.
 

--- a/files/en-us/web/api/batterymanager/level/index.md
+++ b/files/en-us/web/api/batterymanager/level/index.md
@@ -4,11 +4,10 @@ slug: Web/API/BatteryManager/level
 tags:
   - API
   - Property
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.level
 ---
-{{deprecated_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 The **`BatteryManager.level`** property indicates the current battery charge level as a value between `0.0` and `1.0`.
 A value of `0.0` means the battery is empty and the system is about to be suspended.

--- a/files/en-us/web/api/batterymanager/levelchange_event/index.md
+++ b/files/en-us/web/api/batterymanager/levelchange_event/index.md
@@ -4,11 +4,10 @@ slug: Web/API/BatteryManager/levelchange_event
 tags:
   - API
   - Event
-  - Deprecated
   - Reference
 browser-compat: api.BatteryManager.levelchange_event
 ---
-{{deprecated_header}} {{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 The **`levelchange`** event of the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) is fired when the battery {{domxref("BatteryManager.level","level")}} property is updated.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Battery Status API shouldn't be considered deprecated anymore.

#### Motivation
It's not deprecated (anymore).

#### Supporting details
- Spec history: https://www.w3.org/standards/history/battery-status
- BCD

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
