### PR TITLE
Use code font for `color-gamut`

### DIFF
--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -14,7 +14,7 @@ browser-compat: css.types.color.color
 
 The **`color()`** functional notation allows a color to be specified in a particular, specified colorspace rather than the implicit sRGB colorspace that most of the other color functions operate in.
 
-Support for a particular colorspace can be detected with the [color-gamut](/en-US/docs/Web/CSS/@media/color-gamut) CSS media feature.
+Support for a particular colorspace can be detected with the [`color-gamut`](/en-US/docs/Web/CSS/@media/color-gamut) CSS media feature.
 
 The [`@color-profile`](/en-US/docs/Web/CSS/@color-profile) [CSS](/en-US/docs/Web/CSS) {{cssxref("at-rule")}} can be used to define and names a color profile to be used in the `color()` function to specify a color.
 


### PR DESCRIPTION
`color-gamut` is an identifier used in media queries. It should be using the code typeface. This fixes it.