### PR TITLE
fix: replace var with const in JavaScript code snippets in using_css_animations

### DIFF
--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -307,7 +307,7 @@ We start with creating the CSS for the animation. This animation will last for 3
 We'll use JavaScript code to listen for all three possible animation events. This code configures our event listeners; we call it when the document is first loaded in order to set things up.
 
 ```js
-var element = document.getElementById("watchme");
+const element = document.getElementById("watchme");
 element.addEventListener("animationstart", listener, false);
 element.addEventListener("animationend", listener, false);
 element.addEventListener("animationiteration", listener, false);
@@ -325,7 +325,7 @@ The events get delivered to the `listener()` function, which is shown below.
 
 ```js
 function listener(event) {
-  var l = document.createElement("li");
+  const l = document.createElement("li");
   switch(event.type) {
     case "animationstart":
       l.textContent = `Started: elapsed time is ${event.elapsedTime}`;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Replace `var` with `const` in JavaScript code snippets in [Using CSS Animations page](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations).
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
`const` is better suited to use rather than `var` in the code examples shown in this document.
Reference: [JavaScript Guidelines on Declaring Variables on MDN](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Code_guidelines/JavaScript#declaring_variables)

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
