### PR TITLE
Javascript performance link fix

### DIFF
--- a/files/en-us/learn/performance/business_case_for_performance/index.md
+++ b/files/en-us/learn/performance/business_case_for_performance/index.md
@@ -64,7 +64,7 @@ Setting conversion rate, time on site, and/or net promotion scores as KPIs give 
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/business_case_for_performance/index.md
+++ b/files/en-us/learn/performance/business_case_for_performance/index.md
@@ -64,7 +64,7 @@ Setting conversion rate, time on site, and/or net promotion scores as KPIs give 
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -65,7 +65,7 @@ The {{cssxref('contain')}} CSS property allows an author to indicate that an ele
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -65,7 +65,7 @@ The {{cssxref('contain')}} CSS property allows an author to indicate that an ele
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/html/index.md
+++ b/files/en-us/learn/performance/html/index.md
@@ -63,7 +63,7 @@ HTML is by default fast and accessible. It is our job, as developers, to ensure 
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/html/index.md
+++ b/files/en-us/learn/performance/html/index.md
@@ -63,7 +63,7 @@ HTML is by default fast and accessible. It is our job, as developers, to ensure 
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/javascript_performance/index.md
+++ b/files/en-us/learn/performance/javascript_performance/index.md
@@ -71,7 +71,7 @@ While optimizing your media files and scripts will get you very far along in ter
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/javascript_performance/index.md
+++ b/files/en-us/learn/performance/javascript_performance/index.md
@@ -71,7 +71,7 @@ While optimizing your media files and scripts will get you very far along in ter
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/measuring_performance/index.md
+++ b/files/en-us/learn/performance/measuring_performance/index.md
@@ -107,7 +107,7 @@ This article provided a brief overview of the web performance metrics to help in
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/measuring_performance/index.md
+++ b/files/en-us/learn/performance/measuring_performance/index.md
@@ -107,7 +107,7 @@ This article provided a brief overview of the web performance metrics to help in
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/multimedia/index.md
+++ b/files/en-us/learn/performance/multimedia/index.md
@@ -139,7 +139,7 @@ In this section we took a look at image optimization. You now have a general und
 - [How do users perceive performance?](/en-US/docs/Learn/Performance/Perceived_performance)
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/multimedia/index.md
+++ b/files/en-us/learn/performance/multimedia/index.md
@@ -139,7 +139,7 @@ In this section we took a look at image optimization. You now have a general und
 - [How do users perceive performance?](/en-US/docs/Learn/Performance/Perceived_performance)
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -131,7 +131,7 @@ Optimizing video has the potential to significantly improve website performance.
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -131,7 +131,7 @@ Optimizing video has the potential to significantly improve website performance.
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/why_web_performance/index.md
+++ b/files/en-us/learn/performance/why_web_performance/index.md
@@ -90,7 +90,7 @@ Web performance is important for accessibility and also for other website metric
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/JavaScript).
+- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)

--- a/files/en-us/learn/performance/why_web_performance/index.md
+++ b/files/en-us/learn/performance/why_web_performance/index.md
@@ -90,7 +90,7 @@ Web performance is important for accessibility and also for other website metric
 - [Measuring performance](/en-US/docs/Learn/Performance/Measuring_performance)
 - [Multimedia: images](/en-US/docs/Learn/Performance/Multimedia)
 - [Multimedia: video](/en-US/docs/Learn/Performance/video)
-- [JavaScript performance best practices](/en-US/docs/Learn/Performance/javascript_performance)
+- [JavaScript performance](/en-US/docs/Learn/Performance/javascript_performance)
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
 - [Fonts and performance](/en-US/docs/Learn/Performance/Fonts)


### PR DESCRIPTION

#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Corrected link to javascript performance page in multiple pages under Performance, and removed unnecessary period at the end.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Readers were unable to access the Javascript Performance page.

#### Metadata
This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
