### PR TITLE
fix syntax in example: correct arrow function syntax

### DIFF
--- a/files/en-us/web/api/window/gamepadconnected_event/index.md
+++ b/files/en-us/web/api/window/gamepadconnected_event/index.md
@@ -23,7 +23,7 @@ This event is not cancelable and does not bubble.
 To be informed when a gamepad is connected, you can add a handler to the window using {{domxref("EventTarget.addEventListener", "addEventListener()")}}, like this:
 
 ```js
-window.addEventListener('gamepadconnected', (event) => {
+window.addEventListener('gamepadconnected', event => {
     // All buttons and axes values can be accessed through
     const gamepad = event.gamepad;
 });
@@ -32,10 +32,10 @@ window.addEventListener('gamepadconnected', (event) => {
 Alternatively, you can use the `window.ongamepadconnected` event handler property to establish a handler for the `gamepadconnected` event:
 
 ```js
-window.ongamepadconnected ((event) => {
+window.ongamepadconnected = event => {
     // All buttons and axes values can be accessed through
     const gamepad = event.gamepad;
-});
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/window/gamepadconnected_event/index.md
+++ b/files/en-us/web/api/window/gamepadconnected_event/index.md
@@ -23,7 +23,7 @@ This event is not cancelable and does not bubble.
 To be informed when a gamepad is connected, you can add a handler to the window using {{domxref("EventTarget.addEventListener", "addEventListener()")}}, like this:
 
 ```js
-window.addEventListener('gamepadconnected', event => {
+window.addEventListener('gamepadconnected', (event) => {
     // All buttons and axes values can be accessed through
     const gamepad = event.gamepad;
 });
@@ -32,7 +32,7 @@ window.addEventListener('gamepadconnected', event => {
 Alternatively, you can use the `window.ongamepadconnected` event handler property to establish a handler for the `gamepadconnected` event:
 
 ```js
-window.ongamepadconnected = event => {
+window.ongamepadconnected ((event) => {
     // All buttons and axes values can be accessed through
     const gamepad = event.gamepad;
 });


### PR DESCRIPTION
fixes #13626