### PR TITLE
Fix formatting for events links

### DIFF
--- a/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.md
@@ -75,5 +75,5 @@ For an example of the ended event in use, see our [audio-buffer example on GitHu
 - {{domxref("HTMLVideoElement")}}
 - {{HTMLElement("audio")}}
 - {{HTMLElement("video")}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("MediaStreamTrack.ended_event", 'MediaStreamTrack: ended event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The MediaStreamTrack {{domxref("MediaStreamTrack.ended_event", 'ended')}} event

--- a/files/en-us/web/api/htmlmediaelement/canplay_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplay_event/index.md
@@ -76,24 +76,24 @@ video.oncanplay = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.md
@@ -80,24 +80,24 @@ video.oncanplaythrough = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/durationchange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/durationchange_event/index.md
@@ -78,24 +78,24 @@ video.ondurationchange = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/emptied_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/emptied_event/index.md
@@ -76,24 +76,24 @@ video.onemptied = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.md
@@ -87,24 +87,24 @@ video.onended = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -80,24 +80,24 @@ video.onloadeddata = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -80,24 +80,24 @@ video.onloadedmetadata = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/pause_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/pause_event/index.md
@@ -92,24 +92,24 @@ video.onpause = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/play_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play_event/index.md
@@ -78,24 +78,24 @@ video.onplay = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/playing_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/playing_event/index.md
@@ -76,24 +76,24 @@ video.onplaying = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/ratechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ratechange_event/index.md
@@ -77,24 +77,24 @@ video.onratechange = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/seeked_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seeked_event/index.md
@@ -77,24 +77,24 @@ video.onseeked = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/seeking_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seeking_event/index.md
@@ -77,24 +77,24 @@ video.onseeking = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/stalled_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/stalled_event/index.md
@@ -77,24 +77,24 @@ video.onstalled = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/suspend_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/suspend_event/index.md
@@ -77,24 +77,24 @@ video.onsuspend = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.md
@@ -78,24 +78,24 @@ video.ontimeupdate = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
@@ -78,24 +78,24 @@ video.onvolumechange = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/waiting_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/waiting_event/index.md
@@ -77,24 +77,24 @@ video.onwaiting = (event) => {
 
 ## Related Events
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
-- {{domxref("HTMLMediaElement.seeked_event", 'HTMLMediaElement: seeked event')}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("HTMLMediaElement.loadedmetadata_event", 'HTMLMediaElement: loadedmetadata event')}}
-- {{domxref("HTMLMediaElement.loadeddata_event", 'HTMLMediaElement: loadeddata event')}}
-- {{domxref("HTMLMediaElement.canplay_event", 'HTMLMediaElement: canplay event')}}
-- {{domxref("HTMLMediaElement.canplaythrough_event", 'HTMLMediaElement: canplaythrough event')}}
-- {{domxref("HTMLMediaElement.durationchange_event", 'HTMLMediaElement: durationchange event')}}
-- {{domxref("HTMLMediaElement.timeupdate_event", 'HTMLMediaElement: timeupdate event')}}
-- {{domxref("HTMLMediaElement.play_event", 'HTMLMediaElement: play event')}}
-- {{domxref("HTMLMediaElement.pause_event", 'HTMLMediaElement: pause event')}}
-- {{domxref("HTMLMediaElement.ratechange_event", 'HTMLMediaElement: ratechange event')}}
-- {{domxref("HTMLMediaElement.volumechange_event", 'HTMLMediaElement: volumechange event')}}
-- {{domxref("HTMLMediaElement.suspend_event", 'HTMLMediaElement: suspend event')}}
-- {{domxref("HTMLMediaElement.emptied_event", 'HTMLMediaElement: emptied event')}}
-- {{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} event
 
 ## See also
 

--- a/files/en-us/web/api/mediastreamtrack/ended_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/ended_event/index.md
@@ -79,10 +79,10 @@ track.onended = function() {
 
 ## See also
 
-- {{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}
-- {{domxref("HTMLMediaElement.waiting_event", 'HTMLMediaElement: waiting event')}}
-- {{domxref("HTMLMediaElement.seeking_event", 'HTMLMediaElement: seeking event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} event
+- The HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} event
 - {{HTMLElement("audio")}}
 - {{HTMLElement("video")}}
-- {{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}
-- {{domxref("AudioScheduledSourceNode.ended_event", 'AudioScheduledSourceNode: ended event')}}
+- The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event
+- The AudioScheduledSourceNode {{domxref("AudioScheduledSourceNode.ended_event", 'ended')}} event


### PR DESCRIPTION
On various pages, we have links structured like `{{domxref("HTMLMediaElement.ended_event", 'HTMLMediaElement: ended event')}}`.  This PR replaces them with a style like `The HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} event`.

Regex used:
`{{domxref\(\"(\w+)\.(\w+)_event\", '(\w+): (\w+) event'\)}}` -> `The $1 {{domxref("$1.$2_event", '$2')}} event`
