### PR TITLE
WebAPI: Clean syntax from property pages, part 4

### DIFF
--- a/files/en-us/web/api/element/ariasort/index.md
+++ b/files/en-us/web/api/element/ariasort/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaSort
 
 The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 
-## Syntax
-
-```js
-var ariaSort = element.ariaSort;
-element.ariaSort = ariaSort
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/element/ariavaluemax/index.md
+++ b/files/en-us/web/api/element/ariavaluemax/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaValueMax
 
 The **`ariaValueMax`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute, which defines the maximum allowed value for a range widget.
 
-## Syntax
-
-```js
-var ariaValueMax = element.ariaValueMax;
-element.ariaValueMax = ariaValueMax
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains a number.
 

--- a/files/en-us/web/api/element/ariavaluemin/index.md
+++ b/files/en-us/web/api/element/ariavaluemin/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaValueMin
 
 The **`ariaValueMin`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) attribute, which defines the minimum allowed value for a range widget.
 
-## Syntax
-
-```js
-var ariaValueMin = element.ariaValueMin;
-element.ariaValueMin = ariaValueMin
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains a number.
 

--- a/files/en-us/web/api/element/ariavaluenow/index.md
+++ b/files/en-us/web/api/element/ariavaluenow/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaValueNow
 
 The **`ariaValueNow`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 
-## Syntax
-
-```js
-var ariaValueNow = element.ariaValueNow;
-element.ariaValueNow = ariaValueNow
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains a number.
 

--- a/files/en-us/web/api/element/ariavaluetext/index.md
+++ b/files/en-us/web/api/element/ariavaluetext/index.md
@@ -15,14 +15,7 @@ browser-compat: api.Element.ariaValueText
 
 The **`ariaValueText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
-## Syntax
-
-```js
-var ariaValueText = element.ariaValueText;
-element.ariaValueText = ariaValueText
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/assignedslot/index.md
+++ b/files/en-us/web/api/element/assignedslot/index.md
@@ -18,13 +18,7 @@ property of the {{domxref("Element")}} interface returns an
 {{domxref("HTMLSlotElement")}} representing the {{htmlelement("slot")}} element the
 node is inserted in.
 
-## Syntax
-
-```js
-var slotElement = elementInstance.assignedSlot
-```
-
-### Value
+## Value
 
 An {{domxref('HTMLSlotElement')}} instance, or `null` if the element is not
 assigned to a slot, or if the associated shadow root was attached with its

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -21,15 +21,7 @@ within the element.
 To insert the HTML into the document rather than replace the contents of an element,
 use the method {{domxref("Element.insertAdjacentHTML", "insertAdjacentHTML()")}}.
 
-## Syntax
-
-```js
-const content = element.innerHTML;
-
-element.innerHTML = content;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the HTML serialization of the element's
 descendants. Setting the value of `innerHTML` removes all of the element's

--- a/files/en-us/web/api/element/openorclosedshadowroot/index.md
+++ b/files/en-us/web/api/element/openorclosedshadowroot/index.md
@@ -28,13 +28,7 @@ property represents the shadow root hosted by the element, regardless if its
 Use {{DOMxRef("Element.attachShadow()")}} to add a shadow
 root to an existing element.
 
-## Syntax
-
-```js
-var shadowroot = element.openOrClosedShadowRoot;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("ShadowRoot")}} object instance, regardless if its
 {{DOMxRef("ShadowRoot.mode", "mode")}} is set to `open` or

--- a/files/en-us/web/api/element/outerhtml/index.md
+++ b/files/en-us/web/api/element/outerhtml/index.md
@@ -26,15 +26,7 @@ To only obtain the HTML representation of the contents of an element, or to repl
 contents of an element, use the {{domxref("Element.innerHTML", "innerHTML")}} property
 instead.
 
-## Syntax
-
-```js
-var content = element.outerHTML;
-
-element.outerHTML = htmlString;
-```
-
-### Value
+## Value
 
 Reading the value of `outerHTML` returns a {{domxref("DOMString")}}
 containing an HTML serialization of the `element` and its descendants.

--- a/files/en-us/web/api/element/scrollheight/index.md
+++ b/files/en-us/web/api/element/scrollheight/index.md
@@ -29,13 +29,7 @@ fit without a need for vertical scrollbar, its `scrollHeight` is equal to
 > **Note:** This property will round the value to an integer. If you need a fractional value, use
 > {{domxref("Element.getBoundingClientRect()")}}.
 
