### PR TITLE
modernize service worker examples to use async/await

### DIFF
--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -119,7 +119,7 @@ After your service worker is registered, the browser will attempt to install the
 
 The install event is fired when an install is successfully completed. The install event is generally used to populate your browser's offline caching capabilities with the assets you need to run your app offline. To do this, we use Service Worker's storage API — {{domxref("cache")}} — a global object on the service worker that allows us to store assets delivered by responses, and keyed by their requests. This API works in a similar way to the browser's standard cache, but it is specific to your domain. It persists until you tell it not to — again, you have full control.
 
-Let's start this section by looking at a code sample — this is the first one of two important [parts you'll find in our service worker](https://github.com/mdn/sw-test/blob/gh-pages/sw.js#L1-54):
+Here's how our service worker handles the `install` event:
 
 ```js
 const addResourcesToCache = async (resources) => {

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -344,7 +344,7 @@ self.addEventListener('activate', (event) => {
 
 Then use {{domxref("FetchEvent.preloadResponse", "event.preloadResponse")}} to wait for the preloaded resource to finish downloading in the `fetch` event handler.
 
-Continuing the example from the previous sections, we insert the code to wait for the preloaded resource between the cache check and fetching from the network if that doesn't succeed.
+Continuing the example from the previous sections, we insert the code to wait for the preloaded resource after the cache check, and before fetching from the network if that doesn't succeed.
 
 The new process is:
 

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -52,14 +52,6 @@ To demonstrate just the very basics of registering and installing a service work
 
 You can see the [source code on GitHub](https://github.com/mdn/sw-test/), and [view the example live](https://mdn.github.io/sw-test/).
 
-
-
-## Enter service workers
-
-> **Note:** We're using the [es6](http://es6-features.org/) **arrow functions** syntax in the Service Worker Implementation.
-
-Now let's get on to service workers!
-
 ### Registering your worker
 
 The first block of code in our app's JavaScript file — `app.js` — is as follows. This is our entry point into using service workers.

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -342,7 +342,7 @@ self.addEventListener('activate', (event) => {
 });
 ```
 
-Then use {{domxref("FetchEvent.preloadResponse", "event.preloadResponse")}} to wait for the preloaded resource to finish downloading in our `fetch` event handler.
+Then use {{domxref("FetchEvent.preloadResponse", "event.preloadResponse")}} to wait for the preloaded resource to finish downloading in the `fetch` event handler.
 
 Continuing the example from the previous sections, we insert the code to wait for the preloaded resource between the cache check and fetching from the network if that doesn't succeed.
 

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -341,7 +341,7 @@ If the resources aren't in the cache, they are requested from the network.
 If we were being really clever, we would not only request the resource from the network; we would also save it into the cache so that later requests for that resource could be retrieved offline too! This would mean that if extra images were added to the Star Wars gallery, our app could automatically grab them and cache them. The following would do the trick:
 
 ```js
-const putInCache = async response => {
+const putInCache = async (request, response) => {
   const cache = await caches.open("v1");
   await cache.put(request, response);
 }

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -422,7 +422,7 @@ If your service worker has previously been installed, but then a new version of 
 You'll want to update your `install` event listener in the new service worker to something like this (notice the new version number):
 
 ```js
-const addResourcesToCache = async (resources)=>{
+const addResourcesToCache = async (resources) => {
   const cache = await caches.open('v2')
   await cache.addAll(resources);
 }

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -422,22 +422,25 @@ If your service worker has previously been installed, but then a new version of 
 You'll want to update your `install` event listener in the new service worker to something like this (notice the new version number):
 
 ```js
-const addResourcesToCache = async ()=>{
+const addResourcesToCache = async (resources)=>{
   const cache = await caches.open('v2')
-  await cache.addAll([
-    './sw-test/',
-    './sw-test/index.html',
-    './sw-test/style.css',
-    './sw-test/app.js',
-    './sw-test/image-list.js',
-
-    …
-
-    // include other new resources for the new version...
-  ]);
+  await cache.addAll(resources);
 }
+
 self.addEventListener('install', (event) => {
-  event.waitUntil(addResourcesToCache());
+  event.waitUntil(addResourcesToCache(
+    [
+      './sw-test/',
+      './sw-test/index.html',
+      './sw-test/style.css',
+      './sw-test/app.js',
+      './sw-test/image-list.js',
+
+      …
+
+      // include other new resources for the new version...
+    ]
+  ));
 });
 ```
 

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -323,9 +323,10 @@ We have opted for this fallback image because the only updates that are likely t
 
 ## Service Worker Navigation Preload
 
-If enabled, this feature starts downloading resources as soon as the fetch request is made, and in parallel with service worker bootup. This ensures that download starts immediately, rather than having to wait until the service worker has booted. That delay happens relatively rarely, but is unavoidable when it does happen, and significant.
+If enabled, the [navigation preload](/en-US/docs/Web/API/NavigationPreloadManager) feature starts downloading resources as soon as the fetch request is made, and in parallel with service worker bootup.
+This ensures that download starts immediately, rather than having to wait until the service worker has booted. That delay happens relatively rarely, but is unavoidable when it does happen, and may be significant.
 
-First the feature needs be enabled with `registration.navigationPreload.enable()`:
+First the feature needs be enabled with {{domxref("NavigationPreloadManager.enable()", "registration.navigationPreload.enable()")}}:
 
 ```js
 const enableNavigationPreload = async () => {
@@ -340,7 +341,9 @@ self.addEventListener('activate', (event) => {
 });
 ```
 
-Then we need to make use of `event.preloadResponse`, which is passed as `preloadResponsePromise` to the `cacheFirst` function. Instead of first doing a cache check and then fetching from the network if that doesn't succeed, there is a middle step. So the new process is:
+Then we need to make use of {{domxref("FetchEvent.preloadResponse", "event.preloadResponse")}}, which is passed as `preloadResponsePromise` to the `cacheFirst` function.
+Instead of first doing a cache check and then fetching from the network if that doesn't succeed, there is a middle step.
+So the new process is:
 
 1. Check cache
 2. Wait on `preloadResponsePromise`
@@ -364,7 +367,7 @@ const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
     return responseFromCache;
   }
 
-  // Next try to use the preloaded response, if it's there
+  // Next try to use (and cache) the preloaded response, if it's there
   const preloadResponse = await preloadResponsePromise;
   if (preloadResponse) {
     console.info('using preload response', preloadResponse);


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/7006
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Updates the service worker examples to use async/await instead of promise.then.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
In many cases, async/await makes the code easier to understand. The service worker examples are probably a good use case for `async`/`await`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
https://github.com/mdn/content/issues/2739

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
