### PR TITLE
Removed Experimental tags

### DIFF
--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Background
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.background-position-x

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Background
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.background-position-y

--- a/files/en-us/web/css/block-size/index.md
+++ b/files/en-us/web/css/block-size/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.block-size

--- a/files/en-us/web/css/border-block-color/index.md
+++ b/files/en-us/web/css/border-block-color/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-block-color

--- a/files/en-us/web/css/border-block-end-color/index.md
+++ b/files/en-us/web/css/border-block-end-color/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-color

--- a/files/en-us/web/css/border-block-end-style/index.md
+++ b/files/en-us/web/css/border-block-end-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-end

--- a/files/en-us/web/css/border-block-end-width/index.md
+++ b/files/en-us/web/css/border-block-end-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-end

--- a/files/en-us/web/css/border-block-end/index.md
+++ b/files/en-us/web/css/border-block-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-end-color

--- a/files/en-us/web/css/border-block-start-color/index.md
+++ b/files/en-us/web/css/border-block-start-color/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-color

--- a/files/en-us/web/css/border-block-start-style/index.md
+++ b/files/en-us/web/css/border-block-start-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-start

--- a/files/en-us/web/css/border-block-start-width/index.md
+++ b/files/en-us/web/css/border-block-start-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-start

--- a/files/en-us/web/css/border-block-start/index.md
+++ b/files/en-us/web/css/border-block-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-block
   - border-block-start

--- a/files/en-us/web/css/border-block-width/index.md
+++ b/files/en-us/web/css/border-block-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-block-width

--- a/files/en-us/web/css/border-end-end-radius/index.md
+++ b/files/en-us/web/css/border-end-end-radius/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-end-end-radius
   - recipe:css-property

--- a/files/en-us/web/css/border-end-start-radius/index.md
+++ b/files/en-us/web/css/border-end-start-radius/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-end-start-radius
   - recipe:css-property

--- a/files/en-us/web/css/border-inline-color/index.md
+++ b/files/en-us/web/css/border-inline-color/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-inline-color

--- a/files/en-us/web/css/border-inline-end-color/index.md
+++ b/files/en-us/web/css/border-inline-end-color/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-color

--- a/files/en-us/web/css/border-inline-end-style/index.md
+++ b/files/en-us/web/css/border-inline-end-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-end

--- a/files/en-us/web/css/border-inline-end-width/index.md
+++ b/files/en-us/web/css/border-inline-end-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-end

--- a/files/en-us/web/css/border-inline-end/index.md
+++ b/files/en-us/web/css/border-inline-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-end

--- a/files/en-us/web/css/border-inline-start-color/index.md
+++ b/files/en-us/web/css/border-inline-start-color/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-color

--- a/files/en-us/web/css/border-inline-start-style/index.md
+++ b/files/en-us/web/css/border-inline-start-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-start

--- a/files/en-us/web/css/border-inline-start-width/index.md
+++ b/files/en-us/web/css/border-inline-start-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-start

--- a/files/en-us/web/css/border-inline-start/index.md
+++ b/files/en-us/web/css/border-inline-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-inline
   - border-inline-start

--- a/files/en-us/web/css/border-inline-style/index.md
+++ b/files/en-us/web/css/border-inline-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-inline-style

--- a/files/en-us/web/css/border-inline-width/index.md
+++ b/files/en-us/web/css/border-inline-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.border-inline-width

--- a/files/en-us/web/css/border-inline/index.md
+++ b/files/en-us/web/css/border-inline/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-shorthand-property
 browser-compat: css.properties.border-inline

--- a/files/en-us/web/css/border-start-end-radius/index.md
+++ b/files/en-us/web/css/border-start-end-radius/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-start-end-radius
   - recipe:css-property

--- a/files/en-us/web/css/border-start-start-radius/index.md
+++ b/files/en-us/web/css/border-start-start-radius/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - border-start-start-radius
   - recipe:css-property

