### PR TITLE
Mark negative NumberFormat as experimental

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -132,7 +132,7 @@ new Intl.NumberFormat(locales, options)
         - "`auto`" sign display for negative numbers only
         - "`exceptZero`" sign display for positive and negative
           numbers, but not zero
-        - "`negative`" sign display for negative numbers only, excluding negative zero.
+        - "`negative`" sign display for negative numbers only, excluding negative zero. {{experimental_inline}}
         - "`never`" never display sign
 
     - `style`


### PR DESCRIPTION
The first part of the fix for #13045. Add an "experimental" label next to a NumberFormat V3 feature supported only by Gecko.

(There still needs to be a companion PR for BCD)