### PR TITLE
WebAPI: Clean syntax from property pages, part 1

### DIFF
--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -15,7 +15,7 @@ browser-compat: api.AbortController.signal
 
 The **`signal`** read-only property of the {{domxref("AbortController")}} interface returns an {{domxref("AbortSignal")}} object instance, which can be used to communicate with/abort a DOM request as desired.
 
-### Value
+## Value
 
 An {{domxref("AbortSignal")}} object instance.
 

--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -15,12 +15,6 @@ browser-compat: api.AbortController.signal
 
 The **`signal`** read-only property of the {{domxref("AbortController")}} interface returns an {{domxref("AbortSignal")}} object instance, which can be used to communicate with/abort a DOM request as desired.
 
-## Syntax
-
-```js
-var signal = abortController.signal;
-```
-
 ### Value
 
 An {{domxref("AbortSignal")}} object instance.

--- a/files/en-us/web/api/addresserrors/addressline/index.md
+++ b/files/en-us/web/api/addresserrors/addressline/index.md
@@ -18,12 +18,6 @@ browser-compat: api.AddressErrors.addressLine
 
 An object based on {{domxref("AddressErrors")}} includes an **`addressLine`** property when validation of the address finds one or more errors in the array of strings in the address's {{domxref("PaymentAddress.addressLine", "addressLine")}}. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var addressLineError = AddressErrors.addressLine;
-```
-
 ### Value
 
 If an error occurred during validation of the address due to one of the strings in the {{domxref("PaymentAddress.addressLine", "addressLine")}} array having an invalid value, this property is set to a {{domxref("DOMString")}} providing a human-readable error message explaining the validation error.

--- a/files/en-us/web/api/addresserrors/addressline/index.md
+++ b/files/en-us/web/api/addresserrors/addressline/index.md
@@ -18,7 +18,7 @@ browser-compat: api.AddressErrors.addressLine
 
 An object based on {{domxref("AddressErrors")}} includes an **`addressLine`** property when validation of the address finds one or more errors in the array of strings in the address's {{domxref("PaymentAddress.addressLine", "addressLine")}}. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If an error occurred during validation of the address due to one of the strings in the {{domxref("PaymentAddress.addressLine", "addressLine")}} array having an invalid value, this property is set to a {{domxref("DOMString")}} providing a human-readable error message explaining the validation error.
 

--- a/files/en-us/web/api/addresserrors/city/index.md
+++ b/files/en-us/web/api/addresserrors/city/index.md
@@ -19,7 +19,7 @@ browser-compat: api.AddressErrors.city
 
 An object based on {{domxref("AddressErrors")}} includes a **`city`** property when validation of the address fails for the value given for the address's {{domxref("PaymentAddress.city", "city")}} property. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.city", "city")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/city/index.md
+++ b/files/en-us/web/api/addresserrors/city/index.md
@@ -19,12 +19,6 @@ browser-compat: api.AddressErrors.city
 
 An object based on {{domxref("AddressErrors")}} includes a **`city`** property when validation of the address fails for the value given for the address's {{domxref("PaymentAddress.city", "city")}} property. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var cityError = AddressErrors.city;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.city", "city")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/country/index.md
+++ b/files/en-us/web/api/addresserrors/country/index.md
@@ -18,7 +18,7 @@ browser-compat: api.AddressErrors.country
 
 An object based on {{domxref("AddressErrors")}} includes a **`country`** property if during validation of the address the specified value of {{domxref("PaymentAddress.country", "country")}} was determined to be invalid. The value is a string describing the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If an error occurred during validation of the address due to the {{domxref("PaymentAddress.country", "country")}} property having an invalid value, this property is set to a {{domxref("DOMString")}} providing a human-readable error message explaining the validation error.
 

--- a/files/en-us/web/api/addresserrors/country/index.md
+++ b/files/en-us/web/api/addresserrors/country/index.md
@@ -18,12 +18,6 @@ browser-compat: api.AddressErrors.country
 
 An object based on {{domxref("AddressErrors")}} includes a **`country`** property if during validation of the address the specified value of {{domxref("PaymentAddress.country", "country")}} was determined to be invalid. The value is a string describing the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var countryError = AddressErrors.country;
-```
-
 ### Value
 
 If an error occurred during validation of the address due to the {{domxref("PaymentAddress.country", "country")}} property having an invalid value, this property is set to a {{domxref("DOMString")}} providing a human-readable error message explaining the validation error.

--- a/files/en-us/web/api/addresserrors/dependentlocality/index.md
+++ b/files/en-us/web/api/addresserrors/dependentlocality/index.md
@@ -19,12 +19,6 @@ browser-compat: api.AddressErrors.dependentLocality
 
 An object based on {{domxref("AddressErrors")}} includes a **`dependentLocality`** property when the address's {{domxref("PaymentAddress.dependentLocality", "dependentLocality")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var localityError = AddressErrors.dependentLocality;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.dependentLocality", "dependentLocality")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/dependentlocality/index.md
+++ b/files/en-us/web/api/addresserrors/dependentlocality/index.md
@@ -19,7 +19,7 @@ browser-compat: api.AddressErrors.dependentLocality
 
 An object based on {{domxref("AddressErrors")}} includes a **`dependentLocality`** property when the address's {{domxref("PaymentAddress.dependentLocality", "dependentLocality")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.dependentLocality", "dependentLocality")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/languagecode/index.md
+++ b/files/en-us/web/api/addresserrors/languagecode/index.md
@@ -20,12 +20,6 @@ browser-compat: api.AddressErrors.languageCode
 
 An object based on {{domxref("AddressErrors")}} includes a **`languageCode`** property when the address's {{domxref("PaymentAddress.languageCode", "languageCode")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var languageError = AddressErrors.languageCode;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.languageCode", "languageCode")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/languagecode/index.md
+++ b/files/en-us/web/api/addresserrors/languagecode/index.md
@@ -20,7 +20,7 @@ browser-compat: api.AddressErrors.languageCode
 
 An object based on {{domxref("AddressErrors")}} includes a **`languageCode`** property when the address's {{domxref("PaymentAddress.languageCode", "languageCode")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.languageCode", "languageCode")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/organization/index.md
+++ b/files/en-us/web/api/addresserrors/organization/index.md
@@ -19,7 +19,7 @@ browser-compat: api.AddressErrors.organization
 
 An object based on {{domxref("AddressErrors")}} includes an **`organization`** property when the address's {{domxref("PaymentAddress.organization", "organization")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.organization", "organization")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/organization/index.md
+++ b/files/en-us/web/api/addresserrors/organization/index.md
@@ -19,12 +19,6 @@ browser-compat: api.AddressErrors.organization
 
 An object based on {{domxref("AddressErrors")}} includes an **`organization`** property when the address's {{domxref("PaymentAddress.organization", "organization")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var organizationError = AddressErrors.organization;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.organization", "organization")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/phone/index.md
+++ b/files/en-us/web/api/addresserrors/phone/index.md
@@ -22,7 +22,7 @@ browser-compat: api.AddressErrors.phone
 
 An object based on {{domxref("AddressErrors")}} includes a **`phone`** property when the address's {{domxref("PaymentAddress.phone", "phone")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.phone", "phone")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/phone/index.md
+++ b/files/en-us/web/api/addresserrors/phone/index.md
@@ -22,12 +22,6 @@ browser-compat: api.AddressErrors.phone
 
 An object based on {{domxref("AddressErrors")}} includes a **`phone`** property when the address's {{domxref("PaymentAddress.phone", "phone")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var phoneError = AddressErrors.phone;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.phone", "phone")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/postalcode/index.md
+++ b/files/en-us/web/api/addresserrors/postalcode/index.md
@@ -23,7 +23,7 @@ browser-compat: api.AddressErrors.postalCode
 
 An object based on {{domxref("AddressErrors")}} includes a **`postalCode`** property when the address's {{domxref("PaymentAddress.postalCode", "postalCode")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.postalCode", "postalCode")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/postalcode/index.md
