### PR TITLE
WebAPI: Clean syntax from property pages, part 2

### DIFF
--- a/files/en-us/web/api/audiotrack/language/index.md
+++ b/files/en-us/web/api/audiotrack/language/index.md
@@ -27,13 +27,7 @@ For tracks that include multiple languages
 (such as a movie in English in which a few lines are spoken in other languages), this
 should be the video's primary language.
 
-## Syntax
-
-```js
-var audioTrackLanguage = AudioTrack.language;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the BCP 47 ({{RFC(5646)}}) format language tag of
 the primary language used in the audio track, or an empty string (`""`) if

--- a/files/en-us/web/api/audiotrack/sourcebuffer/index.md
+++ b/files/en-us/web/api/audiotrack/sourcebuffer/index.md
@@ -25,13 +25,7 @@ created by a {{domxref("SourceBuffer")}} or the {{domxref("SourceBuffer")}} has 
 removed from the {{domxref("MediaSource.sourceBuffers")}} attribute of its parent
 media source.
 
-## Syntax
-
-```js
-var sourceBuffer = AudioTrack.sourceBuffer;
-```
-
-### Value
+## Value
 
 A {{domxref("SourceBuffer")}} or null.
 

--- a/files/en-us/web/api/audiotracklist/length/index.md
+++ b/files/en-us/web/api/audiotracklist/length/index.md
@@ -23,13 +23,7 @@ property **`length`** returns the number of entries in the
 representing one audio track in the media element. A value of 0 indicates that
 there are no audio tracks in the media.
 
-## Syntax
-
-```js
-var trackCount = AudioTrackList.length;
-```
-
-### Value
+## Value
 
 A number indicating how many audio tracks are included in the
 `AudioTrackList`. Each track can be accessed by treating the

--- a/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.md
@@ -14,13 +14,7 @@ browser-compat: api.AuthenticatorAssertionResponse.authenticatorData
 
 The **`authenticatorData`** property of the {{domxref("AuthenticatorAssertionResponse")}} interface returns an {{jsxref("ArrayBuffer")}} containing information from the authenticator such as the Relying Party ID Hash (rpIdHash), a signature counter, test of user presence, user verification flags, and any extensions processed by the authenticator.
 
-## Syntax
-
-```js
-var authnrData = authenticatorAssertionResponse.authenticatorData;
-```
-
-### Value
+## Value
 
 An {{jsxref("ArrayBuffer")}} that has a {{jsxref("ArrayBuffer.byteLength")}} of at least 37 bytes, containing the following fields:
 

--- a/files/en-us/web/api/authenticatorassertionresponse/signature/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/signature/index.md
@@ -30,13 +30,7 @@ the credential's generation.
 > **Note:** This property may only be used in top-level contexts and will
 > not be available in an {{HTMLElement("iframe")}} for example.
 
-## Syntax
-
-```js
-signature = authenticatorAssertionResponse.signature
-```
-
-### Value
+## Value
 
 An {{jsxref("ArrayBuffer")}} object which the signature of the authenticator (using its
 private key) for both {{domxref("AuthenticatorAssertionResponse.authenticatorData")}}

--- a/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.md
@@ -29,13 +29,7 @@ the creation of the `PublicKeyCredential` instance).
 > **Note:** This property may only be used in top-level contexts and will
 > not be available in an {{HTMLElement("iframe")}} for example.
 
-## Syntax
-
-```js
-userHandle = authenticatorAssertionResponse.userHandle
-```
-
-### Value
+## Value
 
 An {{jsxref("ArrayBuffer")}} object which is an opaque identifier for the current user.
 This is not human-readable and does **not** contain any personally

--- a/files/en-us/web/api/authenticatorresponse/clientdatajson/index.md
+++ b/files/en-us/web/api/authenticatorresponse/clientdatajson/index.md
@@ -21,14 +21,7 @@ child objects of `AuthenticatorResponse`, specifically
 {{domxref("AuthenticatorAttestationResponse")}} or
 {{domxref("AuthenticatorAssertionResponse")}}.
 
-## Syntax
-
-```js
-var arrayBuffer = AuthenticatorAttestationResponse.clientDataJSON;
-var arrayBuffer = AuthenticatorAssertionResponse.clientDataJSON;
-```
-
-### Value
+## Value
 
 An {{jsxref("ArrayBuffer")}}.
 

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchEvent.registration
 
 The **`registration`** read-only property of the {{domxref("BackgroundFetchEvent")}} interface returns a {{domxref("BackgroundFetchRegistration")}} object.
 
-## Syntax
-
-```js
-let registration = BackgroundFetchEvent.registration;
-```
-
-### Value
+## Value
 
 A {{domxref("BackgroundFetchRegistration")}}.
 

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchRecord.request
 
 The **`request`** read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns the details of the resource to be fetched.
 
-## Syntax
-
-```js
-var request = BackgroundFetchRecord.request;
-```
-
-### Value
+## Value
 
 A {{domxref("Request")}}.
 

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchRecord.responseReady
 
 The **`responseReady`** read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Response")}}.
 
-## Syntax
-
-```js
-var response = BackgroundFetchRecord.responseReady;
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}} that resolves with a {{domxref("Response")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
@@ -15,13 +15,7 @@ The **`downloaded`** read-only property of the {{domxref("BackgroundFetchRegistr
 
 If the value of this property changes, the  [progress](/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event) event is fired at the associated {{domxref("BackgroundFetchRegistration")}} object.
 
-## Syntax
-
-```js
-let downloaded = BackgroundFetchRegistration.downloaded;
-```
-
-### Value
+## Value
 
 A {{jsxref("number")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchRegistration.downloadTotal
 
 The **`downloadTotal`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total size in bytes of this download. This is set when the background fetch was registered, or `0` if not set.
 
-## Syntax
-
-```js
-let downloadTotal = BackgroundFetchRegistration.downloadTotal;
-```
-
-### Value
+## Value
 
 A {{jsxref("number")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.md
@@ -15,13 +15,7 @@ The **`failureReason`** read-only property of the {{domxref("BackgroundFetchRegi
 
 If the value of this property changes, the  [progress](/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event) event is fired at the associated {{domxref("BackgroundFetchRegistration")}} object.
 
-## Syntax
-
-```js
-let failureReason = BackgroundFetchRegistration.failureReason;
-```
-
-### Value
+## Value
 
 One of the following strings:
 

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchRegistration.id
 
 The **`id`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a copy of the background fetch's `ID`.
 
-## Syntax
-
-```js
-let id = BackgroundFetchRegistration.id;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchRegistration.recordsAvailable
 
 The **`recordsAvailable`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns `true` if there are requests and responses to be accessed. If this returns false then {{domxref("BackgroundFetchRegistration.match()","match()")}} and {{domxref("BackgroundFetchRegistration.matchAll()","matchAll()")}} can't be used.
 
-## Syntax
-
-```js
-let recordsAvailable = BackgroundFetchRegistration.recordsAvailable;
-```
-
-### Value
+## Value
 
 A {{jsxref("boolean")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/result/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/result/index.md
@@ -15,13 +15,7 @@ The **`result`** read-only property of the {{domxref("BackgroundFetchRegistratio
 
 If the value of this property changes, the  [progress](/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event) event is fired at the associated {{domxref("BackgroundFetchRegistration")}} object.
 
-## Syntax
-
-```js
-let theResult = BackgroundFetchRegistration.result;
-```
-
-### Value
+## Value
 
 One of the following strings:
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.md
@@ -15,13 +15,7 @@ The **`uploaded`** read-only property of the {{domxref("BackgroundFetchRegistrat
 
 If the value of this property changes, the  [progress](/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event) event is fired at the associated {{domxref("BackgroundFetchRegistration")}} object.
 
-## Syntax
-
-```js
-let uploaded = BackgroundFetchRegistration.uploaded;
-```
-
-### Value
+## Value
 
 A {{jsxref("number")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BackgroundFetchRegistration.uploadTotal
 
 The **`uploadTotal`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total number of bytes to be sent to the server.
 
-## Syntax
-
-```js
-let uploadTotal = BackgroundFetchRegistration.uploadTotal;
-```
-
-### Value
+## Value
 
 A {{jsxref("number")}}.
 

--- a/files/en-us/web/api/barprop/visible/index.md
+++ b/files/en-us/web/api/barprop/visible/index.md
@@ -13,13 +13,7 @@ browser-compat: api.BarProp.visible
 
 The **`visible`** read-only property of the {{domxref("BarProp")}} interface returns `true` if the user interface element it represents is visible.
 
-## Syntax
-
-```js
-let visible = BarProp.visible;
-```
-
-### Value
+## Value
 
 A {{jsxref("Boolean")}}, which is true if the top-level window is opened by
 {{domxref("window.open")}} with the {{domxref("window.open", "requesting a popup window", "popup_feature", 1)}}.

--- a/files/en-us/web/api/blobevent/timecode/index.md
+++ b/files/en-us/web/api/blobevent/timecode/index.md
@@ -21,13 +21,7 @@ produced by this recorder.
 Note that the timecode in the first produced
 BlobEvent does not need to be zero.
 
-## Syntax
-
-```js
-var timecode = blobEvent.timecode
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}}.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.md
@@ -20,13 +20,7 @@ property of the {{domxref("BluetoothCharacteristicProperties")}} interface retur
 `boolean` that is `true` if signed writing to the characteristic
 value is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.authenticatedSignedWrites;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.md
@@ -20,13 +20,7 @@ The **`broadcast`** read-only property of the
 `boolean` that is `true` if the broadcast of the characteristic
 value is permitted using the Server Characteristic Configuration Descriptor.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.broadcast;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.md
@@ -20,13 +20,7 @@ The **`indicate`** read-only property of the
 `boolean` that is `true` if indications of the characteristic
 value with acknowledgement is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.indicate;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.md
@@ -20,13 +20,7 @@ The **`notify`** read-only property of the
 `boolean` that is `true` if notifications of the characteristic
 value without acknowledgement is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.notify;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.md
@@ -20,13 +20,7 @@ The **`read`** read-only property of the
 `boolean` that is `true` if the reading of the characteristic
 value is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.read;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.md
@@ -21,13 +21,7 @@ the {{domxref("BluetoothCharacteristicProperties")}} interface returns a
 `boolean` that is `true` if reliable writes to the characteristic
 is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.reliableWrite;
-```
-
-### Value
+## Value
 
 A boolean value
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.md
@@ -20,13 +20,7 @@ property of the {{domxref("BluetoothCharacteristicProperties")}} interface retur
 `boolean` that is `true` if reliable writes to the characteristic
 descriptor is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.writableAuxiliaries;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.md
@@ -20,13 +20,7 @@ The **`write`** read-only property of the
 `boolean` that is `true` if the writing to the characteristic with
 response is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.write;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.md
@@ -20,13 +20,7 @@ property of the {{domxref("BluetoothCharacteristicProperties")}} interface retur
 `boolean` that is `true` if the writing to the characteristic
 without response is permitted.
 
-## Syntax
-
-```js
-var aBoolean = BluetoothCharacteristicProperties.writeWithoutResponse;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/client/type/index.md
+++ b/files/en-us/web/api/client/type/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Client.type
 The **`type`** read-only property of the {{domxref("Client")}}
 interface indicates the type of client the service worker is controlling.
 
-## Syntax
-
-```js
-var myClientType = client.type;
-```
-
-### Value
+## Value
 
 A string, representing the client type. The value can be one of
 

--- a/files/en-us/web/api/client/url/index.md
+++ b/files/en-us/web/api/client/url/index.md
@@ -16,13 +16,7 @@ browser-compat: api.Client.url
 The **`url`** read-only property of the {{domxref("Client")}}
 interface returns the URL of the current service worker client.
 
-## Syntax
-
-```js
-var clientUrl = client.url;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/clipboarditem/presentationstyle/index.md
+++ b/files/en-us/web/api/clipboarditem/presentationstyle/index.md
@@ -21,13 +21,7 @@ The read-only
 **`presentationStyle`** property of the {{domxref("ClipboardItem")}}
 interface returns a {{jsxref("String")}} indicating how an item should be presented.
 
-## Syntax
-
-```js
-var presentationStyle = clipboardItem.presentationStyle;
-```
-
-### Value
+## Value
 
 One of either `"unspecified"`, `"inline"` or `"attachment"`.
 

--- a/files/en-us/web/api/clipboarditem/types/index.md
+++ b/files/en-us/web/api/clipboarditem/types/index.md
@@ -22,13 +22,7 @@ The read-only
 interface returns an {{jsxref("Array")}} of {{Glossary("MIME type", 'MIME types')}}
 available within the {{domxref("ClipboardItem")}}
 
-## Syntax
-
-```js
-var types = clipboardItem.types;
-```
-
-### Value
+## Value
 
 An {{jsxref("Array")}} of available {{Glossary("MIME type", 'MIME types')}}.
 

--- a/files/en-us/web/api/compositionevent/data/index.md
+++ b/files/en-us/web/api/compositionevent/data/index.md
@@ -16,13 +16,7 @@ The **`data`** read-only property of the
 method that raised the event; its exact nature varies depending on the type of event
 that generated the `CompositionEvent` object.
 
-## Syntax
-
-```js
- myData = compositionEvent.data
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the event data:
 

--- a/files/en-us/web/api/compositionevent/locale/index.md
+++ b/files/en-us/web/api/compositionevent/locale/index.md
@@ -20,13 +20,7 @@ The **`locale`** read-only property of the
 > Even if technically it is accessible, the way to set it up when creating a {{domxref("CompositionEvent")}}
 > is not guaranteed to be coherent.
 
-## Syntax
-
-```js
-myLocale = CompositionEvent.locale
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the locale of current input method.
 

--- a/files/en-us/web/api/compressionstream/readable/index.md
+++ b/files/en-us/web/api/compressionstream/readable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.CompressionStream.readable
 
 The **`readable`** read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("ReadableStream")}}.
 
-## Syntax
-
-```js
-let stream = CompressionStream.readable;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/compressionstream/writable/index.md
+++ b/files/en-us/web/api/compressionstream/writable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.CompressionStream.writable
 
 The **`writable`** read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("WritableStream")}}.
 
-## Syntax
-
-```js
-let writableStream = CompressionStream.writable;
-```
-
-### Value
+## Value
 
 A {{domxref("WritableStream")}}.
 

--- a/files/en-us/web/api/constantsourcenode/offset/index.md
+++ b/files/en-us/web/api/constantsourcenode/offset/index.md
@@ -26,16 +26,7 @@ by the source when asked for the next sample.
 > myConstantSourceNode.offset.value = newValue;
 > ```
 
-## Syntax
-
-```js
-let offsetParameter = ConstantAudioNode.offset;
-
-let offset = ConstantSourceNode.offset.value;
-ConstantSourceNode.offset.value = newValue;
-```
-
-### Value
+## Value
 
 An {{ domxref("AudioParam") }} object indicating the [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) value returned for every
 sample by this node. The default value is 1.0.

--- a/files/en-us/web/api/contentindexevent/id/index.md
+++ b/files/en-us/web/api/contentindexevent/id/index.md
@@ -17,13 +17,7 @@ The read-only **`id`** property of the
 {{domxref("ContentIndexEvent")}} interface is a {{jsxref('String')}} which identifies
 the deleted content index via its `id`.
 
-## Syntax
-
-```js
-var id = ContentIndexEvent.id;
-```
-
-### Value
+## Value
 
 A {{jsxref("String")}} representation of the deleted content index id.
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -13,13 +13,7 @@ browser-compat: api.CookieChangeEvent.changed
 
 The **`changed`** read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been changed.
 
-## Syntax
-
-```js
-var array = CookieChangeEvent.changed;
-```
-
-### Value
+## Value
 
 An array of objects containing the changed cookie(s). Each object contains the following properties:
 

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -13,13 +13,7 @@ browser-compat: api.CookieChangeEvent.deleted
 
 The **`deleted`** read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been deleted by the given `CookieChangeEvent` instance.
 
-## Syntax
-
-```js
-var array = CookieChangeEvent.deleted;
-```
-
-### Value
+## Value
 
 An array of objects containing the deleted cookie(s). Each object contains the following properties:
 

--- a/files/en-us/web/api/credential/id/index.md
+++ b/files/en-us/web/api/credential/id/index.md
@@ -18,13 +18,7 @@ The **`id`** property of the
 credential's identifier. This might be any one of a GUID, username, or email
 address.
 
-## Syntax
-
-```js
-var id = Credential.id;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the credential's identifier.
 

--- a/files/en-us/web/api/credential/type/index.md
+++ b/files/en-us/web/api/credential/type/index.md
@@ -17,13 +17,7 @@ The **`type`** property of the
 credential's type. Valid values are `password`, `federated` and
 `public-key`.
 
-## Syntax
-
-```js
-var credType = Credential.type;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} contains a credential's given name.
 

--- a/files/en-us/web/api/crypto/subtle/index.md
+++ b/files/en-us/web/api/crypto/subtle/index.md
@@ -16,13 +16,7 @@ The **`Crypto.subtle`** read-only property returns a
 {{domxref("SubtleCrypto")}} which can then be used to perform low-level
 cryptographic operations.
 
-## Syntax
-
-```js
-var crypto = crypto.subtle;
-```
-
-### Value
+## Value
 
 A {{domxref("SubtleCrypto")}} object you can use to interact with the Web Crypto API's
 low-level cryptography features.

--- a/files/en-us/web/api/css/paintworklet/index.md
+++ b/files/en-us/web/api/css/paintworklet/index.md
@@ -21,13 +21,7 @@ read-only property of the {{DOMxRef("CSS")}} interface that provides access to t
 {{DOMxRef("PaintWorklet")}}, which programmatically generates an image where a CSS
 property expects a file.
 
-## Syntax
-
-```js
-var worklet = CSS.paintWorklet;
-```
-
-### Value
+## Value
 
 The {{DOMxRef('PaintWorklet')}} object.
 

--- a/files/en-us/web/api/cssanimation/animationname/index.md
+++ b/files/en-us/web/api/cssanimation/animationname/index.md
@@ -16,13 +16,7 @@ The **`animationName`** property of the
 specifies one or more keyframe at-rules which describe the animation applied to the
 element.
 
-## Syntax
-
-```js
-const animationName = CSSAnimation.animationName;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}.
 

--- a/files/en-us/web/api/cssconditionrule/conditiontext/index.md
+++ b/files/en-us/web/api/cssconditionrule/conditiontext/index.md
@@ -15,14 +15,7 @@ The **`conditionText`** property of
 the {{domxref("CSSConditionRule")}} interface returns or sets the text of the CSS
 rule.
 
-## Syntax
-
-```js
-var text = CSSConditionRule.conditionText
-cssConditionRule.conditionText = text
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}}.
 

--- a/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.additiveSymbols
 
 The **`additiveSymbols`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/additive-symbols","additive-symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let additiveSymbols = CSSCounterStyleRule.additiveSymbols;
-CSSCounterStyleRule.additiveSymbols = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}.
 

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.md
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.fallback
 
 The **`fallback`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/fallback","fallback")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let fallback = CSSCounterStyleRule.fallback;
-CSSCounterStyleRule.fallback = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}.
 

--- a/files/en-us/web/api/csscounterstylerule/name/index.md
+++ b/files/en-us/web/api/csscounterstylerule/name/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.name
 
 The **`name`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the `name` for the associated rule.
 
-## Syntax
-
-```js
-let name = CSSCounterStyleRule.name;
-CSSCounterStyleRule.name = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/negative/index.md
+++ b/files/en-us/web/api/csscounterstylerule/negative/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.negative
 
 The **`negative`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/negative","negative")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let negative = CSSCounterStyleRule.negative;
-CSSCounterStyleRule.negative = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/pad/index.md
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.pad
 
 The **`pad`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/pad", "pad")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let pad = CSSCounterStyleRule.pad;
-CSSCounterStyleRule.pad = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/prefix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/prefix/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.prefix
 
 The **`prefix`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/prefix","prefix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let prefix = CSSCounterStyleRule.prefix;
-CSSCounterStyleRule.prefix = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/range/index.md
+++ b/files/en-us/web/api/csscounterstylerule/range/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.range
 
 The **`range`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/range","range")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let range = CSSCounterStyleRule.range;
-CSSCounterStyleRule.range = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/speakas/index.md
+++ b/files/en-us/web/api/csscounterstylerule/speakas/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.speakAs
 
 The **`speakAs`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/speak-as","speak-as")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let speakAs = CSSCounterStyleRule.speakAs;
-CSSCounterStyleRule.speakAs = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/suffix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/suffix/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.suffix
 
 The **`suffix`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/suffix","suffix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let suffix = CSSCounterStyleRule.suffix;
-CSSCounterStyleRule.suffix = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/symbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/symbols/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.symbols
 
 The **`symbols`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/symbols","symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let symbols = CSSCounterStyleRule.symbols;
-CSSCounterStyleRule.symbols = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/csscounterstylerule/system/index.md
+++ b/files/en-us/web/api/csscounterstylerule/system/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSCounterStyleRule.system
 
 The **`system`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/system", "system")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 
-## Syntax
-
-```js
-let system = CSSCounterStyleRule.system;
-CSSCounterStyleRule.system = a;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}
 

--- a/files/en-us/web/api/cssfontfacerule/style/index.md
+++ b/files/en-us/web/api/cssfontfacerule/style/index.md
@@ -14,13 +14,7 @@ browser-compat: api.CSSFontFaceRule.style
 
 The read-only **`style`** property of the {{domxref("CSSFontFaceRule")}} interface returns the style information from the {{cssxref("@font-face")}} [at-rule](/en-US/docs/Web/CSS/At-rule). This will be in the form of a {{domxref("CSSStyleDeclaration")}} object.
 
-## Syntax
-
-```js
-var style = CSSFontFaceRule.style;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSStyleDeclaration")}}.
 

--- a/files/en-us/web/api/cssgroupingrule/cssrules/index.md
+++ b/files/en-us/web/api/cssgroupingrule/cssrules/index.md
@@ -15,13 +15,7 @@ The **`cssRules`** property of the
 {{domxref("CSSGroupingRule")}} interface returns a {{domxref("CSSRuleList")}} containing
 a collection of {{domxref("CSSRule")}} objects.
 
-## Syntax
-
-```js
-let cssRules = cssGroupingRule.cssRules;
-```
-
-### Value
+## Value
 
 a {{domxref("CSSRuleList")}}.
 

--- a/files/en-us/web/api/cssimportrule/href/index.md
+++ b/files/en-us/web/api/cssimportrule/href/index.md
@@ -19,13 +19,7 @@ The read-only **`href`** property of the
 The resolved URL will be the {{HTMLAttrxRef("href","link")}} attribute of the
 associated stylesheet.
 
-## Syntax
-
-```js
-var href = CSSImportRule.href;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/cssimportrule/media/index.md
+++ b/files/en-us/web/api/cssimportrule/media/index.md
@@ -16,13 +16,7 @@ The read-only **`media`** property of the
 {{domxref("CSSImportRule")}} interface returns a {{domxref("MediaList")}} object,
 containing the value of the `media` attribute of the associated stylesheet.
 
-## Syntax
-
-```js
-let media = CSSImportRule.media;
-```
-
-### Value
+## Value
 
 Returns a {{domxref("MediaList")}} object.
 

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.md
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.md
@@ -20,13 +20,7 @@ in the form of a {{domxref("CSSStyleSheet")}} object.
 An {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/At-rule) always has
 an associated stylesheet.
 
-## Syntax
-
-```js
-var href = CSSImportRule.styleSheet;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSStyleSheet")}}.
 

--- a/files/en-us/web/api/csskeyframerule/keytext/index.md
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.md
@@ -14,14 +14,7 @@ browser-compat: api.CSSKeyframeRule.keyText
 
 The **`keyText`** property of the {{domxref("CSSKeyframeRule")}} interface represents the keyframe selector as a comma-separated list of percentage values. The from and to keywords map to 0% and 100%, respectively.
 
-## Syntax
-
-```js
-var text = CSSKeyframeRule.keyText;
-CSSKeyframeRule.keyText = text;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}}.
 

--- a/files/en-us/web/api/csskeyframerule/style/index.md
+++ b/files/en-us/web/api/csskeyframerule/style/index.md
@@ -14,13 +14,7 @@ browser-compat: api.CSSKeyframeRule.style
 
 The read-only **`CSSKeyframeRule.style`** property is the {{ domxref("CSSStyleDeclaration") }} interface for the [declaration block](https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block) of the {{ domxref("CSSKeyframeRule") }}.
 
-## Syntax
-
-```js
-styleObj = cssKeyframeRule.style
-```
-
-### Value
+## Value
 
 A {{domxref("CSSStyleDeclaration")}} object, with the following properties:
 

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.md
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.md
@@ -14,13 +14,7 @@ browser-compat: api.CSSKeyframesRule.cssRules
 
 The read-only **`cssRules`** property of the {{domxref("CSSKeyframeRule")}} interface returns a {{domxref("CSSRuleList")}} containing the rules in the keyframes {{cssxref("at-rule")}}.
 
-## Syntax
-
-```js
-var cssRules = CSSKeyframesRule.cssRules;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSRuleList')}}.
 

--- a/files/en-us/web/api/csskeyframesrule/name/index.md
+++ b/files/en-us/web/api/csskeyframesrule/name/index.md
@@ -14,14 +14,7 @@ browser-compat: api.CSSKeyframesRule.name
 
 The **`name`** property of the {{domxref("CSSKeyframeRule")}} interface gets and sets the name of the animation as used by the {{cssxref("animation-name")}} property.
 
-## Syntax
-
-```js
-var name = CSSKeyframesRule.name;
-CSSKeyframesRule.name = name;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}}.
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -18,14 +18,7 @@ The **`value`** property of the
 {{domxref("CSSKeywordValue")}} interface returns or sets the value of the
 `CSSKeywordValue`.
 
-## Syntax
-
-```js
-var val = cssKeywordValue.value
-cssKeywordValue.value = val
-```
-
-### Value
+## Value
 
 A {{domxref('USVString')}}.
 

--- a/files/en-us/web/api/cssmathinvert/value/index.md
+++ b/files/en-us/web/api/cssmathinvert/value/index.md
@@ -16,13 +16,7 @@ browser-compat: api.CSSMathInvert.value
 The CSSMathInvert.value read-only property of the
 {{domxref("CSSMathInvert")}} interface returns a {{domxref('CSSNumericValue')}} object.
 
-## Syntax
-
-```js
-var cssNumericValue = CSSMathInvert.value;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssmathmax/values/index.md
+++ b/files/en-us/web/api/cssmathmax/values/index.md
@@ -17,13 +17,7 @@ The CSSMathMax.values read-only property of the
 {{domxref("CSSMathMax")}} interface returns a {{domxref('CSSNumericArray')}} object
 which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-## Syntax
-
-```js
-var cssNumericArray = CSSMathMax.values;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericArray')}}.
 

--- a/files/en-us/web/api/cssmathmin/values/index.md
+++ b/files/en-us/web/api/cssmathmin/values/index.md
@@ -18,13 +18,7 @@ The CSSMathMin.values read-only property of the
 {{domxref("CSSMathMin")}} interface returns a {{domxref('CSSNumericArray')}} object
 which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-## Syntax
-
-```js
-var cssNumericArray = CSSMathMin.values;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericArray')}}.
 

--- a/files/en-us/web/api/cssmathnegate/value/index.md
+++ b/files/en-us/web/api/cssmathnegate/value/index.md
@@ -16,13 +16,7 @@ browser-compat: api.CSSMathNegate.value
 The CSSMathNegate.value read-only property of the
 {{domxref("CSSMathNegate")}} interface returns a {{domxref('CSSNumericValue')}} object.
 
-## Syntax
-
-```js
-var cssNumericValue = CSSMathNegate.value;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssmathproduct/values/index.md
+++ b/files/en-us/web/api/cssmathproduct/values/index.md
@@ -20,13 +20,7 @@ property of the {{domxref("CSSMathProduct")}} interface returns a
 {{domxref('CSSNumericArray')}} object which contains one or more
 {{domxref('CSSNumericValue')}} objects.
 
-## Syntax
-
-```js
-var cssNumericArray = CSSMathProduct.values;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericArray')}}.
 

--- a/files/en-us/web/api/cssmathsum/values/index.md
+++ b/files/en-us/web/api/cssmathsum/values/index.md
@@ -19,13 +19,7 @@ The **`CSSMathSum.values`** read-only property
 of the {{domxref("CSSMathSum")}} interface returns a {{domxref('CSSNumericArray')}}
 object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-## Syntax
-
-```js
-var cssNumericArray = CSSMathSum.values;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericArray')}}.
 

--- a/files/en-us/web/api/cssmathvalue/operator/index.md
+++ b/files/en-us/web/api/cssmathvalue/operator/index.md
@@ -20,13 +20,7 @@ current subtype represents. For example, if the current `CSSMathValue`
 subtype is `CSSMathSum`, this property will return the string
 `"sum"`.
 
-## Syntax
-
-```js
-var aString = CSSMathValue.operator;
-```
-
-### Value
+## Value
 
 A {{jsxref('String')}}.
 

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
@@ -21,13 +21,7 @@ The **`matrix`** property of the
 See the [matrix()](</en-US/docs/Web/CSS/transform-function/matrix()>) and [matrix3d()](</en-US/docs/Web/CSS/transform-function/matrix3d()>) pages for
 examples.
 
-## Syntax
-
-```js
-var matrix = CSSMatrixComponent.matrix;
-```
-
-### Value
+## Value
 
 a matrix.
 

--- a/files/en-us/web/api/cssmediarule/media/index.md
+++ b/files/en-us/web/api/cssmediarule/media/index.md
@@ -15,13 +15,7 @@ The read-only **`media`** property of the
 {{domxref("CSSMediaRule")}} interface {{domxref("MediaList")}} represents the intended
 destination medium for style information.
 
-## Syntax
-
-```js
-var media = CSSMediaRule.media;
-```
-
-### Value
+## Value
 
 a {{domxref("MediaList")}}
 

--- a/files/en-us/web/api/csspagerule/selectortext/index.md
+++ b/files/en-us/web/api/csspagerule/selectortext/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSPageRule.selectorText
 
 The **`selectorText`** property of the {{domxref("CSSPageRule")}} interface gets and sets the selectors associated with the `CSSPageRule`.
 
-## Syntax
-
-```js
-var text = CSSPageRule.selectorText;
-CSSPageRule.selectorText = text;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}}.
 

--- a/files/en-us/web/api/csspagerule/style/index.md
+++ b/files/en-us/web/api/csspagerule/style/index.md
@@ -14,13 +14,7 @@ browser-compat: api.CSSPageRule.style
 
 The **`style`** read-only property of the {{domxref("CSSPageRule")}} interface returns a {{domxref("CSSStyleDeclaration")}} object. This represents an object that is a [CSS declaration block](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block), and exposes style information and various style-related methods and properties.
 
-## Syntax
-
-```js
-var style = CSSPageRule.style;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSStyleDeclaration")}} object, which represents a [CSS declaration block](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block) with the following properties:
 

--- a/files/en-us/web/api/cssperspective/length/index.md
+++ b/files/en-us/web/api/cssperspective/length/index.md
@@ -20,13 +20,7 @@ The **`length`** property of the
 It is used to apply a perspective transform to the element and its content. If the
 value is 0 or a negative number, no perspective transform is applied.
 
-## Syntax
-
-```js
-var length = CSSPerspective.length;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/csspositionvalue/x/index.md
+++ b/files/en-us/web/api/csspositionvalue/x/index.md
@@ -19,13 +19,7 @@ The **`x`** property of the
 {{domxref("CSSPositionValue")}} interface returns the item's position along the web
 page's horizontal axis.
 
-## Syntax
-
-```js
-var x = CSSPositionValue.x
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/csspositionvalue/y/index.md
+++ b/files/en-us/web/api/csspositionvalue/y/index.md
@@ -19,13 +19,7 @@ The **`y`** property of the
 {{domxref("CSSPositionValue")}} interface returns the item's position along the
 vertical axis.
 
-## Syntax
-
-```js
-var y = CSSPositionValue.y
-```
-
-### Value
+## Value
 
 A {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
@@ -23,13 +23,7 @@ The **`primitiveType`** read-only property of the
 > - the untyped [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model), widely supported, or
 > - the modern [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API), less supported and considered experimental.
 
-## Syntax
-
-```js
-type = cssPrimitiveValue.primitiveType;
-```
-
-### Value
+## Value
 
 An `unsigned short` representing the type of the value. Possible values are:
 

--- a/files/en-us/web/api/csspropertyrule/inherits/index.md
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.md
@@ -17,13 +17,7 @@ browser-compat: api.CSSPropertyRule.inherits
 
 The read-only **`inherits`** property of the {{domxref("CSSPropertyRule")}} interface returns the inherit flag of the custom property registration represented by the {{cssxref("@property")}} rule, a boolean describing whether or not the property inherits by default.
 
-## Syntax
-
-```js
-const inherits = CSSPropertyRule.inherits;
-```
-
-### Value
+## Value
 
 A boolean.
 

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.md
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.md
@@ -17,13 +17,7 @@ browser-compat: api.CSSPropertyRule.initialValue
 
 The read-only **`initialValue`** nullable property of the {{domxref("CSSPropertyRule")}} interface returns the initial value of the custom property registration represented by the {{cssxref("@property")}} rule, controlling the property's initial value.
 
-## Syntax
-
-```js
-const initialValue = CSSPropertyRule.initialValue;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} which is a {{CSSXref("&lt;declaration-value&gt;")}} as
 defined in [CSS

--- a/files/en-us/web/api/csspropertyrule/name/index.md
+++ b/files/en-us/web/api/csspropertyrule/name/index.md
@@ -17,13 +17,7 @@ browser-compat: api.CSSPropertyRule.name
 
 The read-only **`name`** property of the {{domxref("CSSPropertyRule")}} interface represents the property name, this being the serialization of the name given to the custom property in the {{cssxref("@property")}} rule's prelude.
 
-## Syntax
-
-```js
-const name = CSSPropertyRule.name;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/csspropertyrule/syntax/index.md
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.md
@@ -17,13 +17,7 @@ browser-compat: api.CSSPropertyRule.syntax
 
 The read-only **`syntax`** property of the {{domxref("CSSPropertyRule")}} interface returns the literal syntax of the custom property registration represented by the {{cssxref("@property")}} rule, controlling how the property's value is parsed at computed-value time.
 
-## Syntax
-
-```js
-const syntax = CSSPropertyRule.syntax;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/csspseudoelement/element/index.md
+++ b/files/en-us/web/api/csspseudoelement/element/index.md
@@ -16,13 +16,7 @@ The **`element`** read-only property of the
 {{DOMxRef('CSSPseudoElement')}} interface returns a reference to the originating element
 of the pseudo-element, in other words its parent element.
 
-## Syntax
-
-```js
-var originatingElement = cssPseudoElement.element;
-```
-
-### Value
+## Value
 
 An {{DOMxRef('Element')}} representing the pseudo-element's originating element.
 

--- a/files/en-us/web/api/csspseudoelement/type/index.md
+++ b/files/en-us/web/api/csspseudoelement/type/index.md
@@ -16,13 +16,7 @@ The **`type`** read-only property of the
 {{DOMxRef('CSSPseudoElement')}} interface returns the type of the pseudo-element as a
 string, represented in the form of a [CSS selector](/en-US/docs/Web/CSS/CSS_Selectors#pseudo-elements).
 
-## Syntax
-
-```js
-var typeOfPseudoElement = cssPseudoElement.type;
-```
-
-### Value
+## Value
 
 A {{DOMxRef('CSSOMString')}} containing one of the following values:
 

--- a/files/en-us/web/api/cssrotate/angle/index.md
+++ b/files/en-us/web/api/cssrotate/angle/index.md
@@ -19,13 +19,7 @@ The **`angle`** property of the
 {{domxref("CSSRotate")}} interface gets and sets the angle of rotation. A positive angle
 denotes a clockwise rotation, a negative angle a counter-clockwise one.
 
-## Syntax
-
-```js
-var rotateAngle = CSSRotate.angle;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -18,13 +18,7 @@ The **`x`** property of the
 {{domxref("CSSRotate")}} interface gets and sets the abscissa or x-axis of the
 translating vector.
 
-## Syntax
-
-```js
-var rotateX = CSSRotate.x;
-```
-
-### Value
+## Value
 
 A double integer or a {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -19,13 +19,7 @@ The **`y`** property of the
 {{domxref("CSSRotate")}} interface gets and sets the ordinate or y-axis of the
 translating vector.
 
-## Syntax
-
-```js
-varrotateY = CSSRotate.y;
-```
-
-### Value
+## Value
 
 A double integer or a {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -20,13 +20,7 @@ The **`z`** property of the
 vector. A positive value moves the element towards the viewer, and a negative value
 farther away.
 
-## Syntax
-
-```js
-var rotateZ = CSSRotate.z;
-```
-
-### Value
+## Value
 
 A double integer or a {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/cssrule/parentrule/index.md
+++ b/files/en-us/web/api/cssrule/parentrule/index.md
@@ -15,13 +15,7 @@ The **`parentRule`** property of the {{domxref("CSSRule")}}
 interface returns the containing rule of the current rule if this exists, or otherwise
 returns null.
 
-## Syntax
-
-```js
-var parentRule = cssRule.parentRule
-```
-
-### Values
+## Values
 
 - `parentRule`
   - : A {{domxref("CSSRule")}} which is the type of the containing rules. If the current

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -15,13 +15,7 @@ The **`parentStyleSheet`** property of the
 {{domxref("CSSRule")}} interface returns the {{domxref("StyleSheet")}} object in which
 the current rule is defined.
 
-## Syntax
-
-```js
-var stylesheet = cssRule.parentStyleSheet
-```
-
-### Values
+## Values
 
 - `stylesheet`
   - : A {{domxref("StyleSheet")}} object.

--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -16,13 +16,7 @@ The read-only **`type`** property of the
 {{domxref("CSSRule")}} interface is a deprecated property that returns an integer
 indicating which type of rule the {{domxref("CSSRule")}} represents.
 
-## Syntax
-
-```js
-var type = cssRule.type;
-```
-
-### Value
+## Value
 
 An integer which will be one of the type constants listed in the table below.
 

--- a/files/en-us/web/api/cssrulelist/length/index.md
+++ b/files/en-us/web/api/cssrulelist/length/index.md
@@ -13,13 +13,7 @@ browser-compat: api.CSSRuleList.length
 
 The **`length`** property of the {{domxref("CSSRuleList")}} interface returns the number of {{domxref("CSSRule")}} objects in the list.
 
-## Syntax
-
-```js
-let length = CSSRuleList.length;
-```
-
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/cssscale/x/index.md
+++ b/files/en-us/web/api/cssscale/x/index.md
@@ -18,13 +18,7 @@ The **`x`** property of the
 {{domxref("CSSScale")}} interface gets and sets the abscissa or x-axis of the
 translating vector.
 
-## Syntax
-
-```js
-var scaleX = CSSScale.x;
-```
-
-### Value
+## Value
 
 A double integer or a {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -18,13 +18,7 @@ The **`y`** property of the
 {{domxref("CSSScale")}} interface gets and sets the ordinate or y-axis of the
 translating vector.
 
-## Syntax
-
-```js
-var scaleY = CSSScale.y;
-```
-
-### Value
+## Value
 
 A double integer or a {{domxref("CSSNumericValue")}}
 

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -22,13 +22,7 @@ farther away.
 If this value is present then the transform is a 3D transform and the `is2D`
 property will be set to false.
 
-## Syntax
-
-```js
-var scaleZ = CSSScale.z;
-```
-
-### Value
+## Value
 
 A double integer or a {{domxref("CSSNumericValue")}}
 


### PR DESCRIPTION
#### Summary
Sequel of #14195 .
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

@teoli2003 I'll commit pages without `Value` sections at last so things will be easy to review.


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
