### PR TITLE
Remove page macro in pip resize event

### DIFF
--- a/files/en-us/web/api/pictureinpictureevent/index.md
+++ b/files/en-us/web/api/pictureinpictureevent/index.md
@@ -24,6 +24,9 @@ The **`PictureInPictureEvent`** interface represents picture-in-picture-related 
 
 _This interface also inherits properties from its parent {{domxref("Event")}}_.
 
+- {{domxref("PictureInPictureEvent.pictureInPictureWindow)}}
+  - : Returns the {{domxref("PictireInPictureWindow)}} the event relates to.
+
 ## Methods
 
 _This interface also inherits properties from its parent {{domxref("Event")}}_.

--- a/files/en-us/web/api/pictureinpictureevent/index.md
+++ b/files/en-us/web/api/pictureinpictureevent/index.md
@@ -25,7 +25,7 @@ The **`PictureInPictureEvent`** interface represents picture-in-picture-related 
 _This interface also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("PictureInPictureEvent.pictureInPictureWindow")}}
-  - : Returns the {{domxref("PictireInPictureWindow")}} the event relates to.
+  - : Returns the {{domxref("PictureInPictureWindow")}} the event relates to.
 
 ## Methods
 

--- a/files/en-us/web/api/pictureinpictureevent/index.md
+++ b/files/en-us/web/api/pictureinpictureevent/index.md
@@ -24,8 +24,8 @@ The **`PictureInPictureEvent`** interface represents picture-in-picture-related 
 
 _This interface also inherits properties from its parent {{domxref("Event")}}_.
 
-- {{domxref("PictureInPictureEvent.pictureInPictureWindow)}}
-  - : Returns the {{domxref("PictireInPictureWindow)}} the event relates to.
+- {{domxref("PictureInPictureEvent.pictureInPictureWindow")}}
+  - : Returns the {{domxref("PictireInPictureWindow")}} the event relates to.
 
 ## Methods
 

--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
@@ -38,7 +38,7 @@ An {{domxref("PictureInPictureWindow")}}. Inherits from {{domxref("Event")}}.
 _In addition to the properties listed below, properties from the parent interface, {{domxref("Event")}}, are available._
 
 - {{domxref("PictureInPictureEvent.pictureInPictureWindow")}}
-  - : Returns the {{domxref("PictireInPictureWindow")}} that is resized.
+  - : Returns the {{domxref("PictureInPictureWindow")}} that is resized.
 
 ## Examples
 

--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
@@ -37,8 +37,8 @@ An {{domxref("PictureInPictureWindow")}}. Inherits from {{domxref("Event")}}.
 
 _In addition to the properties listed below, properties from the parent interface, {{domxref("Event")}}, are available._
 
-- {{domxref("PictureInPictureEvent.pictureInPictureWindow)}}
-  - : Returns the {{domxref("PictireInPictureWindow)}} that is resized.
+- {{domxref("PictureInPictureEvent.pictureInPictureWindow")}}
+  - : Returns the {{domxref("PictireInPictureWindow")}} that is resized.
 
 ## Examples
 

--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
@@ -35,7 +35,10 @@ An {{domxref("PictureInPictureWindow")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/PictureInPictureWindow", "Properties")}}
+_In addition to the properties listed below, properties from the parent interface, {{domxref("Event")}}, are available._
+
+- {{domxref("PictureInPictureEvent.pictureInPictureWindow)}}
+  - : Returns the {{domxref("PictireInPictureWindow)}} that is resized.
 
 ## Examples
 


### PR DESCRIPTION
Picture in Picture's resize event has been adapted to the new event structure in #13570.

It still makes use of a `{{page}}` macro:

This PR:
- remove the page macro (that was linking to the wrong page anyway) and included the correct text
- added the actual property (there is one!) to the property list of `PictureInPictureEvent`.

This will also helps when we get to `HTMLVideoElement` that has 2 events of type `PictureInPictureEvent`.