### PR TITLE
Fix syntax in code example in ElementInternals article

### DIFF
--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -153,7 +153,7 @@ window.customElements.define('custom-checkbox', CustomCheckbox);
 let element = document.createElement('custom-checkbox');
 let form = document.createElement('form');
 
-// Append elment to form to associate it
+// Append element to form to associate it
 form.appendChild(element);
 
 console.log(element.internals_.form);

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -146,12 +146,18 @@ class CustomCheckbox extends HTMLElement {
   }
 
   /* ... */
+}
 
-  window.customElements.define("custom-checkbox", CustomCheckbox);
-})();
+window.customElements.define('custom-checkbox', CustomCheckbox);
 
-let element = document.getElementById("custom-checkbox");
+let element = document.createElement('custom-checkbox');
+let form = document.createElement('form');
+
+// Append elment to form to associate it
+form.appendChild(element);
+
 console.log(element.internals_.form);
+// expected output: <form><custom-checkbox></custom-checkbox></form>
 ```
 
 ## Specifications


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13356

Use correct syntax and provide better context in example

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Update code under [Examples](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals#examples) to use correct syntax and provide better context on how the API works.

#### Motivation

Primarily Issue #13356, but also made some changes to provide context on how appending the custom element to a form updates it's internals' form property to point to the parent form. 

This also fixes the selector that was being used incorrectly: `let element = document.getElementById("custom-checkbox");` which makes the `console.log()` work.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- [Issue with "ElementInternals": syntactically wrong code example](https://github.com/mdn/content/issues/13356)
- [HTML Standard - The `CustomElementRegistry` interface](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-api)
- [MDN `CustomElementRegistry.define()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
