### PR TITLE
Adapt api.HIDDevice.oninputreport to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7963,6 +7963,7 @@
 /en-US/docs/Web/API/GlobalFetch/GlobalFetch.fetch()	/en-US/docs/Web/API/fetch
 /en-US/docs/Web/API/GlobalFetch/fetch	/en-US/docs/Web/API/fetch
 /en-US/docs/Web/API/Guide/Events/Creating_and_triggering_events	/en-US/docs/Web/Events/Creating_and_triggering_events
+/en-US/docs/Web/API/HIDDevice/oninputreport	/en-US/docs/Web/API/HIDDevice/inputreport_event
 /en-US/docs/Web/API/HTMLAnchorElement.rel	/en-US/docs/Web/API/HTMLAnchorElement/rel
 /en-US/docs/Web/API/HTMLAnchorElement.relList	/en-US/docs/Web/API/HTMLAnchorElement/relList
 /en-US/docs/Web/API/HTMLAnchorElement/referrer	/en-US/docs/Web/API/HTMLAnchorElement/referrerPolicy

--- a/files/en-us/web/api/hiddevice/index.md
+++ b/files/en-us/web/api/hiddevice/index.md
@@ -29,10 +29,10 @@ This interface also inherits properties from {{domxref("EventTarget")}}.
 - {{domxref("HIDDevice.collections")}}{{ReadOnlyInline}}
   - : Returns an array of report formats for the HID device.
 
-### Event handlers
+### Events
 
-- {{domxref("HIDDevice.oninputreport")}}
-  - : An event handler that fires when a report is sent from the device.
+- {{domxref("HIDDevice.inputreport_event", "inputreport")}}
+  - : Fires when a report is sent from the device.
 
 ## Methods
 

--- a/files/en-us/web/api/hiddevice/inputreport_event/index.md
+++ b/files/en-us/web/api/hiddevice/inputreport_event/index.md
@@ -1,26 +1,37 @@
 ---
-title: HIDDevice.oninputreport
-slug: Web/API/HIDDevice/oninputreport
+title: 'HIDDevice: inputreport event'
+slug: Web/API/HIDDevice/inputreport_event
 tags:
   - API
   - Property
   - Reference
   - oninputreport
   - HIDDevice
-browser-compat: api.HIDDevice.oninputreport
+browser-compat: api.HIDDevice.inputreport_event
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
-The **`oninputreport`** event handler of the {{domxref("HIDDevice")}} interface processes inputreport events.
-
-The event fires when a new report is received from the HID device.
+The **`inputreport`** event of the {{domxref("HIDDevice")}} interface fires when a new report is received from the HID device.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-HIDDevice.oninputreport = function;
-HIDDevice.addEventListener('inputreport', function);
+addEventListener('inputreport', event => { });
+
+oninputreport = event => { };
 ```
+
+## Event type
+
+An {{domxref("HIDInputReportEvent")}}. Inherits from {{domxref("Event")}}.
+
+{{InheritanceDiagram("HIDInputReportEvent")}}
+
+## Event properties
+
+{{page("/en-US/docs/Web/API/HIDInputReportEvent", "Properties")}}
 
 ## Example
 

--- a/files/en-us/web/api/hidinputreportevent/index.md
+++ b/files/en-us/web/api/hidinputreportevent/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HIDInputReportEvent
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebHID API")}}
 
-The **`HIDInputReportEvent`** interface of the {{domxref('WebHID API')}} is passed to {{domxref("HIDDevice.oninputreport")}} when an input report is received from any associated HID device.
+The **`HIDInputReportEvent`** interface of the {{domxref('WebHID API')}} is passed to {{domxref("HIDDevice.inputreport_event")}} when an input report is received from any associated HID device.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/webhid_api/index.md
+++ b/files/en-us/web/api/webhid_api/index.md
@@ -24,7 +24,7 @@ A Human Interface Device (HID) is a type of device that takes input from or prov
 <!---->
 
 - {{domxref("HIDInputReportEvent")}}
-  - : Passed to {{domxref("HIDDevice.oninputreport")}} when an input report is received from any associated HID device.
+  - : Passed to {{domxref("HIDDevice.inputreport_event")}} when an input report is received from any associated HID device.
 
 <!---->
 


### PR DESCRIPTION
This PR adapts the inputreport event of the HIDDevice API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15155
