### PR TITLE
Adapt FontFaceSet API to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7822,6 +7822,11 @@
 /en-US/docs/Web/API/FocusEvent.FocusEvent	/en-US/docs/Web/API/FocusEvent/FocusEvent
 /en-US/docs/Web/API/FocusEvent.relatedTarget	/en-US/docs/Web/API/FocusEvent/relatedTarget
 /en-US/docs/Web/API/FontFace/FontFace.style	/en-US/docs/Web/API/FontFace/style
+/en-US/docs/Web/API/FontFaceSet/loading_error	/en-US/docs/Web/API/FontFaceSet/loading_event
+/en-US/docs/Web/API/FontFaceSet/loadingdone_error	/en-US/docs/Web/API/FontFaceSet/loadingdone_event
+/en-US/docs/Web/API/FontFaceSet/onloading	/en-US/docs/Web/API/FontFaceSet/loading_event
+/en-US/docs/Web/API/FontFaceSet/onloadingdone	/en-US/docs/Web/API/FontFaceSet/loadingdone_event
+/en-US/docs/Web/API/FontFaceSet/onloadingerror	/en-US/docs/Web/API/FontFaceSet/loadingerror_event
 /en-US/docs/Web/API/FullscreenOptions	/en-US/docs/Web/API/Element/requestFullScreen
 /en-US/docs/Web/API/FullscreenOptions/navigationUI	/en-US/docs/Web/API/Element/requestFullScreen
 /en-US/docs/Web/API/GLbitfield	/en-US/docs/Web/API/WebGL_API/Types

--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -27,12 +27,12 @@ The **`FontFaceSet`** interface of the [CSS Font Loading API](/en-US/docs/Web/AP
 
 ### Events
 
-- {{domxref("FontFaceSet.onloading")}}
-  - : An {{domxref("EventListener")}} called whenever an event of type `loading` is fired, indicating a font-face set has started loading.
-- {{domxref("FontFaceSet.onloadingdone")}}
-  - : An {{domxref("EventListener")}} called whenever an event of type `loadingdone` is fired, indicating that a font face set has finished loading.
-- {{domxref("FontFaceSet.onloadingerror")}}
-  - : An {{domxref("EventListener")}} called whenever an event of type `loadingerror` is fired, indicating that an error occurred whilst loading a font-face set.
+- {{domxref("FontFaceSet.loading_event", "loading")}}
+  - : Fires when a font-face set has started loading.
+- {{domxref("FontFaceSet.loadingdone_event", "loadingdone")}}
+  - : Fires when a font face set has finished loading.
+- {{domxref("FontFaceSet.loadingerror_event", "loadingerror")}}
+  - : Fires when an error occurred whilst loading a font-face set.
 
 ## Methods
 

--- a/files/en-us/web/api/fontfaceset/loading_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loading_event/index.md
@@ -1,25 +1,26 @@
 ---
-title: FontFaceSet.onloading
-slug: Web/API/FontFaceSet/onloading
+title: 'FontFaceSet: loading event'
+slug: Web/API/FontFaceSet/loading_event
 tags:
   - API
   - Property
   - Reference
   - onloading
   - FontFaceSet
-browser-compat: api.FontFaceSet.onloading
+browser-compat: api.FontFaceSet.loading_event
 ---
 {{APIRef("CSS Font Loading API")}}
-
-The **`onloading`** EventHandler of the {{domxref("FontFaceSet")}} interface processes `loading` events.
 
 The `loading` event fires when the document begins loading fonts.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-FontFaceSet.onloading = function;
-FontFaceSet.addEventListener('loading', function);
+addEventListener('loading', event => { });
+
+onloading = event => { };
 ```
 
 ## Example

--- a/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
@@ -1,25 +1,26 @@
 ---
-title: FontFaceSet.onloadingdone
-slug: Web/API/FontFaceSet/onloadingdone
+title: 'FontFaceSet: loadingdone event'
+slug: Web/API/FontFaceSet/loadingdone_event
 tags:
   - API
   - Property
   - Reference
   - onloadingdone
   - FontFaceSet
-browser-compat: api.FontFaceSet.onloadingdone
+browser-compat: api.FontFaceSet.loadingdone_event
 ---
 {{APIRef("CSS Font Loading API")}}
 
-The **`onloadingdone`** EventHandler of the {{domxref("FontFaceSet")}} interface processes `loadingdone` events.
-
-The `loadingdone` event fires when the document has loaded all fonts.
+The `loadingdone` event fires when the document has loaded all events.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-FontFaceSet.onloadingdone = function;
-FontFaceSet.addEventListener('loadingdone', function);
+addEventListener('loadingdone', event => { });
+
+onloadingdone = event => { };
 ```
 
 ## Example

--- a/files/en-us/web/api/fontfaceset/loadingerror_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingerror_event/index.md
@@ -1,25 +1,26 @@
 ---
-title: FontFaceSet.onloadingerror
-slug: Web/API/FontFaceSet/onloadingerror
+title: 'FontFaceSet: loadingerror event'
+slug: Web/API/FontFaceSet/loadingerror_event
 tags:
   - API
   - Property
   - Reference
   - onloadingerror
   - FontFaceSet
-browser-compat: api.FontFaceSet.onloadingerror
+browser-compat: api.FontFaceSet.loadingerror_event
 ---
 {{APIRef("CSS Font Loading API")}}
-
-The **`onloadingerror`** EventHandler of the {{domxref("FontFaceSet")}} interface processes `loadingerror` events.
 
 The `loadingerror` event fires when fonts have finished loading, but some or all fonts have failed to load.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-FontFaceSet.onloadingerror = function;
-FontFaceSet.addEventListener('loadingerror', function);
+addEventListener('loadingerror', event => { });
+
+onloadingerror = event => { };
 ```
 
 ## Example
@@ -43,3 +44,4 @@ document.fonts.onloadingerror = () => {
 ## Browser compatibility
 
 {{Compat}}
+


### PR DESCRIPTION
This PR adapts the FontFaceSet API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15132
