### PR TITLE
Remove link to forme Flash article in LA

### DIFF
--- a/files/en-us/learn/html/howto/index.md
+++ b/files/en-us/learn/html/howto/index.md
@@ -52,7 +52,6 @@ HTML only sets up document structure. To solve presentation issues, use {{glossa
 ### Embedded content
 
 - [How to embed a webpage within another webpage](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies)
-- [How to add Flash content within a webpage](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies#the_%3cembed%3e_and_%3cobject%3e_elements)
 
 ## Uncommon or advanced problems
 


### PR DESCRIPTION
Fixes #14261 

Flash is dead and the linked pages hadn't the right info anyway.