-## Syntax
-
-```js
-elemScrollHeight = element.scrollHeight;
-```
-
-### Value
+## Value
 
 An integer corresponding to the scrollHeight pixel value of the element.
 

--- a/files/en-us/web/api/element/shadowroot/index.md
+++ b/files/en-us/web/api/element/shadowroot/index.md
@@ -17,13 +17,7 @@ represents the shadow root hosted by the element.
 
 Use {{DOMxRef("Element.attachShadow()")}} to add a shadow root to an existing element.
 
-## Syntax
-
-```js
-var shadowroot = element.shadowRoot;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("ShadowRoot")}} object instance, or `null` if the associated
 shadow root was attached with its {{DOMxRef("ShadowRoot.mode", "mode")}} set to

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -19,14 +19,7 @@ A slot is a placeholder inside a [web
 component](/en-US/docs/Web/Web_Components) that users can fill with their own markup (see [Using templates and
 slots](/en-US/docs/Web/Web_Components/Using_templates_and_slots) for more information).
 
-## Syntax
-
-```js
-var aString = element.slot
-element.slot = aString
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -24,13 +24,7 @@ For example, if the element is an {{HTMLElement("img")}}, its
 `tagName` property is `"IMG"` (for HTML documents; it may be cased
 differently for XML/XHTML documents).
 
-## Syntax
-
-```js
-elementName = Element.tagName;
-```
-
-### Value
+## Value
 
 A string indicating the element's tag name. This string's capitalization depends on the
 document type:

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -17,14 +17,7 @@ The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface r
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaAtomic = ElementInternals.ariaAtomic;
-ElementInternals.ariaAtomic = ariaAtomic;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -17,14 +17,7 @@ The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} inter
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaAutoComplete = ElementInternals.ariaAutoComplete;
-ElementInternals.ariaAutoComplete = ariaAutoComplete;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -17,14 +17,7 @@ The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface ref
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaBusy = ElementInternals.ariaBusy;
-ElementInternals.ariaBusy = ariaBusy;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -17,14 +17,7 @@ The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface 
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaChecked = ElementInternals.ariaChecked;
-ElementInternals.ariaChecked = ariaChecked;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -17,14 +17,7 @@ The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaColCount = ElementInternals.ariaColCount;
-ElementInternals.ariaColCount = ariaColCount;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -17,14 +17,7 @@ The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaColIndex = ElementInternals.ariaColIndex;
-ElementInternals.ariaColIndex = ariaColIndex;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -17,14 +17,7 @@ The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} inter
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaColIndexText = ElementInternals.ariaColIndexText;
-ElementInternals.ariaColIndexText = ariaColIndexText;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -17,14 +17,7 @@ The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface 
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaColSpan = ElementInternals.ariaColSpan;
-ElementInternals.ariaColSpan = ariaColSpan;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -17,14 +17,7 @@ The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface 
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaCurrent = ElementInternals.ariaCurrent;
-ElementInternals.ariaCurrent = ariaCurrent;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -17,14 +17,7 @@ The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interf
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaDescription = ElementInternals.ariaDescription;
-ElementInternals.ariaDescription = ariaDescription;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -17,14 +17,7 @@ The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaDisabled = ElementInternals.ariaDisabled;
-ElementInternals.ariaDisabled = ariaDisabled;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -17,14 +17,7 @@ The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaExpanded = ElementInternals.ariaExpanded;
-ElementInternals.ariaExpanded = ariaExpanded;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -17,14 +17,7 @@ The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaHasPopup = ElementInternals.ariaHasPopup;
-ElementInternals.ariaHasPopup = ariaHasPopup;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariahidden/index.md
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.md
@@ -17,14 +17,7 @@ The **`ariaHidden`** property of the {{domxref("ElementInternals")}} interface r
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaHidden = ElementInternals.ariaHidden;
-ElementInternals.ariaHidden = ariaHidden;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -17,14 +17,7 @@ The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} inter
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaKeyShortcuts = ElementInternals.ariaKeyShortcuts;
-ElementInternals.ariaKeyShortcuts = ariaKeyShortcuts;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -17,14 +17,7 @@ The **`ariaLabel`** property of the {{domxref("ElementInternals")}} interface re
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaLabel = ElementInternals.ariaLabel;
-ElementInternals.ariaLabel = ariaLabel;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -17,14 +17,7 @@ The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface re
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaLevel = ElementInternals.ariaLevel;
-ElementInternals.ariaLevel = ariaLevel;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer.
 

