### PR TITLE
Object.prototype.toString: clarify what “ignored” means

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -66,7 +66,7 @@ method. The `toString()` function you create must return a primitive. If it
 returns an object and the method is called implicitly (i.e. during type
 conversion or coercion), then its result will be ignored and the value of a
 related method, `{{jsxref("Object/valueOf", "valueOf()")}}`, will be used
-instead, or a `TypeError` will be thrown, if none of these methods return a
+instead, or a `TypeError` will be thrown if none of these methods return a
 primitive.
 
 The following code defines the `Dog` object type and creates

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -59,7 +59,7 @@ By default `toString()` takes no parameters. However, objects that inherit from 
 
 ## Examples
 
-### Overriding the default `toString` method
+### Overriding the default toString method
 
 You can create a function to be called in place of the default `toString()`
 method. The `toString()` function you create must return a primitive. If it

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -59,10 +59,15 @@ By default `toString()` takes no parameters. However, objects that inherit from 
 
 ## Examples
 
-### Overriding the default toString method
+### Overriding the default `toString` method
 
 You can create a function to be called in place of the default `toString()`
-method. The `toString()` function you create must return a primitive, otherwise it will be ignored.
+method. The `toString()` function you create must return a primitive. If it
+returns an object and the method is called implicitly (i.e. during type
+conversion or coercion), then its result will be ignored and the value of a
+related method, `{{jsxref("Object/valueOf", "valueOf()")}}`, will be used
+instead, or a `TypeError` will be thrown, if none of these methods return a
+primitive.
 
 The following code defines the `Dog` object type and creates
 `theDog`, an object of type `Dog`:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

I have expanded the sentence _“The `toString()` function you create must return a primitive, otherwise it will be ignored.”_ to clarify it.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

This sentence recently came up in a Stack Overflow question: [What does it mean that `toString` gets “ignored” if it returns a non-primitive?](https://stackoverflow.com/q/71194027/4642212). This part of the documentation isn’t as clear as it could be and potentially misleads developers to think that code like the following should return `"[object Object]"` (either because it gets replaced by the original `Object.prototype.toString` or because the return value `{}` is stringified), or something else, and, at least, shouldn’t throw an error:

```js
(new class {
  toString(){
    return {};
  }
}).toString(); // Returns `{}` just fine! It’s not ignored!

String(new class {
  toString(){
    return {};
  }
}); // Throws a TypeError! It’s not ignored!
```

We had to do quite a bit of detective work to find the relevant section in the specification and find an example that demonstrates how this sentence was likely supposed to be interpreted:

```js
String(new class {
  toString(){
    return {};
  }
  valueOf(){
    return 2;
  }
}); // Returns `"2"`. Wow, `toString` really is ignored!
```

In my answer, I describe how I eventually found out that this was the correct original intent of the sentence. Note that “type conversion or coercion” was explained in the description section already, so it’s not necessary to explain what it is in this section as well.

I’m going to ping @dev-nicolaos here: is my rewording fine?

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

My answer under the Stack Overflow question provides all the necessary context, but for convenience, here are links to relevant resources:

* [OrdinaryToPrimitive](https://tc39.es/ecma262/#sec-ordinarytoprimitive) abstract operation in current ECMAScript specification
* Original [review comment in the original pull request](https://github.com/mdn/content/pull/11739#discussion_r778562255) introducing this wording
* Original [commit](https://github.com/mdn/content/commit/8622152c7c8babc78b1b67878bb066127ca28e12)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
