### PR TITLE
fix: change "I" to "we" in values_and_units

### DIFF
--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -311,7 +311,7 @@ You can also use RGBA colors — these work in exactly the same way as RGB color
 
 > **Note:** Setting an alpha channel on a color has one key difference to using the {{cssxref("opacity")}} property we looked at earlier. When you use opacity you make the element and everything inside it opaque, whereas using RGBA colors only makes the color you are specifying opaque.
 
-In the example below I have added a background image to the containing block of our colored boxes. I have then set the boxes to have different opacity values — notice how the background shows through more when the alpha channel value is smaller.
+In the example below, we have added a background image to the containing block of our colored boxes. We have then set the boxes to have different opacity values — notice how the background shows through more when the alpha channel value is smaller.
 
 {{EmbedGHLiveSample("css-examples/learn/values-units/color-rgba.html", '100%', 770)}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Changes two instances of "I" to "we" in [values_and_units/index.md](https://github.com/mdn/content/blob/main/files/en-us/learn/css/building_blocks/values_and_units/index.md). 
Corresponding mdn webpage: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Throughout the webpage, mdn is reffered to as "we". "I" comes off as inconsistent.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
