### PR TITLE
Adapt NetworkInformation API to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7516,10 +7516,10 @@
 /en-US/docs/Web/API/Connection	/en-US/docs/Web/API/NetworkInformation
 /en-US/docs/Web/API/Connection.bandwidth	/en-US/docs/Web/API/NetworkInformation
 /en-US/docs/Web/API/Connection.metered	/en-US/docs/Web/API/NetworkInformation
-/en-US/docs/Web/API/Connection.onchange	/en-US/docs/Web/API/NetworkInformation/onchange
+/en-US/docs/Web/API/Connection.onchange	/en-US/docs/Web/API/NetworkInformation/change_event
 /en-US/docs/Web/API/Connection/bandwidth	/en-US/docs/Web/API/NetworkInformation
 /en-US/docs/Web/API/Connection/metered	/en-US/docs/Web/API/NetworkInformation
-/en-US/docs/Web/API/Connection/onchange	/en-US/docs/Web/API/NetworkInformation/onchange
+/en-US/docs/Web/API/Connection/onchange	/en-US/docs/Web/API/NetworkInformation/change_event
 /en-US/docs/Web/API/Console._exception	/en-US/docs/Web/API/console/error
 /en-US/docs/Web/API/Console.count	/en-US/docs/Web/API/console/count
 /en-US/docs/Web/API/Console.debug	/en-US/docs/Web/API/console/log
@@ -8518,7 +8518,7 @@
 /en-US/docs/Web/API/Navigator.connection	/en-US/docs/Web/API/Navigator/connection
 /en-US/docs/Web/API/Navigator.connection.bandwidth	/en-US/docs/Web/API/NetworkInformation
 /en-US/docs/Web/API/Navigator.connection.metered	/en-US/docs/Web/API/NetworkInformation
-/en-US/docs/Web/API/Navigator.connection.onchange	/en-US/docs/Web/API/NetworkInformation/onchange
+/en-US/docs/Web/API/Navigator.connection.onchange	/en-US/docs/Web/API/NetworkInformation/change_event
 /en-US/docs/Web/API/Navigator.cookieEnabled	/en-US/docs/Web/API/Navigator/cookieEnabled
 /en-US/docs/Web/API/Navigator.geolocation	/en-US/docs/Web/API/Navigator/geolocation
 /en-US/docs/Web/API/Navigator.getBattery	/en-US/docs/Web/API/Navigator/getBattery
@@ -8586,10 +8586,11 @@
 /en-US/docs/Web/API/NavigatorStorage	/en-US/docs/Web/API/Navigator
 /en-US/docs/Web/API/NavigatorStorage/storage	/en-US/docs/Web/API/Navigator/storage
 /en-US/docs/Web/API/NetworkInformation.connection	/en-US/docs/Web/API/Navigator/connection
-/en-US/docs/Web/API/NetworkInformation.ontypechange	/en-US/docs/Web/API/NetworkInformation/onchange
+/en-US/docs/Web/API/NetworkInformation.ontypechange	/en-US/docs/Web/API/NetworkInformation/change_event
 /en-US/docs/Web/API/NetworkInformation/NetworkInformation.rtt	/en-US/docs/Web/API/NetworkInformation/rtt
 /en-US/docs/Web/API/NetworkInformation/connection	/en-US/docs/Web/API/Navigator/connection
-/en-US/docs/Web/API/NetworkInformation/ontypechange	/en-US/docs/Web/API/NetworkInformation/onchange
+/en-US/docs/Web/API/NetworkInformation/onchange	/en-US/docs/Web/API/NetworkInformation/change_event
+/en-US/docs/Web/API/NetworkInformation/ontypechange	/en-US/docs/Web/API/NetworkInformation/change_event
 /en-US/docs/Web/API/Node.appendChild	/en-US/docs/Web/API/Node/appendChild
 /en-US/docs/Web/API/Node.attributes	/en-US/docs/Web/API/Element/attributes
 /en-US/docs/Web/API/Node.baseURI	/en-US/docs/Web/API/Node/baseURI
