### PR TITLE
Remove manch macro

### DIFF
--- a/files/en-us/web/api/blobbuilder/index.md
+++ b/files/en-us/web/api/blobbuilder/index.md
@@ -17,8 +17,8 @@ browser-compat: api.BlobBuilder
 
 The **`BlobBuilder`** interface provides an easy way to
 construct {{domxref("Blob")}} objects. Just create a `BlobBuilder` and append
-chunks of data to it by calling the {{manch("append")}} method. When you're done
-building your blob, call {{manch("getBlob")}} to retrieve a {{domxref("Blob")}}
+chunks of data to it by calling the [`append()`](#append) method. When you're done
+building your blob, call [`getBlob()`](#getblob) to retrieve a {{domxref("Blob")}}
 containing the data you sent into the blob builder.
 
 ## Method overview
@@ -107,7 +107,7 @@ void append(
 ### getBlob()
 
 Returns the {{domxref("Blob")}} object that has been constructed using the data passed
-through calls to {{manch("append")}}.
+through calls to [`append()`](#append).
 
 ```js
 Blob getBlob(
@@ -124,8 +124,8 @@ Blob getBlob(
 #### Return value
 
 A {{domxref("Blob")}} object containing all of the data passed to any calls to
-{{manch("append")}} made since the `BlobBuilder` was created. This also
-resets the `BlobBuilder` so that the next call to {{manch("append")}} is
+[`append()`](#append) made since the `BlobBuilder` was created. This also
+resets the `BlobBuilder` so that the next call to [`append()`](#append) is
 starting a new, empty blob.
 
 ### getFile() {{non-standard_inline}}

--- a/files/en-us/web/api/websocket/bufferedamount/index.md
+++ b/files/en-us/web/api/websocket/bufferedamount/index.md
@@ -12,10 +12,10 @@ browser-compat: api.WebSocket.bufferedAmount
 {{APIRef("Web Sockets API")}}
 
 The **`WebSocket.bufferedAmount`** read-only property returns
-the number of bytes of data that have been queued using calls to {{manch("send")}} but
+the number of bytes of data that have been queued using calls to [`send()`](/en-US/docs/Web/API/WebSocket/send) but
 not yet transmitted to the network. This value resets to zero once all queued data has
 been sent. This value does not reset to zero when the connection is closed; if you keep
-calling {{manch("send")}}, this will continue to climb.
+calling [`send()`](/en-US/docs/Web/API/WebSocket/send), this will continue to climb.
 
 ## Syntax
 


### PR DESCRIPTION
#### Summary
Remove `{{manch}}` macro calls

#### Motivation
Side effect of https://github.com/mdn/translated-content/pull/4617

Also, glad to be the cheapest counterpart ever of # 13802

#### Supporting details

https://developer.mozilla.org/en-US/docs/MDN/Structures/Macros/Other#linking

Tested with looking for `manch[ ]*\(` regexp under the tree (also looked for `manch` afterwards to be sure not to have false negatives)

#### Metadata


This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

