### PR TITLE
Update <menu> tags, add simple styles for the example

### DIFF
--- a/files/en-us/web/html/element/menu/index.md
+++ b/files/en-us/web/html/element/menu/index.md
@@ -5,17 +5,9 @@ tags:
   - Element
   - Experimental
   - HTML
-  - HTML interactive elements
-  - Navigation
+  - HTML grouping content
   - Reference
-  - Site Navigation
-  - UI
-  - UX
-  - User Interface
-  - User experience
   - Web
-  - menu
-  - menus
 browser-compat: html.elements.menu
 ---
 
@@ -23,7 +15,56 @@ browser-compat: html.elements.menu
 
 The **`<menu>`** [HTML](/en-US/docs/Web/HTML) element is a semantic alternative to {{HTMLElement("ul")}}. It represents an unordered list of items (represented by {{HTMLElement("li")}} elements), each of these represent a link or other command that the user can activate.
 
-> **Note:** In previous version of the HTML specification, the `<menu>` element had an additional use case as a context menu. This functionality is now considered obsolete, and has been removed from the specification. Firefox was the only browser to implement this functionality which included the {{HTMLAttrDef("label")}} {{Deprecated_inline}} and `context` {{Deprecated_inline}} attributes.
+## Attributes
+
+This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+
+## Usage notes
+
+The `<menu>` and {{HTMLElement("ul")}} elements both represent an unordered list of items. The key difference is that {{HTMLElement("ul")}} primarily contains items for display, whilst `<menu>` is intended for interactive items, to act on.
+
+> **Note:** In previous version of the HTML specification, the `<menu>` element had an additional use case as a context menu. This functionality is now considered obsolete, and has been removed from the specification.
+
+## Examples
+
+### Toolbar
+
+In this example, a `<menu>` is used to create a toolbar for an editing application.
+
+#### HTML
+
+```html
+<menu>
+  <li><button onclick="copy()">Copy</button></li>
+  <li><button onclick="cut()">Cut</button></li>
+  <li><button onclick="paste()">Paste</button></li>
+</menu>
+```
+
+#### CSS
+
+```css
+menu {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  width: 400px;
+}
+
+li {
+  flex-grow: 1;
+}
+
+button {
+  width: 100%;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Toolbar", "100%", 100)}}
+
+## Technical summary
 
 <table class="properties">
   <tbody>
@@ -100,36 +141,6 @@ The **`<menu>`** [HTML](/en-US/docs/Web/HTML) element is a semantic alternative 
   </tbody>
 </table>
 
-## Attributes
-
-This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
-
-## Usage notes
-
-The {{HTMLElement("menu")}} and {{HTMLElement("ul")}} elements both represent an unordered list of items. The key difference is that {{HTMLElement("ul")}} primarily contains items for display, whilst {{HTMLElement("menu")}} is intended for interactive items, to act on.
-
-## Examples
-
-### Toolbar
-
-In this example, a `<menu>` is used to create a toolbar in an editing application.
-
-> **Warning:** Toolbar menus haven't been implemented in any known browsers yet.
-
-#### HTML
-
-```html
-<menu>
-  <li><button onclick="copy()">Copy</button></li>
-  <li><button onclick="cut()">Cut</button></li>
-  <li><button onclick="paste()">Paste</button></li>
-</menu>
-```
-
-#### Result
-
-{{EmbedLiveSample("Toolbar", "100%", 100)}}
-
 ## Specifications
 
 {{Specifications}}
@@ -140,5 +151,4 @@ In this example, a `<menu>` is used to create a toolbar in an editing applicatio
 
 ## See also
 
-- Other list-related HTML Elements: {{HTMLElement("ol")}}, {{HTMLElement("ul")}}, {{HTMLElement("li")}}, {{HTMLElement("hr")}}, and the obsolete {{HTMLElement("dir")}}.
-- The [`contextmenu`](/en-US/docs/Web/HTML/Global_attributes#attr-contextmenu) [global attribute](/en-US/docs/Web/HTML/Global_attributes) can be used on an element to refer to the `id` of a `menu` with {{HTMLAttrxRef("type", "menu", 'type="context"')}}.
+- Other list-related HTML Elements: {{HTMLElement("ol")}}, {{HTMLElement("ul")}}, and {{HTMLElement("li")}}.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Updated `<menu>`'s tags to remove it from _Interactive elements_, and added simple styles to the example.

#### Motivation

It goes under _Interactive elements_ in [HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element), which is outdated as `<menu>` is just a semantic `<ul>` now. 

The example doesn't quite look like a toolbar, so by simply removing its bullets and laying it horizontally, I tried to make it more like one.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
