### PR TITLE
Update ref to deprecated getUserMedia location

### DIFF
--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.md
@@ -11,7 +11,8 @@ browser-compat: api.MediaStreamAudioDestinationNode
 ---
 {{APIRef("Web Audio API")}}
 
-The `MediaStreamAudioDestinationNode` interface represents an audio destination consisting of a [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("MediaStream")}} with a single `AudioMediaStreamTrack`, which can be used in a similar way to a `MediaStream` obtained from {{ domxref("Navigator.getUserMedia()") }}.
+The `MediaStreamAudioDestinationNode` interface represents an audio destination consisting of a [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("MediaStream")}} with a single `AudioMediaStreamTrack`, which can be used in a similar way to a `MediaStream` obtained from {{domxref("MediaDevices.getUserMedia",
+      "navigator.mediaDevices.getUserMedia()")}}.
 
 It is an {{domxref("AudioNode")}} that acts as an audio destination, created using the {{domxref("AudioContext.createMediaStreamDestination()")}} method.
 


### PR DESCRIPTION
#### Summary
Reference navigator.mediaDevices.getUserMedia() rather than the deprecated navigator.getUserMedia()

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
