### PR TITLE
WebAPI: Clean syntax from property pages, part 5

### DIFF
--- a/files/en-us/web/api/gamepad/hapticactuators/index.md
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Gamepad.hapticActuators
 
 The **`hapticActuators`** read-only property of the {{domxref("Gamepad")}} interface returns an array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.
 
-## Syntax
-
-```js
-var myHapticActuators = gamepadInstance.hapticActuators;
-```
-
-### Value
+## Value
 
 An array containing {{domxref("GamepadHapticActuator")}} objects.
 

--- a/files/en-us/web/api/gamepad/index/index.md
+++ b/files/en-us/web/api/gamepad/index/index.md
@@ -20,11 +20,9 @@ currently connected to the system.
 This can be used to distinguish multiple controllers; a gamepad that is disconnected
 and reconnected will retain the same index.
 
-## Syntax
+## Value
 
-```js
-const index = gamepad.index;
-```
+A {{jsxref("number") }}.
 
 ## Example
 
@@ -34,10 +32,6 @@ window.addEventListener("gamepadconnected", function() {
   gamepadInfo.innerHTML = "Gamepad connected at index " + gp.index + ": " + gp.id + ".";
 });
 ```
-
-### Value
-
-A {{jsxref("number") }}.
 
 ## Specifications
 

--- a/files/en-us/web/api/gamepad/pose/index.md
+++ b/files/en-us/web/api/gamepad/pose/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Gamepad.pose
 
 The **`pose`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g. its position and orientation in 3D space).
 
-## Syntax
-
-```js
-var myGamepadPose = gamepadInstance.pose;
-```
-
-### Value
+## Value
 
 A {{domxref("GamepadPose")}} object.
 

--- a/files/en-us/web/api/gamepadhapticactuator/type/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/type/index.md
@@ -16,13 +16,7 @@ browser-compat: api.GamepadHapticActuator.type
 
 The **`type`** read-only property of the {{domxref("GamepadHapticActuator")}} interface returns an enum representing the type of the haptic hardware.
 
-## Syntax
-
-```js
-var myActuatorType = gamepadHapticActuatorInstance.type;
-```
-
-### Value
+## Value
 
 An enum of type [`GamepadHapticActuatorType`](https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuatortype-enum); currently available types are:
 

--- a/files/en-us/web/api/gamepadpose/angularacceleration/index.md
+++ b/files/en-us/web/api/gamepadpose/angularacceleration/index.md
@@ -19,13 +19,7 @@ The **`angularAcceleration`** read-only property of the {{domxref("GamepadPose")
 
 In other words, the current acceleration of the sensor's rotation around the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myGamepadAngAcc = gamepadPoseInstance.angularAcceleration;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the gamepad is not able to provide angular acceleration information.
 

--- a/files/en-us/web/api/gamepadpose/angularvelocity/index.md
+++ b/files/en-us/web/api/gamepadpose/angularvelocity/index.md
@@ -19,13 +19,7 @@ The **`angularVelocity`** read-only property of the {{domxref("GamepadPose")}} i
 
 In other words, the current velocity at which the sensor is rotating around the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myGamepadAngVel = gamepadPoseInstance.angularVelocity;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the gamepad is not able to provide angular velocity information.
 

--- a/files/en-us/web/api/gamepadpose/hasorientation/index.md
+++ b/files/en-us/web/api/gamepadpose/hasorientation/index.md
@@ -17,13 +17,7 @@ browser-compat: api.GamepadPose.hasOrientation
 
 The **`hasOrientation`** read-only property of the {{domxref("GamepadPose")}} interface returns a boolean value stating whether the {{domxref("Gamepad")}} can track and return orientation information.
 
-## Syntax
-
-```js
-var hasItGotOrientation = gamepadPoseInstance.hasOrientation;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/gamepadpose/hasposition/index.md
+++ b/files/en-us/web/api/gamepadpose/hasposition/index.md
@@ -17,13 +17,7 @@ browser-compat: api.GamepadPose.hasPosition
 
 The **`hasPosition`** read-only property of the {{domxref("GamepadPose")}} interface returns a boolean value stating whether the {{domxref("Gamepad")}} can track and return position information.
 
-## Syntax
-
-```js
-var hasItGotPosition = gamepadPoseInstance.hasPosition;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/gamepadpose/linearacceleration/index.md
+++ b/files/en-us/web/api/gamepadpose/linearacceleration/index.md
@@ -19,13 +19,7 @@ The **`linearAcceleration`** read-only property of the {{domxref("GamepadPose")}
 
 In other words, the current acceleration of the sensor, along the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myGamepadLinAcc = gamepadPoseInstance.linearAcceleration;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the gamepad is not able to provide linear acceleration data.
 

--- a/files/en-us/web/api/gamepadpose/linearvelocity/index.md
+++ b/files/en-us/web/api/gamepadpose/linearvelocity/index.md
@@ -19,13 +19,7 @@ The **`linearVelocity`** read-only property of the {{domxref("GamepadPose")}} in
 
 In other words, the current velocity at which the sensor is moving along the `x`, `y`, and `z` axes.
 
-## Syntax
-
-```js
-var myGamepadLinVel = gamepadPoseInstance.linearVelocity;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the gamepad is not able to provide linear velocity data.
 

--- a/files/en-us/web/api/gamepadpose/orientation/index.md
+++ b/files/en-us/web/api/gamepadpose/orientation/index.md
@@ -26,13 +26,7 @@ The value is a {{jsxref("Float32Array")}}, made up of the following values:
 
 The orientation yaw (rotation around the y axis) is relative to the initial yaw of the sensor when it was first read.
 
-## Syntax
-
-```js
-var myGamepadOrientation = gamepadPoseInstance.orientation;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide orientation data.
 

--- a/files/en-us/web/api/gamepadpose/position/index.md
+++ b/files/en-us/web/api/gamepadpose/position/index.md
@@ -25,13 +25,7 @@ The coordinate system is as follows:
 
 Positions are measured in meters from an origin point — this point is the position the sensor was first read at.
 
-## Syntax
-
-```js
-var myGamepadPosition = gamepadPoseInstance.position;
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}, or `null` if the gamepad is not able to provide position data.
 

