### PR TITLE
Describe the format of WebCrypto ECDSA signatures (reference IEEE-P1363)

### DIFF
--- a/files/en-us/web/api/subtlecrypto/sign/index.md
+++ b/files/en-us/web/api/subtlecrypto/sign/index.md
@@ -96,9 +96,18 @@ the {{domxref("SubtleCrypto.sign()", "sign()")}} and {{domxref("SubtleCrypto.ver
 ### ECDSA
 
 ECDSA (Elliptic Curve Digital Signature Algorithm) is a variant of the Digital
-Signature Algorithm, specified in [FIPS-186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf), that
-uses Elliptic Curve Cryptography ([RFC
-6090](https://datatracker.ietf.org/doc/html/rfc6090)).
+Signature Algorithm, specified in [FIPS-186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf),
+that uses Elliptic Curve Cryptography ([RFC 6090](https://datatracker.ietf.org/doc/html/rfc6090)).
+
+Signatures are encoded as the `s1` and `s2` values specified in RFC 6090 (known respectively as `r`
+and `s` in [RFC 4754](https://datatracker.ietf.org/doc/html/rfc4754#section-3)), each in big-endian
+byte arrays, with their length the bit size of the curve rounded up to a whole number of bytes.
+These values are concatenated together in this order.
+
+This encoding was also proposed by the [IEEE 1363-2000](https://standards.ieee.org/ieee/1363/2049/)
+standard, and is sometimes referred to as the IEEE P1363 format. It differs from the
+[X.509](https://www.itu.int/rec/T-REC-X.509) signature structure, which is the default format
+produced by some tools and libraries such as [OpenSSL](https://www.openssl.org).
 
 ### HMAC
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
(edited) Adds a description of the ECDSA signature format to the existing algorithms section under the SubtleCrypto.sign docs, and reference the IEEE P1363 format, which is the name used by some tools (notably Node.js in its native Crypto API) as opposed to their default of the X.509/DER signature format.

_Original PR text follows:_

Add short mention to the SubtleCrypto.verify docs that the signature is expected to be in IEEE P1393 format for ECDSA.

#### Motivation
The DER signature format being used by OpenSSL / X509 and Node.js Crypto, while the WebCrypto standard being `r`+`s` aka IEEE P1393 makes for a very confusing experience at their intersection! While Node.js is able to generate and verify p1393 signatures, it would still be helpful to have this noted here so the requirement is understood!

#### Supporting details
- https://stackoverflow.com/questions/39554165/ecdsa-signatures-between-node-js-and-webcrypto-appear-to-be-incompatible
- https://www.w3.org/TR/WebCryptoAPI/#ecdsa-operations

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
