### PR TITLE
Add short section introducing unicode regular expressions

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -409,7 +409,7 @@ For example, the following regular exppression might be used to match against an
 
 There are a number of other differences between unicode and non-unicode regular expressions that one should be aware of:
 
-- Unicode regular expressions do not support so-called "identity escapes"; that is, patterns where an escaping backslash is superfluous and effectively ignored. For example, `/\a/` is a valid regular expression matching the letter 'a', but `/\a/u` is not.
+- Unicode regular expressions do not support so-called "identity escapes"; that is, patterns where an escaping backslash is not needed and effectively ignored. For example, `/\a/` is a valid regular expression matching the letter 'a', but `/\a/u` is not.
 
 - Curly brackets need to be escaped when not used as quantifiers. For example, `/{/` is a valid regular expression matching the curly bracket '{', but `/{/u` is not -- instead, the bracket should be escaped and `/\{/u` should be used instead.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -407,7 +407,7 @@ For example, the following regular exppression might be used to match against an
 /\p{L}*/u
 ```
 
-However, there are a number of other differences between unicode and non-unicode regular expressions that one should be aware of:
+There are a number of other differences between unicode and non-unicode regular expressions that one should be aware of:
 
 - Unicode regular expressions do not support so-called "identity escapes"; that is, patterns where an escaping backslash is superfluous and effectively ignored. For example, `/\a/` is a valid regular expression matching the letter 'a', but `/\a/u` is not.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -401,7 +401,7 @@ console.log(str.match(re)); // ["fee ", "fi ", "fo "]
 
 The "u" flag is used to create "unicode" regular expressions; that is, regular expressions which support matching against unicode text. This is mainly accomplished through the use of [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), which are supported only within "unicode" regular expressions.
 
-For example, the following regular exppression might be used to match against an arbitrary unicode "word":
+For example, the following regular expression might be used to match against an arbitrary unicode "word":
 
 ```js
 /\p{L}*/u

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -397,6 +397,24 @@ In contrast, {{jsxref("String.prototype.match()")}} method returns all matches a
 console.log(str.match(re)); // ["fee ", "fi ", "fo "]
 ```
 
+#### Using unicode regular expressions
+
+The "u" flag is used to create "unicode" regular expressions; that is, regular expressions which support matching against unicode text. This is mainly accomplished through the use of [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), which are supported only within "unicode" regular expressions.
+
+For example, the following regular exppression might be used to match against an arbitrary unicode "word":
+
+```js
+/\p{L}*/u
+```
+
+However, there are a number of other differences between unicode and non-unicode regular expressions that one should be aware of:
+
+- Unicode regular expressions do not support so-called "identity escapes"; that is, patterns where an escaping backslash is superfluous and effectively ignored. For example, `/\a/` is a valid regular expression matching the letter 'a', but `/\a/u` is not.
+
+- Curly brackets need to be escaped when not used as quantifiers. For example, `/{/` is a valid regular expression matching the curly bracket '{', but `/{/u` is not -- instead, the bracket should be escaped and `/\{/u` should be used instead.
+
+- The `-` character is interpreted differently within character classes. In particular, for unicode regular expressions, `-` is interpreted as a literal `-` (and not as part of a range) only if it appears at the start or end of a pattern. For example, `/[\w-:]/` is a valid regular expression matching a word character, a `-`, or `:`, but `/\w-:/u` is an invalid regular expression, as `\w` to `:` is not a well-defined range of characters.
+
 ## Examples
 
 > **Note:** Several examples are also available in:

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -411,7 +411,7 @@ There are a number of other differences between unicode and non-unicode regular 
 
 - Unicode regular expressions do not support so-called "identity escapes"; that is, patterns where an escaping backslash is not needed and effectively ignored. For example, `/\a/` is a valid regular expression matching the letter 'a', but `/\a/u` is not.
 
-- Curly brackets need to be escaped when not used as quantifiers. For example, `/{/` is a valid regular expression matching the curly bracket '{', but `/{/u` is not -- instead, the bracket should be escaped and `/\{/u` should be used instead.
+- Curly brackets need to be escaped when not used as [quantifiers](en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers). For example, `/{/` is a valid regular expression matching the curly bracket '{', but `/{/u` is not -- instead, the bracket should be escaped and `/\{/u` should be used instead.
 
 - The `-` character is interpreted differently within character classes. In particular, for unicode regular expressions, `-` is interpreted as a literal `-` (and not as part of a range) only if it appears at the start or end of a pattern. For example, `/[\w-:]/` is a valid regular expression matching a word character, a `-`, or `:`, but `/\w-:/u` is an invalid regular expression, as `\w` to `:` is not a well-defined range of characters.
 


### PR DESCRIPTION

#### Summary

Adds a section to the Regular Expressions guide, briefly introducing unicode regular expressions, plus a small set of differences for users to be aware of.

Note: I am not an expert here; comments are appreciated!

#### Motivation

Users might not be aware that there are some different rules governing what is considered a valid regular expression when the unicode flag is set.

#### Supporting details

https://262.ecma-international.org/12.0/#sec-pattern-semantics is probably the most relevant section of the standard.

#### Related issues

Fixes https://github.com/mdn/content/issues/13799.

#### Metadata

- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
