### PR TITLE
Add a footnote to explain potential confusion

### DIFF
--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -118,6 +118,7 @@ typeof myNumber;
 To fix the calculation, you can do this:
 
 ```js
+let myNumber = '74';
 Number(myNumber) + 3;
 ```
 

--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -122,7 +122,7 @@ let myNumber = '74';
 Number(myNumber) + 3;
 ```
 
-Note that the result is 746. Our script took the string we modified - 743, changed temporarily its type to number and added 3.
+The result is then 77, as initially expected.
 
 ## Arithmetic operators
 

--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -121,6 +121,8 @@ To fix the calculation, you can do this:
 Number(myNumber) + 3;
 ```
 
+Note that the result is 746. Our script took the string we modified - 743, changed temporarily its type to number and added 3.
+
 ## Arithmetic operators
 
 Arithmetic operators are the basic operators that we use to do sums in JavaScript:


### PR DESCRIPTION
In the following tutorial user is tasked to add 3 to 74 (which type is string). First we add 3 to string so the result is 743. Tutorial explains that we need to change data type in the operation to get desirable result. After changing type in calculation output is 746, not 77 because we added 3 to 743. This may confuse the user to think that he made something wrong(also 743 and 746 are very similar visually, user may not spot the difference) in tutorial we wanted to get 77.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
