### PR TITLE
code example contained copy text

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -253,8 +253,8 @@ console.log(i1.getAttribute('aria-selected'));
 
 console.log(i2.getAttribute('aria-selected'));
 //  'true'
-Note: even if selected: !null, then giving oldval.setAttribute is not a function
 ```
+Note: even if selected: !null, then giving oldval.setAttribute is not a function
 
 ### Value correction and an extra property
 


### PR DESCRIPTION
a code example for Proxy contained a text meant to be part of the main text body without being marked as comment.