### PR TITLE
using `Number.MAX_SAFE_INTEGER` in code example

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -92,10 +92,15 @@ You can obtain the largest safe value that can be incremented with Numbers by us
 This example demonstrates, where incrementing the {{jsxref("Number.MAX_SAFE_INTEGER")}} returns the expected result:
 
 ```js
-> const x = 2n ** 53n;
-9007199254740992n
-> const y = x + 1n;
-9007199254740993n
+// BigInt
+> const x = BigInt(Number.MAX_SAFE_INTEGER);
+9007199254740991n
+> x + 1n === x + 2n; // 9007199254740992n === 9007199254740993n
+false
+
+// Number
+> Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2; // 9007199254740992 === 9007199254740992
+true
 ```
 
 You can use the operators `+`, `*`, `-`, `**`, and `%` with BigInts—just like with Numbers. A BigInt is not strictly equal to a Number, but it is loosely so.


### PR DESCRIPTION
#### Summary

Use `Number.MAX_SAFE_INTEGER` in code example to match the description. And add comparation with `Number Type`.

#### Related issues

Fixes #14068

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
