### PR TITLE
fixed constructor link descriptions 3

### DIFF
--- a/files/en-us/web/api/css/factory_functions/index.md
+++ b/files/en-us/web/api/css/factory_functions/index.md
@@ -16,7 +16,7 @@ functions**, such as `CSS.em()` and
 `CSS.turn()` are methods that return [CSSUnitValues](/en-US/docs/Web/API/CSSUnitValue) with the value being
 the numeric argument and the unit being the name of the method used. These
 functions create new numeric values less verbosely than using the
-{{domxref('CSSUnitValue.CSSUnitValue()')}} constructor.
+{{domxref("CSSUnitValue.CSSUnitValue", "CSSUnitValue()")}} constructor.
 
 ## Syntax
 
@@ -101,4 +101,4 @@ console.log(currentMargin.value, currentMargin.unit); // 40, 'px'
 
 ## See also
 
-- {{domxref('CSSUnitValue.CSSUnitValue()')}}
+- {{domxref("CSSUnitValue.CSSUnitValue", "CSSUnitValue()")}}

--- a/files/en-us/web/api/css_typed_om_api/index.md
+++ b/files/en-us/web/api/css_typed_om_api/index.md
@@ -43,7 +43,7 @@ The {{domxref('StylePropertyMap')}} interface of the CSS Typed Object Model API 
 
 The {{domxref('CSSUnparsedValue')}} interface of the CSS Typed Object Model API represents property values that reference custom properties. It consists of a list of string fragments and variable references.
 
-- {{domxref('CSSUnparsedValue.CSSUnparsedValue()')}} constructor
+- {{domxref("CSSUnparsedValue.CSSUnparsedValue", "CSSUnparsedValue()")}} constructor
   - : Creates a new CSSUnparsedValue object which represents property values that reference custom properties.
 - {{domxref('CSSUnparsedValue.entries()')}}
   - : Method returning an array of a given object's own enumerable property \[key, value] pairs in the same order as that provided by a for...in loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
@@ -56,8 +56,8 @@ The {{domxref('CSSUnparsedValue')}} interface of the CSS Typed Object Model API 
 
 The {{domxref('CSSKeywordValue')}} interface of the CSS Typed Object Model API creates an object to represent CSS keywords and other identifiers.
 
-- {{domxref('CSSKeywordValue.CSSKeywordValue()')}} constructor
-  - : Constructor creates a new {{domxref('CSSKeywordValue.CSSKeywordValue()')}} object which represents CSS keywords and other identifiers.
+- {{domxref("CSSKeywordValue.CSSKeywordValue", "CSSKeywordValue()")}} constructor
+  - : Constructor creates a new {{domxref("CSSKeywordValue.CSSKeywordValue", "CSSKeywordValue()")}} object which represents CSS keywords and other identifiers.
 - {{domxref('CSSKeywordValue.value()')}}
   - : Property of the CSSKeywordValue interface returning or setting the value of the CSSKeywordValue.
 

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
@@ -21,7 +21,7 @@ would be represented by a `CSSNumericValue`.
 ## Syntax
 
 ```js
-var CSSUnitValue = new CSSUnitValue()
+new CSSUnitValue()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -19,7 +19,7 @@ The **`CSSUnitValue`** interface of the {{domxref('CSS_Object_Model#css_typed_ob
 
 ## Constructor
 
-- {{domxref("CSSUnitValue/CSSUnitValue", "CSSStyleValue.CSSUnitValue()")}}
+- {{domxref("CSSUnitValue.CSSUnitValue", "CSSUnitValue()")}}
   - : Creates a new `CSSUnitValue` object.
 
 ## Properties

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.md
@@ -21,7 +21,7 @@ that reference custom properties.
 ## Syntax
 
 ```js
-var CSSUnparsedValue = new CSSUnparsedValue(members)
+new CSSUnparsedValue(members)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssunparsedvalue/length/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.md
@@ -31,7 +31,7 @@ An integer.
 
 ## Examples
 
-In this example we employ the {{domxref('CSSUnparsedValue.CSSUnparsedValue()')}}
+In this example we employ the {{domxref("CSSUnparsedValue.CSSUnparsedValue", "CSSUnparsedValue()")}}
 constructor, then query the length:
 
 ```js

--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -21,7 +21,7 @@ To access the API you would use the {{domxref('Sanitizer.Sanitizer()','Sanitizer
 The configuration options parameter allows you to specify the allowed and dis-allowed elements and attributes, and to enable custom elements and comments.
 
 The most common use-case - preventing XSS - is handled by the default configuration.
-Creating a {{domxref('Sanitizer.Sanitizer')}} with a custom configuration is necessary only to handle additional, application-specific use cases.
+Creating a {{domxref("Sanitizer.Sanitizer", "Sanitizer()")}} with a custom configuration is necessary only to handle additional, application-specific use cases.
 
 The API has three main methods for sanitizing data:
 

--- a/files/en-us/web/api/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/index.md
@@ -19,7 +19,7 @@ This configuration may be customized using constructor options.
 
 ## Constructors
 
-- {{domxref('Sanitizer.Sanitizer')}}
+- {{domxref("Sanitizer.Sanitizer", "Sanitizer()")}}
   - : Creates and returns a `Sanitizer` object, optionally with custom sanitization behavior.
 
 ## Methods


### PR DESCRIPTION
#### Summary
Similar to #14046  

Constructors links were appearing like properties. Fixed the descriptions.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->