### PR TITLE
Update ECMA-262 version in Glossary

### DIFF
--- a/files/en-us/glossary/javascript/index.md
+++ b/files/en-us/glossary/javascript/index.md
@@ -19,7 +19,7 @@ JavaScript is primarily used in the browser, enabling developers to manipulate w
 
 Conceived as a server-side language by Brendan Eich (then employed by the Netscape Corporation), JavaScript soon came to Netscape Navigator 2.0 in September 1995. JavaScript enjoyed immediate success and {{glossary("Microsoft Internet Explorer", "Internet Explorer 3.0")}} introduced JavaScript support under the name JScript in August 1996.
 
-In November 1996, Netscape began working with ECMA International to make JavaScript an industry standard. Since then, the standardized JavaScript is called ECMAScript and specified under ECMA-262, whose latest (eleventh, ES2020) edition is available as of June 2020.
+In November 1996, Netscape began working with Ecma International to make JavaScript an industry standard. Since then, the standardized JavaScript is called ECMAScript and specified under ECMA-262, whose latest (twelfth, ES2021) edition is available as of June 2021.
 
 Recently, JavaScript's popularity has expanded even further through the successful [Node.js](https://nodejs.org/) platform—the most popular cross-platform JavaScript runtime environment outside the browser. Node.js - built using [Chrome's V8 JavaScript Engine](<https://en.wikipedia.org/wiki/V8_(JavaScript_engine)>) - allows developers to use JavaScript as a scripting language to automate things on a computer and build fully functional {{Glossary("HTTP")}} and {{Glossary("WebSockets")}} servers.
 


### PR DESCRIPTION
#### Summary

Update the version of ECMA-262 mentioned here and fix the case problem when referring Ecma International

#### Supporting details

> To reflect the global activities of the Europe-based Ecma  organization, the name of the association was changed in 1994 to: **Ecma International** – European association for standardizing information and communication systems. Though before 1994, ECMA was known as “European  Computer Manufacturers Association”, after 1994, when the organization  became global, the “trademark” “Ecma” was kept for historical reasons.
>
> https://www.ecma-international.org/about-ecma/history/

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
