### PR TITLE
Adapt api.SharedWorker.onerror to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9055,6 +9055,7 @@
 /en-US/docs/Web/API/ServiceWorker_API/Using_Service_Workers:_The_Basics	/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 /en-US/docs/Web/API/SharedWorker.SharedWorker	/en-US/docs/Web/API/SharedWorker/SharedWorker
 /en-US/docs/Web/API/SharedWorker.port	/en-US/docs/Web/API/SharedWorker/port
+/en-US/docs/Web/API/SharedWorker/onerror	/en-US/docs/Web/API/SharedWorker/error_event
 /en-US/docs/Web/API/SharedWorkerGlobalScope.applicationCache	/en-US/docs/Web/API/SharedWorkerGlobalScope/applicationCache
 /en-US/docs/Web/API/SharedWorkerGlobalScope.name	/en-US/docs/Web/API/SharedWorkerGlobalScope/name
 /en-US/docs/Web/API/SharedWorkerGlobalScope.onconnect	/en-US/docs/Web/API/SharedWorkerGlobalScope/onconnect

--- a/files/en-us/web/api/sharedworker/error_event/index.md
+++ b/files/en-us/web/api/sharedworker/error_event/index.md
@@ -1,6 +1,6 @@
 ---
-title: SharedWorker.onerror
-slug: Web/API/SharedWorker/onerror
+title: 'SharedWorker: error event'
+slug: Web/API/SharedWorker/error_event
 tags:
   - API
   - SharedWorker
@@ -10,17 +10,25 @@ tags:
   - Web Workers
   - Workers
   - onerror
-browser-compat: api.SharedWorker.onerror
+browser-compat: api.SharedWorker.error_event
 ---
 {{APIRef("Web Workers API")}}
 
-The **`onerror`** property of the {{domxref("SharedWorker")}} interface represents an [event handler](/en-US/docs/Web/Events/Event_handlers), that is a function to be called when the {{event("error")}} event occurs.
+The **`error`** event of the {{domxref("SharedWorker")}} interface fires when an error occurs in the worker.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-mySharedWorker.onerror = function(event) { /* ... */ };
+addEventListener('error', event => { });
+
+onerror = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Example
 

--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -27,10 +27,13 @@ The **`SharedWorker`** interface represents a specific kind of worker that can b
 
 _Inherits properties from its parent, {{domxref("EventTarget")}}._
 
-- {{domxref("SharedWorker.onerror")}}
-  - : Is an {{domxref("EventListener")}} that is called whenever an {{domxref("ErrorEvent")}} of type `error` event occurs.
 - {{domxref("SharedWorker.port")}} {{readonlyInline}}
   - : Returns a {{domxref("MessagePort")}} object used to communicate with and control the shared worker.
+
+## Events
+
+- {{domxref("SharedWorker.error_event", "error")}}
+  - : Fires when an error occurs in the shared worker.
 
 ## Methods
 


### PR DESCRIPTION
This PR adapts the error event of the SharedWorker API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15202
