### PR TITLE
removes some page macros

### DIFF
--- a/files/en-us/web/api/mediaerror/index.md
+++ b/files/en-us/web/api/mediaerror/index.md
@@ -24,7 +24,7 @@ A `MediaError` object describes the error in general terms using a numeric `code
 _This interface doesn't inherit any properties._
 
 - {{domxref("MediaError.code")}}
-  - : A number which represents the general type of error that occurred, as follows: {{page("/en-US/docs/Web/API/MediaError/code", "Media error code constants")}}
+  - : A number which represents [the general type of error that occurred](/en-US/docs/Web/API/MediaError/code#media_error_code_constants).
 - {{domxref("MediaError.message")}}
   - : A {{domxref("DOMString")}} object containing a human-readable string which provides _specific diagnostic information_ to help the reader understand the error condition which occurred; specifically, it isn't a summary of what the error code means, but actual diagnostic information to help in understanding what exactly went wrong. This text and its format is not defined by the specification and will vary from one {{Glossary("user agent")}} to another. If no diagnostics are available, or no explanation can be provided, this value is an empty string (`""`).
 

--- a/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.md
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.md
@@ -34,18 +34,15 @@ The **`RTCDTMFToneChangeEvent()`** constructor creates a new
 
     - `tone`
       - : A {{domxref("DOMString")}} containing a single DTMF tone character which has
-        just begun to play, or an empty string (`""`) to indicate that the
-        previous tone has stopped playing. See {{anch("Tone characters")}} for details on
-        what characters are permitted.
+        just begun to play, or an empty string (`""`) to indicate that the previous
+        tone has stopped playing. See 
+        [Tone characters](/en-US/docs/Web/API/RTCDTMFSender/toneBuffer#tone_buffer_format)
+        for details on what characters are permitted.
 
 ### Return value
 
 A newly-created {{domxref("RTCDTMFToneChangeEvent")}}, configured as specified in the
 provided options.
-
-### Tone characters
-
-{{page("/en-US/docs/Web/API/RTCDTMFSender/toneBuffer", "DTMF tone characters")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -61,4 +61,4 @@ listed [here](/en-US/docs/Web/API/WebGL_API#extensions).
 ## See also
 
 - {{domxref("WebGLRenderingContext.getSupportedExtensions()")}}
-- [webglreport.com](http://webglreport.com)
+- [webglreport.com](https://webglreport.com)

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -46,9 +46,9 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 ## WebGL extensions
 
 Extensions for the WebGL API are registered in the [WebGL Extension
-Registry](https://www.khronos.org/registry/webgl/extensions/). The current extensions are:
+Registry](https://www.khronos.org/registry/webgl/extensions/). They are also
+listed [here](/en-US/docs/Web/API/WebGL_API#extensions).
 
-{{page("en-US/docs/Web/API/WebGL_API", "Extensions")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -41,9 +41,7 @@ specific extension object.
 ## WebGL extensions
 
 Extensions for the WebGL API are registered in the [WebGL Extension
-Registry](https://www.khronos.org/registry/webgl/extensions/). The current extensions are:
-
-{{page("en-US/docs/Web/API/WebGL_API", "Extensions")}}
+Registry](https://www.khronos.org/registry/webgl/extensions/). They are also listed [here](/en-US/docs/Web/API/WebGL_API#extensions). 
 
 ## Specifications
 

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -54,4 +54,4 @@ Registry](https://www.khronos.org/registry/webgl/extensions/). They are also lis
 ## See also
 
 - {{domxref("WebGLRenderingContext.getExtension()")}}
-- [webglreport.com](http://webglreport.com)
+- [webglreport.com](https://webglreport.com)

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
@@ -55,7 +55,8 @@ the input parameters provided.
 
 ## Event types
 
-{{page("/en-US/docs/Web/API/XRInputSourcesChangeEvent", "Event types")}}
+- {{domxref("XRSession.inputsourceschange_event", "inputsourceschange")}}
+  - : Delivered to the {{domxref("XRSession")}} when the set of input devices available to it changes.
 
 ## Example
 


### PR DESCRIPTION
#### Summary
Removes some page macros by adding links and duplicating content for one.

#### Motivation
| I want to publicly demonstrate my own skills to improve my chances of getting a job.

#### Supporting details
NA

#### Related issues
Partially fixes #3196

#### Metadata
- [x] Fixes a typo, bug, or other error
