### PR TITLE
FF98 Relnotes, Experimental Features: <dialog> available by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -22,47 +22,6 @@ Experimental features can be enabled or disabled using the [Firefox Configuratio
 
 ## HTML
 
-### Element: \<dialog>
-
-The HTML {{HTMLElement("dialog")}} element and its associated DOM APIs provide support for HTML-based modal dialog boxes.
-The current implementation is a little inelegant but is basically functional. (See {{bug(840640)}} for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>53</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>53</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>53</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>53</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.dialog_element.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### inert attribute
 
 The {{domxref("HTMLElement")}} property {{DOMxRef("HTMLElement.inert")}} is a {{jsxref("Boolean")}}, when present, may make the browser "ignore" the element from assistive technologies, page search and text selection. For more details on the status of this feature see {{bug(1655722)}}.

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -17,6 +17,8 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ### HTML
 
+- The HTML {{HTMLElement("dialog")}} element and its associated DOM APIs provide support for HTML-based modal dialog boxes. This element is now available by default. ({{bug(1733536)}})
+
 #### Removals
 
 ### CSS

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -17,7 +17,7 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ### HTML
 
-- The HTML {{HTMLElement("dialog")}} element and its associated DOM APIs provide support for HTML-based modal dialog boxes. This element is now available by default. ({{bug(1733536)}})
+- The HTML {{HTMLElement("dialog")}} element and its associated DOM APIs provide support for HTML-based modal dialog boxes. This element is now available by default ({{bug(1733536)}}).
 
 #### Removals
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

In FF98, the `dom.dialog_element.enabled` preference is set to true by default.

- [Experimental Features](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features): Removed "Element: `<dialog>`" entry from the HTML section.
- [Release Notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/98): Added information about `<dialog>` in the HTML section as it is now available by default and not behind a preference setting.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1733536

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Other related doc updates: https://github.com/mdn/content/issues/12578
