### PR TITLE
Headers.get: example is missing a space

### DIFF
--- a/files/en-us/web/api/headers/get/index.md
+++ b/files/en-us/web/api/headers/get/index.md
@@ -64,7 +64,7 @@ the values, in the order they were added to the Headers object:
 ```js
 myHeaders.append('Accept-Encoding', 'deflate');
 myHeaders.append('Accept-Encoding', 'gzip');
-myHeaders.get('Accept-Encoding'); // Returns "deflate,gzip"
+myHeaders.get('Accept-Encoding'); // Returns "deflate, gzip"
 myHeaders.get('Accept-Encoding').split(',').map(v => v.trimStart()); // Returns [ "deflate", "gzip" ]
 ```
 


### PR DESCRIPTION
#### Summary

An example incorrectly displays the return value of Headers.get when there are multiple headers with the same name.

In Headers.get, multiple headers are joined by a comma and a space, not just a comma.

#### Motivation

I want the example to be correct.

#### Supporting details

The similar example in https://developer.mozilla.org/en-US/docs/Web/API/Headers/append gets this correct.

This is specified in https://fetch.spec.whatwg.org/#concept-header-list-get


#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
