### PR TITLE
Fix the Syntax section WebSocket() constructor article

### DIFF
--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -17,7 +17,8 @@ The **`WebSocket()`** constructor returns a new
 ## Syntax
 
 ```js
-var aWebSocket = new WebSocket(url, [protocols]);
+new WebSocket(url)
+new WebSocket(url, protocols)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -17,7 +17,7 @@ The **`WebSocket()`** constructor returns a new
 ## Syntax
 
 ```js
-var aWebSocket = new WebSocket(url [, protocols]);
+var aWebSocket = new WebSocket(url, [protocols]);
 ```
 
 ### Parameters


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
source:  var aWebSocket = new WebSocket(url [, protocols]);
fix to:  var aWebSocket = new WebSocket(url, [protocols]);
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
