### PR TITLE
Mark compositionend|update Cancelable: No, to conform to spec

### DIFF
--- a/files/en-us/web/api/element/compositionend_event/index.md
+++ b/files/en-us/web/api/element/compositionend_event/index.md
@@ -20,7 +20,7 @@ For example, this event could be fired after a user finishes entering a Chinese 
     </tr>
     <tr>
       <th>Cancelable</th>
-      <td>Yes</td>
+      <td>No</td>
     </tr>
     <tr>
       <th>Interface</th>

--- a/files/en-us/web/api/element/compositionupdate_event/index.md
+++ b/files/en-us/web/api/element/compositionupdate_event/index.md
@@ -20,7 +20,7 @@ For example, this event could be fired while a user enters a Chinese character u
     </tr>
     <tr>
       <th>Cancelable</th>
-      <td>Yes</td>
+      <td>No</td>
     </tr>
     <tr>
       <th>Interface</th>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14062. Spec references:

- https://w3c.github.io/uievents/#event-type-compositionend
- https://w3c.github.io/uievents/#event-type-compositionupdate

But note, https://w3c.github.io/uievents/#event-type-compositionstart specifies Cancelable: Yes