### PR TITLE
Remove links that point to document that are long gone

### DIFF
--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -168,8 +168,3 @@ document.addEventListener("visibilitychange", handleVisibilityChange, false);
 ### `Document.visibilityState`
 
 {{Compat("api.Document.visibilityState")}}
-
-## See also
-
-- Description of the [Page Visibility API](https://blogs.msdn.com/b/ie/archive/2011/07/08/using-pc-hardware-more-efficiently-in-html5-new-web-performance-apis-part-2.aspx "Page Visibility on IEBlog") on the IEBlog.
-- Description of the [Page Visibility API](https://code.google.com/chrome/whitepapers/pagevisibility.html) by Google


### PR DESCRIPTION
Fixes #14168

Remove links to documents that are long gone. (The blogs don't exist and/or redirect to the spec)