### PR TITLE
Fix broken link to a Fx devtool link

### DIFF
--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -42,5 +42,4 @@ console.timeStamp(label);
 
 - {{domxref("console.time()")}}
 - {{domxref("console.timeEnd()")}}
-- [Adding
-  timestamps to the Waterfall](/en-US/docs/Tools/Performance/Waterfall#timestamp_markers)
+- [Adding timestamps to the Waterfall](https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#timestamp_markers)

--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -42,4 +42,4 @@ console.timeStamp(label);
 
 - {{domxref("console.time()")}}
 - {{domxref("console.timeEnd()")}}
-- [Adding timestamps to the Waterfall](https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#timestamp_markers)
+- [Adding timestamps to the waterfall](https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#timestamp_markers)


### PR DESCRIPTION
Since the Firefox dev tool documentation has been moved, this link leads to an unnecessary redirection. This fixes it.

(Not hunting them, but I just stumbled on it)