### PR TITLE
Adjust example directory structure authentication

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -178,14 +178,17 @@ The URLs (and implicitly, views) that we just added expect to find their associa
 
 For this site, we'll put our HTML pages in the **templates/registration/** directory. This directory should be in your project root directory, i.e the same directory as the **catalog** and **locallibrary** folders. Please create these folders now.
 
-> **Note:** Your folder structure should now look like the below: \
-> locallibrary (Django project folder) \
-> \\_catalog \
-> \\_locallibrary \
-> \\_templates **(new)** \
-> &nbsp;&nbsp;&nbsp;&nbsp;\\_registration **(new)**
+> **Note:** Your folder structure should now look like the below:
+> ```
+> locallibrary/   #Django project folder
+>   catalog/
+>   locallibrary/
+>   templates/
+>     registration/
+> ```
 
-To make the **templates** directory visible to the template loader we need to add it in the template search path. Open the project settings (**/locallibrary/locallibrary/settings.py**).
+To make the **templates** directory visible to the template loader we need to add it in the template search path.
+Open the project settings (**/locallibrary/locallibrary/settings.py**).
 
 Then import the `os` module (add the following line near the top of the file).
 

--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -178,12 +178,12 @@ The URLs (and implicitly, views) that we just added expect to find their associa
 
 For this site, we'll put our HTML pages in the **templates/registration/** directory. This directory should be in your project root directory, i.e the same directory as the **catalog** and **locallibrary** folders. Please create these folders now.
 
-> **Note:** Your folder structure should now look like the below:
+> **Note:** Your folder structure should now look like the below: \
 > locallibrary (Django project folder) \
 > \\_catalog \
 > \\_locallibrary \
 > \\_templates **(new)** \
-> \\_registration
+> &nbsp;&nbsp;&nbsp;&nbsp;\\_registration **(new)**
 
 To make the **templates** directory visible to the template loader we need to add it in the template search path. Open the project settings (**/locallibrary/locallibrary/settings.py**).
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In the authentication example, the registration directory should be inside the templates directory. I added a few non-breaking space HTML entities to signify the correct place of the registration directory. I also added an extra backward slash, to force `locallibrary` to start at a new line as well, which should make the whole example a bit clearer.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Visually it looked like the registration directory should be placed in the Django project folder directly, which is confusing, since that will turn into an error while following the documentation up to this point.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[Chapter: Django Tutorial Part 8: User authentication and permissions - Template directory](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Authentication#template_directory)

This is how the directory structure looks like now in the documentation: `locallibrary` is not placed at a new line yet and the `registration` directory is not 'inside' the `templates` directory.
![old-structure](https://user-images.githubusercontent.com/11903368/158021416-555259bd-d803-4397-a0cf-a39ed35ce269.png)

This is how the structure should be (screenshot is of my local development environment):
![new-structure](https://user-images.githubusercontent.com/11903368/158021442-83bb724e-5dea-444a-ac7f-7756706ea54c.png)


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
