### PR TITLE
Fixes #10070 - Adds exception for `div` inside `a`

### DIFF
--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -92,7 +92,7 @@ You can change the *visual presentation* of an element using the CSS {{cssxref("
 In brief, here are the basic conceptual differences between inline and block-level elements:
 
 - Content model
-  - : Generally, inline elements may contain only data and other inline elements. You can't put block elements inside inline elements.
+  - : Generally, inline elements may contain only data and other inline elements. An exception is the inline `a` element that may contain block level elements such as `div`.
 - Formatting
   - : By default, inline elements do not force a new line to begin in the document flow. Block elements, on the other hand, typically cause a line break to occur (although, as usual, this can be changed using CSS).
 

--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -93,6 +93,8 @@ In brief, here are the basic conceptual differences between inline and block-lev
 
 - Content model
   - : Generally, inline elements may contain only data and other inline elements. An exception is the inline `a` element which may contain block level elements such as `div`.
+    > **Note:** Links that wrap multiple lines of block-level content make for a poor-to-unusable experience for some assistive technology. It is one of those things where just because you technically can does not mean you should in the practical.
+
 - Formatting
   - : By default, inline elements do not force a new line to begin in the document flow. Block elements, on the other hand, typically cause a line break to occur (although, as usual, this can be changed using CSS).
 

--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -93,7 +93,7 @@ In brief, here are the basic conceptual differences between inline and block-lev
 
 - Content model
   - : Generally, inline elements may contain only data and other inline elements. An exception is the inline `a` element which may contain block level elements such as `div`.
-    > **Note:** Links that wrap multiple lines of block-level content make for a poor-to-unusable experience for some assistive technology. It is one of those things where just because you technically can does not mean you should in the practical.
+    > **Note:** Links that wrap multiple lines of block-level content make for a poor-to-unusable experience for some assistive technologies and should be avoided.
 
 - Formatting
   - : By default, inline elements do not force a new line to begin in the document flow. Block elements, on the other hand, typically cause a line break to occur (although, as usual, this can be changed using CSS).

--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -92,7 +92,7 @@ You can change the *visual presentation* of an element using the CSS {{cssxref("
 In brief, here are the basic conceptual differences between inline and block-level elements:
 
 - Content model
-  - : Generally, inline elements may contain only data and other inline elements. An exception is the inline `a` element that may contain block level elements such as `div`.
+  - : Generally, inline elements may contain only data and other inline elements. An exception is the inline `a` element which may contain block level elements such as `div`.
 - Formatting
   - : By default, inline elements do not force a new line to begin in the document flow. Block elements, on the other hand, typically cause a line break to occur (although, as usual, this can be changed using CSS).
 

--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -146,7 +146,7 @@ The following elements are inline by default (although block and inline elements
 - {{ HTMLElement("strong") }}
 - {{ HTMLElement("sub") }}
 - {{ HTMLElement("sup") }}
-- {{ HTMLElement("svg") }}
+- {{ SVGElement("svg") }}
 - {{ HTMLElement("template") }}
 - {{ HTMLElement("textarea") }}
 - {{ HTMLElement("time") }}


### PR DESCRIPTION
#### Summary
Adds exception to the rule - **inline cannot contain block**

#### Motivation
| I want to publicly demonstrate my own skills to improve my chances of getting a job.

#### Supporting details
Thanks @ShanjithR for reporting
Thanks @cw118 for the analysis

#### Related issues
Fixes #10070

#### Metadata
- [x] Fixes a typo, bug, or other error