### PR TITLE
Add null as possible return value in Drag&Drop DataTransferItem.webkitGetAsEntry

### DIFF
--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -17,10 +17,7 @@ browser-compat: api.DataTransferItem.webkitGetAsEntry
 ---
 {{APIRef("File System API")}}{{SeeCompatTable}}{{Non-standard_header}}
 
-If the item described by the {{domxref("DataTransferItem")}} is a file,
-`webkitGetAsEntry()` returns a {{domxref("FileSystemFileEntry")}} or
-{{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file,
-`null` is returned.
+If the item described by the {{domxref("DataTransferItem")}} is a file, `webkitGetAsEntry()` returns a {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file, `null` is returned.
 
 > **Note:** This function is implemented as `webkitGetAsEntry()` in non-WebKit browsers including Firefox at this time; it may be renamed to
 > `getAsEntry()` in the future, so you should code defensively, looking for both.
@@ -28,7 +25,7 @@ If the item described by the {{domxref("DataTransferItem")}} is a file,
 ## Syntax
 
 ```js
-DataTransferItem.webkitGetAsEntry();
+webkitGetAsEntry()
 ```
 
 ### Parameters
@@ -37,8 +34,8 @@ None.
 
 ### Return value
 
-A {{domxref("FileSystemEntry")}}-based object describing the dropped item. This will be
-either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.
+A {{domxref("FileSystemEntry")}}-based object describing the dropped item.
+This will be either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.
 The method aborts and returns `null` if the dropped item isn't a file, or if the {{domxref("DataTransferItem")}} object is not in read or read/write mode.
 
 ## Example
@@ -49,9 +46,7 @@ directory listing.
 
 ### HTML content
 
-The HTML establishes the drop zone itself, which is a {{HTMLElement("div")}} element
-with the ID `"dropzone"`, and an unordered list element with the ID
-`"listing"`.
+The HTML establishes the drop zone itself, which is a {{HTMLElement("div")}} element with the ID `"dropzone"`, and an unordered list element with the ID `"listing"`.
 
 ```html
 <p>Drag files and/or directories to the box below!</p>
@@ -100,14 +95,11 @@ body {
 
 ### JavaScript content
 
-First, let's look at the recursive `scanFiles()` function. This function
-takes as input a {{domxref("FileSystemEntry")}} representing an entry in the file system
-to be scanned and processed (the `item` parameter), and an element into which
-to insert the list of contents (the `container` parameter).
+First, let's look at the recursive `scanFiles()` function.
+This function takes as input a {{domxref("FileSystemEntry")}} representing an entry in the file system to be scanned and processed (the `item` parameter), and an element into which to insert the list of contents (the `container` parameter).
 
-> **Note:** To read all files in a directory, `readEntries` needs to be
-> called repeatedly until it returns an empty array. In Chromium-based browsers, the
-> following example will only return a max of 100 entries.
+> **Note:** To read all files in a directory, `readEntries` needs to be called repeatedly until it returns an empty array.
+> In Chromium-based browsers, the following example will only return a max of 100 entries.
 
 ```js
 let dropzone = document.getElementById("dropzone");
@@ -131,29 +123,20 @@ function scanFiles(item, container) {
 }
 ```
 
-`scanFiles()` begins by creating a new {{HTMLElement("li")}} element to
-represent the item being scanned, inserts the name of the item into it as its text
-content, and then appends it to the container. The container is always a list element in
-this example, as you'll see shortly.
+`scanFiles()` begins by creating a new {{HTMLElement("li")}} element to represent the item being scanned, inserts the name of the item into it as its text content, and then appends it to the container.
+The container is always a list element in this example, as you'll see shortly.
 
-Once the current item is in the list, the item's
-{{domxref("FileSystemEntry.isDirectory", "isDirectory")}} property is checked. If the
-item is a directory, we need to recurse into that directory. The first step is to create
-a {{domxref("FileSystemDirectoryReader")}} to handle fetching the directory's contents.
-That's done by calling the item's {{domxref("FileSystemDirectoryEntry.createReader",
-  "createReader()")}} method. Then a new {{HTMLElement("ul")}} is created and appended to
-the parent list; this will contain the directory's contents in the next level down in
-the list's hierarchy.
+Once the current item is in the list, the item's {{domxref("FileSystemEntry.isDirectory", "isDirectory")}} property is checked.
+If the item is a directory, we need to recurse into that directory.
+The first step is to create a {{domxref("FileSystemDirectoryReader")}} to handle fetching the directory's contents.
+That's done by calling the item's {{domxref("FileSystemDirectoryEntry.createReader", "createReader()")}} method.
+Then a new {{HTMLElement("ul")}} is created and appended to the parent list; this will contain the directory's contents in the next level down in the list's hierarchy.
 
-After that, {{domxref("FileSystemDirectoryReader.readEntries",
-  "directoryReader.readEntries()")}} is called to read in all the entries in the
-directory. These are each, in turn, passed into a recursive call to
-`scanFiles()` to process them. Any of them which are files are inserted into
-the list; any which are directories are inserted into the list and a new level of the
-list's hierarchy is added below, and so forth.
+After that, {{domxref("FileSystemDirectoryReader.readEntries", "directoryReader.readEntries()")}} is called to read in all the entries in the directory.
+These are each, in turn, passed into a recursive call to `scanFiles()` to process them.
+Any of them which are files are inserted into the list; any which are directories are inserted into the list and a new level of the list's hierarchy is added below, and so forth.
 
-Then come the event handlers. First, we prevent the {{event("dragover")}} event from
-being handled by the default handler, so that our drop zone can receive the drop:
+Then come the event handlers. First, we prevent the {{event("dragover")}} event from being handled by the default handler, so that our drop zone can receive the drop:
 
 ```js
 dropzone.addEventListener("dragover", function(event) {
@@ -161,8 +144,7 @@ dropzone.addEventListener("dragover", function(event) {
 }, false);
 ```
 
-The event handler that kicks everything off, of course, is the handler for the
-{{event("drop")}} event:
+The event handler that kicks everything off, of course, is the handler for the {{event("drop")}} event:
 
 ```js
 dropzone.addEventListener("drop", function(event) {
@@ -181,25 +163,19 @@ dropzone.addEventListener("drop", function(event) {
 }, false);
 ```
 
-This fetches the list of {{domxref("DataTransferItem")}} objects representing the items
-dropped from `event.dataTransfer.items`. Then we call
-{{domxref("Event.preventDefault()")}} to prevent the event from being handled further
-after we're done.
+This fetches the list of {{domxref("DataTransferItem")}} objects representing the items dropped from `event.dataTransfer.items`.
+Then we call {{domxref("Event.preventDefault()")}} to prevent the event from being handled further after we're done.
 
-Now it's time to start building the list. First, the list is emptied by setting
-{{domxref("Node.textContent", "listing.textContent")}} to be empty. That leaves us with
-an empty {{domxref("ul")}} to begin inserting directory entries into.
+Now it's time to start building the list. First, the list is emptied by setting {{domxref("Node.textContent", "listing.textContent")}} to be empty.
+That leaves us with an empty {{domxref("ul")}} to begin inserting directory entries into.
 
-Then we iterate over the items in the list of dropped items. For each one, we call its
-{{domxref("DataTransferItem.webkitGetAsEntry", "webkitGetAsEntry()")}} method to obtain
-a {{domxref("FileSystemEntry")}} representing the file. If that's successful, we call
-`scanFiles()` to process the item—either by adding it to the list if it's
-just a file or by adding it and walking down into it if it's a directory.
+Then we iterate over the items in the list of dropped items.
+For each one, we call its {{domxref("DataTransferItem.webkitGetAsEntry", "webkitGetAsEntry()")}} method to obtain a {{domxref("FileSystemEntry")}} representing the file.
+If that's successful, we call `scanFiles()` to process the item—either by adding it to the list if it's just a file or by adding it and walking down into it if it's a directory.
 
 ### Result
 
-You can see how this works by trying it out below. Find some files and directories and
-drag them in, and take a look at the resulting output.
+You can see how this works by trying it out below. Find some files and directories and drag them in, and take a look at the resulting output.
 
 {{ EmbedLiveSample('Example', 600, 400) }}
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -39,6 +39,7 @@ None.
 
 A {{domxref("FileSystemEntry")}}-based object describing the dropped item. This will be
 either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.
+If the item isn't a file, `null` is returned.
 
 ## Example
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -39,7 +39,7 @@ None.
 
 A {{domxref("FileSystemEntry")}}-based object describing the dropped item. This will be
 either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.
-If the item isn't a file, `null` is returned.
+The method aborts and returns `null` if the dropped item isn't a file, or if the {{domxref("DataTransferItem")}} object is not in read or read/write mode.
 
 ## Example
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add `null` as possible return value of this method in the "Return value" paragraph.

#### Motivation
The "Return value" paragraph should include complete information about the possible return values.

#### Supporting details
Accodring to the specification linked at the bottom of this MDN page - https://wicg.github.io/entries-api/#dom-datatransferitem-webkitgetasentry

> The webkitGetAsEntry() method steps are:
>   1. If the DataTransferItem object is not in the read/write mode or the read-only mode, return null and abort these steps.
>   2. If the drag data item kind is not File, then return null and abort these steps.
>   3. Return a new FileSystemEntry object representing the entry.

Points 1 and 2 state that the return value can be `null`. This is also stated in the first paragraph on this MDN page.

#### Related issues
*didn't found any*

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
