### PR TITLE
Fix: "switch statement" to example code, typo

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -648,7 +648,7 @@ In this example, you are going to take the ternary operator example we saw earli
 
 - It should accept the `choice` variable as its input expression.
 - For each case, the choice should equal one of the possible `<option> value`s that can be selected, that is, `white`, `black`, `purple`, `yellow`, or `psychedelic`.
-- For each case, the `update()` function should be run, and be passed two color values, the first one for the background color, and the second one for the text color. Remember that color values are strings, so need to be wrapped in quotes.
+- For each case, the `update()` function should be run, and be passed two color values, the first one for the background color, and the second one for the text color. Remember that color values are strings, so they need to be wrapped in quotes.
 
 If you make a mistake, you can always reset the example with the "Reset" button. If you get really stuck, press "Show solution" to see a solution.
 
@@ -677,7 +677,7 @@ const html = document.querySelector('.output');
 select.addEventListener('change', () => {
   const choice = select.value;
 
-  // ADD CONDITIONAL HERE
+  // ADD SWITCH STATEMENT
 });
 
 function update(bgColor, textColor) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

In the paragraph it says "// ADD SWITCH STATEMENT", yet in the example code it says "// ADD CONDITIONAL HERE", which might be confusing to some. Also, there was a word (probably 'they') missing in the same paragraph, added that as well.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Correcting small errors makes it easier and faster to read and comprehend

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
