### PR TITLE
Substitute 'random' for 'white'. 

### DIFF
--- a/files/en-us/web/api/audioworkletnode/index.md
+++ b/files/en-us/web/api/audioworkletnode/index.md
@@ -46,13 +46,13 @@ _The `AudioWorkletNode` interface does not define any methods of its own._
 
 ## Examples
 
-In this example we create a custom `AudioWorkletNode` that outputs white noise.
+In this example we create a custom `AudioWorkletNode` that outputs random noise.
 
-First, we need to define a custom {{domxref("AudioWorkletProcessor")}}, which will output white noise, and register it. Note that this should be done in a separate file.
+First, we need to define a custom {{domxref("AudioWorkletProcessor")}}, which will output random noise, and register it. Note that this should be done in a separate file.
 
 ```js
-// white-noise-processor.js
-class WhiteNoiseProcessor extends AudioWorkletProcessor {
+// random-noise-processor.js
+class RandomNoiseProcessor extends AudioWorkletProcessor {
   process (inputs, outputs, parameters) {
     const output = outputs[0]
     output.forEach(channel => {
@@ -64,16 +64,16 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
   }
 }
 
-registerProcessor('white-noise-processor', WhiteNoiseProcessor)
+registerProcessor('random-noise-processor', RandomNoiseProcessor)
 ```
 
 Next, in our main script file we'll load the processor, create an instance of `AudioWorkletNode` passing it the name of the processor, and connect the node to an audio graph.
 
 ```js
 const audioContext = new AudioContext()
-await audioContext.audioWorklet.addModule('white-noise-processor.js')
-const whiteNoiseNode = new AudioWorkletNode(audioContext, 'white-noise-processor')
-whiteNoiseNode.connect(audioContext.destination)
+await audioContext.audioWorklet.addModule('random-noise-processor.js')
+const randomNoiseNode = new AudioWorkletNode(audioContext, 'random-noise-processor')
+randomNoiseNode.connect(audioContext.destination)
 ```
 
 ## Specifications


### PR DESCRIPTION
Light and sound are not physically 1:1. Naming a sound a color is completely arbitrary. Not necessary here. Just use random noise, as that is what you are doing.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
