### PR TITLE
Add redirect for `/en-US/docs/Tools/about_colon_debugging`

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -6864,6 +6864,7 @@
 /en-US/docs/Tools/Web_Console/WebConsoleHelp	https://firefox-source-docs.mozilla.org/devtools-user/web_console/helpers/index.html
 /en-US/docs/Tools/about:debugging	https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/index.html
 /en-US/docs/Tools/about:debugging/about:debugging_before_Firefox_67	https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/about_colon_debugging_before_firefox_68/index.html
+/en-US/docs/Tools/about_colon_debugging	https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/index.html
 /en-US/docs/Tools/about_colon_debugging/about_colon_debugging_before_firefox_68	https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/about_colon_debugging_before_firefox_68/index.html
 /en-US/docs/Tools/accessibility_inspector/simulation	https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/simulation/index.html
 /en-US/docs/Tools/accessing_the_developer_tools	https://firefox-source-docs.mozilla.org/devtools-user/accessing_the_developer_tools/index.html


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Add a missing redirect from the recent devtools migration.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

A page within this tree is redirected, but not its parent.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

- Devtools migration: https://github.com/mdn/content/pull/14140
- Not all devtools (and other) redirects work; see https://github.com/mdn/yari/issues/5780.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
