### PR TITLE
FF99 ReleaseNote: Navigator.pdfViewerEnabled

### DIFF
--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -37,6 +37,10 @@ This article provides information about the changes in Firefox 99 that will affe
 
 ### APIs
 
+- {{domxref("navigator.pdfViewerEnabled")}} is now enabled, and is the recommend way to determine whether a browser supports inline display of PDF files when navigating to them.
+  Sites that use the deprecated properties {{domxref("navigator.plugins")}} and {{domxref("navigator.mimeTypes")}} to infer PDF viewer support should now use the new property, even though these now return hard-coded mock values that match the signal provided by `pdfViewerEnabled` ({{bug(1720353)}}).
+
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF99 supports `Navigator.pdfViewerEnabled`  - see bug  https://bugzilla.mozilla.org/show_bug.cgi?id=1720353

This adds a release note. The other docs work can be tracked in #13370
