### PR TITLE
Fix typo in Client-side Form Validation lesson

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -574,7 +574,7 @@ input:focus:invalid {
 }
 ```
 
-Now lets look at the JavaScript that implements the custom error validation.
+Now let's look at the JavaScript that implements the custom error validation.
 
 ```js
 // There are many ways to pick a DOM node; here we get the form itself and the email


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I changed the word "lets" to "let's" because "let's" is the contraction for "let us," whereas "lets" is the third-person singular present tense form of the verb "let." In the context of the sentence, "let's" is the correct word to use.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I made the change so that the correct word is used in the sentence and the sentence is accurate.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.grammarly.com/blog/lets-vs-lets/

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