--- a/files/en-us/web/api/geolocationcoordinates/accuracy/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/accuracy/index.md
@@ -17,13 +17,7 @@ a strictly positive `double` representing the accuracy, with a 95% confidence
 level, of the {{domxref("GeolocationCoordinates.latitude")}} and
 {{domxref("GeolocationCoordinates.longitude")}} properties expressed in meters.
 
-## Syntax
-
-```js
-let acc = geolocationCoordinatesInstance.accuracy
-```
-
-### Value
+## Value
 
 A positive `double` representing the accuracy, with a 95% confidence level,
 of the {{domxref("GeolocationCoordinates.latitude")}} and

--- a/files/en-us/web/api/geolocationcoordinates/altitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/altitude/index.md
@@ -17,13 +17,7 @@ a `double` representing the altitude of the position in meters above the [WGS84]
 ellipsoid (which defines the nominal sea level surface). This value is `null`
 if the implementation cannot provide this data.
 
-## Syntax
-
-```js
-let alt = geolocationCoordinatesInstance.altitude
-```
-
-### Value
+## Value
 
 A `double` representing the altitude of the position in meters above the [WGS84](http://earth-info.nga.mil/GandG/publications/tr8350.2/wgs84fin.pdf)
 ellipsoid.

--- a/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.md
@@ -17,13 +17,7 @@ property is a strictly positive `double` representing the accuracy, with a
 95% confidence level, of the `altitude` expressed in meters. This value is
 `null` if the implementation doesn't support measuring altitude.
 
-## Syntax
-
-```js
-let altAcc = geolocationCoordinatesInstance.altitudeAccuracy
-```
-
-### Value
+## Value
 
 A positive `double` representing the accuracy, with a 95% confidence level,
 of the `altitude` expressed in meters.

--- a/files/en-us/web/api/geolocationcoordinates/heading/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/heading/index.md
@@ -22,13 +22,7 @@ degrees). If {{domxref("GeolocationCoordinates.speed")}} is `0`,
 [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN). If
 the device is not able to provide heading information, this value is `null`.
 
-## Syntax
-
-```js
-let heading = geolocationCoordinatesInstance.heading
-```
-
-### Value
+## Value
 
 A `double` representing the direction in which the device is traveling.
 

--- a/files/en-us/web/api/geolocationcoordinates/latitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/latitude/index.md
@@ -14,13 +14,7 @@ browser-compat: api.GeolocationCoordinates.latitude
 
 The **`GeolocationCoordinates.latitude`** read-only property is a `double` representing the latitude of the position in decimal degrees.
 
-## Syntax
-
-```js
-let lat = geolocationCoordinatesInstance.latitude
-```
-
-### Value
+## Value
 
 A `double` representing the latitude of the position in decimal degrees.
 

--- a/files/en-us/web/api/geolocationcoordinates/longitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/longitude/index.md
@@ -25,13 +25,7 @@ the `GeolocationCoordinates` object is part of the
 {{domxref("GeolocationPosition")}} interface, which is the object type returned by
 Geolocation API functions that obtain and return a geographical position.
 
-## Syntax
-
-```js
-let longitude = geolocationCoordinatesInstance.longitude
-```
-
-### Value
+## Value
 
 The value in `longitude` is the geographical longitude of the location on
 Earth described by the `Coordinates` object, in decimal degrees. The value is

--- a/files/en-us/web/api/geolocationcoordinates/speed/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/speed/index.md
@@ -16,13 +16,7 @@ The **`GeolocationCoordinates.speed`** read-only property is a
 `double` representing the velocity of the device in meters per second. This
 value is `null` if the implementation is not able to measure it.
 
-## Syntax
-
-```js
-let speed = geolocationCoordinatesInstance.speed
-```
-
-### Value
+## Value
 
 A `double` representing the velocity of the device in meters per second.
 

--- a/files/en-us/web/api/geolocationposition/coords/index.md
+++ b/files/en-us/web/api/geolocationposition/coords/index.md
@@ -18,13 +18,7 @@ contains the location, that is longitude and latitude on the Earth, the altitude
 the speed of the object concerned, regrouped inside the returned value. It also contains
 accuracy information about these values.
 
-## Syntax
-
-```js
-let coord = geolocationPositionInstance.coords
-```
-
-### Value
+## Value
 
 A {{domxref("GeolocationCoordinates")}} object instance.
 

--- a/files/en-us/web/api/geolocationpositionerror/message/index.md
+++ b/files/en-us/web/api/geolocationpositionerror/message/index.md
@@ -15,13 +15,7 @@ browser-compat: api.GeolocationPositionError.message
 The **`GeolocationPositionError.message`** read-only property
 returns a human-readable {{domxref("DOMString")}} describing the details of the error.
 
-## Syntax
-
-```js
-let msg = geolocationPositionErrorInstance.message
-```
-
-### Value
+## Value
 
 A human-readable {{domxref("DOMString")}} describing the details of the error.
 

--- a/files/en-us/web/api/hidconnectionevent/device/index.md
+++ b/files/en-us/web/api/hidconnectionevent/device/index.md
@@ -13,13 +13,7 @@ browser-compat: api.HIDConnectionEvent.device
 
 The **`device`** read-only property of the {{domxref("HIDConnectionEvent")}} interface returns the {{domxref("HIDDevice")}} associated with this connection event.
 
-## Syntax
-
-```js
-let device = HIDConnectionEvent.device;
-```
-
-### Value
+## Value
 
 A {{domxref("HIDDevice")}}.
 

--- a/files/en-us/web/api/hiddevice/collections/index.md
+++ b/files/en-us/web/api/hiddevice/collections/index.md
@@ -13,13 +13,7 @@ browser-compat: api.HIDDevice.collections
 
 The **`collections`** read-only property of the {{domxref("HIDDevice")}} interface returns an array of report formats
 
-## Syntax
-
-```js
-let collections = HIDDevice.collections;
-```
-
-### Value
+## Value
 
 An array of report formats. Each entry contains the following:
 

--- a/files/en-us/web/api/hiddevice/opened/index.md
+++ b/files/en-us/web/api/hiddevice/opened/index.md
@@ -13,13 +13,7 @@ browser-compat: api.HIDDevice.opened
 
 The **`opened`** read-only property of the {{domxref("HIDDevice")}} interface returns true if the connection to the {{domxref("HIDDevice")}} is open and ready to transfer data.
 
-## Syntax
-
-```js
-let opened = HIDDevice.opened;
-```
-
-### Value
+## Value
 
 A boolean value, true if the connection is open.
 

