### PR TITLE
Have a separate note about not having a live editor in the Loops page

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__loops/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__loops/index.md
@@ -11,9 +11,11 @@ tags:
 
 This aim of this skill test is to assess whether you've understood our [Looping code](/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code) article.
 
-> **Note:** You can try out solutions for the tasks below by downloading the code, putting it in an online tool such as [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/), then working on the tasks. We didn't provide live editable versions of these tasks because of the risk of creating infinite loops and crashing the assessment page!
+> **Note:** You can try out solutions for the tasks below by downloading the code, putting it in an online tool such as [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/), then working on the tasks.
 >
 > If you get stuck, then ask us for help — see the [Assessment or further help](#assessment_or_further_help) section at the bottom of this page.
+
+> **Note:** We didn't provide live editable versions of these tasks because of the risk of creating infinite loops and crashing the assessment page!
 
 ## DOM manipulation: considered useful
 


### PR DESCRIPTION
This came out of https://github.com/mdn/content/issues/14184 - the note is almost like all the other notes, but buries a sentence about not having live editors, unlike the other pages. Not having live editors in the page is surprising to readers if they miss the buried sentence. This PR makes that bit into a separate note, so it's easier to see.