### PR TITLE
Clearer "truthy" description wording

### DIFF
--- a/files/en-us/glossary/truthy/index.md
+++ b/files/en-us/glossary/truthy/index.md
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - JavaScript
 ---
-In {{Glossary("JavaScript")}}, a **truthy** value is a value that is considered `true` when encountered in a {{Glossary("Boolean")}} context. All values are truthy unless they are defined as {{Glossary("Falsy", "falsy")}}. That is all values are _truthy_ except `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`.
+In {{Glossary("JavaScript")}}, a **truthy** value is a value that is considered `true` when encountered in a {{Glossary("Boolean")}} context. All values are truthy unless they are defined as {{Glossary("Falsy", "falsy")}}. That is, all values are _truthy_ except `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`.
 
 {{Glossary("JavaScript")}} uses {{Glossary("Type_Coercion", "type coercion")}} in Boolean contexts.
 

--- a/files/en-us/glossary/truthy/index.md
+++ b/files/en-us/glossary/truthy/index.md
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - JavaScript
 ---
-In {{Glossary("JavaScript")}}, a **truthy** value is a value that is considered `true` when encountered in a {{Glossary("Boolean")}} context. All values are truthy unless they are defined as {{Glossary("Falsy", "falsy")}} (i.e., except for `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`).
+In {{Glossary("JavaScript")}}, a **truthy** value is a value that is considered `true` when encountered in a {{Glossary("Boolean")}} context. All values are truthy unless they are defined as {{Glossary("Falsy", "falsy")}}. That is all values are _truthy_ except `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`.
 
 {{Glossary("JavaScript")}} uses {{Glossary("Type_Coercion", "type coercion")}} in Boolean contexts.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Use a clearer wording for what a *Truthy* value is. The use of "except for" was less clear than the use of "except". 

"Except for" is to be favored when you want to show that the statement in the main part of the sentence is not exactly true which is not the case here, cf. https://www.myhappyenglish.com/free-english-lesson/2013/12/11/except-vs-except-for-confusing-english-vocabulary-lesson/

#### Motivation

I was explaining to a colleague what *Truthy* is and giving him the reference on MDN, and I had to read the description of *Truthy* two or three times to be sure I understood the text correctly.

#### Supporting details

I'm not a native English speaker, but the following document explains what I feel about "except" vs "except for":
https://www.myhappyenglish.com/free-english-lesson/2013/12/11/except-vs-except-for-confusing-english-vocabulary-lesson/

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