--- a/files/en-us/web/api/hiddevice/productid/index.md
+++ b/files/en-us/web/api/hiddevice/productid/index.md
@@ -13,13 +13,7 @@ browser-compat: api.HIDDevice.productId
 
 The **`productId`** read-only property of the {{domxref("HIDDevice")}} interface returns the product ID of the connected HID device.
 
-## Syntax
-
-```js
-let productId = HIDDevice.productId;
-```
-
-### Value
+## Value
 
 An integer. If the device has no product ID, or the product ID cannot be accessed this will return `0`.
 

--- a/files/en-us/web/api/hiddevice/productname/index.md
+++ b/files/en-us/web/api/hiddevice/productname/index.md
@@ -13,13 +13,7 @@ browser-compat: api.HIDDevice.productName
 
 The **`productName`** read-only property of the {{domxref("HIDDevice")}} interface returns the product name of the connected HID device.
 
-## Syntax
-
-```js
-let productName = HIDDevice.productName;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}.
 

--- a/files/en-us/web/api/hiddevice/vendorid/index.md
+++ b/files/en-us/web/api/hiddevice/vendorid/index.md
@@ -13,13 +13,7 @@ browser-compat: api.HIDDevice.vendorId
 
 The **`vendorId`** read-only property of the {{domxref("HIDDevice")}} interface returns the vendor ID of the connected HID device. This identifies the vendor of the device.
 
-## Syntax
-
-```js
-let vendorId = HIDDevice.vendorId;
-```
-
-### Value
+## Value
 
 An integer. If the device has no vendor ID, or the vendor ID cannot be accessed this will return `0`.
 

--- a/files/en-us/web/api/history/scrollrestoration/index.md
+++ b/files/en-us/web/api/history/scrollrestoration/index.md
@@ -16,13 +16,7 @@ The **`scrollRestoration`** property of {{DOMxRef("History")}}
 interface allows web applications to explicitly set default scroll restoration behavior
 on history navigation.
 
-## Syntax
-
-```js
-const scrollRestore = history.scrollRestoration
-```
-
-### Values
+## Values
 
 - `auto`
   - : The location on the page to which the user has scrolled will be restored.

--- a/files/en-us/web/api/history/state/index.md
+++ b/files/en-us/web/api/history/state/index.md
@@ -16,13 +16,7 @@ The **`History.state`** property
 returns a value representing the state at the top of the history stack. This is
 a way to look at the state without having to wait for a {{domxref("Window/popstate_event", "popstate")}} event.
 
-## Syntax
-
-```js
-const currentState = history.state
-```
-
-### Value
+## Value
 
 The state at the top of the history stack. The value is {{jsxref("null")}} until the
 {{domxref("History.pushState","pushState()")}} or

--- a/files/en-us/web/api/htmldataelement/value/index.md
+++ b/files/en-us/web/api/htmldataelement/value/index.md
@@ -17,14 +17,7 @@ The **`value`** property of the {{domxref("HTMLDataElement")}}
 interface returns a {{domxref("DOMString")}} reflecting the {{htmlattrxref("value",
   "data")}} HTML attribute.
 
-## Syntax
-
-```js
-var aValue = htmlDataElement.value
-htmlDataElement.value = aValue
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/htmlelement/hidden/index.md
+++ b/files/en-us/web/api/htmlelement/hidden/index.md
@@ -38,15 +38,7 @@ Inappropriate use cases include:
 
 > **Note:** Elements that are not `hidden` must not link to elements which are.
 
-## Syntax
-
-```js
-isHidden = HTMLElement.hidden;
-
-HTMLElement.hidden = true | false;
-```
-
-### Value
+## Value
 
 A Boolean which is `true` if the element is hidden from view; otherwise, the
 value is `false`.

--- a/files/en-us/web/api/htmlformelement/elements/index.md
+++ b/files/en-us/web/api/htmlformelement/elements/index.md
@@ -32,13 +32,7 @@ Prior to HTML 5, the returned object was an {{domxref("HTMLCollection")}}, on wh
 > within a given document using the document's {{domxref("Document.forms", "forms")}}
 > property.
 
-## Syntax
-
-```js
-nodeList = HTMLFormElement.elements
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLFormControlsCollection")}} containing all non-image controls in the
 form. This is a live collection; if form controls are added to or removed from the form,

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.md
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.md
@@ -20,13 +20,7 @@ The **`allowPaymentRequest`** property of the
 whether the [Payment Request
 API](/en-US/docs/Web/API/Payment_Request_API) may be invoked on a cross-origin iframe.
 
-## Syntax
-
-```js
-var allow = htmlIFrameElement.allowPaymentRequest
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/htmliframeelement/csp/index.md
+++ b/files/en-us/web/api/htmliframeelement/csp/index.md
@@ -17,14 +17,7 @@ The **`csp`** property of the {{domxref("HTMLIFrameElement")}}
 interface specifies the [Content Security Policy](/en-US/docs/Web/HTTP/CSP) that an
 embedded document must agree to enforce upon itself.
 
-## Syntax
-
-```js
-var csp = HTMLIFrameElement.csp
-HTMLIFrameElement.csp = csp
-```
-
-### Value
+## Value
 
 A content security policy.
 

