### PR TITLE
ResizeObserver(): Add `optional` to `observer` parameter for callback

### DIFF
--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.md
@@ -33,7 +33,7 @@ new ResizeObserver(callback)
     - `entries`
       - : An array of {{domxref('ResizeObserverEntry')}} objects that can be used to
         access the new dimensions of the element after each change.
-    - `observer`
+    - `observer`{{optional_inline}}
       - : A reference to the `ResizeObserver` itself, so it will definitely be
         accessible from inside the callback, should you need it. This could be used for
         example to automatically unobserve the observer when a certain condition is


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This pull request edits the documentation for the [ResizeObserver() constructor](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver). It adds the word `optional` next to the `observer` parameter for the callback function.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This helps readers know at a glance that `observer` is an optional parameter. It may also help readers who are confused why the example on this page or elsewhere doesn't pass an `observer` argument. 
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
On this very page (documentation for ResizeObserver() constructor), under `Parameters > callback > observer`, it says `"you can omit it if you don't need it"`. This supports that the `observer` parameter is optional and that we should add the `optional` signifier.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
