### PR TITLE
Added use case of HTTPRange-14 to 303 See Other

### DIFF
--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -11,7 +11,7 @@ browser-compat: http.status.303
 {{HTTPSidebar}}
 
 The HyperText Transfer Protocol (HTTP) **`303 See Other`**
-redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object — see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14), or an upload-progress page). This response code is often sent back as a result of
+redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object — see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14) — or an upload-progress page). This response code is often sent back as a result of
 {{HTTPMethod("PUT")}} or {{HTTPMethod("POST")}}. The method used to display this
 redirected page is always {{HTTPMethod("GET")}}.
 

--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -11,9 +11,8 @@ browser-compat: http.status.303
 {{HTTPSidebar}}
 
 The HyperText Transfer Protocol (HTTP) **`303 See Other`**
-redirect status response code indicates that the redirects don't link to the newly
-uploaded resources, but to another page (such as a confirmation page or an upload
-progress page). This response code is usually sent back as a result of
+redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object (see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14)), or an upload
+progress page). This response code is often sent back as a result of
 {{HTTPMethod("PUT")}} or {{HTTPMethod("POST")}}. The method used to display this
 redirected page is always {{HTTPMethod("GET")}}.
 

--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -11,8 +11,7 @@ browser-compat: http.status.303
 {{HTTPSidebar}}
 
 The HyperText Transfer Protocol (HTTP) **`303 See Other`**
-redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object (see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14)), or an upload
-progress page). This response code is often sent back as a result of
+redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object — see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14), or an upload-progress page). This response code is often sent back as a result of
 {{HTTPMethod("PUT")}} or {{HTTPMethod("POST")}}. The method used to display this
 redirected page is always {{HTTPMethod("GET")}}.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I added the use of 303 for IRI dereferencing of real-world entities, redirecting them towards their representation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
For dereferencing IRIs of real-world objects, 303 is also commonly used to redirect towards a representation of the thing. This was not represented in the documentation, which made it appear as if 303 was only used as a way to respond to PUT or POST.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

About [HTTP Range 14 on Wikipedia](https://en.wikipedia.org/wiki/HTTPRange-14)

The fact that this practice is common is supported by for example Wikidata: `curl -IL http://www.wikidata.org/entity/Q3273508` shows 303 redirects for this purpose

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
No separate issue opened

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
