### PR TITLE
Fixed link to MS Edge DevTools

### DIFF
--- a/files/en-us/web/index.md
+++ b/files/en-us/web/index.md
@@ -61,5 +61,5 @@ The open Web presents incredible opportunities for developers. To take full adva
   - : Documentation for the set of web-developer tools built into Chrome.
 - [Safari Web Inspector](https://webkit.org/web-inspector/)
   - : Documentation for the set of web-developer tools built into Safari.
-- [Edge DevTools](https://webkit.org/web-inspector/)
+- [Edge DevTools](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/)
   - : Documentation for the set of web-developer tools built into Edge.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Microsoft Edge DevTools currently links to Safari WebKit Devtools documentation. Changes link to Microsoft's documentation for Edge DevTools instead.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Fixes incorrect link

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
