### PR TITLE
new operator precedence example

### DIFF
--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -80,7 +80,7 @@ console.log( A() && B() );
 The AND operator has a higher precedence than the OR operator, meaning the `&&` operator is executed before the `||` operator (see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
 
 ```js
-false || true && true            // returns true
+true || false && false           // returns true
 true && (false || false)         // returns false
 (2 == 3) || (4 < 0) && (1 == 1)  // returns false
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
swapped truth values in first example of Operator precedence in the Logical AND page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Currently, 
`false || true && true === (false || true) && true === true`

It would be better to have at least one example which changes its truth value based on precedence. In the new example,
`true || false && false === true `
but
`(true || false) && false === false`
showing that JavaScript does indeed evaluate && first.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Other two examples also do not change their truth value in this manner.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
