### PR TITLE
Link to a reset button from form.reset page

### DIFF
--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -15,7 +15,7 @@ browser-compat: api.HTMLFormElement.reset
 
 The **`HTMLFormElement.reset()`** method restores a form
 element's default values. This method does the same thing as clicking the form's
-[`<input type="reset">`](/en-US/docs/Web/HTML/Element/input/reset).
+[`<input type="reset">`](/en-US/docs/Web/HTML/Element/input/reset) control.
 
 If a form control (such as a reset button) has a name or id of _reset_ it will
 mask the form's reset method. It does not reset other attributes in the input, such as

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -14,8 +14,8 @@ browser-compat: api.HTMLFormElement.reset
 {{APIRef("HTML DOM")}}
 
 The **`HTMLFormElement.reset()`** method restores a form
-element's default values. This method does the same thing as clicking the form's reset
-button.
+element's default values. This method does the same thing as clicking the form's
+{{domxref("Element.input.reset", "reset button")}}.
 
 If a form control (such as a reset button) has a name or id of _reset_ it will
 mask the form's reset method. It does not reset other attributes in the input, such as

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -15,7 +15,7 @@ browser-compat: api.HTMLFormElement.reset
 
 The **`HTMLFormElement.reset()`** method restores a form
 element's default values. This method does the same thing as clicking the form's
-{{domxref("Element.input.reset", "reset button")}}.
+[`<input type="reset">`](/en-US/docs/Web/HTML/Element/input/reset).
 
 If a form control (such as a reset button) has a name or id of _reset_ it will
 mask the form's reset method. It does not reset other attributes in the input, such as


### PR DESCRIPTION
#### Summary
Link to input type=reset button from the `reset()` page

Affected page: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset

#### Motivation
It would be useful to know what a "forms reset button" is. 

#### Questions

- [ ] Is this how you actually link to that page? (attempting to link to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/reset)
- [ ] Is this the right page to link to? ([`button type=reset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) is also a thing. Not sure if there is a more generic place to link to.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
