### PR TITLE
Add missing apostrophe

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -90,7 +90,7 @@ Bear in mind that some built-in browser functions are not part of the core JavaS
 
 ## Functions versus methods
 
-Programmers call **functions** that are part of objects **methods**. You don't need to learn about the inner workings of structured JavaScript objects yet — you can wait until our later module that will teach you all about the inner workings of objects, and how to create your own. For now, we just wanted to clear up any possible confusion of method versus function — you are likely to meet both terms as you look at the available related resources across the Web.
+Programmers call **functions** that are part of objects' **methods**. You don't need to learn about the inner workings of structured JavaScript objects yet — you can wait until our later module that will teach you all about the inner workings of objects, and how to create your own. For now, we just wanted to clear up any possible confusion of method versus function — you are likely to meet both terms as you look at the available related resources across the Web.
 
 The built-in code we've made use of so far come in both forms: **functions** and **methods.** You can check the full list of the built-in functions, as well as the built-in objects and their corresponding methods [here](/en-US/docs/Web/JavaScript/Reference/Global_Objects).
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Methods belong to objects, so add an apostrophe to indicate possession: "objects methods" -> "objects' methods"

#### Motivation
I'm improving the grammatical correctness of the MDN documentation.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
