### PR TITLE
Fix formatting flub in JS Reference/Errors/Deprecated_octal

### DIFF
--- a/files/en-us/web/javascript/reference/errors/deprecated_octal/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_octal/index.md
@@ -32,7 +32,7 @@ for octal literals use the "0o" prefix instead
 Octal literals and octal escape sequences are deprecated and will throw a
 {{jsxref("SyntaxError")}} in strict mode. With ECMAScript 2015 and later, the
 standardized syntax uses a leading zero followed by a lowercase or uppercase Latin
-letter "O" (`0o` or `0O)`.
+letter "O" (`0o` or `0O`).
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
fix a small formatting typo

#### Motivation
clarity :)

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
