### PR TITLE
Remove fallback :focus outline for :focus-visible

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -78,6 +78,7 @@ custom-button:focus {
   custom-button:focus {
     /* Remove the focus indicator on mouse-focus for browsers
        that do support :focus-visible */
+    outline: none;
     background: transparent;
   }
 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

The example provides fallback `background` and `outline` styles for when the browser doesn't support `:focus-visible`, but doesn't then remove the `outline` when `:focus-visible` is supported.

#### Motivation

The example is confusing at the moment because it leaves some of the fallback styles in place when they're not needed.

#### Supporting details

N/A

#### Related issues

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
