### PR TITLE
Array.groupBy - remove interactive example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Array.groupBy
 The **`groupBy()`** method groups the elements of the calling array according to the values returned by a provided testing function.
 The returned object has separate properties for each group, containing arrays with the elements in the group.
 
-{{EmbedInteractiveExample("pages/js/array-groupby.html")}}
+<!-- {{EmbedInteractiveExample("pages/js/array-groupby.html")}} -->
 
 Note that the returned object references the _same_ elements as the original array (not {{glossary("deep copy","deep copies")}}). 
 Changing the internal structure of these elements will be reflected in both the original array and the returned object.

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -78,12 +78,9 @@ In JavaScript, arrays aren't [primitives](/en-US/docs/Glossary/Primitive) but ar
   - : Returns a new array formed by applying a given callback function to each element of the calling array, and then flattening the result by one level.
 - {{jsxref("Array.prototype.forEach()")}}
   - : Calls a function for each element in the calling array.
-
 - {{jsxref("Array.prototype.groupBy()")}}
   - : Groups the elements of an array according to the results of a test function.
     The resulting groups are accessed using object properties.
-  The `groupBy()` method groups the elements of the provided array according to the values returned by a provided testing function. The returned object has separate properties for each group, containing arrays with the elements in the group.
-
 - {{jsxref("Array.prototype.includes()")}}
   - : Determines whether the calling array contains a value, returning `true` or `false` as appropriate.
 - {{jsxref("Array.prototype.indexOf()")}}


### PR DESCRIPTION
Fixes #13112

Hides the interactive example and fixes text in information about method from Array topic.