### PR TITLE
Adapt api.Document.pointerlock[change/error] to new events structure

### DIFF
--- a/files/en-us/web/api/document/pointerlockchange_event/index.md
+++ b/files/en-us/web/api/document/pointerlockchange_event/index.md
@@ -13,28 +13,21 @@ browser-compat: api.Document.pointerlockchange_event
 
 The `pointerlockchange` event is fired when the pointer is locked/unlocked.
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Bubbles</th>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th scope="row">Cancelable</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th scope="row">Interface</th>
-      <td>{{domxref("Event")}}</td>
-    </tr>
-    <tr>
-      <th scope="row">Event handler property</th>
-      <td>
-        {{domxref("Document/onpointerlockchange", "onpointerlockchange")}}
-      </td>
-    </tr>
-  </tbody>
-</table>
+This event is not cancelable.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('pointerlockchange', event => { });
+
+onpointerlockchange = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/document/pointerlockerror_event/index.md
+++ b/files/en-us/web/api/document/pointerlockerror_event/index.md
@@ -13,28 +13,21 @@ browser-compat: api.Document.pointerlockerror_event
 
 The `pointerlockerror` event is fired when locking the pointer failed (for technical reasons or because the permission was denied).
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Bubbles</th>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th scope="row">Cancelable</th>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th scope="row">Interface</th>
-      <td>{{domxref("Event")}}</td>
-    </tr>
-    <tr>
-      <th scope="row">Event handler property</th>
-      <td>
-        {{domxref("Document/onpointerlockerror", "onpointerlockerror")}}
-      </td>
-    </tr>
-  </tbody>
-</table>
+This event is not cancelable.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('pointerlockerror', event => { });
+
+onpointerlockerror = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 


### PR DESCRIPTION
This PR adapts the pointerlockchange and pointerlockerror event of the Document API to conform to the new events structure.
