### PR TITLE
Several fixes for `FileSystemDirectoryHandle` page

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -26,19 +26,22 @@ _Inherits properties from its parent, {{DOMxRef("FileSystemHandle")}}._
 _Inherits methods from its parent, {{DOMxRef("FileSystemHandle")}}._
 
 - {{domxref('FileSystemDirectoryHandle.entries()')}}
-  - : Returns an {{jsxref('Array')}} of a given object's own enumerable property `[key, value]` pairs
+  - : Returns a new _async iterator_ of a given object's own enumerable property `[key, value]` pairs
 - {{domxref('FileSystemDirectoryHandle.getFileHandle()')}}
-  - : Returns a {{domxref('FileSystemFileHandle')}} for a file with the specified name, within the directory the method is called.
+  - : Returns a {{jsxref('Promise')}} fulfilled with a {{domxref('FileSystemFileHandle')}} for a file with the specified name, within the directory the method is called.
 - {{domxref('FileSystemDirectoryHandle.getDirectoryHandle()')}}
-  - : Returns a {{domxref('FileSystemDirectoryHandle')}} for a subdirectory with the specified name within the directory handle on which the method is called.
+  - : Returns a {{jsxref('Promise')}} fulfilled with a {{domxref('FileSystemDirectoryHandle')}} for a subdirectory with the specified name within the directory handle on which the method is called.
 - {{domxref('FileSystemDirectoryHandle.keys()')}}
-  - : Returns a new _array iterator_ containing the keys for each item in `FileSystemDirectoryHandle`.
+  - : Returns a new _async iterator_ containing the keys for each item in `FileSystemDirectoryHandle`.
 - {{domxref('FileSystemDirectoryHandle.removeEntry()')}}
-  - : Attempts to remove an entry if the directory handle contains a file or directory called the name specified.
+  - : Attempts to asynchromously remove an entry if the directory handle contains a file or directory called the name specified.
 - {{domxref('FileSystemDirectoryHandle.resolve()')}}
-  - : Returns an {{jsxref('Array')}} of directory names from the parent handle to the specified child entry, with the name of the child entry as the last array item.
+  - : Returns a {{jsxref('Promise')}} fulfilled with an {{jsxref('Array')}} of directory names from the parent handle to the specified child entry, with the name of the child entry as the last array item.
 - {{domxref('FileSystemDirectoryHandle.values()')}}
-  - : Returns a new _array iterator_ containing the values for each index in the `FileSystemDirectoryHandle` object.
+  - : Returns a new _async iterator_ containing the values for each index in the `FileSystemDirectoryHandle` object.
+- [`FileSystemDirectoryHandle[@@asyncIterator]()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries)
+  - : Returns the `entries` function by default.
+
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

None of those methods return an `Array` nor an `ArrayIterator`.

I wasn't sure how to handle `@@asyncIterator`, I got inspiration from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The current state is not aligned with the spec, not the Chromium implementation.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Refs: https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
