### PR TITLE
Small fix: AuthenticatorAttestationResponse.getTransports()

### DIFF
--- a/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
@@ -40,8 +40,7 @@ None.
 ### Return value
 
 An {{jsxref("Array")}} containing the different transports supported by the
-authenticator or nothing if this information is not available.of the processing of the
-different extensions by the client. The elements of this array are supposed to be in
+authenticator or nothing if this information is not available. The elements of this array are supposed to be in
 lexicographical order. Their values may be :
 
 - `"usb"`: the authenticator can be contacted via a removable USB link


### PR DESCRIPTION
#### Summary
Removed copy-paste error (partial sentence) from the `Return value` section of the [AuthenticatorAttestationResponse.getTransports()](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports) page.

#### Motivation
It seems that there was a coped partial sentence inserted into `Return value` section, which should not be on this page.
The removed sentence part seems to be "coming from" the [getClientExtensionResults](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/getClientExtensionResults) page.

#### Supporting details
- Fixing this page: https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports
- Copy-pasted partial sentence came from this page: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/getClientExtensionResults

#### Related issues
N/A

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
