### PR TITLE
Fix bug in groupBy example code snippet

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -123,8 +123,7 @@ let result = inventory.groupBy( ({ type }) => type );
 /* Result is:
 { 
   vegetables: [ 
-    { name: "  { name: 'asparagus', type: 'vegetables', quantity: 5 },
-", type: "vegetables", quantity: 5 } 
+    { name: "  { name: 'asparagus', type: 'vegetables', quantity: 5 }
   ],
   fruit: [
     { name: "bananas", type: "fruit", quantity: 0 },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes junk within "expected output" comment within example code block.

Highlighted line in screenshot shouldn't be there:

![image](https://user-images.githubusercontent.com/1072438/156208232-e0bbc56a-a542-49d4-9fce-ddf059b18a5f.png)

#### Motivation
Was reading the page, saw the junk in the code snippet, wanted to fix it

#### Supporting details
Link to live page: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/groupBy#examples

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
