### PR TITLE
WebAPI: Clean syntax from property pages, part 3

### DIFF
--- a/files/en-us/web/api/cssskew/ax/index.md
+++ b/files/en-us/web/api/cssskew/ax/index.md
@@ -18,13 +18,7 @@ The **`ax`** property of the
 {{domxref("CSSSkew")}} interface gets and sets the angle used to distort the element
 along the x-axis (or abscissa).
 
-## Syntax
-
-```js
-var skewax = CSSSkew.ax;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSNumericValue")}}.
 

--- a/files/en-us/web/api/cssskew/ay/index.md
+++ b/files/en-us/web/api/cssskew/ay/index.md
@@ -18,13 +18,7 @@ The **`ay`** property of the
 {{domxref("CSSSkew")}} interface gets and sets the angle used to distort the element
 along the y-axis (or ordinate).
 
-## Syntax
-
-```js
-var skeway = CSSSkew.ay;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSNumericValue")}}.
 

--- a/files/en-us/web/api/cssskewx/ax/index.md
+++ b/files/en-us/web/api/cssskewx/ax/index.md
@@ -18,13 +18,7 @@ The **`ax`** property of the
 {{domxref("CSSSkewX")}} interface gets and sets the angle used to distort the element
 along the x-axis (or abscissa).
 
-## Syntax
-
-```js
-var skewax = CSSSkewX.ax;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSNumericValue")}}.
 

--- a/files/en-us/web/api/cssskewy/ay/index.md
+++ b/files/en-us/web/api/cssskewy/ay/index.md
@@ -18,13 +18,7 @@ The **`ay`** property of the
 {{domxref("CSSSkewY")}} interface gets and sets the angle used to distort the element
 along the y-axis (or ordinate).
 
-## Syntax
-
-```js
-var skeway = CSSSkewY.ay;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSNumericValue")}}.
 

--- a/files/en-us/web/api/cssstylerule/selectortext/index.md
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.md
@@ -13,14 +13,7 @@ browser-compat: api.CSSStyleRule.selectorText
 
 The **`selectorText`** property of the {{domxref("CSSStyleRule")}} interface gets and sets the selectors associated with the `CSSStyleRule`.
 
-## Syntax
-
-```js
-var text = CSSStyleRule.selectorText;
-CSSStyleRule.selectorText = text;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}}.
 

--- a/files/en-us/web/api/cssstylerule/style/index.md
+++ b/files/en-us/web/api/cssstylerule/style/index.md
@@ -13,13 +13,7 @@ browser-compat: api.CSSStyleRule.style
 
 The read-only **`style`** property is the {{ domxref("CSSStyleDeclaration") }} interface for the [declaration block](https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block) of the {{ DOMXref("CSSStyleRule") }}.
 
-## Syntax
-
-```js
-styleObj = cssRule.style
-```
-
-### Value
+## Value
 
 A {{domxref("CSSStyleDeclaration")}} object, with the following properties:
 

--- a/files/en-us/web/api/cssstylesheet/cssrules/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssrules/index.md
@@ -23,13 +23,7 @@ provides a real-time, up-to-date list of every CSS rule which comprises the
 stylesheet. Each item in the list is a {{domxref("CSSRule")}} defining a single
 rule.
 
-## Syntax
-
-```js
-var rules = cssStyleSheet.cssRules;
-```
-
-### Value
+## Value
 
 A live-updating {{domxref("CSSRuleList")}} containing each of the CSS rules making up
 the stylesheet. Each entry in the rule list is a {{domxref("CSSRule")}} object

--- a/files/en-us/web/api/cssstylesheet/ownerrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/ownerrule/index.md
@@ -26,13 +26,7 @@ corresponding to the {{cssxref("@import")}} at-rule which imported the styleshee
 the document. If the stylesheet wasn't imported into the document using
 `@import`, the returned value is `null`.
 
-## Syntax
-
-```js
-var ownerRule = cssStyleSheet.ownerRule;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSImportRule")}} corresponding to the {{cssxref("@import")}} rule which
 imported the stylesheet into the document. If the stylesheet wasn't imported into the

--- a/files/en-us/web/api/cssstylesheet/rules/index.md
+++ b/files/en-us/web/api/cssstylesheet/rules/index.md
@@ -31,13 +31,7 @@ stylesheet.
 > While `rules` is unlikely to be removed soon, its availability is not as
 > widespread and using it will result in compatibility problems for your site or app.
 
-## Syntax
-
-```js
-var rules = cssStyleSheet.rules;
-```
-
-### Value
+## Value
 
 A live-updating {{domxref("CSSRuleList")}} containing each of the CSS rules making up
 the stylesheet. Each entry in the rule list is a {{domxref("CSSRule")}} object

--- a/files/en-us/web/api/csstransition/transitionproperty/index.md
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.md
@@ -16,13 +16,7 @@ The **`transitionProperty`** property of the
 name** of the transition. This is the longhand CSS property for which the
 transition was generated.
 
