### PR TITLE
Opt for embedding vs. copying on Event properties sections

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -120,12 +120,9 @@ _An {{domxref("XRSessionEvent")}}. Inherits from {{domxref("Event")}}._
 
 ## Event properties
 
-If the event is not just a generic {{domxref("Event")}}, list the additional properties the event has.
+If the event is not just a generic {{domxref("Event")}}, include this section and embed the `Properties` section from the event's page.
 
-_In addition to the properties listed below, properties from the parent interface, {{domxref("Event")}}, are available._
-
-- {{domxref("XRSessionEvent.session", "session")}} {{ReadOnlyInline}}
-  - : The {{domxref("XRSession")}} to which the event refers.
+{{page("Web/API/XRSessionEvent", "Properties")}}
 
 ## Description
 


### PR DESCRIPTION
This PR replaces the "Event properties" section of the events page template with a call to the `page()` macro to embed the "Properties" section of the correlating event.  This will provide better maintenance in the future as contributors need only update a single file for all of these pages.
