### PR TITLE
Fix for issue #13290.  Added two examples for .toString() being used …

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tostring/index.md
@@ -9,6 +9,7 @@ tags:
   - String
 browser-compat: javascript.builtins.String.toString
 ---
+
 {{JSRef}}
 
 The **`toString()`** method returns a string representing the
@@ -19,7 +20,7 @@ specified object.
 ## Syntax
 
 ```js
-toString()
+toString();
 ```
 
 ### Return value
@@ -32,7 +33,7 @@ The {{jsxref("String")}} object overrides the `toString()` method of the
 {{jsxref("Object")}} object; it does not inherit
 {{jsxref("Object.prototype.toString()")}}. For {{jsxref("String")}} objects, the
 `toString()` method returns a string representation of the object and is the
-same as the {{jsxref("String.prototype.valueOf()")}} method.
+same as the {{jsxref("String.prototype.valueOf()")}} method. Using `toString()` on a {{jsxref("Number")}} object returns the binary equivalent. Using `parseInt().toString()` on a {{jsxref("String")}} object returns the binary equivalent.
 
 ## Examples
 
@@ -41,9 +42,25 @@ same as the {{jsxref("String.prototype.valueOf()")}} method.
 The following example displays the string value of a {{jsxref("String")}} object:
 
 ```js
-var x = new String('Hello world');
+var x = new String("Hello world");
 
 console.log(x.toString()); // logs 'Hello world'
+```
+
+The following example displays the binary value of a {{jsxref("String")}} object:
+
+```js
+var x = new String("13");
+
+console.log(parseInt(x).toString(2)); // logs '1101'
+```
+
+The following example displays the binary value of a {{jsxref("Number")}} object:
+
+```js
+var x = new Number(13);
+
+console.log(x.toString(2)); // logs '1101'
 ```
 
 ## Specifications


### PR DESCRIPTION
Fix for issue #13290.  Added two examples for .toString() being used on String object and Number object.  Added to the description field the basic usage of these.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
MDN docs were missing documentation and examples for the usage of .toString() with number to binary conversion.  I added two examples to show the usage with a String object parsed as an int then converted using toString() to represent the binary equivalent.  I also added an example of using .toString() on a Number object to show that the return is the binary representation.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This issue was labeled good first issue and since I am new to open source I wanted to take on a smaller change here.  This change allows readers to actually understand another implementation of the function which before was not documented.

#### Related issues
Fixes#13290

This PR…
-->
- [ ] Adds new documentation regarding toString() used 
- [ ] Adds examples show that toString can be used to convert strings and numbers to binary

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
