### PR TITLE
Undo incorrect fix to justify-items syntax

### DIFF
--- a/files/en-us/web/css/justify-items/index.md
+++ b/files/en-us/web/css/justify-items/index.md
@@ -95,7 +95,7 @@ This property can take one of four different forms:
 - `left`
   - : The items are packed flush to each other toward the left edge of the alignment container. If the property's axis is not parallel with the inline axis, this value behaves like `start`.
 - `right`
-  - : The items are packed flush to each other toward the right edge of the alignment container in the appropriate axis. If the property's axis is not parallel with the inline axis, this value behaves like `end`.
+  - : The items are packed flush to each other toward the right edge of the alignment container in the appropriate axis. If the property's axis is not parallel with the inline axis, this value behaves like `start`.
 - `baseline`, `first baseline`, `last baseline`
   - : Specifies participation in first- or last-baseline alignment: aligns the alignment baseline of the box's first or last baseline set with the corresponding baseline in the shared first or last baseline set of all the boxes in its baseline-sharing group.
     The fallback alignment for `first baseline` is `start`, the one for `last baseline` is `end`.


### PR DESCRIPTION
See https://github.com/mdn/content/issues/11138#issuecomment-1060395183 - we changed this value in https://github.com/mdn/content/pull/13295 but it looks like that was incorrect.