### PR TITLE
Fix dead link and a URL http -> https (Quirks Mode and Standards Mode)

### DIFF
--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -39,11 +39,11 @@ Make sure you put the DOCTYPE right at the beginning of your HTML document. Anyt
 
 In HTML5, the only purpose of the DOCTYPE is to activate full standards mode. Older versions of the HTML standard gave additional meaning to the DOCTYPE, but no browser has ever used the DOCTYPE for anything other than switching between quirks mode and standards mode.
 
-See also a detailed description of [when different browsers choose various modes](http://hsivonen.iki.fi/doctype/).
+See also a detailed description of [when different browsers choose various modes](https://hsivonen.iki.fi/doctype/).
 
 ### XHTML
 
-If you serve your page as [XHTML](/en-US/docs/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a DOCTYPE to enable standards mode, as such documents always use full standards mode. Note however that serving your pages as `application/xhtml+xml` will cause Internet Explorer 8 to [show a download dialog](/en-US/docs/XHTML#Support) box for an unknown format instead of displaying your page, as the first version of Internet Explorer with support for XHTML is Internet Explorer 9.
+If you serve your page as [XHTML](/en-US/docs/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a DOCTYPE to enable standards mode, as such documents always use full standards mode. Note however that serving your pages as `application/xhtml+xml` will cause Internet Explorer 8 to show a download dialog box for an unknown format instead of displaying your page, as the first version of Internet Explorer with support for XHTML is Internet Explorer 9.
 
 If you serve XHTML-like content using the `text/html` MIME type, browsers will read it as HTML, and you will need the DOCTYPE to use standards mode.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I removed a link to a page that doesn't contain the relevant information anymore and changed a URL from `http` to `https`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
So that readers aren't confused by a non-working link and so that the other external link is more secure.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
At the moment, if you click the 'show a download dialog' link you see this page https://developer.mozilla.org/en-US/docs/Glossary/XHTML#support, which has no Support section and neither does the 'See also' link https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/XHTML.
Originally the link pointed to this page: https://web.archive.org/web/20200205161252/https://developer.mozilla.org/en-US/docs/Glossary/XHTML#Support. But since then, that text has been incorporated into the Quirks Mode and Standards Mode page, in the same paragraph that I removed the link from - so I don't think there's a need for it anymore.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
