### PR TITLE
fix Element.shadow example bug

### DIFF
--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -175,7 +175,7 @@ class WordCount extends HTMLParagraphElement {
 
     function countWords(node){
       var text = node.innerText || node.textContent
-      return text.split(/\s+/g).length;
+      return text.trim().split(/\s+/g).filter(a => a.trim().length > 0).length;
     }
 
     var count = 'Words: ' + countWords(wcParent);

--- a/files/en-us/web/api/customelementregistry/index.md
+++ b/files/en-us/web/api/customelementregistry/index.md
@@ -42,7 +42,7 @@ class WordCount extends HTMLParagraphElement {
 
     function countWords(node){
       var text = node.innerText || node.textContent
-      return text.split(/\s+/g).length;
+      return text.trim().split(/\s+/g).filter(a => a.trim().length > 0).length;
     }
 
     var count = 'Words: ' + countWords(wcParent);

--- a/files/en-us/web/api/element/attachshadow/index.md
+++ b/files/en-us/web/api/element/attachshadow/index.md
@@ -106,7 +106,7 @@ class WordCount extends HTMLParagraphElement {
 
     function countWords(node){
       var text = node.innerText || node.textContent
-      return text.trim().split(/\s+/g).length;
+      return text.trim().split(/\s+/g).filter(a => a.trim().length > 0).length;
     }
 
     var count = 'Words: ' + countWords(wcParent);


### PR DESCRIPTION
#### Summary

[Fixes issue #13454]( https://github.com/mdn/content/issues/13454) - fixes function `countWords` where for empty strings it returns 0 instead of 1.

#### Motivation
function `countWords returns 2 when there is an empty an empty string.

#### Related issues
[fixes #13454]( https://github.com/mdn/content/issues/13454)
[Linked PR on web components](https://github.com/mdn/web-components-examples/pull/39)

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
