### PR TITLE
Adapt api.Window.orientationchange_event to new events structure

### DIFF
--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -449,7 +449,6 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
     Also available via the {{domxref("WindowEventHandlers/onlanguagechange", "onlanguagechange")}} property.
 - {{domxref("Window/orientationchange_event", "orientationchange")}} {{deprecated_inline}}
   - : Fired when the orientation of the device has changed.
-    Also available via the {{domxref("Window/onorientationchange", "onorientationchange")}} property.
 - {{domxref("Window/devicemotion_event", "devicemotion")}}
   - : Fired at a regular interval, indicating the amount of physical force of acceleration the device is receiving and the rate of rotation, if available.
 - {{domxref("Window/deviceorientation_event", "deviceorientation")}}

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -37,7 +37,7 @@ A generic {{domxref("Event")}}.
 You can use the `orientationchange` event in an {{domxref("EventTarget/addEventListener", "addEventListener")}} method:
 
 ```js
-window.addEventListener("orientationchange", (event) => {
+window.addEventListener("orientationchange", event => {
   console.log("the orientation of the device is now " + event.target.screen.orientation.angle);
 });
 ```

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -37,7 +37,7 @@ A generic {{domxref("Event")}}.
 You can use the `orientationchange` event in an {{domxref("EventTarget/addEventListener", "addEventListener")}} method:
 
 ```js
-window.addEventListener("orientationchange", function(event) {
+window.addEventListener("orientationchange", (event) => {
   console.log("the orientation of the device is now " + event.target.screen.orientation.angle);
 });
 ```

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -45,7 +45,7 @@ window.addEventListener("orientationchange", function(event) {
 Or use the `onorientationchange` event handler property:
 
 ```js
-window.onorientationchange = function(event) {
+window.onorientationchange = event => {
   console.log("the orientation of the device is now " + event.target.screen.orientation.angle);
 };
 ```

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -7,37 +7,30 @@ tags:
   - Reference
   - Sensors
   - Window
-  - onorientationchange
+  - orientationchange
 browser-compat: api.Window.orientationchange_event
 ---
 {{APIRef}} {{Deprecated_Header}}
 
 The `orientationchange` event is fired when the orientation of the device has changed.
 
+This event is not cancelable and does not bubble.
+
 This event is deprecated. Listen for the {{domxref("ScreenOrientation/onchange", "ScreenOrientation.onchange")}} event instead.
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Bubbles</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th scope="row">Cancelable</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th scope="row">Interface</th>
-      <td>{{domxref("Event")}}</td>
-    </tr>
-    <tr>
-      <th scope="row">Event handler</th>
-      <td>
-        {{domxref("Window/onorientationchange", "onorientationchange")}}
-      </td>
-    </tr>
-  </tbody>
-</table>
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('orientationchange', event => { });
+
+onorientationchange = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Example
 
@@ -49,7 +42,7 @@ window.addEventListener("orientationchange", function(event) {
 });
 ```
 
-Or use the {{domxref("Window/onorientationchange", "onorientationchange")}} event handler property:
+Or use the `onorientationchange` event handler property:
 
 ```js
 window.onorientationchange = function(event) {


### PR DESCRIPTION
This PR adapts the orientationchange event of the Window API to conform to the new events structure.

