### PR TITLE
docs: Add documentation around `Headers` constructor init arg as an array of name-value pairs, where each pair is a 2-element string array

### DIFF
--- a/files/en-us/web/api/headers/headers/index.md
+++ b/files/en-us/web/api/headers/headers/index.md
@@ -25,7 +25,7 @@ var myHeaders = new Headers(init);
 - `init` {{optional_inline}}
   - : An object containing any [HTTP headers](/en-US/docs/Web/HTTP/Headers)
     that you want to pre-populate your `Headers` object with. This can be a
-    simple object literal with {{jsxref("String")}} values, a two-dimensional array of {{jsxref("String")}} values; or an existing
+    simple object literal with {{jsxref("String")}} values, an array of name-value pairs, where each pair is a 2-element string array; or an existing
     `Headers` object. In the last case, the new `Headers` object
     copies its data from the existing `Headers` object.
 
@@ -70,7 +70,7 @@ var headers = [
   ['Set-Cookie', 'greeting=hello'],
   ['Set-Cookie', 'name=world']
 ];
-var myHeaders = new Headers(httpHeaders);
+var myHeaders = new Headers(headers);
 ```
 
 

--- a/files/en-us/web/api/headers/headers/index.md
+++ b/files/en-us/web/api/headers/headers/index.md
@@ -25,7 +25,7 @@ var myHeaders = new Headers(init);
 - `init` {{optional_inline}}
   - : An object containing any [HTTP headers](/en-US/docs/Web/HTTP/Headers)
     that you want to pre-populate your `Headers` object with. This can be a
-    simple object literal with {{jsxref("String")}} values; or an existing
+    simple object literal with {{jsxref("String")}} values, a two-dimensional array of {{jsxref("String")}} values; or an existing
     `Headers` object. In the last case, the new `Headers` object
     copies its data from the existing `Headers` object.
 
@@ -60,6 +60,19 @@ You can now create another `Headers` object, passing it the first
 var secondHeadersObj = new Headers(myHeaders);
 secondHeadersObj.get('Content-Type'); // Would return 'image/jpeg' — it inherits it from the first headers object
 ```
+
+You can also add the headers you want as the `Headers` object is created by using a two-dimensional array to add multiple headers with the same values. In
+the following snippet we create a new {{domxref("Headers")}} object with multiple `Set-Cookie` headers
+by passing the constructor an init array as an argument:
+
+```js
+var headers = [
+  ['Set-Cookie', 'greeting=hello'],
+  ['Set-Cookie', 'name=world']
+];
+var myHeaders = new Headers(httpHeaders);
+```
+
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary
The `Headers` constructor accepts an array of name-value pairs, where each pair is a 2-element string array, in place of a bare object or another Headers object and it should be represented on the docs.

#### Motivation

In situations where multiple headers of the same name exist in a headers object, this documentation update provides users an alternative to `headers.append()` calls. 

#### Supporting details

There already exists an example of using a 2d string array on this page: https://developer.mozilla.org/en-US/docs/Web/API/Headers but it is not called out in the constructor documentation.

https://fetch.spec.whatwg.org/#typedefdef-headersinit


#### Metadata
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

Note: I am not sure which metadata buttons should be checked here, so I checked 2 that could apply.