-## Syntax
-
-```js
-const transitionProperty = CSSAnimation.transitionProperty;
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}}.
 

--- a/files/en-us/web/api/csstranslate/x/index.md
+++ b/files/en-us/web/api/csstranslate/x/index.md
@@ -18,13 +18,7 @@ The **`x`** property of the
 {{domxref("CSSTranslate")}} interface gets and sets the abscissa or x-axis of the
 translating vector.
 
-## Syntax
-
-```js
-var translateX = CSSTranslate.x;
-```
-
-### Value
+## Value
 
 A {{cssxref('length-percentage')}}
 

--- a/files/en-us/web/api/csstranslate/y/index.md
+++ b/files/en-us/web/api/csstranslate/y/index.md
@@ -18,13 +18,7 @@ The **`y`** property of the
 {{domxref("CSSTranslate")}} interface gets and sets the ordinate or y-axis of the
 translating vector.
 
-## Syntax
-
-```js
-var translateY = CSSTranslate.y;
-```
-
-### Value
+## Value
 
 A {{cssxref('length-percentage')}}
 

--- a/files/en-us/web/api/csstranslate/z/index.md
+++ b/files/en-us/web/api/csstranslate/z/index.md
@@ -22,13 +22,7 @@ farther away.
 If this value is present then the transform is a 3D transform and the `is2D`
 property will be set to false.
 
-## Syntax
-
-```js
-var translateZ = CSSTranslate.z;
-```
-
-### Value
+## Value
 
 A {{cssxref('length')}}.
 

--- a/files/en-us/web/api/cssunitvalue/unit/index.md
+++ b/files/en-us/web/api/cssunitvalue/unit/index.md
@@ -18,13 +18,7 @@ The **`CSSUnitValue.unit`** read-only property
 of the {{domxref("CSSUnitValue")}} interface returns a {{jsxref('USVString')}}
 indicating the type of unit.
 
-## Syntax
-
-```js
-var aString = CSSUnitValue.unit;
-```
-
-### Value
+## Value
 
 A {{jsxref('USVString')}}.
 

--- a/files/en-us/web/api/cssunitvalue/value/index.md
+++ b/files/en-us/web/api/cssunitvalue/value/index.md
@@ -17,14 +17,7 @@ browser-compat: api.CSSUnitValue.value
 The **`CSSUnitValue.value`** property of the
 {{domxref("CSSUnitValue")}} interface returns a double indicating the number of units.
 
-## Syntax
-
-```js
-var cssUnitValue = CSSUnitValue.value;
-CSSUnitValue.value = cssUnitValue;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/cssunparsedvalue/length/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.md
@@ -19,13 +19,7 @@ browser-compat: api.CSSUnparsedValue.length
 The **`length`** read-only property of the
 {{domxref("CSSUnparsedValue")}} interface returns the number of items in the object.
 
-## Syntax
-
-```js
-var length = CSSUnparsedValue.length;
-```
-
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -23,13 +23,7 @@ interface represents the current computed CSS property value.
 > - the untyped [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model), widely supported, or
 > - the modern [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API), less supported and considered experimental.
 
-## Syntax
-
-```js
-cssText = cssValue.cssText;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the current CSS property value.
 

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.md
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.md
@@ -25,13 +25,7 @@ property value.
 > - the untyped [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model), widely supported, or
 > - the modern [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API), less supported and considered experimental.
 
-## Syntax
-
-```js
-cssValueType = cssValue.cssValueType;
-```
-
-### Value
+## Value
 
 An `unsigned short` representing a code defining the type of the value.
 Possible values are:

--- a/files/en-us/web/api/cssvaluelist/length/index.md
+++ b/files/en-us/web/api/cssvaluelist/length/index.md
@@ -27,13 +27,7 @@ in the list. The range of valid values of the indices is `0` to
 > - the untyped [CSS Object Model](CSS_Object_Model), widely supported, or
 > - the modern [CSS Typed Object Model API](CSS_Typed_OM_API), less supported and considered experimental.
 
-## Syntax
-
-```js
-var length = cssValueList.length;
-```
-
-### Value
+## Value
 
 An `unsigned long` representing the number of {{domxref("CSSValue")}}s.
 

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
@@ -18,13 +18,7 @@ The **`fallback`** read-only property of the
 {{domxref("CSSVariableReferenceValue")}} interface returns the [custom
 property fallback value](/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values) of the {{domxref("CSSVariableReferenceValue")}}.
 
-## Syntax
-
-```js
-var fallback = cssVariableReferenceValue.fallback;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSUnparsedValue')}}.
 

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
@@ -18,13 +18,7 @@ The **`variable`** property of the
 {{domxref("CSSVariableReferenceValue")}} interface returns the [custom property name](/en-US/docs/Web/CSS/--*) of the
 {{domxref("CSSVariableReferenceValue")}}.
 