--- a/files/en-us/web/api/htmliframeelement/featurepolicy/index.md
+++ b/files/en-us/web/api/htmliframeelement/featurepolicy/index.md
@@ -17,13 +17,7 @@ property of the {{DOMxRef("HTMLIFrameElement")}} interface returns the
 {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting
 the feature policies applied to a specific frame.
 
-## Syntax
-
-```js
-var policy = HTMLIFrameElement.featurePolicy
-```
-
-### Value
+## Value
 
 A [`FeaturePolicy`](/en-US/docs/Web/API/FeaturePolicy) object
 that can be used to inspect the Feature Policy settings applied to the frame.

--- a/files/en-us/web/api/htmlimageelement/align/index.md
+++ b/files/en-us/web/api/htmlimageelement/align/index.md
@@ -30,14 +30,7 @@ to the left or right margin.
 The `align` property reflects the HTML {{htmlattrxref("align", "img")}}
 content attribute.
 
-## Syntax
-
-```js
-htmlImageElement.align = alignMode;
-alignMode = htmlImageElement.align;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying one of the following strings which set the
 alignment mode for the image.

--- a/files/en-us/web/api/htmlimageelement/alt/index.md
+++ b/files/en-us/web/api/htmlimageelement/alt/index.md
@@ -38,14 +38,7 @@ for example, to support visually impaired users.
 The alternate text is displayed in the space the image would occupy and should be able
 to take the place of the image _without altering the meaning of the page_.
 
-## Syntax
-
-```js
-htmlImageElement.alt = altText;
-let altText = htmlImageElement.alt;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains the alternate text to display when the image
 is not loaded or for use by assistive devices.

--- a/files/en-us/web/api/htmlimageelement/border/index.md
+++ b/files/en-us/web/api/htmlimageelement/border/index.md
@@ -35,14 +35,7 @@ For compatibility (or perhaps other) reasons, you can use the older properties i
 (or in addition): {{cssxref("border-top-width")}}, {{cssxref("border-right-width")}},
 {{cssxref("border-bottom-width")}}, and {{cssxref("border-left-width")}}.
 
-## Syntax
-
-```js
-htmlImageElement.border = thickness;
-let thickness = htmlImageElement.border;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing an integer value specifying the thickness of the
 border that should surround the image, in CSS pixels. A value of `0`, or an

--- a/files/en-us/web/api/htmlimageelement/complete/index.md
+++ b/files/en-us/web/api/htmlimageelement/complete/index.md
@@ -19,13 +19,7 @@ The read-only {{domxref("HTMLImageElement")}} interface's
 **`complete`** attribute is a Boolean value which indicates
 whether or not the image has completely loaded.
 
-## Syntax
-
-```js
-let doneLoading = htmlImageElement.complete;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the image has completely loaded;
 otherwise, the value is `false`.

--- a/files/en-us/web/api/htmlimageelement/crossorigin/index.md
+++ b/files/en-us/web/api/htmlimageelement/crossorigin/index.md
@@ -22,14 +22,7 @@ interface's **`crossOrigin`** attribute is a string which
 specifies the Cross-Origin Resource Sharing ({{Glossary("CORS")}}) setting to use when
 retrieving the image.
 
-## Syntax
-
-```js
-htmlImageElement.crossOrigin = crossOriginMode;
-let crossOriginMode = htmlImageElement.crossOrigin;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} of a keyword specifying the CORS mode to use when fetching
 the image resource. If you don't specify `crossOrigin`, the image is fetched

--- a/files/en-us/web/api/htmlimageelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlimageelement/currentsrc/index.md
@@ -18,13 +18,7 @@ The read-only {{domxref("HTMLImageElement")}} property
 **`currentSrc`** indicates the URL of the image which is
 currently presented in the {{HTMLElement("img")}} element it represents.
 
-## Syntax
-
-```js
-let currentSource = htmlImageElement.currentSrc;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} indicating the full URL of the image currently visible in
 the {{HTMLElement("img")}} element represented by the `HTMLImageElement`.

--- a/files/en-us/web/api/htmlimageelement/height/index.md
+++ b/files/en-us/web/api/htmlimageelement/height/index.md
@@ -22,14 +22,7 @@ drawn, in {{Glossary("CSS pixels")}} if the image is being drawn or rendered to 
 visual medium such as the screen or a printer; otherwise, it's the natural, pixel
 density corrected height of the image.
 
-## Syntax
-
-```js
-htmlImageElement.height = newHeight;
-let height = htmlImageElement.height;
-```
-
-### Value
+## Value
 
 An integer value indicating the height of the image. The terms in which the height is
 defined depends on whether the image is being rendered to a visual medium or not.

--- a/files/en-us/web/api/htmlimageelement/hspace/index.md
+++ b/files/en-us/web/api/htmlimageelement/hspace/index.md
@@ -31,14 +31,7 @@ when laying out the page.
 This property reflects the {{Glossary("HTML")}} {{htmlattrxref("hspace", "img")}}
 attribute.
 
-## Syntax
-
-```js
-htmlImageElement.hspace = marginWidth;
-marginWidth = htmlImageElement.hspace;
-```
-
-### Value
+## Value
 
 An integer value specifying the width, in pixels, of the horizontal margin to apply to
 the left and right sides of the image.

--- a/files/en-us/web/api/htmlimageelement/loading/index.md
+++ b/files/en-us/web/api/htmlimageelement/loading/index.md
@@ -32,14 +32,7 @@ This helps
 to optimize the loading of the document's contents by postponing loading the image until
 it's expected to be needed, rather than immediately during the initial page load.
 
-## Syntax
-
-```js
-let imageLoadScheduling = htmlImageElement.loading;
-htmlImageElement.loading = eagerOrLazy;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} providing a hint to the user agent as to how to best
 schedule the loading of the image to optimize page performance. The possible values are:

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.md
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.md
@@ -23,14 +23,7 @@ which contains a long-form description of the image. This can be used to
 provide optional added details beyond the short description provided in the
 {{htmlattrxref("title")}} attribute.
 
-## Syntax
-
-```js
-descURL = htmlImageElement.longDesc;
-htmlImageElement.longDesc = descURL;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which may be either an empty string (indicating that no long
 description is available) or the URL of a file containing a long form description of the

--- a/files/en-us/web/api/htmlimageelement/name/index.md
+++ b/files/en-us/web/api/htmlimageelement/name/index.md
@@ -21,14 +21,7 @@ interface's *deprecated* **`name`** property specifies
 a name for the element. This has been replaced by the {{domxref("Element.id", "id")}}
 property available on all elements.
 
