### PR TITLE
Change history.pushstate|replacestate 2nd param name to “unused”

### DIFF
--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -24,8 +24,8 @@ session history stack.
 ## Syntax
 
 ```js
-history.pushState(state, title)
-history.pushState(state, title, url)
+history.pushState(state, unused)
+history.pushState(state, unused, url)
 ```
 
 ### Parameters
@@ -47,12 +47,9 @@ history.pushState(state, title, url)
     space than this, you're encouraged to use {{domxref("Window.sessionStorage",
     "sessionStorage")}} and/or {{domxref("Window.localStorage", "localStorage")}}.
 
-- `title`
-  - : [Most browsers currently ignore
-    this parameter](https://github.com/whatwg/html/issues/2174), although they may use it in the future. Passing the empty string
-    here should be safe against future changes to the method. Alternatively, you could
-    pass a short title for the state to which you're moving. If you don't need the title to be
-    changed you could use {{domxref("Document.title", "document.title")}}.
+- `unused`
+  - : This parameter exists for historical reasons, and cannot be omitted; passing the empty string is safe against future changes to the method.
+
 - `url` {{optional_inline}}
   - : The new history entry's URL is given by this parameter. Note that the browser won't
     attempt to load this URL after a call to `pushState()`, but it might
@@ -83,17 +80,15 @@ fired, even if the new URL differs from the old URL only in its hash.
 
 ## Examples
 
-This creates a new browser history entry setting the _state_, _title_,
-and _url_.
+This creates a new browser history entry setting the _state_ and _url_.
 
 ### JavaScript
 
 ```js
 const state = { 'page_id': 1, 'user_id': 5 }
-const title = ''
 const url = 'hello-world.html'
 
-history.pushState(state, title, url)
+history.pushState(state, '', url)
 ```
 
 ### Change a query parameter

--- a/files/en-us/web/api/history/replacestate/index.md
+++ b/files/en-us/web/api/history/replacestate/index.md
@@ -13,15 +13,16 @@ browser-compat: api.History.replaceState
 {{APIRef("History API")}}
 
 The **`History.replaceState()`** method modifies the current
-history entry, replacing it with the `stateObj`, `title`, and
-`URL` passed in the method parameters. This method is particularly useful
+history entry, replacing it with the state object and
+URL passed in the method parameters. This method is particularly useful
 when you want to update the state object or URL of the current history entry in response
 to some user action.
 
 ## Syntax
 
 ```js
-history.replaceState(stateObj, title, [url])
+history.replaceState(stateObj, unused)
+history.replaceState(stateObj, unused, url)
 ```
 
 ### Parameters
@@ -30,11 +31,8 @@ history.replaceState(stateObj, title, [url])
   - : The state object is a JavaScript object which is associated with the history entry
     passed to the `replaceState` method. The state object can be
     `null`.
-- `title`
-  - : [Most browsers currently ignore
-    this parameter](https://github.com/whatwg/html/issues/2174), although they may use it in the future. Passing the empty string
-    here should be safe against future changes to the method. Alternatively, you could
-    pass a short title for the state.
+- `unused`
+  - : This parameter exists for historical reasons, and cannot be omitted; passing the empty string is traditional, and safe against future changes to the method.
 - `url` {{optional_inline}}
   - : The URL of the history entry. The new URL must be of the same origin as the current
     URL; otherwise replaceState throws an exception.


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13313 • Related BCD change: https://github.com/mdn/browser-compat-data/pull/15149

Relevant spec sections:

- https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate
- https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate
- https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate-dev
- https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate-dev