-## Syntax
-
-```js
-var variable = cssVariableReferenceValue.variable;
-```
-
-### Value
+## Value
 
 A {{domxref('USVString')}} beginning with `--` (that is, a [custom property name](/en-US/docs/Web/CSS/--*)).
 

--- a/files/en-us/web/api/datatransferitemlist/length/index.md
+++ b/files/en-us/web/api/datatransferitemlist/length/index.md
@@ -20,13 +20,7 @@ The read-only **`length`** property of the
 {{domxref("DataTransferItemList")}} interface returns the number of items currently in
 the drag item list.
 
-## Syntax
-
-```js
-length = DataTransferItemList.length;
-```
-
-### Value
+## Value
 
 The number of drag data items in the list, or 0 if the list is empty or disabled. The
 drag item list is considered to be disabled if the item list's

--- a/files/en-us/web/api/decompressionstream/readable/index.md
+++ b/files/en-us/web/api/decompressionstream/readable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.DecompressionStream.readable
 
 The **`readable`** read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("ReadableStream")}}.
 
-## Syntax
-
-```js
-let stream = DecompressionStream.readable;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/decompressionstream/writable/index.md
+++ b/files/en-us/web/api/decompressionstream/writable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.DecompressionStream.writable
 
 The **`writable`** read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("WritableStream")}}.
 
-## Syntax
-
-```js
-let writableStream = DecompressionStream.writable;
-```
-
-### Value
+## Value
 
 A {{domxref("WritableStream")}}.
 

--- a/files/en-us/web/api/deprecationreportbody/anticipatedremoval/index.md
+++ b/files/en-us/web/api/deprecationreportbody/anticipatedremoval/index.md
@@ -13,13 +13,7 @@ browser-compat: api.DeprecationReportBody.anticipatedRemoval
 
 The **`anticipatedRemoval`** read-only property of the {{domxref("DeprecationReportBody")}} interface returns the date that the browser version which removes the feature will ship. This value can be used to prioritize warnings. If this property returns `null` because the date is unknown, then the deprecation should be considered low priority.
 
-## Syntax
-
-```js
-let anticipatedRemoval = DeprecationReportBody.anticipatedRemoval;
-```
-
-### Value
+## Value
 
 A {{jsxref("date")}} object, or `null` if the date is not known.
 

--- a/files/en-us/web/api/deprecationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/deprecationreportbody/columnnumber/index.md
@@ -15,13 +15,7 @@ The **`columnNumber`** read-only property of the {{domxref("DeprecationReportBod
 
 > **Note:** This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} and {{domxref("DeprecationReportBody.lineNumber")}} as it enables the location of the column in that file and line where the error occurred.
 
-## Syntax
-
-```js
-let columnNumber = DeprecationReportBody.columnNumber;
-```
-
-### Value
+## Value
 
 An integer, or `null` if the column is not known.
 

--- a/files/en-us/web/api/deprecationreportbody/id/index.md
+++ b/files/en-us/web/api/deprecationreportbody/id/index.md
@@ -13,13 +13,7 @@ browser-compat: api.DeprecationReportBody.id
 
 The **`id`** read-only property of the {{domxref("DeprecationReportBody")}} interface returns a string representing the feature or API that is deprecated. This can be used to group or count related reports.
 
-## Syntax
-
-```js
-let id = DeprecationReportBody.id;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}.
 

--- a/files/en-us/web/api/deprecationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/deprecationreportbody/linenumber/index.md
@@ -15,13 +15,7 @@ The **`lineNumber`** read-only property of the {{domxref("DeprecationReportBody"
 
 > **Note:** This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} as it enables the location of the line in that file where the error occurred.
 
-## Syntax
-
-```js
-let lineNumber = DeprecationReportBody.lineNumber;
-```
-
-### Value
+## Value
 
 An integer, or `null` if the line is not known.
 

--- a/files/en-us/web/api/deprecationreportbody/message/index.md
+++ b/files/en-us/web/api/deprecationreportbody/message/index.md
@@ -13,13 +13,7 @@ browser-compat: api.DeprecationReportBody.message
 
 The **`message`** read-only property of the {{domxref("DeprecationReportBody")}} interface returns a human-readable description of the deprecation. This typically matches the message a browser will display in its DevTools console regarding a deprecated feature.
 
-## Syntax
-
-```js
-let message = DeprecationReportBody.message;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}.
 

--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
@@ -15,13 +15,7 @@ The **`sourceFile`** read-only property of the {{domxref("DeprecationReportBody"
 
 > **Note:** This property can be used with {{domxref("DeprecationReportBody.lineNumber")}} and {{domxref("DeprecationReportBody.columnNumber")}} to locate the column and line in the file where the error occurred.
 
-## Syntax
-
-```js
-let sourceFile = DeprecationReportBody.sourceFile;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}, or `null` if the path is not known.
 

--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -33,13 +33,7 @@ aren't text input elements are not typically focusable by default.
 > the same thing as selection (the currently highlighted part of the document). You can
 > get the current selection using {{domxref("window.getSelection()")}}.
 
-## Syntax
-
-```js
-element = document.activeElement
-```
-
-### Value
+## Value
 
 The {{domxref('Element')}} which currently has focus, {{HTMLElement("body")}} or
 `null` if there is no focused element.

--- a/files/en-us/web/api/document/all/index.md
+++ b/files/en-us/web/api/document/all/index.md
@@ -19,13 +19,7 @@ property returns an {{DOMxRef("HTMLAllCollection")}} rooted at the document node
 other words, it returns all of the document's elements, accessible by order (like an
 array) and by ID (like a regular object).
 
