### PR TITLE
Remove Django deprecations in v3.1, in prep for v4

### DIFF
--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -19,15 +19,13 @@ Now that you know what Django is for, we'll show you how to set up and test a Dj
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic knowledge of using a terminal/command line and how to install
-        software packages on your development computer's operating system.
+        Basic knowledge of using a terminal/command line and how to install software packages on your development computer's operating system.
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        To have a development environment for Django (3.*) running on your
-        computer.
+        To have a development environment for Django (3.*) running on your computer.
       </td>
     </tr>
   </tbody>
@@ -70,8 +68,6 @@ You can use any Python version supported by your target Django release. For Djan
 
 The Django project _recommends_ (and "officially supports") using the newest available supported Python release.
 
-> **Note:** Python 2.7 cannot be used with the current releases of Django (The Django 1.11.x series is the last to support Python 2.7).
-
 #### Where can we download Django?
 
 There are three places to download Django:
@@ -112,14 +108,16 @@ This section briefly explains how you can check what versions of Python are pres
 
 ### Ubuntu 20.04
 
-Ubuntu Linux 20.04 LTS includes Python 3.8.5 by default. You can confirm this by running the following command in the bash terminal:
+Ubuntu Linux 20.04 LTS includes Python 3.8.10 by default.
+You can confirm this by running the following command in the bash terminal:
 
 ```bash
 python3 -V
- Python 3.8.5
+ Python 3.8.10
 ```
 
-However, the Python Package Index tool (_pip3_) you'll need to install packages for Python 3 (including Django) is **not** available by default. You can install _pip3_ in the bash terminal using:
+However, the Python Package Index tool (_pip3_) you'll need to install packages for Python 3 (including Django) is **not** available by default.
+You can install _pip3_ in the bash terminal using:
 
 ```bash
 sudo apt install python3-pip
@@ -138,10 +136,9 @@ You can easily install Python 3 (along with the _pip3_ tool) from [python.org](h
 
 1. Download the required installer:
 
-    1. Go to <https://www.python.org/downloads/>
-    2. Select the **Download Python 3.8.6** button (the exact version number may differ).
-
-        > **Note:** The version offered may be different. Ensure that the version you download is supported by Django (if needed, links for getting older versions can be found on the same page).
+    1. Go to <https://www.python.org/downloads/macos/>
+    2. Download the most recent [supported version](https://docs.djangoproject.com/en/3.1/faq/install/#what-python-version-can-i-use-with-django) that works with Django 3.1.2.
+       (at time of writing this is Python 3.8.12).
 
 2. Locate the file using _Finder_, and double-click the package file. Following the installation prompts.
 
@@ -149,7 +146,7 @@ You can now confirm successful installation by checking for the _Python 3_ versi
 
 ```bash
 python3 -V
- Python 3.9.0
+ Python 3.8.12
 ```
 
 You can similarly check that _pip3_ is installed by listing the available packages:
@@ -164,11 +161,9 @@ Windows doesn't include Python by default, but you can easily install it (along 
 
 1. Download the required installer:
 
-    1. Go to <https://www.python.org/downloads/>
-    2. Select the **Download Python 3.8.6** button (the exact version number may differ).
-
-        > **Note:** The version offered may be different. Ensure that the version you download [is supported by Django](https://docs.djangoproject.com/en/3.1/faq/install/#what-python-version-can-i-use-with-django) (if needed, links for getting older versions can be found on the same page).
-
+    1. Go to <https://www.python.org/downloads/windows/>
+    2. Download the most recent [supported version](https://docs.djangoproject.com/en/3.1/faq/install/#what-python-version-can-i-use-with-django) that works with Django 3.1.2.
+       (at time of writing this is Python 3.8.12).
 2. Install Python by double-clicking on the downloaded file and following the installation prompts
 3. Be sure to check the box labeled "Add Python to PATH"
 
@@ -176,16 +171,19 @@ You can then verify that Python 3 was installed by entering the following text i
 
 ```bash
 py -3 -V
- Python 3.8.6
+ Python 3.8.12
 ```
 
-The Windows installer incorporates _pip3_ (the Python package manager) by default. You can list installed packages as shown:
+The Windows installer incorporates _pip3_ (the Python package manager) by default.
+You can list installed packages as shown:
 
 ```bash
 pip3 list
 ```
 
-> **Note:** The installer should set up everything you need for the above command to work. If however you get a message that Python cannot be found, you may have forgotten to add it to your system path. You can do this by running the installer again, selecting "Modify", and checking the box labeled "Add Python to environment variables" on the second page.
+> **Note:** The installer should set up everything you need for the above command to work.
+> If however you get a message that Python cannot be found, you may have forgotten to add it to your system path.
+> You can do this by running the installer again, selecting "Modify", and checking the box labeled "Add Python to environment variables" on the second page.
 
 ## Using Django inside a Python virtual environment
 

--- a/files/en-us/learn/server-side/django/forms/index.md
+++ b/files/en-us/learn/server-side/django/forms/index.md
@@ -22,18 +22,14 @@ In this tutorial, we'll show you how to work with HTML Forms in Django, and, in 
       <th scope="row">Prerequisites:</th>
       <td>
         Complete all previous tutorial topics, including
-        <a href="/en-US/docs/Learn/Server-side/Django/Authentication"
-          >Django Tutorial Part 8: User authentication and permissions</a
-        >.
+        <a href="/en-US/docs/Learn/Server-side/Django/Authentication">Django Tutorial Part 8: User authentication and permissions</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        To understand how to write forms to get information from users and
-        update the database. To understand how the generic class-based editing
-        views can vastly simplify creating forms for working with a single
-        model.
+        To understand how to write forms to get information from users and update the database.
+        To understand how the generic class-based editingviews can vastly simplify creating forms for working with a single model.
       </td>
     </tr>
   </tbody>
@@ -167,7 +163,7 @@ import datetime
 from django import forms
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 class RenewBookForm(forms.Form):
     renewal_date = forms.DateField(help_text="Enter a date between now and 4 weeks (default 3).")
@@ -190,7 +186,8 @@ class RenewBookForm(forms.Form):
 There are two important things to note. The first is that we get our data using `self.cleaned_data['renewal_date']` and that we return this data whether or not we change it at the end of the function.
 This step gets us the data "cleaned" and sanitized of potentially unsafe input using the default validators, and converted into the correct standard type for the data (in this case a Python `datetime.datetime` object).
 
-The second point is that if a value falls outside our range we raise a `ValidationError`, specifying the error text that we want to display in the form if an invalid value is entered. The example above also wraps this text in one of [Django's translation functions](https://docs.djangoproject.com/en/3.1/topics/i18n/translation/), `ugettext_lazy()` (imported as `_()`), which is good practice if you want to translate your site later.
+The second point is that if a value falls outside our range we raise a `ValidationError`, specifying the error text that we want to display in the form if an invalid value is entered.
+The example above also wraps this text in one of Django's [translation functions](https://docs.djangoproject.com/en/3.1/topics/i18n/translation/), `gettext_lazy()` (imported as `_()`), which is good practice if you want to translate your site later.
 
 > **Note:** There are numerous other methods and examples for validating forms in [Form and field validation](https://docs.djangoproject.com/en/3.1/ref/forms/validation/) (Django docs). For example, in cases where you have multiple fields that depend on each other, you can override the [Form.clean()](https://docs.djangoproject.com/en/3.1/ref/forms/api/#django.forms.Form.clean) function and again raise a `ValidationError`.
 


### PR DESCRIPTION
We're going to update to Django 4. The first step in that is to remove the know v3.12 deprecations.

Fixes #13070