### PR TITLE
Remove remaining obsolete icons

### DIFF
--- a/files/en-us/mdn/contribute/howto/tag/index.md
+++ b/files/en-us/mdn/contribute/howto/tag/index.md
@@ -30,7 +30,7 @@ Tags get used on MDN several ways:
 - [API identification](#api_identification)
   - : Reference pages about an API need to identify the specific component of the API being documented (that is, what interface it's a part of, and what property or method the page covers, if applicable).
 - [Technology status](#technology_status)
-  - : What's the status of the technology? Is it non-standard? Obsolete or deprecated? Experimental?
+  - : What's the status of the technology? Is it non-standard? Deprecated? Experimental?
 - [Skill level](#skill_level)
   - : For tutorials and guides, how advanced is the material covered by the article?
 - [Document metadata](#document_metadata)
@@ -124,9 +124,7 @@ Here are possible values for these tags:
 - `Non-standard`
   - : Indicates that the technology or API described on the page is not part of a standard, whether it's stable or not in any browsers which implement it (if it's not stable, it should also be Experimental). If you don't use this tag, your readers will assume the technology is standard. The compatibility table on the page should clarify which browser(s) support this technology or API.
 - `Deprecated`
-  - : The technology or API covered on the page is marked as deprecated in the specification, and is likely to eventually be removed, but is generally still available in current versions of browsers.
-- `Obsolete`
-  - : The technology or API has been deemed obsolete and has been removed (or is actively being removed) from all or most current browsers.
+  - : The technology or API covered on the page is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality.
 - `Experimental`
   - : The technology is not standardized, and is an experimental technology or API that may or may not ever become part of a standard. It is also subject to change in the browser engine (typically only one) that implements it. If the technology isn't part of any specification (even in draft form), it should also have the Non-standard tag.
 - `Needs Privileges`

--- a/files/en-us/web/api/rtcdatachannel/index.md
+++ b/files/en-us/web/api/rtcdatachannel/index.md
@@ -107,9 +107,9 @@ _Also inherits event handlers from {{DOMxRef("EventTarget")}}._
 
 ### Obsolete properties
 
-- {{DOMxRef("RTCDataChannel.reliable", "reliable")}} {{ReadOnlyInline}} {{Obsolete_Inline}}
+- {{DOMxRef("RTCDataChannel.reliable", "reliable")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : Indicates whether or not the data channel is _reliable_.
-- {{DOMxRef("RTCDataChannel.stream", "stream")}} {{ReadOnlyInline}} {{Obsolete_Inline}}
+- {{DOMxRef("RTCDataChannel.stream", "stream")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : Returns an ID number (between 0 and 65,535)
     which uniquely identifies the data channel.
 

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -225,23 +225,23 @@ _Also inherits methods from {{DOMxRef("EventTarget")}}._
 
 ### Obsolete methods
 
-- {{DOMxRef("RTCPeerConnection.addStream", "addStream()")}} {{Obsolete_Inline}}
+- {{DOMxRef("RTCPeerConnection.addStream", "addStream()")}} {{deprecated_inline}}
   - : Adds a {{DOMxRef("MediaStream")}} as a local source of audio or video.
     Instead of using this obsolete method,
     you should instead use {{DOMxRef("RTCPeerConnection.addTrack", "addTrack()")}}
     once for each track
     you wish to send to the remote peer.
-- {{DOMxRef("RTCPeerConnection.createDTMFSender", "createDTMFSender()")}} {{Obsolete_Inline}}
+- {{DOMxRef("RTCPeerConnection.createDTMFSender", "createDTMFSender()")}} {{deprecated_inline}}
   - : Creates a new {{DOMxRef("RTCDTMFSender")}},
     associated to a specific {{DOMxRef("MediaStreamTrack")}},
     that will be able to send {{Glossary("DTMF")}} phone signaling over the connection.
-- {{DOMxRef("RTCPeerConnection.getStreamById", "getStreamById()")}} {{Obsolete_Inline}}
+- {{DOMxRef("RTCPeerConnection.getStreamById", "getStreamById()")}} {{deprecated_inline}}
   - : Returns the {{DOMxRef("MediaStream")}} with the given id
     that is associated with local or remote end of the connection.
     This property has been replaced
     with the {{DOMxRef("RTCPeerConnection.getSenders", "getSenders()")}}
     and {{DOMxRef("RTCPeerConnection.getReceivers", "getReceivers()")}} methods.
-- {{DOMxRef("RTCPeerConnection.removeStream", "removeStream()")}} {{Obsolete_Inline}}
+- {{DOMxRef("RTCPeerConnection.removeStream", "removeStream()")}} {{deprecated_inline}}
   - : Removes a {{DOMxRef("MediaStream")}} as a local source of audio or video.
     Because this method is obsolete,
     you should instead use {{DOMxRef("RTCPeerConnection.removeTrack", "removeTrack()")}}.
@@ -278,12 +278,12 @@ Listen to these events using {{domxref("EventTarget.addEventListener", "addEvent
 
 ### Obsolete events
 
-- {{domxref("RTCPeerConnection.addstream_event", "addstream")}} {{Obsolete_Inline}}
+- {{domxref("RTCPeerConnection.addstream_event", "addstream")}} {{deprecated_inline}}
   - : Sent when a new {{domxref("MediaStream")}} has been added to the connection.
     Instead of listening for this obsolete event,
     you should listen for {{domxref("RTCPeerConnection.track_event", "track")}} events;
     one is sent for each {{domxref("MediaStreamTrack")}} added to the connection.
-- {{domxref("RTCPeerConnection.removestream_event", "removestream")}} {{Obsolete_Inline}}
+- {{domxref("RTCPeerConnection.removestream_event", "removestream")}} {{deprecated_inline}}
   - : Sent when a {{domxref("MediaStream")}} is removed from the connection.
     Instead of listening for this obsolete event,
     you should listen for {{domxref("MediaStream.removetrack_event", "removetrack")}} events on each stream.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Remove obsolete, as it's been recommended against for several years. I manually looked at every result from https://github.com/mdn/content/search?q=obsolete. https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel#obsolete_properties and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#obsolete_events are the only pages out of those still using the obsolete icon (rather than just the word obsolete).


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The obsolete icon is nearly invisible in dark mode.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Noticed while implementing https://github.com/mdn/yari/pull/5644

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
