### PR TITLE
Fix: Use a period to end the first paragraph

### DIFF
--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -13,7 +13,7 @@ browser-compat: html.elements.select
 
 {{HTMLRef}}
 
-The **`<select>`** [HTML](/en-US/docs/Web/HTML) element represents a control that provides a menu of options:
+The **`<select>`** [HTML](/en-US/docs/Web/HTML) element represents a control that provides a menu of options.
 
 {{EmbedInteractiveExample("pages/tabbed/select.html", "tabbed-standard")}}
 


### PR DESCRIPTION
#### Summary
This PR changes the first paragraph's last character from a colon (`:`) to a period (`.`) for the  [`<select>` element page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select).

#### Motivation
The first paragraph in an HTML element page is extracted as a description of the element in the [HTML elements reference page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#forms). So it'd be better to use a period instead of a colon to end the paragraph.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
