### PR TITLE
Add an example for passing an object of params

### DIFF
--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -83,10 +83,19 @@ const new_params = new URLSearchParams([
 console.log(new_params);
 // a=hello&b=world&c=a&d=2&e=false
 
-const new_url = new URL(`${url.origin}/?${new_params}`);
+const new_url = new URL(`${url.origin}${url.pathname}/?${new_params}`);
 
 console.log(new_url.href);
 // https://example.com/?a=hello&b=world&c=a&d=2&e=false
+
+// or here it is as a function
+const addSearchParams = (url, params = {}) =>
+  new URL(
+    `${url.origin}${url.pathname}?${new URLSearchParams([
+      ...Array.from(url.searchParams.entries()),
+      ...Object.entries(params),
+    ]).toString()}`
+  );
 ```
 
 ## Specifications

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -62,30 +62,31 @@ var params4 = new URLSearchParams({"foo": "1", "bar": "2"});
 This example shows how to build a new URL with an object of search parameters from an existing URL that has search parameters
 
 ```js
-const url = new URL('https://example.com/?d=hello&e=world');
+const url = new URL('https://example.com/?a=hello&b=world');
 
 console.log(url.href);
-// https://example.com/?d=hello&e=world
+// https://example.com/?a=hello&b=world
 
 console.log(url.origin);
 // https://example.com
 
 const add_params = {
-    a: 'a',
-    b: new String(2),
-    c: false.toString(),
+    c: 'a',
+    d: new String(2),
+    e: false.toString(),
 }
 
 const new_params = new URLSearchParams([
-    ...Object.entries(add_params), // [["a","a"],["b","2"],["c","false"]]
     ...Array.from(url.searchParams.entries()), // [["d","hello"],["e","world"]]
+    ...Object.entries(add_params), // [["a","a"],["b","2"],["c","false"]]
 ]).toString();
-// a=a&b=2&c=false&d=hello&e=world
+console.log(new_params);
+// a=hello&b=world&c=a&d=2&e=false
 
 const new_url = new URL(`${url.origin}/?${new_params}`);
 
 console.log(new_url.href);
-// https://example.com/?a=a&b=2&c=false&d=hello&e=world
+// https://example.com/?a=hello&b=world&c=a&d=2&e=false
 ```
 
 ## Specifications

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -83,12 +83,12 @@ const new_params = new URLSearchParams([
 console.log(new_params);
 // a=hello&b=world&c=a&d=2&e=false
 
-const new_url = new URL(`${url.origin}${url.pathname}/?${new_params}`);
+const new_url = new URL(`${url.origin}${url.pathname}?${new_params}`);
 
 console.log(new_url.href);
 // https://example.com/?a=hello&b=world&c=a&d=2&e=false
 
-// or here it is as a function
+// Here it is as a function that accepts (URL, Record<string, string>)
 const addSearchParams = (url, params = {}) =>
   new URL(
     `${url.origin}${url.pathname}?${new URLSearchParams([

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -77,8 +77,8 @@ const add_params = {
 }
 
 const new_params = new URLSearchParams([
-    ...Array.from(url.searchParams.entries()), // [["d","hello"],["e","world"]]
-    ...Object.entries(add_params), // [["a","a"],["b","2"],["c","false"]]
+    ...Array.from(url.searchParams.entries()), // [["a","hello"],["b","world"]]
+    ...Object.entries(add_params), // [["c","a"],["d","2"],["e","false"]]
 ]).toString();
 console.log(new_params);
 // a=hello&b=world&c=a&d=2&e=false

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -59,6 +59,35 @@ var params3 = new URLSearchParams([["foo", "1"], ["bar", "2"]]);
 var params4 = new URLSearchParams({"foo": "1", "bar": "2"});
 ```
 
+This example shows how to build a new URL with an object of search parameters from an existing URL that has search parameters
+
+```js
+const url = new URL('https://example.com/?d=hello&e=world');
+
+console.log(url.href);
+// https://example.com/?d=hello&e=world
+
+console.log(url.origin);
+// https://example.com
+
+const add_params = {
+    a: 'a',
+    b: new String(2),
+    c: false.toString(),
+}
+
+const new_params = new URLSearchParams([
+    ...Object.entries(add_params), // [["a","a"],["b","2"],["c","false"]]
+    ...Array.from(url.searchParams.entries()), // [["d","hello"],["e","world"]]
+]).toString();
+// a=a&b=2&c=false&d=hello&e=world
+
+const new_url = new URL(`${url.origin}/?${new_params}`);
+
+console.log(new_url.href);
+// https://example.com/?a=a&b=2&c=false&d=hello&e=world
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -59,7 +59,7 @@ var params3 = new URLSearchParams([["foo", "1"], ["bar", "2"]]);
 var params4 = new URLSearchParams({"foo": "1", "bar": "2"});
 ```
 
-This example shows how to build a new URL with an object of search parameters from an existing URL that has search parameters
+This example shows how to build a new URL with an object of search parameters from an existing URL that has search parameters.
 
 ```js
 const url = new URL('https://example.com/?a=hello&b=world');


### PR DESCRIPTION
Works with any existing URL object

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This example shows how to build a new URL with an object of search parameters from an existing URL that has search parameters

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
There was no example for this online and I think it's likely a common use case

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
