### PR TITLE
Adapt NDEFReader API to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8504,7 +8504,9 @@
 /en-US/docs/Web/API/MutationObserverInit/characterDataOldValue	/en-US/docs/Web/API/MutationObserver/observe
 /en-US/docs/Web/API/MutationObserverInit/childList	/en-US/docs/Web/API/MutationObserver/observe
 /en-US/docs/Web/API/MutationObserverInit/subtree	/en-US/docs/Web/API/MutationObserver/observe
-/en-US/docs/Web/API/NDEFReader/onerror	/en-US/docs/Web/API/NDEFReader/onreadingerror
+/en-US/docs/Web/API/NDEFReader/onerror	/en-US/docs/Web/API/NDEFReader/readingerror_event
+/en-US/docs/Web/API/NDEFReader/onreading	/en-US/docs/Web/API/NDEFReader/reading_event
+/en-US/docs/Web/API/NDEFReader/onreadingerror	/en-US/docs/Web/API/NDEFReader/readingerror_event
 /en-US/docs/Web/API/NDEFWriter	/en-US/docs/Web/API/NDEFReader
 /en-US/docs/Web/API/NDEFWriter/NDEFWriter	/en-US/docs/Web/API/NDEFReader/NDEFReader
 /en-US/docs/Web/API/NDEFWriter/write	/en-US/docs/Web/API/NDEFReader/write

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -60839,13 +60839,13 @@
       "bershanskiy"
     ]
   },
-  "Web/API/NDEFReader/onreading": {
+  "Web/API/NDEFReader/reading_event": {
     "modified": "2020-10-15T22:28:15.471Z",
     "contributors": [
       "bershanskiy"
     ]
   },
-  "Web/API/NDEFReader/onreadingerror": {
+  "Web/API/NDEFReader/readingerror_event": {
     "modified": "2020-12-08T07:17:13.308Z",
     "contributors": [
       "sideshowbarker"

--- a/files/en-us/web/api/ndefmessage/index.md
+++ b/files/en-us/web/api/ndefmessage/index.md
@@ -9,7 +9,7 @@ browser-compat: api.NDEFMessage
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 
-The **`NDEFMessage`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) represents the content of an NDEF message that has been read from or could be written to an NFC tag. An instance is acquired by calling the `NDEFMessage()` constructor or from the {{domxref("NDEFReadingEvent.message")}} property, which is passed to the {{domxref("NDEFReader.reading_event", "reading")}} event..
+The **`NDEFMessage`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) represents the content of an NDEF message that has been read from or could be written to an NFC tag. An instance is acquired by calling the `NDEFMessage()` constructor or from the {{domxref("NDEFReadingEvent.message")}} property, which is passed to the {{domxref("NDEFReader.reading_event", "reading")}} event.
 
 ## Constructor
 

--- a/files/en-us/web/api/ndefmessage/index.md
+++ b/files/en-us/web/api/ndefmessage/index.md
@@ -9,7 +9,7 @@ browser-compat: api.NDEFMessage
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 
-The **`NDEFMessage`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) represents the content of an NDEF message that has been read from or could be written to an NFC tag. An instance is acquired by calling the `NDEFMessage()` constructor or from the {{domxref("NDEFReadingEvent.message")}} property, which is passed to {{domxref("NDEFReader.onreading")}}.
+The **`NDEFMessage`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) represents the content of an NDEF message that has been read from or could be written to an NFC tag. An instance is acquired by calling the `NDEFMessage()` constructor or from the {{domxref("NDEFReadingEvent.message")}} property, which is passed to the {{domxref("NDEFReader.reading_event", "reading")}} event..
 
 ## Constructor
 

--- a/files/en-us/web/api/ndefmessage/records/index.md
+++ b/files/en-us/web/api/ndefmessage/records/index.md
@@ -26,7 +26,7 @@ A list of {{DOMxRef("NDEFRecord")}} object that represent data recorded in the m
 
 ## Examples
 
