### PR TITLE
WebAPI: Clean syntax from property pages, part 6

### DIFF
--- a/files/en-us/web/api/texttrackcue/pauseonexit/index.md
+++ b/files/en-us/web/api/texttrackcue/pauseonexit/index.md
@@ -13,14 +13,7 @@ browser-compat: api.TextTrackCue.pauseOnExit
 
 The **`pauseOnExit`** property of the {{domxref("TextTrackCue")}} interface returns or sets the flag indicating whether playback of the media should pause when the end of the range to which this cue applies is reached.
 
-## Syntax
-
-```js
-let pauseOnExit = TextTrackCue.pauseOnExit;
-TextTrackCue.pauseOnExit = true;
-```
-
-### Value
+## Value
 
 A {{jsxref("Boolean")}}, true if the media will pause.
 

--- a/files/en-us/web/api/texttrackcue/starttime/index.md
+++ b/files/en-us/web/api/texttrackcue/starttime/index.md
@@ -13,14 +13,7 @@ browser-compat: api.TextTrackCue.startTime
 
 The **`startTime`** property of the {{domxref("TextTrackCue")}} interface returns and sets the start time of the cue.
 
-## Syntax
-
-```js
-let startTime = TextTrackCue.startTime;
-TextTrackCue.startTime = 1;
-```
-
-### Value
+## Value
 
 An integer representing the start time, in seconds.
 

--- a/files/en-us/web/api/texttrackcue/track/index.md
+++ b/files/en-us/web/api/texttrackcue/track/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextTrackCue.track
 
 The **`track`** read-only property of the {{domxref("TextTrackCue")}} interface returns the {{domxref("TextTrack")}} object that this cue belongs to.
 
-## Syntax
-
-```js
-let track = TextTrackCue.track;
-```
-
-### Value
+## Value
 
 A {{domxref("TextTrack")}} object.
 

--- a/files/en-us/web/api/texttrackcuelist/length/index.md
+++ b/files/en-us/web/api/texttrackcuelist/length/index.md
@@ -15,13 +15,7 @@ browser-compat: api.TextTrackCueList.length
 
 The **`length`** read-only property of the {{domxref("TextTrackCueList")}} interface returns the number of cues in the list.
 
-## Syntax
-
-```js
-var length = TextTrackCueList.length;
-```
-
-### Value
+## Value
 
 An `unsigned long` which is the number of cues in the list.
 

--- a/files/en-us/web/api/texttracklist/length/index.md
+++ b/files/en-us/web/api/texttracklist/length/index.md
@@ -24,13 +24,7 @@ one track in the media element.
 A value of 0 indicates that there are no text
 tracks in the media.
 
-## Syntax
-
-```js
-var trackCount = TextTrackList.length;
-```
-
-### Value
+## Value
 
 A number indicating how many text tracks are included in the
 `TextTrackList`. Each track can be accessed by treating the

--- a/files/en-us/web/api/trackevent/track/index.md
+++ b/files/en-us/web/api/trackevent/track/index.md
@@ -24,13 +24,7 @@ event applies.
 The media track will be an {{domxref("AudioTrack")}},
 {{domxref("VideoTrack")}}, or {{domxref("TextTrack")}} object.
 
-## Syntax
-
-```js
-track = TrackEvent.track;
-```
-
-### Value
+## Value
 
 An object which is one of the types {{domxref("AudioTrack")}},
 {{domxref("VideoTrack")}}, or {{domxref("TextTrack")}}, depending on the type of media

--- a/files/en-us/web/api/transformstream/readable/index.md
+++ b/files/en-us/web/api/transformstream/readable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TransformStream.readable
 
 The **`readable`** read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("ReadableStream")}} instance controlled by this `TransformStream`.
 
