### PR TITLE
Correct webm codecs parameter specification

### DIFF
--- a/files/en-us/web/media/formats/codecs_parameter/index.md
+++ b/files/en-us/web/media/formats/codecs_parameter/index.md
@@ -643,10 +643,10 @@ As part of a move toward a standardized and powerful format for the `codecs` par
 In this format, the `codecs` parameter's value begins with a four-character code identifying the codec being used in the container, which is then followed by a series of period (`.`) separated two-digit values.
 
 ```plain
-cccc.PP.LL.DD.CC[.cp[.tc[.mc[.FF]]]]
+cccc.PP.LL.DD[.CC.cp.tc.mc.FF]
 ```
 
-The first five components are required; everything from `cp` (color primaries) onward is optional; you can stop including components at any point from then onward. Each of these components is described in the following table. Following the table are some examples.
+The first four components are required; everything from `CC` (chroma subsampling) onward is optional, but all or nothing. Each of these components is described in the following table. Following the table are some examples.
 
 <table class="standard-table">
   <caption>

--- a/files/en-us/web/media/formats/codecs_parameter/index.md
+++ b/files/en-us/web/media/formats/codecs_parameter/index.md
@@ -643,7 +643,8 @@ As part of a move toward a standardized and powerful format for the `codecs` par
 In this format, the `codecs` parameter's value begins with a four-character code identifying the codec being used in the container, which is then followed by a series of period (`.`) separated two-digit values.
 
 ```plain
-cccc.PP.LL.DD[.CC.cp.tc.mc.FF]
+cccc.PP.LL.DD
+cccc.PP.LL.DD.CC.cp.tc.mc.FF
 ```
 
 The first four components are required; everything from `CC` (chroma subsampling) onward is optional, but all or nothing. Each of these components is described in the following table. Following the table are some examples.


### PR DESCRIPTION
This did not match the spec.  https://www.webmproject.org/vp9/mp4/

Mandatory Fields:  sample entry 4CC, profile, level, and bitDepth are all mandatory fields.

Optional Fields:  colourPrimaries, transferCharacteristics, matrixCoefficients, videoFullRangeFlag, and chromaSubsampling are OPTIONAL, mutually inclusive (all or none) fields. If not specified then the processing device MUST use the values listed in the table below as defaults when deciding if the device is able to decode and potentially render the video.

So the five should be four in this document, and the other (last) five are not all individually optional, they are all or none

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
