### PR TITLE
Resolve: "Breadcrumb Navigation": various refinements needed #14155

### DIFF
--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -45,6 +45,8 @@ This pattern is laid out using a simple flex layout demonstrating how a line of 
 
 I have used the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) and [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attributes to help users understand what this navigation is and where the current page is in the structure. See the related links for more information.
 
+Beware that the arrows `→` added via `content` are also exposed to screen readers or braille displays.
+
 ## Browser compatibility
 
 The various layout methods have different browser support. See the charts below for details on basic support for the properties used.


### PR DESCRIPTION
- [x] Mention that pseudo content like this will be exposed by modern browsers to AT.
- [ ] Indicate that if one does not wish to have these dividers announced, they could either use decorative images or use pseudo elements to create their own basic shapes (see: https://scottaohara.github.io/a11y_breadcrumbs/)
- [ ] If someone still wants to do this, they should use the ::after pseudo selector instead. Then, at least, the divider content is announced after the important content (link) of the list item
- [ ] Call out that one could also use [CSS content alternative text](https://www.stefanjudis.com/today-i-learned/css-content-accepts-alternative-text/), but for the fact it's only supported by chromium browsers. Testing with Chrome+VO, adding a / " " to the content declaration resulted in the right arrow being ignored.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

mdn/content#20729

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
