### PR TITLE
Additional information about speculative connections

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.md
@@ -20,6 +20,8 @@ Google Chrome provides [an extension API also called "proxy"](https://developer.
 
 To use this API you need to have the "proxy" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). Also, where you want to intercept requests, you also need [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the URLs of intercepted requests.
 
+> **Note:** The browser can make speculative connections, where it determines that a request to a URI may be coming soon. This type of connection does not provide valid tab information, so request details such as `tabId`, `frameId`, `parentFrameId`, etc. are inaccurate. These connections have a {{WebExtAPIRef("webRequest.ResourceType")}} of `speculative`. 
+
 ## Types
 
 - {{WebExtAPIRef("proxy.ProxyInfo")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -69,6 +69,10 @@ In the listener, you can then return a {{WebExtAPIRef("webRequest.BlockingRespon
 
 When a listener is registered with the `"blocking"` option and is registered during the extension startup, if a request is made during the browser startup that matches the listener the extension starts early. This enables the extension to observe the request at browser startup. If you don't take these steps, requests made at startup could be missed.
 
+## Speculative requests
+
+The browser can make speculative connections, where it determines that a request to a URI may be coming soon. This type of connection does not provide valid tab information, so request details such as `tabId`, `frameId`, `parentFrameId`, etc. are inaccurate. These connections have a {{WebExtAPIRef("webRequest.ResourceType")}} of `speculative`. 
+ 
 ## Accessing security information
 
 In the {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}} listener you can access the [TLS](/en-US/docs/Glossary/TLS) properties of a request by calling {{WebExtAPIRef("webRequest.getSecurityInfo()", "getSecurityInfo()")}}. To do this you must also pass "blocking" in the `extraInfoSpec` argument to the event's `addListener()`.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -54,7 +54,7 @@ Values of this type are strings. Possible values are:
 - `script`
   - : Code that is loaded to be executed by a {{HTMLElement("script")}} element or running in a [Worker](/en-US/docs/Web/API/Web_Workers_API).
 - `speculative`
-  - : In a speculative connection the browser has determined that a request to a URI may be coming soon, so it starts a TCP and/or TLS handshake immediately, so it is ready more quickly when the resource is actually requested.
+  - : In a speculative connection, the browser has determined that a request to a URI may be coming soon, so it starts a TCP and/or TLS handshake immediately, so it is ready more quickly when the resource is actually requested. Note that this type of connection does not provide valid tab information, so request details such as `tabId`, `frameId`, `parentFrameId`, etc. are inaccurate.
 - `stylesheet`
   - : [CSS](/en-US/docs/Web/CSS) stylesheets loaded to describe the representation of a document.
 - `sub_frame`


### PR DESCRIPTION
#### Summary
Additional information about speculative connections relating to the availability of tab and frame details.

#### Motivation
To address documentation needs identified as part of [Bug 1719972](https://bugzilla.mozilla.org/show_bug.cgi?id=1719972) The tab.url/tabId in proxy.RequestDetails is wrong for new URL accessed through address bar.

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error