### PR TITLE
Fix isNaN polyfill code

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/isnan/index.md
@@ -82,7 +82,7 @@ never-equal-to-itself characteristic of `NaN`):
 ```js
 const isNaN = function(value) {
     const n = Number(value);
-    return n !== n;
+    return n !== value;
 };
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
As the polyfill incorrectly uses the number-coerced value for its comparison, thus always returning `false`, we need to change the comparison to compare to the initial value.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To improve MDN docs.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [✅  ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
