### PR TITLE
Selection API is not experimental

### DIFF
--- a/files/en-us/web/api/document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/index.md
@@ -50,7 +50,6 @@ To learn more about what the DOM is and how it represents documents, see our art
 - {{DOMxRef("NodeIterator")}}
 - {{DOMxRef("NodeList")}}
 - {{DOMxRef("ProcessingInstruction")}}
-- {{DOMxRef("Selection")}} {{Experimental_Inline}}
 - {{DOMxRef("Range")}}
 - {{DOMxRef("Text")}}
 - {{DOMxRef("TextDecoder")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/selection/addrange/index.md
+++ b/files/en-us/web/api/selection/addrange/index.md
@@ -3,14 +3,13 @@ title: Selection.addRange()
 slug: Web/API/Selection/addRange
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.addRange
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.addRange()`** method adds a
 {{domxref("Range")}} to a {{domxref("Selection")}}.

--- a/files/en-us/web/api/selection/anchornode/index.md
+++ b/files/en-us/web/api/selection/anchornode/index.md
@@ -3,7 +3,6 @@ title: Selection.anchorNode
 slug: Web/API/Selection/anchorNode
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Property
   - Read-only
@@ -11,7 +10,7 @@ tags:
   - Selection
 browser-compat: api.Selection.anchorNode
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.anchorNode`** read-only property returns the
 {{domxref("Node")}} in which the selection begins.

--- a/files/en-us/web/api/selection/anchoroffset/index.md
+++ b/files/en-us/web/api/selection/anchoroffset/index.md
@@ -3,7 +3,6 @@ title: Selection.anchorOffset
 slug: Web/API/Selection/anchorOffset
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Property
   - Read-only
@@ -11,7 +10,7 @@ tags:
   - Selection
 browser-compat: api.Selection.anchorOffset
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.anchorOffset`** read-only property returns the
 number of characters that the selection's anchor is offset within the

--- a/files/en-us/web/api/selection/collapse/index.md
+++ b/files/en-us/web/api/selection/collapse/index.md
@@ -3,14 +3,13 @@ title: Selection.collapse()
 slug: Web/API/Selection/collapse
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.collapse
 ---
-{{ApiRef("DOM")}}{{SeeCompatTable}}
+{{ApiRef("DOM")}}
 
 The **`Selection.collapse()`** method collapses the current
 selection to a single point. The document is not modified. If the content is focused and

--- a/files/en-us/web/api/selection/collapsetoend/index.md
+++ b/files/en-us/web/api/selection/collapsetoend/index.md
@@ -3,14 +3,13 @@ title: Selection.collapseToEnd()
 slug: Web/API/Selection/collapseToEnd
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.collapseToEnd
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.collapseToEnd()`** method collapses the
 selection to the end of the last range in the selection. If the content of the selection

--- a/files/en-us/web/api/selection/collapsetostart/index.md
+++ b/files/en-us/web/api/selection/collapsetostart/index.md
@@ -3,14 +3,13 @@ title: Selection.collapseToStart()
 slug: Web/API/Selection/collapseToStart
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.collapseToStart
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.collapseToStart()`** method collapses the
 selection to the start of the first range in the selection. If the content of the

--- a/files/en-us/web/api/selection/containsnode/index.md
+++ b/files/en-us/web/api/selection/containsnode/index.md
@@ -3,14 +3,13 @@ title: Selection.containsNode()
 slug: Web/API/Selection/containsNode
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.containsNode
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.containsNode()`** method indicates whether a
 specified node is part of the selection.

--- a/files/en-us/web/api/selection/deletefromdocument/index.md
+++ b/files/en-us/web/api/selection/deletefromdocument/index.md
@@ -3,7 +3,6 @@ title: Selection.deleteFromDocument()
 slug: Web/API/Selection/deleteFromDocument
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
@@ -11,7 +10,7 @@ tags:
   - deleteFromDocument
 browser-compat: api.Selection.deleteFromDocument
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`deleteFromDocument()`** method of the
 {{domxref("Selection")}} interface deletes the selected text from the document's DOM.

--- a/files/en-us/web/api/selection/extend/index.md
+++ b/files/en-us/web/api/selection/extend/index.md
@@ -3,14 +3,13 @@ title: Selection.extend()
 slug: Web/API/Selection/extend
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.extend
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.extend()`** method moves the focus of the
 selection to a specified point. The anchor of the selection does not move. The selection

--- a/files/en-us/web/api/selection/focusnode/index.md
+++ b/files/en-us/web/api/selection/focusnode/index.md
@@ -3,7 +3,6 @@ title: Selection.focusNode
 slug: Web/API/Selection/focusNode
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Property
   - Read-only
@@ -11,7 +10,7 @@ tags:
   - Selection
 browser-compat: api.Selection.focusNode
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.focusNode`** read-only property returns the
 {{domxref("Node")}} in which the selection ends.

--- a/files/en-us/web/api/selection/focusoffset/index.md
+++ b/files/en-us/web/api/selection/focusoffset/index.md
@@ -3,7 +3,6 @@ title: Selection.focusOffset
 slug: Web/API/Selection/focusOffset
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Property
   - Read-only
@@ -11,7 +10,7 @@ tags:
   - Selection
 browser-compat: api.Selection.focusOffset
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.focusOffset`** read-only property returns the
 number of characters that the selection's focus is offset within the

--- a/files/en-us/web/api/selection/getrangeat/index.md
+++ b/files/en-us/web/api/selection/getrangeat/index.md
@@ -3,14 +3,13 @@ title: Selection.getRangeAt()
 slug: Web/API/Selection/getRangeAt
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.getRangeAt
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.getRangeAt()`** method returns a range object
 representing one of the ranges currently selected.

--- a/files/en-us/web/api/selection/iscollapsed/index.md
+++ b/files/en-us/web/api/selection/iscollapsed/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Selection/isCollapsed
 tags:
   - API
   - DOM
-  - Experimental
   - HTML Editing
   - Property
   - Read-only
@@ -12,7 +11,7 @@ tags:
   - Selection
 browser-compat: api.Selection.isCollapsed
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.isCollapsed`** read-only property returns a
 boolean value which indicates whether or not there is currently any text

--- a/files/en-us/web/api/selection/rangecount/index.md
+++ b/files/en-us/web/api/selection/rangecount/index.md
@@ -3,7 +3,6 @@ title: Selection.rangeCount
 slug: Web/API/Selection/rangeCount
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Property
   - Read-only
@@ -11,7 +10,7 @@ tags:
   - Selection
 browser-compat: api.Selection.rangeCount
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.rangeCount`** read-only property returns the
 number of ranges in the selection.

--- a/files/en-us/web/api/selection/removeallranges/index.md
+++ b/files/en-us/web/api/selection/removeallranges/index.md
@@ -3,14 +3,13 @@ title: Selection.removeAllRanges()
 slug: Web/API/Selection/removeAllRanges
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.removeAllRanges
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.removeAllRanges()`** method removes all ranges
 from the selection, leaving the {{domxref("Selection.anchorNode", "anchorNode")}} and

--- a/files/en-us/web/api/selection/removerange/index.md
+++ b/files/en-us/web/api/selection/removerange/index.md
@@ -3,14 +3,13 @@ title: Selection.removeRange()
 slug: Web/API/Selection/removeRange
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.removeRange
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.removeRange()`** method removes a range from a
 selection.

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -3,14 +3,13 @@ title: Selection.setBaseAndExtent()
 slug: Web/API/Selection/setBaseAndExtent
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Selection
   - setBaseAndExtent
 browser-compat: api.Selection.setBaseAndExtent
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`setBaseAndExtent()`** method of the
 {{domxref("Selection")}} interface sets the selection to be a range including all or

--- a/files/en-us/web/api/selection/tostring/index.md
+++ b/files/en-us/web/api/selection/tostring/index.md
@@ -3,14 +3,13 @@ title: Selection.toString()
 slug: Web/API/Selection/toString
 tags:
   - API
-  - Experimental
   - HTML Editing
   - Method
   - Reference
   - Selection
 browser-compat: api.Selection.toString
 ---
-{{ ApiRef("DOM") }}{{SeeCompatTable}}
+{{ ApiRef("DOM") }}
 
 The **`Selection.toString()`** method returns a string
 currently being represented by the selection object, i.e. the currently selected text.

--- a/files/en-us/web/api/selection/type/index.md
+++ b/files/en-us/web/api/selection/type/index.md
@@ -3,14 +3,13 @@ title: Selection.type
 slug: Web/API/Selection/type
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Selection
   - Type
 browser-compat: api.Selection.type
 ---
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("DOM")}}
 
 The **`type`** read-only property of the
 {{domxref("Selection")}} interface returns a {{domxref("DOMString")}} describing the


### PR DESCRIPTION
This is half of the fix for https://github.com/mdn/content/issues/13685.

It removes the tags and macro calls that indicate that this interface is experimental. I also removed the link to it from https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model#dom_interfaces, since it should not appear there, and that link also incorrectly marks the interface as experimental.

The other half of the fix will be to add the stuff for the Selection API.