### PR TITLE
Add more links to the top-level en-US/docs/Web index page

### DIFF
--- a/files/en-us/web/index.md
+++ b/files/en-us/web/index.md
@@ -12,29 +12,43 @@ The open Web presents incredible opportunities for developers. To take full adva
 - [Web Developer Guide](/en-US/docs/Web/Guide)
   - : The Web Developer Guide provides useful how-to content to help you actually use Web technologies to do what you want or need to do.
 - [Tutorials for Web developers](/en-US/docs/Web/Tutorials)
-  - : A list of tutorials to take you step-by-step through learning APIs, technologies, or broad topic areas.
-- [Progressive web apps (PWAs)](/en-US/docs/Web/Progressive_web_apps)
-  - : Progressive Web Apps are web apps that use emerging web browser APIs and features along with traditional progressive enhancement strategy to bring a native app-like user experience to cross-platform web applications.
+  - : Tutorials to take you step-by-step through learning HTML, CSS, JavaScript, and Web APIs.
 - [Accessibility](/en-US/docs/Web/Accessibility)
   - : Enabling as many people as possible to use Web sites, even when those people's abilities are limited in some way.
-- [Web Performance](/en-US/docs/Web/Performance)
+- [Performance](/en-US/docs/Web/Performance)
   - : Making content as available and interactive as possible, as soon as possible.
+- [Security](/en-US/docs/Web/Security)
+  - : Protecting users from data leaks and data theft, side-channel attacks, and attacks such as cross-site scripting, content injection, and click-jacking.
 
 ## Web technology references
 
 - [Web APIs](/en-US/docs/Web/API)
-  - : Reference material for each of the individual APIs that comprise the Web's powerful scriptability, including the DOM and all of the related APIs and interfaces you can use to build Web content and apps.
+  - : JavaScript programming APIs you can use to build apps on the Web.
 - [HTML](/en-US/docs/Web/HTML)
-  - : HyperText Markup Language is the language used to describe and define the content of a Web page.
+  - : HTML provides the fundamental building blocks for structuring Web documents and apps.
 - [CSS](/en-US/docs/Web/CSS)
-  - : Cascading Style Sheets are used to describe the appearance of Web content.
+  - : Cascading Style Sheets are used to describe the appearance of Web documents and apps.
 - [JavaScript](/en-US/docs/Web/JavaScript)
-  - : JavaScript is a programming language used to add interactivity to a website.
+  - : JavaScript is the Web’s native programming language.
+- [WebAssembly](/en-US/docs/WebAssembly)
+  - : WebAssembly allows programs written in C, C++, Rust, Swift, C#, Go, and more to run on the Web.
 - [Events](/en-US/docs/Web/Events)
-  - : Events are actions or occurrences that happen in the system you are programming, which the system tells you about so your code can react to them.
+  - : Events are what you build Web apps to react to; for example, when a Web page finishes loading, or a user selects something, presses a key, resizes a window, submits a form, or pauses a video.
+- [HTTP](/en-US/docs/Web/HTTP)
+  - : HTTP is the fundamental Internet protocol for fetching documents, stylesheets, scripts, images, videos, fonts, and other resources over the Web — and for sending data back to Web servers.
+- [Media](/en-US/docs/Web/Media)
+  - : Formats, codecs, protocols, APIs, and techniques for embedding and streaming video, audio, and image content in Web documents and apps.
 - [SVG](/en-US/docs/Web/SVG)
-  - : Scalable Vector Graphics let you describe images as sets of vectors and shapes in order to allow them to scale smoothly regardless of the size at which they're drawn.
+  - : Scalable Vector Graphics let you to create images that scale smoothly to any size.
 - [MathML](/en-US/docs/Web/MathML)
-  - : The Mathematical Markup Language makes it possible to display complex mathematical equations and syntax.
+  - : MathML lets you display complex mathematical notation on the Web.
 - [Web Components](/en-US/docs/Web/Web_Components)
-  - : Web Components are custom elements that you can define and reuse in your apps.
+  - : Web Components are custom elements that you can define and reuse in your Web apps.
+- [WebDriver](/en-US/docs/Web/WebDriver)
+  - : WebDriver is a browser-automation mechanism for remotely controlling a browser by emulating the actions of a real person using the browser. It’s widely used for cross-browser testing of Web apps.
+- [Web Extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions)
+  - : Web Extensions are a way for you to give users enhanced capabilities in their browsers — for doing things such as blocking ads and other content, customizing the appearance of pages, and more.
+- [Web App Manifests](/en-US/docs/Web/Manifest)
+  - : Web App Manifests let you enable users to install Web apps to their device home screens, with aspects such as portrait/landscape screen orientation and display mode (e.g., full screen) pre-set.
+- [Progressive Web Apps (PWAs)](/en-US/docs/Web/Progressive_web_apps)
+  - : Progressive Web Apps provide a user experience similar to native mobile apps.


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13482. This adds several new links to the main en-US/docs/Web index page:

- WebAssembly
- Web Extensions
- Web App Manifests
- WebDriver
- HTTP
- Media
- Security

It also includes copy edits to make some of the existing wording more consistent and more concise.