### PR TITLE
Update index.md line 200 'grid-gap' with 'gap'

### DIFF
--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -197,7 +197,7 @@ Similar to flexbox, we enable Grid Layout with its specific display value — `d
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: 100px 100px;
-    grid-gap: 10px;
+    gap: 10px;
 }
 ```
 

--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -235,7 +235,7 @@ Once you have a grid, you can explicitly place your items on it, rather than rel
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: 100px 100px;
-    grid-gap: 10px;
+    gap: 10px;
 }
 
 .box1 {


### PR DESCRIPTION
update 'grip-gap' with 'gap' since 'grid-gap' is obsolete.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changing the 'grid-gap' on line 200 with 'gap'.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
 'grid-gap' has been deprecated
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
