### PR TITLE
Removes broken link

### DIFF
--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -131,6 +131,5 @@ Not part of any standard.
 ## See also
 
 - WebKit blog on [Styling Scrollbars](https://webkit.org/blog/363/styling-scrollbars/)
-- [WebKit test](https://trac.webkit.org/export/41842/trunk/LayoutTests/scrollbars/overflow-scrollbar-combinations.html) for scrollbar styles mentioned above
 - {{CSSxRef("scrollbar-width")}}
 - {{CSSxRef("scrollbar-color")}}


### PR DESCRIPTION
Fixes #14116
I removed the link because:
- it is broken and I didn't find a replacement
- it is linked (and still broken) in the blog post listed immediately above, so doesn't bring much.