### PR TITLE
Added documentation for the priority hints interface

### DIFF
--- a/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
@@ -1,0 +1,61 @@
+---
+title: HTMLIFrameElement.fetchpriority
+slug: Web/API/HTMLIFrameElement/fetchpriority
+tags:
+  - API
+  - HTML DOM
+  - HTMLIFrameElement
+  - Property
+  - Reference
+  - fetchpriority
+browser-compat: api.HTMLIFrameElement.fetchpriority
+---
+{{APIRef}}
+
+The **`fetchpriority`** property of the
+{{domxref("HTMLIFrameElement")}} interface represents a hint given to the
+browser on how it should prioritize the fetch of the iframe document relative
+to other iframe documents.
+
+## Syntax
+
+```js
+refStr = iframeElem.fetchpriority;
+iframeElem.fetchpriority = refStr;
+```
+
+### Values
+
+A {{domxref("DOMString")}} representing the priority hint. Possible values are:
+
+- **`high`**: Fetch the iframe document at a high priority relative to other
+  iframe documents.
+- **`low`**: Fetch the iframe document at a low priority relative to other
+  iframe documents.
+- **`auto`**: Default mode, which indicates no preference for
+  the fetch priority. The browser decides what is best for the user.
+
+## Usage notes
+
+The `fetchpriority` property allows you to signal high or low priority iframe
+document fetches. This can be useful when applied to {{HTMLElement("iframe")}}
+elements to signal "less-important" iframes to the user experience early in the
+loading process. It should be used sparingly for exceptional cases where the
+browser may not be able to infer the best way to load the iframe automatically.
+Over-use can result in degrading performance.
+
+## Examples
+
+```js
+var iframe = document.createElement("iframe");
+iframe.fetchpriority = 'low';
+iframe.src = "/";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
@@ -17,14 +17,7 @@ The **`fetchpriority`** property of the
 browser on how it should prioritize the fetch of the iframe document relative
 to other iframe documents.
 
-## Syntax
-
-```js
-refStr = iframeElem.fetchpriority;
-iframeElem.fetchpriority = refStr;
-```
-
-### Values
+## Values
 
 A {{domxref("DOMString")}} representing the priority hint. Possible values are:
 
@@ -35,14 +28,17 @@ A {{domxref("DOMString")}} representing the priority hint. Possible values are:
 - **`auto`**: Default mode, which indicates no preference for
   the fetch priority. The browser decides what is best for the user.
 
-## Usage notes
-
 The `fetchpriority` property allows you to signal high or low priority iframe
 document fetches. This can be useful when applied to {{HTMLElement("iframe")}}
-elements to signal "less-important" iframes to the user experience early in the
-loading process. It should be used sparingly for exceptional cases where the
-browser may not be able to infer the best way to load the iframe automatically.
-Over-use can result in degrading performance.
+elements to signal iframes that are "less-important" to the user experience
+early in the loading process.
+
+The effects of the hint on resource loading is browser-specific so make sure to
+test on multiple browser engines.
+
+Use it sparingly for exceptional cases where the browser may not be able to
+infer the best way to load the iframe automatically. Over use can result in
+degrading performance.
 
 ## Examples
 

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -32,6 +32,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
   - : Returns a {{domxref("WindowProxy")}}, the window proxy for the nested browsing context.
 - {{domxref("HTMLIFrameElement.csp")}}
   - : Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.
+- {{domxref("HTMLIFrameElement.fetchpriority")}}
+  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of the iframe document relative to other iframe documents. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLIFrameElement.frameBorder")}} {{deprecated_inline}}
   - : A string that indicates whether to create borders between frames.
 - {{domxref("HTMLIFrameElement.height")}}

--- a/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
@@ -1,0 +1,58 @@
+---
+title: HTMLImageElement.fetchpriority
+slug: Web/API/HTMLImageElement/fetchpriority
+tags:
+  - API
+  - HTML DOM
+  - HTMLImageElement
+  - Property
+  - Reference
+  - fetchpriority
+browser-compat: api.HTMLImageElement.fetchpriority
+---
+{{APIRef}}
+
+The **`fetchpriority`** property of the
+{{domxref("HTMLImageElement")}} interface represents a hint given to the browser on how
+it should prioritize the fetch of the image relative to other images.
+
+## Syntax
+
+```js
+refStr = imgElem.fetchpriority;
+imgElem.fetchpriority = refStr;
+```
+
+### Values
+
+A {{domxref("DOMString")}} representing the priority hint. Possible values are:
+
+- **`high`**: Fetch the image at a high priority relative to other images.
+- **`low`**: Fetch the image at a low priority relative to other images.
+- **`auto`**: Default mode, which indicates no preference for
+  the fetch priority. The browser decides what is best for the user.
+
+## Usage notes
+
+The `fetchpriority` property allows you to signal high or low priority image
+fetches. This can be useful when applied to {{HTMLElement("img")}} elements
+to signal "important" images to the user experience early in the loading
+process. It should be used sparingly for exceptional cases where the browser
+may not be able to infer the best way to load the image automatically.
+Over-use can result in degrading performance.
+
+## Examples
+
+```js
+var img = new Image();
+img.fetchpriority = 'high';
+img.src = 'img/logo.png';
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
@@ -16,14 +16,7 @@ The **`fetchpriority`** property of the
 {{domxref("HTMLImageElement")}} interface represents a hint given to the browser on how
 it should prioritize the fetch of the image relative to other images.
 
