### PR TITLE
Add docs Array.groupByToMap

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -642,7 +642,47 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ## JavaScript
 
-No experimental features
+### Array grouping methods
+
+The {{jsxref("Array.prototype.groupBy()")}} and {{jsxref("Array.prototype.groupByToMap()")}} methods are used to group the elements of an array using a string or value, respectively, returned by a test function.
+The `groupBy` method should be used when strings can be used to represent element groups, while `groupByToMap()` should be used in cases where it makes sense to use a value as the key.
+(See {{bug(1739648)}} for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version removed</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>98</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>98</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">None</td>
+    </tr>
+  </tbody>
+</table>
 
 ## APIs
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Array.groupBy
 ---
 {{JSRef}} {{SeeCompatTable}}
 
-The **`groupBy()`** method groups the elements of the calling array according to the values returned by a provided testing function.
+The **`groupBy()`** method groups the elements of the calling array according to the string values returned by a provided testing function.
 The returned object has separate properties for each group, containing arrays with the elements in the group.
 
 <!-- {{EmbedInteractiveExample("pages/js/array-groupby.html")}} -->
@@ -21,7 +21,7 @@ Note that the returned object references the _same_ elements as the original arr
 Changing the internal structure of these elements will be reflected in both the original array and the returned object.
 
 This method can be used when group names can be represented by strings.
-If you need to group elements using a key that is some arbitrary object, use {{jsxref("Array.prototype.groupByToMap()")}} instead.
+If you need to group elements using a key that is some arbitrary value, use {{jsxref("Array.prototype.groupByToMap()")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -101,11 +101,11 @@ Each food has a `type`, which might need to be stored differently, and a `quanti
 
 ```js
 const inventory = [
-  {name: 'apples', type: 'vegetables', quantity: 5},
-  {name: 'bananas',  type: 'fruit', quantity: 0},
-  {name: 'goat', type: 'meat', quantity: 23},
-  {name: 'cherries', type: 'fruit', quantity: 5},
-  {name: 'fish', type: 'meat', quantity: 22}
+  { name: 'asparagus', type: 'vegetables', quantity: 5 },
+  { name: 'bananas',  type: 'fruit', quantity: 0 },
+  { name: 'goat', type: 'meat', quantity: 23 },
+  { name: 'cherries', type: 'fruit', quantity: 5 },
+  { name: 'fish', type: 'meat', quantity: 22 }
 ];
 ```
 
@@ -117,7 +117,8 @@ let result = inventory.groupBy( ({ type }) => type );
 /* Result is:
 { 
   vegetables: [ 
-    { name: "apples", type: "vegetables", quantity: 5 } 
+    { name: "  { name: 'asparagus', type: 'vegetables', quantity: 5 },
+", type: "vegetables", quantity: 5 } 
   ],
   fruit: [
     { name: "bananas", type: "fruit", quantity: 0 },
@@ -149,7 +150,7 @@ result = inventory.groupBy( myCallback );
 /* Result is:
 { 
   reorder: [
-    { name: "apples", type: "vegetables", quantity: 5 },
+    { name: "asparagus", type: "vegetables", quantity: 5 },
     { name: "bananas", type: "fruit", quantity: 0 },
     { name: "cherries", type: "fruit", quantity: 5 }
   ], 
@@ -161,7 +162,7 @@ result = inventory.groupBy( myCallback );
 */
 ```
 
-The callback syntax provides access to the array and current index, so it is possible to implement grouping strategies based on th values of other elements in the array.
+The callback syntax provides access to the array and current index, so it is possible to implement grouping strategies based on the values of other elements in the array.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -7,9 +7,10 @@ tags:
   - Method
   - Prototype
   - Reference
+  - Experimental
 browser-compat: javascript.builtins.Array.groupBy
 ---
-{{JSRef}}
+{{JSRef}} {{SeeCompatTable}}
 
 The **`groupBy()`** method groups the elements of the calling array according to the values returned by a provided testing function.
 The returned object has separate properties for each group, containing arrays with the elements in the group.

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -50,9 +50,9 @@ groupBy(function(element, index, array) { /* ... */ }, thisArg)
 
     - `element`
       - : The value of the current element in the array.
-    - `index` {{optional_inline}}
+    - `index`
       - : The index (position) of the current element in the array.
-    - `array` {{optional_inline}}
+    - `array`
       - : The array that `groupBy()` was called on.
 
     The object returned from the callback indicates the group of the current element.

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -87,6 +87,8 @@ This means it may be less efficient for sparse arrays, compared to methods that 
 If a `thisArg` parameter is provided to `groupBy()`, it will be used as the `this` value inside each invocation of the `callbackFn`.
 If it is not provided, then {{jsxref("undefined")}} is used.
 
+### Mutating the array in the callback
+
 The `groupBy()` method does not mutate the array on which it is called, but the function provided to `callbackFn` can.
 Note however that the elements processed by `groupBy()` are set _before_ the first invocation of `callbackFn`.
 Therefore:

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -78,6 +78,9 @@ The `groupBy()` method executes the `callbackFn` function once for each index of
 A new property and array is created in the result object for each unique group name that is returned by the callback.
 Each element is added to the array in the property that corresponds to its group.
 
+`callbackFn` is called with the value of the current element, the current index, and the array itself.
+While groups often depend only on the current element, it is possible to implement grouping strategies based on the values of other elements in the array.
+
 `callbackFn` is invoked for _every_ index of the array, not just those with assigned values.
 This means it may be less efficient for sparse arrays, compared to methods that only visit assigned values.
 
@@ -163,7 +166,6 @@ result = inventory.groupBy( myCallback );
 */
 ```
 
-The callback syntax provides access to the array and current index, so it is possible to implement grouping strategies based on the values of other elements in the array.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -98,7 +98,7 @@ Therefore:
 ## Examples
 
 First we define an array containing objects representing an inventory of different foodstuffs.
-Each food has a `type`, which might need to be stored differently, and a `quantity` that can be used to determine when we need to reorder each item.
+Each food has a `type` and a `quantity`.
 
 ```js
 const inventory = [
@@ -139,18 +139,18 @@ This unpacks the `type` property of an object passed as a parameter, and assigns
 This is a very succinct way to access the relevant values of elements within a function.
 
 We can also create groups inferred from values in one or more properties of the elements.
-Below is a very similar example that uses a callback function and the `quantity` field to define that an element is in the `ok` or `reorder` groups.
+Below is a very similar example that puts the items into `ok` or `restock` groups based on the value of the `quantity` field.
 
 ```js
 function myCallback( { quantity } ) {
-  return quantity > 5 ? 'ok' : 'reorder';
+  return quantity > 5 ? 'ok' : 'restock';
 }
 
 result = inventory.groupBy( myCallback );
 
 /* Result is:
 { 
-  reorder: [
+  restock: [
     { name: "asparagus", type: "vegetables", quantity: 5 },
     { name: "bananas", type: "fruit", quantity: 0 },
     { name: "cherries", type: "fruit", quantity: 5 }

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -17,10 +17,7 @@ The returned object has separate properties for each group, containing arrays wi
 
 <!-- {{EmbedInteractiveExample("pages/js/array-groupby.html")}} -->
 
-Note that the returned object references the _same_ elements as the original array (not {{glossary("deep copy","deep copies")}}).
-Changing the internal structure of these elements will be reflected in both the original array and the returned object.
-
-This method can be used when group names can be represented by strings.
+This method should be used when group names can be represented by strings.
 If you need to group elements using a key that is some arbitrary value, use {{jsxref("Array.prototype.groupByToMap()")}} instead.
 
 ## Syntax
@@ -77,6 +74,9 @@ The value is an object that does not inherit from `Object.prototype`.
 The `groupBy()` method executes the `callbackFn` function once for each index of the array, returning a string (or value that can be coerced to a string) indicating the group of the element.
 A new property and array is created in the result object for each unique group name that is returned by the callback.
 Each element is added to the array in the property that corresponds to its group.
+
+Note that the returned object references the _same_ elements as the original array (not {{glossary("deep copy","deep copies")}}).
+Changing the internal structure of these elements will be reflected in both the original array and the returned object.
 
 `callbackFn` is called with the value of the current element, the current index, and the array itself.
 While groups often depend only on the current element, it is possible to implement grouping strategies based on the values of other elements in the array.

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -13,13 +13,13 @@ browser-compat: javascript.builtins.Array.groupByToMap
 ---
 {{JSRef}} {{SeeCompatTable}}
 
-The **`groupByToMap()`** method groups the elements of the calling array using the _objects_ returned by a provided testing function.
-The final returned {{jsxref("Map")}} uses the unique objects from the test function as keys, which can be used to get the array of elements in each group.
+The **`groupByToMap()`** method groups the elements of the calling array using the values returned by a provided testing function.
+The final returned {{jsxref("Map")}} uses the unique values from the test function as keys, which can be used to get the array of elements in each group.
 
 <!-- {{EmbedInteractiveExample("pages/js/array-groupbytomap.html")}} -->
 
 The elements in the {{jsxref("Map")}} and the original array are the same (not {{glossary("deep copy","deep copies")}}).
-Changing the internal structure of the elements will be reflected in both the original array and the returned object.
+Changing the internal structure of the elements will be reflected in both the original array and the returned {{jsxref("Map")}}.
 
 An object that needs to access the groups must keep a reference to the original key; the properties of a key can be modified, but you can't use another object that just happens to have the same name and properties.
 
@@ -53,13 +53,13 @@ groupByToMap(function(element, index, array) { /* ... */ }, thisArg)
   - : Function to execute on each element in the array, taking 3 arguments:
 
     - `element`
-      - : The value of the current element in the array.
+      - : The current element in the array.
     - `index` {{optional_inline}}
       - : The index (position) of the current element in the array.
     - `array` {{optional_inline}}
       - : The array that `groupBy()` was called on.
 
-    The object returned from the callback indicates the group of the current element.
+    The value ({{Glossary("object")}} or {{Glossary("primitive")}}) returned from the callback indicates the group of the current element.
 
 - `thisArg` {{optional_inline}}
   - : Object to use as {{jsxref("Operators/this", "this")}} inside `callbackFn`.
@@ -76,8 +76,9 @@ A {{jsxref("Map")}} object with keys for each group, each assigned to an array c
 
 ## Description
 
-The `groupByToMap()` method executes the `callbackFn` function once for each index of the array, returning an object indicating the group of the associated element.
-The objects returned by the callback are used as keys for a {{jsxref("Map")}} (later returned by `groupByToMap()`), where the associated value is an array containing all the elements for which the callback returned the same object.
+The `groupByToMap()` method executes the `callbackFn` function once for each index of the array, returning a value indicating the group of the associated element.
+The values returned by the callback are used as keys for the {{jsxref("Map")}} returned by `groupByToMap()`.
+Each key has an associated array containing all the elements for which the callback returned the same value.
 
 `callbackFn` is invoked for _every_ index of the array, not just those with assigned values.
 This means it may be less efficient for sparse arrays, compared to methods that only visit assigned values.
@@ -111,7 +112,7 @@ const inventory = [
 ];
 ```
 
-The code below uses `groupByToMap()` with an arrow function that returns the object key named `reorder` or `sufficient`, depending on whether the element has `quantity < 6`.
+The code below uses `groupByToMap()` with an arrow function that returns the object keys named `reorder` or `sufficient`, depending on whether the element has `quantity < 6`.
 The returned `result` object is a `Map` so we need to call `get()` with the key to obtain the array.
 
 ```js
@@ -127,7 +128,7 @@ This unpacks the `quantity` property of an object passed as a parameter, and ass
 This is a very succinct way to access the relevant values of elements within a function.
 
 
-The object key can be modified and still used.
+An object key can be modified and still used.
 However you can't recreate the key and still use it.
 For this reason it is important that anything that needs to use the map keeps a reference to its keys.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -1,0 +1,158 @@
+---
+title: Array.prototype.groupByToMap()
+slug: Web/JavaScript/Reference/Global_Objects/Array/groupByToMap
+tags:
+  - Array
+  - groupByToMap
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
+browser-compat: javascript.builtins.Array.groupByToMap
+---
+{{JSRef}}
+
+The **`groupByToMap()`** method groups the elements of the calling array using the _objects_ returned by a provided testing function.
+The final returned {{jsxref("Map")}} uses the unique objects from the test function as keys, which can be used to get the array of elements in each group.
+
+<!-- {{EmbedInteractiveExample("pages/js/array-groupbytomap.html")}} -->
+
+The elements in the {{jsxref("Map")}} and the original array are the same (not {{glossary("deep copy","deep copies")}}).
+Changing the internal structure of the elements will be reflected in both the original array and the returned object.
+
+An object that needs to access the groups must keep a reference to the original key; the properties of a key can be modified, but you can't use another object that just happens to have the same name and properties.
+
+This method is useful when mapping related information to a specific object that might change over time.
+If the mapping object is invariant then you could instead use {{jsxref("Array.prototype.groupBy()")}} to group the elements, representing the object with a string.
+
+
+## Syntax
+
+```js
+// Arrow function
+groupByToMap((element) => { /* ... */ } )
+groupByToMap((element, index) => { /* ... */ } )
+groupByToMap((element, index, array) => { /* ... */ } )
+
+// Callback function
+groupByToMap(callbackFn)
+groupByToMap(callbackFn, thisArg)
+
+// Inline callback function
+groupByToMap(function(element) { /* ... */ })
+groupByToMap(function(element, index) { /* ... */ })
+groupByToMap(function(element, index, array){ /* ... */ })
+groupByToMap(function(element, index, array) { /* ... */ }, thisArg)
+```
+
+### Parameters
+
+- `callbackFn`
+
+  - : Function to execute on each element in the array, taking 3 arguments:
+
+    - `element`
+      - : The value of the current element in the array.
+    - `index` {{optional_inline}}
+      - : The index (position) of the current element in the array.
+    - `array` {{optional_inline}}
+      - : The array that `groupBy()` was called on.
+
+    The object returned from the callback indicates the group of the current element.
+
+- `thisArg` {{optional_inline}}
+  - : Object to use as {{jsxref("Operators/this", "this")}} inside `callbackFn`.
+      If not specified, `undefined` will be used.
+
+### Return value
+
+A {{jsxref("Map")}} object with keys for each group, each assigned to an array containing the elements of the associated group.
+
+### Exceptions
+
+- `TypeError`
+  - : The specified callback function is not callable.
+
+## Description
+
+The `groupBytoMap()` method executes the `callbackFn` function once for each index of the array, returning an object indicating the group of the associated element.
+The objects returned by the callback are used as keys for a {{jsxref("Map")}} (later returned by `groupBytoMap()`), where the associated value is an array containing all the elements for which the callback returned the same object.
+
+`callbackFn` is invoked for _every_ index of the array, not just those with assigned values.
+This means it may be less efficient for sparse arrays, compared to methods that only visit assigned values.
+
+If a `thisArg` parameter is provided to `groupBytoMap()`, it will be used as the `this` value inside each invocation of the `callbackFn`.
+If it is not provided, then {{jsxref("undefined")}} is used.
+
+The `groupBytoMap()` method does not mutate the array on which it is called, but the function provided to `callbackFn` can.
+Note however that the elements processed by `groupBytoMap()` are set _before_ the first invocation of `callbackFn`.
+Therefore:
+
+- `callbackFn` will not visit any elements added to the array after the call to `groupBytoMap()` begins.
+- Elements that are assigned to indexes already visited, or to indexes outside the range, will not be visited by `callbackFn`.
+- If an existing, yet-unvisited element of the array is changed by `callbackFn`, its value passed to the `callbackFn` will be the value at the time `groupBytoMap()` visits that element's index.
+- Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.
+
+> **Warning:** Concurrent modifications of the kind described above frequently lead to hard-to-understand code and are generally to be avoided (except in special cases).
+
+## Examples
+
+First we define an array containing objects representing an inventory of different foodstuffs.
+Each food has a `type`, which might need to be stored differently, and a `quantity` that can be used to determine when we need to reorder each item.
+
+```js
+const inventory = [
+  { name: 'asparagus', type: 'vegetables', quantity: 9 },
+  { name: 'bananas',  type: 'fruit', quantity: 5 },
+  { name: 'goat', type: 'meat', quantity: 23 },
+  { name: 'cherries', type: 'fruit', quantity: 12 },
+  { name: 'fish', type: 'meat', quantity: 22 }
+];
+```
+
+The code below uses `groupByToMap()` with an arrow function that returns the object key named `reorder` or `sufficient`, depending on whether the element has `quantity < 6`.
+The returned `result` object is a `Map` so we need to call `get()` with the key to obtain the array.
+
+```js
+let reorder  = { reorder: true };
+const sufficient = { reorder: false };
+const result = inventory.groupByToMap( ({ quantity }) => quantity < 6 ? reorder : sufficient );
+console.log(result.get(reorder));
+// expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
+```
+
+Note that the function argument `{ quantity }` is a basic example of [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_fields_from_objects_passed_as_a_function_parameter).
+This unpacks the `quantity` property of an object passed as a parameter, and assigns it to a variable named `quantity` in the body of the function.
+This is a very succinct way to access the relevant values of elements within a function.
+
+
+The object key can be modified and still used.
+However you can't recreate the key and still use it.
+For this reason it is important that anything that needs to use the map keeps a reference to its keys.
+
+```js
+// A modified key can still be used in a Map
+reorder['fast']  = true ;
+console.log(result.get(reorder));
+// expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
+
+// But you can't use a different key, even if it has the same structure!
+const reorder2  = { reorder: true };
+console.log(result.get(reorder2));
+// expected output: undefined
+```
+
+The callback syntax provides access to the array and current index, so it is possible to implement grouping strategies based on the values of other elements in the array.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Array.prototype.groupBy()")}}
+- [Polyfill of `Array.prototype.groupBy` in `core-js`](https://github.com/zloirock/core-js#array-grouping)

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -8,9 +8,10 @@ tags:
   - Method
   - Prototype
   - Reference
+  - Experimental
 browser-compat: javascript.builtins.Array.groupByToMap
 ---
-{{JSRef}}
+{{JSRef}} {{SeeCompatTable}}
 
 The **`groupByToMap()`** method groups the elements of the calling array using the _objects_ returned by a provided testing function.
 The final returned {{jsxref("Map")}} uses the unique objects from the test function as keys, which can be used to get the array of elements in each group.
@@ -75,22 +76,22 @@ A {{jsxref("Map")}} object with keys for each group, each assigned to an array c
 
 ## Description
 
-The `groupBytoMap()` method executes the `callbackFn` function once for each index of the array, returning an object indicating the group of the associated element.
-The objects returned by the callback are used as keys for a {{jsxref("Map")}} (later returned by `groupBytoMap()`), where the associated value is an array containing all the elements for which the callback returned the same object.
+The `groupByToMap()` method executes the `callbackFn` function once for each index of the array, returning an object indicating the group of the associated element.
+The objects returned by the callback are used as keys for a {{jsxref("Map")}} (later returned by `groupByToMap()`), where the associated value is an array containing all the elements for which the callback returned the same object.
 
 `callbackFn` is invoked for _every_ index of the array, not just those with assigned values.
 This means it may be less efficient for sparse arrays, compared to methods that only visit assigned values.
 
-If a `thisArg` parameter is provided to `groupBytoMap()`, it will be used as the `this` value inside each invocation of the `callbackFn`.
+If a `thisArg` parameter is provided to `groupByToMap()`, it will be used as the `this` value inside each invocation of the `callbackFn`.
 If it is not provided, then {{jsxref("undefined")}} is used.
 
-The `groupBytoMap()` method does not mutate the array on which it is called, but the function provided to `callbackFn` can.
-Note however that the elements processed by `groupBytoMap()` are set _before_ the first invocation of `callbackFn`.
+The `groupByToMap()` method does not mutate the array on which it is called, but the function provided to `callbackFn` can.
+Note however that the elements processed by `groupByToMap()` are set _before_ the first invocation of `callbackFn`.
 Therefore:
 
-- `callbackFn` will not visit any elements added to the array after the call to `groupBytoMap()` begins.
+- `callbackFn` will not visit any elements added to the array after the call to `groupByToMap()` begins.
 - Elements that are assigned to indexes already visited, or to indexes outside the range, will not be visited by `callbackFn`.
-- If an existing, yet-unvisited element of the array is changed by `callbackFn`, its value passed to the `callbackFn` will be the value at the time `groupBytoMap()` visits that element's index.
+- If an existing, yet-unvisited element of the array is changed by `callbackFn`, its value passed to the `callbackFn` will be the value at the time `groupByToMap()` visits that element's index.
 - Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.
 
 > **Warning:** Concurrent modifications of the kind described above frequently lead to hard-to-understand code and are generally to be avoided (except in special cases).

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -93,7 +93,7 @@ Therefore:
 - `callbackFn` will not visit any elements added to the array after the call to `groupByToMap()` begins.
 - Elements that are assigned to indexes already visited, or to indexes outside the range, will not be visited by `callbackFn`.
 - If an existing, yet-unvisited element of the array is changed by `callbackFn`, its value passed to the `callbackFn` will be the value at the time `groupByToMap()` visits that element's index.
-- Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.
+- Elements that are [deleted](/en-US/docs/Web/JavaScript/Reference/Operators/delete#deleting_array_elements) are still visited.
 
 > **Warning:** Concurrent modifications of the kind described above frequently lead to hard-to-understand code and are generally to be avoided (except in special cases).
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -94,6 +94,8 @@ This means it may be less efficient for sparse arrays, compared to methods that 
 If a `thisArg` parameter is provided to `groupByToMap()`, it will be used as the `this` value inside each invocation of the `callbackFn`.
 If it is not provided, then {{jsxref("undefined")}} is used.
 
+### Mutating the array in the callback
+
 The `groupByToMap()` method does not mutate the array on which it is called, but the function provided to `callbackFn` can.
 Note however that the elements processed by `groupByToMap()` are set _before_ the first invocation of `callbackFn`.
 Therefore:

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -76,9 +76,13 @@ A {{jsxref("Map")}} object with keys for each group, each assigned to an array c
 
 ## Description
 
-The `groupByToMap()` method executes the callback function once for each index of the array. The callback function returns a value indicating the group of the associated element.
-The values returned by the callback are used as keys for the {{jsxref("Map")}} returned by `groupByToMap()`.
+The `groupByToMap()` method executes `callbackFn` once for each index of the array.
+The callback function returns a value indicating the group of the associated element.
+The values returned by `callbackFn` are used as keys for the {{jsxref("Map")}} returned by `groupByToMap()`.
 Each key has an associated array containing all the elements for which the callback returned the same value.
+
+`callbackFn` is called with the value of the current element, the current index, and the array itself.
+While groups often depend only on the current element, it is possible to implement grouping strategies based on the values of other elements in the array.
 
 `callbackFn` is invoked for _every_ index of the array, not just those with assigned values.
 This means it may be less efficient for sparse arrays, compared to methods that only visit assigned values.
@@ -142,8 +146,6 @@ const restock2  = { restock: true };
 console.log(result.get(restock2));
 // expected output: undefined
 ```
-
-The callback syntax provides access to the array and current index, so it is possible to implement grouping strategies based on the values of other elements in the array.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -51,7 +51,7 @@ groupByToMap(function(element, index, array) { /* ... */ }, thisArg)
     - `index`
       - : The index (position) of the current element in the array.
     - `array`
-      - : The array that `groupBy()` was called on.
+      - : The array that `groupByToMap()` was called on.
 
     The value ({{Glossary("object")}} or {{Glossary("primitive")}}) returned from the callback indicates the group of the current element.
 
@@ -82,7 +82,7 @@ This method is useful when you need to group information that is related to a pa
 This is because even if the object is modified, it will continue to work as a key to the returned `Map`.
 If you instead create a string representation for the object and use that as a grouping key in {{jsxref("Array.prototype.groupBy()")}}, you must maintain the mapping between the original object and its representation as the object changes.
 
-> **Note:** An object that needs to access the groups must keep a reference to the _original_ key (although you may modify its properties).
+> **Note:** To access the groups in the returned `Map`, you must use the same object that was originally used as a key in the `Map` (although you may modify its properties).
 > You can't use another object that just happens to have the same name and properties.
 
 `callbackFn` is called with the value of the current element, the current index, and the array itself.

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -54,9 +54,9 @@ groupByToMap(function(element, index, array) { /* ... */ }, thisArg)
 
     - `element`
       - : The current element in the array.
-    - `index` {{optional_inline}}
+    - `index`
       - : The index (position) of the current element in the array.
-    - `array` {{optional_inline}}
+    - `array`
       - : The array that `groupBy()` was called on.
 
     The value ({{Glossary("object")}} or {{Glossary("primitive")}}) returned from the callback indicates the group of the current element.

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -76,7 +76,7 @@ A {{jsxref("Map")}} object with keys for each group, each assigned to an array c
 
 ## Description
 
-The `groupByToMap()` method executes the `callbackFn` function once for each index of the array, returning a value indicating the group of the associated element.
+The `groupByToMap()` method executes the callback function once for each index of the array. The callback function returns a value indicating the group of the associated element.
 The values returned by the callback are used as keys for the {{jsxref("Map")}} returned by `groupByToMap()`.
 Each key has an associated array containing all the elements for which the callback returned the same value.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -126,7 +126,7 @@ The code below uses `groupByToMap()` with an arrow function that returns the obj
 The returned `result` object is a `Map` so we need to call `get()` with the key to obtain the array.
 
 ```js
-let restock  = { restock: true };
+const restock  = { restock: true };
 const sufficient = { restock: false };
 const result = inventory.groupByToMap( ({ quantity }) => quantity < 6 ? restock : sufficient );
 console.log(result.get(restock));

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -18,14 +18,8 @@ The final returned {{jsxref("Map")}} uses the unique values from the test functi
 
 <!-- {{EmbedInteractiveExample("pages/js/array-groupbytomap.html")}} -->
 
-The elements in the {{jsxref("Map")}} and the original array are the same (not {{glossary("deep copy","deep copies")}}).
-Changing the internal structure of the elements will be reflected in both the original array and the returned {{jsxref("Map")}}.
-
-An object that needs to access the groups must keep a reference to the original key; the properties of a key can be modified, but you can't use another object that just happens to have the same name and properties.
-
-This method is useful when mapping related information to a specific object that might change over time.
-If the mapping object is invariant then you could instead use {{jsxref("Array.prototype.groupBy()")}} to group the elements, representing the object with a string.
-
+The method is primarily useful when grouping elements that are associated with an object, and in particular when that object might change over time.
+If the object is invariant, you might instead represent it using a string, and group elements with {{jsxref("Array.prototype.groupBy()")}}.
 
 ## Syntax
 
@@ -81,6 +75,16 @@ The callback function returns a value indicating the group of the associated ele
 The values returned by `callbackFn` are used as keys for the {{jsxref("Map")}} returned by `groupByToMap()`.
 Each key has an associated array containing all the elements for which the callback returned the same value.
 
+The elements in the returned {{jsxref("Map")}} and the original array are the same (not {{glossary("deep copy","deep copies")}}).
+Changing the internal structure of the elements will be reflected in both the original array and the returned {{jsxref("Map")}}.
+
+This method is useful when you need to group information that is related to a particular object that might potentially change over time.
+This is because even if the object is modified, it will continue to work as a key to the returned `Map`.
+If you instead create a string representation for the object and use that as a grouping key in {{jsxref("Array.prototype.groupBy()")}}, you must maintain the mapping between the original object and its representation as the object changes.
+
+> **Note:** An object that needs to access the groups must keep a reference to the _original_ key (although you may modify its properties).
+> You can't use another object that just happens to have the same name and properties.
+
 `callbackFn` is called with the value of the current element, the current index, and the array itself.
 While groups often depend only on the current element, it is possible to implement grouping strategies based on the values of other elements in the array.
 
@@ -131,17 +135,17 @@ Note that the function argument `{ quantity }` is a basic example of [object des
 This unpacks the `quantity` property of an object passed as a parameter, and assigns it to a variable named `quantity` in the body of the function.
 This is a very succinct way to access the relevant values of elements within a function.
 
-An object key can be modified and still used.
+The key to a `Map` can be modified and still used.
 However you can't recreate the key and still use it.
 For this reason it is important that anything that needs to use the map keeps a reference to its keys.
 
 ```js
-// A modified key can still be used in a Map
+// The key can be modified and still used
 restock['fast']  = true ;
 console.log(result.get(restock));
 // expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
 
-// But you can't use a different key, even if it has the same structure!
+// A new key can't be used, even if it has the same structure!
 const restock2  = { restock: true };
 console.log(result.get(restock2));
 // expected output: undefined

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -100,7 +100,7 @@ Therefore:
 ## Examples
 
 First we define an array containing objects representing an inventory of different foodstuffs.
-Each food has a `type`, which might need to be stored differently, and a `quantity` that can be used to determine when we need to reorder each item.
+Each food has a `type` and a `quantity`.
 
 ```js
 const inventory = [
@@ -112,14 +112,14 @@ const inventory = [
 ];
 ```
 
-The code below uses `groupByToMap()` with an arrow function that returns the object keys named `reorder` or `sufficient`, depending on whether the element has `quantity < 6`.
+The code below uses `groupByToMap()` with an arrow function that returns the object keys named `restock` or `sufficient`, depending on whether the element has `quantity < 6`.
 The returned `result` object is a `Map` so we need to call `get()` with the key to obtain the array.
 
 ```js
-let reorder  = { reorder: true };
-const sufficient = { reorder: false };
-const result = inventory.groupByToMap( ({ quantity }) => quantity < 6 ? reorder : sufficient );
-console.log(result.get(reorder));
+let restock  = { restock: true };
+const sufficient = { restock: false };
+const result = inventory.groupByToMap( ({ quantity }) => quantity < 6 ? restock : sufficient );
+console.log(result.get(restock));
 // expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
 ```
 
@@ -127,20 +127,19 @@ Note that the function argument `{ quantity }` is a basic example of [object des
 This unpacks the `quantity` property of an object passed as a parameter, and assigns it to a variable named `quantity` in the body of the function.
 This is a very succinct way to access the relevant values of elements within a function.
 
-
 An object key can be modified and still used.
 However you can't recreate the key and still use it.
 For this reason it is important that anything that needs to use the map keeps a reference to its keys.
 
 ```js
 // A modified key can still be used in a Map
-reorder['fast']  = true ;
-console.log(result.get(reorder));
+restock['fast']  = true ;
+console.log(result.get(restock));
 // expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
 
 // But you can't use a different key, even if it has the same structure!
-const reorder2  = { reorder: true };
-console.log(result.get(reorder2));
+const restock2  = { restock: true };
+console.log(result.get(restock2));
 // expected output: undefined
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -447,6 +447,41 @@ console.log(fruitsAlias);
 // ['Apple', 'Banana', 'Strawberry', 'Mango']
 ```
 
+
+### Grouping the elements of an array
+
+The {{jsxref("Array.prototype.groupBy()")}} methods can be used group the elements of an array, using a test function that returns a string indicating the group of the current element.
+
+Here we have a simple inventory array that contains "food" objects that have a `name` and a `type`.
+```js
+const inventory = [
+  { name: 'asparagus', type: 'vegetables' },
+  { name: 'bananas',  type: 'fruit' },
+  { name: 'goat', type: 'meat' },
+  { name: 'cherries', type: 'fruit' },
+  { name: 'fish', type: 'meat' }
+];
+```
+
+To use `groupBy()`, you supply a callback function that is called with the current element, and optionally the current index and array, and returns a string indicating the group of the element.
+
+The code below uses a arrow function to return the `type` of each array element (this uses [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_fields_from_objects_passed_as_a_function_parameter) to unpack the `type` element from the passed object).
+The result is an object that has properties named after the unique strings returned by the callback.
+Each property is assigned an array containing the elements in the group. 
+
+```js
+let result = inventory.groupBy( ({ type }) => type );
+console.log(result.vegetables)
+// expected output: Array [Object { name: "asparagus", type: "vegetables" }]
+```
+
+Note that the returned object references the _same_ elements as the original array (not {{glossary("deep copy","deep copies")}}).
+Changing the internal structure of these elements will be reflected in both the original array and the returned object.
+
+If you can't use a string as the key, for example, if the information to group is associated with an object that might change, then you can instead use {{jsxref("Array.prototype.groupByToMap()")}}.
+This is very similar to `groupBy` except that it groups the elements of the array into a {{jsxref("Map")}} that can use an arbitrary value ({{Glossary("object")}} or {{Glossary("primitive")}}) as a key.
+
+
 ## Other examples
 
 ### Creating a two-dimensional array

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -78,10 +78,10 @@ In JavaScript, arrays aren't [primitives](/en-US/docs/Glossary/Primitive) but ar
   - : Returns a new array formed by applying a given callback function to each element of the calling array, and then flattening the result by one level.
 - {{jsxref("Array.prototype.forEach()")}}
   - : Calls a function for each element in the calling array.
-- {{jsxref("Array.prototype.groupBy()")}}
+- {{jsxref("Array.prototype.groupBy()")}} {{Experimental_Inline}}
   - : Groups the elements of an array into an object according to the strings returned by a test function.
-- {{jsxref("Array.prototype.groupByToMap()")}}
-  - : Groups the elements of an array into a {{jsxref("Map")}} according to objects returned by a test function.
+- {{jsxref("Array.prototype.groupByToMap()")}} {{Experimental_Inline}}
+  - : Groups the elements of an array into a {{jsxref("Map")}} according to values returned by a test function.
 - {{jsxref("Array.prototype.includes()")}}
   - : Determines whether the calling array contains a value, returning `true` or `false` as appropriate.
 - {{jsxref("Array.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -79,8 +79,9 @@ In JavaScript, arrays aren't [primitives](/en-US/docs/Glossary/Primitive) but ar
 - {{jsxref("Array.prototype.forEach()")}}
   - : Calls a function for each element in the calling array.
 - {{jsxref("Array.prototype.groupBy()")}}
-  - : Groups the elements of an array according to the results of a test function.
-    The resulting groups are accessed using object properties.
+  - : Groups the elements of an array into an object according to the strings returned by a test function.
+- {{jsxref("Array.prototype.groupByToMap()")}}
+  - : Groups the elements of an array into a {{jsxref("Map")}} according to objects returned by a test function.
 - {{jsxref("Array.prototype.includes()")}}
   - : Determines whether the calling array contains a value, returning `true` or `false` as appropriate.
 - {{jsxref("Array.prototype.indexOf()")}}


### PR DESCRIPTION
Array grouping proposal added to FF nightly in FF98. 
This adds `groupByToMap` docs. There is an associated interactive example in https://github.com/mdn/interactive-examples/pull/2015.

Additionally:
- Updates to `Array.groupBy()`, following on from https://github.com/mdn/content/pull/12980
- Updated `Array` with links to `groupBy` and `groupByToMap`
- Updated `Array` with grouping example section.
- Added methods to Experimental features page.

Part of #12579
