### PR TITLE
Update `color-mix()` article to correct outdated information

### DIFF
--- a/files/en-us/web/css/color_value/color-mix()/index.md
+++ b/files/en-us/web/css/color_value/color-mix()/index.md
@@ -25,7 +25,7 @@ color-mix(in srgb, #34c9eb 20%, white);
 
 - Functional notation: `color-mix( in <colorspace> , [ <color> && <percentage>? ]#{2})`
 
-  - : `<colorspace>` is one of `srgb`, `hsl`, `hwb`, `xyz`, `lab`, `lch`. If no colorspace is specified the default is `lch`.
+  - : `<colorspace>` is one of `srgb`, `srgb-linear`, `lab`, `oklab`, `xyz`, `xyz-d50`, `xyz-d65`, `hsl`, `hwb`, `lch`, `oklch`. There is no default.
 
     `<color>` is any valid {{cssxref("color_value","color")}}.
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Update to latest CSS Color 5 spec for the [list of colorspaces](https://drafts.csswg.org/css-color-4/#interpolation-space). Removed the LCH default (colorspace is now required)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'm the spec editor and want MDN to be up to date

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
