### PR TITLE
AudioData: fixed document title

### DIFF
--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -1,5 +1,5 @@
 ---
-title: AudioData.AudioData()
+title: AudioData()
 slug: Web/API/AudioData/AudioData
 tags:
   - API


### PR DESCRIPTION
#### Summary
There is no `AudioData.AudioData` function. `AudioData` itself is a function.
So `AudioData()` is the correct tittle.

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