--- a/files/en-us/web/css/box-decoration-break/index.md
+++ b/files/en-us/web/css/box-decoration-break/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Fragmentation
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.box-decoration-break

--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Property
   - CSS Text
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.hanging-punctuation

--- a/files/en-us/web/css/inset-block-end/index.md
+++ b/files/en-us/web/css/inset-block-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.inset-block-end

--- a/files/en-us/web/css/inset-block-start/index.md
+++ b/files/en-us/web/css/inset-block-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.inset-block-start

--- a/files/en-us/web/css/inset-block/index.md
+++ b/files/en-us/web/css/inset-block/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-shorthand-property
 browser-compat: css.properties.inset-block

--- a/files/en-us/web/css/inset-inline-end/index.md
+++ b/files/en-us/web/css/inset-inline-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - NeedsContent
   - Reference
   - recipe:css-property

--- a/files/en-us/web/css/inset-inline-start/index.md
+++ b/files/en-us/web/css/inset-inline-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.inset-inline-start

--- a/files/en-us/web/css/inset-inline/index.md
+++ b/files/en-us/web/css/inset-inline/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-shorthand-property
 browser-compat: css.properties.inset-inline

--- a/files/en-us/web/css/inset/index.md
+++ b/files/en-us/web/css/inset/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Property
   - Reference
   - recipe:css-property

--- a/files/en-us/web/css/margin-block-end/index.md
+++ b/files/en-us/web/css/margin-block-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - NeedsContent
   - Reference
   - margin-block

--- a/files/en-us/web/css/margin-block-start/index.md
+++ b/files/en-us/web/css/margin-block-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - NeedsContent
   - Reference
   - margin-block

--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - margin-block
   - recipe:css-shorthand-property

--- a/files/en-us/web/css/margin-inline-end/index.md
+++ b/files/en-us/web/css/margin-inline-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - NeedsContent
   - Reference
   - margin-inline

--- a/files/en-us/web/css/margin-inline-start/index.md
+++ b/files/en-us/web/css/margin-inline-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - margin-inline
   - margin-inline-start

--- a/files/en-us/web/css/margin-inline/index.md
+++ b/files/en-us/web/css/margin-inline/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - margin-inline
   - recipe:css-shorthand-property

--- a/files/en-us/web/css/mask-border-mode/index.md
+++ b/files/en-us/web/css/mask-border-mode/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - NeedsContent
   - NeedsExample
   - Reference

--- a/files/en-us/web/css/mask-border-outset/index.md
+++ b/files/en-us/web/css/mask-border-outset/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - NeedsCompatTable
   - NeedsExample
   - Reference

--- a/files/en-us/web/css/mask-border-repeat/index.md
+++ b/files/en-us/web/css/mask-border-repeat/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - NeedsCompatTable
   - NeedsExample
   - Reference

--- a/files/en-us/web/css/mask-border-slice/index.md
+++ b/files/en-us/web/css/mask-border-slice/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - NeedsCompatTable
   - NeedsExample
   - Reference

--- a/files/en-us/web/css/mask-border-source/index.md
+++ b/files/en-us/web/css/mask-border-source/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - NeedsCompatTable
   - NeedsExample
   - Reference

--- a/files/en-us/web/css/mask-border-width/index.md
+++ b/files/en-us/web/css/mask-border-width/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - NeedsCompatTable
   - NeedsExample
   - Reference

--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-clip

--- a/files/en-us/web/css/mask-composite/index.md
+++ b/files/en-us/web/css/mask-composite/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-composite

--- a/files/en-us/web/css/mask-image/index.md
+++ b/files/en-us/web/css/mask-image/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-image

--- a/files/en-us/web/css/mask-mode/index.md
+++ b/files/en-us/web/css/mask-mode/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-mode

--- a/files/en-us/web/css/mask-origin/index.md
+++ b/files/en-us/web/css/mask-origin/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-origin

--- a/files/en-us/web/css/mask-position/index.md
+++ b/files/en-us/web/css/mask-position/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-position

