### PR TITLE
FF99 NetworkInformation API support removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -39,7 +39,9 @@ This article provides information about the changes in Firefox 99 that will affe
 
 - {{domxref("navigator.pdfViewerEnabled")}} is now enabled, and is the recommend way to determine whether a browser supports inline display of PDF files when navigating to them.
   Sites that use the deprecated properties {{domxref("navigator.plugins")}} and {{domxref("navigator.mimeTypes")}} to infer PDF viewer support should now use the new property, even though these now return hard-coded mock values that match the signal provided by `pdfViewerEnabled` ({{bug(1720353)}}).
-
+- The [Network Information API](/en-US/docs/Web/API/Network_Information_API) was previously enabled on Android (only), but is now disabled by default on all platforms.
+  The API is on the path for removal because it exposes a significant amount of user information that might be used for fingerprinting.
+  ({{bug(1720353)}}).
 
 #### DOM
 

--- a/files/en-us/web/api/navigator/connection/index.md
+++ b/files/en-us/web/api/navigator/connection/index.md
@@ -13,21 +13,11 @@ browser-compat: api.Navigator.connection
 ---
 {{APIRef("Network Information API")}}{{SeeCompatTable}}
 
-The **`Navigator.connection`**
-read-only property returns a {{domxref("NetworkInformation")}} object containing
-information about the system's connection, such as the current bandwidth of the user's
-device or whether the connection is metered.
+The **`Navigator.connection`** read-only property returns a {{domxref("NetworkInformation")}} object containing information about the system's connection, such as the current bandwidth of the user's device or whether the connection is metered.
 
-This could be used to select high
-definition content or low definition content based on the user's connection.
+This could be used to select high definition content or low definition content based on the user's connection.
 
-## Syntax
-
-```js
-var networkInformation = navigator.connection
-```
-
-### Value
+## Value
 
 A {{domxref("NetworkInformation")}} object.
 
@@ -41,5 +31,4 @@ A {{domxref("NetworkInformation")}} object.
 
 ## See also
 
-- [Online and
-  offline events](/en-US/docs/Web/API/Navigator/Online_and_offline_events)
+- [Online and offline events](/en-US/docs/Web/API/Navigator/Online_and_offline_events)

--- a/files/en-us/web/api/network_information_api/index.md
+++ b/files/en-us/web/api/network_information_api/index.md
@@ -21,7 +21,7 @@ The interface consists of a single {{domxref("NetworkInformation")}} object, an 
 ## Interfaces
 
 - {{domxref("NetworkInformation")}}
-  - : Provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes. The `NetworkInformation` interfaces cannot be instantiated. It is instead accessed through the {{domxref("Navigator")}} interface.
+  - : Provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes. The `NetworkInformation` interface cannot be instantiated. It is instead accessed through the {{domxref("Navigator")}} interface.
 
 ## Examples
 

--- a/files/en-us/web/api/network_information_api/index.md
+++ b/files/en-us/web/api/network_information_api/index.md
@@ -7,12 +7,21 @@ tags:
   - Network Information API
   - Reference
   - WebAPI
+browser-compat: api.NetworkInformation
 ---
 {{DefaultAPISidebar("Network Information API")}}{{SeeCompatTable}}
 
-The Network Information API provides information about the system's connection in terms of general connection type (e.g., 'wifi', 'cellular', etc.). This can be used to select high definition content or low definition content based on the user's connection. The entire API consists of the addition of the {{domxref("NetworkInformation")}} interface and a single property to the {{domxref("Navigator")}} interface: {{domxref("Navigator.connection")}}.
+The Network Information API provides information about the system's connection in terms of general connection type (e.g., 'wifi', 'cellular', etc.).
+This can be used to select high definition content or low definition content based on the user's connection.
+
+The interface consists of a single {{domxref("NetworkInformation")}} object, an instance of which is returned by the {{domxref("Navigator.connection")}} property.
 
 {{AvailableInWorkers}}
+
+## Interfaces
+
+- {{domxref("NetworkInformation")}}
+  - : Provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes. The `NetworkInformation` interfaces cannot be instantiated. It is instead accessed through the {{domxref("Navigator")}} interface.
 
 ## Examples
 
@@ -46,22 +55,18 @@ if (connection) {
 }
 ```
 
-## Interfaces
-
-- {{domxref("NetworkInformation")}}
-  - : Provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes. The `NetworkInformation` interfaces cannot be instantiated. It is instead accessed through the {{domxref("Navigator")}} interface.
-
 ## Specifications
 
-| Specification                                              |
-| ---------------------------------------------------------- |
-| [Network Information API](https://wicg.github.io/netinfo/) |
+{{Specifications}}
+
+{{Specifications("api.Navigator.connection")}}
+
 
 ## Browser compatibility
 
 ### NetworkInformation
 
-{{Compat("api.NetworkInformation")}}
+{{Compat}}
 
 ### Navigator.connection
 
@@ -69,6 +74,4 @@ if (connection) {
 
 ## See also
 
-- {{spec("https://w3c.github.io/netinfo/", "Network Information API Specification", "ED")}}
 - [Online and offline events](/en-US/docs/Web/API/Navigator/Online_and_offline_events)
-- {{domxref("Navigator.connection", "window.navigator.connection")}}

--- a/files/en-us/web/api/networkinformation/index.md
+++ b/files/en-us/web/api/networkinformation/index.md
@@ -13,7 +13,7 @@ browser-compat: api.NetworkInformation
 {{APIRef("Network Information API")}}{{SeeCompatTable}}
 
 The **`NetworkInformation`** interface of the [Network Information API](/en-US/docs/Web/API/Network_Information_API) provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes.
-The `NetworkInformation` interfaces cannot be instantiated. It is instead accessed through the `connection` property of the {{domxref("Navigator")}} interface.
+The `NetworkInformation` interface cannot be instantiated. It is instead accessed through the `connection` property of the {{domxref("Navigator")}} interface.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/networkinformation/index.md
+++ b/files/en-us/web/api/networkinformation/index.md
@@ -12,7 +12,8 @@ browser-compat: api.NetworkInformation
 ---
 {{APIRef("Network Information API")}}{{SeeCompatTable}}
 
-The **`NetworkInformation`** interface provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes. The `NetworkInformation` interfaces cannot be instantiated. It is instead accessed through the `connection` property of the {{domxref("Navigator")}} interface.
+The **`NetworkInformation`** interface of the [Network Information API](/en-US/docs/Web/API/Network_Information_API) provides information about the connection a device is using to communicate with the network and provides a means for scripts to be notified if the connection type changes.
+The `NetworkInformation` interfaces cannot be instantiated. It is instead accessed through the `connection` property of the {{domxref("Navigator")}} interface.
 
 {{AvailableInWorkers}}
 
@@ -64,6 +65,4 @@ _This interface also inherits methods of its parent, {{domxref("EventTarget")}}.
 
 ## See also
 
-- [Network Information API](/en-US/docs/Web/API/Network_Information_API)
 - [Online and offline events](/en-US/docs/Online_and_offline_events)
-- The {{domxref("Navigator")}} interface that implements it.


### PR DESCRIPTION
FF99 removes support for the platform from Android (it was previously enabled on Android by default, but behind a pref on Desktop) - https://bugzilla.mozilla.org/show_bug.cgi?id=1637922

This:
- Adds a release note
- Tidies up the docs a little to current standard.

I chose not to add this pref as an experimental feature as it is "on the way out".