### PR TITLE
Adapt api.MediaQueryList.onchange to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8369,6 +8369,7 @@
 /en-US/docs/Web/API/MediaPositionState/playbackRate	/en-US/docs/Web/API/MediaSession/setPositionState
 /en-US/docs/Web/API/MediaPositionState/position	/en-US/docs/Web/API/MediaSession/setPositionState
 /en-US/docs/Web/API/MediaQueryList/addListener()	/en-US/docs/Web/API/MediaQueryList/addListener
+/en-US/docs/Web/API/MediaQueryList/onchange	/en-US/docs/Web/API/MediaQueryList/change_event
 /en-US/docs/Web/API/MediaQueryListListener	/en-US/docs/Web/API/MediaQueryList
 /en-US/docs/Web/API/MediaRecorder.ondataavailable	/en-US/docs/Web/API/MediaRecorder/ondataavailable
 /en-US/docs/Web/API/MediaRecorder.onerror	/en-US/docs/Web/API/MediaRecorder/onerror

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -58295,6 +58295,16 @@
       "chrisdavidmills"
     ]
   },
+  "Web/API/MediaQueryList/change_event": {
+    "modified": "2020-10-15T21:54:09.424Z",
+    "contributors": [
+      "mfuji09",
+      "chrisdavidmills",
+      "seven-deuce",
+      "ExE-Boss",
+      "fscholz"
+    ]
+  },
   "Web/API/MediaQueryList/matches": {
     "modified": "2020-10-15T21:54:08.347Z",
     "contributors": [
@@ -58314,16 +58324,6 @@
       "ExE-Boss",
       "fscholz",
       "chrisdavidmills"
-    ]
-  },
-  "Web/API/MediaQueryList/onchange": {
-    "modified": "2020-10-15T21:54:09.424Z",
-    "contributors": [
-      "mfuji09",
-      "chrisdavidmills",
-      "seven-deuce",
-      "ExE-Boss",
-      "fscholz"
     ]
   },
   "Web/API/MediaQueryList/removeListener": {

--- a/files/en-us/web/api/mediaquerylist/change_event/index.md
+++ b/files/en-us/web/api/mediaquerylist/change_event/index.md
@@ -6,7 +6,7 @@ tags:
   - CSSOM View
   - Event Handler
   - MediaQueryList
-  - Property
+  - Event
   - Reference
   - onchange
 browser-compat: api.MediaQueryList.change_event

--- a/files/en-us/web/api/mediaquerylist/change_event/index.md
+++ b/files/en-us/web/api/mediaquerylist/change_event/index.md
@@ -33,7 +33,12 @@ An {{domxref("MediaQueryListEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/MediaQueryListEvent", "Properties")}}
+_The `MediaQueryListEvent` interface inherits properties from its parent interface, {{DOMxRef("Event")}}._
+
+- {{DOMxRef("MediaQueryListEvent.matches")}}{{ReadOnlyInline}}
+  - : A boolean value that is `true` if the {{DOMxRef("document")}} currently matches the media query list, or `false` if not.
+- {{DOMxRef("MediaQueryListEvent.media")}}{{ReadOnlyInline}}
+  - : A {{DOMxRef("DOMString")}} representing a serialized media query.
 
 ## Example
 

--- a/files/en-us/web/api/mediaquerylist/change_event/index.md
+++ b/files/en-us/web/api/mediaquerylist/change_event/index.md
@@ -1,6 +1,6 @@
 ---
-title: MediaQueryList.onchange
-slug: Web/API/MediaQueryList/onchange
+title: 'MediaQueryList: change event'
+slug: Web/API/MediaQueryList/change_event
 tags:
   - API
   - CSSOM View
@@ -9,23 +9,31 @@ tags:
   - Property
   - Reference
   - onchange
-browser-compat: api.MediaQueryList.onchange
+browser-compat: api.MediaQueryList.change_event
 ---
 {{APIRef("CSSOM")}}
 
-The **`onchange`** property of the
-{{DOMxRef("MediaQueryList")}} interface is an event handler property representing a
-function that is invoked when the {{domxref("MediaQueryList/change_event", "change")}}
-event fires — that is, when the status of media query support changes. The event object is a
-{{DOMxRef("MediaQueryListEvent")}} instance, which is recognized as a
-`MediaListQuery` instance in older browsers, for backwards compatibility
-purposes.
+The **`change`** event of the {{DOMxRef("MediaQueryList")}} interface fires when the status of media query support changes.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-MediaQueryList.onchange = function() { /* ... */ };
+addEventListener('change', event => { });
+
+onchange = event => { };
 ```
+
+## Event type
+
+An {{domxref("MediaQueryListEvent")}}. Inherits from {{domxref("Event")}}.
+
+{{InheritanceDiagram("MediaQueryListEvent")}}
+
+## Event properties
+
+{{page("/en-US/docs/Web/API/MediaQueryListEvent", "Properties")}}
 
 ## Example
 

--- a/files/en-us/web/api/mediaquerylist/index.md
+++ b/files/en-us/web/api/mediaquerylist/index.md
@@ -47,7 +47,6 @@ _The following events are delivered to `MediaQueryList` objects:_
 
 - {{DOMxRef("MediaQueryList.change_event", "change")}}
   - : Sent to the `MediaQueryList` when the result of running the media query against the document changes. For example, if the media query is `(min-width: 400px)`, the `change` event is fired any time the width of the document's {{Glossary("viewport")}} changes such that its width moves across the 400px boundary in either direction.
-    Also available using the {{DOMxRef("MediaQueryList.onchange", "onchange")}} event handler property.
 
 ## Examples
 

--- a/files/en-us/web/api/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/index.md
@@ -12,7 +12,7 @@ browser-compat: api.MediaQueryListEvent
 ---
 {{APIRef("CSSOM")}}
 
-The `MediaQueryListEvent` object stores information on the changes that have happened to a {{DOMxRef("MediaQueryList")}} object — instances are available as the event object on a function referenced by a {{DOMxRef("MediaQueryList.onchange")}} property or {{DOMxRef("MediaQueryList.addListener()")}} call.
+The `MediaQueryListEvent` object stores information on the changes that have happened to a {{DOMxRef("MediaQueryList")}} object — instances are available as the event object on a function referenced by a {{DOMxRef("MediaQueryList.change_event")}} event.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/index.md
@@ -12,7 +12,7 @@ browser-compat: api.MediaQueryListEvent
 ---
 {{APIRef("CSSOM")}}
 
-The `MediaQueryListEvent` object stores information on the changes that have happened to a {{DOMxRef("MediaQueryList")}} object — instances are available as the event object on a function referenced by a {{DOMxRef("MediaQueryList.change_event")}} event.
+The `MediaQueryListEvent` object stores information on the changes that have happened to a {{DOMxRef("MediaQueryList")}} object — instances are available as the event object on a function referenced by a {{DOMxRef("MediaQueryList.change_event", "change")}} event.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
This PR adapts the change event of the MediaQueryList API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15168
