### PR TITLE
replace "elemnets" with "nodes"

### DIFF
--- a/files/en-us/web/api/node/lastchild/index.md
+++ b/files/en-us/web/api/node/lastchild/index.md
@@ -12,11 +12,11 @@ browser-compat: api.Node.lastChild
 The read-only **`lastChild`** property of the {{domxref("Node")}} interface
 returns the last child of the node.
 If its parent is an element, then the child is generally an element node, a text node, or a comment node.
-It returns `null` if there are no child elements.
+It returns `null` if there are no child nodes.
 
 ## Value
 
-A {{domxref("Node")}} that is the last child of the node, or `null` is there are no child elements.
+A {{domxref("Node")}} that is the last child of the node, or `null` is there are no child nodes.
 
 ## Example
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace "elemnets" with "nodes" in Node.lastChild.
Because the method doesn't return `null` if there is a child node which is not an element.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
