### PR TITLE
Fixed Javascript Performance link

### DIFF
--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -131,7 +131,7 @@ Optimizing video has the potential to significantly improve website performance.
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)


### PR DESCRIPTION
#### Summary
Removed period at the end of link and updated url to link to the correct location. Also removed random period at the end of the link.

#### Motivation
Previous link linked to the incorrect location, reader is unable to access the javascript performance page as a result.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
