### PR TITLE
Write an overview page for the Selection API

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9034,7 +9034,6 @@
 /en-US/docs/Web/API/Selection.toString	/en-US/docs/Web/API/Selection/toString
 /en-US/docs/Web/API/Selection/empty	/en-US/docs/Web/API/Selection/removeAllRanges
 /en-US/docs/Web/API/Selection/setPosition	/en-US/docs/Web/API/Selection/collapse
-/en-US/docs/Web/API/Selection_API	/en-US/docs/Web/API/Selection
 /en-US/docs/Web/API/Sensor/onactivate	/en-US/docs/Web/API/Sensor/activate_event
 /en-US/docs/Web/API/Sensor/onerror	/en-US/docs/Web/API/Sensor/error_event
 /en-US/docs/Web/API/Sensor/onreading	/en-US/docs/Web/API/Sensor/reading_event

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -8,7 +8,7 @@ tags:
   - Selection
 browser-compat: api.Selection
 ---
-{{ ApiRef("DOM") }}
+{{ ApiRef("Selection API") }}
 
 A **`Selection`** object represents the range of text selected by the user or the current position of the caret. To obtain a `Selection` object for examination or manipulation, call {{DOMxRef("window.getSelection()")}}.
 

--- a/files/en-us/web/api/selection_api/index.md
+++ b/files/en-us/web/api/selection_api/index.md
@@ -1,0 +1,39 @@
+---
+title: Selection API
+slug: Web/API/Selection_API
+tags:
+  - API
+  - Selection
+spec-urls: https://w3c.github.io/selection-api/#selection-interface
+---
+{{DefaultAPISidebar("Selection API")}}
+
+> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+
+The **Selection API** enables developers to access and manipulate the portion of a document selected by the user.
+
+The {{domxref("Window/getSelection()", "Window.getSelection()")}} and {{domxref("Document/getSelection()", "Document.getSelection()")}} methods return a {{domxref("Selection")}} object representing the portion of the document selected by the user. A `Selection` object provides methods to:
+- access the currently selected nodes
+- modify the current selection, expanding or collapsing it or selecting an entirely different part of the document
+- delete parts of the current selection from the DOM.
+
+The Selection API also provides two events, both firing on {{domxref("Document")}}:
+- the {{domxref("Document/selectstart_event", "selectstart")}} event is fired when the user starts to make a new selection
+- the {{domxref("Document/selectionchange_event", "selectionchange")}} event is fired when the current selection changes.
+
+## Interfaces
+
+- {{domxref("Selection")}}
+  - : An interface which epresents the part of the document selected by the user or the current position of the caret.
+- {{domxref("Document/getSelection()", "Document.getSelection()")}}
+  - : A method returning a `Selection` object representing the current selection or current position of the caret.
+- {{domxref("Window/getSelection()", "Window.getSelection()")}}
+  - : A method returning a `Selection` object representing the current selection or current position of the caret.
+- {{domxref("Document/selectionchange_event", "Document.selectionchange")}}
+  - : An event which is fired when the current selection is changed.
+- {{domxref("Document/selectstart_event", "Document.selectstart")}}
+  - : An event which is fired when a user starts a new selection.
+
+## Specifications
+
+{{Specifications}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1212,6 +1212,7 @@
       "events": []
     },
     "Selection API": {
+      "overview": ["Selection API"],
       "interfaces": ["Selection"],
       "properties": [
         "Document.onselectionchange",


### PR DESCRIPTION
This is the second half of the fix for https://github.com/mdn/content/issues/13685.

It adds an API overview page for the Selection API, and an entry for that page in GroupData: this will make it appear in the listing in https://developer.mozilla.org/en-US/docs/Web/API#specifications.