### PR TITLE
Adapt api.Document.onreadystatechange to new events structure

### DIFF
--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -126,8 +126,6 @@ _The `Document` interface for HTML documents inherits from the {{DOMxRef("HTMLDo
 
 _The `Document` interface is extended with additional event handlers defined in [GlobalEventHandlers](/en-US/docs/Web/API/GlobalEventHandlers#event_handlers)._
 
-- {{DOMxRef("Document.onreadystatechange")}}
-  - : Represents the event handling code for the {{domxref("Document/readystatechange_event", "readystatechange")}} event.
 - {{DOMxRef("GlobalEventHandlers.onselectionchange")}} {{Experimental_Inline}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Document/selectionchange_event", "selectionchange")}} event is raised.
 - {{DOMxRef("Document.onvisibilitychange")}}
@@ -402,7 +400,6 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Fired when the document has been completely loaded and parsed, without waiting for stylesheets, images, and subframes to finish loading.
 - {{DOMxRef("Document/readystatechange_event", "readystatechange")}}
   - : Fired when the {{DOMxRef("Document/readyState", "readyState")}} attribute of a document has changed.
-    Also available via the `onreadystatechange` property.
 
 ### Pointer events
 

--- a/files/en-us/web/api/document/readystatechange_event/index.md
+++ b/files/en-us/web/api/document/readystatechange_event/index.md
@@ -12,26 +12,21 @@ browser-compat: api.Document.readystatechange_event
 
 The **`readystatechange`** event is fired when the {{domxref("Document.readyState", "readyState")}} attribute of a document has changed.
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Bubbles</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th scope="row">Cancelable</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th scope="row">Interface</th>
-      <td>{{domxref("Event")}}</td>
-    </tr>
-    <tr>
-      <th scope="row">Event handler property</th>
-      <td><code>onreadystatechange</code></td>
-    </tr>
-  </tbody>
-</table>
+This event is not cancelable and does not bubble.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('readystatechange', event => { });
+
+onreadystatechange = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 
@@ -49,6 +44,8 @@ The **`readystatechange`** event is fired when the {{domxref("Document.readyStat
   <textarea readonly class="event-log-contents" rows="8" cols="30"></textarea>
 </div>
 ```
+
+#### CSS
 
 ```css hidden
 body {


### PR DESCRIPTION
This PR adapts the readystatechange event of the Document API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15085
