### PR TITLE
Fix and modernise touch events example

### DIFF
--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -60,11 +60,11 @@ When the page loads, the `startup()` function shown below will be called.
 ```js
 function startup() {
   const el = document.getElementById("canvas");
-  el.addEventListener("touchstart", handleStart, false);
-  el.addEventListener("touchend", handleEnd, false);
-  el.addEventListener("touchcancel", handleCancel, false);
-  el.addEventListener("touchmove", handleMove, false);
-  log("Initialized.");
+  el.addEventListener('touchstart', handleStart, false);
+  el.addEventListener('touchend', handleEnd, false);
+  el.addEventListener('touchcancel', handleCancel, false);
+  el.addEventListener('touchmove', handleMove, false);
+  log('Initialized.');
 }
 
 document.addEventListener("DOMContentLoaded", startup);
@@ -85,20 +85,20 @@ When a {{domxref("Element/touchstart_event", "touchstart")}} event occurs, indic
 ```js
 function handleStart(evt) {
   evt.preventDefault();
-  console.log("touchstart.");
-  const el = document.getElementById("canvas");
-  const ctx = el.getContext("2d");
+  console.log('touchstart.');
+  const el = document.getElementById('canvas');
+  const ctx = el.getContext('2d');
   const touches = evt.changedTouches;
 
   for (let i = 0; i < touches.length; i++) {
-    console.log("touchstart:" + i + "...");
+    console.log(`touchstart: ${i}...`);
     ongoingTouches.push(copyTouch(touches[i]));
     const color = colorForTouch(touches[i]);
     ctx.beginPath();
     ctx.arc(touches[i].pageX, touches[i].pageY, 4, 0, 2 * Math.PI, false);  // a circle at the start
     ctx.fillStyle = color;
     ctx.fill();
-    console.log("touchstart:" + i + ".");
+    console.log(`touchstart: ${i}.`);
   }
 }
 ```
@@ -114,8 +114,8 @@ Each time one or more fingers move, a {{domxref("Element/touchmove_event", "touc
 ```js
 function handleMove(evt) {
   evt.preventDefault();
-  const el = document.getElementById("canvas");
-  const ctx = el.getContext("2d");
+  const el = document.getElementById('canvas');
+  const ctx = el.getContext('2d');
   const touches = evt.changedTouches;
 
   for (let i = 0; i < touches.length; i++) {
@@ -123,20 +123,20 @@ function handleMove(evt) {
     const idx = ongoingTouchIndexById(touches[i].identifier);
 
     if (idx >= 0) {
-      console.log("continuing touch "+idx);
+      console.log(`continuing touch ${ idx }`);
       ctx.beginPath();
-      console.log("ctx.moveTo(" + ongoingTouches[idx].pageX + ", " + ongoingTouches[idx].pageY + ");");
+      console.log(`ctx.moveTo( ${ ongoingTouches[idx].pageX }, ${ ongoingTouches[idx].pageY } );`);
       ctx.moveTo(ongoingTouches[idx].pageX, ongoingTouches[idx].pageY);
-      console.log("ctx.lineTo(" + touches[i].pageX + ", " + touches[i].pageY + ");");
+      console.log(`ctx.lineTo( ${ touches[i].pageX }, ${ touches[i].pageY } );`);
       ctx.lineTo(touches[i].pageX, touches[i].pageY);
       ctx.lineWidth = 4;
       ctx.strokeStyle = color;
       ctx.stroke();
 
       ongoingTouches.splice(idx, 1, copyTouch(touches[i]));  // swap in the new touch record
-      console.log(".");
+      console.log('.');
     } else {
-      console.log("can't figure out which touch to continue");
+      console.log('can\'t figure out which touch to continue');
     }
   }
 }
@@ -156,8 +156,8 @@ When the user lifts a finger off the surface, a {{domxref("Element/touchend_even
 function handleEnd(evt) {
   evt.preventDefault();
   log("touchend");
-  const el = document.getElementById("canvas");
-  const ctx = el.getContext("2d");
+  const el = document.getElementById('canvas');
+  const ctx = el.getContext('2d');
   const touches = evt.changedTouches;
 
   for (let i = 0; i < touches.length; i++) {
@@ -173,7 +173,7 @@ function handleEnd(evt) {
       ctx.fillRect(touches[i].pageX - 4, touches[i].pageY - 4, 8, 8);  // and a square at the end
       ongoingTouches.splice(idx, 1);  // remove it; we're done
     } else {
-      console.log("can't figure out which touch to end");
+      console.log('can\'t figure out which touch to end');
     }
   }
 }
@@ -188,7 +188,7 @@ If the user's finger wanders into browser UI, or the touch otherwise needs to be
 ```js
 function handleCancel(evt) {
   evt.preventDefault();
-  console.log("touchcancel.");
+  console.log('touchcancel.');
   const touches = evt.changedTouches;
 
   for (let i = 0; i < touches.length; i++) {
@@ -217,7 +217,7 @@ function colorForTouch(touch) {
   g = g.toString(16); // make it a hex digit
   b = b.toString(16); // make it a hex digit
   const color = "#" + r + g + b;
-  console.log("color for touch with identifier " + touch.identifier + " = " + color);
+  console.log(`color for touch with identifier ${ touch.identifier } = ${ color }`);
   return color;
 }
 ```
@@ -256,7 +256,7 @@ function ongoingTouchIndexById(idToFind) {
 ```js
 function log(msg) {
   const p = document.getElementById('log');
-  p.innerHTML = msg + "\n" + p.innerHTML;
+  p.innerHTML = `${ msg } \n${ p.innerHTML }`;
 }
 ```
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -60,10 +60,10 @@ When the page loads, the `startup()` function shown below will be called.
 ```js
 function startup() {
   const el = document.getElementById("canvas");
-  el.addEventListener('touchstart', handleStart, false);
-  el.addEventListener('touchend', handleEnd, false);
-  el.addEventListener('touchcancel', handleCancel, false);
-  el.addEventListener('touchmove', handleMove, false);
+  el.addEventListener('touchstart', handleStart);
+  el.addEventListener('touchend', handleEnd);
+  el.addEventListener('touchcancel', handleCancel);
+  el.addEventListener('touchmove', handleMove);
   log('Initialized.');
 }
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -48,7 +48,7 @@ This example tracks multiple touchpoints at a time, allowing the user to draw in
   Your browser does not support canvas element.
 </canvas>
 <br>
-<button onclick="window.startup();">Initialize</button>
+<button id="myBtn">Initialize</button>
 <br>
 Log: <pre id="log" style="border: 1px solid #ccc;"></pre>
 ```
@@ -56,10 +56,11 @@ Log: <pre id="log" style="border: 1px solid #ccc;"></pre>
 ### Setting up the event handlers
 
 When the page loads, the `startup()` function shown below will be called.
+This sets up all the event listeners for our {{HTMLElement("canvas")}} element so we can handle the touch events as they occur.
 
 ```js
 function startup() {
-  const el = document.getElementById("canvas");
+  const el = document.getElementById('canvas');
   el.addEventListener('touchstart', handleStart);
   el.addEventListener('touchend', handleEnd);
   el.addEventListener('touchcancel', handleCancel);
@@ -70,7 +71,13 @@ function startup() {
 document.addEventListener("DOMContentLoaded", startup);
 ```
 
-This sets up all the event listeners for our {{HTMLElement("canvas")}} element so we can handle the touch events as they occur.
+In addition, below we add an event listener for the "Initialize" button, which also calls the `startup()` method.
+This allows you to refresh the event handlers without reloading the page (this is not strictly needed by the example, but makes simulating the events on desktop a little bit easier.)
+
+```js
+const myBtn = document.getElementById('myBtn');
+myBtn.addEventListener('click', () => {window.startup()} );
+```
 
 #### Tracking new touches
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -51,6 +51,14 @@ This example tracks multiple touchpoints at a time, allowing the user to draw in
 Log: <pre id="log" style="border: 1px solid #ccc;"></pre>
 ```
 
+```css
+#log {
+  height: 200px;
+  width: 600px;
+  overflow: scroll;
+}
+```
+
 ### Setting up the event handlers
 
 When the page loads, the `startup()` function shown below will be called.
@@ -82,20 +90,20 @@ When a {{domxref("Element/touchstart_event", "touchstart")}} event occurs, indic
 ```js
 function handleStart(evt) {
   evt.preventDefault();
-  console.log('touchstart.');
+  log('touchstart.');
   const el = document.getElementById('canvas');
   const ctx = el.getContext('2d');
   const touches = evt.changedTouches;
 
   for (let i = 0; i < touches.length; i++) {
-    console.log(`touchstart: ${i}...`);
+    log(`touchstart: ${i}.`);
     ongoingTouches.push(copyTouch(touches[i]));
     const color = colorForTouch(touches[i]);
+    log(`color of touch with id ${ touches[i].identifier } = ${ color }`);
     ctx.beginPath();
     ctx.arc(touches[i].pageX, touches[i].pageY, 4, 0, 2 * Math.PI, false);  // a circle at the start
     ctx.fillStyle = color;
     ctx.fill();
-    console.log(`touchstart: ${i}.`);
   }
 }
 ```
@@ -120,20 +128,19 @@ function handleMove(evt) {
     const idx = ongoingTouchIndexById(touches[i].identifier);
 
     if (idx >= 0) {
-      console.log(`continuing touch ${ idx }`);
+      log(`continuing touch ${ idx }`);
       ctx.beginPath();
-      console.log(`ctx.moveTo( ${ ongoingTouches[idx].pageX }, ${ ongoingTouches[idx].pageY } );`);
+      log(`ctx.moveTo( ${ ongoingTouches[idx].pageX }, ${ ongoingTouches[idx].pageY } );`);
       ctx.moveTo(ongoingTouches[idx].pageX, ongoingTouches[idx].pageY);
-      console.log(`ctx.lineTo( ${ touches[i].pageX }, ${ touches[i].pageY } );`);
+      log(`ctx.lineTo( ${ touches[i].pageX }, ${ touches[i].pageY } );`);
       ctx.lineTo(touches[i].pageX, touches[i].pageY);
       ctx.lineWidth = 4;
       ctx.strokeStyle = color;
       ctx.stroke();
 
       ongoingTouches.splice(idx, 1, copyTouch(touches[i]));  // swap in the new touch record
-      console.log('.');
     } else {
-      console.log('can\'t figure out which touch to continue');
+      log('can\'t figure out which touch to continue');
     }
   }
 }
@@ -170,7 +177,7 @@ function handleEnd(evt) {
       ctx.fillRect(touches[i].pageX - 4, touches[i].pageY - 4, 8, 8);  // and a square at the end
       ongoingTouches.splice(idx, 1);  // remove it; we're done
     } else {
-      console.log('can\'t figure out which touch to end');
+      log('can\'t figure out which touch to end');
     }
   }
 }
@@ -185,7 +192,7 @@ If the user's finger wanders into browser UI, or the touch otherwise needs to be
 ```js
 function handleCancel(evt) {
   evt.preventDefault();
-  console.log('touchcancel.');
+  log('touchcancel.');
   const touches = evt.changedTouches;
 
   for (let i = 0; i < touches.length; i++) {
@@ -203,7 +210,8 @@ This example uses two convenience functions that should be looked at briefly to 
 
 #### Selecting a color for each touch
 
-To make each touch's drawing look different, the `colorForTouch()` function is used to pick a color based on the touch's unique identifier. This identifier is an opaque number, but we can at least rely on it differing between the currently-active touches.
+To make each touch's drawing look different, the `colorForTouch()` function is used to pick a color based on the touch's unique identifier.
+This identifier is an opaque number, but we can at least rely on it differing between the currently-active touches.
 
 ```js
 function colorForTouch(touch) {
@@ -214,12 +222,12 @@ function colorForTouch(touch) {
   g = g.toString(16); // make it a hex digit
   b = b.toString(16); // make it a hex digit
   const color = "#" + r + g + b;
-  console.log(`color for touch with identifier ${ touch.identifier } = ${ color }`);
   return color;
 }
 ```
 
-The result from this function is a string that can be used when calling {{HTMLElement("canvas")}} functions to set drawing colors. For example, for a {{domxref("Touch.identifier")}} value of 10, the resulting string is "#a31".
+The result from this function is a string that can be used when calling {{HTMLElement("canvas")}} functions to set drawing colors.
+For example, for a {{domxref("Touch.identifier")}} value of 10, the resulting string is "#a31".
 
 #### Copying a touch object
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -48,8 +48,6 @@ This example tracks multiple touchpoints at a time, allowing the user to draw in
   Your browser does not support canvas element.
 </canvas>
 <br>
-<button id="myBtn">Initialize</button>
-<br>
 Log: <pre id="log" style="border: 1px solid #ccc;"></pre>
 ```
 
@@ -69,14 +67,6 @@ function startup() {
 }
 
 document.addEventListener("DOMContentLoaded", startup);
-```
-
-In addition, below we add an event listener for the "Initialize" button, which also calls the `startup()` method.
-This allows you to refresh the event handlers without reloading the page (this is not strictly needed by the example, but makes simulating the events on desktop a little bit easier.)
-
-```js
-const myBtn = document.getElementById('myBtn');
-myBtn.addEventListener('click', () => {window.startup()} );
 ```
 
 #### Tracking new touches
@@ -275,7 +265,7 @@ You can test this example on mobile devices by touching the box below.
 
 > **Note:** More generally, the example will work on platforms that provide touch events. 
 > You can test this on desktop platforms that can simulate such events:
-> - On Firefox enable "touch simulation" in [Responsive Design Mode](/en-US/docs/Tools/Responsive_Design_Mode#toggling_responsive_design_mode), and then press the "Initialize" button to reload the content.
+> - On Firefox enable "touch simulation" in [Responsive Design Mode](/en-US/docs/Tools/Responsive_Design_Mode#toggling_responsive_design_mode) (you may need to reload the page).
 > - On Chrome use [Device mode](https://developer.chrome.com/docs/devtools/device-mode/) and set the [Device type](https://developer.chrome.com/docs/devtools/device-mode/#type) to one that sends touch events.
 
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -267,9 +267,10 @@ You can test this example on mobile devices by touching the box below.
 {{EmbedLiveSample('Example','100%', 880)}}
 
 > **Note:** More generally, the example will work on platforms that provide touch events. 
-> You can test this on desktop versions of Firefox by enabling "touch simulation" in [Responsive Design Mode](/en-US/docs/Tools/Responsive_Design_Mode#toggling_responsive_design_mode), and then pressing the "Initialize" button to reload the content.
+> You can test this on desktop platforms that can simulate such events:
+> - On Firefox enable "touch simulation" in [Responsive Design Mode](/en-US/docs/Tools/Responsive_Design_Mode#toggling_responsive_design_mode), and then press the "Initialize" button to reload the content.
+> - On Chrome use [Device mode](https://developer.chrome.com/docs/devtools/device-mode/) and set the [Device type](https://developer.chrome.com/docs/devtools/device-mode/#type) to one that sends touch events.
 
-You can also [try it out on jsFiddle here](https://jsfiddle.net/Darbicus/z3Xdx/10/).
 
 ## Additional tips
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -120,7 +120,7 @@ function handleMove(evt) {
 
   for (let i = 0; i < touches.length; i++) {
     const color = colorForTouch(touches[i]);
-    let idx = ongoingTouchIndexById(touches[i].identifier);
+    const idx = ongoingTouchIndexById(touches[i].identifier);
 
     if (idx >= 0) {
       console.log("continuing touch "+idx);
@@ -216,7 +216,7 @@ function colorForTouch(touch) {
   r = r.toString(16); // make it a hex digit
   g = g.toString(16); // make it a hex digit
   b = b.toString(16); // make it a hex digit
-  let color = "#" + r + g + b;
+  const color = "#" + r + g + b;
   console.log("color for touch with identifier " + touch.identifier + " = " + color);
   return color;
 }
@@ -285,7 +285,7 @@ function onTouch(evt) {
   if (evt.touches.length > 1 || (evt.type == "touchend" && evt.touches.length > 0))
     return;
 
-  let newEvt = document.createEvent("MouseEvents");
+  const newEvt = document.createEvent("MouseEvents");
   let type = null;
   let touch = null;
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -260,9 +260,11 @@ function ongoingTouchIndexById(idToFind) {
 
 ```js
 function log(msg) {
-  const p = document.getElementById('log');
-  p.innerHTML = `${ msg } \n${ p.innerHTML }`;
+  const container = document.getElementById('log');
+  container.textContent = `${ msg } \n${ container.textContent }`;
 }
+
+
 ```
 
 ### Result

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -48,6 +48,8 @@ This example tracks multiple touchpoints at a time, allowing the user to draw in
   Your browser does not support canvas element.
 </canvas>
 <br>
+<button onclick="window.startup();">Initialize</button>
+<br>
 Log: <pre id="log" style="border: 1px solid #ccc;"></pre>
 ```
 
@@ -57,11 +59,12 @@ When the page loads, the `startup()` function shown below will be called.
 
 ```js
 function startup() {
-  var el = document.getElementById("canvas");
+  const el = document.getElementById("canvas");
   el.addEventListener("touchstart", handleStart, false);
   el.addEventListener("touchend", handleEnd, false);
   el.addEventListener("touchcancel", handleCancel, false);
   el.addEventListener("touchmove", handleMove, false);
+  log("Initialized.");
 }
 
 document.addEventListener("DOMContentLoaded", startup);
@@ -74,7 +77,7 @@ This sets up all the event listeners for our {{HTMLElement("canvas")}} element s
 We'll keep track of the touches in-progress.
 
 ```js
-var ongoingTouches = [];
+const ongoingTouches = [];
 ```
 
 When a {{domxref("Element/touchstart_event", "touchstart")}} event occurs, indicating that a new touch on the surface has occurred, the `handleStart()` function below is called.
@@ -83,14 +86,14 @@ When a {{domxref("Element/touchstart_event", "touchstart")}} event occurs, indic
 function handleStart(evt) {
   evt.preventDefault();
   console.log("touchstart.");
-  var el = document.getElementById("canvas");
-  var ctx = el.getContext("2d");
-  var touches = evt.changedTouches;
+  const el = document.getElementById("canvas");
+  const ctx = el.getContext("2d");
+  const touches = evt.changedTouches;
 
-  for (var i = 0; i < touches.length; i++) {
+  for (let i = 0; i < touches.length; i++) {
     console.log("touchstart:" + i + "...");
     ongoingTouches.push(copyTouch(touches[i]));
-    var color = colorForTouch(touches[i]);
+    const color = colorForTouch(touches[i]);
     ctx.beginPath();
     ctx.arc(touches[i].pageX, touches[i].pageY, 4, 0, 2 * Math.PI, false);  // a circle at the start
     ctx.fillStyle = color;
@@ -111,13 +114,13 @@ Each time one or more fingers move, a {{domxref("Element/touchmove_event", "touc
 ```js
 function handleMove(evt) {
   evt.preventDefault();
-  var el = document.getElementById("canvas");
-  var ctx = el.getContext("2d");
-  var touches = evt.changedTouches;
+  const el = document.getElementById("canvas");
+  const ctx = el.getContext("2d");
+  const touches = evt.changedTouches;
 
-  for (var i = 0; i < touches.length; i++) {
-    var color = colorForTouch(touches[i]);
-    var idx = ongoingTouchIndexById(touches[i].identifier);
+  for (let i = 0; i < touches.length; i++) {
+    const color = colorForTouch(touches[i]);
+    let idx = ongoingTouchIndexById(touches[i].identifier);
 
     if (idx >= 0) {
       console.log("continuing touch "+idx);
@@ -153,13 +156,13 @@ When the user lifts a finger off the surface, a {{domxref("Element/touchend_even
 function handleEnd(evt) {
   evt.preventDefault();
   log("touchend");
-  var el = document.getElementById("canvas");
-  var ctx = el.getContext("2d");
-  var touches = evt.changedTouches;
+  const el = document.getElementById("canvas");
+  const ctx = el.getContext("2d");
+  const touches = evt.changedTouches;
 
-  for (var i = 0; i < touches.length; i++) {
-    var color = colorForTouch(touches[i]);
-    var idx = ongoingTouchIndexById(touches[i].identifier);
+  for (let i = 0; i < touches.length; i++) {
+    const color = colorForTouch(touches[i]);
+    let idx = ongoingTouchIndexById(touches[i].identifier);
 
     if (idx >= 0) {
       ctx.lineWidth = 4;
@@ -186,10 +189,10 @@ If the user's finger wanders into browser UI, or the touch otherwise needs to be
 function handleCancel(evt) {
   evt.preventDefault();
   console.log("touchcancel.");
-  var touches = evt.changedTouches;
+  const touches = evt.changedTouches;
 
-  for (var i = 0; i < touches.length; i++) {
-    var idx = ongoingTouchIndexById(touches[i].identifier);
+  for (let i = 0; i < touches.length; i++) {
+    let idx = ongoingTouchIndexById(touches[i].identifier);
     ongoingTouches.splice(idx, 1);  // remove it; we're done
   }
 }
@@ -207,13 +210,13 @@ To make each touch's drawing look different, the `colorForTouch()` function is u
 
 ```js
 function colorForTouch(touch) {
-  var r = touch.identifier % 16;
-  var g = Math.floor(touch.identifier / 3) % 16;
-  var b = Math.floor(touch.identifier / 7) % 16;
+  let r = touch.identifier % 16;
+  let g = Math.floor(touch.identifier / 3) % 16;
+  let b = Math.floor(touch.identifier / 7) % 16;
   r = r.toString(16); // make it a hex digit
   g = g.toString(16); // make it a hex digit
   b = b.toString(16); // make it a hex digit
-  var color = "#" + r + g + b;
+  let color = "#" + r + g + b;
   console.log("color for touch with identifier " + touch.identifier + " = " + color);
   return color;
 }
@@ -237,8 +240,8 @@ The `ongoingTouchIndexById()` function below scans through the `ongoingTouches` 
 
 ```js
 function ongoingTouchIndexById(idToFind) {
-  for (var i = 0; i < ongoingTouches.length; i++) {
-    var id = ongoingTouches[i].identifier;
+  for (let i = 0; i < ongoingTouches.length; i++) {
+    const id = ongoingTouches[i].identifier;
 
     if (id == idToFind) {
       return i;
@@ -252,16 +255,21 @@ function ongoingTouchIndexById(idToFind) {
 
 ```js
 function log(msg) {
-  var p = document.getElementById('log');
+  const p = document.getElementById('log');
   p.innerHTML = msg + "\n" + p.innerHTML;
 }
 ```
 
-#### Result
+### Result
 
-{{EmbedLiveSample('Demo')}}
+You can test this example on mobile devices by touching the box below.
 
-You can also {{LiveSampleLink('Demo', 'view the results of the demo code in a separate page')}} (or try it out on [jsFiddle here](https://jsfiddle.net/Darbicus/z3Xdx/10/)).
+{{EmbedLiveSample('Example','100%', 880)}}
+
+> **Note:** More generally, the example will work on platforms that provide touch events. 
+> You can test this on desktop versions of Firefox by enabling "touch simulation" in [Responsive Design Mode](/en-US/docs/Tools/Responsive_Design_Mode#toggling_responsive_design_mode), and then pressing the "Initialize" button to reload the content.
+
+You can also [try it out on jsFiddle here](https://jsfiddle.net/Darbicus/z3Xdx/10/).
 
 ## Additional tips
 
@@ -277,9 +285,9 @@ function onTouch(evt) {
   if (evt.touches.length > 1 || (evt.type == "touchend" && evt.touches.length > 0))
     return;
 
-  var newEvt = document.createEvent("MouseEvents");
-  var type = null;
-  var touch = null;
+  let newEvt = document.createEvent("MouseEvents");
+  let type = null;
+  let touch = null;
 
   switch (evt.type) {
     case "touchstart":


### PR DESCRIPTION
The [Touch events](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#results) example did not work. This fixes it as suggested by @wbamberg in https://github.com/mdn/content/issues/13590#issuecomment-1064765288

- [x] fix the argument to EmbedLiveSample and fix the size of the iframe so it's big enough for the example
- [x] remove the LiveSampleLink macro call and the JSFiddle link
- [x] update the example to have an "Initialize" button, like the JSFiddle version
- [x] update the code to be modern JS style
- [x] add a note about how to enable touch event simulation for desktop browsers

Fixes #13590

@wbamberg The example works. I "think" I got the const/let right :-)