### PR TITLE
fix `ReadableStreamDefaultController.prototype.error` docs

### DIFF
--- a/files/en-us/web/api/readablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/error/index.md
@@ -37,8 +37,7 @@ readableStreamDefaultController.error(e);
 ### Exceptions
 
 - TypeError
-  - : The source object is not a `ReadableStreamDefaultController`, or the
-    stream is not readable for some other reason.
+  - : The source object is not a `ReadableStreamDefaultController`.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The method is not supposed to throw an exception if the stream is not readable, but to fail silently.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The current docs are not aligned with the spec and major implementations.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://streams.spec.whatwg.org/#rs-default-controller-error says:
> The `error(e)` method steps are:
> Perform ! [ReadableStreamDefaultControllerError](https://streams.spec.whatwg.org/#readable-stream-default-controller-error)([this](https://webidl.spec.whatwg.org/#this), e).

https://streams.spec.whatwg.org/#readable-stream-default-controller-error says:

> ReadableStreamDefaultControllerError(controller, e) performs the following steps:
> Let stream be controller.[[[stream]]](https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-stream).
>
> If stream.[[[state]]](https://streams.spec.whatwg.org/#readablestream-state) is not "readable", return.


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes: https://github.com/nodejs/node/issues/39756

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
