### PR TITLE
Fix a typo

### DIFF
--- a/files/en-us/web/http/headers/server-timing/index.md
+++ b/files/en-us/web/http/headers/server-timing/index.md
@@ -29,7 +29,7 @@ The **`Server-Timing`** header communicates one or more metrics and descriptions
 
 The syntax of the `Server-Timing` header allows you to communicate metrics in different ways: server metric name only, metric with value, metric with value and description, and metric with description.
 
-The specification advices that names and descriptions should be kept as short as possible (use abbreviations and omit optional values where possible) to minimize the HTTP overhead.
+The specification advises that names and descriptions should be kept as short as possible (use abbreviations and omit optional values where possible) to minimize the HTTP overhead.
 
 ```
 // Single metric without value


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I fixed the spelling of the verb "advises" (meaning: "it gives advice to ..."). 

#### Motivation
I just want to fix a small typo :-)

#### Supporting details
In this use it's a verb ("to give advice to ..."), so the correct spelling is _advise_. It's spelled _advice_ when it's a noun. ([advise](https://www.merriam-webster.com/dictionary/advise), [advice](https://www.merriam-webster.com/dictionary/advice)).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
