### PR TITLE
example when browser doesn't support ruby annotations

### DIFF
--- a/files/en-us/web/html/element/rp/index.md
+++ b/files/en-us/web/html/element/rp/index.md
@@ -100,6 +100,22 @@ The result looks like this in your browser:
 
 See the article about the {{HTMLElement("ruby")}} element for further examples.
 
+### Without ruby support
+
+If your browser does not support ruby annotations, the result looks like this instead:
+
+```html hidden
+漢 (Kan) 字 (ji)
+```
+
+```css hidden
+body {
+  font-size: 22px;
+}
+```
+
+{{EmbedLiveSample("Without_ruby_support", 600, 60)}}
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Show an example of the output when your browser doesn't support ruby annotations.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

It'd be nice to add an example of how it looks like when ruby annotations aren't supported, which was what I was trying to find on this page after a google search for the `<rp>` tag.

I noticed that the example already exists in the French translation of the page, but was missing from the English page.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Compare English vs French version of the same page: 
* English: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp 
* French: https://developer.mozilla.org/fr/docs/Web/HTML/Element/rp#sans_prise_en_charge_de_ruby

You can see the markdown code of the French page here: 

https://github.com/mdn/translated-content/blob/main/files/fr/web/html/element/rp/index.md?plain=1#L49

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
