### PR TITLE
JS Learn: update client-side APIs, part 4

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -47,7 +47,7 @@ The APIs we've covered so far are built into the browser, but not all APIs are. 
 
 Third party APIs are APIs provided by third parties — generally companies such as Facebook, Twitter, or Google — to allow you to access their functionality via JavaScript and use it on your site. One of the most obvious examples is using mapping APIs to display custom maps on your pages.
 
-Let's look at a [Simple Mapquest API example](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/mapquest/), and use it to illustrate how third-party APIs differ from browser APIs.
+Let's look at a [Simple Mapquest API example](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/mapquest/live/index.html), and use it to illustrate how third-party APIs differ from browser APIs.
 
 > **Note:** You might want to just [get all our code examples](/en-US/docs/Learn#getting_our_code_examples) at once, in which case you can then just search the repo for the example files you need in each section.
 
@@ -66,15 +66,15 @@ const audioSource = audioCtx.createMediaElementSource(audioElement);
 
 Third party APIs, on the other hand, are located on third party servers. To access them from JavaScript you first need to connect to the API functionality and make it available on your page. This typically involves first linking to a JavaScript library available on the server via a {{htmlelement("script")}} element, as seen in our Mapquest example:
 
-```js
-<script src="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.js"></script>
+```html
+<script src="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.js" defer></script>
 <link type="text/css" rel="stylesheet" href="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.css"/>
 ```
 
 You can then start using the objects available in that library. For example:
 
 ```js
-let map = L.mapquest.map('map', {
+const map = L.mapquest.map('map', {
   center: [53.480759, -2.242631],
   layers: L.mapquest.tileLayer('map'),
   zoom: 12
@@ -111,7 +111,7 @@ Requiring a key enables the API provider to hold users of the API accountable fo
 
 Let's add some more functionality to the Mapquest example to show how to use some other features of the API.
 
-1. To start this section, make yourself a copy of the [mapquest starter file](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/mapquest/starter-file.html), in a new directory. If you've already [cloned the examples repository](/en-US/docs/Learn#getting_our_code_examples), you'll already have a copy of this file, which you can find in the _javascript/apis/third-party-apis/mapquest_ directory.
+1. To start this section, make yourself a copy of the [mapquest starter file](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/mapquest/start/index.html), in a new directory. If you've already [cloned the examples repository](/en-US/docs/Learn#getting_our_code_examples), you'll already have a copy of this file, which you can find in the _javascript/apis/third-party-apis/mapquest/start_ directory.
 2. Next, you need to go to the [Mapquest developer site](https://developer.mapquest.com/), create an account, and then create a developer key to use with your example. (At the time of writing, it was called a "consumer key" on the site, and the key creation process also asked for an optional "callback URL". You don't need to fill in a URL here: just leave it blank.)
 3. Open up your starting file, and replace the API key placeholder with your key.
 
@@ -127,7 +127,7 @@ Try changing `'map'` to `'hybrid'` to show a hybrid-style map. Try some other va
 
 ### Adding different controls
 
-The map has a number of different controls available; by default it just shows a zoom control. You can expand the controls available using the `map.addControl()` method; add this to your code, inside the `window.onload` handler:
+The map has a number of different controls available; by default it just shows a zoom control. You can expand the controls available using the `map.addControl()` method; add this to your code:
 
 ```js
 map.addControl(L.mapquest.control());
@@ -169,7 +169,7 @@ Finally, we chain `.addTo(map)` to the end of the chain to actually add the mark
 
 Have a play with the other options shown in the documentation and see what you can come up with! Mapquest provides some pretty advanced functionality, such as directions, searching, etc.
 
-> **Note:** If you have trouble getting the example to work, check your code against our finished version — see [expanded-example.html](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/mapquest/expanded-example.html) (also [see it running live here](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/mapquest/expanded-example.html)).
+> **Note:** If you have trouble getting the example to work, check your code against our [finished version](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/mapquest/finished/script.js) (also [see it running live here](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/mapquest/finished/)).
 
 ## What about Google Maps?
 
@@ -196,7 +196,7 @@ Most APIs require you to use some kind of developer key, for reasons of security
 
 1. Let's request a key for the Article Search API — create a new app, selecting this as the API you want to use (fill in a name and description, toggle the switch under the "Article Search API" to the on position, and then click "Create").
 2. Get the API key from the resulting page.
-3. Now, to start the example off, make copies of [nytimes_start.html](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/nytimes/nytimes_start.html) and [nytimes.css](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/nytimes/nytimes.css) in a new directory on your computer. If you've already [cloned the examples repository](/en-US/docs/Learn#getting_our_code_examples), you'll already have a copy of these files, which you can find in the _javascript/apis/third-party-apis/nytimes_ directory. Initially the `<script>` element contains a number of variables needed for the setup of the example; below we'll fill in the required functionality.
+3. Now, to start the example off, make a copy of all the files in the [nytimes/start](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/nytimes/start) directory. If you've already [cloned the examples repository](/en-US/docs/Learn#getting_our_code_examples), you'll already have a copy of these files, which you can find in the _javascript/apis/third-party-apis/nytimes/start_ directory. Initially the `script.js` file contains a number of variables needed for the setup of the example; below we'll fill in the required functionality.
 
 The app will end up allowing you to type in a search term and optional start and end dates, which it will then use to query the Article Search API and display the search results.
 
@@ -209,7 +209,7 @@ First, you'll need to make a connection between the API and your app. In the cas
 1. Find the following line:
 
     ```js
-    let key = ' ... ';
+    const key = 'INSERT-YOUR-API-KEY-HERE';
     ```
 
     Replace the existing API key with the actual API key you got in the previous section.
@@ -233,16 +233,16 @@ First, you'll need to make a connection between the API and your app. In the cas
       e.preventDefault();
 
       // Assemble the full URL
-      url = baseURL + '?api-key=' + key + '&page=' + pageNumber + '&q=' + searchTerm.value + '&fq=document_type:("article")';
+      //url = baseURL + '?api-key=' + key + '&page=' + pageNumber + '&q=' + searchTerm.value + '&fq=document_type:("article")';
+      let url = `${baseURL}?api-key=${key}&page=${pageNumber}&q=${searchTerm.value}&fq=document_type:("article")`;
 
-      if(startDate.value !== '') {
-        url += '&begin_date=' + startDate.value;
+      if (startDate.value !== '') {
+        url = `${url}&begin_date=${startDate.value}`;
       };
 
-      if(endDate.value !== '') {
-        url += '&end_date=' + endDate.value;
+      if (endDate.value !== '') {
+        url = `${url}&end_date=${endDate.value}`;
       };
-
     }
     ```
 
@@ -274,14 +274,13 @@ Add the following code block inside the `fetchResults()` function, just above th
 
 ```js
 // Use fetch() to make the request to the API
-fetch(url).then(function(result) {
-  return result.json();
-}).then(function(json) {
-  displayResults(json);
-});
+fetch(url)
+  .then( response => response.json() )
+  .then( json => displayResults(json) )
+  .catch( error => console.error(`Error fetching data: ${error.message}`) );
 ```
 
-Here we run the request by passing our `url` variable to [`fetch()`](/en-US/docs/Web/API/fetch), convert the response body to JSON using the [`json()`](/en-US/docs/Web/API/Response/json) function, then pass the resulting JSON to the `displayResults()` function so the data can be displayed in our UI.
+Here we run the request by passing our `url` variable to [`fetch()`](/en-US/docs/Web/API/fetch), convert the response body to JSON using the [`json()`](/en-US/docs/Web/API/Response/json) function, then pass the resulting JSON to the `displayResults()` function so the data can be displayed in our UI. We also catch and log any errors that might be thrown.
 
 ### Displaying the data
 
@@ -290,80 +289,75 @@ OK, let's look at how we'll display the data. Add the following function below y
 ```js
 function displayResults(json) {
   while (section.firstChild) {
-      section.removeChild(section.firstChild);
+    section.removeChild(section.firstChild);
   }
 
   const articles = json.response.docs;
 
-  if(articles.length === 10) {
+  if (articles.length === 10) {
     nav.style.display = 'block';
   } else {
     nav.style.display = 'none';
   }
 
-  if(articles.length === 0) {
+  if (articles.length === 0) {
     const para = document.createElement('p');
     para.textContent = 'No results returned.'
     section.appendChild(para);
   } else {
-    for(var i = 0; i < articles.length; i++) {
+    for (const current of articles) {
       const article = document.createElement('article');
       const heading = document.createElement('h2');
       const link = document.createElement('a');
       const img = document.createElement('img');
       const para1 = document.createElement('p');
-      const para2 = document.createElement('p');
-      const clearfix = document.createElement('div');
+      const keywordPara = document.createElement('p');
+      keywordPara.classList.add('keywords');
 
-      let current = articles[i];
       console.log(current);
 
       link.href = current.web_url;
       link.textContent = current.headline.main;
       para1.textContent = current.snippet;
-      para2.textContent = 'Keywords: ';
-      for(let j = 0; j < current.keywords.length; j++) {
+      keywordPara.textContent = 'Keywords: ';
+      for (const keyword of current.keywords) {
         const span = document.createElement('span');
-        span.textContent += current.keywords[j].value + ' ';
-        para2.appendChild(span);
+        span.textContent = `${keyword.value} `;
+        keywordPara.appendChild(span);
       }
 
-      if(current.multimedia.length > 0) {
-        img.src = 'http://www.nytimes.com/' + current.multimedia[0].url;
+      if (current.multimedia.length > 0) {
+        img.src = `http://www.nytimes.com/${current.multimedia[0].url}`;
         img.alt = current.headline.main;
       }
-
-      clearfix.setAttribute('class','clearfix');
 
       article.appendChild(heading);
       heading.appendChild(link);
       article.appendChild(img);
       article.appendChild(para1);
-      article.appendChild(para2);
-      article.appendChild(clearfix);
+      article.appendChild(keywordPara);
       section.appendChild(article);
     }
   }
-}
+};
 ```
 
 There's a lot of code here; let's explain it step by step:
 
 - The [`while`](/en-US/docs/Web/JavaScript/Reference/Statements/while) loop is a common pattern used to delete all of the contents of a DOM element, in this case, the {{htmlelement("section")}} element. We keep checking to see if the `<section>` has a first child, and if it does, we remove the first child. The loop ends when `<section>` no longer has any children.
 - Next, we set the `articles` variable to equal `json.response.docs` — this is the array holding all the objects that represent the articles returned by the search. This is done purely to make the following code a bit simpler.
-- The first [`if()`](/en-US/docs/Web/JavaScript/Reference/Statements/if...else) block checks to see if 10 articles are returned (the API returns up to 10 articles at a time.) If so, we display the {{htmlelement("nav")}} that contains the _Previous 10_/_Next 10_ pagination buttons. If less than 10 articles are returned, they will all fit on one page, so we don't need to show the pagination buttons. We will wire up the pagination functionality in the next section.
+- The first [`if()`](/en-US/docs/Web/JavaScript/Reference/Statements/if...else) block checks to see if 10 articles are returned (the API returns up to 10 articles at a time.) If so, we display the {{htmlelement("nav")}} that contains the _Previous 10_/_Next 10_ pagination buttons. If fewer than 10 articles are returned, they will all fit on one page, so we don't need to show the pagination buttons. We will wire up the pagination functionality in the next section.
 - The next `if()` block checks to see if no articles are returned. If so, we don't try to display any — we create a {{htmlelement("p")}} containing the text "No results returned." and insert it into the.`<section>`
 - If some articles are returned, we, first of all, create all the elements that we want to use to display each news story, insert the right contents into each one, and then insert them into the DOM at the appropriate places. To work out which properties in the article objects contained the right data to show, we consulted the Article Search API reference (see [NYTimes APIs](https://developer.nytimes.com/apis)). Most of these operations are fairly obvious, but a few are worth calling out:
 
-  - We used a [for loop](/en-US/docs/Web/JavaScript/Reference/Statements/for) (`for(var j = 0; j < current.keywords.length; j++) { ... }` ) to loop through all the keywords associated with each article, and insert each one inside its own {{htmlelement("span")}}, inside a `<p>`. This was done to make it easy to style each one.
+  - We used a [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop to go through all the keywords associated with each article, and insert each one inside its own {{htmlelement("span")}}, inside a `<p>`. This was done to make it easy to style each one.
   - We used an `if()` block (`if(current.multimedia.length > 0) { ... }`) to check whether each article has any images associated with it (some stories don't.) We display the first image only if it exists (otherwise an error would be thrown).
-  - We gave our `<div>` element a class of "clearfix", so we can easily apply clearing to it.
 
 ### Wiring up the pagination buttons
 
 To make the pagination buttons work, we will increment (or decrement) the value of the `pageNumber` variable, and then re-rerun the fetch request with the new value included in the page URL parameter. This works because the NYTimes API only returns 10 results at a time — if more than 10 results are available, it will return the first 10 (0-9) if the `page` URL parameter is set to 0 (or not included at all — 0 is the default value), the next 10 (10-19) if it is set to 1, and so on.
 
-This allows us to write a simplistic pagination function easily.
+This allows us to write a simplistic pagination function.
 
 1. Below the existing [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) call, add these two new ones, which cause the `nextPage()` and `previousPage()` functions to be invoked when the relevant buttons are clicked:
 
@@ -390,11 +384,11 @@ This allows us to write a simplistic pagination function easily.
     };
     ```
 
-    The first function is simple — we increment the `pageNumber` variable, then run the `fetchResults()` function again to display the next page's results.
+    The first function increments the `pageNumber` variable, then run the `fetchResults()` function again to display the next page's results.
 
-    The second function works nearly exactly the same way in reverse, but we also have to take the extra step of checking that `pageNumber` is not already zero before decrementing it — if the fetch request runs with a minus `page` URL parameter, it could cause errors. If the `pageNumber` is already 0, we [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) out of the function, to avoid wasting processing power (If we are already at the first page, we don't need to load the same results again).
+    The second function works nearly exactly the same way in reverse, but we also have to take the extra step of checking that `pageNumber` is not already zero before decrementing it — if the fetch request runs with a minus `page` URL parameter, it could cause errors. If the `pageNumber` is already 0, we [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) out of the function — if we are already at the first page, we don't need to load the same results again.
 
-> **Note:** You can find our [finished NYTimes API example code on GitHub](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/nytimes/index.html) (also [see it running live here](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/nytimes/)).
+> **Note:** You can find our [finished NYTimes API example code on GitHub](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/nytimes/finished/index.html) (also [see it running live here](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/nytimes/finished/)).
 
 ## YouTube example
 

--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -233,7 +233,6 @@ First, you'll need to make a connection between the API and your app. In the cas
       e.preventDefault();
 
       // Assemble the full URL
-      //url = baseURL + '?api-key=' + key + '&page=' + pageNumber + '&q=' + searchTerm.value + '&fq=document_type:("article")';
       let url = `${baseURL}?api-key=${key}&page=${pageNumber}&q=${searchTerm.value}&fq=document_type:("article")`;
 
       if (startDate.value !== '') {

--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -171,13 +171,6 @@ Have a play with the other options shown in the documentation and see what you c
 
 > **Note:** If you have trouble getting the example to work, check your code against our [finished version](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/mapquest/finished/script.js) (also [see it running live here](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/mapquest/finished/)).
 
-## What about Google Maps?
-
-Google Maps is arguably the most popular maps API, so why didn't we use it for our maps example? We did [create an example](https://github.com/mdn/learning-area/blob/master/javascript/apis/third-party-apis/google-maps/finished-maps-example.html) to show how to use it, but in the end we went with Mapquest for a couple of reasons:
-
-- It is much easier to get started with. For Google APIs in general, you need to create a Google account and log into the [Google Cloud Platform Console](https://console.cloud.google.com) to create API keys, etc., and the process is fairly complex. For the [Google Maps API](https://cloud.google.com/maps-platform/) in particular, you need to provide a credit card for billing purposes (although basic usage is free), which we didn't think was acceptable for a basic tutorial.
-- We wanted to show that there are other alternatives available.
-
 ## A RESTful API — NYTimes
 
 Now let's look at another API example — the [New York Times API](https://developer.nytimes.com). This API allows you to retrieve New York Times news story information and display it on your site. This type of API is known as a **RESTful API** — instead of getting data using the features of a JavaScript library like we did with Mapquest, we get data by making HTTP requests to specific URLs, with data like search terms and other properties encoded in the URL (often as URL parameters). This is a common pattern you'll encounter with APIs.


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/10337, the project to modernize the JS Learning Area.

This is the fourth PR that updates the final module, [Client-side web APIs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs). It makes major updates to the fourth article, [Third-party APIs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Third_party_APIs).

Many of the changes here are to reflect some juggling of example code in mdn/learning-area, especially to have JS in separate files. So this PR has a corresponding PR in mdn/learning-area: both PRs should be merged together, and changes in one will need corresponding changes in the other one. For that reason I'm marking it draft, although it is ready for review.