### PR TITLE
Add note about common misunderstanding in codePointAt

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.String.codePointAt
 
 The **`codePointAt()`** method returns a non-negative integer
 that is the Unicode code point value at the given position. 
-Note that function does not give the n'th code point in a string,
+Note that this function does not give the nth code point in a string,
 but the code point starting at the specified string index.
 
 {{EmbedInteractiveExample("pages/js/string-codepointat.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -14,7 +14,9 @@ browser-compat: javascript.builtins.String.codePointAt
 {{JSRef}}
 
 The **`codePointAt()`** method returns a non-negative integer
-that is the Unicode code point value at the given position.
+that is the Unicode code point value at the given position. 
+Note that function does not give the n'th code point in a string,
+but the code point starting at the specified string index.
 
 {{EmbedInteractiveExample("pages/js/string-codepointat.html","shorter")}}
 


### PR DESCRIPTION
I've heard multiple developers now (everyone I've talked to about this) think that this function gives the n'th code point in a string, including myself. It took quite a lot of poking around, trying to figure out why it seemingly wasn't O(n) before I tried indexing into the middle of an emoji, like I now see others have done in the examples here.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
