### PR TITLE
Update flex shorthand explanation, minor

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -173,7 +173,7 @@ Using `flex: auto` is the same as using `flex: 1 1 auto`; everything is as with 
 
 Using `flex: none` will create fully inflexible flex items. It is as if you wrote `flex: 0 0 auto`. The items cannot grow or shrink but will be laid out using flexbox with a `flex-basis` of `auto`.
 
-The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is as if you used `flex: 1 1 0`. The items can grow and shrink from a `flex-basis` of 0.
+The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is as if you used `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items can grow and shrink from a `flex-basis` of 0.
 
 Try these shorthand values in the live example below.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fixed minor bug in the explanation of the `flex` shorthand in Flexbox. The explanation was saying `flex: 1` or `flex: 2` is like doing `flex: 1 1 0`. I added .....or `flex: 2 1 0`, respectively. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
`flex: 2` was not well explained in this document. An inexperienced reader could guess (wrongly) that it is equivalent to `flex: 2 2 0`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://css-tricks.com/snippets/css/a-guide-to-flexbox/ makes the example with of `flex: 5`

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
