### PR TITLE
Add a note about our policy for teaching modern JavaScript

### DIFF
--- a/files/en-us/learn/javascript/index.md
+++ b/files/en-us/learn/javascript/index.md
@@ -41,6 +41,16 @@ After getting familiar with the basics of JavaScript, you should be in a positio
 
 ## Modules
 
+> **Callout:**
+>
+> **Our policy on modern JavaScript**
+>
+> JavaScript is an actively evolving language and has changed greatly over the years. In particular, the 6th edition of the language (sometimes known as ECMAScript 2015 or ES6), introduced in 2015, added many new features. At the same time, to maintain backwards compatibility with older websites, old features of the language have been retained, even when they are no longer considered good practice.
+>
+> We think that the features added to JavaScript in ECMAScript 2015 and subsequent versions enable developers to write more readable, reliable, and expressive code, and that it's important to learn about them.
+>
+> The features we teach in this course are stable and have been supported by all major browsers for several years. You're only likely to have trouble using them in obsolete browsers, in particular Internet Explorer. If you do need to support obsolete browsers, we recommend using a tool like [Babel](https://babeljs.io/), which enables you to write modern JavaScript but have it run in browsers that don't support it.
+
 This topic contains the following modules, in a suggested order for working through them.
 
 - [JavaScript first steps](/en-US/docs/Learn/JavaScript/First_steps)


### PR DESCRIPTION
This note is intended to clarify the policy in the Learning Area for the "modernity" of the JS we teach. It should express that:

1. we teach "modern JS", as long as a feature is stable and well-supported
2. we do this because we think it's important for people to learn "the new way" as the primary way of doing things
3. this will only be a problem if you have to support obsolete browsers: if you do, we recommend using (something like) Babel, and still writing modern JS.