### PR TITLE
Fix Element.animate hyperlink (#13480)

### DIFF
--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -34,7 +34,7 @@ animate(keyframes, options)
 - `options`
 
   - : Either an **integer representing the animation's duration** (in
-    milliseconds), **or** an Object containing one or more timing properties described in the [`KeyframeEffect()` options parameter](/en-US/docs/Web/API/KeyframeEffect) and/or the following options:
+    milliseconds), **or** an Object containing one or more timing properties described in the [`KeyframeEffect()` options parameter](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) and/or the following options:
 
     - `id {{optional_inline}}`
       - : A property unique to `animate()`: a [`DOMString`](/en-US/docs/Web/API/DOMString)


### PR DESCRIPTION
Fixes #13480.