--- a/files/en-us/web/api/elementinternals/arialive/index.md
+++ b/files/en-us/web/api/elementinternals/arialive/index.md
@@ -16,14 +16,7 @@ The **`ariaLive`** property of the {{domxref("ElementInternals")}} interface ref
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaLive = ElementInternals.ariaLive;
-ElementInternals.ariaLive = ariaLive;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -17,14 +17,7 @@ The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface re
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaModal = ElementInternals.ariaModal;
-ElementInternals.ariaModal = ariaModal;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -17,14 +17,7 @@ The **`ariaMultiline`** property of the {{domxref("ElementInternals")}} interfac
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaMultiline = ElementInternals.ariaMultiline;
-ElementInternals.ariaMultiline = ariaMultiline;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -17,14 +17,7 @@ The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} in
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaMultiSelectable = ElementInternals.ariaMultiSelectable;
-ElementInternals.ariaMultiSelectable = ariaMultiSelectable;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.md
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.md
@@ -17,14 +17,7 @@ The **`ariaOrientation`** property of the {{domxref("ElementInternals")}} interf
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaOrientation = ElementInternals.ariaOrientation;
-ElementInternals.ariaOrientation = ariaOrientation;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -17,14 +17,7 @@ The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interf
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaPlaceholder = ElementInternals.ariaPlaceholder;
-ElementInternals.ariaPlaceholder = ariaPlaceholder;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -17,14 +17,7 @@ The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaPosInSet = ElementInternals.ariaPosInSet;
-ElementInternals.ariaPosInSet = ariaPosInSet;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer.
 

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -17,14 +17,7 @@ The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface 
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaPressed = ElementInternals.ariaPressed;
-ElementInternals.ariaPressed = ariaPressed;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -17,14 +17,7 @@ The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaReadOnly = ElementInternals.ariaReadOnly;
-ElementInternals.ariaReadOnly = ariaReadOnly;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -17,14 +17,7 @@ The **`ariaRelevant`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRelevant = ElementInternals.ariaRelevant;
-ElementInternals.ariaRelevant = ariaRelevant;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing one or more of the following values, space separated:
 

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -17,14 +17,7 @@ The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRequired = ElementInternals.ariaRequired;
-ElementInternals.ariaRequired = ariaRequired;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -17,14 +17,7 @@ The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface r
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRoleDescription = ElementInternals.ariaRoleDescription;
-ElementInternals.ariaRoleDescription = ariaRoleDescription;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -17,14 +17,7 @@ The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRowCount = ElementInternals.ariaRowCount;
-ElementInternals.ariaRowCount = ariaRowCount;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -17,14 +17,7 @@ The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRowIndex = ElementInternals.ariaRowIndex;
-ElementInternals.ariaRowIndex = ariaRowIndex;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -17,14 +17,7 @@ The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} inter
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRowIndexText = ElementInternals.ariaRowIndexText;
-ElementInternals.ariaRowIndexText = ariaRowIndexText;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -17,14 +17,7 @@ The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface 
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaRowSpan = ElementInternals.ariaRowSpan;
-ElementInternals.ariaRowSpan = ariaRowSpan;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an integer.
 

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -17,14 +17,7 @@ The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaSelected = ElementInternals.ariaSelected;
-ElementInternals.ariaSelected = ariaSelected;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -17,14 +17,7 @@ The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface 
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaSetSize = ElementInternals.ariaSetSize;
-ElementInternals.ariaSetSize = ariaSetSize;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer.
 

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -17,14 +17,7 @@ The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface ref
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaSort = ElementInternals.ariaSort;
-ElementInternals.ariaSort = ariaSort;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} with one of the following values:
 

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.md
@@ -17,14 +17,7 @@ The **`ariaValueMax`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaValueMax = ElementInternals.ariaValueMax;
-ElementInternals.ariaValueMax = ariaValueMax;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains a number.
 

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.md
@@ -17,14 +17,7 @@ The **`ariaValueMin`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaValueMin = ElementInternals.ariaValueMin;
-ElementInternals.ariaValueMin = ariaValueMin;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains a number.
 

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.md
@@ -17,14 +17,7 @@ The **`ariaValueNow`** property of the {{domxref("ElementInternals")}} interface
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaValueNow = ElementInternals.ariaValueNow;
-ElementInternals.ariaValueNow = ariaValueNow;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains a number.
 

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.md
@@ -17,14 +17,7 @@ The **`ariaValueText`** property of the {{domxref("ElementInternals")}} interfac
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
-## Syntax
-
-```js
-let ariaValueText = ElementInternals.ariaValueText;
-ElementInternals.ariaValueText = ariaValueText;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ElementInternals.role
 
 The **`role`** read-only property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles) for the element. For example, a checkbox might have [`role="checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)
 
