### PR TITLE
Change HTML table to a modern list (AudioProcessingEvent)

### DIFF
--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -20,72 +20,21 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` re
 
 ## Properties
 
-_The list below includes the properties inherited from its parent, {{domxref("Event")}}_.
+_Also implements the properties inherited from its parent, {{domxref("Event")}}_.
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Property</th>
-      <th scope="col">Type</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>target</code> {{ReadOnlyInline}}</td>
-      <td>{{domxref("EventTarget")}}</td>
-      <td>The event target (the topmost target in the DOM tree).</td>
-    </tr>
-    <tr>
-      <td><code>type</code> {{ReadOnlyInline}}</td>
-      <td>{{domxref("DOMString")}}</td>
-      <td>The type of event.</td>
-    </tr>
-    <tr>
-      <td><code>bubbles</code> {{ReadOnlyInline}}</td>
-      <td><code>boolean</code></td>
-      <td>Does the event normally bubble?</td>
-    </tr>
-    <tr>
-      <td><code>cancelable</code> {{ReadOnlyInline}}</td>
-      <td><code>boolean</code></td>
-      <td>Is it possible to cancel the event?</td>
-    </tr>
-    <tr>
-      <td><code>playbackTime</code> {{ReadOnlyInline}}</td>
-      <td><code>double</code></td>
-      <td>
-        The time when the audio will be played, as defined by the time of
-        {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}
-      </td>
-    </tr>
-    <tr>
-      <td><code>inputBuffer</code> {{ReadOnlyInline}}</td>
-      <td>{{domxref("AudioBuffer")}}</td>
-      <td>
-        The buffer containing the input audio data to be processed. The number
-        of channels is defined as a parameter,
-        <code>numberOfInputChannels</code>, of the factory method
-        {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
-        Note the returned <code>AudioBuffer</code> is only valid in the scope of
-        the <code>onaudioprocess</code> function.
-      </td>
-    </tr>
-    <tr>
-      <td><code>outputBuffer</code> {{ReadOnlyInline}}</td>
-      <td>{{domxref("AudioBuffer")}}</td>
-      <td>
-        The buffer where the output audio data should be written. The number of
-        channels is defined as a parameter, <code>numberOfOutputChannels</code>,
-        of the factory method
-        {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
-        Note the returned <code>AudioBuffer</code> is only valid in the scope of
-        the <code>onaudioprocess</code> function.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
+- `playbackTime` {{ReadOnlyInline}}</td>
+ - : A double representing the time when the audio will be played, 
+   as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
+- `inputBuffer` {{ReadOnlyInline}}
+  - : An {{domxref("AudioBuffer")}} that is the buffer containing the input audio data to be processed. 
+    The number of channels is defined as a parameter `numberOfInputChannels`,
+    of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
+    Note that the returned <code>AudioBuffer</code> is only valid in the scope of the event handler.
+- `outputBuffer` {{ReadOnlyInline}}
+  - : An {{domxref("AudioBuffer")}} that is the buffer where the output audio data should be written. 
+    The number of channels is defined as a parameter, <code>numberOfOutputChannels</code>,
+    of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
+    Note that the returned <code>AudioBuffer</code> is only valid in the scope of the event handler.
 ## Example
 
 See [`BaseAudioContext.createScriptProcessor()`](/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example) for example code that uses an `AudioProcessingEvent`.


### PR DESCRIPTION
The properties are listed in an HTML table. This PR changes it to the modern dl list, conforming to the modern template.