### PR TITLE
FF99Relnote -  RTCPeerConnection.setConfiguration()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -45,6 +45,9 @@ This article provides information about the changes in Firefox 99 that will affe
 
 #### Media, WebRTC, and Web Audio
 
+- The [`RTCPeerConnection.setConfiguration()`](/en-US/docs/Web/API/RTCPeerConnection/setConfiguration) method is now supported.
+  Among other things, this allows sites to adjust the configuration to changing network conditions ({{bug(1253706)}}).
+
 #### Removals
 
 ### WebAssembly

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -22,55 +22,48 @@ case) is to replace the set of ICE servers to be used. Two potential scenarios i
 this might be done:
 
 - The {{domxref("RTCPeerConnection")}} was instantiated without specifying any ICE
-  servers. If, for example, the {{domxref("RTCPeerConnection.RTCPeerConnection()",
-    "RTCPeerConnection()")}} constructor was called with no parameters, you would have to
-  then call `setConfiguration()` to add ICE servers before ICE negotiation
-  could begin.
+  servers. If, for example, the {{domxref("RTCPeerConnection.RTCPeerConnection()", "RTCPeerConnection()")}} constructor was called with no parameters, you would have to
+  then call `setConfiguration()` to add ICE servers before ICE negotiation could begin.
 - Renegotiation of the connection is needed, and a different set of ICE servers needs
   to be used for some reason. Perhaps the user has moved into a new region, so using new
-  regional ICE servers is necessary, for example. In this situation, one might call
-  `setConfiguration()` to switch to new regional ICE servers, then initiate
-  an [ICE
-  restart](/en-US/docs/Web/API/WebRTC_API/Session_lifetime#ICE_restart).
+  regional ICE servers is necessary, for example.
+  In this situation, one might call `setConfiguration()` to switch to new regional ICE servers, then initiate an [ICE restart](/en-US/docs/Web/API/WebRTC_API/Session_lifetime#ICE_restart).
 
-> **Note:** You cannot change the identity information for a connection once it's already been
-> set.
+> **Note:** You cannot change the identity information for a connection once it's already been set.
 
 ## Syntax
 
 ```js
-RTCPeerConnection.setConfiguration(configuration);
+setConfiguration(configuration)
 ```
 
 ### Parameters
 
 - `configuration`
-  - : An object which provides the options to be set. The
-    changes are not additive; instead, the new values completely replace the existing ones. See [`RTCPeerConnection()`](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#parameters) for more information on what options are allowed.
+  - : An object which provides the options to be set.
+    The changes are not additive; instead, the new values completely replace the existing ones.
+    See [`RTCPeerConnection()`](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#parameters) for more information on what options are allowed.
 
 ### Exceptions
 
 - `InvalidAccessError` {{domxref("DOMException")}}
-  - : Thrown if one or more of the URLs specified in `configuration.iceServers` is a
-    {{Glossary("TURN")}} server, but complete login information is not provided (that is,
-    either the {{domxref("RTCIceServer.username")}} or
-    {{domxref("RTCIceServer.credentials")}} is missing). This prevents successful login to
-    the server.
+  - : Thrown if one or more of the URLs specified in `configuration.iceServers` is a {{Glossary("TURN")}} server, but complete login information is not provided (that is,
+    either the {{domxref("RTCIceServer.username")}} or {{domxref("RTCIceServer.credential")}} is missing, or if {{domxref("RTCIceServer.credentialType")}} is "password" and {{domxref("RTCIceServer.credential")}} is not a {{domxref("DOMString")}}).
+    This prevents successful login to the server.
 - `InvalidModificationError` {{domxref("DOMException")}}
-  - : Thrown if the `configuration` includes changed identity information, but the
-    connection already has identity information specified. This happens if
-    `configuration.peerIdentity` or `configuration.certificates` is
-    set and their values differ from the current configuration.
+  - : Thrown if the `configuration` includes changed identity information, but the connection already has identity information specified.
+    This happens if `configuration.peerIdentity` or `configuration.certificates` are set and their values differ from the current configuration.
+    This may also be thrown if there are changes to `configuration.bundlePolicy` or `configuration.rtcpMuxPolicy`, or to `configuration.iceCandidatePoolSize`when {{domxref("RTCPeerConnection.setLocalDescription()")}} has already been called.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("RTCPeerConnection")}} is closed.
 - `SyntaxError` {{domxref("DOMException")}}
-  - : Thrown if one or more of the URLs provided in the `configuration.iceServers` list
-    is invalid.
+  - : Thrown if the `configuration.iceServers` contains no URLs or if one of the values in the list is invalid.
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : Thrown if `configuration.iceServers` contains an URL with a scheme that is not supported.
 
 ## Example
 
-In this example, it has already been determined that ICE restart is needed, and that
-negotiation needs to be done using a different ICE server.
+In this example, it has already been determined that ICE restart is needed, and that negotiation needs to be done using a different ICE server.
 
 ```js
 var restartConfig = {


### PR DESCRIPTION
FF99 supports [RTCPeerConnection.setConfiguration()](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setConfiguration) - see https://bugzilla.mozilla.org/show_bug.cgi?id=1253706.

This PR adds a release note, and also updates `RTCPeerConnection.setConfiguration()` to fix the syntax block (to match current guidelines) and adds some missing exceptions.

Related docs work can be tracked in  #13371