### PR TITLE
fix(window.applicationCache): add missing APIRef

### DIFF
--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -13,7 +13,7 @@ tags:
   - Window
 browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
-{{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}
+{{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}
 
 > **Warning**: Application cache is being removed from web platform. Consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
 


### PR DESCRIPTION
#### Summary

Adds `{{APIRef}}` to the [Window.applicationCache](https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache) article.

#### Motivation

The article did not have a sidebar on the left, and this should fix it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