+++ b/files/en-us/web/api/addresserrors/postalcode/index.md
@@ -23,12 +23,6 @@ browser-compat: api.AddressErrors.postalCode
 
 An object based on {{domxref("AddressErrors")}} includes a **`postalCode`** property when the address's {{domxref("PaymentAddress.postalCode", "postalCode")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var postcodeError = AddressErrors.postCode;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.postalCode", "postalCode")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/recipient/index.md
+++ b/files/en-us/web/api/addresserrors/recipient/index.md
@@ -19,7 +19,7 @@ browser-compat: api.AddressErrors.recipient
 
 An object based on {{domxref("AddressErrors")}} includes a **`recipient`** property when the address's {{domxref("PaymentAddress.recipient", "recipient")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.recipient", "recipient")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/recipient/index.md
+++ b/files/en-us/web/api/addresserrors/recipient/index.md
@@ -19,12 +19,6 @@ browser-compat: api.AddressErrors.recipient
 
 An object based on {{domxref("AddressErrors")}} includes a **`recipient`** property when the address's {{domxref("PaymentAddress.recipient", "recipient")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var recipientError = AddressErrors.recipient;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.recipient", "recipient")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/region/index.md
+++ b/files/en-us/web/api/addresserrors/region/index.md
@@ -20,12 +20,6 @@ browser-compat: api.AddressErrors.region
 
 An object based on {{domxref("AddressErrors")}} includes a **`region`** property when the address's {{domxref("PaymentAddress.region", "region")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var regionError = AddressErrors.region;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.region", "region")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/region/index.md
+++ b/files/en-us/web/api/addresserrors/region/index.md
@@ -20,7 +20,7 @@ browser-compat: api.AddressErrors.region
 
 An object based on {{domxref("AddressErrors")}} includes a **`region`** property when the address's {{domxref("PaymentAddress.region", "region")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.region", "region")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/addresserrors/sortingcode/index.md
+++ b/files/en-us/web/api/addresserrors/sortingcode/index.md
@@ -20,12 +20,6 @@ browser-compat: api.AddressErrors.sortingCode
 
 An object based on {{domxref("AddressErrors")}} includes a **`sortingCode`** property when the address's {{domxref("PaymentAddress.sortingCode", "sortingCode")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-## Syntax
-
-```js
-var sortingCodeError = AddressErrors.sortingCode;
-```
-
 ### Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.sortingCode", "sortingCode")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.

--- a/files/en-us/web/api/addresserrors/sortingcode/index.md
+++ b/files/en-us/web/api/addresserrors/sortingcode/index.md
@@ -20,7 +20,7 @@ browser-compat: api.AddressErrors.sortingCode
 
 An object based on {{domxref("AddressErrors")}} includes a **`sortingCode`** property when the address's {{domxref("PaymentAddress.sortingCode", "sortingCode")}} property couldn't be validated. The returned string explains the error and should offer suggestions for how to correct it.
 
-### Value
+## Value
 
 If the value specified in the {{domxref("PaymentAddress")}} object's {{domxref("PaymentAddress.sortingCode", "sortingCode")}} property could not be validated, this property contains a {{domxref("DOMString")}} offering a human-readable explanation of the validation error and offers suggestions for correcting it.
 

