### PR TITLE
Ordered lists and case sensitive matching on attribute selector

### DIFF
--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -210,7 +210,7 @@ ol[type="c" i] {
 
 ```html
 <ol type="A">
-  <li>Red background if case-insensitive matching for current document language.</li>
+  <li>Red background if case-insensitive matching (default for the type selector).</li>
 </ol>
 <ol type="b">
   <li>Lime background if s flag supported (case-sensitive match)</li>

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -177,8 +177,7 @@ div[data-lang="zh-TW"] {
 
 ### HTML ordered lists
 
-The HTML specification requires the {{htmlattrxref("type", "input")}} attribute to be matched case-insensitively due to it primarily being used in the {{HTMLElement("input")}} element.
-Case-sensitive and case-insensitive matching can be forced using the `s` and `i` modifiers, respectively.
+The HTML specification requires the {{htmlattrxref("type", "input")}} attribute to be matched case-insensitively because it is primarily used in the {{HTMLElement("input")}} element.
 Note that if the modifiers are not supported by the user agent, then the selector will not match.
 
 #### CSS
@@ -210,16 +209,16 @@ ol[type="c" i] {
 
 ```html
 <ol type="A">
-  <li>Red background if case-insensitive matching (default for the type selector).</li>
+  <li>Red background for case-insensitive matching (default for the type selector)</li>
 </ol>
 <ol type="b">
-  <li>Lime background if s flag supported (case-sensitive match)</li>
+  <li>Lime background if `s` modifier is supported (case-sensitive match)</li>
 </ol>
 <ol type="B">
-  <li>Grey background if s flag supported (case-sensitive match)</li>
+  <li>Grey background if `s` modifier is supported (case-sensitive match)</li>
 </ol>
 <ol type="C">
-  <li>Green background if i flag supported (case-insensitive match)</li>
+  <li>Green background if `i` modifier is supported (case-insensitive match)</li>
 </ol>
 ```
 

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -177,25 +177,32 @@ div[data-lang="zh-TW"] {
 
 ### HTML ordered lists
 
-The HTML specification requires the {{htmlattrxref("type", "input")}} attribute to be matched case-insensitively due to it primarily being used in the {{HTMLElement("input")}} element, and trying to use attribute selectors with the {{htmlattrxref("type", "ol")}} attribute of an {{HTMLElement("ol", "ordered list")}} doesn't work without the [case-sensitive](#case-sensitive) modifier.
+Using attribute selectors on {{HTMLElement("ol", "Ordered lists")}} is the same as for other elements: the case sensitivity of the selection depends on the document language.
+Case-sensitive and case-insensitive matching can be forced using the `s` and `i` modifiers, respectively.
+Note that if the modifiers are not supported by the user agent, then the selector will not match.
 
 #### CSS
 
 ```css
-/* List types require the case sensitive flag due to a quirk in how HTML treats the type attribute. */
+/* Case-sensitivity depends on document language */
 ol[type="a"] {
   list-style-type: lower-alpha;
   background: red;
 }
 
-ol[type="a" s] {
+ol[type="b" s] {
   list-style-type: lower-alpha;
   background: lime;
 }
 
-ol[type="A" s] {
+ol[type="B" s] {
   list-style-type: upper-alpha;
-  background: lime;
+  background: grey;
+}
+
+ol[type="c" i] {
+  list-style-type: upper-alpha;
+  background: green;
 }
 ```
 
@@ -203,7 +210,16 @@ ol[type="A" s] {
 
 ```html
 <ol type="A">
-  <li>Example list</li>
+  <li>Red background if case-insensitive matching for current document language.</li>
+</ol>
+<ol type="b">
+  <li>Lime background if s flag supported (case-sensitive match)</li>
+</ol>
+<ol type="B">
+  <li>Grey background if s flag supported (case-sensitive match)</li>
+</ol>
+<ol type="C">
+  <li>Green background if i flag supported (case-insensitive match)</li>
 </ol>
 ```
 

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -177,7 +177,7 @@ div[data-lang="zh-TW"] {
 
 ### HTML ordered lists
 
-The HTML specification requires the {{htmlattrxref("type", "input")}} attribute to be matched case-insensitively due to it primarily being used in the {{HTMLElement("input")}} element, trying to use attribute selectors to with the {{htmlattrxref("type", "ol")}} attribute of an {{HTMLElement("ol", "ordered list")}} doesn't work without the [case-sensitive](#case-sensitive) modifier.
+The HTML specification requires the {{htmlattrxref("type", "input")}} attribute to be matched case-insensitively due to it primarily being used in the {{HTMLElement("input")}} element, and trying to use attribute selectors with the {{htmlattrxref("type", "ol")}} attribute of an {{HTMLElement("ol", "ordered list")}} doesn't work without the [case-sensitive](#case-sensitive) modifier.
 
 #### CSS
 

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -177,7 +177,7 @@ div[data-lang="zh-TW"] {
 
 ### HTML ordered lists
 
-Using attribute selectors on {{HTMLElement("ol", "Ordered lists")}} is the same as for other elements: the case sensitivity of the selection depends on the document language.
+The HTML specification requires the {{htmlattrxref("type", "input")}} attribute to be matched case-insensitively due to it primarily being used in the {{HTMLElement("input")}} element.
 Case-sensitive and case-insensitive matching can be forced using the `s` and `i` modifiers, respectively.
 Note that if the modifiers are not supported by the user agent, then the selector will not match.
 


### PR DESCRIPTION
 Summary
I removed a wrongly placed word to make a statement more easily understandable.
I also added a word to make the flow seamless.

Motivation
I could not understand the sentence in my first read due to the typo. 
Correcting it makes it easier for other readers to understand the statement without any disruption.

 Supporting details
[<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#html_ordered_lists)

Related issues
N/A

Metadata
N/A

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [✅  ] Fixes a typo, bug, or other error
