### PR TITLE
HTML Sanitizer API: added `experimental` tag

### DIFF
--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -3,6 +3,7 @@ title: HTML Sanitizer API
 slug: Web/API/HTML_Sanitizer_API
 tags:
   - HTML Sanitizer API
+  - Experimental
   - Landing
   - Web API
   - sanitize


### PR DESCRIPTION
In [Web API](https://developer.mozilla.org/en-US/docs/Web/API) list experimental badge was not shown. So added the tag.

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
