### PR TITLE
Added nav link to Multimedia: images

### DIFF
--- a/files/en-us/learn/performance/multimedia/index.md
+++ b/files/en-us/learn/performance/multimedia/index.md
@@ -138,6 +138,7 @@ In this section we took a look at image optimization. You now have a general und
 - [What is web performance?](/en-US/docs/Learn/Performance/What_is_web_performance)
 - [How do users perceive performance?](/en-US/docs/Learn/Performance/Perceived_performance)
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
+- [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
 - [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance).
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)


### PR DESCRIPTION
#### Summary
Multimedia: images module link at the bottom of the page was missing and resulting in an inconsistency. Added link to module list.

#### Motivation
Noticed an inconsistency in the modules link section at the page bottom where the Multimedia: images link was missing and therefore unable to be bolded as the active page. Made it easy to lose track of what module the reader is currently on.

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
