### PR TITLE
Update intentionally incorrect brand

### DIFF
--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -56,7 +56,7 @@ Sec-CH-UA-Full-Version-List: "<brand>";v="<full version>", ...
 ### Directives
 
 - `<brand>`
-  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `" Not A;Brand"` or `"(Not(A:Brand"`.
+  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand _like_ `" Not A;Brand"` or `"(Not(A:Brand"`.
 - `<full version>`
   - : A full version number, such as 98.0.4750.0.
 

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -56,7 +56,7 @@ Sec-CH-UA-Full-Version-List: "<brand>";v="<full version>", ...
 ### Directives
 
 - `<brand>`
-  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `"Not A;Brand"`.
+  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand like `" Not A;Brand"` or `"(Not(A:Brand"`.
 - `<full version>`
   - : A full version number, such as 98.0.4750.0.
 

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -56,7 +56,8 @@ Sec-CH-UA-Full-Version-List: "<brand>";v="<full version>", ...
 ### Directives
 
 - `<brand>`
-  - : A brand associated with the user agent, like "Chromium", "Google Chrome", or an intentionally incorrect brand _like_ `" Not A;Brand"` or `"(Not(A:Brand"`.
+  - : A brand associated with the user agent, like "Chromium", "Google Chrome".
+     This may be an intentionally incorrect brand like `" Not A;Brand"` or `"(Not(A:Brand"` (the actual value is expected change over time and be unpredictable).
 - `<full version>`
   - : A full version number, such as 98.0.4750.0.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`" Not A;Brand"` contains a space in front, as it can be seen on the example request on docs. Also, on newer versions this is replaced with `"(Not(A:Brand"`
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36

Sec-CH-UA: "(Not(A:Brand";v="8.0.0.0", "Chromium";v="98.0.4758.102"
Sec-CH-UA-Platform: Windows
Sec-CH-UA-Mobile: ?0
Sec-CH-UA-Full-Version: 98.0.4758.102
Sec-CH-UA-Platform-Version: 10.0.0
Sec-CH-UA-Arch: x86
Sec-CH-UA-Bitness: "64"
Sec-CH-Prefers-Color-Scheme: light
```

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
