### PR TITLE
Add cookieStoreId to userScripts.register

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.md
@@ -41,6 +41,8 @@ await registeredUserScript.unregister();
       - : A `JSON` object containing arbitrary metadata properties associated with the registered user scripts. However, while arbitrary, the object must be serializable, so it is compatible with [the structured clone algorithm.](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) This metadata is used to pass details from the script to the [`API script`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts)[](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts). For example, providing details of a subset of the APIs that need to be injected by the [`API script`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts). The API  does not use this metadata,
     - `allFrames` {{Optional_Inline}}
       - : Same as `all_frames` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
+    - `cookieStoreId` {{optional_inline}}
+      - : An array of cookie store ID strings or a string containing a cookie store ID. Registers the user script in the tabs that belong to the cookie store IDs. This enables scripts to be registered for all default or non-contextual identity tabs, private browsing tabs (if extensions are enabled in private browsing), the tabs of a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities), or a combination of these.
     - `excludeGlobs` {{Optional_Inline}}
       - : Same as `exclude_globs` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
     - `excludeMatches` {{Optional_Inline}}

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -63,6 +63,8 @@ This article provides information about the changes in Firefox 98 that will affe
 
 ## Changes for add-on developers
 
+- `cookieStoreId` added to {{WebExtAPIRef("userScripts.register")}}. This enables extensions to register container-specific user scripts ({{bug(1738567)}}).
+
 #### Removals
 
 ### Other


### PR DESCRIPTION
#### Summary
Add details about the addition of `cookieStoreId` to `userScripts.register` including release note.

#### Supporting details
Addresses MDN documentation requirements for [bug 1738567](https://bugzilla.mozilla.org/show_bug.cgi?id=1738567).

#### Related issues
The related compatibility data is updated in [PR #15098](https://github.com/mdn/browser-compat-data/pull/15098).
 
#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error