### PR TITLE
TextEncoderStream(): Wrong variable name `TextEncoderStream`

### DIFF
--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.md
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.md
@@ -15,7 +15,7 @@ The **`TextEncoderStream()`** constructor creates a new {{domxref("TextEncoderSt
 ## Syntax
 
 ```js
-var TextEncoderStream = new TextEncoderStream();
+let encoderStream = new TextEncoderStream();
 ```
 
 ## Examples

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.md
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.md
@@ -15,7 +15,7 @@ The **`TextEncoderStream()`** constructor creates a new {{domxref("TextEncoderSt
 ## Syntax
 
 ```js
-let encoderStream = new TextEncoderStream();
+new TextEncoderStream();
 ```
 
 ## Examples


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Used variable name `TextEncoderStream` is problematic.

#### Motivation
```js
var TextEncoderStream = new TextEncoderStream();
```
Here using exact same variable name as the function `TextEncoderStream()` replaces the function with object instance. After executing this statement we can no longer be able to create more TextEncoderStream() objects.

So used different variable name, which is not same as the function name:
```js
let encoderStream = new TextEncoderStream();
```


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
