### PR TITLE
Rename heading: Polyfills > Polyfill

### DIFF
--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -162,11 +162,9 @@ console.log(element.internals_.form);
 
 {{Compat}}
 
-## Polyfill
-
-[ElementInternals polyfill](https://www.npmjs.com/package/element-internals-polyfill)
-
 ## See also
 
 - [More capable form controls](https://web.dev/more-capable-form-controls/)
 - [Creating custom form controls with ElementInternals](https://css-tricks.com/creating-custom-form-controls-with-elementinternals/)
+- [ElementInternals polyfill](https://www.npmjs.com/package/element-internals-polyfill)
+

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -162,9 +162,9 @@ console.log(element.internals_.form);
 
 {{Compat}}
 
-## Polyfills
+## Polyfill
 
-- [ElementInternals polyfill](https://www.npmjs.com/package/element-internals-polyfill)
+[ElementInternals polyfill](https://www.npmjs.com/package/element-internals-polyfill)
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Renamed the heading "Polyfills" to "Polyfill".

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The section contains only one polyfill. It is also the only page that contains such a heading. Usually this section is called "Polyfill":

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat#polyfill
- https://developer.mozilla.org/en-US/docs/Web/API/atob#polyfill

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
