### PR TITLE
animation cancel event - change from finish event

### DIFF
--- a/files/en-us/web/api/animation/cancel_event/index.md
+++ b/files/en-us/web/api/animation/cancel_event/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Animation.cancel_event
 ---
 {{ APIRef("Web Animations") }}
 
-The **`finish`** event of the {{domxref("Animation")}} interface is fired when the {{domxref("Animation.cancel()")}} method is called or when the animation enters the `"idle"` play state from another state, such as when the animation is removed from an element before it finishes playing.
+The **`cancel`** event of the {{domxref("Animation")}} interface is fired when the {{domxref("Animation.cancel()")}} method is called or when the animation enters the `"idle"` play state from another state, such as when the animation is removed from an element before it finishes playing.
 
 > **Note:** Creating a new animation that is initially idle does not trigger a `cancel` event on the new animation.
 


### PR DESCRIPTION
Fixes #13346

Text refers to "The **`finish`** event" but we're in the context of an event called the cancel event. Just swapped the word.