### PR TITLE
Add link to DOM interface to input element types

### DIFF
--- a/files/en-us/web/html/element/input/button/index.md
+++ b/files/en-us/web/html/element/input/button/index.md
@@ -44,6 +44,10 @@ browser-compat: html.elements.input.input-button
       <td><code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>None</td>
     </tr>

--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -47,6 +47,10 @@ browser-compat: html.elements.input.input-checkbox
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}}

--- a/files/en-us/web/html/element/input/color/index.md
+++ b/files/en-us/web/html/element/input/color/index.md
@@ -53,6 +53,10 @@ The element's presentation may vary substantially from one browser and/or platfo
       <td><code>list</code> and <code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}}

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -58,6 +58,10 @@ The input UI generally varies from browser to browser; see [Browser compatibilit
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -63,6 +63,10 @@ Some browsers may resort to a text-only input element that validates that the re
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -58,6 +58,10 @@ On browsers that don't support inputs of type `email`, a `email` input falls bac
       <td><code>list</code> and <code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}}

--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -58,16 +58,6 @@ browser-compat: html.elements.input.input-file
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Properties</strong></td>
-      <td>
-        <p>
-          <a href="/en-US/docs/Web/API/HTMLInputElement#properties_file"
-            >Properties that apply only to elements of type <code>file</code></a
-          >
-        </p>
-      </td>
-    </tr>
-    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}}

--- a/files/en-us/web/html/element/input/hidden/index.md
+++ b/files/en-us/web/html/element/input/hidden/index.md
@@ -39,6 +39,10 @@ browser-compat: html.elements.input.input-hidden
       <td><code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>None.</td>
     </tr>

--- a/files/en-us/web/html/element/input/image/index.md
+++ b/files/en-us/web/html/element/input/image/index.md
@@ -52,6 +52,10 @@ browser-compat: html.elements.input.input-image
       <td>None.</td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>None.</td>
     </tr>

--- a/files/en-us/web/html/element/input/month/index.md
+++ b/files/en-us/web/html/element/input/month/index.md
@@ -67,6 +67,10 @@ The Microsoft Edge `month` control looks like this:
       <td><code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -51,6 +51,10 @@ On browsers that don't support inputs of type `number`, a `number` input falls b
       <td><code>list</code>, <code>value</code>, <code>valueAsNumber</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -70,6 +70,10 @@ Both approaches help a user check that they entered the intended password, which
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/radio/index.md
+++ b/files/en-us/web/html/element/input/radio/index.md
@@ -63,6 +63,10 @@ They are called radio buttons because they look and operate in a similar manner 
       <td><code>checked</code> and <code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}}

--- a/files/en-us/web/html/element/input/range/index.md
+++ b/files/en-us/web/html/element/input/range/index.md
@@ -60,6 +60,10 @@ If the user's browser doesn't support type `range`, it will fall back and treat 
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.stepDown", "stepDown()")}}

--- a/files/en-us/web/html/element/input/reset/index.md
+++ b/files/en-us/web/html/element/input/reset/index.md
@@ -46,6 +46,10 @@ browser-compat: html.elements.input.input-reset
       <td><code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>None</td>
     </tr>

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -52,6 +52,10 @@ browser-compat: html.elements.input.input-search
       <td><code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -44,6 +44,10 @@ browser-compat: html.elements.input.input-submit
       <td><code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>None</td>
     </tr>

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -64,6 +64,10 @@ Despite the fact that inputs of type `tel` are functionally identical to standar
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -56,6 +56,10 @@ browser-compat: html.elements.input.input-text
       <td>{{htmlattrxref("list", "input")}}, <code>value</code></td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -80,6 +80,10 @@ The Edge `time` control is somewhat more elaborate, opening up an hour and minut
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -63,6 +63,10 @@ On browsers that don't support inputs of type `url`, a `url` input falls back to
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},

--- a/files/en-us/web/html/element/input/week/index.md
+++ b/files/en-us/web/html/element/input/week/index.md
@@ -67,6 +67,10 @@ The Edge `week` control is somewhat more elaborate, opening up week and year pic
       </td>
     </tr>
     <tr>
+      <td><strong>DOM interface</strong></td>
+      <td><p>{{domxref("HTMLInputElement")}}</p></td>
+    </tr>
+    <tr>
       <td><strong>Methods</strong></td>
       <td>
         {{domxref("HTMLInputElement.select", "select()")}},


### PR DESCRIPTION
#### Summary
This PR removes a broken link on the `<input type="file">` page. Also, it consistently adds links to `HTMLInputElement` to all `<input>` element types.

#### Motivation
The broken link was misleading, as the target did not list all properties of the element. The new links to `HTMLInputElement` can be used to get the full list instead.

#### Related issues
References #14209

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