-## Syntax
-
-```js
-var htmlAllCollection = document.all;
-```
-
-### Value
+## Value
 
 An {{DOMxRef("HTMLAllCollection")}} which contains every element in the document.
 

--- a/files/en-us/web/api/document/anchors/index.md
+++ b/files/en-us/web/api/document/anchors/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Document.anchors
 The **`anchors`** read-only property of the
 {{domxref("Document")}} interface returns a list of all of the anchors in the document.
 
-## Syntax
-
-```js
-nodeList = document.anchors;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}}.
 

--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -20,13 +20,7 @@ interface returns a list of the applets within a document.
 > 2015](https://bugs.chromium.org/p/chromium/issues/detail?id=470301). Since then, calling `document.applets` in those browsers always
 > returns an empty {{domxref("HTMLCollection")}}. Removal is being considered in [WebKit](https://bugs.webkit.org/show_bug.cgi?id=157926) and [Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11946645/).
 
-## Syntax
-
-```js
-var nodeList = document.applets;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}}.
 

--- a/files/en-us/web/api/document/compatmode/index.md
+++ b/files/en-us/web/api/document/compatmode/index.md
@@ -15,13 +15,7 @@ The **`Document.compatMode`** read-only property indicates
 whether the document is rendered in [Quirks mode](/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode) or
 Standards mode.
 
-## Syntax
-
-```js
-const mode = document.compatMode
-```
-
-### Value
+## Value
 
 An enumerated value that can be:
 

--- a/files/en-us/web/api/document/contenttype/index.md
+++ b/files/en-us/web/api/document/contenttype/index.md
@@ -21,13 +21,7 @@ performed by either the browser or extensions.
 > **Note:** This property is unaffected by {{HTMLElement("meta")}}
 > elements.
 
-## Syntax
-
-```js
-contentType = document.contentType;
-```
-
-### Value
+## Value
 
 `contentType` is a read-only property.
 

--- a/files/en-us/web/api/document/designmode/index.md
+++ b/files/en-us/web/api/document/designmode/index.md
@@ -21,14 +21,7 @@ this standard. The earlier versions of Chrome and IE default to `"inherit"`.
 Starting in Chrome 43, the default is `"off"` and `"inherit"` is
 no longer supported. In IE6-10, the value is capitalized.
 
-## Syntax
-
-```js
-var mode = document.designMode;
-document.designMode = value;
-```
-
-### Value
+## Value
 
 A string indicating whether `designMode` is (or should be) set to on or off.
 Valid values are `on` and `off`.

--- a/files/en-us/web/api/document/embeds/index.md
+++ b/files/en-us/web/api/document/embeds/index.md
@@ -15,13 +15,7 @@ The **`embeds`** read-only property of the
 {{domxref("Document")}} interface returns a list of the embedded
 {{htmlelement("embed")}} elements within the current document.
 
-## Syntax
-
-```js
-nodeList = document.embeds
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}}.
 

--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -19,13 +19,7 @@ all the {{HTMLElement("form")}} elements contained in the document.
 > **Note:** Similarly, you can access a list of a form's component user
 > input elements using the {{domxref("HTMLFormElement.elements")}} property.
 
-## Syntax
-
-```js
-collection = document.forms;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}} object listing all of the document's forms. Each item
 in the collection is a {{domxref("HTMLFormElement")}} representing a single

