### PR TITLE
Web API - Headers: Navlink shouldn't be experimental anymore

### DIFF
--- a/files/en-us/web/api/headers/append/index.md
+++ b/files/en-us/web/api/headers/append/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Headers/append
 tags:
   - API
   - Append
-  - Experimental
   - Fetch
   - Method
   - Reference

--- a/files/en-us/web/api/headers/delete/index.md
+++ b/files/en-us/web/api/headers/delete/index.md
@@ -3,7 +3,6 @@ title: Headers.delete()
 slug: Web/API/Headers/delete
 tags:
   - API
-  - Experimental
   - Fetch
   - Method
   - Reference

--- a/files/en-us/web/api/headers/entries/index.md
+++ b/files/en-us/web/api/headers/entries/index.md
@@ -3,7 +3,6 @@ title: Headers.entries()
 slug: Web/API/Headers/entries
 tags:
   - API
-  - Experimental
   - Fetch API
   - Headers
   - Method

--- a/files/en-us/web/api/headers/get/index.md
+++ b/files/en-us/web/api/headers/get/index.md
@@ -3,7 +3,6 @@ title: Headers.get()
 slug: Web/API/Headers/get
 tags:
   - API
-  - Experimental
   - Fetch
   - Headers
   - Method

--- a/files/en-us/web/api/headers/has/index.md
+++ b/files/en-us/web/api/headers/has/index.md
@@ -3,7 +3,6 @@ title: Headers.has()
 slug: Web/API/Headers/has
 tags:
   - API
-  - Experimental
   - Fetch
   - Method
   - Reference

--- a/files/en-us/web/api/headers/headers/index.md
+++ b/files/en-us/web/api/headers/headers/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Headers/Headers
 tags:
   - API
   - Constructor
-  - Experimental
   - Fetch
   - Reference
 browser-compat: api.Headers.Headers

--- a/files/en-us/web/api/headers/keys/index.md
+++ b/files/en-us/web/api/headers/keys/index.md
@@ -3,7 +3,6 @@ title: Headers.keys()
 slug: Web/API/Headers/keys
 tags:
   - API
-  - Experimental
   - Fetch API
   - Headers
   - Method

--- a/files/en-us/web/api/headers/set/index.md
+++ b/files/en-us/web/api/headers/set/index.md
@@ -3,7 +3,6 @@ title: Headers.set()
 slug: Web/API/Headers/set
 tags:
   - API
-  - Experimental
   - Fetch
   - Method
   - Reference

--- a/files/en-us/web/api/headers/values/index.md
+++ b/files/en-us/web/api/headers/values/index.md
@@ -3,7 +3,6 @@ title: Headers.values()
 slug: Web/API/Headers/values
 tags:
   - API
-  - Experimental
   - Fetch API
   - Headers
   - Method


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
https://developer.mozilla.org/en-US/docs/Web/API/Headers
Removed experimental badges from navbar quicklimes.  The properties are not experimental anymore as per BCT table.


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