--- a/files/en-us/web/css/mask-repeat/index.md
+++ b/files/en-us/web/css/mask-repeat/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-repeat

--- a/files/en-us/web/css/mask-size/index.md
+++ b/files/en-us/web/css/mask-size/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.mask-size

--- a/files/en-us/web/css/max-block-size/index.md
+++ b/files/en-us/web/css/max-block-size/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Layout
   - Maximum Height
   - Maximum Width

--- a/files/en-us/web/css/max-inline-size/index.md
+++ b/files/en-us/web/css/max-inline-size/index.md
@@ -7,7 +7,6 @@ tags:
   - CSS Logical Property
   - CSS Property
   - Element size
-  - Experimental
   - Reference
   - Text Direction
   - Writing Mode

--- a/files/en-us/web/css/min-block-size/index.md
+++ b/files/en-us/web/css/min-block-size/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - min-block-size
   - recipe:css-property

--- a/files/en-us/web/css/min-inline-size/index.md
+++ b/files/en-us/web/css/min-inline-size/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - min-inline-size
   - recipe:css-property

--- a/files/en-us/web/css/offset-distance/index.md
+++ b/files/en-us/web/css/offset-distance/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Motion Path
   - CSS Property
-  - Experimental
   - Motion Path
   - Reference
   - motion-offset

--- a/files/en-us/web/css/offset-rotate/index.md
+++ b/files/en-us/web/css/offset-rotate/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Motion Path
   - CSS Property
-  - Experimental
   - Reference
   - offset-rotate
   - recipe:css-property

--- a/files/en-us/web/css/offset/index.md
+++ b/files/en-us/web/css/offset/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Motion Path
   - CSS Property
-  - Experimental
   - Reference
   - recipe:css-shorthand-property
 browser-compat: css.properties.offset

--- a/files/en-us/web/css/padding-block-end/index.md
+++ b/files/en-us/web/css/padding-block-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - padding-block
   - padding-block-end

--- a/files/en-us/web/css/padding-block-start/index.md
+++ b/files/en-us/web/css/padding-block-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - padding-block
   - padding-block-start

--- a/files/en-us/web/css/padding-inline-end/index.md
+++ b/files/en-us/web/css/padding-inline-end/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - padding-inline
   - padding-inline-end

--- a/files/en-us/web/css/padding-inline-start/index.md
+++ b/files/en-us/web/css/padding-inline-start/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Logical Property
   - CSS Property
-  - Experimental
   - Reference
   - padding-inline
   - padding-inline-start

--- a/files/en-us/web/css/text-align-last/index.md
+++ b/files/en-us/web/css/text-align-last/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Property
   - CSS Text
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.text-align-last

--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Property
   - CSS Writing Modes
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.text-combine-upright

--- a/files/en-us/web/css/text-decoration-skip-ink/index.md
+++ b/files/en-us/web/css/text-decoration-skip-ink/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Property
   - CSS Text Decoration
-  - Experimental
   - Layout
   - Reference
   - Web

--- a/files/en-us/web/css/transform-box/index.md
+++ b/files/en-us/web/css/transform-box/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Property
   - CSS Transforms
-  - Experimental
   - NeedsExample
   - Reference
   - recipe:css-property

--- a/files/en-us/web/css/transform-style/index.md
+++ b/files/en-us/web/css/transform-style/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Property
   - CSS Transforms
-  - Experimental
   - Reference
   - recipe:css-property
 browser-compat: css.properties.transform-style


### PR DESCRIPTION
#### Summary
I removed Experimental tag from all CSS properties that don't have Experimental tag in their Compatibility table, as advised in [#13453](https://github.com/mdn/content/pull/13453).

There is one exception. [mask-border-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-mode) doesn't have compatibility data, yet I still removed Experimental flag from it. Together with other mask-border properties it is listed in [specification](https://www.w3.org/TR/css-masking-1/#positioned-masks) and rest of them don't have Experimental tag in compatibility table.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes [#13453](https://github.com/mdn/content/pull/13453)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
