### PR TITLE
Remove redundant "Polyfill" section

### DIFF
--- a/files/en-us/web/api/atob/index.md
+++ b/files/en-us/web/api/atob/index.md
@@ -50,11 +50,6 @@ const encodedData = btoa('Hello, world'); // encode a string
 const decodedData = atob(encodedData); // decode the string
 ```
 
-## Polyfill
-
-You can use a polyfill from <https://github.com/MaxArt2501/base64-js/blob/master/base64.js>
-for browsers that don't support it.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -436,10 +436,6 @@ if (window.fetch) {
 }
 ```
 
-## Polyfill
-
-To use Fetch in unsupported browsers, there is a [Fetch Polyfill](https://github.com/github/fetch) available that recreates the functionality for non-supporting browsers.
-
 ## Specifications
 
 | Specification                | Status                   | Comment            |

--- a/files/en-us/web/api/web_animations_api/web_animations_api_concepts/index.md
+++ b/files/en-us/web/api/web_animations_api/web_animations_api_concepts/index.md
@@ -69,10 +69,6 @@ We can assemble all these pieces together to create a working animation with the
 
 The API allows for the creation of dynamic animations that can be updated on the fly as well as more straightforward, declarative animations like those CSS creates. It can be used in automated tests to ensure that your UI animations are running correctly. It opens up the browser's rendering engine for building animation development tools like timelines. It is also a performant base on which to build a custom or commercial animation library. (See [Animating like you just don't care with Element.animate](https://hacks.mozilla.org/2016/08/animating-like-you-just-dont-care-with-element-animate/).) In some instances, it may negate the need for a fully fledged library entirely in the same way Vanilla JavaScript can be used without jQuery for many purposes.
 
-## Polyfill
-
-The Web Animation API has a [polyfill](https://github.com/web-animations/web-animations-js) that you can use today.
-
 ## See also
 
 - [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) — main page


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Removed redundant "Polyfill" section.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The documents already have a link to the polyfill in the "See also" section. Also, almost all documents that have a link to the polyfill contain it in the "See also" section, not in a separate section.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
