### PR TITLE
iframe is cropped at a height 60px

### DIFF
--- a/files/en-us/web/css/outline/index.md
+++ b/files/en-us/web/css/outline/index.md
@@ -112,7 +112,7 @@ a:focus {
 
 #### Result
 
-{{EmbedLiveSample("Using_outline_to_set_a_focus_style", "100%", 60)}}
+{{EmbedLiveSample("Using_outline_to_set_a_focus_style", "100%", 85)}}
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary
The iframe `Using_outline_to_set_a_focus_style` is currently obscuring the lower half of the example as it is not tall enough. This PR increases these hight of the iframe to a balanced 85px.

#### Motivation
Example in iframe `Using_outline_to_set_a_focus_style` is obscured.

#### Supporting details
N/A

#### Related issues
N/A
#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error