### PR TITLE
Fixing a typo "event" -> "ev"

### DIFF
--- a/files/en-us/web/api/datatransferitem/getasfile/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.md
@@ -42,7 +42,7 @@ This example shows the use of the `getAsFile()` method in a
 function drop_handler(ev) {
  console.log("Drop");
  ev.preventDefault();
- var data = event.dataTransfer.items;
+ var data = ev.dataTransfer.items;
  for (var i = 0; i < data.length; i += 1) {
    if ((data[i].kind == 'string') &&
        (data[i].type.match('^text/plain'))) {


### PR DESCRIPTION
Fixed a small typo in the code. Changed "event" to "ev" which is the argument taken by the function.

This PR fixes a typo.
