### PR TITLE
Fix EventTarget.addEventListener anchor reference

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -475,6 +475,7 @@ Click the outer, middle, inner containers respectively to see how the options wo
 Before using a particular value in the `options` object, it's a
 good idea to ensure that the user's browser supports it, since these are an addition
 that not all browsers have supported historically. See {{anch("Safely detecting option support")}} for details.
+
 ## Other notes
 
 ### The value of "this" within the handler

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -475,7 +475,7 @@ Click the outer, middle, inner containers respectively to see how the options wo
 Before using a particular value in the `options` object, it's a
 good idea to ensure that the user's browser supports it, since these are an addition
 that not all browsers have supported historically. See {{anch("Safely detecting option
-  support")}} for details.
+ support")}} for details.
 
 ## Other notes
 

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -474,9 +474,7 @@ Click the outer, middle, inner containers respectively to see how the options wo
 
 Before using a particular value in the `options` object, it's a
 good idea to ensure that the user's browser supports it, since these are an addition
-that not all browsers have supported historically. See {{anch("Safely detecting option
- support")}} for details.
-
+that not all browsers have supported historically. See {{anch("Safely detecting option support")}} for details.
 ## Other notes
 
 ### The value of "this" within the handler


### PR DESCRIPTION
#### Summary
This fixes a broken same-page anchor on the `EventTarget.addEventListener` page.

#### Motivation
I clicked this link and it went to the top of the page instead of the correct section. It looks like some newline wrapping added an extra space and broke the reference.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
