### PR TITLE
Fix layer import syntax in @layer doc

### DIFF
--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -39,7 +39,7 @@ The `@layer` at-rule is used to create a cascade layer in one of three ways. The
 A cascade layer can be created with {{cssxref("@import")}}, in this case the rules would be in the imported stylesheet:
 
 ```css
-@import(utilities.css) layer(utilities);
+@import 'utilities.css' layer(utilities);
 ```
 
 You can also create a named cascade layer without assigning any styles. This can be a single name:


### PR DESCRIPTION
fixing syntax of layer import

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes #14134

Import syntax is not a function as per https://developer.mozilla.org/en-US/docs/Web/CSS/@import#importing_css_rules