### PR TITLE
Remove 'Test skills' from 1st article abt strings

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -251,10 +251,6 @@ console.log(output);  // I like the song.
 
 See our [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals) reference page for more examples and details of advanced features.
 
-## Test your skills!
-
-You've reached the end of this article, but can you remember the most important information? You can find some further tests to verify that you've retained this information before you move on — see [Test your skills: Strings](/en-US/docs/Learn/JavaScript/First_steps/Test_your_skills:_Strings). Note that this also requires knowledge from the next article, so you might want to read that first.
-
 ## Conclusion
 
 So that's the very basics of strings covered in JavaScript. In the next article, we'll build on this, looking at some of the built-in methods available to strings in JavaScript and how we can use them to manipulate our strings into just the form we want.


### PR DESCRIPTION
#### Summary
The 'Handling text - strings in JavaScript' has a link to 'Test Your Skills' for Strings. 

However all the tests require knowledge of basic string methods which is in the *next* article. So keeping 'Test Your Skills' before that confuses the student. Hence suggesting that it be removed from this 1st article about strings.

#### Motivation
To make it easier for those who use this tutorial.
