### PR TITLE
Xpath - delete broken link to tool

### DIFF
--- a/files/en-us/web/xpath/index.md
+++ b/files/en-us/web/xpath/index.md
@@ -38,8 +38,6 @@ XPath uses a path notation (as in URLs) for navigating through the hierarchical 
 
 ## Tools
 
-- [XMLQuire (formerly known as SketchPath)](http://qutoric.com/xmlquire/)
-  - : A Graphical XPath Builder/Debugger(.NET).
 - [XPath tester](https://extendsclass.com/xpath-tester.html)
   - : An online XPath Builder/Debugger.
 
@@ -48,4 +46,17 @@ XPath uses a path notation (as in URLs) for navigating through the hierarchical 
 - [XSLT](/en-US/docs/Web/XSLT), [XML](/en-US/docs/Web/XML), [DOM](/en-US/docs/Web/API/Document_Object_Model)
 - [Comparison of CSS Selectors and XPath](/en-US/docs/Web/XPath/Comparison_with_CSS_selectors)
 
-<section id="Quick_links"><ol><li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li><li class="toggle"><details open><summary>Guides</summary><ol><li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li><li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li></ol></details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}</details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}</details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
+    <li class="toggle"><details open><summary>Guides</summary>
+      <ol>
+        <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li>
+        <li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li>
+      </ol></details>
+    </li>
+    <li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}</details></li>
+    <li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}</details></li>
+  </ol>
+</section>


### PR DESCRIPTION
This removes link to XMLQuire tool. The link is broken, as is the site URL. The tool is still "around" for download on the Internet, but then so are others and there is no particular reason to link to this one - and good reasons not to now that its author website is down.

Fixes #13737