### PR TITLE
Remove scrolling on -webkit-line-clamp sample

### DIFF
--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -77,7 +77,7 @@ p {
 
 #### Result
 
-{{EmbedLiveSample("Truncating_a_paragraph", "100%", "100")}}
+{{EmbedLiveSample("Truncating_a_paragraph", "100%", "130")}}
 
 ## Specifications
 


### PR DESCRIPTION
The -webkit-line-clamp sample has scrollbars, without need. This PR makes it tall enough to remove those.

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error