### PR TITLE
Fix minor typo @ is at sign and not ampersand

### DIFF
--- a/files/en-us/learn/forms/html5_input_types/index.md
+++ b/files/en-us/learn/forms/html5_input_types/index.md
@@ -60,7 +60,7 @@ You can also use the [`multiple`](/en-US/docs/Web/HTML/Attributes/multiple) attr
 
 On some devices — notably touch devices with dynamic keyboards like smart phones — a different virtual keypad might be presented that is more suitable for entering email addresses, including the `@` key. See the Firefox for Android keyboard screenshot below for an example:
 
-![firefox for android email keyboard, with ampersand displayed by default.](fx-android-email-type-keyboard.jpg)
+![firefox for android email keyboard, with the at sign displayed by default.](fx-android-email-type-keyboard.jpg)
 
 > **Note:** You can find examples of the basic text input types at [basic input examples](https://mdn.github.io/learning-area/html/forms/basic-input-examples/) (see the [source code](https://github.com/mdn/learning-area/blob/main/html/forms/basic-input-examples/index.html) also).
 


### PR DESCRIPTION
#### Summary
A screenshot alt text mentioned the ampersand character whereas it should have been @/at sign

#### Motivation
Just detected a typo during the French rework of this page and wanted to get this fixed.

#### Supporting details
https://en.wikipedia.org/wiki/At_sign
https://en.wikipedia.org/wiki/Ampersand
https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types/fx-android-email-type-keyboard.jpg showing the at sign (relevant for email address)

#### Related issues
None to my knowledge

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
