### PR TITLE
Fix line-height example (issue#13882)

### DIFF
--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -619,6 +619,7 @@ p {
   font-size: 1.5rem;
   color: red;
   font-family: Helvetica, Arial, sans-serif;
+  line-height: 1.6;
 }
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Added a missing line to the [`line-height` example](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#line_height).

### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

There was a bug in the `line-height` example.


### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #13882

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
