### PR TITLE
frequencyBinCount -> fftSize for AnalyserNode.getFloatTimeDomainData() array size

### DIFF
--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -26,7 +26,7 @@ analyser.getFloatTimeDomainData(dataArray); // fill the Float32Array with data r
 
 - `array`
   - : The {{jsxref("Float32Array")}} that the time domain data will be copied to.
-    If the array has fewer elements than the {{domxref("AnalyserNode.frequencyBinCount")}}, excess elements are dropped. If it has more elements than needed, excess elements are ignored.
+    If the array has fewer elements than the {{domxref("AnalyserNode.fftSize")}}, excess elements are dropped. If it has more elements than needed, excess elements are ignored.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Change frequencyBinCount to fftSize in the text specifying the size of the array passed to AnalyserNode.getFloatTimeDomainData().

#### Motivation
I think this should be `fftSize`, since that is the value used to initialise the array in the code snippet. I think this may have been copied from the description for the array passed into AnalyserNode.getFloatFrequencyData().

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I think this should be `fftSize`, since that is the value used to initialise the array in the code snippet.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