-## Syntax
-
-```js
-let readable = TransformStream.readable;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/transformstream/writable/index.md
+++ b/files/en-us/web/api/transformstream/writable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TransformStream.writable
 
 The **`writable`** read-only property of the {{domxref("TransformStream")}} interface returns the {{domxref("WritableStream")}} instance controlled by this `TransformStream`.
 
-## Syntax
-
-```js
-let writable = TransformStream.writable;
-```
-
-### Value
+## Value
 
 A {{domxref("WritableStream")}}.
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.md
@@ -17,13 +17,7 @@ The internal queue of a `ReadableStream` contains chunks that have been enqueued
 
 If the `desiredSize` is `0` then the queue is full. Therefore you can use this information to [manually apply backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) to manage the queue.
 
-## Syntax
-
-```js
-let desiredSize = TransformStreamDefaultController.desiredSize;
-```
-
-### Value
+## Value
 
 The desired size.
 

--- a/files/en-us/web/api/trustedtypepolicy/name/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TrustedTypePolicy.name
 
 The **`name`** read-only property of the {{domxref("TrustedTypePolicy")}} interface returns the name of the policy.
 
-## Syntax
-
-```js
-var name = TrustedTypePolicy.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the name of the policy.
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.md
@@ -15,13 +15,7 @@ The **`defaultPolicy`** read-only property of the {{domxref("TrustedTypePolicyFa
 
 > **Note:** Information about the creation and use of default policies can be found in the [`createPolicy()`](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#default_policy) documentation.
 
-## Syntax
-
-```js
-var defaultPolicy = TrustedTypePolicyFactory.defaultPolicy;
-```
-
-### Value
+## Value
 
 A {{domxref("TrustedTypePolicy")}} or null.
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.md
@@ -15,13 +15,7 @@ The **`emptyHTML`** read-only property of the {{domxref("TrustedTypePolicyFactor
 
 This object can be used when the application requires an empty string to be inserted into an injection sink.
 
-## Syntax
-
-```js
-var emptyHTML = TrustedTypePolicyFactory.emptyHTML;
-```
-
-### Value
+## Value
 
 A {{domxref("TrustedHTML")}} object.
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.md
@@ -15,13 +15,7 @@ The **`emptyScript`** read-only property of the {{domxref("TrustedTypePolicyFact
 
 This object can be used when the application requires an empty string to be inserted into an injection sink which is expecting a `TrustedScript` object.
 
-## Syntax
-
-```js
-var emptyScript = TrustedTypePolicyFactory.emptyScript;
-```
-
-### Value
+## Value
 
 A {{domxref("TrustedScript")}} object.
 

--- a/files/en-us/web/api/url/hash/index.md
+++ b/files/en-us/web/api/url/hash/index.md
@@ -20,14 +20,7 @@ have a fragment identifier, this property contains an empty string — `""`.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const string = url.hash
-url.hash = newHash
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/host/index.md
+++ b/files/en-us/web/api/url/host/index.md
@@ -18,14 +18,7 @@ a {{domxref("USVString")}} containing the host, that is the {{domxref("URL.hostn
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const host = url.host
-url.host = newHost
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/hostname/index.md
+++ b/files/en-us/web/api/url/hostname/index.md
@@ -16,14 +16,7 @@ is a {{domxref("USVString")}} containing the {{glossary("domain name")}} of the 
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const domain = url.hostname
-url.hostname = domain
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/href/index.md
+++ b/files/en-us/web/api/url/href/index.md
@@ -16,14 +16,7 @@ a {{domxref("USVString")}} containing the whole URL.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const urlString = url.href
-url.href = newUrlString
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -31,13 +31,7 @@ varies depending on the type of URL:
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const originString = url.origin
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/password/index.md
+++ b/files/en-us/web/api/url/password/index.md
@@ -20,14 +20,7 @@ property, it silently fails.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const passwordString = url.password
-url.password = newPassword
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/pathname/index.md
+++ b/files/en-us/web/api/url/pathname/index.md
@@ -18,14 +18,7 @@ is no path).
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const path = url.pathname
-url.pathname = newPath
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -18,14 +18,7 @@ contain an explicit port number, it will be set to `''`.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const portNumber = url.port
-url.port = newPortNumber
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/protocol/index.md
+++ b/files/en-us/web/api/url/protocol/index.md
@@ -17,14 +17,7 @@ final `':'`.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const protocol = url.protocol
-url.protocol = newProtocol
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/url/searchparams/index.md
+++ b/files/en-us/web/api/url/searchparams/index.md
@@ -18,13 +18,7 @@ access to the {{httpmethod("GET")}} decoded query arguments contained in the URL
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const urlSearchParams = url.searchParams
-```
-
-### Value
+## Value
 
 A {{domxref("URLSearchParams")}} object.
 

--- a/files/en-us/web/api/url/username/index.md
+++ b/files/en-us/web/api/url/username/index.md
@@ -17,14 +17,7 @@ is a {{domxref("USVString")}} containing the username specified before the domai
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const usernameString = url.username
-url.username = newUsername
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.md
@@ -20,13 +20,7 @@ to describe this configuration. This is equal to the value of the string descrip
 the index provided in the [`iConfiguration`](https://www.beyondlogic.org/usbnutshell/usb5.shtml#ConfigurationDescriptors)
 field of the configuration descriptor defining this configuration.
 
-## Syntax
-
-```js
-  var name = USBConfiguration.configurationName
-```
-
-### Value
+## Value
 
 The name provided by the device to describe this configuration.
 

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
@@ -17,13 +17,7 @@ browser-compat: api.USBConfiguration.configurationValue
 The **`configurationValue`** read-only property
 of the {{domxref("USBConfiguration")}} interface null
 
-## Syntax
-
-```js
-var value = USBConfiguration.configurationValue
-```
-
-### Value
+## Value
 
 The [configuration
 descriptor](https://www.beyondlogic.org/usbnutshell/usb5.shtml#ConfigurationDescriptors) of the {{domxref("USBDevice")}} specified in the constructor of the

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.md
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.md
@@ -18,13 +18,7 @@ The **`interfaces`** read-only property of the
 {{domxref("USBConfiguration")}} interface returns an array containing instances of the
 {{domxref('USBInterface')}} describing each interface supported by this configuration.
 
-## Syntax
-
-```js
-  var interfaces[] = USBConfiguration.interfaces
-```
-
-### Value
+## Value
 
 An array containing instances of {{domxref('USBInterface')}}.
 

--- a/files/en-us/web/api/usbconnectionevent/device/index.md
+++ b/files/en-us/web/api/usbconnectionevent/device/index.md
@@ -13,13 +13,7 @@ browser-compat: api.USBConnectionEvent.device
 
 The **`device`** read-only property of the {{domxref("USBConnectionEvent")}} interface returns a {{domxref("USBDevice")}} object representing the device being connected or disconnected.
 
-## Syntax
-
-```js
-let device = USBConnectionEvent.device;
-```
-
-### Value
+## Value
 
 A {{domxref("USBDevice")}} object.
 

--- a/files/en-us/web/api/usbdevice/configuration/index.md
+++ b/files/en-us/web/api/usbdevice/configuration/index.md
@@ -18,13 +18,7 @@ The **`configuration`** read only property of the
 {{domxref("USBDevice")}} interface returns a {{domxref("USBConfiguration")}} object for
 the currently selected interface for a paired USB device.
 
-## Syntax
-
-```js
-var USBConfiguration = USBDevice.configuration
-```
-
-### Value
+## Value
 
 A {{domxref("USBConfiguration")}} object.
 

--- a/files/en-us/web/api/usbdevice/configurations/index.md
+++ b/files/en-us/web/api/usbdevice/configurations/index.md
@@ -18,13 +18,7 @@ The **`configurations`** read only property of the
 {{domxref("USBDevice")}} interface an {{jsxref("array")}} of device-specific interfaces
 for controlling a paired USB device.
 
-## Syntax
-
-```js
-var USBConfiguration[] = USBDevice.configurations
-```
-
-### Value
+## Value
 
 An {{jsxref("array")}} of {{domxref("USBConfiguration")}} objects.
 

--- a/files/en-us/web/api/usbdevice/deviceclass/index.md
+++ b/files/en-us/web/api/usbdevice/deviceclass/index.md
@@ -19,13 +19,7 @@ The **`deviceClass`** read only property of the
 the purpose of loading a USB driver that will work with that device. The other two
 properties are USBDevice.deviceSubclass and USBDevice.deviceprotocol.
 
-## Syntax
-
-```js
-var number = USBDevice.deviceClass
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/usbdevice/deviceprotocol/index.md
+++ b/files/en-us/web/api/usbdevice/deviceprotocol/index.md
@@ -20,13 +20,7 @@ the purpose of loading a USB driver that will work with that device. The other t
 properties are `USBDevice.deviceClass`
 and `USBDevice.deviceSubclass`.
 
-## Syntax
-
-```js
-var number = USBDevice.deviceProtocol
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/usbdevice/devicesubclass/index.md
+++ b/files/en-us/web/api/usbdevice/devicesubclass/index.md
@@ -19,13 +19,7 @@ The **`deviceSubclass`** read only property of the
 the purpose of loading a USB driver that will work with that device. The other two
 properties are USBDevice.deviceClass and USBDevice.deviceProtocol.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.deviceSubclass
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/usbdevice/deviceversionmajor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionmajor/index.md
@@ -18,13 +18,7 @@ The **`deviceVersionMajor`** read only property of the
 {{domxref("USBDevice")}} interface he major version number of the device in a semantic
 versioning scheme.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.deviceVersionMajor
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/usbdevice/deviceversionminor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionminor/index.md
@@ -18,13 +18,7 @@ The **`deviceVersionMinor`** read only property of the
 {{domxref("USBDevice")}} interface the minor version number of the device in a semantic
 versioning scheme.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.deviceVersionMinor
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/usbdevice/deviceversionsubminor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionsubminor/index.md
@@ -18,13 +18,7 @@ The **`deviceVersionSubminor`** read only property of the
 {{domxref("USBDevice")}} interface the patch version number of the device in a semantic
 versioning scheme.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.deviceVersionSubminor
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/usbdevice/manufacturername/index.md
+++ b/files/en-us/web/api/usbdevice/manufacturername/index.md
@@ -18,13 +18,7 @@ The **`manufacturerName`** read only property of the
 {{domxref("USBDevice")}} interface the of the organization that manufactured the USB
 device.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.manufacturerName
-```
-
-### Value
+## Value
 
 A {{jsxref("DOMString")}}.
 

--- a/files/en-us/web/api/usbdevice/opened/index.md
+++ b/files/en-us/web/api/usbdevice/opened/index.md
@@ -18,13 +18,7 @@ The **`opened`** read only property of the
 {{domxref("USBDevice")}} interface indicates whether a session has been started with a
 paired USB device. A device must be opened before it can be controlled by a web page.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.opened
-```
-
-### Value
+## Value
 
 A {{jsxref("boolean")}}.
 

--- a/files/en-us/web/api/usbdevice/productid/index.md
+++ b/files/en-us/web/api/usbdevice/productid/index.md
@@ -18,13 +18,7 @@ The **`productId`** read only property of the
 {{domxref("USBDevice")}} interface the manufacturer-defined code that identifies a USB
 device.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.productId
-```
-
-### Value
+## Value
 
 The manufacturer-defined code that identifies a USB device.
 

--- a/files/en-us/web/api/usbdevice/productname/index.md
+++ b/files/en-us/web/api/usbdevice/productname/index.md
@@ -18,13 +18,7 @@ The **`productName`** read only property of the
 {{domxref("USBDevice")}} interface the manufacturer-defined name that identifies a USB
 device.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.productName
-```
-
-### Value
+## Value
 
 The manufacturer-defined name that identifies a USB device.
 

--- a/files/en-us/web/api/usbdevice/serialnumber/index.md
+++ b/files/en-us/web/api/usbdevice/serialnumber/index.md
@@ -18,13 +18,7 @@ The **`serialNumber`** read only property of the
 {{domxref("USBDevice")}} interface is the manufacturer-defined serial number for the
 specific USB device.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.serialNumber
-```
-
-### Value
+## Value
 
 The serial number for the specified USB device
 

--- a/files/en-us/web/api/usbdevice/usbversionmajor/index.md
+++ b/files/en-us/web/api/usbdevice/usbversionmajor/index.md
@@ -19,13 +19,7 @@ The **`usbVersionMajor`** read only property of the
 protocol version supported by the device. The other two properties
 are USBDevice.usbVersionMinor and USBDevice.usbVersionSubminor.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.usbVersionMajor
-```
-
-### Value
+## Value
 
 The last of three properties that declare the USB protocol version supported by the
 device.

--- a/files/en-us/web/api/usbdevice/usbversionminor/index.md
+++ b/files/en-us/web/api/usbdevice/usbversionminor/index.md
@@ -19,13 +19,7 @@ The **`usbVersionMinor`** read only property of the
 protocol version supported by the device. The other two properties
 are USBDevice.usbVersionMajor and USBDevice.usbVersionSubminor.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.usbVersionMinor
-```
-
-### Value
+## Value
 
 The second of three properties that declare the USB protocol version supported by the
 device.

--- a/files/en-us/web/api/usbdevice/usbversionsubminor/index.md
+++ b/files/en-us/web/api/usbdevice/usbversionsubminor/index.md
@@ -19,13 +19,7 @@ The **`usbVersionSubminor`** read only property of the
 protocol version supported by the device. The other two properties
 are USBDevice.usbVersionMajor and USBDevice.usbVersionMinor.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.usbVersionSubminor
-```
-
-### Value
+## Value
 
 The first of three properties that declare the USB protocol version supported by the
 device.

--- a/files/en-us/web/api/usbdevice/vendorid/index.md
+++ b/files/en-us/web/api/usbdevice/vendorid/index.md
@@ -17,13 +17,7 @@ browser-compat: api.USBDevice.vendorId
 The **`vendorId`** read only property of the
 {{domxref("USBDevice")}} interface is the official usg.org-assigned vendor ID.
 
-## Syntax
-
-```js
-var serialNumber = USBDevice.vendorId
-```
-
-### Value
+## Value
 
 The official usb.org-assigned vendor ID.
 

--- a/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
@@ -26,13 +26,7 @@ The {{domxref("VideoPlaybackQuality")}} interface's read-only
 video frames that have been received since the {{HTMLElement("video")}} element was
 last loaded or reloaded.
 
-## Syntax
-
-```js
-corruptFrameFount = videoPlaybackQuality.corruptedVideoFrames;
-```
-
-### Value
+## Value
 
 The number of corrupted video frames that have been received since the
 {{HTMLElement("video")}} element was last loaded or reloaded.

--- a/files/en-us/web/api/videoplaybackquality/creationtime/index.md
+++ b/files/en-us/web/api/videoplaybackquality/creationtime/index.md
@@ -21,13 +21,7 @@ The read-only **`creationTime`** property on the
 {{domxref("VideoPlaybackQuality")}} interface reports the number of milliseconds since
 the browsing context was created this quality sample was recorded.
 
-## Syntax
-
-```js
-value = videoPlaybackQuality.creationTime;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object which indicates the number of milliseconds
 that elapsed between the time the browsing context was created and the time at which

--- a/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
@@ -25,13 +25,7 @@ property of the {{domxref("VideoPlaybackQuality")}} interface returns the number
 video frames which have been dropped rather than being displayed since the last time
 the media was loaded into the {{domxref("HTMLVideoElement")}}.
 
-## Syntax
-
-```js
-value = videoPlaybackQuality.droppedVideoFrames;
-```
-
-### Value
+## Value
 
 An unsigned 64-bit value indicating the number of frames that have been dropped since
 the last time the media in the {{HTMLElement("video")}} element was loaded or reloaded.

--- a/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
@@ -25,13 +25,7 @@ The {{domxref("VideoPlaybackQuality")}} interface's
 number of video frames that have been displayed or dropped since the media was
 loaded.
 
-## Syntax
-
-```js
-value = videoPlaybackQuality.totalVideoFrames;
-```
-
-### Value
+## Value
 
 The total number of frames that the {{HTMLElement("video")}} element has displayed or
 dropped since the media was loaded into it. Essentially, this is the number of frames

--- a/files/en-us/web/api/videotrack/id/index.md
+++ b/files/en-us/web/api/videotrack/id/index.md
@@ -29,13 +29,7 @@ the media associated with a media element.
 The track ID can also be used as the fragment of a URL that loads the specific track
 (if the media supports media fragments).
 
-## Syntax
-
-```js
-var trackID = VideoTrack.id;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which identifies the track, suitable for use when calling
 {{domxref("VideoTrackList.getTrackById", "getTrackById()")}} on an

--- a/files/en-us/web/api/videotrack/kind/index.md
+++ b/files/en-us/web/api/videotrack/kind/index.md
@@ -25,13 +25,7 @@ The `kind` can be used
 to determine the scenarios in which specific tracks should be enabled or disabled. See
 [Video track kind strings](#video_track_kind_strings) for a list of the kinds available for video tracks.
 
-## Syntax
-
-```js
-var trackKind = VideoTrack.kind;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the type of content the media represents. The
 string is one of those found in [Video track kind strings](#video_track_kind_strings) below.

--- a/files/en-us/web/api/videotrack/label/index.md
+++ b/files/en-us/web/api/videotrack/label/index.md
@@ -23,13 +23,7 @@ property **`label`** returns a string specifying the video
 track's human-readable label, if one is available; otherwise, it returns an empty
 string.
 
-## Syntax
-
-```js
-var videoTrackLabel = VideoTrack.label;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the track's human-readable label, if one is
 available in the track metadata. Otherwise, an empty string (`""`) is

--- a/files/en-us/web/api/videotrack/language/index.md
+++ b/files/en-us/web/api/videotrack/language/index.md
@@ -25,13 +25,7 @@ For tracks that include multiple languages
 (such as a movie in English in which a few lines are spoken in other languages), this
 should be the video's primary language.
 
-## Syntax
-
-```js
-var videoTrackLanguage = VideoTrack.language;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the BCP 47 ({{RFC(5646)}}) format language tag of
 the primary language used in the video track, or an empty string (`""`) if

--- a/files/en-us/web/api/videotrack/selected/index.md
+++ b/files/en-us/web/api/videotrack/selected/index.md
@@ -20,15 +20,7 @@ The **{{domxref("VideoTrack")}}** property
 **`selected`** controls whether or not a particular video
 track is active.
 
-## Syntax
-
-```js
-isVideoSelected = VideoTrack.selected;
-
-VideoTrack.selected = true | false;
-```
-
-### Value
+## Value
 
 The `selected` property is a Boolean whose value is `true` if the
 track is active. Only a single video track can be active at any given time, so setting

--- a/files/en-us/web/api/videotrack/sourcebuffer/index.md
+++ b/files/en-us/web/api/videotrack/sourcebuffer/index.md
@@ -25,13 +25,7 @@ created by a {{domxref("SourceBuffer")}} or the {{domxref("SourceBuffer")}} has 
 removed from the {{domxref("MediaSource.sourceBuffers")}} attribute of its parent
 media source.
 
-## Syntax
-
-```js
-var sourceBuffer = VideoTrack.sourceBuffer;
-```
-
-### Value
+## Value
 
 A {{domxref("SourceBuffer")}} or null.
 

--- a/files/en-us/web/api/videotracklist/length/index.md
+++ b/files/en-us/web/api/videotracklist/length/index.md
@@ -25,13 +25,7 @@ one video track in the media element.
 A value of 0 indicates that there are no
 video tracks in the media.
 
-## Syntax
-
-```js
-var trackCount = VideoTrackList.length;
-```
-
-### Value
+## Value
 
 A number indicating how many video tracks are included in the
 `VideoTrackList`. Each track can be accessed by treating the

--- a/files/en-us/web/api/videotracklist/selectedindex/index.md
+++ b/files/en-us/web/api/videotracklist/selectedindex/index.md
@@ -19,13 +19,7 @@ The read-only **{{domxref("VideoTrackList")}}**
 property **`selectedIndex`** returns the index of the
 currently selected track, if any, or `-1` otherwise.
 
-## Syntax
-
-```js
-var index = VideoTrackList.selectedIndex;
-```
-
-### Value
+## Value
 
 A number indicating the index of the currently selected track, if any, or
 `-1` otherwise.

--- a/files/en-us/web/api/visualviewport/height/index.md
+++ b/files/en-us/web/api/visualviewport/height/index.md
@@ -17,13 +17,7 @@ The **`height`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the height of the visual viewport, in
 CSS pixels.
 
-## Syntax
-
-```js
-var height = VisualViewport.height
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/visualviewport/offsetleft/index.md
+++ b/files/en-us/web/api/visualviewport/offsetleft/index.md
@@ -17,13 +17,7 @@ The **`offsetLeft`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the offset of the left edge of the
 visual viewport from the left edge of the layout viewport in CSS pixels.
 
-## Syntax
-
-```js
-var offsetLeft = VisualViewport.offsetLeft
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/visualviewport/offsettop/index.md
+++ b/files/en-us/web/api/visualviewport/offsettop/index.md
@@ -17,13 +17,7 @@ The **`offsetTop`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the offset of the top edge of the visual
 viewport from the top edge of the layout viewport in CSS pixels.
 
-## Syntax
-
-```js
-var offsetTop = VisualViewport.offsetTop
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/visualviewport/pageleft/index.md
+++ b/files/en-us/web/api/visualviewport/pageleft/index.md
@@ -17,13 +17,7 @@ The **`pageLeft`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the x coordinate of the left edge of the
 visual viewport relative to the initial containing block origin, in CSS pixels.
 
-## Syntax
-
-```js
-var pageLeft = VisualViewport.pageLeft
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/visualviewport/pagetop/index.md
+++ b/files/en-us/web/api/visualviewport/pagetop/index.md
@@ -17,13 +17,7 @@ The **`pageTop`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the y coordinate of the top edge of the
 visual viewport relative to the initial containing block origin, in CSS pixels.
 
-## Syntax
-
-```js
-var pageTop = VisualViewport.pageTop
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/visualviewport/scale/index.md
+++ b/files/en-us/web/api/visualviewport/scale/index.md
@@ -17,13 +17,7 @@ The **`scale`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the pinch-zoom scaling factor applied
 to the visual viewport.
 
-## Syntax
-
-```js
-var scale = VisualViewport.scale
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/visualviewport/width/index.md
+++ b/files/en-us/web/api/visualviewport/width/index.md
@@ -17,13 +17,7 @@ The **`width`** read-only property of the
 {{domxref("VisualViewport")}} interface returns the width of the visual viewport, in CSS
 pixels.
 
-## Syntax
-
-```js
-var width = VisualViewport.width
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.md
@@ -19,13 +19,7 @@ The **`downDegrees`** read-only property of the {{domxref("VRFieldOfView")}} int
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myDownDegrees = VRFieldOfView.downDegrees;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.md
@@ -19,13 +19,7 @@ The **`leftDegrees`** read-only property of the {{domxref("VRFieldOfView")}} int
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myLeftDegrees = VRFieldOfView.leftDegrees;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.md
@@ -19,13 +19,7 @@ The **`rightDegrees`** read-only property of the {{domxref("VRFieldOfView")}} in
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myRightDegrees = VRFieldOfView.rightDegrees;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.md
@@ -19,13 +19,7 @@ The **`upDegrees`** read-only property of the {{domxref("VRFieldOfView")}} inter
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-var myUpDegrees = VRFieldOfView.upDegrees;
-```
-
-### Value
+## Value
 
 A double.
 

--- a/files/en-us/web/api/vttcue/align/index.md
+++ b/files/en-us/web/api/vttcue/align/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.align
 
 The **`align`** property of the {{domxref("VTTCue")}} interface represents the alignment of all of the lines of text in the text box.
 
-## Syntax
-
-```js
-let align = VTTCue.align;
-VTTCue.align = a;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing one of the following values:
 

--- a/files/en-us/web/api/vttcue/line/index.md
+++ b/files/en-us/web/api/vttcue/line/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.line
 
 The **`line`** property of the {{domxref("VTTCue")}} interface represents the cue line of this WebVTT cue.
 
-## Syntax
-
-```js
-let line = VTTCue.line;
-  VTTCue.line = a;
-```
-
-### Value
+## Value
 
 A number, or `"auto"` representing the cue line of this WebVTT cue.
 

--- a/files/en-us/web/api/vttcue/linealign/index.md
+++ b/files/en-us/web/api/vttcue/linealign/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.lineAlign
 
 The **`lineAlign`** property of the {{domxref("VTTCue")}} interface represents the alignment of this VTT cue.
 
-## Syntax
-
-```js
-let lineAlign = VTTCue.lineAlign;
-VTTCue.lineAlign = a;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing one of the following values:
 

--- a/files/en-us/web/api/vttcue/position/index.md
+++ b/files/en-us/web/api/vttcue/position/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.position
 
 The **`position`** property of the {{domxref("VTTCue")}} interface represents the indentation of the cue within the line.
 
-## Syntax
-
-```js
-let position = VTTCue.position;
-VTTCue.position = "auto";
-```
-
-### Value
+## Value
 
 A number, or `"auto"` representing the indentation of the cue within the line.
 

--- a/files/en-us/web/api/vttcue/positionalign/index.md
+++ b/files/en-us/web/api/vttcue/positionalign/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.positionAlign
 
 The **`positionAlign`** property of the {{domxref("VTTCue")}} interface is used to determine what {{domxref("VTTCue.position")}} is anchored to.
 
-## Syntax
-
-```js
-let positionAlign = VTTCue.position;
-VTTCue.position = a;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing one of the following values:
 

--- a/files/en-us/web/api/vttcue/region/index.md
+++ b/files/en-us/web/api/vttcue/region/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.region
 
 The **`region`** property of the {{domxref("VTTCue")}} interface returns and sets the {{domxref("VTTRegion")}} that this cue belongs to.
 
-## Syntax
-
-```js
-let region = VTTCue.region;
-VTTCue.region = a;
-```
-
-### Value
+## Value
 
 A {{domxref("VTTRegion")}} object.
 

--- a/files/en-us/web/api/vttcue/size/index.md
+++ b/files/en-us/web/api/vttcue/size/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.size
 
 The **`size`** property of the {{domxref("VTTCue")}} interface represents the size of the cue as a percentage of the video size.
 
-## Syntax
-
-```js
-let size = VTTCue.size;
-VTTCue.size = 50;
-```
-
-### Value
+## Value
 
 A number representing the size of the cue as a percentage of the video size.
 

--- a/files/en-us/web/api/vttcue/snaptolines/index.md
+++ b/files/en-us/web/api/vttcue/snaptolines/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.snapToLines
 
 The **`snapToLines`** property of the {{domxref("VTTCue")}} interface is a {{jsxref("Boolean")}} indicating if the {{domxref("VTTCue.line")}} property is an integer number of lines, or a percentage of the video size.
 
-## Syntax
-
-```js
-let snapToLines = VTTCue.snapToLines;
-VTTCue.snapToLines = a;
-```
-
-### Value
+## Value
 
 A {{jsxref("Boolean")}}.
 

--- a/files/en-us/web/api/vttcue/text/index.md
+++ b/files/en-us/web/api/vttcue/text/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.text
 
 The **`text`** property of the {{domxref("VTTCue")}} interface represents the text contents of the cue.
 
-## Syntax
-
-```js
-let text = VTTCue.text;
-VTTCue.text = a;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the raw text of the cue.
 

--- a/files/en-us/web/api/vttcue/vertical/index.md
+++ b/files/en-us/web/api/vttcue/vertical/index.md
@@ -13,14 +13,7 @@ browser-compat: api.VTTCue.vertical
 
 The **`vertical`** property of the {{domxref("VTTCue")}} interface is a {{domxref("DOMString","string")}} representing the cue's writing direction.
 
-## Syntax
-
-```js
-let vertical = VTTCue.vertical;
-VTTCue.vertical = "lr";
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing one of the following values:
 

--- a/files/en-us/web/api/window/closed/index.md
+++ b/files/en-us/web/api/window/closed/index.md
@@ -15,13 +15,7 @@ browser-compat: api.Window.closed
 The **`Window.closed`** read-only property indicates whether
 the referenced window is closed or not.
 
-## Syntax
-
-```js
-const isClosed = windowRef.closed;
-```
-
-### Value
+## Value
 
 A boolean value. Possible values:
 

--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -34,13 +34,7 @@ value of `devicePixelRatio` changes (which can happen, for example, if the
 user drags the window to a display with a different pixel density). See
 [the example below](#monitoring_screen_resolution_or_zoom_level_changes).
 
-## Syntax
-
-```js
-value = window.devicePixelRatio;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the ratio of the display's
 resolution in physical pixels to the resolution in CSS pixels. A value of 1 indicates a

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -19,13 +19,7 @@ in which the window is embedded.
 > within any embedding point, including {{HTMLElement("object")}},
 > {{HTMLElement("iframe")}}, or {{HTMLElement("embed")}}.
 
-## Syntax
-
-```js
-const frameEl = window.frameElement
-```
-
-### Value
+## Value
 
 The element which the window is embedded into. If the window isn't embedded into
 another document, or if the document into which it's embedded has a different

--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -25,13 +25,7 @@ The value of `innerHeight` is taken from the height of the window's
 {{Glossary("layout viewport")}}. The width can be obtained using the
 {{domxref("Window.innerWidth", "innerWidth")}} property.
 
-## Syntax
-
-```js
-let intViewportHeight = window.innerHeight;
-```
-
-### Value
+## Value
 
 An integer value indicating the window's layout viewport height in pixels. The property
 is read only and has no default value.

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -24,13 +24,7 @@ More precisely, `innerWidth` returns the width of the window's
 layout viewport—can be obtained from the {{domxref("Window.innerHeight",
   "innerHeight")}} property.
 
-## Syntax
-
-```js
-let intViewportWidth = window.innerWidth;
-```
-
-### Value
+## Value
 
 An integer value indicating the width of the window's layout viewport in pixels. This
 property is read-only, and has no default value.

--- a/files/en-us/web/api/window/localstorage/index.md
+++ b/files/en-us/web/api/window/localstorage/index.md
@@ -19,13 +19,7 @@ The **`localStorage`** read-only property of the {{domxref("window")}} interface
 
 `localStorage` is similar to {{DOMxRef("Window.sessionStorage", "sessionStorage")}}, except that while `localStorage` data has no expiration time, `sessionStorage` data gets cleared when the page session ends — that is, when the page is closed. (`localStorage` data for a document loaded in a "private browsing" or "incognito" session is cleared when the last "private" tab is closed.)
 
-## Syntax
-
-```js
-myStorage = window.localStorage;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("Storage")}} object which can be used to access the current origin's local storage space.
 

--- a/files/en-us/web/api/window/mozinnerscreenx/index.md
+++ b/files/en-us/web/api/window/mozinnerscreenx/index.md
@@ -21,13 +21,7 @@ coordinates.
 
 > **Note:** This coordinate is reported in CSS pixels, not in hardware pixels. That means it can be affected by the zoom level; to compute the actual number of physical screen pixels, you should use the [`nsIDOMWindowUtils.screenPixelsPerCSSPixel`](/en-US/docs/XPCOM_Interface_Reference/nsIDOMWindowUtils) property.
 
-## Syntax
-
-```js
-screenX = window.mozInnerScreenX;
-```
-
-### Value
+## Value
 
 - _screenX_ stores the `window.mozInnerScreenX` property value.
 - The `window.mozInnerScreenX` property is a floating point, read-only

--- a/files/en-us/web/api/window/mozinnerscreeny/index.md
+++ b/files/en-us/web/api/window/mozinnerscreeny/index.md
@@ -19,13 +19,7 @@ coordinates.
 
 > **Note:** This coordinate is reported in CSS pixels, not in hardware pixels.
 
-## Syntax
-
-```js
-screenY = window.mozInnerScreenY;
-```
-
-### Value
+## Value
 
 - _screenY_ stores the `window.mozInnerScreenY` property value.
 - The `window.mozInnerScreenY` property is a floating point, read-only

--- a/files/en-us/web/api/window/opener/index.md
+++ b/files/en-us/web/api/window/opener/index.md
@@ -21,13 +21,7 @@ a link with a {{htmlattrxref("target", "a")}} attribute.
 In other words, if window `A` opens window `B`,
 `B.opener` returns `A`.
 
-## Syntax
-
-```js
-const openerWindow = window.opener
-```
-
-### Value
+## Value
 
 A {{domxref("Window")}}-like object referring to the window that opened the current
 window (using {{domxref("window.open()")}}, or by a link with {{htmlattrxref("target",

--- a/files/en-us/web/api/window/pageyoffset/index.md
+++ b/files/en-us/web/api/window/pageyoffset/index.md
@@ -30,13 +30,7 @@ The corresponding {{domxref("Window.pageXOffset", "pageXOffset")}} property, whi
 returns the number of pixels scrolled along the horizontal axis (left and right), is an
 alias for {{domxref("Window.scrollX", "scrollX")}}.
 
-## Syntax
-
-```js
-yOffset = window.pageYOffset;
-```
-
-### Value
+## Value
 
 A floating-point number specifying the number of pixels the {{domxref("Document")}} is
 scrolled vertically within its containing {{domxref("Window")}}. This number is subpixel

--- a/files/en-us/web/api/window/scrollx/index.md
+++ b/files/en-us/web/api/window/scrollx/index.md
@@ -20,13 +20,7 @@ meaning that it isn't necessarily a whole number. You can get the number of pixe
 document is scrolled vertically from the {{domxref("Window.scrollY", "scrollY")}}
 property.
 
-## Syntax
-
-```js
-var x = window.scrollX;
-```
-
-### Value
+## Value
 
 In practice, the returned value is a double-precision floating-point value indicating
 the number of pixels the document is currently scrolled horizontally from the origin,

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -22,13 +22,7 @@ browsers, meaning that it isn't necessarily a whole number. You can get the numb
 pixels the document is scrolled horizontally from the {{domxref("Window.scrollX",
   "scrollX")}} property.
 
-## Syntax
-
-```js
-var y = window.scrollY
-```
-
-### Value
+## Value
 
 In practice, the returned value is a double-precision floating-point value indicating
 the number of pixels the document is currently scrolled vertically from the origin,

--- a/files/en-us/web/api/window/sessionstorage/index.md
+++ b/files/en-us/web/api/window/sessionstorage/index.md
@@ -45,13 +45,7 @@ The keys and the values are _always_ in the UTF-16 {{domxref("DOMString")}}
 format, which uses two bytes per character. As with objects, integer keys are
 automatically converted to strings.
 
-## Syntax
-
-```js
-myStorage = window.sessionStorage;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("Storage")}} object which can be used to access the current origin's
 session storage space.

--- a/files/en-us/web/api/windowclient/focused/index.md
+++ b/files/en-us/web/api/windowclient/focused/index.md
@@ -18,13 +18,7 @@ The **`focused`** read-only property of the
 {{domxref("WindowClient")}} interface is a boolean value that indicates whether
 the current client has focus.
 
-## Syntax
-
-```js
-var myFocused = windowClient.focused;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/windowclient/visibilitystate/index.md
+++ b/files/en-us/web/api/windowclient/visibilitystate/index.md
@@ -19,13 +19,7 @@ The **`visibilityState`** read-only property of the
 This value can be one of `"hidden"`, `"visible"`, or
 `"prerender"`.
 
-## Syntax
-
-```js
-var myVisState = windowClient.visibilityState;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} (See {{domxref("Document.visibilityState")}} for values).
 

--- a/files/en-us/web/api/writablestream/locked/index.md
+++ b/files/en-us/web/api/writablestream/locked/index.md
@@ -17,13 +17,7 @@ The **`locked`** read-only property of the
 {{domxref("WritableStream")}} interface returns a boolean indicating whether the
 `WritableStream` is locked to a writer.
 
-## Syntax
-
-```js
-var locked = writableStream.locked;
-```
-
-### Value
+## Value
 
 A boolean value indicating whether or not the writable stream is locked.
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
@@ -18,13 +18,7 @@ The **`closed`** read-only property of the
 {{jsxref("Promise")}} that fulfills if the stream becomes closed, or rejects if
 the stream errors or the writer's lock is released.
 
-## Syntax
-
-```js
-var closed = writableStreamDefaultWriter.closed;
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
@@ -17,13 +17,7 @@ The **`desiredSize`** read-only property of the
 {{domxref("WritableStreamDefaultWriter")}} interface returns the desired size required
 to fill the stream's internal queue.
 
-## Syntax
-
-```js
-var desiredSize = writableStreamDefaultWriter.desiredSize;
-```
-
-### Value
+## Value
 
 An integer. Note that this can be negative if the queue is over-full.
 

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -25,13 +25,7 @@ JavaScript {{jsxref("Object")}}, or {{domxref("DOMString")}}, depending on the v
 of the request's {{domxref("XMLHttpRequest.responseType", "responseType")}}
 property.
 
-## Syntax
-
-```js
-var body = XMLHttpRequest.response;
-```
-
-### Value
+## Value
 
 An appropriate object based on the value of {{domxref("XMLHttpRequest.responseType",
   "responseType")}}. You may attempt to request the data be provided in a specific format

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -18,13 +18,7 @@ The read-only {{domxref("XMLHttpRequest")}} property
 **`responseText`** returns the text received from a server
 following a request being sent.
 
-## Syntax
-
-```js
-var resultText = XMLHttpRequest.responseText;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains either the textual data received using the
 `XMLHttpRequest` or `null` if the request failed or

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.md
@@ -25,15 +25,7 @@ It also lets the author change the
 response type. If an empty string is set as the value of `responseType`, the
 default value of `text` is used.
 
-## Syntax
-
-```js
-var type = XMLHttpRequest.responseType;
-
-XMLHttpRequest.responseType = type;
-```
-
-### Value
+## Value
 
 A string which specifies what type of data the response contains.
 It can take the following values:

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -40,13 +40,7 @@ If the server doesn't specify the {{HTTPHeader("Content-Type")}} as
 
 This property isn't available to workers.
 
-## Syntax
-
-```js
-var data = XMLHttpRequest.responseXML;
-```
-
-### Value
+## Value
 
 A {{domxref("Document")}} from parsing the XML or HTML received using
 {{domxref("XMLHttpRequest")}}, or `null` if no data was received or if the


### PR DESCRIPTION
@teoli2003

## Summary
Sequel of #14195 .
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
