### PR TITLE
Fixed incorrect type in addEventListener

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -21,9 +21,9 @@ The `readystatechange` event is fired whenever the {{domxref("XMLHttpRequest.rea
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('readyState', event => { })
+addEventListener('readystatechange', event => { })
 
-onreadyState = event => { }
+onreadystatechange = event => { }
 ```
 
 ## Event type


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

```
addEventListener('readyState', event => { })

onreadyState = event => { }
```

should be changed to

```
addEventListener('readystatechange', event => { })

onreadystatechange = event => { }
```
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I think this is a typo.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
none.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
none.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
