### PR TITLE
window.showOpenFilePicker(): corrected typo in syntax section

### DIFF
--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -18,7 +18,7 @@ or multiple files and returns a handle for the file(s).
 ## Syntax
 
 ```js
-var FileSystemHandles = Window.showOpenFilePicker();
+window.showOpenFilePicker();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -19,7 +19,7 @@ Either by selecting an existing file, or entering a name for a new file.
 ## Syntax
 
 ```js
-var FileSystemFileHandle = Window.showSaveFilePicker();
+window.showSaveFilePicker();
 ```
 
 ### Parameters


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
They have used `Window`, which is a function, in syntax section. 
If used it throws TypeError:
> Uncaught TypeError: Window.showOpenFilePicker is not a function

#### Motivation
The `Window`, with capital 'W', is a function and `window`, small 'w', is an object. The methods lie on `window` object. 
Correct syntax is:
```js
window.showOpenFilePicker();
```
Same goes for `window.showSaveFilePicker()` function.

Also, no other Web API on MDN shows return value in Syntax section so removed the `var FileSystemHandles = ` part.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
