### PR TITLE
Correct the description of NodeFilter constants

### DIFF
--- a/files/en-us/web/api/nodefilter/acceptnode/index.md
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.md
@@ -36,23 +36,31 @@ must be accepted or not by the {{ domxref("NodeIterator") }} or {{ domxref("Tree
     <tr>
       <td><code>NodeFilter.FILTER_REJECT</code></td>
       <td>
-        Value to be returned by the
-        {{ domxref("NodeFilter.acceptNode()") }} method when a node
-        should be rejected. The children of rejected nodes are not visited by
-        the {{ domxref("NodeIterator") }} or
-        {{ domxref("TreeWalker") }} object; this value is treated as
-        "skip this node and all its children".
+          <p>
+            Value to be returned by the
+            {{domxref("NodeFilter.acceptNode()")}} method when a
+            node should be rejected. For {{domxref("TreeWalker")}}, child
+            nodes are also rejected.
+          </p>
+          <p>
+            For {{ domxref("NodeIterator") }}, this flag is synonymous
+            with <code>FILTER_SKIP</code>.
+          </p>
       </td>
     </tr>
     <tr>
       <td><code>NodeFilter.FILTER_SKIP</code></td>
       <td>
-        Value to be returned by
-        {{ domxref("NodeFilter.acceptNode()") }} for nodes to be
-        skipped by the {{ domxref("NodeIterator") }} or
-        {{ domxref("TreeWalker") }} object. The children of skipped
-        nodes are still considered. This is treated as "skip this node but not
-        its children".
+          <p>
+            Value to be returned by
+            {{domxref("NodeFilter.acceptNode()")}} for nodes to be
+            skipped by the {{domxref("NodeIterator")}} or
+            {{domxref("TreeWalker")}} object.
+          </p>
+          <p>
+            The children of skipped nodes are still considered. This is treated as
+            "skip this node but not its children".
+          </p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Description of NodeFilter.FILTER_REJECT on [this page is not correct](https://developer.mozilla.org/en-US/docs/Web/API/NodeFilter/acceptNode). If `NodeFilter.FILTER_REJECT` is returned in `NodeIterator` then subtree nodes are processed. Subtree nodes are not processed only in `TreeWalker` when `NodeFilter.FILTER_REJECT` is returned. 

I copied correct description from [this page](https://developer.mozilla.org/en-US/docs/Web/API/NodeFilter).


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
