### PR TITLE
Change "creates a property 'a' on p"

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -97,7 +97,7 @@ console.log(o.m()); // 3
 const p = Object.create(o);
 // p is an object that inherits from o
 
-p.a = 4; // creates a property 'a' on p
+p.a = 4; // assign the value 4 to the property 'a' on p
 console.log(p.m()); // 5
 // when p.m is called, 'this' refers to p.
 // So when p inherits the function m of o,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I changed the word "creates a property 'a'" for "assign the value of 4 to the property 'a'".

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was reading the documentation and got confused because when I use Object.create(o) it is suppose to take all properties from the object "o" but the word "creates" made me think that maybe it only copied functions so I copy the code in my console and saw a already existed when the object "p" was created so there was no need to create "a" just to assign a need value in this case.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ X ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
