### PR TITLE
Misleading description. Fixes a typo

### DIFF
--- a/files/en-us/web/api/webxr_device_api/geometry/index.md
+++ b/files/en-us/web/api/webxr_device_api/geometry/index.md
@@ -37,7 +37,7 @@ WebGL measures all distances and lengths in **meters**. WebXR inherits this stan
 
 ![Diagram showing a WebXR space whose X, Y, and Z coordinate axes each have a minimum value of -1 and a maximum of 1.](defaultspacedimensions.svg)
 
-This two cubic meter space encompasses the entire universe for the purposes of your code. Everything you draw must have its coordinates mapped to fit into this space, either explicitly within your code, or by using a transform to adjust the coordinates of all vertices. The most efficient way, of course, is to design your objects and code to use the same coordinate system as WebGL does.
+This eight cubic meter space encompasses the entire universe for the purposes of your code. Everything you draw must have its coordinates mapped to fit into this space, either explicitly within your code, or by using a transform to adjust the coordinates of all vertices. The most efficient way, of course, is to design your objects and code to use the same coordinate system as WebGL does.
 
 The WebGL coordinates and lengths are transformed automatically at render time to the size of the viewport in which the scene is being rendered.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Description says: the world is a cube two meters wide, two meters tall, and two meters deep...  This two cubic meter space encompasses the entire universe...

Actually it is eight: 2m x 2m x 2m = 8 m^3

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Confuses the reader.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