-## Syntax
-
-```js
-htmlImageElement.name = nameString;
-nameString = htmlImageElement.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} providing a name by which the image can be referenced.
 

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -30,13 +30,7 @@ image height, it will be rendered this tall.
 > images on low-end devices](https://bugs.chromium.org/p/chromium/issues/detail?id=1187043#c7). In such cases, `naturalHeight` will consider the height of the image modified
 > by such browser interventions as the natural height, and returns this value.
 
-## Syntax
-
-```js
-let naturalHeight = htmlImageElement.naturalHeight;
-```
-
-### Value
+## Value
 
 An integer value indicating the intrinsic height, in CSS pixels, of the image. This is
 the height at which the image is naturally drawn when no constraint or specific value is

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.md
@@ -36,13 +36,7 @@ returns the natural height of the image.
 > images on low-end devices](https://bugs.chromium.org/p/chromium/issues/detail?id=1187043#c7). In such cases, `naturalWidth` will consider the width of the image modified
 > by such browser interventions as the natural width, and returns this value.
 
-## Syntax
-
-```js
-let naturalWidth = htmlImageElement.naturalWidth;
-```
-
-### Value
+## Value
 
 An integer value indicating the intrinsic width of the image, in CSS pixels. This is
 the width at which the image is naturally drawn when no constraint or specific value is

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -27,14 +27,7 @@ conditions.
 Each condition is specified using the same conditional format used
 by [media queries](/en-US/docs/Web/CSS/Media_Queries).
 
-## Syntax
-
-```js
-let sizes = htmlImageElement.sizes;
-htmlImageElement.sizes = sizes;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a comma-separated list of source size descriptors
 followed by an optional fallback size. Each **source size descriptor** is

