### PR TITLE
TextDecoderStream: Fixed link and syntax section

### DIFF
--- a/files/en-us/web/api/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/index.md
@@ -14,7 +14,7 @@ The **`TextDecoderStream`** interface of the {{domxref('Encoding API','','',' ')
 
 ## Constructor
 
-- {{domxref("TextDecoderStream.TextDecoderStream()")}}
+- {{domxref("TextDecoderStream.TextDecoderStream","TextDecoderStream()")}}
   - : Creates a new `TextDecoderStream` object.
 
 ## Properties

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
@@ -15,7 +15,7 @@ The **`TextDecoderStream()`** constructor creates a new {{domxref("TextDecoderSt
 ## Syntax
 
 ```js
-var TextDecoderStream = new TextDecoderStream(label,options);
+new TextDecoderStream(label,options);
 ```
 
 ### Parameters


### PR DESCRIPTION
#### Summary
The link was incomplete.
Syntax section code has issue: it replaces original function with object.

Similar to #13932  and #13933 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
