### PR TITLE
fixing copy and paste error for negotiationneeded

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.md
@@ -29,9 +29,9 @@ This event is not cancelable and does not bubble.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('iceconnectionstatechange', event => { });
+addEventListener('negotiationneeded', event => { });
 
-oniceconnectionstatechange = event => { };
+onnegotiationneeded = event => { };
 ```
 
 ## Event type


### PR DESCRIPTION
#### Summary
fixing copy and paste error for negotiationneeded

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

