### PR TITLE
Mention the importance of fixed pos for WCO

### DIFF
--- a/files/en-us/web/css/env/index.md
+++ b/files/en-us/web/css/env/index.md
@@ -201,6 +201,8 @@ main {
 }
 ```
 
+> **Note:** Using `position:fixed` makes sure the header does not scroll with the rest of the content, and instead stays aligned with the window control buttons, even on device/browsers that support elastic overscroll (also known as rubber banding).
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
#### Summary
Added a note to raise awareness about the importance of using fixed positioning when using the Window Controls Overlay feature in a PWA.

#### Motivation
On device/browser pairs that support elastic overscroll, it's important to use fixed positioning for the part of your PWA that positioned with the WCO variables.

Fixed positioned elements do not participate in the elastic overscroll behavior and will therefore stay aligned with the window control buttons.

#### Supporting details
Chromium recently changed `position:fixed` elements to stay out of elastic overscroll: https://chromium-review.googlesource.com/c/chromium/src/+/3537711

Safari on iOS already has this behavior (not sure about macOS though).