### PR TITLE
Remove advice to set a read-only property

### DIFF
--- a/files/en-us/web/css/overflow/index.md
+++ b/files/en-us/web/css/overflow/index.md
@@ -51,7 +51,7 @@ The `overflow` property is specified as one or two keywords chosen from the list
 - `visible`
   - : Content is not clipped and may be rendered outside the padding box.
 - `hidden`
-  - : Content is clipped if necessary to fit the padding box. No scrollbars are provided, and no support for allowing the user to scroll (such as by dragging or using a scroll wheel) is allowed. The content _can_ be scrolled programmatically (for example, by setting the value of a property such as {{domxref("HTMLElement.offsetLeft", "offsetLeft")}}), so the element is still a scroll container.
+  - : Content is clipped if necessary to fit the padding box. No scrollbars are provided, and no support for allowing the user to scroll (such as by dragging or using a scroll wheel) is allowed. The content _can_ be scrolled programmatically (for example, by setting the value of a property such as {{domxref("Element.scrollLeft", "scrollLeft")}} or the {{domxref("Element.scrollTo", "scrollTo()")}} method), so the element is still a scroll container.
 - `clip`
   - : Similar to `hidden`, the content is clipped to the element's padding box. The difference between `clip` and `hidden` is that the `clip` keyword also forbids all scrolling, including programmatic scrolling. The box is not a scroll container, and does not start a new formatting context. If you wish to start a new formatting context, you can use {{cssxref("display", "display: flow-root", "#flow-root")}} to do so.
 - `scroll`


### PR DESCRIPTION
Fixes #14232

`leftOffset` is read-only so cannot be set. To scroll we should use `scrollLeft`  or `scrollTo()`.