-## Syntax
-
-```js
-let role = ElementInternals.role;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains an ARIA role. A full list of ARIA roles can be found on the [ARIA techniques page](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques).
 

--- a/files/en-us/web/api/elementinternals/shadowroot/index.md
+++ b/files/en-us/web/api/elementinternals/shadowroot/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ElementInternals.shadowRoot
 
 The **`shadowRoot`** read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("ShadowRoot")}} for this element.
 
-## Syntax
-
-```js
-let shadowRoot = ElementInternals.shadowRoot;
-```
-
-### Value
+## Value
 
 A {{domxref("ShadowRoot")}} if the element has a shadow root, otherwise `null`.
 

--- a/files/en-us/web/api/elementinternals/states/index.md
+++ b/files/en-us/web/api/elementinternals/states/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ElementInternals.states
 
 The **`states`** read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("CustomStateSet")}} representing the possible states of the custom element.
 
-## Syntax
-
-```js
-let states = ElementInternals.states;
-```
-
-### Value
+## Value
 
 A {{domxref("CustomStateSet")}} which is a {{jsxref("Set")}} of strings.
 

--- a/files/en-us/web/api/elementinternals/validationmessage/index.md
+++ b/files/en-us/web/api/elementinternals/validationmessage/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ElementInternals.validationMessage
 
 The **`validationMessage`** read-only property of the {{domxref("ElementInternals")}} interface returns the validation message for the element.
 
-## Syntax
-
-```js
-let validationMessage = ElementInternals.validationMessage;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing the validation message of this element.
 

--- a/files/en-us/web/api/elementinternals/validity/index.md
+++ b/files/en-us/web/api/elementinternals/validity/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ElementInternals.validity
 
 The **`validity`** read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("ValidityState")}} object which represents the different validity states the element can be in, with respect to constraint validation.
 
-## Syntax
-
-```js
-let validity = ElementInternals.validity;
-```
-
-### Value
+## Value
 
 A {{domxref("ValidityState")}} object.
 

--- a/files/en-us/web/api/eventsource/readystate/index.md
+++ b/files/en-us/web/api/eventsource/readystate/index.md
@@ -16,13 +16,7 @@ The **`readyState`** read-only property of the
 {{domxref("EventSource")}} interface returns a number representing the state of the
 connection.
 
-## Syntax
-
-```js
-var myReadyState = eventSource.readyState;
-```
-
-### Value
+## Value
 
 A number representing the state of the connection. Possible values are:
 

--- a/files/en-us/web/api/eventsource/url/index.md
+++ b/files/en-us/web/api/eventsource/url/index.md
@@ -16,13 +16,7 @@ The **`url`** read-only property of the
 {{domxref("EventSource")}} interface returns a {{domxref("DOMString")}} representing the
 URL of the source.
 
-## Syntax
-
-```js
-var myUrl = eventSource.url;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the URL of the source.
 

--- a/files/en-us/web/api/eventsource/withcredentials/index.md
+++ b/files/en-us/web/api/eventsource/withcredentials/index.md
@@ -16,13 +16,7 @@ The **`withCredentials`** read-only property of the
 {{domxref("EventSource")}} interface returns a boolean value indicating whether
 the `EventSource` object was instantiated with CORS credentials set.
 
-## Syntax
-
-```js
-var myWithCredentials = eventSource.withCredentials;
-```
-
-### Value
+## Value
 
 A boolean value indicating whether the `EventSource` object was
 instantiated with CORS credentials set (`true`), or not (`false`,

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ExtendableCookieChangeEvent.changed
 
 The **`changed`** read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been changed by the given `ExtendableCookieChangeEvent` instance.
 
-## Syntax
-
-```js
-var array = ExtendableCookieChangeEvent.changed;
-```
-
-### Value
+## Value
 
 An array of objects containing the changed cookie(s). Each object contains the following properties:
 

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -13,13 +13,7 @@ browser-compat: api.ExtendableCookieChangeEvent.deleted
 
 The **`deleted`** read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been deleted by the given `ExtendableCookieChangeEvent` instance.
 
-## Syntax
-
-```js
-var array = ExtendableCookieChangeEvent.deleted;
-```
-
-### Value
+## Value
 
 An array of objects containing the deleted cookie(s). Each object contains the following properties:
 

--- a/files/en-us/web/api/extendablemessageevent/data/index.md
+++ b/files/en-us/web/api/extendablemessageevent/data/index.md
@@ -17,13 +17,7 @@ The **`data`** read-only property of the
 {{domxref("ExtendableMessageEvent")}} interface returns the event's data. It can be any
 data type.
 
-## Syntax
-
-```js
-var myData = extendableMessageEvent.data;
-```
-
-### Value
+## Value
 
 Any data type.
 

--- a/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
+++ b/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
@@ -17,13 +17,7 @@ The **`lastEventID`** read-only property of the
 {{domxref("ExtendableMessageEvent")}} interface represents, in [server-sent
 events](/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events), the last event ID of the event source. This is an empty string.
 
-## Syntax
-
-```js
-var myLastEventId = extendableMessageEvent.lastEventId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/extendablemessageevent/origin/index.md
+++ b/files/en-us/web/api/extendablemessageevent/origin/index.md
@@ -17,13 +17,7 @@ The **`origin`** read-only property of the
 {{domxref("ExtendableMessageEvent")}} interface returns the origin of the
 {{domxref("Client")}} that sent the message.
 
