### PR TITLE
Request API: Navlinks shouldn't be experimental anymore

### DIFF
--- a/files/en-us/web/api/request/cache/index.md
+++ b/files/en-us/web/api/request/cache/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Request/cache
 tags:
   - API
   - Cache
-  - Experimental
   - Fetch
   - Property
   - Reference

--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -3,7 +3,6 @@ title: Request.clone()
 slug: Web/API/Request/clone
 tags:
   - API
-  - Experimental
   - Fetch
   - Method
   - Reference

--- a/files/en-us/web/api/request/destination/index.md
+++ b/files/en-us/web/api/request/destination/index.md
@@ -3,7 +3,6 @@ title: Request.destination
 slug: Web/API/Request/destination
 tags:
   - API
-  - Experimental
   - Fetch
   - Fetch API
   - Files

--- a/files/en-us/web/api/request/headers/index.md
+++ b/files/en-us/web/api/request/headers/index.md
@@ -3,7 +3,6 @@ title: Request.headers
 slug: Web/API/Request/headers
 tags:
   - API
-  - Experimental
   - Fetch
   - Headers
   - Property

--- a/files/en-us/web/api/request/integrity/index.md
+++ b/files/en-us/web/api/request/integrity/index.md
@@ -3,7 +3,6 @@ title: Request.integrity
 slug: Web/API/Request/integrity
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference

--- a/files/en-us/web/api/request/method/index.md
+++ b/files/en-us/web/api/request/method/index.md
@@ -3,7 +3,6 @@ title: Request.method
 slug: Web/API/Request/method
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference

--- a/files/en-us/web/api/request/mode/index.md
+++ b/files/en-us/web/api/request/mode/index.md
@@ -3,7 +3,6 @@ title: Request.mode
 slug: Web/API/Request/mode
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference

--- a/files/en-us/web/api/request/redirect/index.md
+++ b/files/en-us/web/api/request/redirect/index.md
@@ -3,7 +3,6 @@ title: Request.redirect
 slug: Web/API/Request/redirect
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Redirect

--- a/files/en-us/web/api/request/referrer/index.md
+++ b/files/en-us/web/api/request/referrer/index.md
@@ -3,7 +3,6 @@ title: Request.referrer
 slug: Web/API/Request/referrer
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference

--- a/files/en-us/web/api/request/referrerpolicy/index.md
+++ b/files/en-us/web/api/request/referrerpolicy/index.md
@@ -3,7 +3,6 @@ title: Request.referrerPolicy
 slug: Web/API/Request/referrerPolicy
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Request/Request
 tags:
   - API
   - Constructor
-  - Experimental
   - Fetch
   - Reference
   - request

--- a/files/en-us/web/api/request/url/index.md
+++ b/files/en-us/web/api/request/url/index.md
@@ -3,7 +3,6 @@ title: Request.url
 slug: Web/API/Request/url
 tags:
   - API
-  - Experimental
   - Fetch
   - Property
   - Reference


### PR DESCRIPTION
#### Summary
https://developer.mozilla.org/en-US/docs/Web/API/Request
Navigation links on the left shouldn't be experimental anymore. As per the main content and BCD table they are not experimental.

Similar to #13952

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
