### PR TITLE
Added Windows shortcut in composition event examples

### DIFF
--- a/files/en-us/web/api/element/compositionend_event/index.md
+++ b/files/en-us/web/api/element/compositionend_event/index.md
@@ -49,7 +49,7 @@ inputElement.addEventListener('compositionend', (event) => {
 
 ```html
 <div class="control">
-  <label for="name">On macOS, click in the textbox below,<br> then type <kbd>option</kbd> + <kbd>`</kbd>, then <kbd>a</kbd>:</label>
+  <label for="name">First select textbox, then to open IME:<ul><li>on macOS type <kbd>option</kbd> + <kbd>`</kbd></li><li>on Windows type <kbd>windows</kbd> + <kbd>.</kbd></li></ul></label>
   <input type="text" id="example" name="example">
 </div>
 

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -52,7 +52,7 @@ inputElement.addEventListener('compositionstart', (event) => {
 
 ```html
 <div class="control">
-  <label for="name">On macOS, click in the textbox below,<br> then type <kbd>option</kbd> + <kbd>`</kbd>, then <kbd>a</kbd>:</label>
+  <label for="name">First select textbox, then to open IME:<ul><li>on macOS type <kbd>option</kbd> + <kbd>`</kbd></li><li>on Windows type <kbd>windows</kbd> + <kbd>.</kbd></li></ul></label>
   <input type="text" id="example" name="example">
 </div>
 

--- a/files/en-us/web/api/element/compositionupdate_event/index.md
+++ b/files/en-us/web/api/element/compositionupdate_event/index.md
@@ -49,7 +49,7 @@ inputElement.addEventListener('compositionupdate', (event) => {
 
 ```html
 <div class="control">
-  <label for="name">On macOS, click in the textbox below,<br> then type <kbd>option</kbd> + <kbd>`</kbd>, then <kbd>a</kbd>:</label>
+  <label for="name">First select textbox, then to open IME:<ul><li>on macOS type <kbd>option</kbd> + <kbd>`</kbd></li><li>on Windows type <kbd>windows</kbd> + <kbd>.</kbd></li></ul></label>
   <input type="text" id="example" name="example">
 </div>
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added information about Windows shortcut to open IME, which can be used to trigger composition event.
![image](https://user-images.githubusercontent.com/100634371/156923874-15c97cc5-9b37-42c4-b73f-4d5b78cd0b8c.png)

Could someone please check if macOS shortcut is still valid?
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
I tested windows shortcut and it works fine.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Issue #13560

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
