### PR TITLE
Chromium team "fixed" PDF rendering issues w/ CORP

### DIFF
--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
@@ -11,10 +11,6 @@ browser-compat: http.headers.Cross-Origin-Resource-Policy
 ---
 {{HTTPSidebar}}
 
-> **Note:** Due to a [bug in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1074261),
-> setting Cross-Origin-Resource-Policy can break PDF rendering,
-> preventing visitors from being able to read past the first page of some PDFs.
-
 The HTTP **`Cross-Origin-Resource-Policy`** response header
 conveys a desire that the browser blocks no-cors cross-origin/cross-site requests to the
 given resource.


### PR DESCRIPTION
Partial rendering now disabled, ergo this issue isn't reproducible / won't impact users by default anymore. Trade-off is that Chrome users lose partial / Range-based PDF loading.

#### Motivation

- There is no longer a need to warn users about production issues they will likely encounter with this header and the Chromium browser.

#### Supporting details

- https://source.chromium.org/chromium/chromium/src/+/main:pdf/pdf_features.cc;l=19-22?q=PdfPartialLoading&ss=chromium%2Fchromium%2Fsrc
- https://bugs.chromium.org/p/chromium/issues/detail?id=1115149

#### Related issues

N/A

#### Metadata

This PR…


- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [x] None of the above

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
