### PR TITLE
Nav requestmidi updates

### DIFF
--- a/files/en-us/web/api/navigator/requestmidiaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmidiaccess/index.md
@@ -12,12 +12,13 @@ tags:
 browser-compat: api.Navigator.requestMIDIAccess
 ---
 
-{{DefaultAPISidebar("Web MIDI API")}}
+{{DefaultAPISidebar("Web MIDI API")}}{{SecureContext_Header}}
 
-The **`requestMIDIAccess()`** method of the {{domxref('Navigator')}} interface
-returns a {{jsxref('Promise')}} representing a request for access to MIDI devices on a user's system. This method is part of the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API), which provides a means for accessing, enumerating, and manipulating MIDI devices.
+The **`requestMIDIAccess()`** method of the {{domxref('Navigator')}} interface returns a {{jsxref('Promise')}} representing a request for access to MIDI devices on a user's system.
+This method is part of the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API), which provides a means for accessing, enumerating, and manipulating MIDI devices.
 
-This method prompts the user for access to MIDI devices available to their system. If the user grants permission, then the {{jsxref('Promise')}} resolves and a [`MIDIAccess`](/en-US/docs/Web/API/MIDIAccess) object is returned.
+This method may prompt the user for access to MIDI devices available to their system, or it may use a previously established preference to grant or deny access.
+If permission is granted then the {{jsxref('Promise')}} resolves and a [`MIDIAccess`](/en-US/docs/Web/API/MIDIAccess) object is returned.
 
 ## Syntax
 
@@ -48,7 +49,7 @@ A {{jsxref('Promise')}} that resolves with a [`MIDIAccess`](/en-US/docs/Web/API/
 - `NotSupportedError`
   - : If the feature or options are not supported by the system.
 - `SecurityError`
-  - : If the user or system denies the application from creating a [MIDIAccess](/en-US/docs/Web/API/MIDIAccess) object with the requested options, or if the document is not allowed to use the feature (for example, an iframe without the correct [feature policy](/en-US/docs/Web/HTTP/Feature_Policy)).
+  - : If the user or system denies the application from creating a [MIDIAccess](/en-US/docs/Web/API/MIDIAccess) object with the requested options, or if the document is not allowed to use the feature (for example, an iframe without the correct [Permission Policy](/en-US/docs/Web/HTTP/Feature_Policy), or when the user has previously denied a permissions access to the feature).
 
 ## Examples
 

--- a/files/en-us/web/api/web_midi_api/index.md
+++ b/files/en-us/web/api/web_midi_api/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
   - Web MIDI API
 ---
-{{DefaultAPISidebar("Web MIDI API")}}
+{{DefaultAPISidebar("Web MIDI API")}}{{SecureContext_Header}}
 
 The Web MIDI API connects to and interacts with with Musical Instrument Digital Interface (MIDI) Devices.
 
@@ -37,7 +37,8 @@ The interfaces deal with the practical aspects of sending and receiving MIDI mes
 
 ### Gaining access to the MIDI port
 
-In the following example the {{domxref("MIDIAccess")}} interface is used to gain access to a MIDI device.
+The {{domxref("navigator.requestMIDIAccess()")}} method returns a promise that resolves to a {{domxref("MIDIAccess")}}, which can then be used to access a MIDI device.
+The method must be called in a secure context.
 
 ```js
 var midi = null;  // global MIDIAccess object


### PR DESCRIPTION
This is part of web midi API updates for FF99.
1. Adds secure context header to the [Web MIDI API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API) and [Navigator.requestMIDIAccess()](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMIDIAccess) pages.
   - QUESTION - these are the only places the header required right? I.e. is present on [MediaAccess](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess) but I don't think it should be?
 2. Tidies a few other bits comments inline.