### PR TITLE
Remove RTCSdpType

### DIFF
--- a/files/en-us/web/api/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/index.md
@@ -25,59 +25,9 @@ The process of negotiating a connection between two peers involves exchanging `R
 _The `RTCSessionDescription` interface doesn't inherit any properties._
 
 - {{domxref("RTCSessionDescription.type")}} {{ReadOnlyInline}}
-  - : An enum of type [`RTCSdpType`](#rtcsdptype) describing the session description's type.
+  - : An enum describing the session description's type.
 - {{domxref("RTCSessionDescription.sdp")}} {{ReadOnlyInline}}
   - : A {{domxref("DOMString")}} containing the {{Glossary("SDP")}} describing the session.
-
-## Constants
-
-### RTCSdpType
-
-This enum defines strings that describe the current state of the session description, as used in the {{domxref("RTCSessionDescription.type", "type")}} property. The session description's type will be specified using one of these values.
-
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Value</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>answer</code></td>
-      <td>
-        The SDP contained in the
-        {{domxref("RTCSessionDescription.sdp", "sdp")}}
-        property is the definitive choice in the exchange. In other words, this
-        session description describes the agreed-upon configuration, and is
-        being sent to finalize negotiation.
-      </td>
-    </tr>
-    <tr>
-      <td><code>offer</code></td>
-      <td>
-        The session description object describes the initial proposal in an
-        offer/answer exchange. The session negotiation process begins with an
-        offer being sent from the caller to the callee.
-      </td>
-    </tr>
-    <tr>
-      <td><code>pranswer</code></td>
-      <td>
-        The session description object describes a provisional answer; that is,
-        a response to a previous offer that is not the final answer. It is
-        usually employed by legacy hardware.
-      </td>
-    </tr>
-    <tr>
-      <td><code>rollback</code></td>
-      <td>
-        This special type with an empty session description is used to roll back
-        to the previous stable state.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Methods
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
@@ -40,12 +40,9 @@ sessionDescription = new RTCSessionDescription(rtcSessionDescriptionInit);
     the following properties:
 
     - `type`
-      - : **Required.** A string which is a member of the
-        `RTCSdpType` enum; it must have one of the following values:{{page("/en-US/docs/Web/API/RTCSessionDescription", "RTCSdpType")}}
+      - : **Required.** A string which is used to set the `type` property of the new `RTCSessionDescription` object.
     - `sdp`
-      - : A string containing a {{Glossary("SDP")}} message describing the session. This
-        value is an empty string (`""`) by default and may not be
-        `null`.
+      - : A string containing a {{Glossary("SDP")}} message describing the session. This value is an empty string (`""`) by default and may not be `null`.
 
 ## Example
 

--- a/files/en-us/web/api/rtcsessiondescription/type/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/type/index.md
@@ -15,7 +15,7 @@ browser-compat: api.RTCSessionDescription.type
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 The property **`RTCSessionDescription.type`** is a read-only
-value of type `RTCSdpType` which describes the description's type.
+string value which describes the description's type.
 
 ## Syntax
 
@@ -26,18 +26,16 @@ sessionDescription.type = value;
 
 ### Value
 
-The possible values are defined by an enum of type RTCSdpType.
+The possible values are:
 
-The allowed values are those of an enum of type `RTCSdpType`:
-
-- `"offer"`, the description is the initial proposal in an offer/answer
-  exchange.
-- `"answer"`, the description is the definitive choice in an offer/answer
-  exchange.
-- `"pranswer"`, the description is a provisional answer and may be changed
-  when the definitive choice will be given.
-- "`rollback`", the description rolls back to offer/answer state to the
-  last stable state.
+- `"answer"`
+  - : The SDP contained in the {{domxref("RTCSessionDescription.sdp", "sdp")}} property is the definitive choice in the exchange. In other words, this session description describes the agreed-upon configuration, and is being sent to finalize negotiation.
+- `"offer"`
+  - : The session description object describes the initial proposal in an offer/answer exchange. The session negotiation process begins with an offer being sent from the caller to the callee.
+- `"pranswer"`
+  - : The session description object describes a provisional answer; that is, a response to a previous offer that is not the final answer. It is usually employed by legacy hardware.
+- `"rollback"`
+  - : This special type with an empty session description is used to roll back to the previous stable state.
 
 ## Example
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1951,7 +1951,6 @@
         "RTCIceGatheringState",
         "RTCPeerConnectionState",
         "RTCIceConnectionState",
-        "RTCSdpType",
         "RTCIceProtocol",
         "RTCIceTcpCandidateType",
         "RTCIceCandidateType",


### PR DESCRIPTION
This PR removes the separate description of RTCSdpType, and folds its content into the place where it is used. Part of https://github.com/mdn/content/issues/3196.