### PR TITLE
clarification: space separate values

### DIFF
--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -106,8 +106,7 @@ p {
 
 {{Compat}}
 
-- [CSS Tricks: Hanging punctuation](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
 ## See also
 
 - {{cssxref('text-indent')}}
+- [CSS Tricks: Hanging punctuation](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)

--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -41,7 +41,7 @@ hanging-punctuation: unset;
 
 ## Syntax
 
-The `hanging-punctuation` property may be specified with one, two, or three values.
+The `hanging-punctuation` property may be specified with one, two, or three space-separated values.
 
 - **One-value** syntax uses any one of the keyword values in the list below.
 - **Two-value** syntax uses one of the following:

--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -107,3 +107,7 @@ p {
 {{Compat}}
 
 - [CSS Tricks: Hanging punctuation](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+## See also
+
+- {{cssxref('text-indent')}}


### PR DESCRIPTION
Added clarifying language that multi-keyword values should be space-separated.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error