### PR TITLE
Add stateful paragraph from re.exec() to re.test()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
@@ -16,6 +16,13 @@ The **`test()`** method executes a search for a match between a
 regular expression and a specified string. Returns `true` or
 `false`.
 
+JavaScript {{jsxref("RegExp")}} objects are **stateful** when they have
+the {{jsxref("RegExp.global", "global")}} or {{jsxref("RegExp.sticky", "sticky")}} flags
+set (e.g. `/foo/g` or `/foo/y`). They store a
+{{jsxref("RegExp.lastIndex", "lastIndex")}} from the previous match. Using this
+internally, `test()` can be used to iterate over multiple matches in a string
+of text (with capture groups).
+
 {{EmbedInteractiveExample("pages/js/regexp-prototype-test.html", "taller")}}
 
 ## Syntax


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`RegExp.prototype.test()` is could also be stateful. This PR simply copies the paragraph from `RegExp.prototype.exec()` with minor editing.  

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
`RegExp.prototype.test()` is could also be stateful just like `RegExp.prototype.exec()`. This statefulness can potentially cause bugs. `RegExp.prototype.exec()` page mentions this explicitly, we should do the same treatment here. 

This PR simply copies the paragraph from `RegExp.prototype.exec()`, and remove the last sentence as there is no stateless alternative. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* https://tc39.es/ecma262/#sec-regexp.prototype.test
  * `.test()` simply calls `RegExpExec` (`.exec()` internal) under the hood without resetting `.lastIndex` 
* https://2ality.com/2020/01/regexp-lastindex.html

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
