### PR TITLE
Remove page macro in RTC docs

### DIFF
--- a/files/en-us/web/api/rtcrtpcapabilities/index.md
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.md
@@ -34,9 +34,7 @@ An `RTCRtpCapabilities` object contains an array of objects conforming to {{domx
 
 ### The codecs array
 
-The `codecs` array is an array of objects conforming to the dictionary {{domxref("RTCRtpCodecCapability")}}. Each of these objects describes a single codec and its basic capabilities. Its properties are:
-
-{{page("/en-US/docs/Web/API/RTCRtpCodecCapability", "Properties")}}
+The `codecs` array is an array of objects conforming to the dictionary {{domxref("RTCRtpCodecCapability")}}. Each of these objects describes a single codec and its basic capabilities.
 
 The browser will only report distinct capability combinations separately. If two sets of capabilities can be described as one, they will be. That means that, for instance, if there are two entries for the H.264 codec (as identified by the {{domxref("RTCRtpCodecCapability.mimeType", "mimeType")}} being "video/H264"), there are other values in the capabilities objects indicating how they're different in some way.
 

--- a/files/en-us/web/api/rtcrtpsendparameters/encodings/index.md
+++ b/files/en-us/web/api/rtcrtpsendparameters/encodings/index.md
@@ -39,10 +39,7 @@ encodingParameterList = sendParameters.encodings;
 
 An array of objects conforming to the {{domxref("RTCRtpEncodingParameters")}}
 dictionary, each of which contains properties which provide settings and parameters that
-describe and configure the codec used for a single destination. Each object's properties
-are:
-
-{{page("/en-US/docs/Web/API/RTCRtpEncodingParameters", "Properties")}}
+describe and configure the codec used for a single destination.
 
 ## Description
 

--- a/files/en-us/web/api/rtcstatsreport/index.md
+++ b/files/en-us/web/api/rtcstatsreport/index.md
@@ -15,8 +15,6 @@ browser-compat: api.RTCStatsReport
 ---
 {{APIRef("WebRTC")}}
 
-{{draft("This page is currently incomplete and under active construction. Please be aware that it's not going to answer all of your questions just yet.")}}
-
 The **`RTCStatsReport`** interface provides a statistics report obtained by calling one of the {{domxref("RTCPeerConnection.getStats()")}}, {{domxref("RTCRtpReceiver.getStats()")}}, and {{domxref("RTCRtpSender.getStats()")}} methods.
 
 This statistics report contains a mapping of statistic category string names to objects containing the corresponding statistics data.
@@ -29,19 +27,11 @@ For each category of statistic information, there is a dictionary whose properti
 
 ### Properties common to all statistic categories
 
-All WebRTC statistics objects are fundamentally based on the {{domxref("RTCStats")}} dictionary, which provides the most fundamental information: the timestamp, the statistic type string, and an ID uniquely identifying the source of the data:
-
-{{page("/en-US/docs/Web/API/RTCStats", "Properties")}}
+All WebRTC statistics objects are fundamentally based on the {{domxref("RTCStats")}} dictionary, which provides the most fundamental information: the timestamp, the statistic type string, and an ID uniquely identifying the source of the data.
 
 ### The statistic categories
 
-The {{domxref("RTCStats.type", "type")}} gives the name of the statistic category represented by the object, and is how you locate the specific type of data you need. The statistic category names are members of the enumerated type {{domxref("RTCStatsType")}}, as follows:
-
-{{page("/en-US/docs/Web/API/RTCStatsType", "Values")}}
-
-## Using RTCStatsReport
-
-_... coming soon-ish ..._
+The {{domxref("RTCStats.type", "type")}} gives the name of the statistic category represented by the object, and is how you locate the specific type of data you need. The statistic category names are members of the enumerated type {{domxref("RTCStatsType")}}.
 
 ## Specifications
 


### PR DESCRIPTION
Removes the last few usages of `{{page}}` in the WebRTC docs. In these cases the transcluded content was also linked, so it seems fine to use the link, as we do almost everywhere else. Part of https://github.com/mdn/content/issues/3196.