### PR TITLE
Update syntax box

### DIFF
--- a/files/en-us/web/api/serialport/getinfo/index.md
+++ b/files/en-us/web/api/serialport/getinfo/index.md
@@ -16,7 +16,7 @@ The **`getInfo()`** method of the {{domxref("SerialPort")}} interface returns an
 ## Syntax
 
 ```js
-var promise = SerialPort.getInfo();
+SerialPort.getInfo();
 ```
 
 ### Parameters


### PR DESCRIPTION
Follow-up #14051, improve #13709

The syntax box was not following the modern template, and hence, confusing.