### PR TITLE
handler.defineProperty intercepts __defineGetter|Setter__

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -51,6 +51,8 @@ The **`handler.defineProperty()`** method is a trap for
 
 This trap can intercept these operations:
 
+- {{jsxref("Object.__defineGetter__()")}}
+- {{jsxref("Object.__defineSetter__()")}}
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Reflect.defineProperty()")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -51,8 +51,8 @@ The **`handler.defineProperty()`** method is a trap for
 
 This trap can intercept these operations:
 
-- {{jsxref("Object.__defineGetter__()")}}
-- {{jsxref("Object.__defineSetter__()")}}
+- {{jsxref("Object.prototype.__defineGetter__()")}}
+- {{jsxref("Object.prototype.__defineSetter__()")}}
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Reflect.defineProperty()")}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
add `__defineGetter__` and `__defineSetter__`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was making some custom rust immutability thing and wanted to make sure that the user couldn't somehow mutate using `__defineGetter__` or `__defineSetter__`

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
When I try `__defineGetter__` and `__defineSetter__` the proxy handler catches it:

```js
const test = new Proxy({}, {
   defineProperty(...args) {
      console.log(...args)
      return Reflect.defineProperty(...args)
   }
})

test.__defineGetter__('a', () => 2) // logs {} 'a' {enumerable: true, configurable: true, get: ƒ}
test.__defineSetter__('a', () => false) // logs {} 'a' {enumerable: true, configurable: true, set: ƒ}
```

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [x] Adds a small amount to a document

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
(edits welcome)
