### PR TITLE
update gethighentropyvalues client hints options and example

### DIFF
--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -13,12 +13,15 @@ browser-compat: api.NavigatorUAData.getHighEntropyValues
 
 The **`getHighEntropyValues()`** method of the {{domxref("NavigatorUAData")}} interface is a {{jsxref("Promise")}} that resolves with a dictionary object containing the _high entropy_ values the user-agent returns.
 
-> **Note:** The terms _high entropy_ and _low entropy_ refer to the amount of information these values reveal about the browser. The values returned as properties are deemed low entropy, and unlikely to identify a user. The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information. These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.
+> **Note:** The terms _high entropy_ and _low entropy_ refer to the amount of information these values reveal about the browser.
+> The values returned as properties are deemed low entropy, and unlikely to identify a user.
+> The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information.
+> These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.
 
 ## Syntax
 
 ```js
-NavigatorUAData.getHighEntropyValues(hints);
+getHighEntropyValues(hints)
 ```
 
 ### Parameters
@@ -36,7 +39,7 @@ NavigatorUAData.getHighEntropyValues(hints);
 
 ### Return value
 
-An object containing some or all of the following values, based on the hints requested:
+A {{jsxref("Promise")}} that resolves to an object containing some or all of the following values (based on the hints requested):
 
 - `architecture`
   - : A {{domxref("DOMString","string")}} containing the platform architecture. For example, `"x86"`.
@@ -49,16 +52,18 @@ An object containing some or all of the following values, based on the hints req
 - `uaFullVersion` {{deprecated_inline}}
   - : A {{domxref("DOMString","string")}} containing the full browser version. For example, `"91.0.4472.124"`.
 - `fullVersionList`
-  - : An array of brand information containing the browser name and full version. For example, `"Chromium";v="91.0.4472.124","Google Chrome";v="91.0.4472.124"`.
+  - : An array of brand information containing the browser name and full version.
+    For example, `"Chromium";v="91.0.4472.124","Google Chrome";v="91.0.4472.124"`.
 
 ### Exceptions
 
-- A {{domxref("DOMException")}} `NotAllowedError`
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if the user-agent decides that one or more of the `hints` requested should not be returned.
 
 ## Examples
 
-In the following example a number of hints are requested using the `getHighEntropyValues()` method. When the promise resolves, this information is printed to the console.
+In the following example a number of hints are requested using the `getHighEntropyValues()` method.
+When the promise resolves, this information is printed to the console.
 
 ```js
 navigator.userAgentData.getHighEntropyValues(

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -31,7 +31,8 @@ NavigatorUAData.getHighEntropyValues(hints);
     - `"bitness"`
     - `"model"`
     - `"platformVersion"`
-    - `"uaFullVersion"`
+    - `"uaFullVersion"` {{deprecated_inline}}
+    - `"fullVersionList"`
 
 ### Return value
 
@@ -45,8 +46,10 @@ An object containing some or all of the following values, based on the hints req
   - : A {{domxref("DOMString","string")}} containing the device model. For example, `"Pixel 2XL"`.
 - `platformVersion`
   - : A {{domxref("DOMString","string")}} containing the platform version. For example, `"10.0"`.
-- `uaFullVersion`
+- `uaFullVersion` {{deprecated_inline}}
   - : A {{domxref("DOMString","string")}} containing the full browser version. For example, `"91.0.4472.124"`.
+- `fullVersionList`
+  - : An array of brand information containing the browser name and full version. For example, `"Chromium";v="91.0.4472.124","Google Chrome";v="91.0.4472.124"`.
 
 ### Exceptions
 
@@ -62,7 +65,7 @@ navigator.userAgentData.getHighEntropyValues(
   ["architecture",
   "model",
   "platformVersion",
-  "uaFullVersion"])
+  "fullVersionList"])
   .then(ua => { console.log(ua) });
 ```
 

--- a/files/en-us/web/api/navigatoruadata/index.md
+++ b/files/en-us/web/api/navigatoruadata/index.md
@@ -52,7 +52,7 @@ navigator.userAgentData.getHighEntropyValues(
   "model",
   "platform",
   "platformVersion",
-  "uaFullVersion"])
+  "fullVersionList"])
   .then(ua => { console.log(ua) });
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
As we are going to deprecate the existing client hint `Sec-CH-UA-Full-Version`, using `Sec-CH-UA-Full-Version-List` instead.
This change is going to update the document for Javascript API  [NavigatorUAData.getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues) to return a list of brand information containing browser name and full version number. 

#### Motivation
This change helps our long-term goal to depreacate `uaFullVersion`, it helps users to start use `fullVersionList `.

#### Supporting details
* https://wicg.github.io/ua-client-hints/#interface
* https://bugs.chromium.org/p/chromium/issues/detail?id=1260418
* https://github.com/mdn/content/pull/10906
* https://user-agent-client-hints.glitch.me/javascript.html

#### Related issues
WICG/ua-client-hints#196.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->