### PR TITLE
Move "Compatibility notes" section inside "Browser compatibility" section

### DIFF
--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.md
@@ -62,7 +62,7 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA8_ETC2_EAC, 512, 51
 
 {{Compat}}
 
-## Compatibility notes
+### Compatibility notes
 
 - This extension was named `WEBGL_compressed_texture_es3` from Firefox 46 to Firefox 51 and used to be available on the WebGL 2 context by default – this is not the case anymore. You have to enable it on both, WebGL 1 and WebGL 2 contexts, in order to use it.
 

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -120,7 +120,7 @@ value2
 
 {{Compat}}
 
-## Compatibility notes
+### Compatibility notes
 
 - Firefox 5 handles the `Content-Disposition` HTTP response header more effectively if both the `filename` and `filename*` parameters are provided; it looks through all provided names, using the `filename*` parameter if one is available, even if a `filename` parameter is included first. Previously, the first matching parameter would be used, thereby preventing a more appropriate name from being used. See {{bug(588781)}}.
 - Firefox 82 (and later) and Chrome prioritize the HTML [\<a> element's](/en-US/docs/Web/HTML/Element/a) `download` attribute over the `Content-Disposition` `inline` parameter (for [same-origin URLs](/en-US/docs/Web/Security/Same-origin_policy)). Earlier Firefox versions prioritize the header and will display the content inline.

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -99,7 +99,7 @@ The following connections are blocked and won't load:
 
 {{Compat}}
 
-## Compatibility notes
+### Compatibility notes
 
 - Prior to Firefox 23, `xhr-src` was used in place of the
   `connect-src` directive and only restricted the use of

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -224,7 +224,7 @@ Set-Cookie: __Host-id=1; Secure; Path=/; Domain=example.com
 
 {{Compat}}
 
-## Compatibility notes
+### Compatibility notes
 
 - Starting with Chrome 52 and Firefox 52, insecure sites (`http:`) can't set cookies with the `Secure` attribute anymore.
 

--- a/files/en-us/web/http/headers/vary/index.md
+++ b/files/en-us/web/http/headers/vary/index.md
@@ -50,7 +50,7 @@ Vary: <header-name>, <header-name>, ...
 
 {{Compat}}
 
-## Compatibility notes
+### Compatibility notes
 
 - [Vary with care – Vary header problems in IE6-9](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
 

--- a/files/en-us/web/http/status/204/index.md
+++ b/files/en-us/web/http/status/204/index.md
@@ -34,7 +34,7 @@ A 204 response is cacheable by default (an {{HTTPHeader("ETag")}} header is incl
 
 {{Compat}}
 
-## Compatibility notes
+### Compatibility notes
 
 - Although this status code is intended to describe a response with no body, servers
   may erroneously include data following the headers. The protocol allows user agents to

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -40,7 +40,7 @@ headers {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}},
 
 {{Compat}}
 
-## Compatibility Notes
+### Compatibility notes
 
 - Browser behavior differs if this response erroneously includes a body on persistent
   connections See [204 No Content](/en-US/docs/Web/HTTP/Status/204) for more

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.md
@@ -37,23 +37,6 @@ initialized to 0.
 A {{jsxref("RangeError")}} is thrown if the `length` is larger than
 {{jsxref("Number.MAX_SAFE_INTEGER")}} (>= 2 \*\* 53) or negative.
 
-## Compatibility notes
-
-Starting with ECMAScript 2015, `ArrayBuffer` constructors require to be
-constructed with a {{jsxref("Operators/new", "new")}} operator. Calling an
-`ArrayBuffer` constructor as a function without `new`, will throw
-a {{jsxref("TypeError")}} from now on.
-
-```js example-bad
-var dv = ArrayBuffer(10);
-// TypeError: calling a builtin ArrayBuffer constructor
-// without new is forbidden
-```
-
-```js example-good
-var dv = new ArrayBuffer(10);
-```
-
 ## Examples
 
 ### Creating an ArrayBuffer
@@ -73,6 +56,23 @@ var view   = new Int32Array(buffer);
 ## Browser compatibility
 
 {{Compat}}
+
+### Compatibility notes
+
+Starting with ECMAScript 2015, `ArrayBuffer` constructors require to be
+constructed with a {{jsxref("Operators/new", "new")}} operator. Calling an
+`ArrayBuffer` constructor as a function without `new`, will throw
+a {{jsxref("TypeError")}} from now on.
+
+```js example-bad
+var dv = ArrayBuffer(10);
+// TypeError: calling a builtin ArrayBuffer constructor
+// without new is forbidden
+```
+
+```js example-good
+var dv = new ArrayBuffer(10);
+```
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Moved the "Compatibility notes" section inside the "Browser compatibility" section.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Consistency improvement.

There are 16 documents that have a "Compatibility notes" section inside the "Browser compatibility" section.

This PR affects the remaining 8 documents that have a "Browser Compatibility" section and a separate "Compatibility notes" section.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
