### PR TITLE
Adapt api.Worker.onerror to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7109,8 +7109,8 @@
 /en-US/docs/Web/API/AbortController/FetchController	/en-US/docs/Web/API/AbortController/AbortController
 /en-US/docs/Web/API/AbortSignal/onabort	/en-US/docs/Web/API/AbortSignal/abort_event
 /en-US/docs/Web/API/AbstractWorker	/en-US/docs/Web/API/Worker
-/en-US/docs/Web/API/AbstractWorker.onerror	/en-US/docs/Web/API/Worker/onerror
-/en-US/docs/Web/API/AbstractWorker/onerror	/en-US/docs/Web/API/Worker/onerror
+/en-US/docs/Web/API/AbstractWorker.onerror	/en-US/docs/Web/API/Worker/error_event
+/en-US/docs/Web/API/AbstractWorker/onerror	/en-US/docs/Web/API/Worker/error_event
 /en-US/docs/Web/API/AddressErrors/regionCode	/en-US/docs/Web/API/AddressErrors
 /en-US/docs/Web/API/AmbientLightSensor/reading	/en-US/docs/Web/API/AmbientLightSensor/illuminance
 /en-US/docs/Web/API/AmbientLightSensorReading	/en-US/docs/Web/API/AmbientLightSensor
@@ -9521,6 +9521,7 @@
 /en-US/docs/Web/API/Worker.terminate	/en-US/docs/Web/API/Worker/terminate
 /en-US/docs/Web/API/Worker/Functions_and_classes_available_to_workers	/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
 /en-US/docs/Web/API/Worker/Functions_available_to_workers	/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
+/en-US/docs/Web/API/Worker/onerror	/en-US/docs/Web/API/Worker/error_event
 /en-US/docs/Web/API/WorkerConsole	/en-US/docs/Web/API/console
 /en-US/docs/Web/API/WorkerConsole.info()	/en-US/docs/Web/API/console/info
 /en-US/docs/Web/API/WorkerConsole.log	/en-US/docs/Web/API/console/log

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -88802,6 +88802,18 @@
       "kscarfone"
     ]
   },
+  "Web/API/Worker/error_event": {
+    "modified": "2020-10-15T21:24:57.038Z",
+    "contributors": [
+      "sideshowbarker",
+      "fscholz",
+      "chrisdavidmills",
+      "nmve",
+      "erikadoyle",
+      "teoli",
+      "tregagnon"
+    ]
+  },
   "Web/API/Worker/message_event": {
     "modified": "2020-10-15T22:17:08.440Z",
     "contributors": [
@@ -88812,18 +88824,6 @@
     "modified": "2020-10-15T22:17:02.572Z",
     "contributors": [
       "wbamberg"
-    ]
-  },
-  "Web/API/Worker/onerror": {
-    "modified": "2020-10-15T21:24:57.038Z",
-    "contributors": [
-      "sideshowbarker",
-      "fscholz",
-      "chrisdavidmills",
-      "nmve",
-      "erikadoyle",
-      "teoli",
-      "tregagnon"
     ]
   },
   "Web/API/Worker/onmessage": {

--- a/files/en-us/web/api/worker/error_event/index.md
+++ b/files/en-us/web/api/worker/error_event/index.md
@@ -5,7 +5,7 @@ tags:
   - API
   - Worker
   - EventHandler
-  - Property
+  - Event
   - Reference
   - Web Workers
   - Workers

--- a/files/en-us/web/api/worker/error_event/index.md
+++ b/files/en-us/web/api/worker/error_event/index.md
@@ -1,6 +1,6 @@
 ---
-title: Worker.onerror
-slug: Web/API/Worker/onerror
+title: 'Worker: error event'
+slug: Web/API/Worker/error_event
 tags:
   - API
   - Worker
@@ -10,17 +10,25 @@ tags:
   - Web Workers
   - Workers
   - onerror
-browser-compat: api.Worker.onerror
+browser-compat: api.Worker.error_event
 ---
 {{APIRef("Web Workers API")}}
 
-The **`onerror`** property of the {{domxref("Worker")}} interface represents an [event handler](/en-US/docs/Web/Events/Event_handlers), that is a function to be called when the {{event("error")}} event occurs.
+The **`error`** event of the {{domxref("Worker")}} interface fires when an error occurs in the worker.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-myWorker.onerror = function(event) { /* ... */ };
+addEventListener('error', event => { });
+
+onerror = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Example
 

--- a/files/en-us/web/api/worker/index.md
+++ b/files/en-us/web/api/worker/index.md
@@ -35,8 +35,6 @@ _Inherits properties from its parent, {{domxref("EventTarget")}}._
 
 ### Event handlers
 
-- {{domxref("Worker.onerror")}}
-  - : An {{ domxref("EventListener") }} called whenever an {{domxref("ErrorEvent")}} of type `error` event occurs.
 - {{domxref("Worker.onmessage")}}
   - : An {{ domxref("EventListener") }} called whenever a {{domxref("MessageEvent")}} of type `message` occurs — i.e. when a message is sent to the parent document from the worker via {{domxref("DedicatedWorkerGlobalScope.postMessage")}}. The message is stored in the event's {{domxref("MessageEvent.data", "data")}} property.
 - {{domxref("Worker.onmessageerror")}}
@@ -53,6 +51,8 @@ _Inherits methods from its parent, {{domxref("EventTarget")}}._
 
 ## Events
 
+- [`error`](/en-US/docs/Web/API/Worker/error_event)
+  - : Fires when an error occurs in the worker.
 - [`message`](/en-US/docs/Web/API/Worker/message_event)
   - : Fires when the worker's parent receives a message from that worker.
     Also available via the [`onmessage`](/en-US/docs/Web/API/Worker/onmessage) property.


### PR DESCRIPTION
This PR adapts the error event of the Worker API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15203
