### PR TITLE
Remove StaticRange toRange method not found in standards

### DIFF
--- a/files/en-us/web/api/staticrange/index.md
+++ b/files/en-us/web/api/staticrange/index.md
@@ -43,11 +43,6 @@ _The properties below are inherited from its parent interface, {{domxref("Abstra
 - {{domxref("StaticRange.startOffset")}} {{ReadOnlyInline}}
   - : Returns an integer value indicating the offset into the node specified by `startContainer` at which the first character of the range is located.
 
-## Methods
-
-- {{domxref("StaticRange.toRange()")}}
-  - : Returns a new {{domxref("Range")}} object which describes the same range as the source `StaticRange`, but is "live" with values that change to reflect changes in the contents of the DOM tree.
-
 ## Usage notes
 
 A DOM range specifies a span of content in a document, potentially beginning inside one node (or element) and ending inside another one. Unlike a {{domxref("Range")}}, a `StaticRange` represents a range which is fixed in time; it does not change to try to keep the same content within it as the document changes. If any changes are made to the DOM, the actual data contained within the range specified by a `StaticRange` may change. This lets the {{Glossary("user agent")}} avoid a lot of work that is unnecessary if the web app or site doesn't need a live-updating range.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The `toRange()` method does not exist on `StaticRange`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The method was removed in https://github.com/garykac/staticrange/commit/c191c84e7e2a765c89b3d87295b4e62b63f05e06#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L78 and it does not appear browsers (tested Chrome and Firefox) have implemented this method. 

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