-## Syntax
-
-```js
-var myOrigin = extendableMessageEvent.origin;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/extendablemessageevent/ports/index.md
+++ b/files/en-us/web/api/extendablemessageevent/ports/index.md
@@ -18,13 +18,7 @@ The **`ports`** read-only property of the
 {{domxref("MessagePort")}} objects representing the ports of the associated message
 channel (the channel the message is being sent through.)
 
-## Syntax
-
-```js
-var myPorts = extendableMessageEvent.ports;
-```
-
-### Value
+## Value
 
 An array of {{domxref("MessagePort")}} objects.
 

--- a/files/en-us/web/api/extendablemessageevent/source/index.md
+++ b/files/en-us/web/api/extendablemessageevent/source/index.md
@@ -17,13 +17,7 @@ The **`source`** read-only property of the
 {{domxref("ExtendableMessageEvent")}} interface returns a reference to the
 {{domxref("Client")}} object from which the message was sent.
 
-## Syntax
-
-```js
-var mySource = extendableMessageEvent.source;
-```
-
-### Value
+## Value
 
 A {{domxref("Client")}}, {{domxref("ServiceWorker")}} or {{domxref("MessagePort")}}
 object.

--- a/files/en-us/web/api/federatedcredential/protocol/index.md
+++ b/files/en-us/web/api/federatedcredential/protocol/index.md
@@ -20,13 +20,7 @@ The **`protocol`** property of the
 property is {{jsxref("null")}}, the protocol may be inferred from the
 {{domxref("FederatedCredential.provider")}} property.
 
-## Syntax
-
-```js
-var protocol = FederatedCredential.protocol
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing a credential's federated identity protocol (e.g.
 `openidconnect`).

--- a/files/en-us/web/api/federatedcredential/provider/index.md
+++ b/files/en-us/web/api/federatedcredential/provider/index.md
@@ -17,13 +17,7 @@ The **`provider`** property of the
 {{domxref("FederatedCredential")}} interface returns a {{domxref("USVString")}}
 containing a credential's federated identity provider.
 
-## Syntax
-
-```js
-var provider = FederatedCredential.provider
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a credential's federated identity provider.
 

--- a/files/en-us/web/api/fetchevent/clientid/index.md
+++ b/files/en-us/web/api/fetchevent/clientid/index.md
@@ -20,13 +20,7 @@ current service worker is controlling.
 The {{domxref("Clients.get()")}} method could then be passed this ID to retrieve the
 associated client.
 
-## Syntax
-
-```js
-var myClientId = fetchEvent.clientId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} that represents the client ID.
 

--- a/files/en-us/web/api/fetchevent/isreload/index.md
+++ b/files/en-us/web/api/fetchevent/isreload/index.md
@@ -22,13 +22,7 @@ dispatched by the user attempting to reload the page, and `false` otherwise.
 Pressing the refresh button is a reload while clicking a link and pressing the back
 button is not.
 
-## Syntax
-
-```js
-var reloaded = FetchEvent.isReload
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/fetchevent/replacesclientid/index.md
+++ b/files/en-us/web/api/fetchevent/replacesclientid/index.md
@@ -27,13 +27,7 @@ Additionally, if the fetch isn't a navigation, `replacesClientId` will be an
 empty string. This could be used to access/communicate with a client that will
 imminently be replaced, right before a navigation.
 
-## Syntax
-
-```js
-var myReplacedClientId = fetchEvent.replacesClientId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/fetchevent/request/index.md
+++ b/files/en-us/web/api/fetchevent/request/index.md
@@ -23,13 +23,7 @@ This property is non-nullable (since version 46, in the case of Firefox.) If a r
 is not provided by some other means, the constructor `init` object must
 contain a request (see {{domxref("FetchEvent.FetchEvent", "FetchEvent()")}}.)
 
