### PR TITLE
Sort Range methods alphabetically

### DIFF
--- a/files/en-us/web/api/range/index.md
+++ b/files/en-us/web/api/range/index.md
@@ -42,56 +42,56 @@ _There are no inherited properties._
 
 _There are no inherited methods._
 
-- {{ domxref("Range.setStart()")}}
-  - : Sets the start position of a `Range`.
-- {{ domxref("Range.setEnd()")}}
-  - : Sets the end position of a `Range`.
-- {{ domxref("Range.setStartBefore()")}}
-  - : Sets the start position of a `Range` relative to another {{ domxref("Node") }}.
-- {{ domxref("Range.setStartAfter()")}}
-  - : Sets the start position of a `Range` relative to another {{ domxref("Node") }}.
-- {{ domxref("Range.setEndBefore()")}}
-  - : Sets the end position of a `Range` relative to another {{ domxref("Node") }}.
-- {{ domxref("Range.setEndAfter()")}}
-  - : Sets the end position of a `Range` relative to another {{ domxref("Node") }}.
-- {{ domxref("Range.selectNode()")}}
-  - : Sets the `Range` to contain the {{ domxref("Node") }} and its contents.
-- {{ domxref("Range.selectNodeContents()")}}
-  - : Sets the `Range` to contain the contents of a {{ domxref("Node") }}.
 - {{ domxref("Range.collapse()")}}
   - : Collapses the `Range` to one of its boundary points.
-- {{ domxref("Range.cloneContents()")}}
-  - : Returns a {{ domxref("DocumentFragment") }} copying the nodes of a `Range`.
-- {{ domxref("Range.deleteContents()")}}
-  - : Removes the contents of a `Range` from the {{ domxref("Document") }}.
-- {{ domxref("Range.extractContents()")}}
-  - : Moves contents of a `Range` from the document tree into a {{ domxref("DocumentFragment") }}.
-- {{ domxref("Range.insertNode()")}}
-  - : Insert a {{ domxref("Node") }} at the start of a `Range`.
-- {{ domxref("Range.surroundContents()")}}
-  - : Moves content of a `Range` into a new {{ domxref("Node") }}.
 - {{ domxref("Range.compareBoundaryPoints()")}}
   - : Compares the boundary points of the `Range` with another `Range`.
-- {{ domxref("Range.cloneRange()")}}
-  - : Returns a `Range` object with boundary points identical to the cloned `Range`.
-- {{ domxref("Range.detach()")}}
-  - : Releases the `Range` from use to improve performance.
-- {{ domxref("Range.toString()")}}
-  - : Returns the text of the `Range`.
 - {{ domxref("Range.compareNode()")}} {{deprecated_inline}}{{non-standard_inline}}
   - : Returns a constant representing whether the {{domxref("Node")}} is before, after, inside, or surrounding the range.
 - {{ domxref("Range.comparePoint()")}} {{experimental_inline}}
   - : Returns -1, 0, or 1 indicating whether the point occurs before, inside, or after the `Range`.
+- {{ domxref("Range.cloneContents()")}}
+  - : Returns a {{ domxref("DocumentFragment") }} copying the nodes of a `Range`.
+- {{ domxref("Range.cloneRange()")}}
+  - : Returns a `Range` object with boundary points identical to the cloned `Range`.
 - {{ domxref("Range.createContextualFragment()")}}{{experimental_inline}}
   - : Returns a {{ domxref("DocumentFragment") }} created from a given string of code.
+- {{ domxref("Range.deleteContents()")}}
+  - : Removes the contents of a `Range` from the {{ domxref("Document") }}.
+- {{ domxref("Range.detach()")}}
+  - : Releases the `Range` from use to improve performance.
+- {{ domxref("Range.extractContents()")}}
+  - : Moves contents of a `Range` from the document tree into a {{ domxref("DocumentFragment") }}.
 - {{ domxref("Range.getBoundingClientRect()") }} {{experimental_inline}}
   - : Returns a {{ domxref("DOMRect") }} object which bounds the entire contents of the `Range`; this would be the union of all the rectangles returned by {{ domxref("range.getClientRects()") }}.
 - {{ domxref("Range.getClientRects()") }} {{experimental_inline}}
   - : Returns a list of {{ domxref("DOMRect") }} objects that aggregates the results of {{ domxref("Element.getClientRects()") }} for all the elements in the `Range`.
-- {{ domxref("Range.intersectsNode()")}} {{experimental_inline}}
-  - : Returns a `boolean` indicating whether the given node intersects the `Range`.
 - {{ domxref("Range.isPointInRange()")}} {{experimental_inline}}
   - : Returns a `boolean` indicating whether the given point is in the `Range`.
+- {{ domxref("Range.insertNode()")}}
+  - : Insert a {{ domxref("Node") }} at the start of a `Range`.
+- {{ domxref("Range.intersectsNode()")}} {{experimental_inline}}
+  - : Returns a `boolean` indicating whether the given node intersects the `Range`.
+- {{ domxref("Range.selectNode()")}}
+  - : Sets the `Range` to contain the {{ domxref("Node") }} and its contents.
+- {{ domxref("Range.selectNodeContents()")}}
+  - : Sets the `Range` to contain the contents of a {{ domxref("Node") }}.
+- {{ domxref("Range.setEnd()")}}
+  - : Sets the end position of a `Range`.
+- {{ domxref("Range.setStart()")}}
+  - : Sets the start position of a `Range`.
+- {{ domxref("Range.setEndAfter()")}}
+  - : Sets the end position of a `Range` relative to another {{ domxref("Node") }}.
+- {{ domxref("Range.setEndBefore()")}}
+  - : Sets the end position of a `Range` relative to another {{ domxref("Node") }}.
+- {{ domxref("Range.setStartAfter()")}}
+  - : Sets the start position of a `Range` relative to another {{ domxref("Node") }}.
+- {{ domxref("Range.setStartBefore()")}}
+  - : Sets the start position of a `Range` relative to another {{ domxref("Node") }}.
+- {{ domxref("Range.surroundContents()")}}
+  - : Moves content of a `Range` into a new {{ domxref("Node") }}.
+- {{ domxref("Range.toString()")}}
+  - : Returns the text of the `Range`.
 
 ## Specifications
 


### PR DESCRIPTION
I think methods are easier to navigate visually if they are sorted alphabetically

#### Summary
sort methods alphabetically

#### Motivation
I think methods are easier to navigate visually if they are sorted alphabetically

#### Supporting details
I think this is how it works in general in MDN right? Properties and methods lists sorted alphabetically

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error