### PR TITLE
`getAsFileSystemHandle` returns a `Promise`

### DIFF
--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -28,7 +28,7 @@ None.
 
 ### Return value
 
-A {{jsxref('Promise')}} which is fulfilled with a {{domxref('FileSystemFileHandle')}} or {{domxref('FileSystemDirectoryHandle')}}.
+A {{jsxref('Promise')}} fulfilled with a {{domxref('FileSystemFileHandle')}} or {{domxref('FileSystemDirectoryHandle')}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -28,7 +28,7 @@ None.
 
 ### Return value
 
-A {{domxref('FileSystemFileHandle')}} or {{domxref('FileSystemDirectoryHandle')}}.
+A {{jsxref("Promise")}} that resolves to a {{domxref('FileSystemFileHandle')}} or {{domxref('FileSystemDirectoryHandle')}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -28,7 +28,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a {{domxref('FileSystemFileHandle')}} or {{domxref('FileSystemDirectoryHandle')}}.
+A {{jsxref('Promise')}} which is fulfilled with a {{domxref('FileSystemFileHandle')}} or {{domxref('FileSystemDirectoryHandle')}}.
 
 ### Exceptions
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fix the return signature of `DataTransferItem.getAsFileSystemHandle()`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://wicg.github.io/file-system-access/#dom-datatransferitem-getasfilesystemhandle

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
