### PR TITLE
Fix hash link and remove unnecessary <p> tag in table

### DIFF
--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -623,7 +623,7 @@ var name = 'Bob', time = 'today';
 `Hello ${name}, how are you ${time}?`
 ```
 
-[Tagged templates](/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_template) are a compact syntax for specifying a template literal along with a call to a "tag" function for parsing it; the name of the template tag function precedes the template literal — as in the following example, where the template tag function is named "`myTag`":
+[Tagged templates](/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) are a compact syntax for specifying a template literal along with a call to a "tag" function for parsing it; the name of the template tag function precedes the template literal — as in the following example, where the template tag function is named "`myTag`":
 
 ```js
 let myTag = (str, name, age) => `${str[0]}${name}${str[1]}${age}${str[2]}`;

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -709,12 +709,10 @@ The following table lists the special characters that you can use in JavaScript 
         <code>\x<em>XX</em></code>
       </td>
       <td>
-        <p>
-          The character with the Latin-1 encoding specified by the two
-          hexadecimal digits <em>XX</em> between <code>00</code> and
-          <code>FF</code>.<br />For example, <code>\xA9</code> is the
-          hexadecimal sequence for the copyright symbol.
-        </p>
+        The character with the Latin-1 encoding specified by the two
+        hexadecimal digits <em>XX</em> between <code>00</code> and
+        <code>FF</code>.<br />For example, <code>\xA9</code> is the
+        hexadecimal sequence for the copyright symbol.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- Fix a hash-link to move to the right position of the page. #tagged_template -> #tagged_templates
- Remove a `<p>` tag in `<td>` 
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
In the table, there are 14 `<tr>` which has 2 `<td>` each, only one `<td>` has a content enclosed in `<p>` and this `<p>` tag is adding extra margin and having different font size.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
