### PR TITLE
updated index.md for typo in Operator Precedence Page in Javascript/Reference

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -183,8 +183,8 @@ Evaluating the right side
   </tbody>
 </table>
 
-Looking at the code snippets above, `6 / 3 / 2` is the same as
-`(6 / 3) / 2` because division is left-associative. Exponentiation, on the
+Looking at the code snippets above, `6 / 2 / 3` is the same as
+`(6 / 2) / 3` because division is left-associative. Exponentiation, on the
 other hand, is right-associative, so `2 ** 3 ** 2` is the same as
 `2 ** (3 ** 2)`. Thus, doing `(2 ** 3) ** 2` changes the order
 and results in the 64 seen in the table above.


### PR DESCRIPTION
Fixed the typo.
Changed the wrong typo in explanatory paragraph of code block.
Wrong typo was : 6 / 3 / 2
Corrected typo is : 6 / 2 / 3

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
