### PR TITLE
window.find(): add badge experimental and non-standard

### DIFF
--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -200,7 +200,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : Displays a dialog with a message that the user needs to respond to.
 - {{domxref("Window.dump()")}} {{Non-standard_inline}}
   - : Writes a message to the console.
-- {{domxref("Window.find()")}}
+- {{domxref("Window.find()")}} {{experimental_inline}} {{Non-standard_inline}}
   - : Searches for a given string in a window.
 - {{domxref("Window.focus()")}}
   - : Sets focus on the current window.


### PR DESCRIPTION
There is NO specifications available for window.find().

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
It is non-standard and experimental.

#### Motivation
There are no specification available for the API.  

#### Supporting details
https://developer.mozilla.org/en-US/docs/Web/API/Window/find
https://www.w3.org/TR/2017/NOTE-findtext-20170620/


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
