### PR TITLE
Remove "Experimental" from ClipboardEvent

### DIFF
--- a/files/en-us/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboarddata/index.md
@@ -15,23 +15,16 @@ browser-compat: api.ClipboardEvent.clipboardData
 ---
 {{APIRef("Clipboard API")}}
 
-The **`ClipboardEvent.clipboardData`** property holds a
-{{domxref("DataTransfer")}} object, which can be used:
+The **`ClipboardEvent.clipboardData`** property holds a {{domxref("DataTransfer")}} object, which can be used:
 
-- to specify what data should be put into the clipboard from the {{event("cut")}} and
-  {{event("copy")}} event handlers, typically with a {{domxref("DataTransfer.setData",
-    "setData(format, data)")}} call;
-- to obtain the data to be pasted from the {{event("paste")}} event handler, typically
-  with a {{domxref("DataTransfer.getData", "getData(format)")}} call.
+- to specify what data should be put into the clipboard from the {{event("cut")}} and {{event("copy")}} event handlers, typically with a {{domxref("DataTransfer.setData", "setData(format, data)")}} call;
+- to obtain the data to be pasted from the {{event("paste")}} event handler, typically with a {{domxref("DataTransfer.getData", "getData(format)")}} call.
 
-See the {{event("cut")}}, {{event("copy")}}, and {{event("paste")}} events
-documentation for more information.
+See the {{event("cut")}}, {{event("copy")}}, and {{event("paste")}} events documentation for more information.
 
-## Syntax
+## Value
 
-```js
-data = ClipboardEvent.clipboardData
-```
+A {{domxref("DataTransfer")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboarddata/index.md
@@ -7,14 +7,13 @@ tags:
   - Clipboard API
   - ClipboardEvent
   - Cut
-  - Experimental
   - Property
   - Read-only
   - copy
   - paste
 browser-compat: api.ClipboardEvent.clipboardData
 ---
-{{ apiref("Clipboard API") }} {{SeeCompatTable}}
+{{APIRef("Clipboard API")}}
 
 The **`ClipboardEvent.clipboardData`** property holds a
 {{domxref("DataTransfer")}} object, which can be used:

--- a/files/en-us/web/api/clipboardevent/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboardevent/index.md
@@ -23,28 +23,24 @@ modification of the clipboard, that is {{event("cut")}}, {{event("copy")}}, and
 ## Syntax
 
 ```js
-var clipboardEvent = new ClipboardEvent(type[, options]);
+new ClipboardEvent(type)
+new ClipboardEvent(type, options)
 ```
 
 ### Parameters
 
-_The `ClipboardEvent()` constructor also inherits arguments from
-{{domxref("Event.Event", "Event()")}}._
+_The `ClipboardEvent()` constructor also inherits arguments from {{domxref("Event.Event", "Event()")}}._
 
 - _type_
-  - : Is a {{domxref("DOMString")}} representing the name of the type of the
-    `ClipboardEvent`. It is case-sensitive and can be: `'copy'`,
-    `'cut'`, or `'paste'`.
+  - : Is a {{domxref("DOMString")}} representing the name of the type of the `ClipboardEvent`.
+    It is case-sensitive and can be: `'copy'`, `'cut'`, or `'paste'`.
 - *options* {{optional_inline}}
 
   - : Options are as follows:
 
-    - `clipboardData`: A {{domxref("DataTransfer")}} containing the data
-      concerned by the clipboard event.
-    - `dataType`{{non-standard_inline}}: A {{domxref("DOMString")}}
-      containing the MIME-type of the data contained in the `data` argument.
-    - `data`{{non-standard_inline}}: A {{domxref("DOMString")}} containing
-      the data concerned by the clipboard event.
+    - `clipboardData`: A {{domxref("DataTransfer")}} containing the data concerned by the clipboard event.
+    - `dataType`{{non-standard_inline}}: A {{domxref("DOMString")}} containing the MIME-type of the data contained in the `data` argument.
+    - `data`{{non-standard_inline}}: A {{domxref("DOMString")}} containing the data concerned by the clipboard event.
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboardevent/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboardevent/index.md
@@ -8,13 +8,12 @@ tags:
   - ClipboardEvent
   - Constructor
   - Cut
-  - Experimental
   - Reference
   - copy
   - paste
 browser-compat: api.ClipboardEvent.ClipboardEvent
 ---
-{{APIRef("Clipboard API")}}{{SeeCompatTable}}
+{{APIRef("Clipboard API")}}
 
 The **`ClipboardEvent()`** constructor returns a newly created
 {{domxref("ClipboardEvent")}}, representing an event providing information related to

--- a/files/en-us/web/api/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/index.md
@@ -7,13 +7,12 @@ tags:
   - Clipboard API
   - Cut
   - Event
-  - Experimental
   - Interface
   - copy
   - paste
 browser-compat: api.ClipboardEvent
 ---
-{{APIRef("Clipboard API")}} {{SeeCompatTable}}
+{{APIRef("Clipboard API")}}
 
 The **`ClipboardEvent`** interface represents events providing information related to modification of the clipboard, that is {{event("cut")}}, {{event("copy")}}, and {{event("paste")}} events.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove "Experimental" from ClipboardEvent because most of browsers support this interface.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
