### PR TITLE
Make GitHub recognize the repo sources are largely Markdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *	text=auto eol=lf
 *.md	linguist-detectable
+CODE_OF_CONDUCT.md	-linguist-detectable
+LICENSE.md	-linguist-detectable
+README.md	-linguist-detectable
+REVIEWING.md	-linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *	text=auto eol=lf
+*.md	linguist-detectable


### PR DESCRIPTION
This change causes GitHub to recognize that the repo sources are currently 97.1% Markdown and 2.9% HTML.

Otherwise, without this change, the GitHub UI incorrectly shows the repo sources as being 100% HTML.

See also https://joshuatz.com/posts/2019/how-to-get-github-to-recognize-a-pure-markdown-repo/#solution-start but note that the syntax used there doesn’t match what’s documented in https://github.com/github/linguist/blob/master/docs/overrides.md#detectable. Specifically, the documentation indicates it’s sufficient to just include the `linguist-detectable` attribute; appending `=true` to it is unnecessary.

And see https://github.com/sideshowbarker/content for what the GitHub UI will show after this change is merged:

![image](https://user-images.githubusercontent.com/194984/159233252-d3ff8205-d4af-493a-8886-bb7f3d946457.png)
