### PR TITLE
Fix a typo in CSSImportRule page

### DIFF
--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -22,7 +22,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
   - : Returns the url specified by the {{cssxref("@import")}} rule.
 - {{domxref("CSSImportRule.media")}}
   - : Returns the value of the `media` attribute of the associated stylesheet.
-- {{domxref("CSSImportRule.stylesheet")}}{{readonlyinline}}
+- {{domxref("CSSImportRule.styleSheet")}}{{readonlyinline}}
   - : Returns the associated stylesheet.
 
 ## Methods


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixes a typo

`CSSImportRule.stylesheet` should be `CSSImportRule.styleSheet` according to the spec

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Fixes a typo

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://drafts.csswg.org/cssom/#the-cssimportrule-interface

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