-## Syntax
-
-```js
-var recentRequest = fetchEvent.request;
-```
-
-### Value
+## Value
 
 A {{domxref("Request")}} object.
 

--- a/files/en-us/web/api/fetchevent/resultingclientid/index.md
+++ b/files/en-us/web/api/fetchevent/resultingclientid/index.md
@@ -26,13 +26,7 @@ If the fetch request is a subresource request or the request's
 [`destination`](/en-US/docs/Web/API/Request/destination) is
 `report`, `resultingClientId` will be an empty string.
 
-## Syntax
-
-```js
-var myResultingClientId = fetchEvent.resultingClientId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/file/webkitrelativepath/index.md
+++ b/files/en-us/web/api/file/webkitrelativepath/index.md
@@ -21,13 +21,7 @@ contains a {{domxref("USVString")}} which specifies the file's path relative to 
 directory selected by the user in an {{HTMLElement("input")}} element with its
 {{htmlattrxref("webkitdirectory", "input")}} attribute set.
 
-## Syntax
-
-```js
-relativePath = File.webkitRelativePath
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing the path of the file relative to the ancestor
 directory the user selected.

--- a/files/en-us/web/api/filesystem/name/index.md
+++ b/files/en-us/web/api/filesystem/name/index.md
@@ -19,13 +19,7 @@ The read-only **`name`** property of the
 {{domxref("USVString")}} is unique among all file systems currently exposed by the [File and Directory Entries
 API](/en-US/docs/Web/API/File_and_Directory_Entries_API).
 
-## Syntax
-
-```js
-var fsName = FileSystem.name;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} representing the file system's name.
 

--- a/files/en-us/web/api/filesystem/root/index.md
+++ b/files/en-us/web/api/filesystem/root/index.md
@@ -19,13 +19,7 @@ The read-only **`root`** property of the
 object representing the root directory of the file system, for use with the [File and Directory Entries
 API](/en-US/docs/Web/API/File_and_Directory_Entries_API).
 
-## Syntax
-
-```js
-var rootDirEnt = FileSystem.root;
-```
-
-### Value
+## Value
 
 A {{domxref("FileSystemDirectoryEntry")}} representing the file system's root
 directory.

--- a/files/en-us/web/api/filesystementry/filesystem/index.md
+++ b/files/en-us/web/api/filesystementry/filesystem/index.md
@@ -19,13 +19,7 @@ property of the {{domxref("FileSystemEntry")}} interface contains a
 {{domxref("FileSystem")}} object that represents the file system on which the entry
 resides.
 
-## Syntax
-
-```js
-var filesystem = FileSystemEntry.filesystem;
-```
-
-### Value
+## Value
 
 A {{domxref("FileSystem")}} representing the file system on which the file or directory
 described by the `FileSystemEntry` is located..

--- a/files/en-us/web/api/filesystementry/fullpath/index.md
+++ b/files/en-us/web/api/filesystementry/fullpath/index.md
@@ -22,13 +22,7 @@ by the entry.
 This can also be thought of as a path which is relative to the root directory, with a
 "/" prepended to it to make it absolute.
 
-## Syntax
-
-```js
-var fullPath = FileSystemEntry.fullPath;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} indicating the entry's full path.
 

--- a/files/en-us/web/api/filesystementry/isdirectory/index.md
+++ b/files/en-us/web/api/filesystementry/isdirectory/index.md
@@ -27,13 +27,7 @@ entry is a file.
 > both `isDirectory` and `isFile` as needed to ensure that the
 > entry is something you know how to work with.
 
-## Syntax
-
-```js
-var isDirectory = FileSystemEntry.isDirectory;
-```
-
-### Value
+## Value
 
 A Boolean indicating whether or not the {{domxref("FileSystemEntry")}} is a directory.
 

--- a/files/en-us/web/api/filesystementry/isfile/index.md
+++ b/files/en-us/web/api/filesystementry/isfile/index.md
@@ -27,13 +27,7 @@ if the entry is a directory.
 > both `isDirectory` and `isFile` as needed to ensure that the
 > entry is something you know how to work with.
 