-The following example shows how to read the contents of an NDEF message. It first sets up an event handler for {{domxref("NDEFReader.onreading")}}, which is passed an instance of {{domxref("NDEFReadingEvent")}}. An `NDEFMessage` object is returned from {{domxref("NDEFReadingEvent.message")}}. It loops through `message.records` and processes each record based on its message type. The data member is a {{jsxref("DataView")}}, which allows handling data encoded in UTF-16.
+The following example shows how to read the contents of an NDEF message. It first sets up an event handler for {{domxref("NDEFReader.reading_event", "onreading")}}, which is passed an instance of {{domxref("NDEFReadingEvent")}}. An `NDEFMessage` object is returned from {{domxref("NDEFReadingEvent.message")}}. It loops through `message.records` and processes each record based on its message type. The data member is a {{jsxref("DataView")}}, which allows handling data encoded in UTF-16.
 
 ```js
 ndefReaderInst.onreading = event => {

--- a/files/en-us/web/api/ndefreader/index.md
+++ b/files/en-us/web/api/ndefreader/index.md
@@ -18,14 +18,14 @@ The **`NDEFReader`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_
 - {{DOMxRef("NDEFReader.NDEFReader", "NDEFReader()")}} {{Experimental_Inline}}
   - : Returns a new `NDEFReader` object.
 
-## Properties
+## Events
 
 _Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
 
-- {{DOMxRef("NDEFReader.onreading")}} {{Experimental_Inline}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) called when the `reading` event is raised.
-- {{DOMxRef("NDEFReader.onreadingerror")}} {{Experimental_Inline}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) called when when the `readingerror` event is raised. This occurs when a tag is in proximity of a reading device, but cannot be read.
+- {{DOMxRef("NDEFReader.reading_event", "reading")}} {{Experimental_Inline}}
+  - : Fires when a new reading is available from compatible NFC devices.
+- {{DOMxRef("NDEFReader.readingerror_event", "readingerror")}} {{Experimental_Inline}}
+  - : Fires when a tag is in proximity of a reading device, but cannot be read.
 
 ## Methods
 

--- a/files/en-us/web/api/ndefreader/index.md
+++ b/files/en-us/web/api/ndefreader/index.md
@@ -18,15 +18,6 @@ The **`NDEFReader`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_
 - {{DOMxRef("NDEFReader.NDEFReader", "NDEFReader()")}} {{Experimental_Inline}}
   - : Returns a new `NDEFReader` object.
 
-## Events
-
-_Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
-
-- {{DOMxRef("NDEFReader.reading_event", "reading")}} {{Experimental_Inline}}
-  - : Fires when a new reading is available from compatible NFC devices.
-- {{DOMxRef("NDEFReader.readingerror_event", "readingerror")}} {{Experimental_Inline}}
-  - : Fires when a tag is in proximity of a reading device, but cannot be read.
-
 ## Methods
 
 _The `NDEFReader` interface inherits the methods of {{domxref("EventTarget")}}, its parent interface._
@@ -35,6 +26,15 @@ _The `NDEFReader` interface inherits the methods of {{domxref("EventTarget")}}, 
   - : Activates a reading device and returns a {{jsxref("Promise")}} that either resolves when an NFC tag is read or rejects if a hardware or permission error is encountered. This method triggers a permission prompt if the "nfc" permission has not been previously granted.
 - {{DOMxRef("NDEFReader.write", "NDEFReader.write()")}} {{Experimental_Inline}}
   - : Attempts to write an NDEF message to a tag and returns a {{jsxref("Promise")}} that either resolves when a message has been written to the tag or rejects if a hardware or permission error is encountered. This method triggers a permission prompt if the "nfc" permission has not been previously granted.
+
+## Events
+
+_Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
+
+- {{DOMxRef("NDEFReader.reading_event", "reading")}} {{Experimental_Inline}}
+  - : Fires when a new reading is available from compatible NFC devices.
+- {{DOMxRef("NDEFReader.readingerror_event", "readingerror")}} {{Experimental_Inline}}
+  - : Fires when a tag is in proximity of a reading device, but cannot be read.
 
 ## Examples
 

--- a/files/en-us/web/api/ndefreader/reading_event/index.md
+++ b/files/en-us/web/api/ndefreader/reading_event/index.md
@@ -1,16 +1,30 @@
 ---
-title: 'NDEFReader: onreadingerror'
-slug: Web/API/NDEFReader/onreadingerror
+title: 'NDEFReader: reading event'
+slug: Web/API/NDEFReader/reading_event
 tags:
   - NDEF
   - Reference
   - Web NFC
-  - Property
-browser-compat: api.NDEFReader.onreadingerror
+  - Event
+browser-compat: api.NDEFReader.reading_event
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 
-The `onreadingerror` property of the {{DOMxRef("NDEFReader")}} interface is called whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.
+The `reading` event of the {{DOMxRef("NDEFReader")}} interface is called whenever a new reading is available from compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('reading', event => { });
+
+onreading = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 
@@ -39,3 +53,7 @@ const ndef = new NDEFReader();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{DOMxRef("NDEFReader.readingerror_event")}}

--- a/files/en-us/web/api/ndefreader/reading_event/index.md
+++ b/files/en-us/web/api/ndefreader/reading_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.NDEFReader.reading_event
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 
-The `reading` event of the {{DOMxRef("NDEFReader")}} interface is called whenever a new reading is available from compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.
+The `reading` event of the {{DOMxRef("NDEFReader")}} interface is fired whenever a new reading is available from compatible NFC devices (e.g. NFC tags supporting NDEF) when these devices are within the reader's magnetic induction field.
 
 ## Syntax
 

--- a/files/en-us/web/api/ndefreader/readingerror_event/index.md
+++ b/files/en-us/web/api/ndefreader/readingerror_event/index.md
@@ -11,7 +11,7 @@ browser-compat: api.NDEFReader.readingerror_event
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 
-The `readingerror` event of the {{DOMxRef("NDEFReader")}} interface is called whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.
+The `readingerror` event of the {{DOMxRef("NDEFReader")}} interface is fired whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.
 
 ## Syntax
 

--- a/files/en-us/web/api/ndefreader/readingerror_event/index.md
+++ b/files/en-us/web/api/ndefreader/readingerror_event/index.md
@@ -2,6 +2,7 @@
 title: 'NDEFReader: readingerror_event'
 slug: Web/API/NDEFReader/readingerror_event
 tags:
+  - Event
   - NDEF
   - Reference
   - Web NFC

--- a/files/en-us/web/api/ndefreader/readingerror_event/index.md
+++ b/files/en-us/web/api/ndefreader/readingerror_event/index.md
@@ -1,16 +1,30 @@
 ---
-title: NDEFReader.onreading
-slug: Web/API/NDEFReader/onreading
+title: 'NDEFReader: readingerror_event'
+slug: Web/API/NDEFReader/readingerror_event
 tags:
   - NDEF
   - Reference
   - Web NFC
   - Property
-browser-compat: api.NDEFReader.onreading
+browser-compat: api.NDEFReader.readingerror_event
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 
-The `onreading` property of the {{DOMxRef("NDEFReader")}} interface is called whenever a new reading is available from compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.
+The `readingerror` event of the {{DOMxRef("NDEFReader")}} interface is called whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('readingerror', event => { });
+
+onreadingerror = event => { };
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 
@@ -39,7 +53,3 @@ const ndef = new NDEFReader();
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- {{DOMxRef("NDEFReader.onreadingerror")}}, property representing handler for `readingerror` events.


### PR DESCRIPTION
This PR adapts the NDEFReader API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15176
