### PR TITLE
MediaMetadata: fixed constructor section and marked experimental

### DIFF
--- a/files/en-us/web/api/mediametadata/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.md
@@ -3,6 +3,7 @@ title: MediaMetadata()
 slug: Web/API/MediaMetadata/MediaMetadata
 tags:
   - Audio
+  - Experimental
   - Media
   - Media Session API
   - MediaMetadata
@@ -21,7 +22,8 @@ The **`MediaMetadata()`** constructor creates a new
 ## Syntax
 
 ```js
-new MediaMetadata([metadata])
+new MediaMetadata()
+new MediaMetadata(metadata)
 ```
 
 ### Parameters


### PR DESCRIPTION
#### Summary
In #14160 we missed this interface to correct the possible constructor uses.
Also, marked Experimental as per BCD.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
