### PR TITLE
Update aria-disabled example

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -47,21 +47,21 @@ While adding `disabled` to an HTML form control causes `:disabled` user-agent st
 > **Note:** If you are using CSS's [`pointer-events: none;`](/en-US/docs/Web/CSS/pointer-events) to make an element non-clickable, make sure you disable interactivity with JavaScript as well. `pointer-events: none;` prevents mouse clicks, but does not prevent the element from being activated via the keyboard.
 
 ```js
+function onClick(event) {
+  event.preventDefault();
+}
+
 function toggleDisabled(element, status, update) {
   if(status) {
     //element.input.disabled = false;
     element.setAttribute('aria-disabled', 'false');
     update.textContent = 'The element is now enabled.';
-    element.removeEventListener('click', function (event) {
-      event.preventDefault();
-    }
+    element.removeEventListener('click', onClick);
   } else {
     //element.input.disabled = true;
     element.setAttribute('aria-disabled', 'true');
     update.textContent = 'The element is now disabled.';
-    element.addEventListener('click', function (event) {
-      event.preventDefault();
-    }
+    element.addEventListener('click', onClick);
   }
 }
 ```


### PR DESCRIPTION
Update an example on the aria-disabled page to not leak event listeners.
Removing an event listener requires calling `removeEventListener` with
the listener reference that a previous call to `addEventListener` added.