-## Syntax
-
-```js
-var isFile = FileSystemEntry.isFile;
-```
-
-### Value
+## Value
 
 A Boolean indicating whether or not the {{domxref("FileSystemEntry")}} is a file.
 

--- a/files/en-us/web/api/filesystementry/name/index.md
+++ b/files/en-us/web/api/filesystementry/name/index.md
@@ -19,13 +19,7 @@ specifying the entry's name; this is the entry within its parent directory (the 
 component of the path as indicated by the {{domxref("FileSystemEntry.fullPath",
     "fullPath")}} property).
 
-## Syntax
-
-```js
-var name = FileSystemEntry.name;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} indicating the entry's name.
 

--- a/files/en-us/web/api/filesystemhandle/kind/index.md
+++ b/files/en-us/web/api/filesystemhandle/kind/index.md
@@ -19,13 +19,7 @@ The **`kind`** read-only property of the
 used to distinguish files from directories when iterating over the contents of a
 directory.
 
-## Syntax
-
-```js
-var FileSystemHandleKind = FileSystemHandle.kind;
-```
-
-### Value
+## Value
 
 - _FileSystemHandleKind_
 

--- a/files/en-us/web/api/filesystemhandle/name/index.md
+++ b/files/en-us/web/api/filesystemhandle/name/index.md
@@ -16,13 +16,7 @@ The **`name`** read-only property of the
 {{domxref("FileSystemHandle")}} interface returns the name of the entry represented by
 handle.
 
-## Syntax
-
-```js
-var String = FileSystemHandle.name;
-```
-
-### Value
+## Value
 
 {{domxref('USVString')}}
 

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -13,14 +13,7 @@ browser-compat: api.FontFace.ascentOverride
 
 The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
 
-## Syntax
-
-```js
-let ascentOverride = FontFace.ascentOverride;
-FontFace.ascentOverride = '90%';
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString","string")}}.
 

--- a/files/en-us/web/api/fontface/descentoverride/index.md
+++ b/files/en-us/web/api/fontface/descentoverride/index.md
@@ -13,14 +13,7 @@ browser-compat: api.FontFace.descentOverride
 
 The **`descentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
 
-## Syntax
-
-```js
-let descentOverride = FontFace.descentOverride;
-FontFace.descentOverride = '90%';
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString","string")}}.
 

--- a/files/en-us/web/api/fontface/display/index.md
+++ b/files/en-us/web/api/fontface/display/index.md
@@ -33,14 +33,7 @@ below.)
   - : If the font face still is not loaded, the fallback font will be shown and no swap
     will occur.
 
-## Syntax
-
-```js
-let display = FontFace.display
-FontFace.display = display
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString")}} with one of the following values.
 

--- a/files/en-us/web/api/fontface/featuresettings/index.md
+++ b/files/en-us/web/api/fontface/featuresettings/index.md
@@ -19,14 +19,7 @@ The **`featureSettings`** property of the
 are not available from a font's variant properties. It is equivalent to the
 {{cssxref("@font-face/font-feature-settings", "font-feature-settings")}} descriptor.
 
-## Syntax
-
-```js
-let featureSettingDescriptor = FontFace.featureSettings;
-FontFace.featureSettings = featureSettingDescriptor;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing a descriptor.
 

--- a/files/en-us/web/api/fontface/linegapoverride/index.md
+++ b/files/en-us/web/api/fontface/linegapoverride/index.md
@@ -13,14 +13,7 @@ browser-compat: api.FontFace.lineGapOverride
 
 The **`lineGapOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
 
-## Syntax
-
-```js
-let lineGapOverride = FontFace.lineGapOverride;
-FontFace.lineGapOverride = '90%';
-```
-
-### Value
+## Value
 
 A {{domxref("CSSOMString","string")}}.
 

--- a/files/en-us/web/api/fontface/loaded/index.md
+++ b/files/en-us/web/api/fontface/loaded/index.md
@@ -19,13 +19,7 @@ The **`loaded`** read-only property of the
 current `FontFace` object when the font specified in the object's constructor
 is done loading or rejects with a `SyntaxError`.
 
-## Syntax
-
-```js
-let promise = FontFace.loaded;
-```
-
-### Value
+## Value
 
 A {{jsxref('Promise')}} that resolves with the current `FontFace` object.
 

--- a/files/en-us/web/api/fontface/status/index.md
+++ b/files/en-us/web/api/fontface/status/index.md
@@ -19,13 +19,7 @@ The **`status`** read-only property of the
 the font, one of `"unloaded"`, `"loading"`, `"loaded"`,
 or `"error"`.
 
-## Syntax
-
-```js
-let status = FontFace.status;
-```
-
-### Value
+## Value
 
 One of `"unloaded"`, `"loading"`, `"loaded"`, or
 `"error"`.

--- a/files/en-us/web/api/fontface/stretch/index.md
+++ b/files/en-us/web/api/fontface/stretch/index.md
@@ -18,14 +18,7 @@ The **`stretch`** property of the
 {{domxref("FontFace")}} interface retrieves or sets how the font stretches. It is
 equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor.
 
-## Syntax
-
-```js
-let stretchDescriptor = FontFace.stretch;
-FontFace.stretch = stretchDescriptor;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing a descriptor as it would be defined in a style
 sheet's `@font-face` rule.

