### PR TITLE
Fix border-color example height

### DIFF
--- a/files/en-us/web/css/border-color/index.md
+++ b/files/en-us/web/css/border-color/index.md
@@ -152,7 +152,7 @@ ul {
 
 #### Result
 
-{{EmbedLiveSample("Complete_border-color_usage", 600, 300)}}
+{{EmbedLiveSample("Complete_border-color_usage", 600, 700)}}
 
 ## Specifications
 


### PR DESCRIPTION
The iframe for the live sample was too short, this PR makes it tall enough.