-## Syntax
-
-```js
-refStr = imgElem.fetchpriority;
-imgElem.fetchpriority = refStr;
-```
-
-### Values
+## Values
 
 A {{domxref("DOMString")}} representing the priority hint. Possible values are:
 
@@ -32,14 +25,17 @@ A {{domxref("DOMString")}} representing the priority hint. Possible values are:
 - **`auto`**: Default mode, which indicates no preference for
   the fetch priority. The browser decides what is best for the user.
 
-## Usage notes
-
 The `fetchpriority` property allows you to signal high or low priority image
 fetches. This can be useful when applied to {{HTMLElement("img")}} elements
-to signal "important" images to the user experience early in the loading
-process. It should be used sparingly for exceptional cases where the browser
-may not be able to infer the best way to load the image automatically.
-Over-use can result in degrading performance.
+to signal images that are "important" to the user experience early in the
+loading process.
+
+The effects of the hint on resource loading is browser-specific so make sure to
+test on multiple browser engines.
+
+Use it sparingly for exceptional cases where the browser may not be able to
+infer the best way to load the image automatically. Over use can result in
+degrading performance.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlimageelement/index.md
+++ b/files/en-us/web/api/htmlimageelement/index.md
@@ -39,6 +39,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : Returns a {{domxref("USVString")}} representing the URL from which the currently displayed image was loaded. This may change as the image is adjusted due to changing conditions, as directed by any [media queries](/en-US/docs/Web/CSS/Media_Queries) which are in place.
 - {{domxref("HTMLImageElement.decoding")}}
   - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should decode the image. If this value is provided, it must be one of the possible permitted values: `sync` to decode the image synchronously, `async` to decode it asynchronously, or `auto` to indicate no preference (which is the default). Read the {{domxref("HTMLImageElement.decoding", "decoding")}} page for details on the implications of this property's values.
+- {{domxref("HTMLImageElement.fetchpriority")}}
+  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of the image relative to other images. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLImageElement.height")}}
   - : An integer value that reflects the {{htmlattrxref("height", "img")}} HTML attribute, indicating the rendered height of the image in CSS pixels.
 - {{domxref("HTMLImageElement.isMap")}}

--- a/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
@@ -19,14 +19,7 @@ The **`fetchpriority`** property of the
 on how it should prioritize the preload of the given resource relative to other
 resources of the same type.
 
-## Syntax
-
-```js
-var priority = HTMLLinkElement.fetchpriority
-HTMLLinkElement.fetchpriority = fetchpriority
-```
-
-### Values
+## Values
 
 A {{domxref("DOMString")}} representing the priority hint. Possible values are:
 
@@ -37,14 +30,17 @@ A {{domxref("DOMString")}} representing the priority hint. Possible values are:
 - **`auto`**: Default mode, which indicates no preference for
   the fetch priority. The browser decides what is best for the user.
 
-## Usage notes
-
 The `fetchpriority` property allows you to signal high or low priority preload
 fetches. This can be useful when applied to {{HTMLElement("link")}} elements
-to signal "important" preloads or less-important preloads to the user
-experience early in the loading process. It should be used sparingly for
-exceptional cases where the browser may not be able to infer the best way to
-load the resource automatically. Over-use can result in degrading performance.
+to signal preloads that are more or less important to the user experience early
+in the loading process.
+
+The effects of the hint on resource loading is browser-specific so make sure to
+test on multiple browser engines.
+
+Use it sparingly for exceptional cases where the browser may not be able to
+infer the best way to load the resource automatically. Over use can result in
+degrading performance.
 
 ## Examples
 

