### PR TITLE
FormData: Mention `fetch` as alternative to `XMLHttpRequest`

### DIFF
--- a/files/en-us/web/api/formdata/index.md
+++ b/files/en-us/web/api/formdata/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FormData
 ---
 {{APIRef("XMLHttpRequest")}}
 
-The **`FormData`** interface provides a way to easily construct a set of key/value pairs representing form fields and their values, which can then be easily sent using the {{domxref("XMLHttpRequest.send()")}} method. It uses the same format a form would use if the encoding type were set to `"multipart/form-data"`.
+The **`FormData`** interface provides a way to easily construct a set of key/value pairs representing form fields and their values, which can then be easily sent using the {{domxref("fetch()")}} or {{domxref("XMLHttpRequest.send()")}} method. It uses the same format a form would use if the encoding type were set to `"multipart/form-data"`.
 
 You can also pass it directly to the {{domxref("URLSearchParams")}} constructor if you want to generate query parameters in the way a {{HTMLElement("form")}} would do if it were using simple `GET` submission.
 


### PR DESCRIPTION
Feel free to merge or close without discussion! Just a small addition, because we probably want new users to learn about `fetch` before `XMLHttpRequest`