### PR TITLE
Fix links to to-do list demo

### DIFF
--- a/files/en-us/web/api/idbdatabase/name/index.md
+++ b/files/en-us/web/api/idbdatabase/name/index.md
@@ -35,8 +35,8 @@ A {{ domxref("DOMString")}} containing the name of the connected database.
 This example shows a database connection being opened, the resulting
 {{domxref("IDBDatabase")}} object being stored in a db variable, and the name property
 then being logged. For a full example, see our
-[To-do Notifications](https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages)
- app ([view example live](https://chrisdavidmills.github.io/to-do-notifications/)).
+[To-do Notifications](https://github.com/mdn/to-do-notifications/tree/gh-pages)
+ app ([view example live](https://mdn.github.io/to-do-notifications/)).
 
 ```js
 // Let us open our database

--- a/files/en-us/web/api/idbrequest/index.md
+++ b/files/en-us/web/api/idbrequest/index.md
@@ -59,7 +59,7 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 
 ## Example
 
-In the following code snippet, we open a database asynchronously and make a request; `onerror` and `onsuccess` functions are included to handle the success and error cases. For a full working example, see our [To-do Notifications](https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages) app ([view example live](https://chrisdavidmills.github.io/to-do-notifications/).)
+In the following code snippet, we open a database asynchronously and make a request; `onerror` and `onsuccess` functions are included to handle the success and error cases. For a full working example, see our [To-do Notifications](https://github.com/mdn/to-do-notifications/tree/gh-pages) app ([view example live](https://mdn.github.io/to-do-notifications/).)
 
 ```js
 var db;


### PR DESCRIPTION
These pages linked to the to-do list demo, which I guess started off under Chris's personal account, then moved to the mdn org. Redirects to the actual repo work, but there aren't redirects to the GitHub pages, so the "try it live" links were broken.
