### PR TITLE
Add missing default value for 'rows' attribute for <textarea>

### DIFF
--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -85,7 +85,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - {{ htmlattrdef("required") }}
   - : This attribute specifies that the user must fill in a value before submitting a form.
 - {{ htmlattrdef("rows") }}
-  - : The number of visible text lines for the control.
+  - : The number of visible text lines for the control. If it is specified, it must be a positive integer. If it is not specified, the default value is 2.
 - {{ htmlattrdef("spellcheck") }}
 
   - : Specifies whether the `<textarea>` is subject to spell checking by the underlying browser/OS. The value can be:


### PR DESCRIPTION
Reference: https://www.w3schools.com/tags/att_textarea_rows.asp

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In `<textarea>` docs page, add missing default value for 'rows' attribute.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
When looking into it, I noticed there was a default value for `cols` but not for `rows`. I googled for it and arrived to [W3C webpage](https://www.w3schools.com/tags/att_textarea_rows.asp) where it says its default value.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* MDN `<textarea>` page
   * [`cols` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols)
   * [`rows` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows)

* https://www.w3schools.com/tags/att_textarea_rows.asp

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
