### PR TITLE
Fixed deprecated icon position

### DIFF
--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -368,8 +368,8 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 - `{{domxref("Element/keydown_event", "keydown")}}`
   - : Fired when a key is pressed.
     Also available via the {{domxref("GlobalEventHandlers/onkeydown", "onkeydown")}} property.
-- `{{domxref("Element/keypress_event", "keypress")}}`
-  - : Fired when a key that produces a character value is pressed down. {{deprecated_inline}}
+- `{{domxref("Element/keypress_event", "keypress")}}` {{deprecated_inline}}
+  - : Fired when a key that produces a character value is pressed down.
     Also available via the {{domxref("GlobalEventHandlers/onkeypress", "onkeypress")}} property.
 - `{{domxref("Element/keyup_event", "keyup")}}`
   - : Fired when a key is released.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Deprecated icon should now be near method name, rather than in middle of a paragraph.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Issue #13562 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
