### PR TITLE
Adapt ServiceWorker API to new events structure

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9063,9 +9063,11 @@
 /en-US/docs/Web/API/Serial/ondisconnect	/en-US/docs/Web/API/SerialPort/disconnect_event
 /en-US/docs/Web/API/SerialPort/onconnect	/en-US/docs/Web/API/SerialPort/connect_event
 /en-US/docs/Web/API/SerialPort/ondisconnect	/en-US/docs/Web/API/SerialPort/disconnect_event
-/en-US/docs/Web/API/ServiceWorker.onstatechange	/en-US/docs/Web/API/ServiceWorker/onstatechange
+/en-US/docs/Web/API/ServiceWorker.onstatechange	/en-US/docs/Web/API/ServiceWorker/statechange_event
 /en-US/docs/Web/API/ServiceWorker.scriptURL	/en-US/docs/Web/API/ServiceWorker/scriptURL
 /en-US/docs/Web/API/ServiceWorker.state	/en-US/docs/Web/API/ServiceWorker/state
+/en-US/docs/Web/API/ServiceWorker/onerror	/en-US/docs/Web/API/ServiceWorker/error_event
+/en-US/docs/Web/API/ServiceWorker/onstatechange	/en-US/docs/Web/API/ServiceWorker/statechange_event
 /en-US/docs/Web/API/ServiceWorkerClient	/en-US/docs/Web/API/Client
 /en-US/docs/Web/API/ServiceWorkerClient/focus	/en-US/docs/Web/API/WindowClient/focus
 /en-US/docs/Web/API/ServiceWorkerClient/postMessage	/en-US/docs/Web/API/Client/postMessage

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -74675,18 +74675,6 @@
       "Meggin"
     ]
   },
-  "Web/API/ServiceWorker/onstatechange": {
-    "modified": "2020-10-15T21:32:16.664Z",
-    "contributors": [
-      "sideshowbarker",
-      "jpmedley",
-      "fscholz",
-      "abbycar",
-      "chrisdavidmills",
-      "Sebastianz",
-      "kscarfone"
-    ]
-  },
   "Web/API/ServiceWorker/scriptURL": {
     "modified": "2020-10-15T21:32:15.265Z",
     "contributors": [
@@ -74705,6 +74693,18 @@
       "sideshowbarker",
       "jpmedley",
       "mfluehr",
+      "fscholz",
+      "abbycar",
+      "chrisdavidmills",
+      "Sebastianz",
+      "kscarfone"
+    ]
+  },
+  "Web/API/ServiceWorker/statechange_event": {
+    "modified": "2020-10-15T21:32:16.664Z",
+    "contributors": [
+      "sideshowbarker",
+      "jpmedley",
       "fscholz",
       "abbycar",
       "chrisdavidmills",

--- a/files/en-us/web/api/serviceworker/error_event/index.md
+++ b/files/en-us/web/api/serviceworker/error_event/index.md
@@ -5,7 +5,6 @@ tags:
   - API
   - ServiceWorker
   - EventHandler
-  - Property
   - Reference
   - Web Workers
   - Workers

--- a/files/en-us/web/api/serviceworker/error_event/index.md
+++ b/files/en-us/web/api/serviceworker/error_event/index.md
@@ -10,6 +10,7 @@ tags:
   - Web Workers
   - Workers
   - onerror
+  - Event
 browser-compat: api.ServiceWorker.error_event
 ---
 {{APIRef("Service Workers API")}}

--- a/files/en-us/web/api/serviceworker/error_event/index.md
+++ b/files/en-us/web/api/serviceworker/error_event/index.md
@@ -1,6 +1,6 @@
 ---
-title: ServiceWorker.onerror
-slug: Web/API/ServiceWorker/onerror
+title: 'ServiceWorker: error event'
+slug: Web/API/ServiceWorker/error_event
 tags:
   - API
   - ServiceWorker
@@ -10,17 +10,25 @@ tags:
   - Web Workers
   - Workers
   - onerror
-browser-compat: api.ServiceWorker.onerror
+browser-compat: api.ServiceWorker.error_event
 ---
 {{APIRef("Service Workers API")}}
 
-The **`onerror`** property of the {{domxref("ServiceWorker")}} interface represents an [event handler](/en-US/docs/Web/Events/Event_handlers), that is a function to be called when the {{event("error")}} event occurs.
+The `error` event fires whenever an error occurs in the service worker.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-myServiceWorker.onerror = function(event) { /* ... */ };
+addEventListener('error', event => { });
+
+onerror = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Example
 

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -30,14 +30,14 @@ _The `ServiceWorker` interface inherits properties from its parent, {{domxref("E
 - {{domxref("ServiceWorker.state")}} {{readonlyinline}}
   - : Returns the state of the service worker. It returns one of the following values: `installing`, `installed,` `activating`, `activated`, or `redundant`.
 
-### Event handlers
-
-- {{domxref("ServiceWorker.onstatechange")}} {{readonlyinline}}
-  - : An {{domxref("EventListener")}} property called whenever an event of type `statechange` is fired; it is basically fired anytime the {{domxref("ServiceWorker.state")}} changes.
-
 ## Methods
 
 _The `ServiceWorker` interface inherits methods from its parent, {{domxref("EventTarget")}}._
+
+## Events
+
+- {{domxref("ServiceWorker.statechange_event", "statechange")}} {{readonlyinline}}
+  - : Fires anytime the {{domxref("ServiceWorker.state")}} changes.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -1,27 +1,32 @@
 ---
-title: ServiceWorker.onstatechange
-slug: Web/API/ServiceWorker/onstatechange
+title: 'ServiceWorker: statechange event'
+slug: Web/API/ServiceWorker/statechange_event
 tags:
   - API
   - Property
   - Reference
   - Service Workers
   - ServiceWorker
-  - onstatechange
-browser-compat: api.ServiceWorker.onstatechange
+  - statechange
+browser-compat: api.ServiceWorker.statechange_event
 ---
 {{APIRef("Service Workers API")}}
 
-An {{domxref("EventListener")}} property called whenever an event of type
-`statechange` is fired; it is basically fired anytime the
-{{domxref("ServiceWorker.state")}} changes.
+The `statechange` event fires anytime the {{domxref("ServiceWorker.state")}} changes.
 
 ## Syntax
 
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
 ```js
-ServiceWorker.onstatechange = function(statechangeevent) { /* ... */ }
-ServiceWorker.addEventListener('statechange', function(statechangeevent) { /* ... */ } )
+addEventListener('statechange', event => { });
+
+onstatechange = event => { };
 ```
+
+## Event type
+
+A generic {{domxref("Event")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -3,7 +3,7 @@ title: 'ServiceWorker: statechange event'
 slug: Web/API/ServiceWorker/statechange_event
 tags:
   - API
-  - Property
+  - Event
   - Reference
   - Service Workers
   - ServiceWorker


### PR DESCRIPTION
This PR adapts the ServiceWorker API to conform to the new events structure.

BCD PR: https://github.com/mdn/browser-compat-data/pull/15199