--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -33,14 +33,7 @@ The `srcset` property, along with the {{domxref("HTMLImageElement.sizes",
 can be used together to make pages that use appropriate images for the rendering
 situation.
 
-## Syntax
-
-```js
-htmlImageElement.srcset = imageCandidateStrings;
-let srcset = htmlImageElement.srcset;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a comma-separated list of one or more image
 candidate strings to be used when determining which image resource to present inside the

--- a/files/en-us/web/api/htmlimageelement/usemap/index.md
+++ b/files/en-us/web/api/htmlimageelement/usemap/index.md
@@ -23,14 +23,7 @@ The **`useMap`** property on the
 {{Glossary("HTML")}} {{htmlattrxref("usemap", "img")}} attribute, which is a string
 providing the name of the client-side image map to apply to the image.
 
-## Syntax
-
-```js
-htmlImageElement.useMap = imageMapAnchor;
-let imageMapAnchor = htmlImageElement.useMap;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} providing the page-local URL (that is, a URL that begins
 with the hash or pound symbol, "`#`") of the {{HTMLElement("map")}} element

--- a/files/en-us/web/api/htmlimageelement/vspace/index.md
+++ b/files/en-us/web/api/htmlimageelement/vspace/index.md
@@ -27,14 +27,7 @@ The *obsolete* **`vspace`** property of the
 to leave empty on the top and bottom of the {{HTMLElement("img")}} element when laying
 out the page.
 
-## Syntax
-
-```js
-htmlImageElement.vspace = marginHeight;
-marginHeight = htmlImageElement.vspace;
-```
-
-### Value
+## Value
 
 An integer value specifying the height, in pixels, of the vertical margin to apply to
 the top and bottom sides of the image.

--- a/files/en-us/web/api/htmlimageelement/width/index.md
+++ b/files/en-us/web/api/htmlimageelement/width/index.md
@@ -21,14 +21,7 @@ drawn in {{Glossary("CSS pixel", "CSS pixels")}} if it's being drawn or rendered
 any visual medium such as a screen or printer. Otherwise, it's the natural, pixel
 density-corrected width of the image.
 
-## Syntax
-
-```js
-htmlImageElement.width = newWidth;
-let width = htmlImageElement.width;
-```
-
-### Value
+## Value
 
 An integer value indicating the width of the image. The way the width is defined
 depends on whether or not the image is being rendered to a visual medium, such as a

--- a/files/en-us/web/api/htmlinputelement/webkitentries/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitentries/index.md
@@ -30,13 +30,7 @@ let the user choose directories.
 > **Note:** This property is called `webkitEntries` in the specification due to its
 > origins as a Google Chrome-specific API. It's likely to be renamed someday.
 
-## Syntax
-
-```js
-var entries = HTMLInputElement.webkitEntries;
-```
-
-### Value
+## Value
 
 An array of objects based on {{domxref("FileSystemEntry")}}, each representing one file
 which is selected in the {{HTMLElement("input")}} element. More specifically, files are

--- a/files/en-us/web/api/htmllabelelement/control/index.md
+++ b/files/en-us/web/api/htmllabelelement/control/index.md
@@ -18,13 +18,7 @@ reference to the control (in the form of an object of type {{domxref("HTMLElemen
 one of its derivatives) with which the {{HTMLElement("label")}} element is associated,
 or `null` if the label isn't associated with a control.
 
-## Syntax
-
-```js
-control = HTMLLabelElement.control
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLElement")}} derived object representing the control with which the
 {{HTMLElement("label")}} is associated, or `null` if the label stands alone.

--- a/files/en-us/web/api/htmllabelelement/form/index.md
+++ b/files/en-us/web/api/htmllabelelement/form/index.md
@@ -20,13 +20,7 @@ that control isn't in a form.
 
 This property is just a shortcut for `HTMLLabelElement.control.form`.
 
-## Syntax
-
-```js
-form = HTMLLabelElement.form
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLFormElement")}} which represents the form with which the label's
 {{domxref("HTMLLabelElement.control", "control")}} is associated. If

--- a/files/en-us/web/api/htmllinkelement/as/index.md
+++ b/files/en-us/web/api/htmllinkelement/as/index.md
@@ -20,14 +20,7 @@ loaded by the HTML link, one of `"script"`, `"style"`,
 `"image"`, `"video"`, `"audio"`, `"track"`,
 `"font"`, `"fetch"`.
 
-## Syntax
-
-```js
-var as = HTMLLinkElement.as
-HTMLLinkElement.as = as
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/htmlmediaelement/autoplay/index.md
+++ b/files/en-us/web/api/htmlmediaelement/autoplay/index.md
@@ -35,15 +35,7 @@ For a much more in-depth look at autoplay, autoplay blocking, and how to respond
 autoplay is blocked by the user's browser, see our article [Autoplay guide for media and Web Audio
 APIs](/en-US/docs/Web/Media/Autoplay_guide).
 
-## Syntax
-
-```js
-HTMLMediaElement.autoplay = true | false;
-
-var autoplay = HTMLMediaElement.autoplay;
-```
-
-### Value
+## Value
 
 A boolean value which is `true` if the media element will
 begin playback as soon as enough content has loaded to allow it to do so without

--- a/files/en-us/web/api/htmlmediaelement/controlslist/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controlslist/index.md
@@ -18,13 +18,7 @@ agent select what controls to show on the media element whenever the user agent 
 its own set of controls. The DOMTokenList takes one or more of three possible values:
 `nodownload`, `nofullscreen`, and `noremoteplayback`.
 
-## Syntax
-
-```js
-var domTokenList = HTMLMediaElement.controlsList;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMTokenList")}}.
 

--- a/files/en-us/web/api/htmlmediaelement/currenttime/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currenttime/index.md
@@ -26,14 +26,7 @@ in seconds.
 Changing the value of `currentTime` seeks the media to
 the new time.
 
-## Syntax
-
-```js
-var currentTime = htmlMediaElement.currentTime;
-htmlMediaElement.currentTime = 35;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the current playback time in
 seconds.

--- a/files/en-us/web/api/htmlmediaelement/duration/index.md
+++ b/files/en-us/web/api/htmlmediaelement/duration/index.md
@@ -19,13 +19,7 @@ The _read-only_ {{domxref("HTMLMediaElement")}}
 property **`duration`** indicates the length of the element's
 media in seconds.
 
-## Syntax
-
-```js
-myDuration = htmlMediaElement.duration
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the duration of the media in
 seconds. If no media data is available, the value `NaN` is returned. If the

--- a/files/en-us/web/api/htmlmediaelement/ended/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended/index.md
@@ -16,13 +16,7 @@ browser-compat: api.HTMLMediaElement.ended
 The **`HTMLMediaElement.ended`** indicates whether the media
 element has ended playback.
 
-## Syntax
-
-```js
-var isEnded = HTMLMediaElement.ended
-```
-
-### Value
+## Value
 
 A boolean value which is `true` if the media contained in the
 element has finished playing.

--- a/files/en-us/web/api/htmlmediaelement/error/index.md
+++ b/files/en-us/web/api/htmlmediaelement/error/index.md
@@ -21,13 +21,7 @@ The **`HTMLMediaElement.error`** is the
 there has not been an error. When an {{event("error")}} event is received by the
 element, you can determine details about what happened by examining this object.
 
-## Syntax
-
-```js
-var myError = HTMLMediaElement.error;
-```
-
-### Value
+## Value
 
 A {{domxref("MediaError")}} object describing the most recent error to occur on the
 media element or `null` if no errors have occurred.

--- a/files/en-us/web/api/htmlmediaelement/src/index.md
+++ b/files/en-us/web/api/htmlmediaelement/src/index.md
@@ -23,13 +23,7 @@ resource to use in the element.
 > an {{domxref("HTMLSourceElement")}} (which represents a {{HTMLElement("source")}}
 > element).
 
-## Syntax
-
-```js
-var mediaUrl = HTMLMediaElement.src;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} object containing the URL of a media resource to use in the
 element; this property reflects the value of the HTML element's `src`

--- a/files/en-us/web/api/htmlmediaelement/srcobject/index.md
+++ b/files/en-us/web/api/htmlmediaelement/srcobject/index.md
@@ -27,15 +27,7 @@ The object can be a {{domxref("MediaStream")}}, a {{domxref("MediaSource")}}, a
 > back to creating a URL with {{domxref("URL.createObjectURL()")}} and assign it to
 > {{domxref("HTMLMediaElement.src")}}. See below for an example.
 
-## Syntax
-
-```js
-var sourceObject = HTMLMediaElement.srcObject;
-
-HTMLMediaElement.srcObject = sourceObject;
-```
-
-### Value
+## Value
 
 A {{domxref('MediaStream')}}, {{domxref('MediaSource')}}, {{domxref('Blob')}}, or
 {{domxref('File')}} object (though see the compatibility table for what is actually

--- a/files/en-us/web/api/htmlobjectelement/contentdocument/index.md
+++ b/files/en-us/web/api/htmlobjectelement/contentdocument/index.md
@@ -18,13 +18,7 @@ the {{domxref("HTMLObjectElement")}} interface Returns a {{domxref("Document")}}
 representing the active document of the object element's nested browsing context, if
 any; otherwise null.
 
-## Syntax
-
-```js
-var document = HTMLObjectElement.contentDocument;
-```
-
-### Value
+## Value
 
 A {{domxref('Document')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
+++ b/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
@@ -18,13 +18,7 @@ the {{domxref("HTMLObjectElement")}} interface returns a {{domxref("WindowProxy"
 representing the window proxy of the object element's nested browsing context, if any;
 otherwise null.
 
-## Syntax
-
-```js
-var WindowProxy = HTMLObjectElement.contentWindow;
-```
-
-### Value
+## Value
 
 A {{domxref('WindowProxy')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/data/index.md
+++ b/files/en-us/web/api/htmlobjectelement/data/index.md
@@ -18,14 +18,7 @@ The **`data`** property of the
 reflects the {{htmlattrxref("data", "object")}} HTML attribute, specifying the address
 of a resource's data.
 
-## Syntax
-
-```js
-var data = HTMLObjectElement.data;
-HTMLObjectElement.data;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/form/index.md
+++ b/files/en-us/web/api/htmlobjectelement/form/index.md
@@ -17,13 +17,7 @@ The **`form`** read-only property of the
 {{domxref("HTMLObjectElement")}} interface returns a {{domxref("HTMLFormElement")}}
 representing the object element's form owner, or null if there isn't one.
 
-## Syntax
-
-```js
-var HTMLFormElement = HTMLObjectElement.form;
-```
-
-### Value
+## Value
 
 A {{domxref('HTMLFormElement')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/height/index.md
+++ b/files/en-us/web/api/htmlobjectelement/height/index.md
@@ -18,14 +18,7 @@ The **`height`** property of the
 reflects the {{htmlattrxref("height", "object")}} HTML attribute, specifying the
 displayed height of the resource in CSS pixels.
 
-## Syntax
-
-```js
-var String = HTMLObjectElement.height;
-HTMLObjectElement.height = String;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/name/index.md
+++ b/files/en-us/web/api/htmlobjectelement/name/index.md
@@ -18,14 +18,7 @@ The **`name`** property of the
 reflects the {{htmlattrxref("name", "object")}} HTML attribute, specifying the name of
 the browsing context.
 
-## Syntax
-
-```js
-var String = HTMLObjectElement.name;
-HTMLObjectElement.name = String;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/type/index.md
+++ b/files/en-us/web/api/htmlobjectelement/type/index.md
@@ -18,14 +18,7 @@ The **`type`** property of the
 reflects the {{htmlattrxref("type", "object")}} HTML attribute, specifying the MIME type
 of the resource.
 
-## Syntax
-
-```js
-var String = HTMLObjectElement.type
-HTMLObjectElement.type = String;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/usemap/index.md
+++ b/files/en-us/web/api/htmlobjectelement/usemap/index.md
@@ -18,14 +18,7 @@ The **`useMap`** property of the
 reflects the {{htmlattrxref("usemap", "object")}} HTML attribute, specifying a
 {{HTMLElement("map")}} element to use.
 
-## Syntax
-
-```js
-var String = HTMLObjectElement.useMap;
-HTMLObjectElement.useMap = String;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/validationmessage/index.md
+++ b/files/en-us/web/api/htmlobjectelement/validationmessage/index.md
@@ -20,13 +20,7 @@ control does not satisfy (if any). This is the empty string if the control is no
 candidate for constraint validation (willValidate is false), or it satisfies its
 constraints.
 
-## Syntax
-
-```js
-var String = HTMLObjectElement.validationMessage;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/htmlobjectelement/validity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/validity/index.md
@@ -17,13 +17,7 @@ The **`validity`** read-only property of the
 {{domxref("HTMLObjectElement")}} interface returns a {{domxref("ValidityState")}} with
 the validity states that this element is in.
 
-## Syntax
-
-```js
-var ValidityState = HTMLObjectElement.validity;
-```
-
-### Value
+## Value
 
 A {{domxref("ValidityState")}} object.
 

--- a/files/en-us/web/api/htmlobjectelement/width/index.md
+++ b/files/en-us/web/api/htmlobjectelement/width/index.md
@@ -18,14 +18,7 @@ The **`width`** property of the
 reflects the {{htmlattrxref("width", "object")}} HTML attribute, specifying the
 displayed width of the resource in CSS pixels.
 
-## Syntax
-
-```js
-var String = HTMLObjectElement.width;
-HTMLObjectElement.width = String;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/htmlobjectelement/willvalidate/index.md
+++ b/files/en-us/web/api/htmlobjectelement/willvalidate/index.md
@@ -18,13 +18,7 @@ the {{domxref("HTMLObjectElement")}} interface returns a boolean value that
 indicates whether the element is a candidate for constraint validation. Always false for
 HTMLObjectElement objects.
 
-## Syntax
-
-```js
-var Boolean = HTMLObjectElement.willValidate;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/htmlselectelement/selectedoptions/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedoptions/index.md
@@ -25,13 +25,7 @@ element that are currently selected. The list of selected options is an
 An option is considered selected if it has an {{domxref("HTMLOptionElement.selected")}}
 attribute.
 
-## Syntax
-
-```js
-var selectedCollection = HTMLSelectElement.selectedOptions;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}} which lists every currently selected
 {{domxref("HTMLOptionElement")}} which is either a child of the

--- a/files/en-us/web/api/htmlslotelement/name/index.md
+++ b/files/en-us/web/api/htmlslotelement/name/index.md
@@ -16,14 +16,7 @@ The **`name`** property of the {{domxref("HTMLSlotElement")}}
 interface returns or sets the slot name. A slot is a placeholder inside a web component
 that users can fill with their own markup.
 
-## Syntax
-
-```js
-let name = htmlSlotElement.name
-htmlSlotElement.name = name
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString','string')}}.
 

--- a/files/en-us/web/api/htmltableelement/cellspacing/index.md
+++ b/files/en-us/web/api/htmltableelement/cellspacing/index.md
@@ -21,14 +21,7 @@ around the individual {{HTMLElement("th")}} and {{HTMLElement("td")}} elements
 representing a table's cells. Any two cells are separated by the sum of the
 `cellSpacing` of each of the two cells.
 
-## Syntax
-
-```js
-HTMLTableElement.cellSpacing = spacing;
-var spacing = HTMLTableElement.cellSpacing;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which is either a number of pixels (such as
 `"10"`) or a percentage value (like `"10%"`).

--- a/files/en-us/web/api/htmltablerowelement/rowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/rowindex/index.md
@@ -20,13 +20,7 @@ table in the right order. Therefore the rows count from `<thead>` to
 `<tbody>`, from `<tbody>` to
 `<tfoot>`.
 
-## Syntax
-
-```js
-var index = HTMLTableRowElement.rowIndex
-```
-
-### Value
+## Value
 
 Returns the index of the row, or `-1` if the row is not part of a table.
 

--- a/files/en-us/web/api/htmltrackelement/src/index.md
+++ b/files/en-us/web/api/htmltrackelement/src/index.md
@@ -18,13 +18,7 @@ The **`HTMLTrackElement.src`** property reflects the value of
 the {{HTMLElement("track")}} element's {{htmlattrxref("src", "track")}} attribute, which
 indicates the URL of the text track's data.
 
-## Syntax
-
-```js
-var textTrackURL = HTMLTrackElement.src;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} object containing the URL of the text track data.
 

--- a/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.md
@@ -22,13 +22,7 @@ The {{domxref("HTMLVideoElement")}}
 attribute indicating whether the video should enter or leave picture-in-picture mode
 automatically.
 
-## Syntax
-
-```js
-autoPictureInPicture = htmlVideoElement.autoPictureInPicture;
-```
-
-### Value
+## Value
 
 A boolean value that is `true` if the video should enter or
 leave picture-in-picture mode automatically when changing tab and/or application.

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -22,13 +22,7 @@ The {{domxref("HTMLVideoElement")}}
 attribute indicating whether the user agent should suggest the
 picture-in-picture feature to users, or request it automatically.
 
-## Syntax
-
-```js
-disablePictureInPicture = htmlVideoElement.disablePictureInPicture;
-```
-
-### Value
+## Value
 
 A boolean value that is `true` if the user agent should
 suggest that feature to users.

--- a/files/en-us/web/api/htmlvideoelement/videoheight/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videoheight/index.md
@@ -31,13 +31,7 @@ height of the media in its natural size.
 See [About intrinsic width and
   height](#about_intrinsic_width_and_height) for more details.
 
-## Syntax
-
-```js
-height = htmlVideoElement.videoHeight;
-```
-
-### Value
+## Value
 
 An integer value specifying the intrinsic height of the video in CSS pixels. If the
 element's {{domxref("HTMLMediaElement.readyState", "readyState")}} is

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.md
@@ -26,13 +26,7 @@ width of the media in its natural size.
 
 See [About intrinsic width and height](#about_intrinsic_width_and_height) for more details.
 
-## Syntax
-
-```js
-width = htmlVideoElement.videoWidth;
-```
-
-### Value
+## Value
 
 An integer value specifying the intrinsic width of the video in CSS pixels. If the
 element's {{domxref("HTMLMediaElement.readyState", "readyState")}} is

--- a/files/en-us/web/api/idbdatabase/name/index.md
+++ b/files/en-us/web/api/idbdatabase/name/index.md
@@ -20,13 +20,7 @@ name of the connected database.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var dbName = IDBDatabase.name;
-```
-
-### Value
+## Value
 
 A {{ domxref("DOMString")}} containing the name of the connected database.
 

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.md
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.md
@@ -21,13 +21,7 @@ stores](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store) curren
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var list[] = IDBDatabase.objectStoreNames;
-```
-
-### Value
+## Value
 
 A {{ domxref("DOMStringList") }} containing a list of
 the names of the [object stores](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#object_store)currently

--- a/files/en-us/web/api/idbdatabase/version/index.md
+++ b/files/en-us/web/api/idbdatabase/version/index.md
@@ -21,13 +21,7 @@ When a database is first created, this attribute is an empty string.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myInteger = IDBDatabase.version;
-```
-
-### Value
+## Value
 
 An integer containing the version of the connected database.
 

--- a/files/en-us/web/api/idbindex/name/index.md
+++ b/files/en-us/web/api/idbindex/name/index.md
@@ -19,14 +19,7 @@ interface contains a string which names the index.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var indexName = IDBIndex.name;
-IDBIndex.name = indexName;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying a name for the index.
 

--- a/files/en-us/web/api/idbindex/unique/index.md
+++ b/files/en-us/web/api/idbindex/unique/index.md
@@ -24,13 +24,7 @@ will not be able to accept duplicate entries.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var isUnique = IDBIndex.unique;
-```
-
-### Value
+## Value
 
 A boolean value:
 

--- a/files/en-us/web/api/idbobjectstore/name/index.md
+++ b/files/en-us/web/api/idbobjectstore/name/index.md
@@ -19,14 +19,7 @@ interface indicates the name of this object store.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-IDBObjectStore.name = myNewName;
-var myObjectStoreName = IDBObjectStore.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the object
 store's name.

--- a/files/en-us/web/api/idbtransaction/durability/index.md
+++ b/files/en-us/web/api/idbtransaction/durability/index.md
@@ -21,13 +21,7 @@ durability when committing the transaction.
 
 The value of this property is defined in the `options` parameter when creating a transaction using {{domxref("IDBDatabase.transaction()")}}.
 
-## Syntax
-
-```js
-var transactionDurability = idbTransaction.durability;
-```
-
-### Value
+## Value
 
 Any of the following literal {{jsxref('String', 'strings')}}:
 

--- a/files/en-us/web/api/idbtransaction/mode/index.md
+++ b/files/en-us/web/api/idbtransaction/mode/index.md
@@ -22,13 +22,7 @@ read-only, or do you want to write to the object stores?) The default value is
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myCurrentMode = IDBTransaction.mode;
-```
-
-### Value
+## Value
 
 An {{domxref("IDBTransactionMode")}} object defining the mode for isolating access to
 data in the current object stores:

--- a/files/en-us/web/api/idbversionchangeevent/newversion/index.md
+++ b/files/en-us/web/api/idbversionchangeevent/newversion/index.md
@@ -20,13 +20,7 @@ database.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var newVersion = IDBVersionChangeEvent.newVersion
-```
-
-### Value
+## Value
 
 A [64-bit
 integer](</en-US/docs/NSPR_API_Reference/Long_Long_(64-bit)_Integers>).

--- a/files/en-us/web/api/idbversionchangeevent/oldversion/index.md
+++ b/files/en-us/web/api/idbversionchangeevent/oldversion/index.md
@@ -23,13 +23,7 @@ When the opened database doesn't exist yet, the value of `oldVersion` is
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var oldVersion = IDBVersionChangeEvent.oldVersion
-```
-
-### Value
+## Value
 
 A [64-bit
 integer](</en-US/docs/NSPR_API_Reference/Long_Long_(64-bit)_Integers>).

--- a/files/en-us/web/api/idledeadline/didtimeout/index.md
+++ b/files/en-us/web/api/idledeadline/didtimeout/index.md
@@ -33,13 +33,7 @@ you should react by performing the needed task or, ideally, a minimal amount of 
 that can be done to keep things moving along, then schedule a new callback to try again
 to get the rest of the work done.
 
-## Syntax
-
-```js
-var timedOut = IdleDeadline.didTimeout;
-```
-
-### Value
+## Value
 
 A Boolean which is `true` if the callback is running due to the callback's
 timeout period elapsing or `false` if the callback is running because the

--- a/files/en-us/web/api/imagecapture/track/index.md
+++ b/files/en-us/web/api/imagecapture/track/index.md
@@ -20,13 +20,7 @@ The **`track`** read-only property of the
 {{domxref("MediaStreamTrack")}} passed to the
 {{domxref("ImageCapture.ImageCapture","ImageCapture()")}} constructor.
 
-## Syntax
-
-```js
-const mediaStreamTrack = imageCaptureObj.track
-```
-
-### Value
+## Value
 
 A {{domxref("MediaStreamTrack")}} object.
 

--- a/files/en-us/web/api/inputevent/data/index.md
+++ b/files/en-us/web/api/inputevent/data/index.md
@@ -20,13 +20,7 @@ The **`data`** read-only property of the
 characters. This may be an empty string if the change doesn't insert text, such as when
 characters are deleted.
 
-## Syntax
-
-```js
-var aString = inputEvent.data;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/inputevent/datatransfer/index.md
+++ b/files/en-us/web/api/inputevent/datatransfer/index.md
@@ -20,13 +20,7 @@ The **`dataTransfer`** read-only property of the
 containing information about richtext or plaintext data being added to or removed from
 editable content.
 
-## Syntax
-
-```js
-var dataTransfer = inputEvent.dataTransfer
-```
-
-### Value
+## Value
 
 A {{domxref("DataTransfer")}} object.
 


### PR DESCRIPTION
@teoli2003

## Summary
Sequel of #14195 .
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
