### PR TITLE
Expanding on definition of button element

### DIFF
--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -12,7 +12,6 @@ browser-compat: html.elements.button
 ---
 
 {{HTMLRef}}
-  
 The **`<button>`** [HTML](/en-US/docs/Web/HTML) element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog.
 
 By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons' appearance with [CSS](/en-US/docs/Web/CSS).

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -13,7 +13,7 @@ browser-compat: html.elements.button
 
 {{HTMLRef}}
 
-The **`<button>`** [HTML](/en-US/docs/Web/HTML) element represents a clickable button, used to submit [forms](/en-US/docs/Learn/Forms) or anywhere in a document for accessible, standard button functionality.
+The **`<button>`** [HTML](/en-US/docs/Web/HTML) is an interactive element that performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog, when activated by a user, whether by mouse click keyboard key, finger touch, voice command, or other assistive technology.
 
 By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons' appearance with [CSS](/en-US/docs/Web/CSS).
 

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -12,6 +12,7 @@ browser-compat: html.elements.button
 ---
 
 {{HTMLRef}}
+
 The **`<button>`** [HTML](/en-US/docs/Web/HTML) element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog.
 
 By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons' appearance with [CSS](/en-US/docs/Web/CSS).

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -12,8 +12,8 @@ browser-compat: html.elements.button
 ---
 
 {{HTMLRef}}
-
-The **`<button>`** [HTML](/en-US/docs/Web/HTML) element is an interactive element that performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog, when activated by a user, whether by mouse click, keyboard key, finger touch, voice command, or other assistive technology.
+  
+The **`<button>`** [HTML](/en-US/docs/Web/HTML) element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog.
 
 By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons' appearance with [CSS](/en-US/docs/Web/CSS).
 

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -13,7 +13,7 @@ browser-compat: html.elements.button
 
 {{HTMLRef}}
 
-The **`<button>`** [HTML](/en-US/docs/Web/HTML) is an interactive element that performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog, when activated by a user, whether by mouse click keyboard key, finger touch, voice command, or other assistive technology.
+The **`<button>`** [HTML](/en-US/docs/Web/HTML) element is an interactive element that performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog, when activated by a user, whether by mouse click, keyboard key, finger touch, voice command, or other assistive technology.
 
 By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons' appearance with [CSS](/en-US/docs/Web/CSS).
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This PR proposes a more elaborate introductory definition of the `<button>` HTML element.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

There are a few things I think need improved about the current `<button>` definition.

- It is circular in that it uses the term it's defining in the definition. This does not bring as much new understanding and can be confusing.
- It assumes prior knowledge of "standard button functionality". This can be frustrating and discouraging to beginners.
- It only mentions mouse click interactions. Expanding on the ways people can interact with `<button>`s, especially in the first sentence on the page, is an opportunity to highlight accessibility and assistive technology right away, helping reinforce that accessibility is a fundamental part of learning HTML. It also has the chance of being someone's first exposure to accessibility since the `<button>` element is so common and this page probably has higher view counts than other less common elements.
- The use of "accessible" feels a little random and lacking detail. Accessibility beginners may struggle to know what "accessible" means in general, let alone in the context of a `<button>`.
- The "or anywhere" portion took a few reads to understand that it was saying "or used anywhere".

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

#### Open questions

Is this PR also a good opportunity to add some glossary terms? I think the glossary would benefit from the addition of two terms that could be hyperlinked in my proposed definition:

- interactive element: this terminology is heavily used in other documentation, such as the HTML Living Standard and various W3C documentation. It's especially important to know in accessibility considerations, such as when thinking about what elements can be placed inside of other elements in markup.
  - One reference the glossary page could link to is [section 4.11 Interactive elements](https://html.spec.whatwg.org/#interactive-elements) of the HTML Living Standard.
- assistive technology: this is used often in this site, and a glossary page would be a good opportunity to:
  - give an introduction to different types of assistive technology
  - link to valuable resources and other definitions, such as the [Tools and Techniques](https://www.w3.org/WAI/people-use-web/tools-techniques/) section of WAI's [How People with Disabilities Use the Web](https://www.w3.org/WAI/people-use-web/) documentation. 