### PR TITLE
Added default for the `delay` parameter

### DIFF
--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -46,7 +46,7 @@ var intervalID = setInterval(code, [delay]);
 - `delay`{{optional_inline}}
   - : The time, in milliseconds (thousandths of a second), the timer should delay in
     between executions of the specified function or code. See {{anch("Delay restrictions")}}
-    below for details on the permitted range of `delay` values.
+    below for details on the permitted range of `delay` values. Defaults to 0 if not specified.
 - `arg1, ..., argN` {{optional_inline}}
   - : Additional arguments which are passed through to the function specified by
     _func_ once the timer expires.

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -45,8 +45,8 @@ var intervalID = setInterval(code, [delay]);
     security risk.
 - `delay`{{optional_inline}}
   - : The time, in milliseconds (thousandths of a second), the timer should delay in
-    between executions of the specified function or code. See {{anch("Delay restrictions")}}
-    below for details on the permitted range of `delay` values. Defaults to 0 if not specified.
+    between executions of the specified function or code. Defaults to 0 if not specified. See {{anch("Delay restrictions")}}
+    below for details on the permitted range of `delay` values.
 - `arg1, ..., argN` {{optional_inline}}
   - : Additional arguments which are passed through to the function specified by
     _func_ once the timer expires.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added the default value for `delay` in the setInterval() function of the Web API

#### Motivation
I was reading the documentation and wondering about this. I checked the spec to determine the default value.

#### Supporting details
(https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval-dev)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