--- a/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
@@ -1,0 +1,66 @@
+---
+title: HTMLLinkElement.fetchpriority
+slug: Web/API/HTMLLinkElement/fetchpriority
+tags:
+  - API
+  - Element
+  - HTMLLinkElement
+  - Link
+  - Preload API
+  - Property
+  - Reference
+  - fetchpriority
+browser-compat: api.HTMLLinkElement.fetchpriority
+---
+{{SeeCompatTable}}{{APIRef("HTML DOM")}}
+
+The **`fetchpriority`** property of the
+{{domxref("HTMLLinkElement")}} interface represents a hint given to the browser
+on how it should prioritize the preload of the given resource relative to other
+resources of the same type.
+
+## Syntax
+
+```js
+var priority = HTMLLinkElement.fetchpriority
+HTMLLinkElement.fetchpriority = fetchpriority
+```
+
+### Values
+
+A {{domxref("DOMString")}} representing the priority hint. Possible values are:
+
+- **`high`**: Fetch the preload at a high priority relative to other resources
+  of the same type.
+- **`low`**: Fetch the image at a low priority relative to other resources of
+  the same type.
+- **`auto`**: Default mode, which indicates no preference for
+  the fetch priority. The browser decides what is best for the user.
+
+## Usage notes
+
+The `fetchpriority` property allows you to signal high or low priority preload
+fetches. This can be useful when applied to {{HTMLElement("link")}} elements
+to signal "important" preloads or less-important preloads to the user
+experience early in the loading process. It should be used sparingly for
+exceptional cases where the browser may not be able to infer the best way to
+load the resource automatically. Over-use can result in degrading performance.
+
+## Examples
+
+```js
+var preloadLink = document.createElement("link");
+preloadLink.href = "myimage.jpg";
+preloadLink.rel = "preload";
+preloadLink.as = "image";
+preloadLink.fetchpriority = "high";
+document.head.appendChild(preloadLink);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -25,6 +25,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : A string that corresponds to the CORS setting for this link element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
 - {{domxref("HTMLLinkElement.disabled")}}
   - : A boolean value which represents whether the link is disabled; currently only used with style sheet links.
+- {{domxref("HTMLLinkElement.fetchpriority")}}
+  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of a preload relative to other resources of the same type. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a higher priority, `low` to fetch at a lower priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLLinkElement.href")}}
   - : A string representing the URI for the target resource.
 - {{domxref("HTMLLinkElement.hreflang")}}

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -51,6 +51,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
     > **Note:** When inserted using the [`document.write()`](/en-US/docs/Web/API/Document/write) method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using [`innerHTML`](/en-US/docs/Web/API/Element/innerHTML) or [`outerHTML`](/en-US/docs/Web/API/Element/outerHTML), they do not execute at all.
 
+- {{domxref("HTMLScriptElement.fetchpriority")}}
+  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of an external script relative to other external scripts. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLScriptElement.noModule")}}
   - : Is a boolean value that if true, stops the script's execution in browsers that support [ES2015 modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) — used to run fallback scripts in older browsers that do _not_ support JavaScript modules.
 - {{domxref("HTMLScriptElement.referrerPolicy")}}

--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -42,6 +42,8 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
   - : Contains the request's method (`GET`, `POST`, etc.)
 - {{domxref("Request.mode")}} {{readonlyInline}}
   - : Contains the mode of the request (e.g., `cors`, `no-cors`, `same-origin`, `navigate`.)
+- {{domxref("Request.priority")}} {{readonlyInline}}
+  - : Contains the request's priority hint (e.g., `high`, `low`, `auto`).
 - {{domxref("Request.redirect")}} {{readonlyinline}}
   - : Contains the mode for how redirects are handled. It may be one of `follow`, `error`, or `manual`.
 - {{domxref("Request.referrer")}} {{readonlyInline}}

--- a/files/en-us/web/api/request/priority/index.md
+++ b/files/en-us/web/api/request/priority/index.md
@@ -1,0 +1,51 @@
+---
+title: Request.priority
+slug: Web/API/Request/priority
+tags:
+  - API
+  - Fetch
+  - Property
+  - Reference
+  - priority
+  - request
+browser-compat: api.Request.priority
+---
+{{APIRef("Fetch")}}
+
+The **`priority`** read-only property of the {{domxref("Request")}}
+interface contains the hinted priority of the request relative to other requests.
+
+## Syntax
+
+```js
+var myPriority = request.priority;
+```
+
+### Value
+
+A {{domxref("USVString")}} indicating the hinted priority of the request.
+
+## Example
+
+In the following snippet, we create a new request using the
+{{domxref("Request.Request", "Request()")}} constructor (for an API endpoint)
+at a low priority, then save the priority of the request in a variable:
+
+```js
+var myRequest = new Request('/background-api-call', {priority: 'low'});
+var myPriority = myRequest.priority; // "low"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API)
+- [HTTP access control (CORS)](/en-US/docs/Web/HTTP/CORS)
+- [HTTP](/en-US/docs/Web/HTTP)

