### PR TITLE
Drop mention of obsolete “legacy generator function” from “yield” doc

### DIFF
--- a/files/en-us/web/javascript/reference/operators/yield/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield/index.md
@@ -12,9 +12,7 @@ browser-compat: javascript.operators.yield
 ---
 {{jsSidebar("Operators")}}
 
-The `yield` keyword is used to pause and resume a generator function
-({{jsxref("Statements/function*", "function*")}} or [legacy
-generator function](/en-US/docs/Archive/Web/JavaScript/Legacy_generator_function_statement)).
+The `yield` keyword is used to pause and resume a [generator function](/en-US/docs/Web/JavaScript/Reference/Statements/function*).
 
 {{EmbedInteractiveExample("pages/js/expressions-yield.html", "taller")}}
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14059. See https://github.com/mdn/archived-content/blob/main/files/en-us/archive/web/javascript/legacy_generator_function/index.html

> The legacy generator function expression was a SpiderMonkey-specific feature, which is removed in Firefox 58+.