### PR TITLE
Replace var with let in code snippets and examples

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -172,7 +172,7 @@ document.addEventListener("click", function(e) {
     return;
   }
 
-  var chosenPage = "https://" + e.target.textContent;
+  let chosenPage = "https://" + e.target.textContent;
   browser.tabs.create({
     url: chosenPage
   });

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var clearAlarm = browser.alarms.clear(
+let clearAlarm = browser.alarms.clear(
   name                       // string
 )
 ```
@@ -43,7 +43,7 @@ function onCleared(wasCleared) {
   console.log(wasCleared);  // true/false
 }
 
-var clearAlarm = browser.alarms.clear("my-periodic-alarm");
+let clearAlarm = browser.alarms.clear("my-periodic-alarm");
 clearAlarm.then(onCleared);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var clearAlarms = browser.alarms.clearAll()
+let clearAlarms = browser.alarms.clearAll()
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ function onClearedAll(wasCleared) {
   console.log(wasCleared);  // true/false
 }
 
-var clearAlarms = browser.alarms.clearAll();
+let clearAlarms = browser.alarms.clearAll();
 clearAlarms.then(onClearedAll);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getAlarm = browser.alarms.get(
+let getAlarm = browser.alarms.get(
   name                   // optional string
 )
 ```
@@ -45,7 +45,7 @@ function gotAlarm(alarm) {
   }
 }
 
-var getAlarm = browser.alarms.get("my-periodic-alarm");
+let getAlarm = browser.alarms.get("my-periodic-alarm");
 getAlarm.then(gotAlarm);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getAlarms = browser.alarms.getAll()
+let getAlarms = browser.alarms.getAll()
 ```
 
 ### Parameters
@@ -37,12 +37,12 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ```js
 function gotAll(alarms) {
-  for (var alarm of alarms) {
+  for (let alarm of alarms) {
     console.log(alarm.name);
   }
 }
 
-var getAlarms = browser.alarms.getAll();
+let getAlarms = browser.alarms.getAll();
 getAlarms.then(gotAll);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var createBookmark = browser.bookmarks.create(
+let createBookmark = browser.bookmarks.create(
   bookmark                  // CreateDetails object
 )
 ```
@@ -47,7 +47,7 @@ function onCreated(node) {
   console.log(node);
 }
 
-var createBookmark = browser.bookmarks.create({
+let createBookmark = browser.bookmarks.create({
   title: "bookmarks.create() on MDN",
   url: "https://developer.mozilla.org/Add-ons/WebExtensions/API/bookmarks/create"
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getBookmarks = browser.bookmarks.get(
+let getBookmarks = browser.bookmarks.get(
   idOrIdList                // string or string array
 )
 ```
@@ -49,7 +49,7 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var gettingBookmarks = browser.bookmarks.get("bookmarkAAAA");
+let gettingBookmarks = browser.bookmarks.get("bookmarkAAAA");
 gettingBookmarks.then(onFulfilled, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingChildren = browser.bookmarks.getChildren(
+let gettingChildren = browser.bookmarks.getChildren(
   id                     // string
 )
 ```
@@ -53,7 +53,7 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var gettingChildren = browser.bookmarks.getChildren("unfiled_____");
+let gettingChildren = browser.bookmarks.getChildren("unfiled_____");
 gettingChildren.then(onFulfilled, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingRecent = browser.bookmarks.getRecent(
+let gettingRecent = browser.bookmarks.getRecent(
   numberOfItems          // integer
 )
 ```
@@ -51,7 +51,7 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var gettingRecent = browser.bookmarks.getRecent(1);
+let gettingRecent = browser.bookmarks.getRecent(1);
 gettingRecent.then(onFulfilled, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingSubTree = browser.bookmarks.getSubTree(
+let gettingSubTree = browser.bookmarks.getSubTree(
   id                     // string
 )
 ```
@@ -57,7 +57,7 @@ function logItems(bookmarkItem, indent) {
     indent++;
   }
   if (bookmarkItem.children) {
-    for (var child of bookmarkItem.children) {
+    for (let child of bookmarkItem.children) {
       logItems(child, indent);
     }
   }
@@ -71,9 +71,9 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var subTreeID = "root_____";
+let subTreeID = "root_____";
 
-var gettingSubTree = browser.bookmarks.getSubTree(subTreeID);
+let gettingSubTree = browser.bookmarks.getSubTree(subTreeID);
 gettingSubTree.then(logSubTree, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingTree = browser.bookmarks.getTree()
+let gettingTree = browser.bookmarks.getTree()
 ```
 
 ### Parameters
@@ -67,7 +67,7 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var gettingTree = browser.bookmarks.getTree();
+let gettingTree = browser.bookmarks.getTree();
 gettingTree.then(logTree, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var movingBookmark = browser.bookmarks.move(
+let movingBookmark = browser.bookmarks.move(
   id,                    // string
   destination           // object
 )
@@ -62,9 +62,9 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var bookmarkId = "abcdefghilkl";
+let bookmarkId = "abcdefghilkl";
 
-var movingBookmark = browser.bookmarks.move(bookmarkId, {index: 0});
+let movingBookmark = browser.bookmarks.move(bookmarkId, {index: 0});
 movingBookmark.then(onMoved, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removingBookmark = browser.bookmarks.remove(
+let removingBookmark = browser.bookmarks.remove(
   id                 // string
 )
 ```
@@ -51,9 +51,9 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var bookmarkId = "abcdefghijkl";
+let bookmarkId = "abcdefghijkl";
 
-var removingBookmark = browser.bookmarks.remove(bookmarkId);
+let removingBookmark = browser.bookmarks.remove(bookmarkId);
 removingBookmark.then(onRemoved, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removingTree = browser.bookmarks.removeTree(
+let removingTree = browser.bookmarks.removeTree(
   id                // string
 )
 ```
@@ -55,12 +55,12 @@ function onRejected(error) {
 
 function removeMDN(searchResults) {
   if (searchResults.length) {
-    var removing = browser.bookmarks.removeTree(searchResults[0].id);
+    let removing = browser.bookmarks.removeTree(searchResults[0].id);
     removing.then(onRemoved, onRejected);
   }
 }
 
-var searchingBookmarks = browser.bookmarks.search({ title: "MDN" });
+let searchingBookmarks = browser.bookmarks.search({ title: "MDN" });
 searchingBookmarks.then(removeMDN, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var searching = browser.bookmarks.search(
+let searching = browser.bookmarks.search(
   query                  // string or object
 )
 ```
@@ -71,7 +71,7 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var searching = browser.bookmarks.search({});
+let searching = browser.bookmarks.search({});
 
 searching.then(onFulfilled, onRejected);
 ```
@@ -92,7 +92,7 @@ function onRejected(error) {
 }
 
 function checkActiveTab(tab) {
-  var searching = browser.bookmarks.search({url: tab.url});
+  let searching = browser.bookmarks.search({url: tab.url});
   searching.then(onFulfilled, onRejected);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var updating = browser.bookmarks.update(
+let updating = browser.bookmarks.update(
   id,                    // string
   changes                // object
 )
@@ -64,7 +64,7 @@ function updateFolders(items) {
   for (item of items) {
     // only folders, so skip items with a `url`
     if (!item.url) {
-      var updating = browser.bookmarks.update(item.id, {
+      let updating = browser.bookmarks.update(item.id, {
         title: "Mozilla Developer Network (MDN)"
       });
       updating.then(onFulfilled, onRejected);
@@ -72,7 +72,7 @@ function updateFolders(items) {
   }
 }
 
-var searching = browser.bookmarks.search({ title: "MDN" });
+let searching = browser.bookmarks.search({ title: "MDN" });
 searching.then(updateFolders, onRejected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingText = browser.browserAction.getBadgeText(
+let gettingText = browser.browserAction.getBadgeText(
   details               // object
 )
 ```
@@ -60,7 +60,7 @@ function gotBadgeText(text) {
   console.log(text);
 }
 
-var gettingBadgeText = browser.browserAction.getBadgeText({});
+let gettingBadgeText = browser.browserAction.getBadgeText({});
 gettingBadgeText.then(gotBadgeText);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingPopup = browser.browserAction.getPopup(
+let gettingPopup = browser.browserAction.getPopup(
   details               // object
 )
 ```
@@ -60,7 +60,7 @@ function gotPopup(popupURL) {
   console.log(popupURL)
 }
 
-var gettingPopup = browser.browserAction.getPopup({});
+let gettingPopup = browser.browserAction.getPopup({});
 gettingPopup.then(gotPopup);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingTitle = browser.browserAction.getTitle(
+let gettingTitle = browser.browserAction.getTitle(
   details               // object
 )
 ```
@@ -67,7 +67,7 @@ function toggleTitle(title) {
 }
 
 browser.browserAction.onClicked.addListener(() => {
-  var gettingTitle = browser.browserAction.getTitle({});
+  let gettingTitle = browser.browserAction.getTitle({});
   gettingTitle.then(toggleTitle);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -64,7 +64,7 @@ This API is also available as `chrome.browserAction.setBadgeText()`.
 Add a badge indicating how many times the user clicked the button:
 
 ```js
-var clicks = 0;
+let clicks = 0;
 
 function increment() {
   browser.browserAction.setBadgeText({text: (++clicks).toString()});

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -28,7 +28,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var settingIcon = browser.browserAction.setIcon(
+let settingIcon = browser.browserAction.setIcon(
   details         // object
 )
 ```
@@ -131,8 +131,8 @@ The code below sets the icon using an [`ImageData`](/en-US/docs/Web/API/ImageDat
 
 ```js
 function getImageData() {
-  var canvas = document.createElement("canvas");
-  var ctx = canvas.getContext("2d");
+  let canvas = document.createElement("canvas");
+  let ctx = canvas.getContext("2d");
 
   ctx.fillStyle = "green";
   ctx.fillRect(10, 10, 100, 100);

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -70,7 +70,7 @@ function toggleTitle(title) {
 }
 
 browser.browserAction.onClicked.addListener(() => {
-  var gettingTitle = browser.browserAction.getTitle({});
+  let gettingTitle = browser.browserAction.getTitle({});
   gettingTitle.then(toggleTitle);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.remove(
+let removing = browser.browsingData.remove(
   removalOptions,            // RemovalOptions object
   dataTypes                  // DataTypeSet object
 )
@@ -59,7 +59,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.remove(
   {since: oneWeekAgo},

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removeCache(
+let removing = browser.browsingData.removeCache(
   removalOptions            // RemovalOptions object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removeCookies(
+let removing = browser.browsingData.removeCookies(
   removalOptions            // RemovalOptions object
 )
 ```
@@ -57,7 +57,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.removeCookies(
   {since: oneWeekAgo}).

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removeDownloads(
+let removing = browser.browsingData.removeDownloads(
   removalOptions            // RemovalOptions object
 )
 ```
@@ -57,7 +57,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.removeDownloads(
   {since: oneWeekAgo}).

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removeFormData(
+let removing = browser.browsingData.removeFormData(
   removalOptions            // RemovalOptions object
 )
 ```
@@ -57,7 +57,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.removeFormData(
   {since: oneWeekAgo}).

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removeHistory(
+let removing = browser.browsingData.removeHistory(
   removalOptions            // RemovalOptions object
 )
 ```
@@ -57,7 +57,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.removeHistory(
   {since: oneWeekAgo}).

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removeLocalStorage(
+let removing = browser.browsingData.removeLocalStorage(
   removalOptions            // RemovalOptions object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removePasswords(
+let removing = browser.browsingData.removePasswords(
   removalOptions            // RemovalOptions object
 )
 ```
@@ -57,7 +57,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.removePasswords({since: oneWeekAgo}).
 then(onRemoved, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.browsingData.removePluginData(
+let removing = browser.browsingData.removePluginData(
   removalOptions            // RemovalOptions object
 )
 ```
@@ -57,7 +57,7 @@ function weekInMilliseconds() {
   return 1000 * 60 * 60 * 24 * 7;
 }
 
-var oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
+let oneWeekAgo = (new Date()).getTime() - weekInMilliseconds();
 
 browser.browsingData.removePluginData({since: oneWeekAgo}).
 then(onRemoved, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getSettings = browser.browsingData.settings()
+let getSettings = browser.browsingData.settings()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
@@ -18,7 +18,7 @@ Returns the time since the last request was completed.
 ## Syntax
 
 ```js
-var state = browser.captivePortal.getLastChecked()
+let state = browser.captivePortal.getLastChecked()
 ```
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
@@ -18,7 +18,7 @@ Returns the portal state as one of `unknown`, `not_captive`, `unlocked_portal`, 
 ## Syntax
 
 ```js
-var state = browser.captivePortal.getState()
+let state = browser.captivePortal.getState()
 ```
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getCommands = browser.commands.getAll();
+let getCommands = browser.commands.getAll();
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ function logCommands(commands) {
   });
 }
 
-var getCommands = browser.commands.getAll();
+let getCommands = browser.commands.getAll();
 getCommands.then(logCommands);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var registering = browser.contentScripts.register(
+let registering = browser.contentScripts.register(
   contentScriptOptions       // object
 )
 ```
@@ -86,7 +86,7 @@ async function register(hosts, code) {
 
 }
 
-var registered = register(defaultHosts, defaultCode);
+let registered = register(defaultHosts, defaultCode);
 ```
 
 This code registers the JS file at content_scripts/example.js:

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -32,7 +32,7 @@ It defines a single function {{WebExtAPIRef("contentScripts.RegisteredContentScr
 This code toggles a registered content script on a browser action click:
 
 ```js
-var registered = null;
+let registered = null;
 
 async function register() {
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -37,7 +37,7 @@ None.
 This code toggles a registered content script on a browser action click:
 
 ```js
-var registered = null;
+let registered = null;
 
 async function register() {
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var createContext = browser.contextualIdentities.create(
+let createContext = browser.contextualIdentities.create(
   details                  // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getContext = browser.contextualIdentities.get(
+let getContext = browser.contextualIdentities.get(
   cookieStoreId                  // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getContext = browser.contextualIdentities.query(
+let getContext = browser.contextualIdentities.query(
   details                  // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removeContext = browser.contextualIdentities.remove(
+let removeContext = browser.contextualIdentities.remove(
   cookieStoreId                  // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var createContext = browser.contextualIdentities.update(
+let createContext = browser.contextualIdentities.update(
   cookieStoreId,           // string
   details                  // object
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -73,7 +73,7 @@ function logCookies(cookies) {
   }
 }
 
-var gettingAll = browser.cookies.getAll({});
+let gettingAll = browser.cookies.getAll({});
 gettingAll.then(logCookies);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -45,7 +45,7 @@ function logStores(cookieStores) {
   }
 }
 
-var getting = browser.cookies.getAllCookieStores();
+let getting = browser.cookies.getAllCookieStores();
 getting.then(logStores);
 ```
 
@@ -53,7 +53,7 @@ The following code snippet gets all cookie stores and then logs the total number
 
 ```js
 browser.cookies.getAllCookieStores().then((stores) => {
-  var incognitoStores = stores.map(store => store.incognito);
+  let incognitoStores = stores.map(store => store.incognito);
   console.log(`Of ${stores.length} cookie stores, ${incognitoStores.length} are incognito.`);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.cookies.get(
+let getting = browser.cookies.get(
   details                // object
 )
 ```
@@ -71,14 +71,14 @@ function logCookie(cookie) {
 }
 
 function getCookie(tabs) {
-  var getting = browser.cookies.get({
+  let getting = browser.cookies.get({
     url: tabs[0].url,
     name: "favorite-color"
   });
   getting.then(logCookie);
 }
 
-var getActive = browser.tabs.query({
+let getActive = browser.tabs.query({
   active: true,
   currentWindow: true
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.cookies.getAll(
+let getting = browser.cookies.getAll(
   details                // object
 )
 ```
@@ -86,7 +86,7 @@ function logCookies(cookies) {
   }
 }
 
-var gettingAll = browser.cookies.getAll({
+let gettingAll = browser.cookies.getAll({
   name: "favorite-color"
 });
 gettingAll.then(logCookies);

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingStores = browser.cookies.getAllCookieStores()
+let gettingStores = browser.cookies.getAllCookieStores()
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ function logStores(cookieStores) {
   }
 }
 
-var getting = browser.cookies.getAllCookieStores();
+let getting = browser.cookies.getAllCookieStores();
 getting.then(logStores);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.cookies.remove(
+let removing = browser.cookies.remove(
   details               // object
 )
 ```
@@ -73,14 +73,14 @@ function onError(error) {
 }
 
 function removeCookie(tabs) {
-  var removing = browser.cookies.remove({
+  let removing = browser.cookies.remove({
     url: tabs[0].url,
     name: "favorite-color"
   });
   removing.then(onRemoved, onError);
 }
 
-var getActive = browser.tabs.query({active: true, currentWindow: true});
+let getActive = browser.tabs.query({active: true, currentWindow: true});
 getActive.then(removeCookie);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var setting = browser.cookies.set(
+let setting = browser.cookies.set(
   details               // object
 )
 ```
@@ -78,7 +78,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 This example sets a cookie for the document hosted by the currently active tab:
 
 ```js
-var getActive = browser.tabs.query({active: true, currentWindow: true});
+let getActive = browser.tabs.query({active: true, currentWindow: true});
 getActive.then(setCookie);
 
 function setCookie(tabs) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -44,7 +44,7 @@ The script gets access to a number of objects that help the injected script inte
 ## Syntax
 
 ```js
-var evaluating = browser.devtools.inspectedWindow.eval(
+let evaluating = browser.devtools.inspectedWindow.eval(
   expression,       // string
   options           // object
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -19,7 +19,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.devtools.network.getHAR()
+let getting = browser.devtools.network.getHAR()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -21,7 +21,7 @@ This function takes: a title, a URL to an icon file, and a URL to an HTML file. 
 ## Syntax
 
 ```js
-var creating = browser.devtools.panels.create(
+let creating = browser.devtools.panels.create(
   title,       // string
   iconPath,    // string
   pagePath     // string

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -29,7 +29,7 @@ This function takes one argument, which is a string representing the pane's titl
 ## Syntax
 
 ```js
-var creating = browser.devtools.panels.elements.createSidebarPane(
+let creating = browser.devtools.panels.elements.createSidebarPane(
   title       // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var evaluating = browser.devtools.panels.setExpression(
+let evaluating = browser.devtools.panels.setExpression(
   expression,       // string
   rootTitle         // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var setting = browser.devtools.panels.setObject(
+let setting = browser.devtools.panels.setObject(
   jsonObject,       // string, array, or JSON object
   rootTitle         // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var resolving = browser.dns.resolve(
+let resolving = browser.dns.resolve(
   hostname,    // string
   flags        // array of string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var prompting = browser.downloads.acceptDanger(
+let prompting = browser.downloads.acceptDanger(
   downloadId      // integer
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var canceling = browser.downloads.cancel(
+let canceling = browser.downloads.cancel(
   downloadId      // integer
 )
 ```
@@ -43,7 +43,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If t
 ## Examples
 
 ```js
-var downloadId = 13;
+let downloadId = 13;
 
 function onCanceled() {
   console.log(`Canceled download`);
@@ -53,7 +53,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var canceling = browser.downloads.cancel(downloadId);
+let canceling = browser.downloads.cancel(downloadId);
 canceling.then(onCanceled, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -29,7 +29,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var downloading = browser.downloads.download(
+let downloading = browser.downloads.download(
   options                   // object
 )
 ```
@@ -95,9 +95,9 @@ function onFailed(error) {
   console.log(`Download failed: ${error}`);
 }
 
-var downloadUrl = "https://example.org/image.png";
+let downloadUrl = "https://example.org/image.png";
 
-var downloading = browser.downloads.download({
+let downloading = browser.downloads.download({
   url : downloadUrl,
   filename : 'my-image-again.png',
   conflictAction : 'uniquify'

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var erasing = browser.downloads.erase(
+let erasing = browser.downloads.erase(
   query                    // DownloadQuery
 )
 ```
@@ -57,7 +57,7 @@ function onError(error) {
   console.log(`Error erasing item: ${error}`);
 }
 
-var erasing = browser.downloads.erase({
+let erasing = browser.downloads.erase({
   limit: 1,
   orderBy: ["-startTime"]
 });
@@ -76,7 +76,7 @@ function onError(error) {
   console.log(`Error erasing item: ${error}`);
 }
 
-var erasing = browser.downloads.erase({});
+let erasing = browser.downloads.erase({});
 erasing.then(onErased, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingIcon = browser.downloads.getFileIcon(
+let gettingIcon = browser.downloads.getFileIcon(
   downloadId,           // integer
   options               // optional object
 )
@@ -67,12 +67,12 @@ function onError(error) {
 function getIcon(downloadItems) {
     if (downloadItems.length > 0) {
       latestDownloadId = downloadItems[0].id;
-      var gettingIcon = browser.downloads.getFileIcon(latestDownloadId);
+      let gettingIcon = browser.downloads.getFileIcon(latestDownloadId);
       gettingIcon.then(gotIcon, onError);
     }
   }
 
-var searching = browser.downloads.search({
+let searching = browser.downloads.search({
   limit: 1,
   orderBy: ["-startTime"]
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -62,7 +62,7 @@ function handleErased(item) {
 
 browser.downloads.onErased.addListener(handleErased);
 
-var erasing = browser.downloads.erase({
+let erasing = browser.downloads.erase({
   limit: 1,
   orderBy: ["-startTime"]
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var opening = browser.downloads.open(
+let opening = browser.downloads.open(
   downloadId      // integer
 )
 ```
@@ -57,12 +57,12 @@ function onError(error) {
 
 function openDownload(downloadItems) {
     if (downloadItems.length > 0) {
-      var opening = browser.downloads.open(downloadItems[0].id);
+      let opening = browser.downloads.open(downloadItems[0].id);
       opening.then(onOpened, onError);
     }
   }
 
-var searching = browser.downloads.search({
+let searching = browser.downloads.search({
   limit: 1,
   orderBy: ["-startTime"]
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var pausing = browser.downloads.pause(
+let pausing = browser.downloads.pause(
   downloadId      // integer
 )
 ```
@@ -51,7 +51,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var pausing = browser.downloads.pause(downloadId);
+let pausing = browser.downloads.pause(downloadId);
 pausing.then(onPaused, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -28,7 +28,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.downloads.removeFile(
+let removing = browser.downloads.removeFile(
   downloadId      // integer
 )
 ```
@@ -61,12 +61,12 @@ function onError(error) {
 
 function remove(downloadItems) {
   if (downloadItems.length > 0) {
-    var removing = browser.downloads.removeFile(downloadItems[0].id);
+    let removing = browser.downloads.removeFile(downloadItems[0].id);
     removing.then(onRemoved, onError);
   }
 }
 
-var searching = browser.downloads.search({
+let searching = browser.downloads.search({
   limit: 1,
   orderBy: ["-startTime"]
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var resuming = browser.downloads.resume(
+let resuming = browser.downloads.resume(
   downloadId      // integer
 )
 ```
@@ -43,7 +43,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If t
 ## Examples
 
 ```js
-var downloadId = 2;
+let downloadId = 2;
 
 function onResumed() {
   console.log(`Resumed download`);
@@ -53,7 +53,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var resuming = browser.downloads.resume(downloadId);
+let resuming = browser.downloads.resume(downloadId);
 resuming.then(onResumed, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var searching = browser.downloads.search(query);
+let searching = browser.downloads.search(query);
 ```
 
 ### Parameters
@@ -56,7 +56,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var searching = browser.downloads.search({
+let searching = browser.downloads.search({
   query:["imgur"]
 });
 
@@ -79,9 +79,9 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var id = 13;
+let id = 13;
 
-var searching = browser.downloads.search({id});
+let searching = browser.downloads.search({id});
 searching.then(logDownloads, onError);
 ```
 
@@ -101,7 +101,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var searching = browser.downloads.search({});
+let searching = browser.downloads.search({});
 searching.then(logDownloads, onError);
 ```
 
@@ -121,7 +121,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var searching = browser.downloads.search({
+let searching = browser.downloads.search({
    limit: 1,
    orderBy: ["-startTime"]
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var showing = browser.downloads.show(
+let showing = browser.downloads.show(
   downloadId             // integer
 )
 ```
@@ -56,12 +56,12 @@ function onError(error) {
 function openDownload(downloadItems) {
     if (downloadItems.length > 0) {
       latestDownloadId = downloadItems[0].id;
-      var showing = browser.downloads.show(latestDownloadId);
+      let showing = browser.downloads.show(latestDownloadId);
       showing.then(onShowing, onError);
     }
   }
 
-var searching = browser.downloads.search({
+let searching = browser.downloads.search({
   limit: 1,
   orderBy: ["-startTime"]
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -36,7 +36,7 @@ None.
 The following snippet contains a show button, which when clicked invokes `showDefaultFolder()` to open the default downloads folder in the platform's file manager:
 
 ```js
-var showBtn = document.querySelector('.show');
+let showBtn = document.querySelector('.show');
 
 showBtn.onclick = function() {
   browser.downloads.showDefaultFolder();

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
@@ -22,7 +22,7 @@ Alias for {{WebExtAPIRef("runtime.getBackgroundPage()")}}.
 ## Syntax
 
 ```js
-var page = browser.extension.getBackgroundPage()
+let page = browser.extension.getBackgroundPage()
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ A script running in a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_
 ```js
 // popup.js
 
-var page = browser.extension.getBackgroundPage();
+let page = browser.extension.getBackgroundPage();
 page.foo(); // -> "I'm defined in background.js"
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
@@ -46,7 +46,7 @@ browser.extension.getURL(
 Given a file packaged with the add-on at "beasts/frog.html", get the full URL like this:
 
 ```js
-var fullURL = browser.extension.getURL("beasts/frog.html");
+let fullURL = browser.extension.getURL("beasts/frog.html");
 
 // -> something like:
 // moz-extension://2c127fa4-62c7-7e4f-90e5-472b45eecfdc/beasts/frog.html

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -27,7 +27,7 @@ In Firefox, if this method is called from a page that is part of a private brows
 ## Syntax
 
 ```js
-var windows = browser.extension.getViews(
+let windows = browser.extension.getViews(
   fetchProperties // optional object
 )
 ```
@@ -56,9 +56,9 @@ var windows = browser.extension.getViews(
 Get all windows belonging to this extension, and log their URLs:
 
 ```js
-var windows = browser.extension.getViews();
+let windows = browser.extension.getViews();
 
-for (var extensionWindow of windows) {
+for (let extensionWindow of windows) {
   console.log(extensionWindow.location.href);
 }
 ```
@@ -66,13 +66,13 @@ for (var extensionWindow of windows) {
 Get only windows in browser tabs hosting content packaged with the extension:
 
 ```js
-var windows = browser.extension.getViews({type: "tab"});
+let windows = browser.extension.getViews({type: "tab"});
 ```
 
 Get only windows in popups:
 
 ```js
-var windows = browser.extension.getViews({type: "popup"});
+let windows = browser.extension.getViews({type: "popup"});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -20,7 +20,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var isAllowed = browser.extension.isAllowedFileSchemeAccess()
+let isAllowed = browser.extension.isAllowedFileSchemeAccess()
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ function logIsAllowed(answer) {
   console.log(`Is allowed: ${answer}`);
 }
 
-var isAllowed = browser.extension.isAllowedFileSchemeAccess();
+let isAllowed = browser.extension.isAllowedFileSchemeAccess();
 isAllowed.then(logIsAllowed);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var isAllowed = browser.extension.isAllowedIncognitoAccess()
+let isAllowed = browser.extension.isAllowedIncognitoAccess()
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ function logIsAllowed(answer) {
   console.log(`Is allowed: ${answer}`);
 }
 
-var isAllowed = browser.extension.isAllowedIncognitoAccess();
+let isAllowed = browser.extension.isAllowedIncognitoAccess();
 isAllowed.then(logIsAllowed);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -256,7 +256,7 @@ The content script:
  * Add a black DIV where the rect is.
  */
 function redactRect(rect) {
-  var redaction = document.createElement("div");
+  let redaction = document.createElement("div");
   redaction.style.backgroundColor = "black";
   redaction.style.position = "absolute";
   redaction.style.top = `${rect.top}px`;

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var addingUrl = browser.history.addUrl(
+let addingUrl = browser.history.addUrl(
   details         // object
 )
 ```
@@ -63,7 +63,7 @@ function onGot(results) {
 }
 
 function onAdded() {
-  var searching = browser.history.search({
+  let searching = browser.history.search({
     text: "https://example.org/",
     startTime: 0,
     maxResults: 1
@@ -71,7 +71,7 @@ function onAdded() {
   searching.then(onGot);
 }
 
-var addingUrl = browser.history.addUrl({url: "https://example.org/"});
+let addingUrl = browser.history.addUrl({url: "https://example.org/"});
 addingUrl.then(onAdded);
 ```
 
@@ -92,14 +92,14 @@ function onGot(visits) {
 }
 
 function onAdded() {
-  var gettingVisits = browser.history.getVisits({
+  let gettingVisits = browser.history.getVisits({
     url: "https://example.org/"
   });
 
   gettingVisits.then(onGot);
 }
 
-var addingUrl = browser.history.addUrl({
+let addingUrl = browser.history.addUrl({
   url: "https://example.org/",
   visitTime: oneDayAgo(),
   transition: "typed"

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var deletingAll = browser.history.deleteAll()
+let deletingAll = browser.history.deleteAll()
 ```
 
 ### Parameters
@@ -49,7 +49,7 @@ function onDeleteAll() {
 }
 
 function deleteAllHistory() {
-  var deletingAll = browser.history.deleteAll();
+  let deletingAll = browser.history.deleteAll();
   deletingAll.then(onDeleteAll);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var deletingRange = browser.history.deleteRange(
+let deletingRange = browser.history.deleteRange(
   range           // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var deletingUrl = browser.history.deleteUrl(
+let deletingUrl = browser.history.deleteUrl(
   details         // object
 )
 ```
@@ -49,7 +49,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) will 
 Remove all visits to "https\://example.org/" from history, then check that this URL no longer returned from {{WebExtAPIRef("history.search()")}}:
 
 ```js
-var urlToRemove = "https://example.org/";
+let urlToRemove = "https://example.org/";
 
 function onGot(results) {
   if (!results.length) {
@@ -60,7 +60,7 @@ function onGot(results) {
 }
 
 function onRemoved() {
-  var searching = browser.history.search({
+  let searching = browser.history.search({
     text: urlToRemove,
     startTime: 0
   });
@@ -68,7 +68,7 @@ function onRemoved() {
   searching.then(onGot);
 }
 
-var deletingUrl = browser.history.deleteUrl({url: urlToRemove});
+let deletingUrl = browser.history.deleteUrl({url: urlToRemove});
 
 deletingUrl.then(onRemoved);
 ```
@@ -91,7 +91,7 @@ function onGot(results) {
   }
 }
 
-var searching = browser.history.search({
+let searching = browser.history.search({
   text: "",
   startTime: 0,
   maxResults: 1

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.history.getVisits(
+let getting = browser.history.getVisits(
   details                // object
 )
 ```
@@ -59,14 +59,14 @@ function gotVisits(visits) {
 function listVisits(historyItems) {
   if (historyItems.length) {
     console.log("URL " + historyItems[0].url);
-    var gettingVisits = browser.history.getVisits({
+    let gettingVisits = browser.history.getVisits({
       url: historyItems[0].url
     });
     gettingVisits.then(gotVisits);
   }
 }
 
-var searching = browser.history.search({
+let searching = browser.history.search({
   text: "",
   startTime: 0,
   maxResults: 1

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var searching = browser.history.search(
+let searching = browser.history.search(
   query                  // object
 )
 ```
@@ -76,7 +76,7 @@ function onGot(historyItems) {
   }
 }
 
-var searching = browser.history.search({text: ""});
+let searching = browser.history.search({text: ""});
 
 searching.then(onGot);
 ```
@@ -91,7 +91,7 @@ function onGot(historyItems) {
   }
 }
 
-var searching = browser.history.search({
+let searching = browser.history.search({
    text: "",
    startTime: 0
 });
@@ -109,7 +109,7 @@ function onGot(historyItems) {
   }
 }
 
-var searching = browser.history.search({
+let searching = browser.history.search({
  text: "mozilla",
  startTime: 0,
  maxResults: 1

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -24,7 +24,7 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 ## Syntax
 
 ```js
-var detectingLanguages = browser.i18n.detectLanguage(
+let detectingLanguages = browser.i18n.detectLanguage(
   text                  // string
 )
 ```
@@ -63,9 +63,9 @@ function onLanguageDetected(langInfo) {
   }
 }
 
-var text = "L'homme est né libre, et partout il est dans les fers."
+let text = "L'homme est né libre, et partout il est dans les fers."
 
-var detecting = browser.i18n.detectLanguage(text);
+let detecting = browser.i18n.detectLanguage(text);
 detecting.then(onLanguageDetected);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -24,7 +24,7 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 ## Syntax
 
 ```js
-var gettingAcceptLanguages = browser.i18n.getAcceptLanguages()
+let gettingAcceptLanguages = browser.i18n.getAcceptLanguages()
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ function onGot(languages) {
   //e.g. Array [ "en-US", "en" ]
 }
 
-var gettingAcceptLanguages = browser.i18n.getAcceptLanguages();
+let gettingAcceptLanguages = browser.i18n.getAcceptLanguages();
 gettingAcceptLanguages.then(onGot);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -56,7 +56,7 @@ browser.i18n.getMessage(
 Get the localized string for `"messageContent"`, with `target.url` substituted:
 
 ```js
-var message = browser.i18n.getMessage("messageContent", target.url);
+let message = browser.i18n.getMessage("messageContent", target.url);
 console.log(message);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -40,7 +40,7 @@ None.
 ## Examples
 
 ```js
-var uiLanguage = browser.i18n.getUILanguage();
+let uiLanguage = browser.i18n.getUILanguage();
 console.log(uiLanguage);
 
 //e.g. "fr"

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -23,7 +23,7 @@ See [Getting a redirect URL](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/ident
 ## Syntax
 
 ```js
-var redirectURL = browser.identity.getRedirectURL()
+let redirectURL = browser.identity.getRedirectURL()
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ A string containing a redirect URL value.
 Get the redirect URL:
 
 ```js
-var redirectURL = browser.identity.getRedirectURL();
+let redirectURL = browser.identity.getRedirectURL();
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -39,7 +39,7 @@ If there's any error, the promise is rejected with an error message. Error condi
 ## Syntax
 
 ```js
-var authorizing = browser.identity.launchWebAuthFlow(
+let authorizing = browser.identity.launchWebAuthFlow(
   details   // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var querying = browser.idle.queryState(
+let querying = browser.idle.queryState(
   detectionIntervalInSeconds // integer
 )
 ```
@@ -53,7 +53,7 @@ function onGot(newState) {
   }
 }
 
-var querying = browser.idle.queryState(15);
+let querying = browser.idle.queryState(15);
 querying.then(onGot);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingInfo = browser.management.get(
+let gettingInfo = browser.management.get(
   id                  // string
 )
 ```
@@ -45,13 +45,13 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Log the name of the add-on whose ID is "my-add-on":
 
 ```js
-var id = "my-add-on";
+let id = "my-add-on";
 
 function got(info) {
   console.log(info.name);
 }
 
-var getting = browser.management.get(id);
+let getting = browser.management.get(id);
 getting.then(got);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingAll = browser.management.getAll()
+let gettingAll = browser.management.getAll()
 ```
 
 ### Parameters
@@ -52,7 +52,7 @@ function gotAll(infoArray) {
   }
 }
 
-var gettingAll = browser.management.getAll();
+let gettingAll = browser.management.getAll();
 gettingAll.then(gotAll);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingWarnings = browser.management.getPermissionWarningsById(
+let gettingWarnings = browser.management.getPermissionWarningsById(
   id                  // string
 )
 ```
@@ -45,7 +45,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Log the permission warnings for the add-on whose ID is "my-add-on":
 
 ```js
-var id = "my-add-on";
+let id = "my-add-on";
 
 function gotWarnings(warnings) {
   for (warning of warnings) {
@@ -53,7 +53,7 @@ function gotWarnings(warnings) {
   }
 }
 
-var gettingWarnings = browser.management.getPermissionWarningsById(id);
+let gettingWarnings = browser.management.getPermissionWarningsById(id);
 gettingWarnings.then(gotWarnings);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingWarnings = browser.management.getPermissionWarningsByManifest(
+let gettingWarnings = browser.management.getPermissionWarningsByManifest(
   manifestString      // string
 )
 ```
@@ -45,14 +45,14 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Log the permission warnings for the given manifest file:
 
 ```js
-var manifest = {
+let manifest = {
   "manifest_version": 2,
   "name": "test",
   "version": "1.0",
   "permissions": ["management", "<all_urls>"]
 }
 
-var manifestString = JSON.stringify(manifest);
+let manifestString = JSON.stringify(manifest);
 
 function gotWarnings(warnings) {
   console.log(warnings);
@@ -62,7 +62,7 @@ function gotError(error) {
   console.log(`Error: ${error}`);
 }
 
-var gettingWarnings = browser.management.getPermissionWarningsByManifest(manifestString);
+let gettingWarnings = browser.management.getPermissionWarningsByManifest(manifestString);
 gettingWarnings.then(gotWarnings, gotError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingSelf = browser.management.getSelf()
+let gettingSelf = browser.management.getSelf()
 ```
 
 ### Parameters
@@ -46,7 +46,7 @@ function gotSelf(info) {
   console.log("Add-on name: " + info.name);
 }
 
-var gettingSelf = browser.management.getSelf();
+let gettingSelf = browser.management.getSelf();
 gettingSelf.then(gotSelf);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -26,7 +26,7 @@ The function allows enabling/disabling of theme addons, but will return an error
 ## Syntax
 
 ```js
-var settingEnabled = browser.management.setEnabled(
+let settingEnabled = browser.management.setEnabled(
   id,              // string
   enabled         // boolean
 )
@@ -52,10 +52,10 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Toggle enable/disable for the add-on whose ID is "my-add-on":
 
 ```js
-var id = "my-add-on";
+let id = "my-add-on";
 
 function toggleEnabled(id) {
-  var getting = browser.management.get(id);
+  let getting = browser.management.get(id);
   getting.then((info) => {
     browser.management.setEnabled(id, !info.enabled);
   });

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var uninstalling = browser.management.uninstall(
+let uninstalling = browser.management.uninstall(
   id,                  // string
   options              // object
 )
@@ -55,13 +55,13 @@ Uninstall the add-on whose ID is "my-addon-id", asking the user to confirm. In t
 Note that we haven't passed a fulfillment handler because if uninstallation succeeds, the add-on is no longer around to handle it.
 
 ```js
-var id = "my-addon-id";
+let id = "my-addon-id";
 
 function onCanceled(error) {
   console.log(`Uninstall canceled: ${error}`);
 }
 
-var uninstalling = browser.management.uninstall(id);
+let uninstalling = browser.management.uninstall(id);
 uninstalling.then(null, onCanceled);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var uninstallingSelf = browser.management.uninstallSelf(
+let uninstallingSelf = browser.management.uninstallSelf(
   options              // object
 )
 ```
@@ -57,7 +57,7 @@ function onCanceled(error) {
   console.log(`Canceled: ${error}`);
 }
 
-var uninstalling = browser.management.uninstallSelf({
+let uninstalling = browser.management.uninstallSelf({
   showConfirmDialog: true
 });
 
@@ -71,7 +71,7 @@ function onCanceled(error) {
   console.log(`Canceled: ${error}`);
 }
 
-var uninstalling = browser.management.uninstallSelf({
+let uninstalling = browser.management.uninstallSelf({
   showConfirmDialog: true,
   dialogMessage: "Testing self-uninstall"
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -163,8 +163,8 @@ browser.menus.create({
   checked: false
 }, onCreated);
 
-var makeItBlue = 'document.body.style.border = "5px solid blue"';
-var makeItGreen = 'document.body.style.border = "5px solid green"';
+let makeItBlue = 'document.body.style.border = "5px solid blue"';
+let makeItGreen = 'document.body.style.border = "5px solid green"';
 
 browser.menus.onClicked.addListener(function(info, tab) {
   if (info.menuItemId == "radio-blue") {

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -100,7 +100,7 @@ browser.menus.create({
   contexts: ["all"]
 }, onCreated);
 
-var checkedState = true;
+let checkedState = true;
 
 browser.menus.create({
   id: "check-uncheck",

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -29,11 +29,11 @@ The handler is passed some information about the menu and its contents, and some
 If the `onShown` handler calls any asynchronous APIs, then it's possible that the menu has been closed again before the handler resumes execution. Because of this, if a handler calls any asynchronous APIs, it should check that the menu is still being displayed before it updates the menu. For example:
 
 ```js
-var lastMenuInstanceId = 0;
-var nextMenuInstanceId = 1;
+let lastMenuInstanceId = 0;
+let nextMenuInstanceId = 1;
 
 browser.menus.onShown.addListener(async function(info, tab) {
-  var menuInstanceId = nextMenuInstanceId++;
+  let menuInstanceId = nextMenuInstanceId++;
   lastMenuInstanceId = menuInstanceId;
 
   // Call an async function
@@ -65,7 +65,7 @@ However, if you call these APIs asynchronously, then you do have to perform the 
 
 ```js
 browser.menus.onShown.addListener(async function(info, tab) {
-  var menuInstanceId = nextMenuInstanceId++;
+  let menuInstanceId = nextMenuInstanceId++;
   lastMenuInstanceId = menuInstanceId;
 
   await browser.menus.update(menuId, ...);

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.menus.remove(
+let removing = browser.menus.remove(
   menuItemId      // integer or string
 )
 ```
@@ -59,7 +59,7 @@ browser.menus.create({
 
 browser.menus.onClicked.addListener(function(info, tab) {
   if (info.menuItemId == "remove-me") {
-    var removing = browser.menus.remove(info.menuItemId);
+    let removing = browser.menus.remove(info.menuItemId);
     removing.then(onRemoved, onError);
   }
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.menus.removeAll()
+let removing = browser.menus.removeAll()
 ```
 
 ### Parameters
@@ -63,7 +63,7 @@ browser.menus.create({
 
 browser.menus.onClicked.addListener(function(info, tab) {
   if (info.menuItemId == "remove-all") {
-    var removing = browser.menus.removeAll();
+    let removing = browser.menus.removeAll();
     removing.then(onRemoved);
   }
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var updating = browser.menus.update(
+let updating = browser.menus.update(
   id,               // integer or string
   updateProperties // object
 )
@@ -136,7 +136,7 @@ browser.menus.create({
 
 browser.menus.onClicked.addListener(function(info, tab) {
   if (info.menuItemId == "do-not-click-me") {
-    var updating = browser.menus.update(info.menuItemId, {
+    let updating = browser.menus.update(info.menuItemId, {
       title: "Do not click this button again"
     });
     updating.then(onUpdated, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var clearing = browser.notifications.clear(
+let clearing = browser.notifications.clear(
   id                            // string
 )
 ```
@@ -45,7 +45,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 This example shows a notification when the user clicks a browser action, unless the notification was already being shown, in which case it clears the notification:
 
 ```js
-var myNotification = "my-notification";
+let myNotification = "my-notification";
 
 function toggleAlarm(all) {
   if (myNotification in all) {
@@ -61,7 +61,7 @@ function toggleAlarm(all) {
 }
 
 function handleClick() {
-  var gettingAll = browser.notifications.getAll();
+  let gettingAll = browser.notifications.getAll();
   gettingAll.then(toggleAlarm);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -28,7 +28,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var creating = browser.notifications.create(
+let creating = browser.notifications.create(
   id,                   // optional string
   options               // NotificationOptions
 )
@@ -50,7 +50,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 This example displays a notification periodically, using {{WebExtAPIRef("alarms", "alarm")}}. Clicking the browser action dismisses the notification. You need the "alarms" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) to create alarms (as well as the "notifications" permission to create notifications).
 
 ```js
-var cakeNotification = "cake-notification"
+let cakeNotification = "cake-notification"
 
 /*
 
@@ -61,7 +61,7 @@ Note that in Chrome, alarms cannot be set for less
 than a minute.
 
 */
-var CAKE_INTERVAL = 0.1;
+let CAKE_INTERVAL = 0.1;
 
 browser.alarms.create("", {periodInMinutes: CAKE_INTERVAL});
 
@@ -75,7 +75,7 @@ browser.alarms.onAlarm.addListener(function(alarm) {
 });
 
 browser.browserAction.onClicked.addListener(()=> {
-  var clearing = browser.notifications.clear(cakeNotification);
+  let clearing = browser.notifications.clear(cakeNotification);
   clearing.then(() => {
     console.log("cleared");
   });

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingAll = browser.notifications.getAll()
+let gettingAll = browser.notifications.getAll()
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ Note that you can define an ID for a notification explicitly by passing it into 
 This example shows a notification when the user clicks a browser action, unless the notification was already being shown, in which case it clears the notification. It uses getAll() to figure out whether the notification is being shown:
 
 ```js
-var myNotification = "my-notification";
+let myNotification = "my-notification";
 
 function toggleAlarm(all) {
   let ids = Object.keys(all);

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var updating = browser.notifications.update(
+let updating = browser.notifications.update(
   id,                            // string
   options                        // NotificationOptions
 )
@@ -50,7 +50,7 @@ This example uses `update()` to update a progress notification. Clicking the bro
 Note that you'll need the "alarms" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) to create alarms (as well as the "notifications" permission to create notifications). Also note that Firefox does not support the `progress` attribute.
 
 ```js
-var cakeNotification = "cake-notification";
+let cakeNotification = "cake-notification";
 
 /*
 
@@ -61,9 +61,9 @@ Note that in Chrome, alarms cannot be set for less than
 a minute.
 
 */
-var CAKE_PREP_INTERVAL = 0.005;
+let CAKE_PREP_INTERVAL = 0.005;
 
-var progress = 0;
+let progress = 0;
 
 browser.alarms.onAlarm.addListener(function(alarm) {
   progress = progress + 10;

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -95,7 +95,7 @@ Return an array of SuggestResult objects,
 one for each CSS property that matches the user's input.
 */
 function getMatchingProperties(input) {
-  var result = [];
+  let result = [];
   for (prop of props) {
     if (prop.indexOf(input) === 0) {
       console.log(prop);

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -95,7 +95,7 @@ Return an array of SuggestResult objects,
 one for each CSS property that matches the user's input.
 */
 function getMatchingProperties(input) {
-  var result = [];
+  let result = [];
   for (prop of props) {
     if (prop.indexOf(input) === 0) {
       console.log(prop);

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingPopup = browser.pageAction.getPopup(
+let gettingPopup = browser.pageAction.getPopup(
   details               // object
 )
 ```
@@ -60,7 +60,7 @@ browser.contextMenus.create({
 
 browser.contextMenus.onClicked.addListener(function(info, tab) {
   if (info.menuItemId == "get-popup") {
-    var gettingPopup = browser.pageAction.getPopup({tabId: tab.id});
+    let gettingPopup = browser.pageAction.getPopup({tabId: tab.id});
     gettingPopup.then(gotPopup);
   }
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingTitle = browser.pageAction.getTitle(
+let gettingTitle = browser.pageAction.getTitle(
   details // object
 )
 ```
@@ -54,7 +54,7 @@ function gotTitle(title) {
 }
 
 browser.pageAction.onClicked.addListener((tab) => {
-  var gettingTitle = browser.pageAction.getTitle({
+  let gettingTitle = browser.pageAction.getTitle({
     tabId: tab.id
   });
   gettingTitle.then(gotTitle);

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -64,7 +64,7 @@ Events have three functions:
     When the user clicks the page action, hide it, and navigate the active tab to "<https://giphy.com/explore/cat>":
 
     ```js
-    var CATGIFS = "https://giphy.com/explore/cat";
+    let CATGIFS = "https://giphy.com/explore/cat";
 
     browser.pageAction.onClicked.addListener((tab) => {
       browser.pageAction.hide(tab.id);

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var settingIcon = browser.pageAction.setIcon(
+let settingIcon = browser.pageAction.setIcon(
   details         // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getContains = browser.permissions.contains(
+let getContains = browser.permissions.contains(
   permissions                // Permissions object
 )
 ```
@@ -46,7 +46,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 // Extension permissions are:
 // "webRequest", "tabs", "*://*.mozilla.org/*"
 
-var testPermissions1 = {
+let testPermissions1 = {
   origins: ["*://mozilla.org/"],
   permissions: ["tabs"]
 };
@@ -55,7 +55,7 @@ browser.permissions.contains(testPermissions1).then((result) => {
   console.log(result);    // true
 });
 
-var testPermissions2 = {
+let testPermissions2 = {
   origins: ["*://mozilla.org/"],
   permissions: ["tabs", "alarms"]
 };
@@ -64,7 +64,7 @@ browser.permissions.contains(testPermissions2).then((result) => {
   console.log(result);   // false, "alarms" doesn't match
 });
 
-var testPermissions3 = {
+let testPermissions3 = {
   origins: ["https://developer.mozilla.org/"],
   permissions: ["tabs", "webRequest"]
 };
@@ -73,7 +73,7 @@ browser.permissions.contains(testPermissions3).then((result) => {
   console.log(result);   // true: "https://developer.mozilla.org/"
 });                      // matches: "*://*.mozilla.org/*"
 
-var testPermissions4 = {
+let testPermissions4 = {
   origins: ["https://example.org/"]
 };
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -20,7 +20,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingAll = browser.permissions.getAll()
+let gettingAll = browser.permissions.getAll()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.permissions.remove(
+let removing = browser.permissions.remove(
   permissions                // Permissions object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -28,7 +28,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var requesting = browser.permissions.request(
+let requesting = browser.permissions.request(
   permissions                // Permissions object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.pkcs11.getModuleSlots(
+let getting = browser.pkcs11.getModuleSlots(
   name              // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var installing = browser.pkcs11.installModule(
+let installing = browser.pkcs11.installModule(
   name,              // string
   flags              // integer
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var checking = browser.pkcs11.isModuleInstalled(
+let checking = browser.pkcs11.isModuleInstalled(
   name              // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var uninstalling = browser.pkcs11.uninstallModule(
+let uninstalling = browser.pkcs11.uninstallModule(
   name              // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -62,12 +62,12 @@ function onSet(result) {
 
 browser.browserAction.onClicked.addListener(() => {
 
-  var getting = browser.privacy.network.webRTCIPHandlingPolicy.get({});
+  let getting = browser.privacy.network.webRTCIPHandlingPolicy.get({});
   getting.then((got) => {
     console.log(got.value);
     if ((got.levelOfControl === "controlled_by_this_extension") ||
         (got.levelOfControl === "controllable_by_this_extension")) {
-      var setting = browser.privacy.network.webRTCIPHandlingPolicy.set({
+      let setting = browser.privacy.network.webRTCIPHandlingPolicy.set({
         value: "default_public_interface_only"
       });
       setting.then(onSet);

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -37,12 +37,12 @@ function onSet(result) {
   }
 }
 
-  var getting = browser.privacy.services.passwordSavingEnabled.get({});
+  let getting = browser.privacy.services.passwordSavingEnabled.get({});
   getting.then((got) => {
     console.log(got.value);
     if ((got.levelOfControl === "controlled_by_this_extension") ||
         (got.levelOfControl === "controllable_by_this_extension")) {
-      var setting = browser.privacy.services.passwordSavingEnabled.set({
+      let setting = browser.privacy.services.passwordSavingEnabled.set({
         value: false
       });
       setting.then(onSet);

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -90,12 +90,12 @@ function onSet(result) {
 
 browser.browserAction.onClicked.addListener(() => {
 
-  var getting = browser.privacy.websites.hyperlinkAuditingEnabled.get({});
+  let getting = browser.privacy.websites.hyperlinkAuditingEnabled.get({});
   getting.then((got) => {
     console.log(got.value);
     if ((got.levelOfControl === "controlled_by_this_extension") ||
         (got.levelOfControl === "controllable_by_this_extension")) {
-      var setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
+      let setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
         value: true
       });
       setting.then(onSet);

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.md
@@ -132,7 +132,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 ## Syntax
 
 ```js
-var registering = browser.proxy.register(
+let registering = browser.proxy.register(
   url   // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var unregistering = browser.proxy.unregister()
+let unregistering = browser.proxy.unregister()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -27,7 +27,7 @@ Note that you can't use this function to connect an extension to its content scr
 ## Syntax
 
 ```js
-var port = browser.runtime.connect(
+let port = browser.runtime.connect(
   extensionId, // optional string
   connectInfo  // optional object
 )
@@ -65,7 +65,7 @@ This content script:
 ```js
 // content-script.js
 
-var myPort = browser.runtime.connect({name:"port-from-cs"});
+let myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.postMessage({greeting: "hello from content script"});
 
 myPort.onMessage.addListener(function(m) {
@@ -92,7 +92,7 @@ The corresponding background script:
 ```js
 // background-script.js
 
-var portFromCS;
+let portFromCS;
 
 function connected(p) {
   portFromCS = p;

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -20,7 +20,7 @@ For more information, see [Native messaging](/en-US/docs/Mozilla/Add-ons/WebExte
 ## Syntax
 
 ```js
-var port = browser.runtime.connectNative(
+let port = browser.runtime.connectNative(
   application // string
 )
 ```
@@ -46,7 +46,7 @@ This example connects to the native application "ping_pong" and starts listening
 /*
 On startup, connect to the "ping_pong" app.
 */
-var port = browser.runtime.connectNative("ping_pong");
+let port = browser.runtime.connectNative("ping_pong");
 
 /*
 Listen for messages from the app.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -36,7 +36,7 @@ This is an asynchronous function that returns a {{JSxRef("Promise")}}.
 ## Syntax
 
 ```js
-var gettingPage = browser.runtime.getBackgroundPage()
+let gettingPage = browser.runtime.getBackgroundPage()
 ```
 
 ### Parameters
@@ -76,7 +76,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var getting = browser.runtime.getBackgroundPage();
+let getting = browser.runtime.getBackgroundPage();
 getting.then(onGot, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a {{JSxRef("Promise")}}.
 ## Syntax
 
 ```js
-var gettingInfo = browser.runtime.getBrowserInfo()
+let gettingInfo = browser.runtime.getBrowserInfo()
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ function gotBrowserInfo(info) {
   console.log(info.name);
 }
 
-var gettingInfo = browser.runtime.getBrowserInfo();
+let gettingInfo = browser.runtime.getBrowserInfo();
 gettingInfo.then(gotBrowserInfo);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -40,7 +40,7 @@ An `object` representing the manifest.
 Get the manifest and log the "name" property:
 
 ```js
-var manifest = browser.runtime.getManifest();
+let manifest = browser.runtime.getManifest();
 console.log(manifest.name);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingEntry = browser.runtime.getPackageDirectoryEntry()
+let gettingEntry = browser.runtime.getPackageDirectoryEntry()
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ function gotDirectoryEntry(directoryEntry) {
   console.log(directoryEntry);
 }
 
-var gettingEntry = browser.runtime.getPackageDirectoryEntry();
+let gettingEntry = browser.runtime.getPackageDirectoryEntry();
 gettingEntry.then(gotDirectoryEntry);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.runtime.getPlatformInfo()
+let getting = browser.runtime.getPlatformInfo()
 ```
 
 ### Parameters
@@ -46,7 +46,7 @@ function gotPlatformInfo(info) {
   console.log(info.os);
 }
 
-var gettingInfo = browser.runtime.getPlatformInfo();
+let gettingInfo = browser.runtime.getPlatformInfo();
 gettingInfo.then(gotPlatformInfo);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -45,7 +45,7 @@ browser.runtime.getURL(
 Given a file packaged with the extension at "beasts/frog.html", get the full URL like this:
 
 ```js
-var fullURL = browser.runtime.getURL("beasts/frog.html");
+let fullURL = browser.runtime.getURL("beasts/frog.html");
 console.log(fullURL);
 // Returns something like:
 // moz-extension://2c127fa4-62c7-7e4f-90e5-472b45eecfdc/beasts/frog.html

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -20,7 +20,7 @@ The ID of the extension.
 ## Syntax
 
 ```js
-var myAddonId = browser.runtime.id;
+let myAddonId = browser.runtime.id;
 ```
 
 ### Value

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -60,7 +60,7 @@ This content script:
 ```js
 // content-script.js
 
-var myPort = browser.runtime.connect({name:"port-from-cs"});
+let myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.postMessage({greeting: "hello from content script"});
 
 myPort.onMessage.addListener(function(m) {
@@ -87,7 +87,7 @@ The corresponding background script:
 ```js
 // background-script.js
 
-var portFromCS;
+let portFromCS;
 
 function connected(p) {
   portFromCS = p;

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -59,7 +59,7 @@ In this example the extension Hansel connects to the extension Gretel:
 
 ```js
 console.log("connecting to Gretel");
-var myPort = browser.runtime.connect(
+let myPort = browser.runtime.connect(
   "gretel@mozilla.org"
 );
 
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener(() => {
 Gretel listens for the connection and checks that the sender is really Hansel:
 
 ```js
-var portFromHansel;
+let portFromHansel;
 
 browser.runtime.onConnectExternal.addListener((port) => {
   console.log(port);

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -20,7 +20,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var openingPage = browser.runtime.openOptionsPage()
+let openingPage = browser.runtime.openOptionsPage()
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var opening = browser.runtime.openOptionsPage();
+let opening = browser.runtime.openOptionsPage();
 opening.then(onOpened, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -114,7 +114,7 @@ This content script:
 ```js
 // content-script.js
 
-var myPort = browser.runtime.connect({name:"port-from-cs"});
+let myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.postMessage({greeting: "hello from content script"});
 
 myPort.onMessage.addListener(function(m) {
@@ -141,7 +141,7 @@ The corresponding background script:
 ```js
 // background-script.js
 
-var portFromCS;
+let portFromCS;
 
 function connected(p) {
   portFromCS = p;
@@ -166,7 +166,7 @@ If you have multiple content scripts communicating at the same time, you might w
 ```js
 // background-script.js
 
-var ports = []
+let ports = []
 
 function connected(p) {
   ports[p.sender.tab.id]    = p
@@ -190,7 +190,7 @@ This example connects to the native application "ping_pong" and starts listening
 /*
 On startup, connect to the "ping_pong" app.
 */
-var port = browser.runtime.connectNative("ping_pong");
+let port = browser.runtime.connectNative("ping_pong");
 
 /*
 Listen for messages from the app.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var requestingCheck = browser.runtime.requestUpdateCheck()
+let requestingCheck = browser.runtime.requestUpdateCheck()
 ```
 
 ### Parameters
@@ -62,7 +62,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var requestingCheck = browser.runtime.requestUpdateCheck(onRequested);
+let requestingCheck = browser.runtime.requestUpdateCheck(onRequested);
 requestingCheck.then(onRequested, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -30,7 +30,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var sending = browser.runtime.sendMessage(
+let sending = browser.runtime.sendMessage(
   extensionId,             // optional string
   message,                 // any
   options                  // optional object
@@ -98,7 +98,7 @@ function handleError(error) {
 }
 
 function notifyBackgroundPage(e) {
-  var sending = browser.runtime.sendMessage({
+  let sending = browser.runtime.sendMessage({
     greeting: "Greeting from the content script"
   });
   sending.then(handleResponse, handleError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -28,7 +28,7 @@ For more information, see [Native messaging](/en-US/docs/Mozilla/Add-ons/WebExte
 ## Syntax
 
 ```js
-var sending = browser.runtime.sendNativeMessage(
+let sending = browser.runtime.sendNativeMessage(
   application,             // string
   message                  // object
 )
@@ -67,7 +67,7 @@ On a click on the browser action, send the app a message.
 */
 browser.browserAction.onClicked.addListener(() => {
   console.log("Sending:  ping");
-  var sending = browser.runtime.sendNativeMessage("ping_pong", "ping");
+  let sending = browser.runtime.sendNativeMessage("ping_pong", "ping");
   sending.then(onResponse, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var settingUrl = browser.runtime.setUninstallURL(
+let settingUrl = browser.runtime.setUninstallURL(
   url             // string
 )
 ```
@@ -51,7 +51,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var settingUrl = browser.runtime.setUninstallURL("https://example.org");
+let settingUrl = browser.runtime.setUninstallURL("https://example.org");
 settingUrl.then(onSetURL, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingEngines = browser.search.get()
+let gettingEngines = browser.search.get()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -19,7 +19,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var forgettingTab = browser.sessions.forgetClosedTab(
+let forgettingTab = browser.sessions.forgetClosedTab(
   windowId,            // integer
   sessionId            // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -19,7 +19,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var forgettingWindow = browser.sessions.forgetClosedWindow(
+let forgettingWindow = browser.sessions.forgetClosedWindow(
   sessionId            // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingSessions = browser.sessions.getRecentlyClosed(
+let gettingSessions = browser.sessions.getRecentlyClosed(
   filter             // optional object
 )
 ```
@@ -65,7 +65,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var gettingSessions = browser.sessions.getRecentlyClosed({
+  let gettingSessions = browser.sessions.getRecentlyClosed({
     maxResults: 1
   });
   gettingSessions.then(restoreMostRecent, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var retrieving = browser.sessions.getTabValue(
+let retrieving = browser.sessions.getTabValue(
   tabId,    // integer
   key       // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var retrieving = browser.sessions.getWindowValue(
+let retrieving = browser.sessions.getWindowValue(
   windowId,    // integer
   key          // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -68,7 +68,7 @@ function onError(error) {
 }
 
 function restoreMostRecent() {
-  var gettingSessions = browser.sessions.getRecentlyClosed({
+  let gettingSessions = browser.sessions.getRecentlyClosed({
     maxResults: 1
   });
   gettingSessions.then(restoreSession, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.sessions.removeTabValue(
+let removing = browser.sessions.removeTabValue(
   tabId,    // integer
   key       // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.sessions.removeWindowValue(
+let removing = browser.sessions.removeWindowValue(
   windowId,    // integer
   key          // string
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var restoringSession = browser.sessions.restore(
+let restoringSession = browser.sessions.restore(
   sessionId             // string
 )
 ```
@@ -62,7 +62,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var gettingSessions = browser.sessions.getRecentlyClosed({
+  let gettingSessions = browser.sessions.getRecentlyClosed({
     maxResults: 1
   });
   gettingSessions.then(restoreMostRecent, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var storing = browser.sessions.setTabValue(
+let storing = browser.sessions.setTabValue(
   tabId,    // integer
   key,      // string
   value     // string or object

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var storing = browser.sessions.setWindowValue(
+let storing = browser.sessions.setWindowValue(
   windowId,    // integer
   key,         // string
   value        // string or object

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingPanel = browser.sidebarAction.getPanel(
+let gettingPanel = browser.sidebarAction.getPanel(
   details               // object
 )
 ```
@@ -63,7 +63,7 @@ function onGot(sidebarUrl) {
   console.log(sidebarUrl);
 }
 
-var gettingPanel = browser.sidebarAction.getPanel({});
+let gettingPanel = browser.sidebarAction.getPanel({});
 gettingPanel.then(onGot);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingTitle = browser.sidebarAction.getTitle(
+let gettingTitle = browser.sidebarAction.getTitle(
   details               // object
 )
 ```
@@ -66,7 +66,7 @@ function toggleTitle(title) {
 }
 
 browser.browserAction.onClicked.addListener(() => {
-  var gettingTitle = browser.sidebarAction.getTitle({});
+  let gettingTitle = browser.sidebarAction.getTitle({});
   gettingTitle.then(toggleTitle);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -37,7 +37,7 @@ If you set a new icon using `setIcon()`, and omit both the `tabId` and `windowId
 ## Syntax
 
 ```js
-var settingIcon = browser.sidebarAction.setIcon(
+let settingIcon = browser.sidebarAction.setIcon(
   details         // object
 )
 ```
@@ -109,7 +109,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 The code below toggles the sidebar icon for the active tab when the user clicks a browser action:
 
 ```js
-var on = false;
+let on = false;
 
 function toggle(tab) {
   if (on) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -67,8 +67,8 @@ browser.sidebarAction.setPanel(
 This code toggles the sidebar document when the user clicks a browser action:
 
 ```js
-var thisPanel = browser.runtime.getURL("/this.html");
-var thatPanel = browser.runtime.getURL("/that.html");
+let thisPanel = browser.runtime.getURL("/this.html");
+let thatPanel = browser.runtime.getURL("/that.html");
 
 function toggle(panel) {
   if (panel === thisPanel) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -71,7 +71,7 @@ browser.sidebarAction.setTitle(
 This code changes the title for the sidebar when the user clicks a browser action, but only for the current tab:
 
 ```js
-var title = "A different title";
+let title = "A different title";
 
 function setTitleForTab(tab) {
   browser.sidebarAction.setTitle({title, tabId: tab.id});

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -40,7 +40,7 @@ Here's an example manifest:
 Given this manifest, the "favorite-color-examples\@mozilla.org" extension could access the data using code like this:
 
 ```js
-var storageItem = browser.storage.managed.get('color');
+let storageItem = browser.storage.managed.get('color');
 storageItem.then((res) => {
   console.log(`Managed color is: ${res.color}`);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var clearing = browser.storage.<storageType>.clear()
+let clearing = browser.storage.<storageType>.clear()
 ```
 
 `<storageType>` will be one of the writable storage types — {{WebExtAPIRef("storage.sync")}} or {{WebExtAPIRef("storage.local")}}.
@@ -51,7 +51,7 @@ function onError(e) {
   console.log(e);
 }
 
-var clearStorage = browser.storage.local.clear();
+let clearStorage = browser.storage.local.clear();
 clearStorage.then(onCleared, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -27,7 +27,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingSpace = browser.storage.<storageType>.getBytesInUse(
+let gettingSpace = browser.storage.<storageType>.getBytesInUse(
   keys                      // null, string, or array of strings
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -71,15 +71,15 @@ If an extension attempts to store items that exceed these limits, the call to [`
 
 The `sync` object implements the methods defined on the {{WebExtAPIRef("storage.StorageArea")}} type:
 
-- {{WebExtAPIRef("storage.StorageArea.get()", "storage.<var>StorageArea</var>.get()")}}
+- {{WebExtAPIRef("storage.StorageArea.get()", "storage.<let>StorageArea</let>.get()")}}
   - : Retrieves one or more items from the storage area.
-- {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.<var>StorageArea</var>.getBytesInUse()")}}
+- {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.<let>StorageArea</let>.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used one or more items being stored in the storage area.
-- {{WebExtAPIRef("storage.StorageArea.set()", "storage.<var>StorageArea</var>.set()")}}
+- {{WebExtAPIRef("storage.StorageArea.set()", "storage.<let>StorageArea</let>.set()")}}
   - : Stores one or more items in the storage area. If the item already exists, its value will be updated.
-- {{WebExtAPIRef("storage.StorageArea.remove()", "storage.<var>StorageArea</var>.remove()")}}
+- {{WebExtAPIRef("storage.StorageArea.remove()", "storage.<let>StorageArea</let>.remove()")}}
   - : Removes one or more items from the storage area.
-- {{WebExtAPIRef("storage.StorageArea.clear()", "storage.<var>StorageArea</var>.clear()")}}
+- {{WebExtAPIRef("storage.StorageArea.clear()", "storage.<let>StorageArea</let>.clear()")}}
   - : Removes all items from the storage area.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var capturing = browser.tabs.captureTab(
+let capturing = browser.tabs.captureTab(
   tabId,               // optional integer
   options              // optional extensionTypes.ImageDetails
 )
@@ -52,7 +52,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var capturing = browser.tabs.captureTab();
+  let capturing = browser.tabs.captureTab();
   capturing.then(onCaptured, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var capturing = browser.tabs.captureVisibleTab(
+let capturing = browser.tabs.captureVisibleTab(
   windowId,               // optional integer
   options                 // optional extensionTypes.ImageDetails
 )
@@ -53,7 +53,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var capturing = browser.tabs.captureVisibleTab();
+  let capturing = browser.tabs.captureVisibleTab();
   capturing.then(onCaptured, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -54,7 +54,7 @@ In this example a background script listens for a click on a [browser action](/e
 ```js
 function connectToTab(tabs) {
   if (tabs.length > 0) {
-    var examplePort = browser.tabs.connect(
+    let examplePort = browser.tabs.connect(
       tabs[0].id,
       {name: "tabs-connect-example"}
     );
@@ -67,7 +67,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var gettingActive = browser.tabs.query({
+  let gettingActive = browser.tabs.query({
     currentWindow: true, active: true
   });
   gettingActive.then(connectToTab, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var creating = browser.tabs.create(
+let creating = browser.tabs.create(
   createProperties   // object
 )
 ```
@@ -95,7 +95,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var creating = browser.tabs.create({
+  let creating = browser.tabs.create({
     url:"https://example.org"
   });
   creating.then(onCreated, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var detecting = browser.tabs.detectLanguage(
+let detecting = browser.tabs.detectLanguage(
   tabId,                  // optional integer
   callback                // optional function
 )
@@ -53,7 +53,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var detecting = browser.tabs.detectLanguage();
+  let detecting = browser.tabs.detectLanguage();
   detecting.then(onLanguageDetected, onError);
 });
 ```
@@ -71,14 +71,14 @@ function onError(error) {
 
 function detectLanguages(tabs) {
   for (tab of tabs) {
-    var onFulfilled = onLanguageDetected.bind(null, tab.url);
-    var detecting = browser.tabs.detectLanguage(tab.id);
+    let onFulfilled = onLanguageDetected.bind(null, tab.url);
+    let detecting = browser.tabs.detectLanguage(tab.id);
     detecting.then(onFulfilled, onError);
   }
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var querying = browser.tabs.query({});
+  let querying = browser.tabs.query({});
   querying.then(detectLanguages, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.md
@@ -26,7 +26,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var discarding = browser.tabs.discard(
+let discarding = browser.tabs.discard(
   tabIds          // integer or integer array
 )
 ```
@@ -55,7 +55,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var discarding = browser.tabs.discard(2);
+let discarding = browser.tabs.discard(2);
 discarding.then(onDiscarded, onError);
 ```
 
@@ -70,7 +70,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var discarding = browser.tabs.discard([15, 14, 1]);
+let discarding = browser.tabs.discard([15, 14, 1]);
 discarding.then(onDiscarded, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var duplicating = browser.tabs.duplicate(
+let duplicating = browser.tabs.duplicate(
   tabId,              // integer
   duplicateProperties // optional object
 )
@@ -64,13 +64,13 @@ function onError(error) {
 function duplicateFirstTab(tabs) {
   console.log(tabs);
   if (tabs.length > 0) {
-    var duplicating = browser.tabs.duplicate(tabs[0].id);
+    let duplicating = browser.tabs.duplicate(tabs[0].id);
     duplicating.then(onDuplicated, onError);
   }
 }
 
 // Query for all open tabs
-var querying = browser.tabs.query({});
+let querying = browser.tabs.query({});
 querying.then(duplicateFirstTab, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.tabs.get(
+let getting = browser.tabs.get(
   tabId              // integer
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.tabs.getAllInWindow(
+let getting = browser.tabs.getAllInWindow(
   windowId            // optional integer
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingSelected = browser.tabs.getSelected(
+let gettingSelected = browser.tabs.getSelected(
   windowId           // optional integer
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingZoom = browser.tabs.getZoom(
+let gettingZoom = browser.tabs.getZoom(
   tabId                     // optional integer
 )
 ```
@@ -49,7 +49,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var gettingZoom = browser.tabs.getZoom();
+let gettingZoom = browser.tabs.getZoom();
 gettingZoom.then(onGot, onError);
 ```
 
@@ -64,7 +64,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var gettingZoom = browser.tabs.getZoom(2);
+let gettingZoom = browser.tabs.getZoom(2);
 gettingZoom.then(onGot, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingZoomSettings = browser.tabs.getZoomSettings(
+let gettingZoomSettings = browser.tabs.getZoomSettings(
   tabId                       // optional integer
 )
 ```
@@ -49,7 +49,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var gettingZoomSettings = browser.tabs.getZoomSettings();
+let gettingZoomSettings = browser.tabs.getZoomSettings();
 gettingZoomSettings.then(onGot, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var withGoingBack = browser.tabs.goBack(
+let withGoingBack = browser.tabs.goBack(
   tabId,                  // optional integer
   callback                  // optional function
 )
@@ -55,7 +55,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var goingBack = browser.tabs.goBack();
+let goingBack = browser.tabs.goBack();
 goingBack.then(onGoBack, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var goingForward = browser.tabs.goForward(
+let goingForward = browser.tabs.goForward(
   tabId,                       // optional integer
   callback                       // optional function
 )
@@ -55,7 +55,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var goingForward = browser.tabs.goForward();
+let goingForward = browser.tabs.goForward();
 goingForward.then(onGoForward, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/hide/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/hide/index.md
@@ -34,7 +34,7 @@ To use this API you must have the "tabHide" [permission](/en-US/docs/Mozilla/Add
 ## Syntax
 
 ```js
-var hiding = browser.tabs.hide(
+let hiding = browser.tabs.hide(
   tabIds          // integer or integer array
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -20,7 +20,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var highlighting = browser.tabs.highlight(
+let highlighting = browser.tabs.highlight(
   highlightInfo         // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -30,7 +30,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var inserting = browser.tabs.insertCSS(
+let inserting = browser.tabs.insertCSS(
   tabId,           // optional integer
   details          // object
 )
@@ -73,7 +73,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 This example inserts into the currently active tab CSS which is taken from a string.
 
 ```js
-var css = "body { border: 20px dotted pink; }";
+let css = "body { border: 20px dotted pink; }";
 
 browser.browserAction.onClicked.addListener(() => {
 
@@ -81,7 +81,7 @@ browser.browserAction.onClicked.addListener(() => {
     console.log(`Error: ${error}`);
   }
 
-  var insertingCSS = browser.tabs.insertCSS({code: css});
+  let insertingCSS = browser.tabs.insertCSS({code: css});
   insertingCSS.then(null, onError);
 });
 ```
@@ -95,7 +95,7 @@ browser.browserAction.onClicked.addListener(() => {
     console.log(`Error: ${error}`);
   }
 
-  var insertingCSS = browser.tabs.insertCSS(2, {file: "content-style.css"});
+  let insertingCSS = browser.tabs.insertCSS(2, {file: "content-style.css"});
   insertingCSS.then(null, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var moving = browser.tabs.move(
+let moving = browser.tabs.move(
   tabIds,              // integer or integer array
   moveProperties       // object
 )
@@ -69,12 +69,12 @@ function firstToLast(windowInfo) {
   if (windowInfo.tabs.length == 0) {
     return;
   }
-  var moving = browser.tabs.move(windowInfo.tabs[0].id, {index: -1});
+  let moving = browser.tabs.move(windowInfo.tabs[0].id, {index: -1});
   moving.then(onMoved, onError);
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var gettingCurrent = browser.windows.getCurrent({populate: true});
+  let gettingCurrent = browser.windows.getCurrent({populate: true});
   gettingCurrent.then(firstToLast, onError);
 });
 ```
@@ -91,13 +91,13 @@ function onError(error) {
 }
 
 function moveMoz(tabs) {
-  var mozTabIds = tabs.map(tabInfo => tabInfo.id);
-  var moving = browser.tabs.move(mozTabIds, {index: -1});
+  let mozTabIds = tabs.map(tabInfo => tabInfo.id);
+  let moving = browser.tabs.move(mozTabIds, {index: -1});
   moving.then(onMoved, onError);
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var gettingMozTabs = browser.tabs.query({url:"*://*.mozilla.org/*"});
+  let gettingMozTabs = browser.tabs.query({url:"*://*.mozilla.org/*"});
   gettingMozTabs.then(moveMoz, onError);
 });
 ```
@@ -114,14 +114,14 @@ function onError(error) {
 }
 
 function moveMoz(tabs) {
-  var mozTabIds = tabs.map(tabInfo => tabInfo.id);
-  var targetWindow = tabs[0].windowId;
-  var moving = browser.tabs.move(mozTabIds, {windowId: targetWindow, index: 0});
+  let mozTabIds = tabs.map(tabInfo => tabInfo.id);
+  let targetWindow = tabs[0].windowId;
+  let moving = browser.tabs.move(mozTabIds, {windowId: targetWindow, index: 0});
   moving.then(onMoved, onError);
 }
 
 browser.browserAction.onClicked.addListener(function() {
-  var gettingMozTabs = browser.tabs.query({url:"*://*.mozilla.org/*"});
+  let gettingMozTabs = browser.tabs.query({url:"*://*.mozilla.org/*"});
   gettingMozTabs.then(moveMoz, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
@@ -25,7 +25,7 @@ window.addEventListener("afterprint", resumeFunction, false);
 ## Syntax
 
 ```js
-var openingPreview = browser.tabs.printPreview()
+let openingPreview = browser.tabs.printPreview()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var reloading = browser.tabs.reload(
+let reloading = browser.tabs.reload(
   tabId,            // optional integer
   reloadProperties  // optional object
 )
@@ -68,7 +68,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var reloading = browser.tabs.reload(2, {bypassCache: true});
+let reloading = browser.tabs.reload(2, {bypassCache: true});
 reloading.then(onReloaded, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.tabs.remove(
+let removing = browser.tabs.remove(
   tabIds          // integer or integer array
 )
 ```
@@ -49,7 +49,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var removing = browser.tabs.remove(2);
+let removing = browser.tabs.remove(2);
 removing.then(onRemoved, onError);
 ```
 
@@ -64,7 +64,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var removing = browser.tabs.remove([15, 14, 1]);
+let removing = browser.tabs.remove([15, 14, 1]);
 removing.then(onRemoved, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.tabs.removeCSS(
+let removing = browser.tabs.removeCSS(
   tabId,           // optional integer
   details          // object
 )
@@ -58,17 +58,17 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 This example adds some CSS using {{WebExtAPIRef("tabs.insertCSS")}}, then removes it again when the user clicks a browser action:
 
 ```js
-var css = "body { border: 20px dotted pink; }";
+let css = "body { border: 20px dotted pink; }";
 
 function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var insertingCSS = browser.tabs.insertCSS(2, {code: css});
+let insertingCSS = browser.tabs.insertCSS(2, {code: css});
 insertingCSS.then(null, onError);
 
 browser.browserAction.onClicked.addListener(() => {
-  var removing = browser.tabs.removeCSS(2, {code: css});
+  let removing = browser.tabs.removeCSS(2, {code: css});
   removing.then(null, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var saving = browser.tabs.saveAsPDF(
+let saving = browser.tabs.saveAsPDF(
   pageSettings   // object
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
@@ -25,7 +25,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var sending = browser.tabs.sendRequest(
+let sending = browser.tabs.sendRequest(
   tabId,                   // integer
   request                  // any
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var zooming = browser.tabs.setZoom(
+let zooming = browser.tabs.setZoom(
   tabId,           // optional integer
   zoomFactor       // number
 )
@@ -48,7 +48,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var setting = browser.tabs.setZoom(2);
+let setting = browser.tabs.setZoom(2);
 setting.then(null, onError);
 ```
 
@@ -59,7 +59,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var setting = browser.tabs.setZoom(16, 0.5);
+let setting = browser.tabs.setZoom(16, 0.5);
 setting.then(null, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var settingZoomSettings = browser.tabs.setZoomSettings(
+let settingZoomSettings = browser.tabs.setZoomSettings(
   tabId,           // optional integer
   zoomSettings     // ZoomSettings
 )
@@ -52,7 +52,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var setting = browser.tabs.setZoomSettings({mode:"disabled"});
+let setting = browser.tabs.setZoomSettings({mode:"disabled"});
 setting.then(onSet, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/show/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var showing = browser.tabs.show(
+let showing = browser.tabs.show(
   tabIds          // integer or integer array
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
@@ -42,7 +42,7 @@ browser.tabs.onUpdated.addListener(handleUpdated);
 ## Syntax
 
 ```js
-var toggling = browser.tabs.toggleReaderMode(
+let toggling = browser.tabs.toggleReaderMode(
   tabId            // optional integer
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var updating = browser.tabs.update(
+let updating = browser.tabs.update(
   tabId,              // optional integer
   updateProperties    // object
 )
@@ -97,7 +97,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var updating = browser.tabs.update({url: "https://developer.mozilla.org"});
+let updating = browser.tabs.update({url: "https://developer.mozilla.org"});
 updating.then(onUpdated, onError);
 ```
 
@@ -113,14 +113,14 @@ function onError(error) {
 }
 
 function updateFirstTab(tabs) {
-  var updating = browser.tabs.update(tabs[0].id, {
+  let updating = browser.tabs.update(tabs[0].id, {
     active: true,
     url: "https://developer.mozilla.org"
   });
   updating.then(onUpdated, onError);
 }
 
-var querying = browser.tabs.query({currentWindow:true});
+let querying = browser.tabs.query({currentWindow:true});
 querying.then(updateFirstTab, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.md
@@ -27,7 +27,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var warming = browser.tabs.warmup(
+let warming = browser.tabs.warmup(
   tabId               // integer
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -21,7 +21,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.theme.getCurrent(
+let getting = browser.theme.getCurrent(
   windowId    // integer
 )
 ```
@@ -55,7 +55,7 @@ function getStyle(themeInfo)
 
 async function getCurrentThemeInfo()
 {
-  var themeInfo = await browser.theme.getCurrent();
+  let themeInfo = await browser.theme.getCurrent();
   getStyle(themeInfo);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -32,7 +32,7 @@ To use the topSites API you must have the "topSites" [API permission](/en-US/doc
 ## Syntax
 
 ```js
-var gettingTopSites = browser.topSites.get(
+let gettingTopSites = browser.topSites.get(
     options  // object
 )
 ```
@@ -83,7 +83,7 @@ function onError(error) {
   console.log(error);
 }
 
-var gettingTopSites = browser.topSites.get();
+let gettingTopSites = browser.topSites.get();
 gettingTopSites.then(logTopSites, onError);
 ```
 
@@ -100,7 +100,7 @@ function onError(error) {
   console.log(error);
 }
 
-var gettingTopSites = browser.topSites.get({
+let gettingTopSites = browser.topSites.get({
   includeBlocked: true,
   onePerDomain: false
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var clearing = setting.clear(
+let clearing = setting.clear(
   details     // object
 )
 ```
@@ -53,7 +53,7 @@ function onCleared(result) {
   }
 }
 
-var clearing = browser.privacy.network.webRTCIPHandlingPolicy.clear({});
+let clearing = browser.privacy.network.webRTCIPHandlingPolicy.clear({});
 clearing.then(onCleared);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -20,7 +20,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = setting.get(
+let getting = setting.get(
   details     // object
 )
 ```
@@ -70,7 +70,7 @@ See {{WebExtAPIRef("types.BrowserSetting")}}.
 Log the value and level of control for the `networkPredictionEnabled` property of the {{WebExtAPIRef("privacy.network")}} object, for private browsing windows. Note that this requires the "privacy" browser permission.
 
 ```js
-var getting = browser.privacy.network.networkPredictionEnabled.get({});
+let getting = browser.privacy.network.networkPredictionEnabled.get({});
 
 getting.then((got) => {
   console.log(`Value: ${got.value}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -34,7 +34,7 @@ The [`BrowserSetting.set()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types
 ## Syntax
 
 ```js
-var setting = setting.set(
+let setting = setting.set(
   details     // object
 )
 ```
@@ -71,7 +71,7 @@ function onSet(result) {
 
 browser.browserAction.onClicked.addListener(() => {
 
-    var setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
+    let setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
       value: false
     });
     setting.then(onSet);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingFrames = browser.webNavigation.getAllFrames(
+let gettingFrames = browser.webNavigation.getAllFrames(
   details                // object
 )
 ```
@@ -73,13 +73,13 @@ function onError(error) {
 }
 
 function logAllFrames(tabs) {
-  var gettingAllFrames = browser.webNavigation.getAllFrames({tabId: tabs[0].id});
+  let gettingAllFrames = browser.webNavigation.getAllFrames({tabId: tabs[0].id});
   gettingAllFrames.then(logFrameInfo, onError);
 }
 
 browser.browserAction.onClicked.addListener(function() {
 
-  var querying = browser.tabs.query({
+  let querying = browser.tabs.query({
     currentWindow: true,
     active: true
   });

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingFrame = browser.webNavigation.getFrame(
+let gettingFrame = browser.webNavigation.getFrame(
   details                // object
 )
 ```
@@ -68,13 +68,13 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var gettingFrame = browser.webNavigation.getFrame({
+let gettingFrame = browser.webNavigation.getFrame({
   tabId: 19,
   frameId: 1537
 });
 
 // Edge specific - processId is required not optional, must be integer not null
-//var gettingFrame = browser.webNavigation.getFrame({ tabId: 19, processId: 0, frameId: 1537 });
+//let gettingFrame = browser.webNavigation.getFrame({ tabId: 19, processId: 0, frameId: 1537 });
 
 gettingFrame.then(onGot, onError);
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -25,7 +25,7 @@ To use this API you must have the `"webRequestBlocking"` [API permission](/en-US
 ## Syntax
 
 ```js
-var filter = browser.webRequest.filterResponseData(
+let filter = browser.webRequest.filterResponseData(
   requestId       // string
 )
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -25,7 +25,7 @@ You must also pass the "blocking" option to `webRequest.onHeadersReceived.addLis
 ## Syntax
 
 ```js
-var gettingInfo = browser.webRequest.getSecurityInfo(
+let gettingInfo = browser.webRequest.getSecurityInfo(
   requestId,       // string
   options          // object
 )

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -35,7 +35,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var flushingCache = browser.webRequest.handlerBehaviorChanged()
+let flushingCache = browser.webRequest.handlerBehaviorChanged()
 ```
 
 ### Parameters
@@ -63,7 +63,7 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-var flushingCache = browser.webRequest.handlerBehaviorChanged();
+let flushingCache = browser.webRequest.handlerBehaviorChanged();
 flushingCache.then(onFlushed, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -247,7 +247,7 @@ const pendingRequests = [];
 // We can stop worrying about it.
 function completed(requestDetails) {
   console.log(`completed: ${requestDetails.requestId}`);
-  var index = pendingRequests.indexOf(requestDetails.requestId);
+  let index = pendingRequests.indexOf(requestDetails.requestId);
   if (index > -1) {
     pendingRequests.splice(index, 1);
   }
@@ -294,7 +294,7 @@ const pendingRequests = [];
 */
 function completed(requestDetails) {
   console.log(`completed: ${requestDetails.requestId}`);
-  var index = pendingRequests.indexOf(requestDetails.requestId);
+  let index = pendingRequests.indexOf(requestDetails.requestId);
   if (index > -1) {
     pendingRequests.splice(index, 1);
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -156,7 +156,7 @@ Events have three functions:
 ## Examples
 
 ```js
-var target = "https://developer.mozilla.org/*";
+let target = "https://developer.mozilla.org/*";
 
 /*
 e.g.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -202,7 +202,7 @@ This code cancels requests for images that are made to URLs under "https\://mdn.
 
 ```js
 // match pattern for the URLs to redirect
-var pattern = "https://mdn.mozillademos.org/*";
+let pattern = "https://mdn.mozillademos.org/*";
 
 // cancel function returns an object
 // which contains a property `cancel` set to `true`
@@ -224,7 +224,7 @@ This code replaces, by redirection, all network requests for images that are mad
 
 ```js
 // match pattern for the URLs to redirect
-var pattern = "https://mdn.mozillademos.org/*";
+let pattern = "https://mdn.mozillademos.org/*";
 
 // redirect function
 // returns an object with a property `redirectURL`
@@ -249,10 +249,10 @@ This code is exactly like the previous example, except that the listener handles
 
 ```js
 // match pattern for the URLs to redirect
-var pattern = "https://mdn.mozillademos.org/*";
+let pattern = "https://mdn.mozillademos.org/*";
 
 // URL we will redirect to
-var redirectUrl = "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif";
+let redirectUrl = "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif";
 
 // redirect function returns a Promise
 // which is resolved with the redirect URL when a timer expires
@@ -277,9 +277,9 @@ browser.webRequest.onBeforeRequest.addListener(
 Another example, that redirects all images to a data url:
 
 ```js
-var pattern = "https://mdn.mozillademos.org/*";
+let pattern = "https://mdn.mozillademos.org/*";
 
-var image = `
+let image = `
   <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
     <rect style="stroke-width: 10; stroke: #666;" width="100%" height="100%" fill="#d4d0c8" />
     <text transform="translate(0, 9)" x="50%" y="50%" width="100%" fill="#666" height="100%" style="text-anchor: middle; font: bold 10pt 'Segoe UI', Arial, Helvetica, Sans-serif;">Blocked</text>
@@ -305,9 +305,9 @@ function randomColor() {
   return "#" + Math.floor(Math.random()*16777215).toString(16);
 }
 
-var pattern = "https://mdn.mozillademos.org/*";
+let pattern = "https://mdn.mozillademos.org/*";
 
-var image = `
+let image = `
   <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
     <rect width="100%" height="100%" fill="${randomColor()}"/>
   </svg>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -178,18 +178,18 @@ This code changes the "User-Agent" header so the browser identifies itself as Op
 /*
 This is the page for which we want to rewrite the User-Agent header.
 */
-var targetPage = "https://httpbin.org/*";
+let targetPage = "https://httpbin.org/*";
 
 /*
 Set UA string to Opera 12
 */
-var ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
+let ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
 
 /*
 Rewrite the User-Agent header to "ua".
 */
 function rewriteUserAgentHeader(e) {
-  for (var header of e.requestHeaders) {
+  for (let header of e.requestHeaders) {
     if (header.name.toLowerCase() === "user-agent") {
       header.value = ua;
     }
@@ -218,20 +218,20 @@ This code is exactly like the previous example, except that the listener is asyn
 /*
 This is the page for which we want to rewrite the User-Agent header.
 */
-var targetPage = "https://httpbin.org/*";
+let targetPage = "https://httpbin.org/*";
 
 /*
 Set UA string to Opera 12
 */
-var ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
+let ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
 
 /*
 Rewrite the User-Agent header to "ua".
 */
 function rewriteUserAgentHeaderAsync(e) {
-  var asyncRewrite = new Promise((resolve, reject) => {
+  let asyncRewrite = new Promise((resolve, reject) => {
     window.setTimeout(() => {
-      for (var header of e.requestHeaders) {
+      for (let header of e.requestHeaders) {
         if (header.name.toLowerCase() === "user-agent") {
           header.value = ua;
         }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -154,7 +154,7 @@ Events have three functions:
 ## Examples
 
 ```js
-var target = "https://developer.mozilla.org/*";
+let target = "https://developer.mozilla.org/*";
 
 /*
 e.g.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -148,7 +148,7 @@ Events have three functions:
 ## Examples
 
 ```js
-var target = "<all_urls>";
+let target = "<all_urls>";
 
 /*
 e.g., with no network:

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -176,12 +176,12 @@ Events have three functions:
 This code sets an extra cookie when requesting a resource from the target URL:
 
 ```js
-var targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
+let targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
 
 // Add the new header to the original array,
 // and return it.
 function setCookie(e) {
-  var setMyCookie = {
+  let setMyCookie = {
     name: "Set-Cookie",
     value: "my-cookie1=my-cookie-value1"
   };
@@ -201,15 +201,15 @@ browser.webRequest.onHeadersReceived.addListener(
 This code does the same thing the previous example, except that the listener is asynchronous, returning a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which is resolved with the new headers:
 
 ```js
-var targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
+let targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
 
 // Return a Promise that sets a timer.
 // When the timer fires, resolve the promise with
 // modified set of response headers.
 function setCookieAsync(e) {
-  var asyncSetCookie = new Promise((resolve, reject) => {
+  let asyncSetCookie = new Promise((resolve, reject) => {
     window.setTimeout(() => {
-      var setMyCookie = {
+      let setMyCookie = {
         name: "Set-Cookie",
         value: "my-cookie1=my-cookie-value1"
       };

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -154,7 +154,7 @@ Events have three functions:
 ## Examples
 
 ```js
-var target = "https://developer.mozilla.org/*";
+let target = "https://developer.mozilla.org/*";
 
 /*
 e.g.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -149,11 +149,11 @@ This code logs all cookies that will be sent in making requests to the target [m
 
 ```js
 // The target match pattern
-var targetPage = "*://*.google.ca/*";
+let targetPage = "*://*.google.ca/*";
 
 // Log cookies sent with this request
 function logCookies(e) {
-  for (var header of e.requestHeaders) {
+  for (let header of e.requestHeaders) {
     if (header.name == "Cookie") {
       console.log(header.value);
     }

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -30,7 +30,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var creating = browser.windows.create(
+let creating = browser.windows.create(
   createData            // optional object
 )
 ```
@@ -91,7 +91,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener((tab) => {
-  var creating = browser.windows.create({
+  let creating = browser.windows.create({
     url: ["https://developer.mozilla.org",
           "https://addons.mozilla.org"]
   });
@@ -111,7 +111,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener((tab) => {
-  var creating = browser.windows.create({
+  let creating = browser.windows.create({
     tabId: tab.id
   });
   creating.then(onCreated, onError);
@@ -131,9 +131,9 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener((tab) => {
 
-  var popupURL = browser.extension.getURL("popup/popup.html");
+  let popupURL = browser.extension.getURL("popup/popup.html");
 
-  var creating = browser.windows.create({
+  let creating = browser.windows.create({
     url: popupURL,
     type: "popup",
     height: 200,

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var getting = browser.windows.get(
+let getting = browser.windows.get(
   windowId,              // integer
   getInfo                // optional object
 )
@@ -69,7 +69,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener((tab) => {
-  var getting = browser.windows.get(tab.windowId, {populate: true});
+  let getting = browser.windows.get(tab.windowId, {populate: true});
   getting.then(logTabs, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingAll = browser.windows.getAll(
+let gettingAll = browser.windows.getAll(
   getInfo                // optional object
 )
 ```
@@ -63,7 +63,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener((tab) => {
-  var getting = browser.windows.getAll({
+  let getting = browser.windows.getAll({
     populate: true,
     windowTypes: ["normal"]
   });

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -24,7 +24,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingCurrent = browser.windows.getCurrent(
+let gettingCurrent = browser.windows.getCurrent(
   getInfo               // optional object
 )
 ```
@@ -66,7 +66,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener((tab) => {
-  var getting = browser.windows.getCurrent({populate: true});
+  let getting = browser.windows.getCurrent({populate: true});
   getting.then(logTabs, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var gettingWindow = browser.windows.getLastFocused(
+let gettingWindow = browser.windows.getLastFocused(
   getInfo               // optional object
 )
 ```
@@ -64,7 +64,7 @@ function onError(error) {
 }
 
 browser.browserAction.onClicked.addListener((tab) => {
-  var getting = browser.windows.getLastFocused({populate: true});
+  let getting = browser.windows.getLastFocused({populate: true});
   getting.then(logTabs, onError);
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var removing = browser.windows.remove(
+let removing = browser.windows.remove(
   windowId        // integer
 )
 ```
@@ -56,7 +56,7 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener((tab) => {
 
-  var removing = browser.windows.remove(tab.windowId);
+  let removing = browser.windows.remove(tab.windowId);
   removing.then(onRemoved, onError);
 
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 ## Syntax
 
 ```js
-var updating = browser.windows.update(
+let updating = browser.windows.update(
   windowId,              // integer
   updateInfo             // object
 )
@@ -76,7 +76,7 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener((tab) => {
 
-  var updating = browser.windows.update(tab.windowId, {
+  let updating = browser.windows.update(tab.windowId, {
     left: 0,
     top: 0
   });

--- a/files/en-us/mozilla/add-ons/webextensions/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_security_policy/index.md
@@ -86,7 +86,7 @@ window.setTimeout("alert('Hello World!');", 500);
 ```
 
 ```js
-var f = new Function("console.log('foo');");
+let f = new Function("console.log('foo');");
 ```
 
 ### Inline JavaScript

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -78,7 +78,7 @@ To make the `"copy"` button copy the contents of the {{HTMLElement("input")}} el
 
 ```js
 function copy() {
-  var copyText = document.querySelector("#input");
+  let copyText = document.querySelector("#input");
   copyText.select();
   document.execCommand("copy");
 }
@@ -92,7 +92,7 @@ However, let's say that instead you trigger the copy from an alarm:
 
 ```js
 function copy() {
-  var copyText = document.querySelector("#input");
+  let copyText = document.querySelector("#input");
   copyText.select();
   document.execCommand("copy");
 }
@@ -156,7 +156,7 @@ To set the content of the {{HTMLElement("textarea")}} element with the ID `"outp
 
 ```js
 function paste() {
-  var pasteText = document.querySelector("#output");
+  let pasteText = document.querySelector("#output");
   pasteText.focus();
   document.execCommand("paste");
   console.log(pasteText.textContent);

--- a/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -112,8 +112,8 @@ The changes here are to:
 Next, replace **background.js** with this:
 
 ```js
-var pattern = "https://developer.mozilla.org/*";
-var targetUrl = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
+let pattern = "https://developer.mozilla.org/*";
+let targetUrl = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
 
 function redirect(requestDetails) {
   console.log("Redirecting: " + requestDetails.url);
@@ -175,9 +175,9 @@ Update your **manifest.json** to include `http://useragentstring.com/`
 Replace "background.js" with code like this:
 
 ```js
-var targetPage = "http://useragentstring.com/*";
+let targetPage = "http://useragentstring.com/*";
 
-var ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
+let ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
 
 function rewriteUserAgentHeader(e) {
   e.requestHeaders.forEach(function(header){

--- a/files/en-us/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/internationalization/index.md
@@ -162,8 +162,8 @@ So, you've got your message strings set up, and your manifest. Now you just need
 In our [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n) example, the [background script](https://github.com/mdn/webextensions-examples/blob/master/notify-link-clicks-i18n/background-script.js) contains the following lines:
 
 ```js
-var title = browser.i18n.getMessage("notificationTitle");
-var content = browser.i18n.getMessage("notificationContent", message.url);
+let title = browser.i18n.getMessage("notificationTitle");
+let content = browser.i18n.getMessage("notificationContent", message.url);
 ```
 
 The first one just retrieves the `notificationTitle message` field from the available `messages.json` file most appropriate for the browser's current locale. The second one is similar, but it is being passed a URL as a second parameter. What gives? This is how you specify the content to replace the `$URL$` placeholder we see in the `notificationContent message` field:

--- a/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -53,7 +53,7 @@ Next, create a file called "page-eater.js" inside the "modify-page" directory, a
 ```js
 document.body.textContent = "";
 
-var header = document.createElement('h1');
+let header = document.createElement('h1');
 header.textContent = "This page has been eaten";
 document.body.appendChild(header);
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -175,7 +175,7 @@ Here's an example background script that establishes a connection with the `"pin
 /*
 On startup, connect to the "ping_pong" app.
 */
-var port = browser.runtime.connectNative("ping_pong");
+let port = browser.runtime.connectNative("ping_pong");
 
 /*
 Listen for messages from the app.
@@ -224,7 +224,7 @@ On a click on the browser action, send the app a message.
 */
 browser.browserAction.onClicked.addListener(() => {
   console.log("Sending:  ping");
-  var sending = browser.runtime.sendNativeMessage(
+  let sending = browser.runtime.sendNativeMessage(
     "ping_pong",
     "ping");
   sending.then(onResponse, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -28,8 +28,8 @@ When working with strings, there are a couple of recommended options to safely a
 A lightweight approach to inserting strings into a page is to use the native DOM manipulation methods: [`document.createElement`](/en-US/docs/Web/API/Document/createElement), [`Element.setAttribute`](/en-US/docs/Web/API/Element/setAttribute), and [`Node.textContent`](/en-US/docs/Web/API/Node/textContent). The safe approach is to create the nodes separately and assign their content using textContent:
 
 ```js example-good
-var data = JSON.parse(responseText);
-var div = document.createElement("div");
+let data = JSON.parse(responseText);
+let div = document.createElement("div");
 div.className = data.className;
 div.textContent = "Your favorite color is now " + data.color;
 addonElement.appendChild(div);
@@ -40,7 +40,7 @@ This approach is safe because the use of `.textContent` automatically escapes an
 However, beware, you can use native methods that aren't safe. Take the following code:
 
 ```js example-bad
-var data = JSON.parse(responseText);
+let data = JSON.parse(responseText);
 addonElement.innerHTML = "<div class='" + data.className + "'>" +
                          "Your favorite color is now " + data.color +
                          "</div>";
@@ -53,7 +53,7 @@ Here, the contents of `data.className` or `data.color` could contain HTML that c
 When using jQuery, functions such as `attr()` and `text()` escape content as it's added to a DOM. So, the "favorite color" example from above, implemented in jQuery, would look like this:
 
 ```js example-good
-var node = $("</div>");
+let node = $("</div>");
 node.addClass(data.className);
 node.text("Your favorite color is now " + data.color);
 ```
@@ -80,16 +80,16 @@ For production use, [DOMPurify](https://github.com/cure53/DOMPurify) comes as a 
 Then, in myinjectionscript.js you can read the external HTML, sanitize it, and add it to a page's DOM:
 
 ```js
-var elem = document.createElement("div");
-var cleanHTML = DOMPurify.sanitize(externalHTML);
+let elem = document.createElement("div");
+let cleanHTML = DOMPurify.sanitize(externalHTML);
 elem.innerHTML = cleanHTML;
 ```
 
 You can use any method to add the sanitized HTML to your DOM, for example jQuery's `.html()` function. Remember though that the `SAFE_FOR_JQUERY` flag needs to be used in this case:
 
 ```js
-var elem = $("<div/>");
-var cleanHTML = DOMPurify.sanitize(externalHTML, { SAFE_FOR_JQUERY: true });
+let elem = $("<div/>");
+let cleanHTML = DOMPurify.sanitize(externalHTML, { SAFE_FOR_JQUERY: true });
 elem.html(cleanHTML);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -61,7 +61,7 @@ The script adds an expando property to the global `window`:
 ```js
 // main.js
 
-var foo = "I'm defined in a page script!";
+let foo = "I'm defined in a page script!";
 ```
 
 Xray vision means that if a content script tries to access `foo`, it will be undefined:
@@ -174,7 +174,7 @@ Because the object contains functions,
 the cloneInto call must include
 the `cloneFunctions` option.
 */
-var messenger = {
+let messenger = {
   notify: function(message) {
     browser.runtime.sendMessage({
       content: "Object method call: " + message

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/notifications/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/notifications/index.md
@@ -23,8 +23,8 @@ You manage notifications programmatically, using the {{WebExtAPIRef("notificatio
 You then use {{WebExtAPIRef("notifications.create")}} to create your notifications, as in this example from [notify-link-clicks-i18n:](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n)
 
 ```js
-var title = browser.i18n.getMessage("notificationTitle");
-var content = browser.i18n.getMessage("notificationContent", message.url);
+let title = browser.i18n.getMessage("notificationTitle");
+let content = browser.i18n.getMessage("notificationContent", message.url);
 browser.notifications.create({
   "type": "basic",
   "iconUrl": browser.extension.getURL("icons/link-48.png"),

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
@@ -84,13 +84,13 @@ All the features of the extension are implemented through [context.js](https://g
 
 The script first gets the 'identity-list' div from context.html.
 
-```json
-var div = document.getElementById('identity-list');
+```js
+let div = document.getElementById('identity-list');
 ```
 
 It then checks whether the contextual identities feature is turned on in the browser. If it's not on, information on how to activate it is added to the popup.
 
-```json
+```js
 if (browser.contextualIdentities === undefined) {
   div.innerText = 'browser.contextualIdentities not available. Check that the privacy.userContext.enabled pref is set to true, and reload the add-on.';
 } else {
@@ -100,7 +100,7 @@ Firefox installs with the contextual identity feature turned off, it's turned on
 
 The script now uses contextualIdentities.query to determine whether there are any contextual identities defined in the browser. If there are none, a message is added to the popup and the script stops.
 
-```json
+```js
   browser.contextualIdentities.query({})
     .then((identities) => {
       if (!identities.length) {
@@ -111,7 +111,7 @@ The script now uses contextualIdentities.query to determine whether there are an
 
 If there are contextual identities present—Firefox comes with four default identities—the script loops through each one adding its name, styled in its chosen color, to the \<div> element. The function `createOptions()` then adds the options to "create" or "close all" to the \<div> before it's added to the popup.
 
-```json
+```js
      for (let identity of identities) {
        let row = document.createElement('div');
        let span = document.createElement('span');
@@ -147,7 +147,7 @@ function eventHandler(event) {
 
 If the user clicks the option to create a tab for an identity, one is opened using tabs.create by passing the identity's cookie store ID.
 
-```json
+```js
   if (event.target.dataset.action == 'create') {
     browser.tabs.create({
       url: 'about:blank',
@@ -158,7 +158,7 @@ If the user clicks the option to create a tab for an identity, one is opened usi
 
 If the user selects the option to close all tabs for the identity, the script performs a tabs.query for all tabs that are using the identity's cookie store. The script then passes this list of tabs to `tabs.remove`.
 
-```json
+```js
   if (event.target.dataset.action == 'close-all') {
     browser.tabs.query({
       cookieStoreId: event.target.dataset.identity

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
@@ -120,7 +120,7 @@ Defines the background script that'll add and remove the page's bookmark and set
 As with any background script, [background.js](https://github.com/mdn/webextensions-examples/blob/master/bookmark-it/background.js) is run as soon as the extension is started. Initially the script calls `updateActiveTab()` that starts by obtaining the `Tabs` object for the current tab, using {{WebExtAPIRef("tabs.query")}}, and passing the object to `updatetab()` with this code:
 
 ```js
-  var gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
+  let gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
   gettingActiveTab.then(updateTab);
 ```
 
@@ -137,8 +137,8 @@ As with any background script, [background.js](https://github.com/mdn/webextensi
 
 ```js
   function isSupportedProtocol(urlString) {
-    var supportedProtocols = ["https:", "http:", "file:"];
-    var url = document.createElement('a');
+    let supportedProtocols = ["https:", "http:", "file:"];
+    let url = document.createElement('a');
     url.href = urlString;
     return supportedProtocols.indexOf(url.protocol) != -1;
   }
@@ -147,7 +147,7 @@ As with any background script, [background.js](https://github.com/mdn/webextensi
 If the protocol is one supported by bookmarks, the extension determines if the tab's URL is already bookmarked and if it is, calls `updateIcon()`:
 
 ```js
-      var searching = browser.bookmarks.search({url: currentTab.url});
+      let searching = browser.bookmarks.search({url: currentTab.url});
       searching.then((bookmarks) => {
         currentBookmark = bookmarks[0];
         updateIcon();

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
@@ -129,15 +129,15 @@ The extension's UI uses a toolbar button ({{WebExtAPIRef("browserAction")}}) imp
 To handle the icon buttons the script first gathers all the class names used for the buttons in the HTML file:
 
 ```js
-var bgBtns = document.querySelectorAll('.bg-container button');
+let bgBtns = document.querySelectorAll('.bg-container button');
 ```
 
 It then loops through all the buttons assigning them their image and creating an onclick listener for each button:
 
 ```js
-for(var i = 0; i < bgBtns.length; i++) {
-  var imgName = bgBtns[i].getAttribute('class');
-  var bgImg = 'url(\'images/' + imgName + '.png\')';
+for(let i = 0; i < bgBtns.length; i++) {
+  let imgName = bgBtns[i].getAttribute('class');
+  let bgImg = 'url(\'images/' + imgName + '.png\')';
   bgBtns[i].style.backgroundImage = bgImg;
 
   bgBtns[i].onclick = function(e) {
@@ -167,7 +167,7 @@ The color setting is handled in a similar way, triggered by a listener on the co
 When the user clicks the reset button, which has been assigned to the variable reset:
 
 ```js
-var reset = document.querySelector('.color-reset button');
+let reset = document.querySelector('.color-reset button');
 ```
 
 `reset.onclick` first finds the active tab. Then, using the tab's ID it passes a message to the page's content script ([updatebg.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/content_scripts/updatebg.js)) to get it to remove the icon and color from the page. The function then clears the cookie values (so the old values aren't carried forward and written onto a cookie created for a new icon or color selection on the same page) before removing the cookie:
@@ -196,7 +196,7 @@ browser.cookies.onChanged.addListener((changeInfo) => {
 A background script ([background.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/background_scripts/background.js)) provides for the possibility that the user has chosen a background icon and color for the website in an earlier session. The script listens for changes in the active tab, either the user switching between tabs or changing the URL of the page displayed in the tab. When either of these events happen, `cookieUpdate()` is called.  `cookieUpdate()` in turn uses `getActiveTab()` to get the active tab ID. The function can then check whether a cookie for the extension exists, using the tab's URL:
 
 ```js
-    var gettingCookies = browser.cookies.get({
+    let gettingCookies = browser.cookies.get({
       url: tabs[0].url,
       name: "bgpicker"
     });
@@ -207,7 +207,7 @@ If the `"bgpicker"` cookie exists for the website, the details of the icon and c
 ```js
     gettingCookies.then((cookie) => {
       if (cookie) {
-        var cookieVal = JSON.parse(cookie.value);
+        let cookieVal = JSON.parse(cookie.value);
         browser.tabs.sendMessage(tabs[0].id, {image: cookieVal.image});
         browser.tabs.sendMessage(tabs[0].id, {color: cookieVal.color});
       }

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -231,7 +231,7 @@ Where `callOnActiveTab()` finds the active tab object by looping through the {{W
 document.addEventListener("click", function(e) {
   function callOnActiveTab(callback) {
     getCurrentWindowTabs().then((tabs) => {
-      for (var tab of tabs) {
+      for (let tab of tabs) {
         if (tab.active) {
           callback(tab, tabs);
         }
@@ -300,7 +300,7 @@ But first, here is a demonstration of the feature in action:
       function callOnActiveTab(callback) {
 
         getCurrentWindowTabs().then((tabs) => {
-          for (var tab of tabs) {
+          for (let tab of tabs) {
             if (tab.active) {
               callback(tab, tabs);
             }
@@ -317,7 +317,7 @@ But first, here is a demonstration of the feature in action:
     ```js
     if (e.target.id === "tabs-move-beginning") {
       callOnActiveTab((tab, tabs) => {
-        var index = 0;
+        let index = 0;
         if (!tab.pinned) {
           index = firstUnpinnedTab(tabs);
         }
@@ -336,7 +336,7 @@ But first, here is a demonstration of the feature in action:
     ```js
     function callOnActiveTab(callback) {
       getCurrentWindowTabs().then((tabs) => {
-        for (var tab of tabs) {
+        for (let tab of tabs) {
           if (tab.active) {
             callback(tab, tabs);
           }
@@ -410,13 +410,13 @@ Let's take a look at how the zoom in is implemented.
     ```js
       else if (e.target.id === "tabs-add-zoom") {
         callOnActiveTab((tab) => {
-          var gettingZoom = browser.tabs.getZoom(tab.id);
+          let gettingZoom = browser.tabs.getZoom(tab.id);
           gettingZoom.then((zoomFactor) => {
             //the maximum zoomFactor is 5, it can't go higher
             if (zoomFactor >= MAX_ZOOM) {
               alert("Tab zoom factor is already at max!");
             } else {
-              var newZoomFactor = zoomFactor + ZOOM_INCREMENT;
+              let newZoomFactor = zoomFactor + ZOOM_INCREMENT;
               //if the newZoomFactor is set to higher than the max accepted
               //it won't change, and will never alert that it's at maximum
               newZoomFactor = newZoomFactor > MAX_ZOOM ? MAX_ZOOM : newZoomFactor;
@@ -503,7 +503,7 @@ Let's walk through how it's set up.
     When first loaded, the extension uses {{WebExtAPIRef("tabs.query()")}} to get a list of all the tabs in the current browser window. It then loops through the tabs calling `initializePageAction()`.
 
     ```js
-    var gettingAllTabs = browser.tabs.query({});
+    let gettingAllTabs = browser.tabs.query({});
 
         gettingAllTabs.then((tabs) => {
           for (let tab of tabs) {
@@ -517,7 +517,7 @@ Let's walk through how it's set up.
 
     ```js
     function protocolIsApplicable(url) {
-      var anchor =  document.createElement('a');
+      let anchor =  document.createElement('a');
       anchor.href = url;
       return APPLICABLE_PROTOCOLS.includes(anchor.protocol);
     }
@@ -568,7 +568,7 @@ Let's walk through how it's set up.
         }
       }
 
-      var gettingTitle = browser.pageAction.getTitle({tabId: tab.id});
+      let gettingTitle = browser.pageAction.getTitle({tabId: tab.id});
 
       gettingTitle.then(gotTitle);
     }


### PR DESCRIPTION
#### Summary
This change replaces the use of the `var` with `let` in the code snippets and examples within the web extension section. This addresses the requirement identified in "Replace var with let in code snippets and examples" #11343 (which in tern was originally identified in discussions on "Use const in place of var" #11135).

After completing the global search and replace, all the files were checked. This discovered:
- one occurrence within a CSS example (on the [theme_experiment](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment) page) that was reverted
- code blocks incorrectly tagged with ` json` on [Work with contextual identities](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) which were also corrected.

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error