### PR TITLE
Intl.Locale - fix Brunei typo in week information

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/weekinfo/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/weekinfo/index.md
@@ -37,7 +37,7 @@ console.log(af.weekInfo); // logs  {firstDay: 7, weekend: [6, 7], minimalDays: 1
 let enGB = new Intl.Locale("en-GB");
 console.log(enGB.weekInfo) // logs  {firstDay: 1, weekend: [6, 7], minimalDays: 4}
 
-let msBN = new Intl.Locale("en-GB");
+let msBN = new Intl.Locale("ms-BN");
 console.log(msBN.weekInfo) // logs {firstDay: 7, weekend: [5, 7], minimalDays: 1}  // Brunei weekend is Friday and Sunday but not Saturday 
 ```
 


### PR DESCRIPTION
Fixes #13337

The example is clearly wrong because it purports to be about Brunei, but the specified locale is  en-GB

Note that that is the only fix I made, which is what I believe to all that is needed.
The issue further proposed a change:

FROM:
> console.log(msBN.weekInfo) // logs {firstDay: 7, weekend: [5, 7], minimalDays: 1}  // Brunei weekend is Friday and Sunday but not Saturday 

TO: 
> console.log(msBN.weekInfo) // logs {firstDay: 7, weekend: [6, 7], minimalDays: 1}  // Brunei weekend is Friday and Sunday but not Saturday

However this extra change is IMO incorrect. 
- [Spec](https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.weekInfo) says days are numbered from 1 to 7, where Monday is 1.
- Brunei has weekend Friday (5) and Sunday (7), which is what the original text says.

I suspect that they have followed what Chrome does (as shown below), but I think that is a bug in Chrome:
![image](https://user-images.githubusercontent.com/5368500/156081503-62541fce-3fd6-4ff2-8db7-f65c14460fd9.png)


