### PR TITLE
Adapt api.PermissionStatus.onchange to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8753,6 +8753,7 @@
 /en-US/docs/Web/API/PeriodicSyncManager/getTags()	/en-US/docs/Web/API/PeriodicSyncManager/getTags
 /en-US/docs/Web/API/PeriodicSyncManager/register()	/en-US/docs/Web/API/PeriodicSyncManager/register
 /en-US/docs/Web/API/PeriodicSyncManager/unregister()	/en-US/docs/Web/API/PeriodicSyncManager/unregister
+/en-US/docs/Web/API/PermissionStatus/onchange	/en-US/docs/Web/API/PermissionStatus/change_event
 /en-US/docs/Web/API/PermissionStatus/status	/en-US/docs/Web/API/PermissionStatus/state
 /en-US/docs/Web/API/PhotoCapabilities	/en-US/docs/Web/API/ImageCapture/getPhotoCapabilities
 /en-US/docs/Web/API/PhotoCapabilities/fillLightMode	/en-US/docs/Web/API/ImageCapture/getPhotoCapabilities

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -66912,7 +66912,7 @@
       "jpmedley"
     ]
   },
-  "Web/API/PermissionStatus/onchange": {
+  "Web/API/PermissionStatus/change_event": {
     "modified": "2020-10-15T21:34:19.516Z",
     "contributors": [
       "sideshowbarker",

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -65,9 +65,9 @@ function handlePermission() {
       report(result.state);
       geoBtn.style.display = 'inline';
     }
-    result.onchange = function() {
+    result.addEventListener('change', function() {
       report(result.state);
-    }
+    });
   });
 }
 
@@ -108,7 +108,7 @@ function revokePermission() {
 
 ### Responding to permission state changes
 
-You'll notice that there is an `onchange` event handler in the code above, attached to the {{domxref("PermissionStatus")}} object — this allows us to respond to any changes in the permission status for the API we are interested in. At the moment we are just reporting the change in state.
+You'll notice that we're listening to the {{domxref("PermissionStatus.change_event", "change")}} event in the code above, attached to the {{domxref("PermissionStatus")}} object — this allows us to respond to any changes in the permission status for the API we are interested in. At the moment we are just reporting the change in state.
 
 ## Conclusion and future work
 

--- a/files/en-us/web/api/permissionstatus/change_event/index.md
+++ b/files/en-us/web/api/permissionstatus/change_event/index.md
@@ -3,13 +3,11 @@ title: 'PermissionStatus: change event'
 slug: Web/API/PermissionStatus/change_event
 tags:
   - API
-  - Event Handler
-  - Experimental
+  - Event
   - PermissionStatus
   - Permissions
-  - Property
   - Reference
-  - onchange
+  - change
 browser-compat: api.PermissionStatus.change_event
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/permissionstatus/change_event/index.md
+++ b/files/en-us/web/api/permissionstatus/change_event/index.md
@@ -1,6 +1,6 @@
 ---
-title: PermissionStatus.onchange
-slug: Web/API/PermissionStatus/onchange
+title: 'PermissionStatus: change event'
+slug: Web/API/PermissionStatus/change_event
 tags:
   - API
   - Event Handler
@@ -10,18 +10,25 @@ tags:
   - Property
   - Reference
   - onchange
-browser-compat: api.PermissionStatus.onchange
+browser-compat: api.PermissionStatus.change_event
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 
-The **`onchange`** event handler of the {{domxref("PermissionStatus")}} interface is called whenever the {{domxref("PermissionStatus.state")}} property changes.
+The **`change`** event of the {{domxref("PermissionStatus")}} interface fires whenever the {{domxref("PermissionStatus.state")}} property changes.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-PermissionStatus.onchange = function() { /* ... */ }
-PermissionStatus.addEventListener('change', function() { /* ... */ })
+addEventListener('change', event => { });
+
+onchange = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Example
 

--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -26,9 +26,9 @@ The **`PermissionStatus`** interface of the [Permissions API](Permissions_API) p
 - `PermissionStatus.status`{{readonlyinline}} {{deprecated_inline}}
   - : Returns the state of a requested permission; one of `'granted'`, `'denied'`, or `'prompt'`. Later versions of the specification replace this with {{domxref("PermissionStatus.state")}}.
 
-### Event Handler
+### Events
 
-- {{domxref("PermissionStatus.onchange")}}
+- {{domxref("PermissionStatus.change_event", "change")}}
   - : An event called whenever `PermissionStatus.status` changes.
 
 ## Example


### PR DESCRIPTION
This PR adapts the change event of the PermissionStatus API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15181
