### PR TITLE
Updated the SVGAttr with CSSRef to fix the link which is not working

### DIFF
--- a/files/en-us/web/svg/attribute/text-anchor/index.md
+++ b/files/en-us/web/svg/attribute/text-anchor/index.md
@@ -8,7 +8,7 @@ browser-compat: svg.attributes.presentation.text-anchor
 ---
 {{SVGRef}}
 
-The **`text-anchor`** attribute is used to align (start-, middle- or end-alignment) a string of pre-formatted text or auto-wrapped text where the wrapping area is determined from the {{SVGAttr("inline-size")}} property relative to a given point.
+The **`text-anchor`** attribute is used to align (start-, middle- or end-alignment) a string of pre-formatted text or auto-wrapped text where the wrapping area is determined from the {{cssxref("inline-size")}} property relative to a given point.
 
 This attribute is not applicable to other types of auto-wrapped text. For those cases you should use {{cssxref("text-align")}}. For multi-line text, the alignment takes place for each line.
 


### PR DESCRIPTION
Earlier the link of inline-size on text-anchor page is redirecting to a page which does not having any doc.
The issue is with the attribute link of the inline-size.

Changes:

Earlier: In the code of index.md of text-anchor
            {{SVGAttr("inline-size")}}
Now   : 
           {{cssxref("inline-size")}}

After this change the page is now redirecting to the right link of inline-size.

![Screenshot from 2022-03-15 00-19-12](https://user-images.githubusercontent.com/50704886/158242037-5c8df5fd-6584-4f78-aeb0-0e7560dbfbb5.png)

On the Image we can see the change on hovering on the inline-size, is now giving the right the link.

As it was my first contribution in the mdn docs, it gives me zest to contribute more in open source projects.

Thank You
