### PR TITLE
Remove useless closing tag

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
+++ b/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
@@ -105,7 +105,7 @@ The "index.html" file and the "style.css" files are already complete:
   <head>
     <meta charset="UTF-8">
     <script type="text/javascript" src="main.js" defer></script>
-    <link href="style.css"rel="stylesheet"></link>
+    <link href="style.css"rel="stylesheet">
   </head>
 
   <body>


### PR DESCRIPTION
Fixes #14142

To be coherent with the other void element in the example.