### PR TITLE
Update Glossary for "HTML"

### DIFF
--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -7,6 +7,7 @@ tags:
   - HTML
   - l10n:priority
 ---
+
 **HTML** (HyperText Markup Language) is a descriptive language that specifies webpage structure.
 
 ## Brief history

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -29,7 +29,6 @@ HTML is normally stored as an `.html` file, served by a {{Glossary("Server","web
 ## See also
 
 - {{interwiki("wikipedia", "HTML", "HTML")}} on Wikipedia
-- [Our HTML tutorial](/en-US/docs/Learn/HTML)
+- [Our HTML Guide](/en-US/docs/Learn/HTML)
 - [The web course on codecademy.com](https://www.codecademy.com/learn/learn-html)
-- [The HTML documentation on MDN](/en-US/docs/Web/HTML)
-- [The HTML specification](https://www.w3.org/TR/html5/)
+- [The HTML specification](https://html.spec.whatwg.org/)

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -8,7 +8,7 @@ tags:
   - l10n:priority
 ---
 
-**HTML** (HyperText Markup Language) is a descriptive language that specifies webpage structure.
+**HTML** (HyperText Markup Language) is a declarative language that specifies webpage structure.
 
 ## Brief history
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -12,7 +12,7 @@ tags:
 
 ## Brief history
 
-In 1990, as part of his vision of the {{Glossary("World Wide Web","Web")}}, Tim Berners-Lee defined the concept of {{Glossary("hypertext")}}, which he then formalized the following year. The {{Glossary("IETF")}} began formally specifying HTML in 1993, and after several drafts released version 2.0 in 1995. In 1994 Berners-Lee founded the {{Glossary("W3C")}} to develop the Web. In 1996, the W3C took over the HTML work and published the HTML 3.2 recommendation a year later. HTML 4.0 was released in 1999 and became an {{Glossary("ISO")}} standard in 2000.
+In 1990, as part of his vision of the {{Glossary("World Wide Web","Web")}}, Tim Berners-Lee defined the concept of {{Glossary("hypertext")}}, which he then formalized the following year. The {{Glossary("IETF")}} began formally specifying HTML in 1993, and after several drafts released version 2.0 in 1995. In 1994, Berners-Lee founded the {{Glossary("W3C")}} to develop the Web. In 1996, the W3C took over the HTML work and published the HTML 3.2 recommendation a year later. HTML 4.0 was released in 1999 and became an {{Glossary("ISO")}} standard in 2000.
 
 At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, prompting the founding of an independent group called {{Glossary("WHATWG")}} in 2004. Thanks to WHATWG, work on {{Glossary("HTML5")}} continued: the two organizations released the first draft in 2008 and the final standard in 2014.
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -20,7 +20,7 @@ At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, p
 
 An HTML document is a plaintext document structured with [elements](/en-US/docs/Web/HTML/Element). Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty tags that cannot enclose any text, for instance {{htmlelement("img")}}.
 
-You can extend HTML tags with {{Glossary("attribute","attributes")}}, which provide additional information affecting how the browser interprets the element:
+You can extend HTML elements with {{Glossary("attribute","attributes")}}:
 
 ![Detail of the structure of an HTML element](anatomy-of-an-html-element.png)
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -24,7 +24,7 @@ You can extend HTML elements with {{Glossary("attribute","attributes")}}:
 
 ![Detail of the structure of an HTML element](anatomy-of-an-html-element.png)
 
-An HTML file is normally saved with an `.htm` or `.html` extension, served by a {{Glossary("Server","web server")}}, and can be rendered by any {{Glossary("Browser","Web browser")}}.
+HTML is normally stored as an `.html` file, served by a {{Glossary("Server","web server")}}, and can be rendered by any {{Glossary("Browser","Web browser")}}.
 
 ## See also
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -20,9 +20,10 @@ At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, p
 
 ## syntax
 
-An HTML document is a plaintext document structured with [elements](/en-US/docs/Web/HTML/Element). Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty tags that cannot enclose any text, for instance {{htmlelement("img")}}.
+An HTML document is a plaintext file structured with {{Glossary("element","elements")}}. Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty tags that cannot enclose any text, for instance {{htmlelement("img")}}. You can further extend HTML elements with {{Glossary("attribute","attributes")}}.
 
-You can extend HTML elements with {{Glossary("attribute","attributes")}}:
+- [All HTML Elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
+- [All HTML Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes)
 
 ![Detail of the structure of an HTML element](anatomy-of-an-html-element.png)
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -18,7 +18,7 @@ At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, p
 
 ## Concept and syntax
 
-An HTML document is a plaintext document structured with {{Glossary("element","elements")}}. Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty or _void_ tags that cannot enclose any text, for instance {{htmlelement("img")}}.
+An HTML document is a plaintext document structured with [elements](/en-US/docs/Web/HTML/Element). Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty tags that cannot enclose any text, for instance {{htmlelement("img")}}.
 
 You can extend HTML tags with {{Glossary("attribute","attributes")}}, which provide additional information affecting how the browser interprets the element:
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -12,7 +12,7 @@ tags:
 
 ## Brief history
 
-In 1990, as part of his vision of the {{Glossary("World Wide Web","Web")}}, Tim Berners-Lee defined the concept of {{Glossary("hypertext")}}, which Berners-Lee formalized the following year through a markup mainly based on {{Glossary("SGML")}}. The {{Glossary("IETF")}} began formally specifying HTML in 1993, and after several drafts released version 2.0 in 1995. In 1994 Berners-Lee founded the {{Glossary("W3C")}} to develop the Web. In 1996, the W3C took over the HTML work and published the HTML 3.2 recommendation a year later. HTML 4.0 was released in 1999 and became an {{Glossary("ISO")}} standard in 2000.
+In 1990, as part of his vision of the {{Glossary("World Wide Web","Web")}}, Tim Berners-Lee defined the concept of {{Glossary("hypertext")}}, which he then formalized the following year. The {{Glossary("IETF")}} began formally specifying HTML in 1993, and after several drafts released version 2.0 in 1995. In 1994 Berners-Lee founded the {{Glossary("W3C")}} to develop the Web. In 1996, the W3C took over the HTML work and published the HTML 3.2 recommendation a year later. HTML 4.0 was released in 1999 and became an {{Glossary("ISO")}} standard in 2000.
 
 At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, prompting the founding of an independent group called {{Glossary("WHATWG")}} in 2004. Thanks to WHATWG, work on {{Glossary("HTML5")}} continued: the two organizations released the first draft in 2008 and the final standard in 2014.
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -24,7 +24,7 @@ You can extend HTML elements with {{Glossary("attribute","attributes")}}:
 
 ![Detail of the structure of an HTML element](anatomy-of-an-html-element.png)
 
-HTML is normally stored as an `.html` file, served by a {{Glossary("Server","web server")}}, and can be rendered by any {{Glossary("Browser","Web browser")}}.
+HTML is normally saved as an `.html` file, served by a {{Glossary("Server","web server")}}, and can be rendered by any {{Glossary("Browser","Web browser")}}.
 
 ## See also
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -10,21 +10,21 @@ tags:
 
 **HTML** (HyperText Markup Language) is a declarative language that specifies webpage structure.
 
+HTML is normally saved as an `.html` file, served by a {{Glossary("Server","web server")}}, and can be rendered by any {{Glossary("Browser","Web browser")}}.
+
 ## Brief history
 
 In 1990, as part of his vision of the {{Glossary("World Wide Web","Web")}}, Tim Berners-Lee defined the concept of {{Glossary("hypertext")}}, which he then formalized the following year. The {{Glossary("IETF")}} began formally specifying HTML in 1993, and after several drafts released version 2.0 in 1995. In 1994, Berners-Lee founded the {{Glossary("W3C")}} to develop the Web. In 1996, the W3C took over the HTML work and published the HTML 3.2 recommendation a year later. HTML 4.0 was released in 1999 and became an {{Glossary("ISO")}} standard in 2000.
 
 At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, prompting the founding of an independent group called {{Glossary("WHATWG")}} in 2004. Thanks to WHATWG, work on {{Glossary("HTML5")}} continued: the two organizations released the first draft in 2008 and the final standard in 2014.
 
-## Concept and syntax
+## syntax
 
 An HTML document is a plaintext document structured with [elements](/en-US/docs/Web/HTML/Element). Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty tags that cannot enclose any text, for instance {{htmlelement("img")}}.
 
 You can extend HTML elements with {{Glossary("attribute","attributes")}}:
 
 ![Detail of the structure of an HTML element](anatomy-of-an-html-element.png)
-
-HTML is normally saved as an `.html` file, served by a {{Glossary("Server","web server")}}, and can be rendered by any {{Glossary("Browser","Web browser")}}.
 
 ## See also
 

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -29,6 +29,7 @@ HTML is normally stored as an `.html` file, served by a {{Glossary("Server","web
 ## See also
 
 - {{interwiki("wikipedia", "HTML", "HTML")}} on Wikipedia
-- [Our HTML Guide](/en-US/docs/Learn/HTML)
+- [HTML Reference](/en-US/docs/Web/HTML)
+- [HTML Guide](/en-US/docs/Learn/HTML)
 - [The web course on codecademy.com](https://www.codecademy.com/learn/learn-html)
 - [The HTML specification](https://html.spec.whatwg.org/)


### PR DESCRIPTION
#### Motivation

I wanted to link to the MDN Glossary entry for HTML, within my own notes/docs, because the [wikipedia version](https://en.wikipedia.org/wiki/HTML) is just to large.

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
