### PR TITLE
Remove clause to match new design

### DIFF
--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -12,7 +12,7 @@ tags:
 ---
 Web technologies contain long lists of jargon and abbreviations that are used in documentation and coding. This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.
 
-Glossary terms can be selected from the sidebar (or listed below on mobile devices and other narrow width screens).
+Glossary terms can be selected from the sidebar.
 
 > **Note:** This glossary is a never-ending work in progress. You can help improve it by [writing new entries](/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary) or by making the existing ones better.
 


### PR DESCRIPTION
Fixes #14089
With the new design, the sidebar is no more below on small screen but can appear when pressing the sidebar button in the breadcrumbs.

This PR remove the confusing clause.