### PR TITLE
Mark navigator.keyboard & its members as secure-context-required

### DIFF
--- a/files/en-us/web/api/keyboard/getlayoutmap/index.md
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.md
@@ -12,7 +12,7 @@ tags:
   - keyboard
 browser-compat: api.Keyboard.getLayoutMap
 ---
-{{APIRef("Keyboard API")}}{{SeeCompatTable}}
+{{APIRef("Keyboard API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **`getLayoutMap()`** method of the
 {{domxref("Keyboard")}} interface returns a {{jsxref('Promise')}} that resolves with
@@ -22,7 +22,7 @@ functions for retrieving the strings associated with specific physical keys.
 ## Syntax
 
 ```js
-var promise = Keyboard.getLayoutMap()
+navigator.keyboard.getLayoutMap()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyboard/index.md
+++ b/files/en-us/web/api/keyboard/index.md
@@ -12,7 +12,7 @@ tags:
   - keyboard
 browser-compat: api.Keyboard
 ---
-{{SeeCompatTable}}{{APIRef("Keyboard API")}}
+{{SeeCompatTable}}{{APIRef("Keyboard API")}}{{securecontext_header}}
 
 The **`Keyboard`** interface of the [Keyboard API](/en-US/docs/Web/API/Keyboard_API) provides functions that retrieve keyboard layout maps and toggle capturing of key presses from the physical keyboard.
 

--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -11,7 +11,7 @@ tags:
   - lock()
 browser-compat: api.Keyboard.lock
 ---
-{{APIRef("Keyboard Map API")}}{{SeeCompatTable}}
+{{APIRef("Keyboard Map API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **`lock()`** method of the
 {{domxref("Keyboard")}} interface returns a {{jsxref('Promise')}} after enabling the
@@ -22,7 +22,8 @@ system.
 ## Syntax
 
 ```js
-var promise = Keyboard.lock([keyCodes[]])
+navigator.keyboard.lock()
+navigator.keyboard.lock(keyCodes)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyboard/unlock/index.md
+++ b/files/en-us/web/api/keyboard/unlock/index.md
@@ -11,7 +11,7 @@ tags:
   - unLock
 browser-compat: api.Keyboard.unlock
 ---
-{{APIRef("Keyboard API")}}{{SeeCompatTable}}
+{{APIRef("Keyboard API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **`unlock()`** method of the
 {{domxref("Keyboard")}} interface unlocks all keys captured by the
@@ -20,7 +20,7 @@ The **`unlock()`** method of the
 ## Syntax
 
 ```js
-Keyboard.unlock()
+navigator.keyboard.unlock()
 ```
 
 ### Parameters


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14169. Spec reference: https://wicg.github.io/keyboard-lock/#keyboard-interface

The `SecureContext` annotation on the `Keyboard` interface means all its members also inherit the requirement for a secure context — including members defined through partial interfaces in other specs (which is the case for `getLayoutMap` https://wicg.github.io/keyboard-map/#keyboard-interface).