### PR TITLE
Removing deprecated Symbol.toSource from methods section

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -104,8 +104,6 @@ The method {{jsxref("Object.getOwnPropertySymbols()")}} returns an array of Symb
 
 ## Instance methods
 
-- {{jsxref("Symbol.prototype.toSource()")}}
-  - : Returns a string containing the source of the Symbol. Overrides the {{jsxref("Object.prototype.toSource()")}} method.
 - {{jsxref("Symbol.prototype.toString()")}}
   - : Returns a string containing the description of the Symbol. Overrides the {{jsxref("Object.prototype.toString()")}} method.
 - {{jsxref("Symbol.prototype.valueOf()")}}


### PR DESCRIPTION
The Symbol.toSource method is deprecated and is not listed in any other built-in object article.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removed the Symbol.toSource part of the article.

<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
In all the other built-in objects articles the toSource instance method is not listed since is deprecated and avoiding its use is recommend, the method has been removed from all major browsers already so its the best to remove it from the Symbol article too.

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
