### PR TITLE
fix: change four instances of "I" to "we"/"We" in line-based_placement_with_css_grid

### DIFF
--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
@@ -16,7 +16,7 @@ Starting your exploration of grid with numbered lines is the most logical place 
 
 As a very simple example we can take a grid with 3 column tracks and 3 row tracks. This gives us 4 lines in each dimension.
 
-Inside our grid container I have four child elements. If we do not place these on to the grid in any way they will lay out according to the auto-placement rules, one item in each of the first four cells. If you use the [Firefox Grid Highlighter](/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts) you can see how the grid has defined columns and rows.
+Inside our grid container we have four child elements. If we do not place these on to the grid in any way they will lay out according to the auto-placement rules, one item in each of the first four cells. If you use the [Firefox Grid Highlighter](/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts) you can see how the grid has defined columns and rows.
 
 ![Our Grid highlighted in DevTools](3_hilighted_grid.png)
 
@@ -59,7 +59,7 @@ Inside our grid container I have four child elements. If we do not place these o
 
 ## Positioning items by line number
 
-We can use line-based placement to control where these items sit on the grid. I would like the first item to start on the far left of the grid and span a single column track. It should also start on the first row line, at the top of the grid and span to the fourth row line.
+We can use line-based placement to control where these items sit on the grid. We would like the first item to start on the far left of the grid and span a single column track. It should also start on the first row line, at the top of the grid and span to the fourth row line.
 
 ```css
 .box1 {
@@ -190,7 +190,7 @@ We have quite a lot of code here to position each item. It should come as no sur
 
 ## Default spans
 
-In the above examples I specified every end row and column line, in order to demonstrate the properties, however in practice if an item only spans one track you can omit the `grid-column-end` or `grid-row-end` value. Grid defaults to spanning one track.
+In the above examples, we specified every end row and column line, in order to demonstrate the properties, however in practice if an item only spans one track you can omit the `grid-column-end` or `grid-row-end` value. Grid defaults to spanning one track.
 
 ### Default spans with longhand placement
 
@@ -376,7 +376,7 @@ When we specify our grid area using the `grid-area` property we first define bot
 
 We can also count backwards from the block and inline end of the grid, for English that would be the right hand column line and final row line. These lines can be addressed as `-1`, and you can count back from there – so the second last line is `-2`. It is worth noting that the final line is the final line of the _explicit grid_, the grid defined by `grid-template-columns` and `grid-template-rows`, and does not take into account any rows or columns added in the _implicit grid_ outside of that.
 
-In this next example I have flipped the layout we were working with by working from the right and bottom of our grid when placing the items.
+In this next example, we have flipped the layout we were working with by working from the right and bottom of our grid when placing the items.
 
 ```css hidden
 * {box-sizing: border-box;}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Changes four instances of "I" to "we"/"We" in line-based_placement_with_css_grid.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

For consistency throughout the document.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
