### PR TITLE
Added 3 CSS properties missing in References

### DIFF
--- a/files/en-us/web/css/border-block-style/index.md
+++ b/files/en-us/web/css/border-block-style/index.md
@@ -6,7 +6,6 @@ tags:
   - CSS Logical Property
   - CSS Property
   - Experimental
-  - Non-standard
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-block-style

--- a/files/en-us/web/css/border-block-style/index.md
+++ b/files/en-us/web/css/border-block-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-block-style

--- a/files/en-us/web/css/border-block/index.md
+++ b/files/en-us/web/css/border-block/index.md
@@ -6,7 +6,6 @@ tags:
   - CSS Logical Property
   - CSS Property
   - Experimental
-  - Non-standard
   - Reference
   - recipe:css-shorthand-property
 browser-compat: css.properties.border-block

--- a/files/en-us/web/css/border-block/index.md
+++ b/files/en-us/web/css/border-block/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-shorthand-property
 browser-compat: css.properties.border-block

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -4,6 +4,7 @@ slug: Web/CSS/border
 tags:
   - CSS
   - CSS Borders
+  - CSS Property
   - CSS Shorthand property
   - Layout
   - Reference


### PR DESCRIPTION
#### Summary
This should be a fix for properties border, border-block & border-block-style not showing up in CSS Properties References.
To verify that they are currently not shown, you can go to [any CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/border), open list of Properties on the left and look for the ones I have mentioned.
Unfortunately I was not able to check, if those changes will fix the problem.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
