### PR TITLE
Move polyfill link to "See also" section

### DIFF
--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -51,6 +51,6 @@ console.log(stylesheet.media);
 
 {{Compat}}
 
-## Polyfill
+## See also
 
 - [construct-style-sheets-polyfill](https://www.npmjs.com/package/construct-style-sheets-polyfill)

--- a/files/en-us/web/api/encoding_api/index.md
+++ b/files/en-us/web/api/encoding_api/index.md
@@ -22,10 +22,6 @@ The API provides four interfaces: {{domxref("TextDecoder")}}, {{domxref("TextEnc
 - {{DOMxRef("TextDecoderStream")}}
 - {{DOMxRef("TextEncoderStream")}}
 
-## Polyfill
-
-- A [shim](https://code.google.com/p/stringencoding/) allowing to use this interface in browsers that don't support it.
-
 ## Specifications
 
 | Specification                    | Status                       | Comment             |
@@ -41,3 +37,7 @@ The API provides four interfaces: {{domxref("TextDecoder")}}, {{domxref("TextEnc
 ### `TextEncoder`
 
 {{Compat("api.TextEncoder")}}
+
+## See also
+
+- A [shim](https://code.google.com/p/stringencoding/) allowing to use this interface in browsers that don't support it

--- a/files/en-us/web/api/trusted_types_api/index.md
+++ b/files/en-us/web/api/trusted_types_api/index.md
@@ -80,10 +80,7 @@ Read more about this example, and discover other ways to sanitize input in the a
 
 See the compatibility data for each of the Trusted Types API interfaces.
 
-## Polyfill
-
-A [polyfill is available](https://github.com/w3c/webappsec-trusted-types#polyfill). The polyfill is also available as an npm package [trusted-types](https://www.npmjs.com/package/trusted-types).
-
 ## See also
 
 - [Prevent DOM-based cross-site scripting vulnerabilities with Trusted Types](https://web.dev/trusted-types/)
+- [Trusted Types polyfill](https://github.com/w3c/webappsec-trusted-types#polyfill) (also available as an [npm package](https://www.npmjs.com/package/trusted-types))

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -91,10 +91,6 @@ custom-button:focus-visible {
 
 {{EmbedLiveSample("Selectively_showing_the_focus_indicator", "100%", 60)}}
 
-## Polyfill
-
-You can polyfill `:focus-visible` using [focus-visible.js](https://github.com/WICG/focus-visible).
-
 ## Accessibility concerns
 
 ### Low vision
@@ -119,3 +115,4 @@ It may not be obvious as to why the focus indicator is appearing and disappearin
 
 - {{CSSxRef(":focus")}}
 - {{CSSxRef(":focus-within")}}
+- [A polyfill for `:focus-visible`](https://github.com/WICG/focus-visible)

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -172,15 +172,10 @@ favDialog.addEventListener('close', function onClose() {
 
 {{Compat}}
 
-## Polyfill
-
-Include this polyfill to provide support for browsers without `<dialog>` element.
-
-[dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill)
-
 ## See also
 
 - The {{domxref("HTMLDialogElement/close_event", "close")}} event
 - The {{domxref("HTMLDialogElement/cancel_event", "cancel")}} event
 - [HTML forms guide](/en-US/docs/Learn/Forms).
 - The {{cssxref("::backdrop")}} pseudo-element
+- [dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill)

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -43,10 +43,6 @@ if (typeof trustedTypes !== 'undefined') {
 }
 ```
 
-## Polyfill
-
-A [polyfill for Trusted Types](https://github.com/w3c/webappsec-trusted-types#polyfill) is available on Github.
-
 ## Specifications
 
 {{Specifications}}
@@ -62,3 +58,4 @@ A [polyfill for Trusted Types](https://github.com/w3c/webappsec-trusted-types#po
 - [DOM XSS injection sinks covered by Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/#injection-sinks)
 - [Prevent DOM-based cross-site scripting vulnerabilities with Trusted Types](https://web.dev/trusted-types)
 - Trusted Types with [DOMPurify](https://github.com/cure53/DOMPurify#what-about-dompurify-and-trusted-types) XSS sanitizer
+- [Trusted Types polyfill](https://github.com/w3c/webappsec-trusted-types#polyfill)

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
@@ -42,10 +42,6 @@ if (typeof trustedTypes !== 'undefined') {
 }
 ```
 
-## Polyfill
-
-A [polyfill for Trusted Types](https://github.com/w3c/webappsec-trusted-types#polyfill) is available on Github.
-
 ## Specifications
 
 {{Specifications}}
@@ -60,3 +56,4 @@ A [polyfill for Trusted Types](https://github.com/w3c/webappsec-trusted-types#po
 - [Cross-Site Scripting (XSS)](/en-US/docs/Glossary/Cross-site_scripting)
 - [Prevent DOM-based cross-site scripting vulnerabilities with Trusted Types](https://web.dev/trusted-types)
 - Trusted Types with [DOMPurify](https://github.com/cure53/DOMPurify#what-about-dompurify-and-trusted-types) XSS sanitizer
+- [Trusted Types polyfill](https://github.com/w3c/webappsec-trusted-types#polyfill)

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -86,11 +86,6 @@ Possible types are the following:
   - : The string used for the yearName in relevant contexts, for example
     "`geng-zi`"
 
-## Polyfill
-
-A polyfill for this feature is available in the [proposal
-repository](https://github.com/zbraniecki/proposal-intl-formatToParts).
-
 ## Examples
 
 `DateTimeFormat` outputs localized, opaque strings that cannot be
@@ -265,3 +260,4 @@ df.formatToParts(date)
 - {{jsxref("Date.prototype.toLocaleString()")}}
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
+- [A polyfill of `Intl.DateTimeFormat.prototype.formatToParts` in the proposal repository](https://github.com/zbraniecki/proposal-intl-formatToParts)

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.md
@@ -162,10 +162,6 @@ console.log(usedOptions.timeZone);
 // → "America/New_York" (the users default timezone)
 ```
 
-## Polyfill
-
-[formatjs Intl.DateTimeFormat polyfill](https://formatjs.io/docs/polyfills/intl-datetimeformat)
-
 ## Specifications
 
 {{Specifications}}
@@ -177,3 +173,4 @@ console.log(usedOptions.timeZone);
 ## See also
 
 - {{jsxref("Intl")}}
+- [A polyfill of `Intl.DateTimeFormat` in FormatJS](https://formatjs.io/docs/polyfills/intl-datetimeformat)

--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -46,11 +46,6 @@ Intl.getCanonicalLocales('EN_US');
 // RangeError:'EN_US' is not a structurally valid language tag
 ```
 
-## Polyfill
-
-[formatjs
-Intl.getCanonicalLocales polyfill](https://formatjs.io/docs/polyfills/intl-getcanonicallocales)
-
 ## Specifications
 
 {{Specifications}}
@@ -64,3 +59,4 @@ Intl.getCanonicalLocales polyfill](https://formatjs.io/docs/polyfills/intl-getca
 - {{jsxref("Intl/NumberFormat/supportedLocalesOf", "Intl.NumberFormat.supportedLocalesOf()")}}
 - {{jsxref("Intl/DateTimeFormat/supportedLocalesOf", "Intl.DateTimeFormat.supportedLocalesOf()")}}
 - {{jsxref("Intl/Collator/supportedLocalesOf", "Intl.Collator.supportedLocalesOf()")}}
+- [A polyfill of `Intl.getCanonicalLocales` in FormatJS](https://formatjs.io/docs/polyfills/intl-getcanonicallocales)

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.md
@@ -70,10 +70,6 @@ console.log(new Intl.ListFormat('en-GB', { style: 'long', type: 'conjunction' })
 //   { "type": "element", "value": "Car" } ];
 ```
 
-## Polyfill
-
-[formatjs Intl.ListFormat polyfill](https://formatjs.io/docs/polyfills/intl-listformat)
-
 ## Specifications
 
 {{Specifications}}
@@ -85,3 +81,4 @@ console.log(new Intl.ListFormat('en-GB', { style: 'long', type: 'conjunction' })
 ## See also
 
 - {{jsxref("Intl")}}
+- [A polyfill of `Intl.ListFormat` in FormatJS](https://formatjs.io/docs/polyfills/intl-listformat)

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -59,11 +59,6 @@ let locale = new Intl.Locale("en-US", { hourCycle: "h12" });
 console.log(locale.hourCycle); // Prints "h12"
 ```
 
-## Polyfill
-
-[formatjs Intl.Locale
-polyfill](https://formatjs.io/docs/polyfills/intl-locale)
-
 ## Specifications
 
 {{Specifications}}
@@ -77,3 +72,4 @@ polyfill](https://formatjs.io/docs/polyfills/intl-locale)
 - {{jsxref("Intl.Collator")}}
 - [Unicode
   locale identifiers spec](https://www.unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers)
+- [A polyfill of `Intl.Locale` in FormatJS](https://formatjs.io/docs/polyfills/intl-locale)

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -121,10 +121,6 @@ console.log((16).toLocaleString('en-GB', {
 // → 16 litres
 ```
 
-## Polyfill
-
-[formatjs Intl.NumberFormat polyfill](https://formatjs.io/docs/polyfills/intl-numberformat)
-
 ## Specifications
 
 {{Specifications}}
@@ -136,3 +132,4 @@ console.log((16).toLocaleString('en-GB', {
 ## See also
 
 - {{jsxref("Intl")}}
+- [A polyfill of `Intl.NumberFormat` in FormatJS](https://formatjs.io/docs/polyfills/intl-numberformat)

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.md
@@ -57,9 +57,6 @@ new Intl.PluralRules('ar-EG').select(18);
 
 ### Using locales
 
-## Polyfill
-
-[formatjs Intl.PluralRules polyfill](https://formatjs.io/docs/polyfills/intl-pluralrules)
 
 ## Specifications
 
@@ -72,3 +69,4 @@ new Intl.PluralRules('ar-EG').select(18);
 ## See also
 
 - {{jsxref("Intl")}}
+- [A polyfill of `Intl.PluralRules` in FormatJS](https://formatjs.io/docs/polyfills/intl-pluralrules)

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
@@ -79,10 +79,6 @@ rtf.formatToParts(100, "day");
 // >  { type: "literal", value: " days" }]
 ```
 
-## Polyfill
-
-[formatjs Intl.RelativeTimeFormat polyfill](https://formatjs.io/docs/polyfills/intl-relativetimeformat)
-
 ## Specifications
 
 {{Specifications}}
@@ -95,3 +91,4 @@ rtf.formatToParts(100, "day");
 
 - {{jsxref("Intl")}}
 - [The Intl.RelativeTimeFormat API](https://developers.google.com/web/updates/2018/10/intl-relativetimeformat)
+- [A polyfill of `Intl.RelativeTimeFormat` in FormatJS](https://formatjs.io/docs/polyfills/intl-relativetimeformat)

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -104,10 +104,6 @@ try {
 }
 ```
 
-## Polyfill
-
-[Intl.supportedValuesOf() polyfill in proposal TC39](https://github.com/tc39/proposal-intl-enumeration/tree/master/polyfill)
-
 ## Specifications
 
 {{Specifications}}
@@ -119,3 +115,4 @@ try {
 ## See also
 
 - {{jsxref("Global_Objects/Intl", "Intl")}}
+- [A polyfill of `Intl.supportedValuesOf` in proposal TC39](https://github.com/tc39/proposal-intl-enumeration/tree/master/polyfill)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Moved polyfill links to the "See also" section in the documents where the "Polyfill" section contains only a link to the polyfill. So the "Polyfill" section is eliminated in these documents.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Consistency improvement. I found that there are about 300 documents with a link to the polyfill in the "See also" section. And there are only 16 documents that have a link to the polyfill in a separate section.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
