### PR TITLE
Update title of FF release landing page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/index.md
+++ b/files/en-us/mozilla/firefox/releases/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox developer release notes
+title: Firefox release notes for developers
 slug: Mozilla/Firefox/Releases
 tags:
   - Firefox


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Updated landing page title from `Firefox developer release notes` to `Firefox release notes for developers`

### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
- To remove ambiguity that the release notes are for developers and not for the developer version of FF.
- The updated title text also matches links to the individual release note links ("for developers").

### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
#### Before
---
<img width="824" alt="Screenshot 2022-03-18 at 1 03 19 PM" src="https://user-images.githubusercontent.com/23019147/158999849-deffb3d4-86b5-45d3-8a7b-8f4b56066030.png">


#### After
---
<img width="816" alt="Screenshot 2022-03-18 at 1 04 54 PM" src="https://user-images.githubusercontent.com/23019147/159000023-46fbc04c-a125-4bfd-aff0-119aa352e9c1.png">



#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Similar change done to the menu text on the sidebar
[PR mdn/yari#5672](https://github.com/mdn/yari/pull/5672)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

