### PR TITLE
Web/JavaScript/Reference/Statements/import: spec link for import calls

### DIFF
--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -11,6 +11,9 @@ tags:
   - dynamic import
   - import
 browser-compat: javascript.statements.import
+spec-urls:
+  - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-imports
+  - https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-calls
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -12,7 +12,6 @@ tags:
   - import
 browser-compat: javascript.statements.import
 spec-urls:
-  - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-imports
   - https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-calls
 ---
 {{jsSidebar("Statements")}}


### PR DESCRIPTION
#### Summary
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
<!-- ✍️ In a sentence or two, describe your changes -->
The page describes import calls ("dynamic imports"), but didn't link to anywhere near the relevant spec section.

Hopefully, this change will fix that 😉.

#### Motivation
When a page describes multiple aspects of a keyword and the spec doesn't have internal cross-references for those, we should link to sections regarding each aspect.

It could be argued that this page should only talk about the statement, however!

  * I'm trying to do a drive-by contribution here, and I can't believe that "it'll only take a moment" to split the page.

  * It might not really be a good idea just because it seems logical.

  * I assume it would need a new browser-compat-data <i>&lt;insert-smart-person-word-here&gt;</i>, with a new *name*. As you know, 
    >There are only two hard things in Computer Science: cache invalidation and naming things.
    > -- Phil Karlton
    So yeah, can't convince myself to try that, either.

So if you want to split the page and/or make a new bcd thingy, you can go ahead and do that; I'm not going to do it for you.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
