### PR TITLE
Adapt api.IdleDetector.onchange to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8266,6 +8266,7 @@
 /en-US/docs/Web/API/IDBVersionChangeEvent.oldVersion	/en-US/docs/Web/API/IDBVersionChangeEvent/oldVersion
 /en-US/docs/Web/API/IDBVersionChangeEvent.version	/en-US/docs/Web/API/IDBVersionChangeEvent/version
 /en-US/docs/Web/API/IIRFilterNode/getFrequencyResponse()	/en-US/docs/Web/API/IIRFilterNode/getFrequencyResponse
+/en-US/docs/Web/API/IdleDetector/onchange	/en-US/docs/Web/API/IdleDetector/change_event
 /en-US/docs/Web/API/Image	/en-US/docs/Web/API/HTMLImageElement/Image
 /en-US/docs/Web/API/ImageBitmapFactories/createImageBitmap	/en-US/docs/Web/API/createImageBitmap
 /en-US/docs/Web/API/ImageBitmapRenderingContext/transferImageBitmap	/en-US/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap

--- a/files/en-us/web/api/idledetector/change_event/index.md
+++ b/files/en-us/web/api/idledetector/change_event/index.md
@@ -3,7 +3,7 @@ title: 'IdleDetector: change event'
 slug: Web/API/IdleDetector/change_event
 tags:
   - API
-  - Property
+  - Event
   - Reference
   - onchange
   - IdleDetector

--- a/files/en-us/web/api/idledetector/change_event/index.md
+++ b/files/en-us/web/api/idledetector/change_event/index.md
@@ -1,26 +1,31 @@
 ---
-title: IdleDetector.onchange
-slug: Web/API/IdleDetector/onchange
+title: 'IdleDetector: change event'
+slug: Web/API/IdleDetector/change_event
 tags:
   - API
   - Property
   - Reference
   - onchange
   - IdleDetector
-browser-compat: api.IdleDetector.onchange
+browser-compat: api.IdleDetector.change_event
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
 
-The **`onchange`** EventHandler of the {{domxref("IdleDetector")}} interface is
-called when the value of `userState` or `screenState` has changed. This method
-receives an {{domxref("Event")}} object.
+The **`change`** event of the {{domxref("IdleDetector")}} interface fires when the value of `userState` or `screenState` has changed.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-IdleDetector.onchange = function;
-IdleDetector.addEventListener('change', function);
+addEventListener('change', event => { });
+
+onchange = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Example
 

--- a/files/en-us/web/api/idledetector/index.md
+++ b/files/en-us/web/api/idledetector/index.md
@@ -38,9 +38,8 @@ This attribute returns `null` before `start()` is called.
 
 ## Events
 
-- {{domxref("IdleDetector.onchange")}}
-  - : Called when the value of `userState` or `screenState` has changed. This method
-receives an `Event` object.
+- {{domxref("IdleDetector.change_event", "change")}}
+  - : Called when the value of `userState` or `screenState` has changed.
 
 ## Methods
 


### PR DESCRIPTION
This PR adapts the change event of the IdleDetector API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15164
