### PR TITLE
Remove useless prefix for an event in PictureInPictureWindow

### DIFF
--- a/files/en-us/web/api/pictureinpicturewindow/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/index.md
@@ -37,7 +37,7 @@ _The `PictureInPictureWindow` interface doesn't inherit any methods._
 
 _The `PictureInPictureWindow` interface doesn't inherit any events._
 
-- {{domxref("PictureInPictureWindow.resize_event", "PictureInPictureWindow.resize")}}
+- {{domxref("PictureInPictureWindow.resize_event", "resize")}}
   - : Sent to a {{DOMxRef("PictureInPictureWindow")}} when the floating video window is resized.
 
 ## Examples


### PR DESCRIPTION
We don't prefix events with the object interface as they are not really part of the interface.