### PR TITLE
updated index.html of  Operator Precedence page

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -204,9 +204,9 @@ short-circuiting.
 Short-circuiting is jargon for conditional evaluation. For example, in the expression
 `a && (b + c)`, if `a` is {{Glossary("falsy")}}, then
 the sub-expression `(b + c)` will not even get evaluated, even if it is in
-parentheses. We could say that the logical disjunction operator ("OR") is
-"short-circuited". Along with logical disjunction, other short-circuited operators
-include logical conjunction ("AND"), nullish-coalescing, optional chaining, and the
+parentheses. We could say that the logical conjuction operator ("&&") is
+"short-circuited". Along with logical conjuction, other short-circuited operators
+include logical disjunction ("OR"), nullish-coalescing, optional chaining, and the
 conditional operator. Some more examples follow.
 
 ```js


### PR DESCRIPTION
Fixed the mistake in a statement whose meaning was completely opposite.
A mistake was with logical conjunction && operator and logical disjunction operator ||.
Kindly check the updated lines and approve the PR.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