@@ -10062,7 +10063,7 @@
 /en-US/docs/Web/API/window.navigator.connection	/en-US/docs/Web/API/Navigator/connection
 /en-US/docs/Web/API/window.navigator.connection.bandwidth	/en-US/docs/Web/API/NetworkInformation
 /en-US/docs/Web/API/window.navigator.connection.metered	/en-US/docs/Web/API/NetworkInformation
-/en-US/docs/Web/API/window.navigator.connection.onchange	/en-US/docs/Web/API/NetworkInformation/onchange
+/en-US/docs/Web/API/window.navigator.connection.onchange	/en-US/docs/Web/API/NetworkInformation/change_event
 /en-US/docs/Web/API/window.navigator.cookieEnabled	/en-US/docs/Web/API/Navigator/cookieEnabled
 /en-US/docs/Web/API/window.navigator.geolocation	/en-US/docs/Web/API/Navigator/geolocation
 /en-US/docs/Web/API/window.navigator.geolocation.clearWatch	/en-US/docs/Web/API/Geolocation/clearWatch

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -62057,6 +62057,16 @@
       "Sebastianz"
     ]
   },
+  "Web/API/NetworkInformation/change_event": {
+    "modified": "2020-10-15T21:39:13.773Z",
+    "contributors": [
+      "fscholz",
+      "jpmedley",
+      "chrisdavidmills",
+      "YuichiNukiyama",
+      "teoli"
+    ]
+  },
   "Web/API/NetworkInformation/downlink": {
     "modified": "2020-10-15T21:56:55.792Z",
     "contributors": [
@@ -62082,16 +62092,6 @@
       "fscholz",
       "jpmedley",
       "diaboltron"
-    ]
-  },
-  "Web/API/NetworkInformation/onchange": {
-    "modified": "2020-10-15T21:39:13.773Z",
-    "contributors": [
-      "fscholz",
-      "jpmedley",
-      "chrisdavidmills",
-      "YuichiNukiyama",
-      "teoli"
     ]
   },
   "Web/API/NetworkInformation/rtt": {

--- a/files/en-us/web/api/networkinformation/change_event/index.md
+++ b/files/en-us/web/api/networkinformation/change_event/index.md
@@ -1,27 +1,34 @@
 ---
-title: NetworkInformation.onchange
-slug: Web/API/NetworkInformation/onchange
+title: 'NetworkInformation: change event'
+slug: Web/API/NetworkInformation/change_event
 tags:
   - API
   - Event Handler
   - Experimental
   - Network Information API
   - NetworkInformation
-  - Property
+  - Event
   - Reference
-browser-compat: api.NetworkInformation.onchange
+browser-compat: api.NetworkInformation.change_event
 ---
 {{apiref("Network Information API")}}{{SeeCompatTable}}
 
-The **`NetworkInformation.onchange`** event handler contains
-the code that is fired when connection information changes, and the {{event("change")}}
+The **`change`** event fires when connection information changes, and the {{event("change")}}
 is received by the {{domxref("NetworkInformation")}} object.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-netInfo.onchange = function() { /* ... */ }
+addEventListener('change', event => { });
+
+onchange = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/networkinformation/index.md
+++ b/files/en-us/web/api/networkinformation/index.md
@@ -46,14 +46,14 @@ _This interface also inherits properties of its parent, {{domxref("EventTarget")
     - `other`
     - `unknown`
 
-### Event handlers
-
-- {{domxref("NetworkInformation.onchange")}}
-  - : The event that's fired when connection information changes and the {{event("change")}} is fired on this object.
-
 ## Methods
 
 _This interface also inherits methods of its parent, {{domxref("EventTarget")}}._
+
+## Events
+
+- {{domxref("NetworkInformation.change_event", "change")}}
+  - : The event that's fired when connection information changes.
 
 ## Specifications
 


### PR DESCRIPTION
This PR adapts the NetworkInformation API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15177