--- a/files/en-us/web/api/request/priority/index.md
+++ b/files/en-us/web/api/request/priority/index.md
@@ -13,17 +13,20 @@ browser-compat: api.Request.priority
 {{APIRef("Fetch")}}
 
 The **`priority`** read-only property of the {{domxref("Request")}}
-interface contains the hinted priority of the request relative to other requests.
+interface contains the hinted priority of the request relative to other
+requests.
 
-## Syntax
-
-```js
-var myPriority = request.priority;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} indicating the hinted priority of the request.
+Possible values are:
+
+- **`high`**: Fetch the iframe document at a high priority relative to other
+  iframe documents.
+- **`low`**: Fetch the iframe document at a low priority relative to other
+  iframe documents.
+- **`auto`**: Default mode, which indicates no preference for
+  the fetch priority. The browser decides what is best for the user.
 
 ## Example
 

--- a/files/en-us/web/api/request/priority/index.md
+++ b/files/en-us/web/api/request/priority/index.md
@@ -21,10 +21,10 @@ requests.
 A {{domxref("USVString")}} indicating the hinted priority of the request.
 Possible values are:
 
-- **`high`**: Fetch the iframe document at a high priority relative to other
-  iframe documents.
-- **`low`**: Fetch the iframe document at a low priority relative to other
-  iframe documents.
+- **`high`**: Fetch the request at a high priority relative to other
+  requests of a similar type.
+- **`low`**: Fetch the request at a low priority relative to other
+  requests of a similar type.
 - **`auto`**: Default mode, which indicates no preference for
   the fetch priority. The browser decides what is best for the user.
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -103,6 +103,18 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("csp")}} {{experimental_inline}}
   - : A [Content Security Policy](/en-US/docs/Web/HTTP/CSP) enforced for the embedded resource. See {{domxref("HTMLIFrameElement.csp")}} for details.
+
+- {{htmlattrdef("fetchpriority")}}
+
+  - : Provides a hint of the relative priority to use when fetching the iframe document. Allowed values:
+
+    - `high`
+      - : Signal a high-priority fetch relative to other iframe documents.
+    - `low`
+      - : Signal a low-priority fetch relative to other iframe documents.
+    - `auto`
+      - : Default: Signal automatic determination of fetch priority relative to other iframe documents.
+
 - {{htmlattrdef("height")}}
   - : The height of the frame in CSS pixels. Default is `150`.
 - {{htmlattrdef("loading")}} {{experimental_inline}}

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -109,11 +109,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Provides a hint of the relative priority to use when fetching the iframe document. Allowed values:
 
     - `high`
-      - : Signal a high-priority fetch relative to other iframe documents.
+      - : Signals a high-priority fetch relative to other iframe documents.
     - `low`
-      - : Signal a low-priority fetch relative to other iframe documents.
+      - : Signals a low-priority fetch relative to other iframe documents.
     - `auto`
-      - : Default: Signal automatic determination of fetch priority relative to other iframe documents.
+      - : Default: Signals automatic determination of fetch priority relative to other iframe documents.
 
 - {{htmlattrdef("height")}}
   - : The height of the frame in CSS pixels. Default is `150`.

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -123,11 +123,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Provides a hint of the relative priority to use when fetching the image. Allowed values:
 
     - `high`
-      - : Signal a high-priority fetch relative to other images.
+      - : Signals a high-priority fetch relative to other images.
     - `low`
-      - : Signal a low-priority fetch relative to other images.
+      - : Signals a low-priority fetch relative to other images.
     - `auto`
-      - : Default: Signal automatic determination of fetch priority relative to other images.
+      - : Default: Signals automatic determination of fetch priority relative to other images.
 
 - {{htmlattrdef("height")}}
   - : The intrinsic height of the image, in pixels. Must be an integer without a unit.

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -118,6 +118,17 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `auto`
       - : Default: no preference for the decoding mode. The browser decides what is best for the user.
 
+- {{htmlattrdef("fetchpriority")}}
+
+  - : Provides a hint of the relative priority to use when fetching the image. Allowed values:
+
+    - `high`
+      - : Signal a high-priority fetch relative to other images.
+    - `low`
+      - : Signal a low-priority fetch relative to other images.
+    - `auto`
+      - : Default: Signal automatic determination of fetch priority relative to other images.
+
 - {{htmlattrdef("height")}}
   - : The intrinsic height of the image, in pixels. Must be an integer without a unit.
 - {{htmlattrdef("intrinsicsize")}} {{deprecated_inline}}

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -184,6 +184,17 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     Setting the `disabled` property in the DOM causes the stylesheet to be removed from the document's {{domxref("Document.styleSheets")}} list.
 
+- {{htmlattrdef("fetchpriority")}}
+
+  - : Provides a hint of the relative priority to use when fetching a preloaded resource. Allowed values:
+
+    - `high`
+      - : Signal a high-priority fetch relative to other resources of the same type.
+    - `low`
+      - : Signal a low-priority fetch relative to other resources of the same type.
+    - `auto`
+      - : Default: Signal automatic determination of fetch priority relative to other resources of the same type.
+
 - {{HTMLAttrDef("href")}}
   - : This attribute specifies the {{glossary("URL")}} of the linked resource. A URL can be absolute or relative.
 - {{HTMLAttrDef("hreflang")}}

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -189,11 +189,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Provides a hint of the relative priority to use when fetching a preloaded resource. Allowed values:
 
     - `high`
-      - : Signal a high-priority fetch relative to other resources of the same type.
+      - : Signals a high-priority fetch relative to other resources of the same type.
     - `low`
-      - : Signal a low-priority fetch relative to other resources of the same type.
+      - : Signals a low-priority fetch relative to other resources of the same type.
     - `auto`
-      - : Default: Signal automatic determination of fetch priority relative to other resources of the same type.
+      - : Default: Signals automatic determination of fetch priority relative to other resources of the same type.
 
 - {{HTMLAttrDef("href")}}
   - : This attribute specifies the {{glossary("URL")}} of the linked resource. A URL can be absolute or relative.

--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -111,6 +111,17 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     This attribute allows the elimination of **parser-blocking JavaScript** where the browser would have to load and evaluate scripts before continuing to parse. `async` has a similar effect in this case.
 
+- {{htmlattrdef("fetchpriority")}}
+
+  - : Provides a hint of the relative priority to use when fetching an external script. Allowed values:
+
+    - `high`
+      - : Signal a high-priority fetch relative to other external scripts..
+    - `low`
+      - : Signal a low-priority fetch relative to other external scripts.
+    - `auto`
+      - : Default: Signal automatic determination of fetch priority relative to other external scripts.
+
 - {{htmlattrdef("integrity")}}
   - : This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered free of unexpected manipulation. See [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity).
 - {{htmlattrdef("nomodule")}}

--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -116,11 +116,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Provides a hint of the relative priority to use when fetching an external script. Allowed values:
 
     - `high`
-      - : Signal a high-priority fetch relative to other external scripts..
+      - : Signals a high-priority fetch relative to other external scripts..
     - `low`
-      - : Signal a low-priority fetch relative to other external scripts.
+      - : Signals a low-priority fetch relative to other external scripts.
     - `auto`
-      - : Default: Signal automatic determination of fetch priority relative to other external scripts.
+      - : Default: Signals automatic determination of fetch priority relative to other external scripts.
 
 - {{htmlattrdef("integrity")}}
   - : This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered free of unexpected manipulation. See [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity).


### PR DESCRIPTION
#### Summary
Added documentation for the [priority hints](https://wicg.github.io/priority-hints/) attributes and properties. This touches the `iframe`, `image`, `script` and `link` elements (HTML and DOM API) as well as the `Request` object for the `fetch` API.

For the HTML elements, it adds a `fetchpriority` attribute for hinting at the importance of a given element fetch. For the fetch API, it exposes a `priority` property on the Request object (for the same purpose).

#### Motivation
[Priority hints](https://wicg.github.io/priority-hints/) was recently spec'd and is shipping [enabled by default in Chrome 101](https://chromestatus.com/feature/5273474901737472) (after running several origin trials over the last few years).

#### Supporting details
Spec: https://wicg.github.io/priority-hints/
Chrome status: https://chromestatus.com/feature/5273474901737472

#### Related issues
Part of the contributions for #14208

#### Metadata
- [x] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