--- a/files/en-us/web/api/document/fullscreen/index.md
+++ b/files/en-us/web/api/document/fullscreen/index.md
@@ -22,13 +22,7 @@ Although this property is read-only, it will not throw if it is modified (even i
 
 > **Note:** Since this property is deprecated, you can determine if fullscreen mode is active on the document by checking to see if {{DOMxRef("Document.fullscreenElement")}} is not `null`.
 
-## Syntax
-
-```js
-var isFullScreen = document.fullscreen;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the document is currently displaying an element in fullscreen mode; otherwise, the value is `false.`
 

--- a/files/en-us/web/api/document/fullscreenenabled/index.md
+++ b/files/en-us/web/api/document/fullscreenenabled/index.md
@@ -28,13 +28,7 @@ attribute set.
 Although this property is read-only, it will not throw if it is modified (even in
 strict mode); the setter is a no-operation and it will be ignored.
 
-## Syntax
-
-```js
-var isFullscreenAvailable = document.fullscreenEnabled;
-```
-
-### Value
+## Value
 
 A boolean value which is `true` if the document and the
 elements within can be placed into fullscreen mode by calling

--- a/files/en-us/web/api/document/head/index.md
+++ b/files/en-us/web/api/document/head/index.md
@@ -15,13 +15,7 @@ The **`head`** read-only property of
 the {{domxref("Document")}} interface returns the {{HTMLElement("head")}} element of
 the current document.
 
-## Syntax
-
-```js
-var objRef = document.head;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLHeadElement")}}.
 

--- a/files/en-us/web/api/document/images/index.md
+++ b/files/en-us/web/api/document/images/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Document.images
 The **`images`** read-only property of
 the {{domxref("Document")}} interface returns a [collection](/en-US/docs/Web/API/HTMLCollection) of the [images](/en-US/docs/Web/API/HTMLImageElement/Image) in the current HTML document.
 
-## Syntax
-
-```js
-var imageCollection = document.images;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}} providing a live list of all of the images contained
 in the current document. Each entry in the collection is an

--- a/files/en-us/web/api/document/links/index.md
+++ b/files/en-us/web/api/document/links/index.md
@@ -13,13 +13,7 @@ browser-compat: api.Document.links
 
 The **`links`** read-only property of the {{domxref("Document")}} interface returns a collection of all {{HTMLElement("area")}} elements and {{HTMLElement("a")}} elements in a document with a value for the [href](/en-US/docs/Web/API/URLUtils.href) attribute.
 
-## Syntax
-
-```js
-nodeList = document.links
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}}.
 

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.md
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.md
@@ -26,13 +26,7 @@ otherwise by a [Feature-Policy](/en-US/docs/Web/HTTP/Headers/Feature-Policy/pict
 Although this property is read-only, it will not throw if it is modified (even in
 strict mode); the setter is a no-operation and will be ignored.
 
-## Syntax
-
-```js
-let isPictureInPictureAvailable = document.pictureInPictureEnabled;
-```
-
-### Value
+## Value
 
 A boolean value, which is `true` if a video can enter
 picture-in-picture and be displayed in a floating window by calling

--- a/files/en-us/web/api/document/plugins/index.md
+++ b/files/en-us/web/api/document/plugins/index.md
@@ -19,13 +19,7 @@ containing one or more {{domxref("HTMLEmbedElement")}}s representing the
 > **Note:** For a list of installed plugins, use [Navigator.plugins](/en-US/docs/Web/API/Navigator/plugins)
 > instead.
 
-## Syntax
-
-```js
-embedArrayObj = document.plugins
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}}.
 

--- a/files/en-us/web/api/document/readystate/index.md
+++ b/files/en-us/web/api/document/readystate/index.md
@@ -16,13 +16,7 @@ state of the {{domxref("document")}}.
 When the value of this property changes, a {{event("readystatechange")}} event fires on
 the {{domxref("document")}} object.
 
-## Syntax
-
-```js
-let string = document.readyState;
-```
-
-### Values
+## Values
 
 The `readyState` of a document can be one of following:
 

--- a/files/en-us/web/api/document/referrer/index.md
+++ b/files/en-us/web/api/document/referrer/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Document.referrer
 The **`Document.referrer`** property returns the [URI](https://www.w3.org/Addressing/#background) of the page that linked to
 this page.
 
-## Syntax
-
-```js
-var referrer = document.referrer;
-```
-
-### Value
+## Value
 
 The value is an empty string if the user navigated to the page directly (not through a
 link, but, for example, by using a bookmark). Because this property returns only a

--- a/files/en-us/web/api/document/scripts/index.md
+++ b/files/en-us/web/api/document/scripts/index.md
@@ -16,13 +16,7 @@ interface returns a list of the {{HTMLElement("script")}}
 elements in the document. The returned object is an
 {{domxref("HTMLCollection")}}.
 
-## Syntax
-
-```js
-var scriptList = document.scripts;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}}. You can use this just like an array to get all the
 elements in the list.

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -26,14 +26,7 @@ The time values for this timeline are calculated as a fixed offset from the glob
 
 > **Note:** A document timeline that is associated with a non-active document is also considered to be **inactive**.
 
-## Syntax
-
-```js
-var pageTimeline = document.timeline;
-var thisMoment = pageTimeline.currentTime;
-```
-
-### Value
+## Value
 
 A {{domxref("DocumentTimeline")}} object.
 

