### PR TITLE
Details for runtime.getFrameId

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
@@ -1,0 +1,66 @@
+---
+title: runtime.getFrameId()
+slug: Mozilla/Add-ons/WebExtensions/API/runtime/getFrameId
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Reference
+  - WebExtensions
+  - getBrowserInfo
+  - runtime
+browser-compat: webextensions.api.runtime.getFrameId
+---
+{{AddonSidebar}}
+
+Returns the frame ID of any window global or frame element when called from a content script.
+
+## Syntax
+
+```js
+var gettingInfo = browser.runtime.getFrameId()
+```
+
+### Parameters
+
+- `target`
+  - : A {{glossary("WindowProxy")}} or a {{glossary("browsing context")}} container [Element](/en-US/docs/Web/API/Element) (iframe, frame, embed, or object) for the target frame.
+
+### Return value
+
+Returns the frame ID of the target frame, or -1 if the frame doesn't exist.
+
+## Examples
+
+This code recursivelly walks descendant frames and gets parent frame IDs.
+
+```js
+let parents = {};
+
+function visit(win) {
+  let frameId = browser.runtime.getFrameId(win);
+  let parentId = browser.runtime.getFrameId(win.parent);
+  parents[frameId] = (win.parent != win) ? parentId : -1;
+
+  try {
+    let frameEl = browser.runtime.getFrameId(win.frameElement);
+    browser.test.assertEq(frameId, frameEl, "frameElement id correct");
+  } catch (e) {
+    // Can't access a cross-origin .frameElement.
+  }
+
+  for (let i = 0; i < win.frames.length; i++) {
+    visit(win.frames[i]);
+  }
+}
+visit(window);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
@@ -14,7 +14,7 @@ browser-compat: webextensions.api.runtime.getFrameId
 ---
 {{AddonSidebar}}
 
-Returns the frame ID of any window global or frame element when called from a content script.
+Returns the frame ID of any window global or frame element when called from a content script or extension page, including background pages.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -53,6 +53,8 @@ It also provides messaging APIs enabling you to:
   - : Retrieves the [Window](/en-US/docs/Web/API/Window) object for the background page running inside the current extension.
 - {{WebExtAPIRef("runtime.openOptionsPage()")}}
   - : Opens your extension's [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages).
+- {{WebExtAPIRef("runtime.getFrameId()")}}
+  - : Gets the `frameId` of any window global or frame element.
 - {{WebExtAPIRef("runtime.getManifest()")}}
   - : Gets the complete [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file, serialized as an object.
 - {{WebExtAPIRef("runtime.getURL()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -54,7 +54,7 @@ It also provides messaging APIs enabling you to:
 - {{WebExtAPIRef("runtime.openOptionsPage()")}}
   - : Opens your extension's [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages).
 - {{WebExtAPIRef("runtime.getFrameId()")}}
-  - : Gets the `frameId` of any window global or frame element.
+  - : Gets the frame ID of any window global or frame element.
 - {{WebExtAPIRef("runtime.getManifest()")}}
   - : Gets the complete [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file, serialized as an object.
 - {{WebExtAPIRef("runtime.getURL()")}}

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -68,6 +68,8 @@ No notable changes.
 
 ## Changes for add-on developers
 
+- Added {{WebExtAPIRef("runtime.getFrameId")}} that gets the `frameId` of any window global or frame element from a content script ({{bug(1733104)}}).
+
 ## Older versions
 
 {{Firefox_for_developers(95)}}

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -68,7 +68,7 @@ No notable changes.
 
 ## Changes for add-on developers
 
-- Added {{WebExtAPIRef("runtime.getFrameId")}} that gets the `frameId` of any window global or frame element from a content script ({{bug(1733104)}}).
+- Added {{WebExtAPIRef("runtime.getFrameId")}} that gets the frame ID of any window global or frame element from a content script ({{bug(1733104)}}).
 
 ## Older versions
 


### PR DESCRIPTION
#### Summary
Add release notes and API reference for `runtime.getFrameId`.

#### Related issues
Provide documentation for [Bug 1733104](https://bugzilla.mozilla.org/show_bug.cgi?id=1733104) Consider allowing retrieval of frameId from <iframe> elements.

Related compatibility data is provided in Adding details for runtime.getFrameId [#15088](https://github.com/mdn/browser-compat-data/pull/15088)

#### Metadata
This PR…
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
