### PR TITLE
Fix the table sorting code example

### DIFF
--- a/files/en-us/web/html/element/table/index.md
+++ b/files/en-us/web/html/element/table/index.md
@@ -354,22 +354,25 @@ The following example adds an event handler to every `<th>` element of every `<t
 ##### JavaScript
 
 ```js
-for (let table of document.querySelectorAll('table')) {
-  for (let th of table.tHead.rows[0].cells) {
-    th.onclick = function(){
-      const tBody = table.tBodies[0];
-      const rows = tBody.rows;
-      for (let tr of rows) {
-        Array.prototype.slice.call(rows)
-          .sort(function(tr1, tr2){
-            const cellIndex = th.cellIndex;
-            return tr1.cells[cellIndex].textContent.localeCompare(tr2.cells[cellIndex].textContent);
-          })
-          .forEach(function(tr){
-            this.appendChild(this.removeChild(tr));
-          }, tBody);
-      }
-    }
+const allTables = document.querySelectorAll('table');
+
+for (let table of allTables) {
+  const tBody = table.tBodies[0];
+  const rows = Array.from(tBody.rows);
+  const headerCells = table.tHead.rows[0].cells;
+
+  for (let th of headerCells) {
+    const cellIndex = th.cellIndex;
+
+    th.addEventListener('click', () => {
+      rows.sort((tr1, tr2) => {
+        const tr1Text = tr1.cells[cellIndex].textContent;
+        const tr2Text = tr2.cells[cellIndex].textContent;
+        return tr1Text.localeCompare(tr2Text);
+      });
+
+      tBody.append(...rows);
+    });
   }
 }
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- Removed the unnecessary inner for-loop described in #13236.
- Made some more adjustments to the code example.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
- The inner for-loop was re-sorting the whole table for every row which is redundant.
- `addEventListener()` should be used instead of `onclick` since it is ["the recommended way to register an event listener"](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).
- [Modern JS features should be used](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Code_guidelines/JavaScript#use_modern_js_features) such as `Array.from()` instead of `Array.prototype.slice.call()`.
- Removing the row in `this.appendChild(this.removeChild(tr))` before inserting it is unnecessary since ["there is no requirement to remove the node from its parent node before appending it to some other node"](https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild). So the `forEach` can be simplified to `tBody.append(...rows)`.

<!-- #### Supporting details -->
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #13236
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error