### PR TITLE
DeviceMotionEvent() : as per the BCD table it is standard now

### DIFF
--- a/files/en-us/web/api/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/index.md
@@ -5,7 +5,6 @@ tags:
   - API
   - Device Orientation
   - DeviceMotionEvent
-  - Experimental
   - Interface
   - Mobile
   - Motion

--- a/files/en-us/web/api/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/index.md
@@ -23,7 +23,7 @@ The `DeviceMotionEvent` provides web developers with information about the speed
 
 ## Constructor
 
-- {{domxref("DeviceMotionEvent.DeviceMotionEvent", "DeviceMotionEvent()")}} {{Non-standard_Inline}}
+- {{domxref("DeviceMotionEvent.DeviceMotionEvent", "DeviceMotionEvent()")}}
   - : Creates a new `DeviceMotionEvent`.
 
 ## Properties


### PR DESCRIPTION
#### Summary
https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent

The constructor `DeviceMotionEvent()` is now standard as per the BCD table. So removed the badge.


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
