### PR TITLE
FF98 Relnotes, Experimental Features: hyphenate-character available by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -512,48 +512,6 @@ The {{cssxref("math-style")}} property indicates whether MathML equations should
   </tbody>
 </table>
 
-### Property: hyphenate-character
-
-The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break.
-It can also be used to specify that the character is selected to be appropriate for the language conventions of the affected content.
-(See {{bug(1746187)}} for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>97</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>97</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>97</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>97</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.hyphenate-character.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Scroll-linked animations
 
 The {{cssxref('@scroll-timeline')}} at-rule and {{cssxref('animation-timeline')}} property allow you to define animations that are linked to container scroll progress (rather than time).

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -21,7 +21,7 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ### CSS
 
-- The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break. (See {{bug(1751024)}} for more details.)
+- The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break ({{bug(1751024)}}).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -21,6 +21,8 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ### CSS
 
+- The {{cssxref("hyphenate-character")}} property can be used to set a string that is used instead of a hyphen character (`-`) at the end of a hyphenation line break. (See {{bug(1751024)}} for more details.)
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

In FF98, the `layout.css.hyphenate-character.enabled` preference is set to true by default.

- [Experimental Features](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features): Removed "Property: hyphenate-character" entry from the CSS section.
- [Release Notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/98): Added information about hyphenate-character in the CSS section as it is now available by default and not behind a preference setting.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1751024

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Other related doc updates for this: https://github.com/mdn/content/issues/12580

