### PR TITLE
window.moveBy(): Moved notes before specs and BCT table

### DIFF
--- a/files/en-us/web/api/window/moveby/index.md
+++ b/files/en-us/web/api/window/moveby/index.md
@@ -41,6 +41,15 @@ function budge() {
 }
 ```
 
+## Notes
+
+As of Firefox 7, websites can no longer move a browser window [in the following
+cases](https://bugzilla.mozilla.org/show_bug.cgi?id=565541#c24):
+
+1. You can't move a window or tab that wasn't created by {{domxref("Window.open()")}}.
+2. You can't move a window or tab when it's in a window with more than one tab.
+
+
 ## Specifications
 
 {{Specifications}}
@@ -48,12 +57,6 @@ function budge() {
 ## Browser compatibility
 
 {{Compat}}
-
-As of Firefox 7, websites can no longer move a browser window [in the following
-cases](https://bugzilla.mozilla.org/show_bug.cgi?id=565541#c24):
-
-1. You can't move a window or tab that wasn't created by {{domxref("Window.open()")}}.
-2. You can't move a window or tab when it's in a window with more than one tab.
 
 ## See also
 

--- a/files/en-us/web/api/window/moveto/index.md
+++ b/files/en-us/web/api/window/moveto/index.md
@@ -39,6 +39,14 @@ function origin() {
 }
 ```
 
+## Notes
+
+As of Firefox 7, websites can no longer move a browser window [in the following
+cases](https://bugzilla.mozilla.org/show_bug.cgi?id=565541#c24):
+
+1. You can't move a window or tab that wasn't created by {{domxref("Window.open()")}}.
+2. You can't move a window or tab when it's in a window with more than one tab.
+
 ## Specifications
 
 {{Specifications}}
@@ -46,12 +54,6 @@ function origin() {
 ## Browser compatibility
 
 {{Compat}}
-
-As of Firefox 7, websites can no longer move a browser window [in the following
-cases](https://bugzilla.mozilla.org/show_bug.cgi?id=565541#c24):
-
-1. You can't move a window or tab that wasn't created by {{domxref("Window.open()")}}.
-2. You can't move a window or tab when it's in a window with more than one tab.
 
 ## See also
 


### PR DESCRIPTION
#### Summary
Notes section was below BCT and specs sections. Put it after Examples section.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
