### PR TITLE
Improve the fallback example for :focus-visible

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -74,10 +74,12 @@ custom-button:focus {
   background: lightgrey;
 }
 
-custom-button:focus:not(:focus-visible) {
-  /* Remove the focus indicator on mouse-focus for browsers
-     that do support :focus-visible */
-  background: transparent;
+@supports selector(:focus-visible) {
+  custom-button:focus {
+    /* Remove the focus indicator on mouse-focus for browsers
+       that do support :focus-visible */
+    background: transparent;
+  }
 }
 
 custom-button:focus-visible {
@@ -89,7 +91,7 @@ custom-button:focus-visible {
 }
 ```
 
-{{EmbedLiveSample("Selectively_showing_the_focus_indicator", "100%", 60)}}
+{{EmbedLiveSample("Selectively_showing_the_focus_indicator", "100%", 72)}}
 
 ## Accessibility concerns
 


### PR DESCRIPTION
#### Summary

Replacing a block of code with a more readable and less problematic one.

#### Motivation

In the overriding selector, the `:not()` pseudo-class increases specificity, which can cause problems with other styles on `:hover`, `:active`, and other pseudo-classes. And in the case of `@supports`, the specificity remains the same as for simple pseudo-class selectors.

In addition, the `@supports` option is easier to read. I often have to give students a link to this code, and many find it difficult to understand such a selector. But `@supports` is always easily understood by everyone.

#### Supporting details

[This code works](https://codepen.io/firefoxic/pen/LYOoGJY) exactly the same as the original one.

#### Metadata

- [x] Rewrites (or significantly expands) a document

