### PR TITLE
fixed constructor link descriptions

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -66,7 +66,7 @@ The summary paragraph — start by naming the interface, saying what API it is p
 
 ## Constructor
 
-- {{DOMxRef("NameOfTheInterface.NameOfTheInterface")}}
+- {{DOMxRef("NameOfTheInterface.NameOfTheInterface", "NameOfTheInterface()")}}
   - : Creates a new instance of the {{DOMxRef("NameOfTheInterface")}} object.
 
 ## Properties

--- a/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.md
+++ b/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.md
@@ -20,7 +20,7 @@ The **`AnimationPlaybackEvent()`** constructor of the [Web Animations API](/en-U
 ## Syntax
 
 ```js
-var animationPlaybackEvent = new AnimationPlaybackEvent(type, eventInitDict);
+new AnimationPlaybackEvent(type, eventInitDict);
 ```
 
 ### Parameters
@@ -51,5 +51,5 @@ var animationPlaybackEvent = new AnimationPlaybackEvent(type, eventInitDict);
 - [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)
 - {{domxref("AnimationPlayBackEvent")}}
 - {{domxref("Animation.playState")}}
-- {{domxref("CustomEvent.CustomEvent")}}
-- {{domxref("Event.Event")}}
+- {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}
+- {{domxref("Event.Event", "Event()")}}

--- a/files/en-us/web/api/animationplaybackevent/index.md
+++ b/files/en-us/web/api/animationplaybackevent/index.md
@@ -23,7 +23,7 @@ As animations play, they report changes to their {{domxref("Animation.playState"
 
 ## Constructor
 
-- {{domxref("AnimationPlaybackEvent.AnimationPlaybackEvent()")}}
+- {{domxref("AnimationPlaybackEvent.AnimationPlaybackEvent", "AnimationPlaybackEvent()")}}
   - : Constructs a new `AnimationPlaybackEvent` object instance.
 
 ## Properties

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.md
@@ -21,7 +21,7 @@ properties that take a position, for example {{cssxref('object-position')}}.
 ## Syntax
 
 ```js
-cvar cssPositionValue = new CSSPositionValue(x, y)
+new CSSPositionValue(x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/index.md
@@ -18,7 +18,7 @@ The **`CSSPositionValue`** interface of the [CSS Typed Object Model API](/en-US/
 
 ## Constructor
 
-- {{domxref("CSSPositionValue.CSSPositionValue()")}}
+- {{domxref("CSSPositionValue.CSSPositionValue", "CSSPositionValue()")}}
   - : Creates a new `CSSPositionValue` object.
 
 ## Properties

--- a/files/en-us/web/api/csspositionvalue/x/index.md
+++ b/files/en-us/web/api/csspositionvalue/x/index.md
@@ -48,7 +48,7 @@ console.log(position.x.value, position.y.value);
 
 ## See also
 
-- {{domxref("CSSPositionValue.CSSPositionValue()")}}
+- {{domxref("CSSPositionValue.CSSPositionValue", "CSSPositionValue()")}}
 - {{domxref("CSSPositionValue.y")}}
 - [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csspositionvalue/y/index.md
+++ b/files/en-us/web/api/csspositionvalue/y/index.md
@@ -48,7 +48,7 @@ console.log(position.x.value, position.y.value);
 
 ## See also
 
-- {{domxref("CSSPositionValue.CSSPositionValue")}}
+- {{domxref("CSSPositionValue.CSSPositionValue", "CSSPositionValue()")}}
 - {{domxref("CSSPositionValue.x")}}
 - [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/index.md
@@ -19,7 +19,7 @@ The **`MIDIConnectionEvent`** interface of the [Web MIDI API](/en-US/docs/Web/AP
 
 ## Constructor
 
-- {{domxref("MIDIConnectionEvent.MIDIConnectionEvent")}}
+- {{domxref("MIDIConnectionEvent.MIDIConnectionEvent", "MIDIConnectionEvent()")}}
   - : Creates a new `MIDIConnectionEvent` object.
 
 ## Properties

--- a/files/en-us/web/api/midimessageevent/index.md
+++ b/files/en-us/web/api/midimessageevent/index.md
@@ -18,7 +18,7 @@ The **`MIDIMessageEvent`** interface of the [Web MIDI API](/en-US/docs/Web/API/W
 
 ## Constructor
 
-- {{domxref("MIDIMessageEvent.MIDIMessageEvent")}}
+- {{domxref("MIDIMessageEvent.MIDIMessageEvent", "MIDIMessageEvent()")}}
   - : Creates a new `MIDIMessageEvent` object instance.
 
 ## Properties

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.md
@@ -19,7 +19,7 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `OfflineAudioCompletionEv
 
 ## Constructor
 
-- {{domxref("OfflineAudioCompletionEvent.OfflineAudioCompletionEvent")}}
+- {{domxref("OfflineAudioCompletionEvent.OfflineAudioCompletionEvent", "OfflineAudioCompletionEvent()")}}
   - : Creates a new `OfflineAudioCompletionEvent` object instance.
 
 ## Properties

--- a/files/en-us/web/api/request/mode/index.md
+++ b/files/en-us/web/api/request/mode/index.md
@@ -54,10 +54,10 @@ Requests can be initiated in a variety of ways, and the mode for a request depen
 the particular means by which it was initiated.
 
 For example, when a `Request` object is created using the
-{{domxref("Request.Request")}} constructor, the value of the `mode` property
+{{domxref("Request.Request", "Request()")}} constructor, the value of the `mode` property
 for that `Request` is set to `cors`.
 
-However, for requests created other than by the {{domxref("Request.Request")}}
+However, for requests created other than by the {{domxref("Request.Request", "Request()")}}
 constructor, `no-cors` is typically used as the mode; for example, for
 embedded resources where the request is initiated from markup, unless the
 [`crossorigin`](/en-US/docs/Web/HTML/Attributes/crossorigin)
@@ -70,7 +70,7 @@ mode — that is, for the {{HTMLElement("link")}} or {{HTMLElement("script")}} e
 ## Example
 
 In the following snippet, we create a new request using the
-{{domxref("Request.Request()")}} constructor (for an image file in the same directory as
+{{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as
 the script), then save the request mode in a variable:
 
 ```js

--- a/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.md
@@ -80,5 +80,5 @@ certificate to the connection.
 ## See also
 
 - {{domxref("RTCPeerConnection.setConfiguration()")}}
-- {{domxref("RTCPeerConnection.RTCPeerConnection")}}
+- {{domxref("RTCPeerConnection.RTCPeerConnection", "RTCPeerConnection()")}}
 - {{domxref("RTCPeerConnection")}}

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -104,5 +104,5 @@ then sending that offer to the other peer.
 ## See also
 
 - {{domxref("RTCPeerConnection.getConfiguration()")}}
-- {{domxref("RTCPeerConnection.RTCPeerConnection")}}
+- {{domxref("RTCPeerConnection.RTCPeerConnection", "RTCPeerConnection()")}}
 - {{domxref("RTCPeerConnection")}}

--- a/files/en-us/web/api/usbalternateinterface/index.md
+++ b/files/en-us/web/api/usbalternateinterface/index.md
@@ -18,7 +18,7 @@ The `USBAlternateInterface` interface of the [WebUSB API](/en-US/docs/Web/API/We
 
 ## Constructor
 
-- {{domxref("USBAlternateInterface.USBAlternateInterface")}}
+- {{domxref("USBAlternateInterface.USBAlternateInterface", "USBAlternateInterface()")}}
   - : Creates a new `USBAlternateInterface` object which will be populated with information about the alternate interface of the provided `USBInterface` with the given alternate setting number.
 
 ## Properties

--- a/files/en-us/web/api/usbendpoint/index.md
+++ b/files/en-us/web/api/usbendpoint/index.md
@@ -16,7 +16,7 @@ The `USBEndpoint` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) 
 
 ## Constructor
 
-- **`{{domxref("USBEndpoint.USBEndpoint")}}`**
+- **`{{domxref("USBEndpoint.USBEndpoint", "USBEndpoint()")}}`**
   - : Creates a new `USBEndpoint` object which will be populated with information about the endpoint on the provided {{domxref('USBAlternateInterface')}} with the given endpoint number and transfer direction.
 
 ## Properties

--- a/files/en-us/web/api/usbinterface/index.md
+++ b/files/en-us/web/api/usbinterface/index.md
@@ -18,7 +18,7 @@ The `USBInterface` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API)
 
 ## Constructor
 
-- {{domxref("USBInterface.USBInterface")}}
+- {{domxref("USBInterface.USBInterface", "USBInterface()")}}
   - : Creates a new `USBInterface` object which will be populated with information about the interface on the provided `USBConfiguration` with the given interface number.
 
 ## Properties


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Similar to #13933
Constructors links were appearing like properties fixed the descriptions.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
