### PR TITLE
Included 'for,' in a sentence

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
@@ -45,7 +45,7 @@ Elements can also have attributes that look like the following:
 
 ![](grumpy-cat-attribute-small.png)
 
-Attributes contain extra information about the element that you don't want to appear in the actual content. Here, `class` is the attribute *name* and `editor-note` is the attribute _value_. The `class` attribute allows you to give the element a non-unique identifier that can be used to target it (and any other elements with the same `class` value) with style information and other things.
+Attributes contain extra information about the element that you don't want for, to appear in the actual content. Here, `class` is the attribute *name* and `editor-note` is the attribute _value_. The `class` attribute allows you to give the element a non-unique identifier that can be used to target it (and any other elements with the same `class` value) with style information and other things.
 
 An attribute should always have the following:
 


### PR DESCRIPTION
Modified the second sentence of the second paragraph in the subheading 'Anatomy of an HTML element'.
Before:>  'Attributes contain extra information about the element that you don't want to appear in the actual content.'
After:> 'Attributes contain extra information about the element that you don't want for, to appear in the actual content.'

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