--- a/files/en-us/web/api/domexception/code/index.md
+++ b/files/en-us/web/api/domexception/code/index.md
@@ -18,13 +18,7 @@ the [error code constants](/en-US/docs/Web/API/DOMException#error_names), or
 exceptions don't use this anymore: they put this info in the
 {{domxref("DOMException.name")}} attribute.
 
-## Syntax
-
-```js
-var domExceptionCode = domExceptionInstance.code;
-```
-
-### Value
+## Value
 
 A short number.
 

--- a/files/en-us/web/api/domexception/message/index.md
+++ b/files/en-us/web/api/domexception/message/index.md
@@ -15,13 +15,7 @@ The **`message`** read-only property of the
 {{domxref("DOMException")}} interface returns a {{ domxref("DOMString") }} representing
 a message or description associated with the given [error name](/en-US/docs/Web/API/DOMException#error_names).
 
-## Syntax
-
-```js
-var domExceptionMessage = domExceptionInstance.message;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/domexception/name/index.md
+++ b/files/en-us/web/api/domexception/name/index.md
@@ -16,13 +16,7 @@ The **`name`** read-only property of the
 {{domxref("DOMException")}} interface returns a {{domxref("DOMString")}} that contains
 one of the strings associated with an [error name](/en-US/docs/Web/API/DOMException#error_names).
 
-## Syntax
-
-```js
-var domExceptionName = domExceptionInstance.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/dompoint/w/index.md
+++ b/files/en-us/web/api/dompoint/w/index.md
@@ -20,13 +20,7 @@ The **`DOMPoint`** interface's
 **`w`** property holds the point's perspective value, w, for a
 point in space.
 
-## Syntax
-
-```js
-var perspective = DOMPoint.w;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the _w_ perspective value for
 the point. This value is **unrestricted**, meaning that it is allowed to be

--- a/files/en-us/web/api/dompoint/x/index.md
+++ b/files/en-us/web/api/dompoint/x/index.md
@@ -24,13 +24,7 @@ In general, positive values `x` mean to the right,
 and negative values of `x` means to the left, barring any transforms that may
 have altered the orientation of the axes.
 
-## Syntax
-
-```js
-var xPos = DOMPoint.x;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the x coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be

--- a/files/en-us/web/api/dompoint/y/index.md
+++ b/files/en-us/web/api/dompoint/y/index.md
@@ -23,13 +23,7 @@ for a point in space.
 Unless transforms have been applied to alter the
 orientation, the value of `y` increases downward and decreases upward.
 
-## Syntax
-
-```js
-var yPos = DOMPoint.y;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the _y_ coordinate's value
 for the point. This value is **unrestricted**, meaning that it is allowed

--- a/files/en-us/web/api/dompoint/z/index.md
+++ b/files/en-us/web/api/dompoint/z/index.md
@@ -26,13 +26,7 @@ Unless transforms have changed the orientation, a `z` of 0 is
 the plane of the screen, with positive values extending outward toward the user from the
 screen, and negative values receding into the distance behind the screen.
 
-## Syntax
-
-```js
-var zPos = DOMPoint.z;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the _z_ coordinate's value
 for the point. This value is **unrestricted**, meaning that it is allowed

--- a/files/en-us/web/api/domrectreadonly/bottom/index.md
+++ b/files/en-us/web/api/domrectreadonly/bottom/index.md
@@ -15,13 +15,7 @@ browser-compat: api.DOMRectReadOnly.bottom
 
 The **`bottom`** read-only property of the **`DOMRectReadOnly`** interface returns the bottom coordinate value of the `DOMRect.` (Has the same value as `y + height`, or `y` if `height` is negative.)
 
-## Syntax
-
-```js
-var recBottom = DOMRect.bottom;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/height/index.md
+++ b/files/en-us/web/api/domrectreadonly/height/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.height
 
 The **`height`** read-only property of the **`DOMRectReadOnly`** interface represents the height of the `DOMRect`.
 
-## Syntax
-
-```js
-var recHeight = DOMRect.height;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/left/index.md
+++ b/files/en-us/web/api/domrectreadonly/left/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.left
 
 The **`left`** read-only property of the **`DOMRectReadOnly`** interface returns the left coordinate value of the `DOMRect.` (Has the same value as `x`, or `x + width` if `width` is negative.)
 
-## Syntax
-
-```js
-var recLeft = DOMRect.left;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/right/index.md
+++ b/files/en-us/web/api/domrectreadonly/right/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.right
 
 The **`right`** read-only property of the **`DOMRectReadOnly`** interface returns the right coordinate value of the `DOMRect.` (Has the same value as `x + width`, or `x` if `width` is negative.)
 
-## Syntax
-
-```js
-var recRight = DOMRect.right;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/top/index.md
+++ b/files/en-us/web/api/domrectreadonly/top/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.top
 
 The **`top`** read-only property of the **`DOMRectReadOnly`** interface returns the top coordinate value of the `DOMRect.` (Has the same value as `y`, or `y + height` if `height` is negative.)
 
-## Syntax
-
-```js
-var recTop = DOMRect.top;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/width/index.md
+++ b/files/en-us/web/api/domrectreadonly/width/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.width
 
 The **`width`** read-only property of the **`DOMRectReadOnly`** interface represents the width of the `DOMRect`.
 
-## Syntax
-
-```js
-var recWidth = DOMRect.width;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/x/index.md
+++ b/files/en-us/web/api/domrectreadonly/x/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.x
 
 The **`x`** read-only property of the **`DOMRectReadOnly`** interface represents the x coordinate of the `DOMRect`'s origin.
 
-## Syntax
-
-```js
-var recX = DOMRect.x;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/domrectreadonly/y/index.md
+++ b/files/en-us/web/api/domrectreadonly/y/index.md
@@ -14,13 +14,7 @@ browser-compat: api.DOMRectReadOnly.y
 
 The **`y`** read-only property of the **`DOMRectReadOnly`** interface represents the y coordinate of the `DOMRect`'s origin.
 
-## Syntax
-
-```js
-var recY = DOMRect.y;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaAtomic
 
 The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.
 
-## Syntax
-
-```js
-var ariaAtomic = element.ariaAtomic;
-element.ariaAtomic = ariaAtomic
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariaautocomplete/index.md
+++ b/files/en-us/web/api/element/ariaautocomplete/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaAutoComplete
 
 The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 
-## Syntax
-
-```js
-var ariaAutoComplete = element.ariaAutoComplete;
-element.ariaAutoComplete = ariaAutoComplete
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaBusy
 
 The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 
-## Syntax
-
-```js
-var ariaBusy = element.ariaBusy;
-element.ariaBusy = ariaBusy
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -17,14 +17,7 @@ The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects 
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaChecked = element.ariaChecked;
-element.ariaChecked = ariaChecked
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaColCount
 
 The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 
-## Syntax
-
-```js
-var ariaColCount = element.ariaColCount;
-element.ariaColCount = ariaColCount
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/ariacolindex/index.md
+++ b/files/en-us/web/api/element/ariacolindex/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaColIndex
 
 The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 
-## Syntax
-
-```js
-var ariaColIndex = element.ariaColIndex;
-element.ariaColIndex = ariaColIndex
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaColIndexText
 
 The **`ariaColIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 
-## Syntax
-
-```js
-var ariaColIndexText = element.ariaColIndexText;
-element.ariaColIndexText = ariaColIndexText
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/ariacolspan/index.md
+++ b/files/en-us/web/api/element/ariacolspan/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaColSpan
 
 The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
-## Syntax
-
-```js
-var ariaColSpan = element.ariaColSpan;
-element.ariaColSpan = ariaColSpan
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/element/ariacurrent/index.md
+++ b/files/en-us/web/api/element/ariacurrent/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaCurrent
 
 The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 
-## Syntax
-
-```js
-var ariaCurrent = element.ariaCurrent;
-element.ariaCurrent = ariaCurrent
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariadescription/index.md
+++ b/files/en-us/web/api/element/ariadescription/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaDescription
 
 The **`ariaDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 
-## Syntax
-
-```js
-var ariaDescription = element.ariaDescription;
-element.ariaDescription = ariaDescription
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -17,14 +17,7 @@ The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects
 
 > **Note:** Where possible, use the {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element —  because those elements have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaDisabled = element.ariaDisabled;
-element.ariaDisabled = ariaDisabled
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariaexpanded/index.md
+++ b/files/en-us/web/api/element/ariaexpanded/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaExpanded
 
 The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 
-## Syntax
-
-```js
-var ariaExpanded = element.ariaExpanded;
-element.ariaExpanded = ariaExpanded
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaHasPopup
 
 The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 
-## Syntax
-
-```js
-var ariaHasPopup = element.ariaHasPopup;
-element.ariaHasPopup = ariaHasPopup
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariahidden/index.md
+++ b/files/en-us/web/api/element/ariahidden/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaHidden
 
 The **`ariaHidden`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)) attribute, which indicates whether the element is exposed to an accessibility API.
 
-## Syntax
-
-```js
-var ariaHidden = element.ariaHidden;
-element.ariaHidden = ariaHidden
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaKeyShortcuts
 
 The **`ariaKeyShortcuts`** property of the {{domxref("Element")}} interface reflects the value of the `aria-keyshortcuts` attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 
-## Syntax
-
-```js
-var ariaKeyShortcuts = element.ariaKeyShortcuts;
-element.ariaKeyShortcuts = ariaKeyShortcuts
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/arialabel/index.md
+++ b/files/en-us/web/api/element/arialabel/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaLabel
 
 The **`ariaLabel`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current element.
 
-## Syntax
-
-```js
-var ariaLabel = element.ariaLabel;
-element.ariaLabel = ariaLabel
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/arialevel/index.md
+++ b/files/en-us/web/api/element/arialevel/index.md
@@ -17,14 +17,7 @@ The **`ariaLevel`** property of the {{domxref("Element")}} interface reflects th
 
 > **Note:** Where possible use an HTML {{htmlelement("h1")}} or other correct heading level as these have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaLevel = element.ariaLevel;
-element.ariaLevel = ariaLevel
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer.
 

--- a/files/en-us/web/api/element/arialive/index.md
+++ b/files/en-us/web/api/element/arialive/index.md
@@ -14,14 +14,7 @@ browser-compat: api.Element.ariaLive
 
 The **`ariaLive`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
-## Syntax
-
-```js
-var ariaLive = element.ariaLive;
-element.ariaLive = ariaLive
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariamodal/index.md
+++ b/files/en-us/web/api/element/ariamodal/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaModal
 
 The **`ariaModal`** property of the {{domxref("Element")}} interface reflects the value of the `aria-modal` attribute, which indicates whether an element is modal when displayed. Applying the `aria-modal` property to an element with `role="dialog"` replaces the technique of using aria-hidden on the background for informing assistive technologies that content outside a dialog is inert.
 
-## Syntax
-
-```js
-var ariaModal = element.ariaModal;
-element.ariaModal = ariaModal
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -17,14 +17,7 @@ The **`ariaMultiline`** property of the {{domxref("Element")}} interface reflect
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaMultiline = element.ariaMultiline;
-element.ariaMultiline = ariaMultiline
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -17,14 +17,7 @@ The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface r
 
 > **Note:** Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaMultiSelectable = element.ariaMultiSelectable;
-element.ariaMultiSelectable = ariaMultiSelectable
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariaorientation/index.md
+++ b/files/en-us/web/api/element/ariaorientation/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaOrientation
 
 The **`ariaOrientation`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 
-## Syntax
-
-```js
-var ariaOrientation = element.ariaOrientation;
-element.ariaOrientation = ariaOrientation
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariaplaceholder/index.md
+++ b/files/en-us/web/api/element/ariaplaceholder/index.md
@@ -17,14 +17,7 @@ The **`ariaPlaceholder`** property of the {{domxref("Element")}} interface refle
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaPlaceholder = element.ariaPlaceholder;
-element.ariaPlaceholder = ariaPlaceholder
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaPosInSet
 
 The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 
-## Syntax
-
-```js
-var ariaPosInSet = element.ariaPosInSet;
-element.ariaPosInSet = ariaPosInSet
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer.
 

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -17,14 +17,7 @@ The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects 
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaPressed = element.ariaPressed;
-element.ariaPressed = ariaPressed
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -17,14 +17,7 @@ The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaReadOnly = element.ariaReadOnly;
-element.ariaReadOnly = ariaReadOnly
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariarelevant/index.md
+++ b/files/en-us/web/api/element/ariarelevant/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaRelevant
 
 The **`ariaRelevant`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 
-## Syntax
-
-```js
-var ariaRelevant = element.ariaRelevant;
-element.ariaRelevant = ariaRelevant
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing one or more of the following values, space separated:
 

--- a/files/en-us/web/api/element/ariarequired/index.md
+++ b/files/en-us/web/api/element/ariarequired/index.md
@@ -17,14 +17,7 @@ The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects
 
 > **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
-## Syntax
-
-```js
-var ariaRequired = element.ariaRequired;
-element.ariaRequired = ariaRequired
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaRoleDescription
 
 The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 
-## Syntax
-
-```js
-var ariaRoleDescription = element.ariaRoleDescription;
-element.ariaRoleDescription = ariaRoleDescription
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaRowCount
 
 The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 
-## Syntax
-
-```js
-var ariaRowCount = element.ariaRowCount;
-element.ariaRowCount = ariaRowCount
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/element/ariarowindex/index.md
+++ b/files/en-us/web/api/element/ariarowindex/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaRowIndex
 
 The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
-## Syntax
-
-```js
-var ariaRowIndex = element.ariaRowIndex;
-element.ariaRowIndex = ariaRowIndex
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaRowIndexText
 
 The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 
-## Syntax
-
-```js
-var ariaRowIndexText = element.ariaRowIndexText;
-element.ariaRowIndexText = ariaRowIndexText
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/ariarowspan/index.md
+++ b/files/en-us/web/api/element/ariarowspan/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaRowSpan
 
 The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
-## Syntax
-
-```js
-var ariaRowSpan = element.ariaRowSpan;
-element.ariaRowSpan = ariaRowSpan
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/element/ariaselected/index.md
+++ b/files/en-us/web/api/element/ariaselected/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaSelected
 
 The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 
-## Syntax
-
-```js
-var ariaSelected = element.ariaSelected;
-element.ariaSelected = ariaSelected
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariasetsize/index.md
+++ b/files/en-us/web/api/element/ariasetsize/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaSetSize
 
 The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 
-## Syntax
-
-```js
-var ariaSetSize = element.ariaSetSize;
-element.ariaSetSize = ariaSetSize
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer.
 


### PR DESCRIPTION
@teoli2003 

## Summary
Sequel of #14195 .
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
