### PR TITLE
Remove meta-docs for {{anch}} macro

### DIFF
--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
@@ -29,13 +29,6 @@ This macro accepts one required parameter and one optional parameter:
 1. The term's name (such as "HTML"): `\{{Glossary("HTML")}}` yields {{Glossary("HTML")}}
 2. Optional: The text to display in the article instead of the term name: `\{{Glossary("CSS", "Cascading Style Sheets")}}` yields {{Glossary("CSS", "Cascading Style Sheets")}}
 
-### Links to in-page sections
-
-[`anch`](https://github.com/mdn/yari/tree/master/kumascript/macros/anch.ejs) - creates link to in-page section:
-
-- `\{{anch("Linking to pages in references")}}`;
-- Demo: {{anch("Linking to pages in references")}}
-
 ### Linking to pages in references
 
 There are macros for locale-independent linking to pages in specific reference areas of MDN: Javascript, CSS, HTML elements, SVG etc.


### PR DESCRIPTION
Sister PR to #13802.  This PR removes the documentation explaining the `{{anch}}` macro.