--- a/files/en-us/web/api/analysernode/fftsize/index.md
+++ b/files/en-us/web/api/analysernode/fftsize/index.md
@@ -14,13 +14,6 @@ browser-compat: api.AnalyserNode.fftSize
 
 The **`fftSize`** property of the {{domxref("AnalyserNode")}} interface is an unsigned long value and represents the window size in samples that is used when performing a [Fast Fourier Transform](https://en.wikipedia.org/wiki/Fast_Fourier_transform) (FFT) to get frequency domain data.
 
-## Syntax
-
-```js
-var curValue = analyserNode.fftSize;
-analyserNode.fftSize = newValue;
-```
-
 ### Value
 
 An unsigned integer, representing the window size of the FFT, given in number of samples. A higher value will result in more details in the frequency domain but fewer details in the time domain.

--- a/files/en-us/web/api/analysernode/fftsize/index.md
+++ b/files/en-us/web/api/analysernode/fftsize/index.md
@@ -14,7 +14,7 @@ browser-compat: api.AnalyserNode.fftSize
 
 The **`fftSize`** property of the {{domxref("AnalyserNode")}} interface is an unsigned long value and represents the window size in samples that is used when performing a [Fast Fourier Transform](https://en.wikipedia.org/wiki/Fast_Fourier_transform) (FFT) to get frequency domain data.
 
-### Value
+## Value
 
 An unsigned integer, representing the window size of the FFT, given in number of samples. A higher value will result in more details in the frequency domain but fewer details in the time domain.
 

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -14,7 +14,7 @@ browser-compat: api.AnalyserNode.frequencyBinCount
 
 The **`frequencyBinCount`** read-only property of the {{domxref("AnalyserNode")}} interface is an unsigned integer half that of the {{domxref("AnalyserNode.fftSize")}}. This generally equates to the number of data values you will have to play with for the visualization.
 
-### Value
+## Value
 
 An unsigned integer, equal to the number of values that {{domxref("AnalyserNode.getByteFrequencyData()")}} and {{domxref("AnalyserNode.getFloatFrequencyData()")}} copy into the provided `TypedArray`.
 

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -14,12 +14,6 @@ browser-compat: api.AnalyserNode.frequencyBinCount
 
 The **`frequencyBinCount`** read-only property of the {{domxref("AnalyserNode")}} interface is an unsigned integer half that of the {{domxref("AnalyserNode.fftSize")}}. This generally equates to the number of data values you will have to play with for the visualization.
 
-## Syntax
-
-```js
-var arrayLength = analyserNode.frequencyBinCount;
-```
-
 ### Value
 
 An unsigned integer, equal to the number of values that {{domxref("AnalyserNode.getByteFrequencyData()")}} and {{domxref("AnalyserNode.getFloatFrequencyData()")}} copy into the provided `TypedArray`.

--- a/files/en-us/web/api/analysernode/maxdecibels/index.md
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.md
@@ -14,7 +14,7 @@ browser-compat: api.AnalyserNode.maxDecibels
 
 The **`maxDecibels`** property of the {{domxref("AnalyserNode")}} interface is a double value representing the maximum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the maximum value for the range of results when using `getByteFrequencyData()`.
 
-### Value
+## Value
 
 A double, representing the maximum [decibel](https://en.wikipedia.org/wiki/Decibel) value for scaling the FFT analysis data, where `0` dB is the loudest possible sound, `-10` dB is a 10th of that, etc. The default value is `-30` dB.
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.md
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.md
@@ -14,13 +14,6 @@ browser-compat: api.AnalyserNode.maxDecibels
 
 The **`maxDecibels`** property of the {{domxref("AnalyserNode")}} interface is a double value representing the maximum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the maximum value for the range of results when using `getByteFrequencyData()`.
 
-## Syntax
-
-```js
-var curValue = analyserNode.maxDecibels;
-analyserNode.maxDecibels = newValue;
-```
-
 ### Value
 
 A double, representing the maximum [decibel](https://en.wikipedia.org/wiki/Decibel) value for scaling the FFT analysis data, where `0` dB is the loudest possible sound, `-10` dB is a 10th of that, etc. The default value is `-30` dB.

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -14,13 +14,6 @@ browser-compat: api.AnalyserNode.minDecibels
 
 The **`minDecibels`** property of the {{ domxref("AnalyserNode") }} interface is a double value representing the minimum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the minimum value for the range of results when using `getByteFrequencyData()`.
 
-## Syntax
-
-```js
-var curValue = analyserNode.minDecibels;
-analyserNode.minDecibels = newValue;
-```
-
 ### Value
 
 A double, representing the minimum [decibel](https://en.wikipedia.org/wiki/Decibel) value for scaling the FFT analysis data, where `0` dB is the loudest possible sound, `-10` dB is a 10th of that, etc. The default value is `-100` dB.

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -14,7 +14,7 @@ browser-compat: api.AnalyserNode.minDecibels
 
 The **`minDecibels`** property of the {{ domxref("AnalyserNode") }} interface is a double value representing the minimum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the minimum value for the range of results when using `getByteFrequencyData()`.
 
-### Value
+## Value
 
 A double, representing the minimum [decibel](https://en.wikipedia.org/wiki/Decibel) value for scaling the FFT analysis data, where `0` dB is the loudest possible sound, `-10` dB is a 10th of that, etc. The default value is `-100` dB.
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -14,7 +14,7 @@ browser-compat: api.AnalyserNode.smoothingTimeConstant
 
 The **`smoothingTimeConstant`** property of the {{ domxref("AnalyserNode") }} interface is a double value representing the averaging constant with the last analysis frame. It's basically an average between the current buffer and the last buffer the `AnalyserNode` processed, and results in a much smoother set of value changes over time.
 
-### Value
+## Value
 
 A double within the range `0` to `1` (`0` meaning no time averaging). The default value is `0.8`.
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -14,13 +14,6 @@ browser-compat: api.AnalyserNode.smoothingTimeConstant
 
 The **`smoothingTimeConstant`** property of the {{ domxref("AnalyserNode") }} interface is a double value representing the averaging constant with the last analysis frame. It's basically an average between the current buffer and the last buffer the `AnalyserNode` processed, and results in a much smoother set of value changes over time.
 
-## Syntax
-
-```js
-var smoothValue = analyserNode.smoothingTimeConstant;
-analyserNode.smoothingTimeConstant = newValue;
-```
-
 ### Value
 
 A double within the range `0` to `1` (`0` meaning no time averaging). The default value is `0.8`.

--- a/files/en-us/web/api/animation/currenttime/index.md
+++ b/files/en-us/web/api/animation/currenttime/index.md
@@ -17,13 +17,6 @@ The **`Animation.currentTime`** property of the [Web Animations API](/en-US/docs
 
 If the animation lacks a {{domxref("AnimationTimeline", "timeline")}}, is inactive, or hasn't been played yet, `currentTime`'s return value is `null`.
 
-## Syntax
-
-```js
-var currentTime = Animation.currentTime;
-Animation.currentTime = newTime;
-```
-
 ### Value
 
 A number representing the current time in milliseconds, or `null` to deactivate the animation.

--- a/files/en-us/web/api/animation/currenttime/index.md
+++ b/files/en-us/web/api/animation/currenttime/index.md
@@ -17,7 +17,7 @@ The **`Animation.currentTime`** property of the [Web Animations API](/en-US/docs
 
 If the animation lacks a {{domxref("AnimationTimeline", "timeline")}}, is inactive, or hasn't been played yet, `currentTime`'s return value is `null`.
 
-### Value
+## Value
 
 A number representing the current time in milliseconds, or `null` to deactivate the animation.
 

--- a/files/en-us/web/api/animation/effect/index.md
+++ b/files/en-us/web/api/animation/effect/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Animation.effect
 
 The **`Animation.effect`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) gets and sets the target effect of an animation. The target effect may be either an effect object of a type based on {{domxref("AnimationEffect")}}, such as {{domxref("KeyframeEffect")}}, or `null`.
 
-### Value
+## Value
 
 A {{domxref("AnimationEffect")}} object describing the target animation effect for the animation, or `null` to indicate no active effect.
 

--- a/files/en-us/web/api/animation/effect/index.md
+++ b/files/en-us/web/api/animation/effect/index.md
@@ -15,14 +15,6 @@ browser-compat: api.Animation.effect
 
 The **`Animation.effect`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) gets and sets the target effect of an animation. The target effect may be either an effect object of a type based on {{domxref("AnimationEffect")}}, such as {{domxref("KeyframeEffect")}}, or `null`.
 
-## Syntax
-
-```js
-var effect = Animation.effect;
-
-Animation.effect = {{domxref("AnimationEffect")}}
-```
-
 ### Value
 
 A {{domxref("AnimationEffect")}} object describing the target animation effect for the animation, or `null` to indicate no active effect.

--- a/files/en-us/web/api/animation/finished/index.md
+++ b/files/en-us/web/api/animation/finished/index.md
@@ -17,12 +17,6 @@ The **`Animation.finished`** read-only property of the [Web Animations API](/en-
 
 > **Note:** Every time the animation leaves the `finished` play state (that is, when it starts playing again), a new `Promise` is created for this property. The new `Promise` will resolve once the new animation sequence has completed.
 
-## Syntax
-
-```js
-var animationsPromise = Animation.finished;
-```
-
 ### Value
 
 A {{jsxref("Promise")}} object which will resolve once the animation has finished running.

--- a/files/en-us/web/api/animation/finished/index.md
+++ b/files/en-us/web/api/animation/finished/index.md
@@ -17,7 +17,7 @@ The **`Animation.finished`** read-only property of the [Web Animations API](/en-
 
 > **Note:** Every time the animation leaves the `finished` play state (that is, when it starts playing again), a new `Promise` is created for this property. The new `Promise` will resolve once the new animation sequence has completed.
 
-### Value
+## Value
 
 A {{jsxref("Promise")}} object which will resolve once the animation has finished running.
 

--- a/files/en-us/web/api/animation/id/index.md
+++ b/files/en-us/web/api/animation/id/index.md
@@ -14,14 +14,6 @@ browser-compat: api.Animation.id
 
 The **`Animation.id`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns or sets a string used to identify the animation.
 
-## Syntax
-
-```js
-var animationsId = Animation.id;
-
-Animation.id = newIdString;
-```
-
 ### Value
 
 A {{domxref("DOMString")}} which can be used to identify the animation, or `null` if the animation has no `id`.

--- a/files/en-us/web/api/animation/id/index.md
+++ b/files/en-us/web/api/animation/id/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Animation.id
 
 The **`Animation.id`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns or sets a string used to identify the animation.
 
-### Value
+## Value
 
 A {{domxref("DOMString")}} which can be used to identify the animation, or `null` if the animation has no `id`.
 

--- a/files/en-us/web/api/animation/pending/index.md
+++ b/files/en-us/web/api/animation/pending/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Animation.pending
 
 The read-only **`Animation.pending`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) indicates whether the animation is currently waiting for an asynchronous operation such as initiating playback or pausing a running animation.
 
-### Value
+## Value
 
 **`true`** if the animation is pending, **`false`** otherwise.
 

--- a/files/en-us/web/api/animation/pending/index.md
+++ b/files/en-us/web/api/animation/pending/index.md
@@ -15,12 +15,6 @@ browser-compat: api.Animation.pending
 
 The read-only **`Animation.pending`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) indicates whether the animation is currently waiting for an asynchronous operation such as initiating playback or pausing a running animation.
 
-## Syntax
-
-```js
-var pending = Animation.pending;
-```
-
 ### Value
 
 **`true`** if the animation is pending, **`false`** otherwise.

--- a/files/en-us/web/api/animation/playbackrate/index.md
+++ b/files/en-us/web/api/animation/playbackrate/index.md
@@ -18,14 +18,6 @@ The **`Animation.playbackRate`** property of the [Web Animations API](/en-US/doc
 
 Animations have a **playback rate** that provides a scaling factor from the rate of change of the animation's {{domxref("DocumentTimeline", "timeline")}} time values to the animation's current time. The playback rate is initially `1`.
 
-## Syntax
-
-```js
-var currentPlaybackRate = Animation.playbackRate;
-
-Animation.playbackRate = newRate;
-```
-
 ### Value
 
 Takes a number that can be 0, negative, or positive. Negative values reverse the animation. The value is a scaling factor, so for example a value of 2 would double the playback rate.

--- a/files/en-us/web/api/animation/playbackrate/index.md
+++ b/files/en-us/web/api/animation/playbackrate/index.md
@@ -18,7 +18,7 @@ The **`Animation.playbackRate`** property of the [Web Animations API](/en-US/doc
 
 Animations have a **playback rate** that provides a scaling factor from the rate of change of the animation's {{domxref("DocumentTimeline", "timeline")}} time values to the animation's current time. The playback rate is initially `1`.
 
-### Value
+## Value
 
 Takes a number that can be 0, negative, or positive. Negative values reverse the animation. The value is a scaling factor, so for example a value of 2 would double the playback rate.
 

--- a/files/en-us/web/api/animation/playstate/index.md
+++ b/files/en-us/web/api/animation/playstate/index.md
@@ -17,14 +17,6 @@ The **`Animation.playState`** property of the [Web Animations API](/en-US/docs/W
 
 > **Note:** This property is read-only for CSS Animations and Transitions.
 
-## Syntax
-
-```js
-var currentPlayState = Animation.playState;
-
-Animation.playState = newState;
-```
-
 ### Value
 
 - `idle`

--- a/files/en-us/web/api/animation/playstate/index.md
+++ b/files/en-us/web/api/animation/playstate/index.md
@@ -17,7 +17,7 @@ The **`Animation.playState`** property of the [Web Animations API](/en-US/docs/W
 
 > **Note:** This property is read-only for CSS Animations and Transitions.
 
-### Value
+## Value
 
 - `idle`
   - : The current time of the animation is unresolved and there are no pending tasks.

--- a/files/en-us/web/api/animation/ready/index.md
+++ b/files/en-us/web/api/animation/ready/index.md
@@ -18,12 +18,6 @@ The read-only **`Animation.ready`** property of the [Web Animations API](/en-US/
 
 > **Note:** Since the same {{jsxref("Promise")}} is used for both pending `play` and pending `pause` requests, authors are advised to check the state of the animation when the promise is resolved.
 
-## Syntax
-
-```js
-var readyPromise = Animation.ready;
-```
-
 ### Value
 
 A {{jsxref("Promise")}} which resolves when the animation is ready to be played. You'll typically use a construct similar to this when using the ready promise:

--- a/files/en-us/web/api/animation/ready/index.md
+++ b/files/en-us/web/api/animation/ready/index.md
@@ -18,7 +18,7 @@ The read-only **`Animation.ready`** property of the [Web Animations API](/en-US/
 
 > **Note:** Since the same {{jsxref("Promise")}} is used for both pending `play` and pending `pause` requests, authors are advised to check the state of the animation when the promise is resolved.
 
-### Value
+## Value
 
 A {{jsxref("Promise")}} which resolves when the animation is ready to be played. You'll typically use a construct similar to this when using the ready promise:
 

--- a/files/en-us/web/api/animation/replacestate/index.md
+++ b/files/en-us/web/api/animation/replacestate/index.md
@@ -14,12 +14,6 @@ browser-compat: api.Animation.replaceState
 
 The read-only **`Animation.replaceState`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns the [replace state](https://drafts.csswg.org/web-animations-1/#animation-replace-state) of the animation. This will be `active` if the animation has been removed, or `persisted` if {{domxref("Animation.persist()")}} has been invoked on it.
 
-## Syntax
-
-```js
-let myReplaceState = Animation.replaceState;
-```
-
 ### Value
 
 A string that represents the replace state of the animation. The value can be one of:

--- a/files/en-us/web/api/animation/replacestate/index.md
+++ b/files/en-us/web/api/animation/replacestate/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Animation.replaceState
 
 The read-only **`Animation.replaceState`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns the [replace state](https://drafts.csswg.org/web-animations-1/#animation-replace-state) of the animation. This will be `active` if the animation has been removed, or `persisted` if {{domxref("Animation.persist()")}} has been invoked on it.
 
-### Value
+## Value
 
 A string that represents the replace state of the animation. The value can be one of:
 

--- a/files/en-us/web/api/animation/starttime/index.md
+++ b/files/en-us/web/api/animation/starttime/index.md
@@ -18,7 +18,7 @@ The **`Animation.startTime`** property of the {{domxref("Animation")}} interface
 
 An animation's **start time** is the time value of its {{domxref("timeline", "DocumentTimeline")}} when its target {{domxref("KeyframeEffect")}} is scheduled to begin playback. An animation's **start time** is initially unresolved (meaning that it's `null` because it has no value).
 
-### Value
+## Value
 
 A floating-point number representing the current time in milliseconds, or `null` if no time is set. You can read this value to determine what the start time is currently set at, and you can change this value to make the animation start at a different time.
 

--- a/files/en-us/web/api/animation/starttime/index.md
+++ b/files/en-us/web/api/animation/starttime/index.md
@@ -18,14 +18,6 @@ The **`Animation.startTime`** property of the {{domxref("Animation")}} interface
 
 An animation's **start time** is the time value of its {{domxref("timeline", "DocumentTimeline")}} when its target {{domxref("KeyframeEffect")}} is scheduled to begin playback. An animation's **start time** is initially unresolved (meaning that it's `null` because it has no value).
 
-## Syntax
-
-```js
-var animationStartedWhen = Animation.startTime;
-
-Animation.startTime = newStartTime;
-```
-
 ### Value
 
 A floating-point number representing the current time in milliseconds, or `null` if no time is set. You can read this value to determine what the start time is currently set at, and you can change this value to make the animation start at a different time.

--- a/files/en-us/web/api/animation/timeline/index.md
+++ b/files/en-us/web/api/animation/timeline/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Animation.timeline
 
 The **`Animation.timeline`** property of the {{domxref("Animation")}} interface returns or sets the {{domxref("AnimationTimeline", "timeline")}} associated with this animation. A timeline is a source of time values for synchronization purposes, and is an {{domxref("AnimationTimeline")}}-based object. By default, the animation's timeline and the {{domxref("Document")}}'s timeline are the same.
 
-### Value
+## Value
 
 A {{domxref("AnimationTimeline", "timeline object", "", 1)}} to use as the timing source for the animation, or `null` to use the default, which is the {{domxref("Document")}}'s timeline.
 

--- a/files/en-us/web/api/animation/timeline/index.md
+++ b/files/en-us/web/api/animation/timeline/index.md
@@ -15,14 +15,6 @@ browser-compat: api.Animation.timeline
 
 The **`Animation.timeline`** property of the {{domxref("Animation")}} interface returns or sets the {{domxref("AnimationTimeline", "timeline")}} associated with this animation. A timeline is a source of time values for synchronization purposes, and is an {{domxref("AnimationTimeline")}}-based object. By default, the animation's timeline and the {{domxref("Document")}}'s timeline are the same.
 
-## Syntax
-
-```js
-var animationsTimeline = Animation.timeline;
-
-Animation.timeline = newTimeline;
-```
-
 ### Value
 
 A {{domxref("AnimationTimeline", "timeline object", "", 1)}} to use as the timing source for the animation, or `null` to use the default, which is the {{domxref("Document")}}'s timeline.

--- a/files/en-us/web/api/animationevent/animationname/index.md
+++ b/files/en-us/web/api/animationevent/animationname/index.md
@@ -16,12 +16,6 @@ The **`AnimationEvent.animationName`** read-only property is a
 {{domxref("DOMString")}} containing the value of the {{cssxref("animation-name")}} CSS
 property associated with the transition.
 
-## Syntax
-
-```js
-name = AnimationEvent.animationName
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/animationevent/animationname/index.md
+++ b/files/en-us/web/api/animationevent/animationname/index.md
@@ -19,7 +19,7 @@ property associated with the transition.
 
 ## Value 
 
-A [DOMString](https://developer.mozilla.org/en-US/docs/Web/API/DOMString) containing the value of the [animation-name](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name) CSS property.
+A string containing the value of the {{cssxref("animation-name")}} CSS property.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationevent/animationname/index.md
+++ b/files/en-us/web/api/animationevent/animationname/index.md
@@ -16,6 +16,11 @@ The **`AnimationEvent.animationName`** read-only property is a
 {{domxref("DOMString")}} containing the value of the {{cssxref("animation-name")}} CSS
 property associated with the transition.
 
+
+## Value 
+
+A [DOMString](https://developer.mozilla.org/en-US/docs/Web/API/DOMString) containing the value of the [animation-name](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name) CSS property.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/animationevent/elapsedtime/index.md
+++ b/files/en-us/web/api/animationevent/elapsedtime/index.md
@@ -20,12 +20,6 @@ when this event fired, excluding any time the animation was paused. For an
 {{cssxref("animation-delay")}}, in which case the event will be fired with
 `elapsedTime` containing `(-1 * delay)`.
 
-## Syntax
-
-```js
-time = AnimationEvent.elapsedTime
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/animationevent/elapsedtime/index.md
+++ b/files/en-us/web/api/animationevent/elapsedtime/index.md
@@ -20,6 +20,11 @@ when this event fired, excluding any time the animation was paused. For an
 {{cssxref("animation-delay")}}, in which case the event will be fired with
 `elapsedTime` containing `(-1 * delay)`.
 
+
+## Value
+
+A `float` giving the amount of time in seconds.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -20,12 +20,6 @@ The **`AnimationEvent.pseudoElement`** read-only property is a
 If the animation doesn't run on a pseudo-element but on the element, an empty string:
 ` ''``. `
 
-## Syntax
-
-```js
-name = AnimationEvent.pseudoElement
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -20,6 +20,10 @@ The **`AnimationEvent.pseudoElement`** read-only property is a
 If the animation doesn't run on a pseudo-element but on the element, an empty string:
 ` ''``. `
 
+## Value
+
+A {{domxref("DOMString")}}, starting with `'::'`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -22,7 +22,7 @@ If the animation doesn't run on a pseudo-element but on the element, an empty st
 
 ## Value
 
-A {{domxref("DOMString")}}, starting with `'::'`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on.
+A string, starting with `'::'`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationtimeline/currenttime/index.md
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.md
@@ -18,7 +18,7 @@ browser-compat: api.AnimationTimeline.currentTime
 
 The **`currentTime`** read-only property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("AnimationTimeline")}} interface returns the timeline's current time in milliseconds, or `null` if the timeline is inactive.
 
-### Value
+## Value
 
 A number representing the timeline's current time in milliseconds, or `null` if the timeline is inactive.
 

--- a/files/en-us/web/api/animationtimeline/currenttime/index.md
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.md
@@ -18,12 +18,6 @@ browser-compat: api.AnimationTimeline.currentTime
 
 The **`currentTime`** read-only property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("AnimationTimeline")}} interface returns the timeline's current time in milliseconds, or `null` if the timeline is inactive.
 
-## Syntax
-
-```js
-var currentTime = AnimationTimeline.currentTime;
-```
-
 ### Value
 
 A number representing the timeline's current time in milliseconds, or `null` if the timeline is inactive.

--- a/files/en-us/web/api/audiobuffer/duration/index.md
+++ b/files/en-us/web/api/audiobuffer/duration/index.md
@@ -16,13 +16,6 @@ The **`duration`** property of the {{ domxref("AudioBuffer")
     }} interface returns a double representing the duration, in seconds, of the PCM data
 stored in the buffer.
 
-## Syntax
-
-```js
-var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
-myArrayBuffer.duration;
-```
-
 ### Value
 
 A double.

--- a/files/en-us/web/api/audiobuffer/duration/index.md
+++ b/files/en-us/web/api/audiobuffer/duration/index.md
@@ -16,7 +16,7 @@ The **`duration`** property of the {{ domxref("AudioBuffer")
     }} interface returns a double representing the duration, in seconds, of the PCM data
 stored in the buffer.
 
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/audiobuffer/length/index.md
+++ b/files/en-us/web/api/audiobuffer/length/index.md
@@ -16,7 +16,7 @@ The **`length`** property of the {{ domxref("AudioBuffer") }}
 interface returns an integer representing the length, in sample-frames, of the PCM data
 stored in the buffer.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audiobuffer/length/index.md
+++ b/files/en-us/web/api/audiobuffer/length/index.md
@@ -16,13 +16,6 @@ The **`length`** property of the {{ domxref("AudioBuffer") }}
 interface returns an integer representing the length, in sample-frames, of the PCM data
 stored in the buffer.
 
-## Syntax
-
-```js
-var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
-myArrayBuffer.length;
-```
-
 ### Value
 
 An integer.

--- a/files/en-us/web/api/audiobuffer/numberofchannels/index.md
+++ b/files/en-us/web/api/audiobuffer/numberofchannels/index.md
@@ -16,7 +16,7 @@ The `numberOfChannels` property of the {{ domxref("AudioBuffer") }}
 interface returns an integer representing the number of discrete audio channels
 described by the PCM data stored in the buffer.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audiobuffer/numberofchannels/index.md
+++ b/files/en-us/web/api/audiobuffer/numberofchannels/index.md
@@ -16,13 +16,6 @@ The `numberOfChannels` property of the {{ domxref("AudioBuffer") }}
 interface returns an integer representing the number of discrete audio channels
 described by the PCM data stored in the buffer.
 
-## Syntax
-
-```js
-var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
-myArrayBuffer.numberOfChannels;
-```
-
 ### Value
 
 An integer.

--- a/files/en-us/web/api/audiobuffer/samplerate/index.md
+++ b/files/en-us/web/api/audiobuffer/samplerate/index.md
@@ -16,7 +16,7 @@ The **`sampleRate`** property of the {{
   domxref("AudioBuffer") }} interface returns a float representing the sample rate, in
 samples per second, of the PCM data stored in the buffer.
 
-### Value
+## Value
 
 A floating-point value indicating the current sample rate of the buffers data, in
 samples per second.

--- a/files/en-us/web/api/audiobuffer/samplerate/index.md
+++ b/files/en-us/web/api/audiobuffer/samplerate/index.md
@@ -16,13 +16,6 @@ The **`sampleRate`** property of the {{
   domxref("AudioBuffer") }} interface returns a float representing the sample rate, in
 samples per second, of the PCM data stored in the buffer.
 
-## Syntax
-
-```js
-var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
-myArrayBuffer.sampleRate;
-```
-
 ### Value
 
 A floating-point value indicating the current sample rate of the buffers data, in

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -22,12 +22,6 @@ using an {{domxref("AudioBuffer")}} as the source of the sound data.
 If the `buffer` property is set to the value `null`, the node
 generates a single channel containing silence (that is, every sample is 0).
 
-## Syntax
-
-```js
-AudioBufferSourceNode.buffer = soundBuffer;
-```
-
 ### Value
 
 An {{domxref("AudioBuffer")}} which contains the data representing the sound which the

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -22,7 +22,7 @@ using an {{domxref("AudioBuffer")}} as the source of the sound data.
 If the `buffer` property is set to the value `null`, the node
 generates a single channel containing silence (that is, every sample is 0).
 
-### Value
+## Value
 
 An {{domxref("AudioBuffer")}} which contains the data representing the sound which the
 node will play.

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.md
@@ -20,7 +20,7 @@ representing detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Ce
 For example, values of +100 and -100 detune the source up or down by one semitone,
 while +1200 and -1200 detune it up or down by one octave.
 
-### Value
+## Value
 
 A [k-rate](/en-US/docs/Web/API/AudioParam#k-rate) {{domxref("AudioParam")}}
 whose value indicates the detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.md
@@ -20,20 +20,13 @@ representing detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Ce
 For example, values of +100 and -100 detune the source up or down by one semitone,
 while +1200 and -1200 detune it up or down by one octave.
 
-## Syntax
-
-```js
-var source = audioCtx.createBufferSource();
-source.detune.value = 100; // value in cents
-```
-
-> **Note:** Though the `AudioParam` returned is read-only, the
-> value it represents is not.
-
 ### Value
 
 A [k-rate](/en-US/docs/Web/API/AudioParam#k-rate) {{domxref("AudioParam")}}
 whose value indicates the detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).
+
+> **Note:** Though the `AudioParam` returned is read-only, the
+> value it represents is not.
 
 ## Example
 

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.md
@@ -21,13 +21,6 @@ the {{domxref("AudioBuffer")}} is reached.
 
 The `loop` property's default value is `false`.
 
-## Syntax
-
-```js
-var loopingEnabled = AudioBufferSourceNode.loop;
-AudioBufferSourceNode.loop = true | false;
-```
-
 ### Value
 
 A Boolean which is `true` if looping is enabled; otherwise, the value is

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.md
@@ -21,7 +21,7 @@ the {{domxref("AudioBuffer")}} is reached.
 
 The `loop` property's default value is `false`.
 
-### Value
+## Value
 
 A Boolean which is `true` if looping is enabled; otherwise, the value is
 `false`.

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
@@ -22,7 +22,7 @@ indicated by the {{domxref("AudioBufferSourceNode.loopStart", "loopStart")}} pro
 This is only used if the {{domxref("AudioBufferSourceNode.loop", "loop")}} property is
 `true`.
 
-### Value
+## Value
 
 A floating-point number indicating the offset, in seconds, into the audio buffer at
 which each loop will loop return to the beginning of the loop (that is, the current play

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
@@ -22,14 +22,6 @@ indicated by the {{domxref("AudioBufferSourceNode.loopStart", "loopStart")}} pro
 This is only used if the {{domxref("AudioBufferSourceNode.loop", "loop")}} property is
 `true`.
 
-## Syntax
-
-```js
-AudioBufferSourceNode.loopEnd = endOffsetInSeconds;
-
-var endOffsetInSeconds = AudioBufferSourceNode.loopEnd;
-```
-
 ### Value
 
 A floating-point number indicating the offset, in seconds, into the audio buffer at

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
@@ -21,14 +21,6 @@ seconds, where in the {{domxref("AudioBuffer")}} the restart of the play must ha
 
 The `loopStart` property's default value is `0`.
 
-## Syntax
-
-```js
-AudioBufferSourceNode.loopStart = startOffsetInSeconds;
-
-startOffsetInSeconds = AudioBufferSourceNode.loopStart;
-```
-
 ### Value
 
 A floating-point number indicating the offset, in seconds, into the audio buffer at

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
@@ -21,7 +21,7 @@ seconds, where in the {{domxref("AudioBuffer")}} the restart of the play must ha
 
 The `loopStart` property's default value is `0`.
 
-### Value
+## Value
 
 A floating-point number indicating the offset, in seconds, into the audio buffer at
 which each loop should begin during playback. This value is only used when the

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
@@ -22,12 +22,6 @@ values less than 1.0 cause the sound to play more slowly, while values greater t
 When set to another value, the `AudioBufferSourceNode` resamples the audio
 before sending it to the output.
 
-## Syntax
-
-```js
-AudioBufferSourceNode.playbackRate.value = playbackRateProportion;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}} whose {{domxref("AudioParam.value", "value")}} is a

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
@@ -22,7 +22,7 @@ values less than 1.0 cause the sound to play more slowly, while values greater t
 When set to another value, the `AudioBufferSourceNode` resamples the audio
 before sending it to the output.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}} whose {{domxref("AudioParam.value", "value")}} is a
 floating-point value indicating the playback rate of the audio as a decimal proportion

--- a/files/en-us/web/api/audiocontext/baselatency/index.md
+++ b/files/en-us/web/api/audiocontext/baselatency/index.md
@@ -23,12 +23,6 @@ into the host system's audio subsystem ready for playing.
 > {{domxref("AudioContext.AudioContext()", "construction time", "", "true")}} with the
 > `latencyHint` option, but the browser may ignore the option.
 
-## Syntax
-
-```js
-var baseLatency = audioCtx.baseLatency;
-```
-
 ### Value
 
 A double representing the base latency in seconds.

--- a/files/en-us/web/api/audiocontext/baselatency/index.md
+++ b/files/en-us/web/api/audiocontext/baselatency/index.md
@@ -23,7 +23,7 @@ into the host system's audio subsystem ready for playing.
 > {{domxref("AudioContext.AudioContext()", "construction time", "", "true")}} with the
 > `latencyHint` option, but the browser may ignore the option.
 
-### Value
+## Value
 
 A double representing the base latency in seconds.
 

--- a/files/en-us/web/api/audiocontext/outputlatency/index.md
+++ b/files/en-us/web/api/audiocontext/outputlatency/index.md
@@ -23,12 +23,6 @@ first sample in the buffer is actually processed by the audio output device.
 
 It varies depending on the platform and the available hardware.
 
-## Syntax
-
-```js
-var outputLatency = audioCtx.outputLatency;
-```
-
 ### Value
 
 A double representing the output latency in seconds.

--- a/files/en-us/web/api/audiocontext/outputlatency/index.md
+++ b/files/en-us/web/api/audiocontext/outputlatency/index.md
@@ -23,7 +23,7 @@ first sample in the buffer is actually processed by the audio output device.
 
 It varies depending on the platform and the available hardware.
 
-### Value
+## Value
 
 A double representing the output latency in seconds.
 

--- a/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
+++ b/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
@@ -16,14 +16,6 @@ The `maxchannelCount` property of the {{ domxref("AudioDestinationNode") }} inte
 
 The {{domxref("AudioNode.channelCount")}} property can be set between 0 and this value (both included). If `maxChannelCount` is `0`, like in {{domxref("OfflineAudioContext")}}, the channel count cannot be changed.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myDestination = audioCtx.destination;
-myDestination.maxChannelCount = 2;
-```
-
 ### Value
 
 An `unsigned long`.

--- a/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
+++ b/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
@@ -16,7 +16,7 @@ The `maxchannelCount` property of the {{ domxref("AudioDestinationNode") }} inte
 
 The {{domxref("AudioNode.channelCount")}} property can be set between 0 and this value (both included). If `maxChannelCount` is `0`, like in {{domxref("OfflineAudioContext")}}, the channel count cannot be changed.
 
-### Value
+## Value
 
 An `unsigned long`.
 

--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.md
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.md
@@ -21,7 +21,7 @@ The deprecated `dopplerFactor` property of the {{ domxref("AudioListener") }} in
 
 The `dopplerFactor` property's default value is `1`, which is a sensible default for most situations.
 
-### Value
+## Value
 
 A double indicating the doppler effect's pitch shift value. The value is 1 by default.
 

--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.md
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.md
@@ -21,14 +21,6 @@ The deprecated `dopplerFactor` property of the {{ domxref("AudioListener") }} in
 
 The `dopplerFactor` property's default value is `1`, which is a sensible default for most situations.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.dopplerFactor = 1;
-```
-
 ### Value
 
 A double indicating the doppler effect's pitch shift value. The value is 1 by default.

--- a/files/en-us/web/api/audiolistener/forwardx/index.md
+++ b/files/en-us/web/api/audiolistener/forwardx/index.md
@@ -17,7 +17,7 @@ The `forwardX` read-only property of the {{ domxref("AudioListener") }} interfac
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.md
+++ b/files/en-us/web/api/audiolistener/forwardx/index.md
@@ -17,14 +17,6 @@ The `forwardX` read-only property of the {{ domxref("AudioListener") }} interfac
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.forwardX.value = 0;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/forwardy/index.md
+++ b/files/en-us/web/api/audiolistener/forwardy/index.md
@@ -17,14 +17,6 @@ The `forwardY` read-only property of the {{ domxref("AudioListener") }} interfac
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.forwardY.value = 0;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/forwardy/index.md
+++ b/files/en-us/web/api/audiolistener/forwardy/index.md
@@ -17,7 +17,7 @@ The `forwardY` read-only property of the {{ domxref("AudioListener") }} interfac
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/forwardz/index.md
+++ b/files/en-us/web/api/audiolistener/forwardz/index.md
@@ -17,14 +17,6 @@ The `forwardZ` read-only property of the {{ domxref("AudioListener") }} interfac
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.forwardZ.value = 0;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is -1, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/forwardz/index.md
+++ b/files/en-us/web/api/audiolistener/forwardz/index.md
@@ -17,7 +17,7 @@ The `forwardZ` read-only property of the {{ domxref("AudioListener") }} interfac
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is -1, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -17,7 +17,7 @@ The `positionX` read-only property of the {{ domxref("AudioListener") }} interfa
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -17,14 +17,6 @@ The `positionX` read-only property of the {{ domxref("AudioListener") }} interfa
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.positionX.value = 1;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -17,14 +17,6 @@ The `positionY` read-only property of the {{ domxref("AudioListener") }} interfa
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.positionY.value = 1;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -17,7 +17,7 @@ The `positionY` read-only property of the {{ domxref("AudioListener") }} interfa
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -17,14 +17,6 @@ The `positionZ` read-only property of the {{ domxref("AudioListener") }} interfa
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.positionZ.value = 1;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -17,7 +17,7 @@ The `positionZ` read-only property of the {{ domxref("AudioListener") }} interfa
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/speedofsound/index.md
+++ b/files/en-us/web/api/audiolistener/speedofsound/index.md
@@ -25,14 +25,6 @@ shift](https://en.wikipedia.org/wiki/Doppler_effect) appropriate for the speed t
 > **Note:** Bear in mind that no propagation delay is automatically
 > applied to a sound far from the listener.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.speedOfSound = 343.3;
-```
-
 ### Value
 
 A double.

--- a/files/en-us/web/api/audiolistener/speedofsound/index.md
+++ b/files/en-us/web/api/audiolistener/speedofsound/index.md
@@ -25,7 +25,7 @@ shift](https://en.wikipedia.org/wiki/Doppler_effect) appropriate for the speed t
 > **Note:** Bear in mind that no propagation delay is automatically
 > applied to a sound far from the listener.
 
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/audiolistener/upx/index.md
+++ b/files/en-us/web/api/audiolistener/upx/index.md
@@ -17,7 +17,7 @@ The `upX` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/upx/index.md
+++ b/files/en-us/web/api/audiolistener/upx/index.md
@@ -17,14 +17,6 @@ The `upX` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.upX.value = 0;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/upy/index.md
+++ b/files/en-us/web/api/audiolistener/upy/index.md
@@ -16,14 +16,6 @@ The `upY` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.upY.value = 0;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 1, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/upy/index.md
+++ b/files/en-us/web/api/audiolistener/upy/index.md
@@ -16,7 +16,7 @@ The `upY` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 1, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audiolistener/upz/index.md
+++ b/files/en-us/web/api/audiolistener/upz/index.md
@@ -17,14 +17,6 @@ The `upZ` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.upZ.value = 0;
-```
-
 ### Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.

--- a/files/en-us/web/api/audiolistener/upz/index.md
+++ b/files/en-us/web/api/audiolistener/upz/index.md
@@ -17,7 +17,7 @@ The `upZ` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 > **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 

--- a/files/en-us/web/api/audionode/channelcount/index.md
+++ b/files/en-us/web/api/audionode/channelcount/index.md
@@ -20,7 +20,7 @@ The **`channelCount`** property of the {{ domxref("AudioNode") }} interface repr
 - It is used as a maximum value if the `channelCountMode` value is `clamped-max`.
 - It is used as the exact value if the `channelCountMode` value is `explicit`.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audionode/channelcount/index.md
+++ b/files/en-us/web/api/audionode/channelcount/index.md
@@ -20,13 +20,6 @@ The **`channelCount`** property of the {{ domxref("AudioNode") }} interface repr
 - It is used as a maximum value if the `channelCountMode` value is `clamped-max`.
 - It is used as the exact value if the `channelCountMode` value is `explicit`.
 
-## Syntax
-
-```js
-var oscillator = audioCtx.createOscillator();
-var channels = oscillator.channelCount;
-```
-
 ### Value
 
 An integer.

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -70,7 +70,7 @@ The possible values of `channelCountMode` and their meanings are:
 
 > **Note:** In older versions of the spec, the default for a {{domxref("ChannelSplitterNode")}} was max.
 
-### Value
+## Value
 
 A enumerated value representing a [channelCountMode](https://webaudio.github.io/web-audio-api/#idl-def-ChannelCountMode).
 

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -70,13 +70,6 @@ The possible values of `channelCountMode` and their meanings are:
 
 > **Note:** In older versions of the spec, the default for a {{domxref("ChannelSplitterNode")}} was max.
 
-## Syntax
-
-```js
-var oscillator = audioCtx.createOscillator();
-oscillator.channelCountMode = 'explicit';
-```
-
 ### Value
 
 A enumerated value representing a [channelCountMode](https://webaudio.github.io/web-audio-api/#idl-def-ChannelCountMode).

--- a/files/en-us/web/api/audionode/channelinterpretation/index.md
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.md
@@ -16,7 +16,7 @@ The **`channelInterpretation`** property of the {{domxref("AudioNode")}} interfa
 
 The property has two options: `speakers` and `discrete`. These are documented in [Basic concepts behind Web Audio API > up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing).
 
-### Value
+## Value
 
 The values are documented in [Basic concepts behind Web Audio API > up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing).
 

--- a/files/en-us/web/api/audionode/channelinterpretation/index.md
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.md
@@ -16,13 +16,6 @@ The **`channelInterpretation`** property of the {{domxref("AudioNode")}} interfa
 
 The property has two options: `speakers` and `discrete`. These are documented in [Basic concepts behind Web Audio API > up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing).
 
-## Syntax
-
-```js
-var oscillator = audioCtx.createOscillator();
-oscillator.channelInterpretation = 'discrete';
-```
-
 ### Value
 
 The values are documented in [Basic concepts behind Web Audio API > up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing).

--- a/files/en-us/web/api/audionode/context/index.md
+++ b/files/en-us/web/api/audionode/context/index.md
@@ -17,12 +17,6 @@ The read-only `context` property of the
 {{domxref("BaseAudioContext")}}, that is the object representing the processing graph
 the node is participating in.
 
-## Syntax
-
-```js
-var aContext = anAudioNode.context;
-```
-
 ### Value
 
 The {{domxref("AudioContext")}} or {{domxref("OfflineAudioContext")}} object that was

--- a/files/en-us/web/api/audionode/context/index.md
+++ b/files/en-us/web/api/audionode/context/index.md
@@ -17,7 +17,7 @@ The read-only `context` property of the
 {{domxref("BaseAudioContext")}}, that is the object representing the processing graph
 the node is participating in.
 
-### Value
+## Value
 
 The {{domxref("AudioContext")}} or {{domxref("OfflineAudioContext")}} object that was
 used to construct this `AudioNode`.

--- a/files/en-us/web/api/audionode/numberofinputs/index.md
+++ b/files/en-us/web/api/audionode/numberofinputs/index.md
@@ -17,7 +17,7 @@ the {{domxref("AudioNode")}} interface returns the number of inputs feeding the
 node. Source nodes are defined as nodes having a `numberOfInputs`
 property with a value of 0.
 
-### Value
+## Value
 
 An integer ≥ 0.
 

--- a/files/en-us/web/api/audionode/numberofinputs/index.md
+++ b/files/en-us/web/api/audionode/numberofinputs/index.md
@@ -17,12 +17,6 @@ the {{domxref("AudioNode")}} interface returns the number of inputs feeding the
 node. Source nodes are defined as nodes having a `numberOfInputs`
 property with a value of 0.
 
-## Syntax
-
-```js
-var numInputs = audioNode.numberOfInputs;
-```
-
 ### Value
 
 An integer ≥ 0.

--- a/files/en-us/web/api/audionode/numberofoutputs/index.md
+++ b/files/en-us/web/api/audionode/numberofoutputs/index.md
@@ -17,7 +17,7 @@ the {{ domxref("AudioNode") }} interface returns the number of outputs coming ou
 the node. Destination nodes — like {{domxref("AudioDestinationNode") }} — have
 a value of 0 for this attribute.
 
-### Value
+## Value
 
 An integer ≥ 0.
 

--- a/files/en-us/web/api/audionode/numberofoutputs/index.md
+++ b/files/en-us/web/api/audionode/numberofoutputs/index.md
@@ -17,12 +17,6 @@ the {{ domxref("AudioNode") }} interface returns the number of outputs coming ou
 the node. Destination nodes — like {{domxref("AudioDestinationNode") }} — have
 a value of 0 for this attribute.
 
-## Syntax
-
-```js
-var numOutputs = audioNode.numberOfOutputs;
-```
-
 ### Value
 
 An integer ≥ 0.

--- a/files/en-us/web/api/audioparam/defaultvalue/index.md
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.md
@@ -17,7 +17,7 @@ read-only property of the {{ domxref("AudioParam") }} interface represents the i
 value of the attributes as defined by the specific {{domxref("AudioNode")}} creating
 the `AudioParam`.
 
-### Value
+## Value
 
 A floating-point {{jsxref("Number")}}.
 

--- a/files/en-us/web/api/audioparam/defaultvalue/index.md
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.md
@@ -17,12 +17,6 @@ read-only property of the {{ domxref("AudioParam") }} interface represents the i
 value of the attributes as defined by the specific {{domxref("AudioNode")}} creating
 the `AudioParam`.
 
-## Syntax
-
-```js
-var defaultVal = audioParam.defaultValue;
-```
-
 ### Value
 
 A floating-point {{jsxref("Number")}}.

--- a/files/en-us/web/api/audioparam/maxvalue/index.md
+++ b/files/en-us/web/api/audioparam/maxvalue/index.md
@@ -17,7 +17,7 @@ The **`maxValue`**
 read-only property of the {{domxref("AudioParam")}} interface represents the maximum
 possible value for the parameter's nominal (effective) range.
 
-### Value
+## Value
 
 A floating-point {{jsxref("Number")}} indicating the maximum value permitted for the
 parameter's nominal range.

--- a/files/en-us/web/api/audioparam/maxvalue/index.md
+++ b/files/en-us/web/api/audioparam/maxvalue/index.md
@@ -17,12 +17,6 @@ The **`maxValue`**
 read-only property of the {{domxref("AudioParam")}} interface represents the maximum
 possible value for the parameter's nominal (effective) range.
 
-## Syntax
-
-```js
-var maxVal = audioParam.maxValue;
-```
-
 ### Value
 
 A floating-point {{jsxref("Number")}} indicating the maximum value permitted for the

--- a/files/en-us/web/api/audioparam/minvalue/index.md
+++ b/files/en-us/web/api/audioparam/minvalue/index.md
@@ -17,12 +17,6 @@ The **`minValue`**
 read-only property of the {{domxref("AudioParam")}} interface represents the minimum
 possible value for the parameter's nominal (effective) range.
 
-## Syntax
-
-```js
-var minVal = audioParam.minValue;
-```
-
 ### Value
 
 A floating-point {{jsxref("Number")}} indicating the minimum value permitted for the

--- a/files/en-us/web/api/audioparam/minvalue/index.md
+++ b/files/en-us/web/api/audioparam/minvalue/index.md
@@ -17,7 +17,7 @@ The **`minValue`**
 read-only property of the {{domxref("AudioParam")}} interface represents the minimum
 possible value for the parameter's nominal (effective) range.
 
-### Value
+## Value
 
 A floating-point {{jsxref("Number")}} indicating the minimum value permitted for the
 parameter's nominal range.

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -23,13 +23,6 @@ calling {{domxref("AudioParam.setValueAtTime")}} with the time returned by the
 `AudioContext`'s {{domxref("BaseAudioContext/currentTime", "currentTime")}}
 property.
 
-## Syntax
-
-```js
-var curValue = audioParam.value;
-audioParam.value = newValue;
-```
-
 ### Value
 
 A floating-point {{jsxref("Number")}} indicating the parameter's value as of the

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -23,7 +23,7 @@ calling {{domxref("AudioParam.setValueAtTime")}} with the time returned by the
 `AudioContext`'s {{domxref("BaseAudioContext/currentTime", "currentTime")}}
 property.
 
-### Value
+## Value
 
 A floating-point {{jsxref("Number")}} indicating the parameter's value as of the
 current time. This value will be between the values specified by the

--- a/files/en-us/web/api/audiotrack/enabled/index.md
+++ b/files/en-us/web/api/audiotrack/enabled/index.md
@@ -24,7 +24,7 @@ track is currently enabled for use. If the track is disabled by setting
 `enabled` to `false`, the track is muted and does not produce
 audio.
 
-### Value
+## Value
 
 The `enabled` property is a Boolean whose value is `true` if the
 track is enabled; enabled tracks produce audio while the media is playing. Setting

--- a/files/en-us/web/api/audiotrack/enabled/index.md
+++ b/files/en-us/web/api/audiotrack/enabled/index.md
@@ -24,14 +24,6 @@ track is currently enabled for use. If the track is disabled by setting
 `enabled` to `false`, the track is muted and does not produce
 audio.
 
-## Syntax
-
-```js
-isAudioEnabled = AudioTrack.enabled;
-
-AudioTrack.enabled = true | false;
-```
-
 ### Value
 
 The `enabled` property is a Boolean whose value is `true` if the

--- a/files/en-us/web/api/audiotrack/id/index.md
+++ b/files/en-us/web/api/audiotrack/id/index.md
@@ -27,12 +27,6 @@ This ID can be used with the
 the media associated with a media element. The track ID can also be used as the fragment of a URL that loads the specific track
 (if the media supports media fragments).
 
-## Syntax
-
-```js
-var trackID = AudioTrack.id;
-```
-
 ### Value
 
 A {{domxref("DOMString")}} which identifies the track, suitable for use when calling

--- a/files/en-us/web/api/audiotrack/id/index.md
+++ b/files/en-us/web/api/audiotrack/id/index.md
@@ -27,7 +27,7 @@ This ID can be used with the
 the media associated with a media element. The track ID can also be used as the fragment of a URL that loads the specific track
 (if the media supports media fragments).
 
-### Value
+## Value
 
 A {{domxref("DOMString")}} which identifies the track, suitable for use when calling
 {{domxref("AudioTrackList.getTrackById", "getTrackById()")}} on an

--- a/files/en-us/web/api/audiotrack/kind/index.md
+++ b/files/en-us/web/api/audiotrack/kind/index.md
@@ -25,12 +25,6 @@ The `kind` can be used
 to determine the scenarios in which specific tracks should be enabled or disabled. See
 [Audio track kind strings](#audio_track_kind_strings) for a list of the kinds available for audio tracks.
 
-## Syntax
-
-```js
-var trackKind = AudioTrack.kind;
-```
-
 ### Value
 
 A {{domxref("DOMString")}} specifying the type of content the media represents. The

--- a/files/en-us/web/api/audiotrack/kind/index.md
+++ b/files/en-us/web/api/audiotrack/kind/index.md
@@ -25,7 +25,7 @@ The `kind` can be used
 to determine the scenarios in which specific tracks should be enabled or disabled. See
 [Audio track kind strings](#audio_track_kind_strings) for a list of the kinds available for audio tracks.
 
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the type of content the media represents. The
 string is one of those found in [Audio track kind strings](#audio_track_kind_strings) below.

--- a/files/en-us/web/api/audiotrack/label/index.md
+++ b/files/en-us/web/api/audiotrack/label/index.md
@@ -23,7 +23,7 @@ property **`label`** returns a string specifying the audio
 track's human-readable label, if one is available; otherwise, it returns an empty
 string.
 
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the track's human-readable label, if one is
 available in the track metadata. Otherwise, an empty string (`""`) is

--- a/files/en-us/web/api/audiotrack/label/index.md
+++ b/files/en-us/web/api/audiotrack/label/index.md
@@ -23,12 +23,6 @@ property **`label`** returns a string specifying the audio
 track's human-readable label, if one is available; otherwise, it returns an empty
 string.
 
-## Syntax
-
-```js
-var audioTrackLabel = AudioTrack.label;
-```
-
 ### Value
 
 A {{domxref("DOMString")}} specifying the track's human-readable label, if one is


### PR DESCRIPTION
#### Summary
Related to #14164

As instructed by @teoli2003 :
> Thanks! Once you are done with constructors, and if you still like this, you could adapt (by removing them) the syntax part of the properties. (See https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_property_subpage_template) ...

I've started working on property pages. This is first PR of many to come.

#### Motivation
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

#### Related issues
#14160

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
