### PR TITLE
EyeDropper API: mark experimental in API list ListGroups

### DIFF
--- a/files/en-us/web/api/eyedropper_api/index.md
+++ b/files/en-us/web/api/eyedropper_api/index.md
@@ -3,6 +3,7 @@ title: EyeDropper API
 slug: Web/API/EyeDropper_API
 tags:
   - API
+  - Experimental
   - EyeDropper
   - Overview
   - Reference


### PR DESCRIPTION
#### Summary
Only chromium browsers have implemented it. 
The specification is in draft version.  Also, on [MDN page](https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API)  it is marked experimental. 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