--- a/files/en-us/web/api/fontface/style/index.md
+++ b/files/en-us/web/api/fontface/style/index.md
@@ -18,14 +18,7 @@ The **`style`** property of the
 {{domxref("FontFace")}} interface retrieves or sets the font's style. It is equivalent
 to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.
 
-## Syntax
-
-```js
-let style = FontFace.style;
-FontFace.style = value;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing the descriptors defined in the style sheet's
 `@font-face` rule.

--- a/files/en-us/web/api/fontface/unicoderange/index.md
+++ b/files/en-us/web/api/fontface/unicoderange/index.md
@@ -19,14 +19,7 @@ The **`unicodeRange`** property of the
 encompassing the font. It is equivalent to the {{cssxref("@font-face/unicode-range",
   "unicode-range")}} descriptor.
 
-## Syntax
-
-```js
-let unicodeRangeDescriptor = FontFace.unicodeRange;
-FontFace.unicodeRange = unicodeRangeDescriptor;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing a descriptor as it would appear in a style
 sheet's `@font-face` rule.

--- a/files/en-us/web/api/fontface/variant/index.md
+++ b/files/en-us/web/api/fontface/variant/index.md
@@ -19,14 +19,7 @@ The **`variant`** property of the
 values. It is equivalent to the {{cssxref("@font-face/font-variant", "font-variant")}}
 descriptor.
 
-## Syntax
-
-```js
-var variantSubProperty = FontFace.variant;
-FontFace.variant = variantSubProperty;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing a descriptor as it would be defined in a style
 sheet's `@font-face` rule.

--- a/files/en-us/web/api/fontface/variationsettings/index.md
+++ b/files/en-us/web/api/fontface/variationsettings/index.md
@@ -19,14 +19,7 @@ The **`variationSettings`** property of the
 It is equivalent to the
 {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.
 
-## Syntax
-
-```js
-let variationSettingDescriptor = FontFace.variationSettings;
-FontFace.variationSettings = variationSettingDescriptor;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing a descriptor.
 

--- a/files/en-us/web/api/fontface/weight/index.md
+++ b/files/en-us/web/api/fontface/weight/index.md
@@ -18,14 +18,7 @@ The **`weight`** property of the
 {{domxref("FontFace")}} interface retrieves or sets the weight of the font. It is
 equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.
 
-## Syntax
-
-```js
-let weightDescriptor = FontFace.weight;
-FontFace.weight = weightDescriptor;
-```
-
-### Value
+## Value
 
 A {{domxref('CSSOMString')}} containing a descriptor as it would be defined in a style
 sheet's `@font-face` rule.

--- a/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.md
@@ -19,13 +19,7 @@ The **`fontfaces`** read-only property of the
 {{domxref("FontFaceSetLoadEvent")}} interface returns an array of
 {{domxref("FontFace")}} instances, each of which represents a single usable font.
 
-## Syntax
-
-```js
-var fontFace[] = FontFaceSetLoadEvent.fontfaces
-```
-
-### Value
+## Value
 
 An array of {{domxref("FontFace")}} instance.
 

--- a/files/en-us/web/api/gamepad/hand/index.md
+++ b/files/en-us/web/api/gamepad/hand/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Gamepad.hand
 
 The **`hand`** read-only property of the {{domxref("Gamepad")}} interface returns an enum defining what hand the controller is being held in, or is most likely to be held in.
 
-## Syntax
-
-```js
-var myHand = gamepadInstance.hand;
-```
-
-### Value
+## Value
 
 A [`GamepadHand`](https://w3c.github.io/gamepad/extensions.html#gamepadhand-enum) enum; possible values are:
 


### PR DESCRIPTION
@teoli2003

## Summary
Sequel of #14195 .
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
