### PR TITLE
WebAPI: fixed constructor section code

### DIFF
--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.md
@@ -15,7 +15,7 @@ The **`BackgroundFetchEvent()`** constructor creates a new {{domxref("Background
 ## Syntax
 
 ```js
-let BackgroundFetchEvent = new BackgroundFetchEvent(type, BackgroundFetchEventInit);
+new BackgroundFetchEvent(type, BackgroundFetchEventInit);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.md
@@ -15,7 +15,7 @@ The **`BackgroundFetchUpdateUIEvent()`** constructor creates a new {{domxref("Ba
 ## Syntax
 
 ```js
-let BackgroundFetchEvent = new BackgroundFetchEvent(type, BackgroundFetchEventInit);
+new BackgroundFetchEvent(type, BackgroundFetchEventInit);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/barcodedetector/barcodedetector/index.md
+++ b/files/en-us/web/api/barcodedetector/barcodedetector/index.md
@@ -19,7 +19,7 @@ barcodes in images.
 ## Syntax
 
 ```js
-var BarcodeDetector = new BarcodeDetector();
+new BarcodeDetector();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -22,7 +22,7 @@ The **`ClipboardItem()`** constructor of the {{domxref("Clipboard API")}} create
 ## Syntax
 
 ```js
-var ClipboardItem = new ClipboardItem(ClipboardItemData);
+new ClipboardItem(ClipboardItemData);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -15,7 +15,7 @@ The **`CompressionStream()`** constructor creates a new {{domxref("CompressionSt
 ## Syntax
 
 ```js
-let CompressionStream = new CompressionStream(format);
+new CompressionStream(format);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.md
@@ -21,7 +21,7 @@ configured as specified.
 ## Syntax
 
 ```js
-var ContentIndexEvent = new ContentIndexEvent(type, ContentIndexEventInit);
+new ContentIndexEvent(type, ContentIndexEventInit);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -17,7 +17,7 @@ The **`CookieChangeEvent()`** constructor creates a new {{domxref("CookieChangeE
 ## Syntax
 
 ```js
-var CookieChangeEvent = new CookieChangeEvent(type,eventInitDict);
+new CookieChangeEvent(type,eventInitDict);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
@@ -20,7 +20,7 @@ new {{domxref("CSSMathInvert")}} object which represents a CSS
 ## Syntax
 
 ```js
-var CSSMathInvert = new CSSMathInvert(arg);
+new CSSMathInvert(arg);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.md
@@ -20,7 +20,7 @@ new {{domxref("CSSMathMax")}} object which represents the CSS {{CSSXref('max()',
 ## Syntax
 
 ```js
-var CSSMathMax = new CSSMathMax(args);
+new CSSMathMax(args);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.md
@@ -20,7 +20,7 @@ new {{domxref("CSSMathMin")}} object which represents the CSS
 ## Syntax
 
 ```js
-var CSSMathMin = new CSSMathMin(args);
+new CSSMathMin(args);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
@@ -19,7 +19,7 @@ new {{domxref("CSSMathNegate")}} object which negates the value passed into it.
 ## Syntax
 
 ```js
-var CSSMathNegate = new CSSMathNegate(arg);
+new CSSMathNegate(arg);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
@@ -21,7 +21,7 @@ a new {{domxref("CSSMathProduct")}} object which creates a new
 ## Syntax
 
 ```js
-var CSSMathProduct = new CSSMathProduct(args)
+new CSSMathProduct(args)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -23,7 +23,7 @@ or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue'
 ## Syntax
 
 ```js
-var CSSMathSum = new CSSMathSum(values)
+new CSSMathSum(values)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
@@ -21,7 +21,7 @@ individual {{CSSXRef('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSMatrixComponent = new CSSMatrixComponent(matrix[,options]);
+new CSSMatrixComponent(matrix[,options]);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssperspective/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.md
@@ -21,7 +21,7 @@ the individual {{CSSXref('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSPerspective = new CSSPerspective(length);
+new CSSPerspective(length);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -21,7 +21,7 @@ individual {{CSSXref('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSRotate = new CSSRotate(x,y,z,angle);
+new CSSRotate(x,y,z,angle);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssscale/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/cssscale/index.md
@@ -21,7 +21,7 @@ individual {{CSSXref('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSScale = new CSSScale(x,y[,z]);
+new CSSScale(x,y[,z]);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssskew/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/cssskew/index.md
@@ -23,7 +23,7 @@ of the individual {{CSSXRef('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSSkew = new CSSSkew(ax, ay);
+new CSSSkew(ax, ay);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssskewx/cssskewx/index.md
+++ b/files/en-us/web/api/cssskewx/cssskewx/index.md
@@ -22,7 +22,7 @@ value of the individual {{CSSXRef('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSSkewX = new CSSSkewX(ax);
+new CSSSkewX(ax);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssskewy/cssskewy/index.md
+++ b/files/en-us/web/api/cssskewy/cssskewy/index.md
@@ -22,7 +22,7 @@ of the individual {{CSSXRef('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSSkewY = new CSSSkewY(ay);
+new CSSSkewY(ay);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
@@ -21,7 +21,7 @@ individual transform objects.
 ## Syntax
 
 ```js
-var CSSTransformValue = new CSSTransformValue(transforms);
+new CSSTransformValue(transforms);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstranslate/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/csstranslate/index.md
@@ -21,7 +21,7 @@ individual {{CSSXref('transform')}} property in CSS.
 ## Syntax
 
 ```js
-var CSSTranslate = new CSSTranslate(x,y[,z]);
+new CSSTranslate(x,y[,z]);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -15,7 +15,7 @@ The **`DecompressionStream()`** constructor creates a new {{domxref("Decompressi
 ## Syntax
 
 ```js
-let DecompressionStream = new DecompressionStream(format);
+new DecompressionStream(format);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
@@ -25,7 +25,7 @@ applied.
 ## Syntax
 
 ```js
-var OverconstrainedError = new OverconstrainedError()
+new OverconstrainedError()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.md
@@ -21,7 +21,7 @@ used. The browser creates these objects itself and provides them to
 ## Syntax
 
 ```js
-var PeriodicSyncEvent = new PeriodicSyncEvent();
+new PeriodicSyncEvent();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.md
@@ -20,7 +20,7 @@ content or border box of an {{domxref('Element')}} or the bounding box of an
 ## Syntax
 
 ```js
-var ResizeObserver = new ResizeObserver(callback)
+new ResizeObserver(callback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -19,7 +19,7 @@ new {{domxref("URLSearchParams")}} object.
 ## Syntax
 
 ```js
-var URLSearchParams = new URLSearchParams(init);
+new URLSearchParams(init);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
@@ -22,7 +22,7 @@ the configuration on the provided USBDevice with the given configuration value.
 ## Syntax
 
 ```js
-var USBConfiguration = new USBConfiguration(device, configurationValue)
+new USBConfiguration(device, configurationValue)
 ```
 
 ### Parameters


### PR DESCRIPTION
Similar to #13932 

#### Summary
On some pages, in constructor syntax section, exact interface name has been used for the variables to collect the objects constructed.
#### Motivation
```js
let BackgroundFetchEvent = new BackgroundFetchEvent(type, BackgroundFetchEventInit);
```
Here using exact same variable name as the function `BackgroundFetchEvent()` replaces the function with object instance. After executing this statement we can no longer be able to create more BackgroundFetchEvent() objects.

As per the guidelines, removed the left hand side of the assignment expression.
```js
new BackgroundFetchEvent(type, BackgroundFetchEventInit);
```

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
