### PR TITLE
New "revert-layer" keyword page

### DIFF
--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -1,0 +1,73 @@
+---
+title: revert-layer
+slug: Web/CSS/revert-layer
+tags:
+  - CSS
+  - CSS Value
+  - Keyword
+  - Reference
+  - revert-layer
+browser-compat: css.types.global_keywords.revert-layer
+---
+{{CSSRef}}
+
+The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in a previous cascade layer or a previous [style origin](/en-US/docs/Glossary/Style_origin). It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
+
+## Revert-layer vs revert
+
+The `revert-layer` keyword lets you rollback values to the ones specified in previous cascade layers, which exist within the author origin. The {{cssxref("revert")}} keyword, in comparison, lets you remove values applied in the author origin and roll back to user or user agent styles.
+
+The `revert-layer` keyword is ideally meant for applying on properties inside a layer. However, if the `revert-layer` keyword is set on a property outside a layer, the value of the property will roll back to the default value established by the user agent's stylesheet (or by user styles, if any exist). So in this scenario, the `revert-layer` keyword behaves like the {{cssxref("revert")}} keyword.
+
+## Example
+
+### Revert to value in a previous cascade layer
+
+In the example below, two cascade layers are defined - `base` and `special`. Rules for the `color` property are defined in both the layers. Ordinarily, rules in the `special` layer will override competing rules in the `base` layer because of the order of the layers in the `@layer` declaration statement. However, when the `revert-layer` keyword is applied to the competing rule in the `special` layer, the property value rolls back to it's definition in the `base` layer.
+
+#### HTML
+
+```html
+<div class="item">
+  <p>This text is green because <code>color</code> is set to <code>revert-layer</code> in the <code>special</code> layer. So the <code>color</code> property rolls back one layer and gets it's value from the <code>base</code> layer.</p>
+  <p>The styles for <code>border</code> and <code>font-size</code> come from the <code>base</code> layer.
+</div>
+```
+
+#### CSS
+
+```css
+@layer base, special;
+
+@layer special {
+  .item {
+    color: revert-layer;
+  }
+}
+
+@layer base {
+  .item {
+    color: green;
+    border: 3px solid blue;
+    font-size: 1.3em;
+  }
+}
+```
+
+{{EmbedLiveSample('Revert_to_value_in_a_previous_cascade_layer')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Use the {{cssxref("initial")}} keyword to set a property to its initial value.
+- Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
+- Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
+- Use the {{cssxref("unset")}} keyword to set a property to its inherited value if it inherits or to its initial value if not.
+- The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -28,24 +28,62 @@ The `revert-layer` keyword is ideally meant for applying on properties inside a 
 
 ## Examples
 
-### Revert to value in a previous cascade layer
+### Cascade layer behaviour
+
+This is the default behaviour
 
 In the example below, two cascade layers are defined in the CSS, `base` and `special`. By default, rules in the `special` layer will override competing rules in the `base` layer because `special` is listed after `base` in the `@layer` declaration statement.
+
 #### HTML
 
 ```html
-<p>This example contains two lists.</p>
+<p>This example contains a list.</p>
 
-<ul class="list">List One
-  <li class="item">Item one</li>
+<ul>
+  <li class="item feature">Item one</li>
   <li class="item">Item two</li>
   <li class="item">Item three</li>
 </ul>
+```
 
-<ul class="list">List Two
-  <li class="item feature">Point one</li>
-  <li class="item feature">Point two</li>
-  <li class="item feature">Point three</li>
+#### CSS
+
+```css
+@layer base, special;
+
+@layer special {
+  .item {
+    color: red;
+  }
+}
+
+@layer base {
+  .item {
+    color: blue;
+  }
+  .feature {
+    color: green;
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Cascade_layer_behaviour')}}
+
+### Revert to value in a previous cascade layer with revert-layer
+
+This is example of revert layer
+
+#### HTML
+
+```html
+<p>This example contains a list.</p>
+
+<ul>
+  <li class="item feature">Item one</li>
+  <li class="item">Item two</li>
+  <li class="item">Item three</li>
 </ul>
 ```
 
@@ -59,109 +97,39 @@ In the example below, two cascade layers are defined in the CSS, `base` and `spe
     color: red;
   }
   .feature {
+    color: revert-layer;
+  }
+}
+
+@layer base {
+  .item {
+    color: blue;
+  }
+  .feature {
     color: green;
   }
 }
-
-@layer base {
-  .feature {
-    color: blue;
-  }
-  .list {
-    color: rebeccapurple;
-  }
-}
 ```
 
-### Results
+#### Result
 
-
-#### A. Default cascade layer behavior
-
-```html hidden
-<p>This example contains two lists. </p>
-<ul class="list">List One
-  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
-</ul>
-
-<ul class="list">List Two
-  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
-</ul>
-```
-
-```css hidden
-@layer base, special;
-@layer special {
-  .item {color: red;}
-  .feature {color: green;}}
-@layer base {
-  .feature {color: blue;}
-  .list {color: rebeccapurple;}}
-```
-
-{{EmbedLiveSample('Default_cascade_layer_behavior', 0, 280)}}
+{{EmbedLiveSample('Revert to value in a previous cascade layer with revert-layer')}}
 
 The color of items in both lists is derived from the `color` property values in the matching rules in the `special` layer. Specifically, items in 'List One' match the `item` rule and are red, and items in 'List Two' match the more specific `feature` rule and are green. The `feature` rule in the `base` layer is ignored.
 
 Now let's examine how the `revert-layer` keyword changes this default behavior.
 
 
-#### B. Revert to matching rule in previous layer
-
 Consider the case where `color` is set to `revert-layer` in the `feature` rule in the `special` layer.
 
-```html hidden
-<p>This example contains two lists.</p>
-<ul class="list">List One
-  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
-</ul>
-
-<ul class="list">List Two
-  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
-</ul>
-```
-
-```css hidden
-@layer base, special;
-@layer special {
-  .item {color: red;}
-  .feature {color: green; color:revert-layer;}}
-@layer base {
-  .feature {color: blue;}
-  .list {color: rebeccapurple;}}
-```
-
-{{EmbedLiveSample('revert_to_matching_rule_in_previous_layer', 0, 280)}}
 
 The `feature` rule applies to items in 'List Two', which also match the `item` and `list` rules, in that order. Of the three rules, only `feature` and `list` rules are defined in the previous cascade layer `base`.
 
 With `color` set to `revert-layer`, the `color` property value rolls back to the value in the more specific matching `feature` rule in the previous layer `base`, and so the items in 'List Two' are now blue.
 
-#### C. Revert to other matching rule in previous layer
 
 Now consider if instead of the `feature` rule, `color` is set to `revert-layer` in the `item` rule in `special` layer.
 
-```html hidden
-<p>This example contains two lists.</p>
-<ul class="list">List One
-  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
-</ul>
-<ul class="list">List Two
-  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
-</ul>
-```
-
-```css hidden
-@layer base, special;
-@layer special {
-  .item {color: red; color:revert-layer;}
-  .feature {color: green; }}
-@layer base {
-  .feature {color: blue;}
-  .list {color: rebeccapurple;}}
-```
-
-{{EmbedLiveSample('revert_to_other_matching_rule_in_previous_layer', 0, 280)}}
 
 The `item` rule impacts items in 'List One' most specifically. Items in 'List One' also match the `list` rule. There is no `item` rule in the previous layer `base`, but there is a matching `list` rule.
 
@@ -171,41 +139,6 @@ With `color` set to `revert-layer`, the `color` property value rolls back to the
 
 The example below shows what happens if there is no cascade layer with a matching CSS rule for the target element to revert to. The CSS file in the previous example has been modified slightly to demonstrate this scenario.
 
-```html hidden
-<p>This example contains two lists.</p>
-<ul class="list">List One
-  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
-</ul>
-<ul class="list">List Two
-  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
-</ul>
-```
-
-#### CSS
-
-```css
-@layer base, special;
-
-@layer special {
-  .list {
-    color: rebeccapurple;
-  }
-  .item {
-    color: revert-layer;
-  }
-  .feature {
-    color: green;
-  }
-}
-
-@layer base {
-  .feature {
-    color: blue;
-  }
-}
-```
-
-{{EmbedLiveSample('Revert_to_inherited_value_in_current_cascade_layer', 0, 280)}}
 
 The `color` property is set to `revert-layer` in the `item` rule in `special` layer. This rule most specifically impacts items in 'List One'. Items in 'List One' also match `list` rule. However, neither of these matching CSS rules exist in the previous `base` layer, and so there is no cascade layer to roll back to.
 
@@ -213,39 +146,33 @@ Therefore, items in 'List One' fall back to inheriting the `color` property valu
 
 ### Revert to style in previous origin
 
+If there's no style in a previous cascade layer it goes to origin
+
 This example shows the `revert-layer` keyword behavior when there is no cascade layer to revert to _and_ there is no matching CSS rule in the current layer to inherit the property value.
 
-```html hidden
-<p>This example contains two lists.</p>
-<ul class="list">List One
-  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
-</ul>
-<ul class="list">List Two
-  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
+#### HTML
+
+```html
+<p>This example contains a list.</p>
+
+<ul>
+  <li class="item feature">Item one</li>
+  <li class="item">Item two</li>
+  <li class="item">Item three</li>
 </ul>
 ```
 
 #### CSS
 
 ```css
-@layer base, special;
+@layer base;
 
-@layer special {
+@layer base {
   .item {
     color: revert-layer;
   }
-  .feature {
-    color: green;
-  }
-}
-
-@layer base {
-  .feature {
-    color: blue;
-  }
 }
 ```
-
 
 {{EmbedLiveSample('Revert_to_style_in_previous_origin', 0, 280)}}
 

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -13,9 +13,9 @@ browser-compat: css.types.global_keywords.revert-layer
 
 The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in the matching CSS rule in a previous cascade layer. The value of the property with this keyword is recalculated as if no rules were specified in the current cascade layer on the target element.
 
-- If there is no other cascade layer to revert to for the matching CSS rule, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_inherited_value_in_current_cascade_layer).)
+If there is no other cascade layer to revert to for the matching CSS rule, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_inherited_value_in_current_cascade_layer).)
 
-- Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin).
+Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin).
 
 
 This keyword can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
@@ -67,9 +67,9 @@ Let's examine how the `revert-layer` keyword changes the default behavior.
 
 {{EmbedLiveSample('Revert_to_value_in_a_previous_cascade_layer')}}
 
-- The first `p` element gets its red color as an inherited style from its parent `div` element. This is the default behavior, where the style is coming from the `special` layer.
+The first `p` element gets its red color as an inherited style from its parent `div` element. This is the default behavior, where the style is coming from the `special` layer.
 
-- The second `p` element gets its green color from the `base` layer. This paragraph is styled by the `item` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. This keyword rolls back the `color` property value to the matching CSS rule of `item` class selector in the previous layer `base`.
+The second `p` element gets its green color from the `base` layer. This paragraph is styled by the `item` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. This keyword rolls back the `color` property value to the matching CSS rule of `item` class selector in the previous layer `base`.
 
 ### Revert to inherited value in current cascade layer
 
@@ -112,9 +112,9 @@ Building on the previous example, the example below shows what happens if there 
 
 {{EmbedLiveSample('Revert_to_inherited_value_current_cascade_layer')}}
 
-- The previous [example](en-US/docs/Web/CSS/revert-layer#revert_to_value_in_a_previous_cascade_layer) explained how the first and second `p` elements get their respective colors.
+The previous [example](en-US/docs/Web/CSS/revert-layer#revert_to_value_in_a_previous_cascade_layer) explained how the first and second `p` elements get their respective colors.
 
-- The third `p` element here gets its red color as an inherited style from its parent `div` element, as specified in the  `special` layer. This paragraph is styled by the `additional` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. There is no matching CSS rule for this element in the previous layer `base`, so there is no cascade layer to roll back to. Therefore, this element falls back to inheriting the style from the current layer `special`. Had there been no matching CSS rule in the current layer, the style would have defaulted to the user-agent origin (or user origin if available).
+The third `p` element here gets its red color as an inherited style from its parent `div` element, as specified in the  `special` layer. This paragraph is styled by the `additional` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. There is no matching CSS rule for this element in the previous layer `base`, so there is no cascade layer to roll back to. Therefore, this element falls back to inheriting the style from the current layer `special`. Had there been no matching CSS rule in the current layer, the style would have defaulted to the user-agent origin (or user origin if available).
 
 ## Specifications
 

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -11,18 +11,18 @@ browser-compat: css.types.global_keywords.revert-layer
 ---
 {{CSSRef}}
 
-The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in the matching CSS rule in a previous cascade layer. The value of the property with this keyword is recalculated as if no rules were specified in the current cascade layer on the target element.
+The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in a CSS rule matching the element in a previous cascade layer. The value of the property with this keyword is recalculated as if no rules were specified on the target element in the current cascade layer.
 
-- If there is no other cascade layer to revert to for the matching CSS rule, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_inherited_value_in_current_cascade_layer).)
+- If there is no other cascade layer to revert to for a matching CSS rule on the target element, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_inherited_value_in_current_cascade_layer).)
 
-- Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin).
+- Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin). (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_style_in_previous_origin).)
 
 
 This keyword can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
 ## Revert-layer vs revert
 
-The `revert-layer` keyword lets you rollback styles to the ones specified in previous cascade layers. All cascade layers exist in the [author origin](/en-US/docs/Glossary/Style_origin). The {{cssxref("revert")}} keyword, in comparison, lets you remove styles applied in the author origin and roll back to user or user agent styles.
+The `revert-layer` keyword lets you rollback styles to the ones specified in previous cascade layers. All cascade layers exist in the [author origin](/en-US/docs/Glossary/Style_origin). The {{cssxref("revert")}} keyword, in comparison, lets you remove styles applied in the author origin and roll back to styles in user origin or user-agent origin.
 
 The `revert-layer` keyword is ideally meant for applying on properties inside a layer. However, if the `revert-layer` keyword is set on a property outside a layer, the value of the property will roll back to the default value established by the user agent's stylesheet (or by user styles, if any exist). So in this scenario, the `revert-layer` keyword behaves like the {{cssxref("revert")}} keyword.
 
@@ -31,16 +31,22 @@ The `revert-layer` keyword is ideally meant for applying on properties inside a 
 ### Revert to value in a previous cascade layer
 
 In the example below, two cascade layers are defined in the CSS, `base` and `special`. By default, rules in the `special` layer will override competing rules in the `base` layer because `special` is listed after `base` in the `@layer` declaration statement.
-
-Let's examine how the `revert-layer` keyword changes the default behavior.
-
 #### HTML
 
 ```html
-<div class="primary">
-  <p>Introduction</p>
-  <p class="item">This text is green because <code>color</code> is set to <code>revert-layer</code> in the <code>special</code> layer. So the <code>color</code> property rolls back to the matching CSS rule in the previous layer and gets it's value from the <code>base</code> layer.</p>
-</div>
+<p>This example contains two lists.</p>
+
+<ul class="list">List One
+  <li class="item">Item one</li>
+  <li class="item">Item two</li>
+  <li class="item">Item three</li>
+</ul>
+
+<ul class="list">List Two
+  <li class="item feature">Point one</li>
+  <li class="item feature">Point two</li>
+  <li class="item feature">Point three</li>
+</ul>
 ```
 
 #### CSS
@@ -49,40 +55,129 @@ Let's examine how the `revert-layer` keyword changes the default behavior.
 @layer base, special;
 
 @layer special {
-  .primary {
+  .item {
     color: red;
   }
-  .item {
-    color: revert-layer;
+  .feature {
+    color: green;
   }
 }
 
 @layer base {
-  .item {
-    color: green;
+  .feature {
+    color: blue;
+  }
+  .list {
+    color: rebeccapurple;
   }
 }
 ```
-#### Result
 
-{{EmbedLiveSample('Revert_to_value_in_a_previous_cascade_layer')}}
+### Results
 
-- The first `p` element gets its red color as an inherited style from its parent `div` element. This is the default behavior, where the style is coming from the `special` layer.
+#### A. Default cascade layer behavior
 
-- The second `p` element gets its green color from the `base` layer. This paragraph is styled by the `item` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. This keyword rolls back the `color` property value to the matching CSS rule of `item` class selector in the previous layer `base`.
+```html hidden
+<p>This example contains two lists. </p>
+<ul class="list">List One
+  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
+</ul>
+
+<ul class="list">List Two
+  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
+</ul>
+```
+
+```css hidden
+@layer base, special;
+@layer special {
+  .item {color: red;}
+  .feature {color: green;}}
+@layer base {
+  .feature {color: blue;}
+  .list {color: rebeccapurple;}}
+```
+
+{{EmbedLiveSample('Default_cascade_layer_behavior', 0, 280)}}
+
+The color of items in both lists is derived from the `color` property values in the matching rules in the `special` layer. Specifically, items in 'List One' match the `item` rule and are red, and items in 'List Two' match the more specific `feature` rule and are green. The `feature` rule in the `base` layer is ignored.
+
+Now let's examine how the `revert-layer` keyword changes this default behavior.
+
+
+#### B. Revert to matching rule in previous layer
+
+Consider the case where `color` is set to `revert-layer` in the `feature` rule in the `special` layer.
+
+```html hidden
+<p>This example contains two lists.</p>
+<ul class="list">List One
+  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
+</ul>
+
+<ul class="list">List Two
+  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
+</ul>
+```
+
+```css hidden
+@layer base, special;
+@layer special {
+  .item {color: red;}
+  .feature {color: green; color:revert-layer;}}
+@layer base {
+  .feature {color: blue;}
+  .list {color: rebeccapurple;}}
+```
+
+{{EmbedLiveSample('revert_to_matching_rule_in_previous_layer', 0, 280)}}
+
+The `feature` rule applies to items in 'List Two', which also match the `item` and `list` rules, in that order. Of the three rules, only `feature` and `list` rules are defined in the previous cascade layer `base`.
+
+With `color` set to `revert-layer`, the `color` property value rolls back to the value in the more specific matching `feature` rule in the previous layer `base`, and so the items in 'List Two' are now blue.
+
+#### C. Revert to other matching rule in previous layer
+
+Now consider if instead of the `feature` rule, `color` is set to `revert-layer` in the `item` rule in `special` layer.
+
+```html hidden
+<p>This example contains two lists.</p>
+<ul class="list">List One
+  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
+</ul>
+<ul class="list">List Two
+  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
+</ul>
+```
+
+```css hidden
+@layer base, special;
+@layer special {
+  .item {color: red; color:revert-layer;}
+  .feature {color: green; }}
+@layer base {
+  .feature {color: blue;}
+  .list {color: rebeccapurple;}}
+```
+
+{{EmbedLiveSample('revert_to_other_matching_rule_in_previous_layer', 0, 280)}}
+
+The `item` rule impacts items in 'List One' most specifically. Items in 'List One' also match the `list` rule. There is no `item` rule in the previous layer `base`, but there is a matching `list` rule.
+
+With `color` set to `revert-layer`, the `color` property value rolls back to the value in the matching `list` rule in the previous layer `base`, and so the items in 'List One' are now rebeccapurple.
 
 ### Revert to inherited value in current cascade layer
 
-Building on the previous example, the example below shows what happens if there is no cascade layer to revert to for the matching CSS rule. An additional `p` element has been added inside the `div` element.
+The example below shows what happens if there is no cascade layer with a matching CSS rule for the target element to revert to. The CSS file in the previous example has been modified slightly to demonstrate this scenario.
 
-#### HTML
-
-```html
-<div class="primary">
-  <p>Introduction</p>
-  <p class="item">This text is green because <code>color</code> is set to <code>revert-layer</code> in the <code>special</code> layer. So the <code>color</code> property rolls back to the matching CSS rule in the previous layer and gets it's value from the <code>base</code> layer.</p>
-  <p class="additional">This is some additional text.</p>
-</div>
+```html hidden
+<p>This example contains two lists.</p>
+<ul class="list">List One
+  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
+</ul>
+<ul class="list">List Two
+  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
+</ul>
 ```
 
 #### CSS
@@ -91,30 +186,68 @@ Building on the previous example, the example below shows what happens if there 
 @layer base, special;
 
 @layer special {
-  .primary {
-    color: red;
+  .list {
+    color: rebeccapurple;
   }
   .item {
     color: revert-layer;
   }
-  .additional {
-    color: revert-layer;
+  .feature {
+    color: green;
   }
 }
 
 @layer base {
-  .item {
-    color: green;
+  .feature {
+    color: blue;
   }
 }
 ```
-#### Result
 
-{{EmbedLiveSample('Revert_to_inherited_value_current_cascade_layer')}}
+{{EmbedLiveSample('Revert_to_inherited_value_in_current_cascade_layer', 0, 280)}}
 
-- The previous [example](en-US/docs/Web/CSS/revert-layer#revert_to_value_in_a_previous_cascade_layer) explained how the first and second `p` elements get their respective colors.
+The `color` property is set to `revert-layer` in the `item` rule in `special` layer. This rule most specifically impacts items in 'List One'. Items in 'List One' also match `list` rule. However, neither of these matching CSS rules exist in the previous `base` layer, and so there is no cascade layer to roll back to.
 
-- The third `p` element here gets its red color as an inherited style from its parent `div` element, as specified in the  `special` layer. This paragraph is styled by the `additional` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. There is no matching CSS rule for this element in the previous layer `base`, so there is no cascade layer to roll back to. Therefore, this element falls back to inheriting the style from the current layer `special`. Had there been no matching CSS rule in the current layer, the style would have defaulted to the user-agent origin (or user origin if available).
+Therefore, items in 'List One' fall back to inheriting the `color` property value from the matching `list` rule in the current `special` layer.
+
+### Revert to style in previous origin
+
+This example shows the `revert-layer` keyword behavior when there is no cascade layer to revert to _and_ there is no matching CSS rule in the current layer to inherit the property value.
+
+```html hidden
+<p>This example contains two lists.</p>
+<ul class="list">List One
+  <li class="item">Item one</li><li class="item">Item two</li><li class="item">Item three</li>
+</ul>
+<ul class="list">List Two
+  <li class="item feature">Point one</li><li class="item feature">Point two</li><li class="item feature">Point three</li>
+</ul>
+```
+
+#### CSS
+
+```css
+@layer base, special;
+
+@layer special {
+  .item {
+    color: revert-layer;
+  }
+  .feature {
+    color: green;
+  }
+}
+
+@layer base {
+  .feature {
+    color: blue;
+  }
+}
+```
+
+{{EmbedLiveSample('Revert_to_style_in_previous_origin', 0, 280)}}
+
+The style for items in 'List One' in this example rolls back to the defaults in the user-agent origin.
 
 ## Specifications
 

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -13,9 +13,7 @@ browser-compat: css.types.global_keywords.revert-layer
 
 The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in a CSS rule matching the element in a previous cascade layer. The value of the property with this keyword is recalculated as if no rules were specified on the target element in the current cascade layer.
 
-If there is no other cascade layer to revert to for the matching CSS rule, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_inherited_value_in_current_cascade_layer).)
-
-Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin).
+If there is no other cascade layer to revert to for the matching CSS rule, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin).
 
 
 This keyword can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
@@ -28,9 +26,7 @@ The `revert-layer` keyword is ideally meant for applying on properties inside a 
 
 ## Examples
 
-### Cascade layer behaviour
-
-This is the default behaviour
+### Default cascade layer behavior
 
 In the example below, two cascade layers are defined in the CSS, `base` and `special`. By default, rules in the `special` layer will override competing rules in the `base` layer because `special` is listed after `base` in the `@layer` declaration statement.
 
@@ -69,11 +65,13 @@ In the example below, two cascade layers are defined in the CSS, `base` and `spe
 
 #### Result
 
-{{EmbedLiveSample('Cascade_layer_behaviour')}}
+{{EmbedLiveSample('Default_cascade_layer_behavior')}}
 
-### Revert to value in a previous cascade layer with revert-layer
+All the `<li>` elements match the `item` rule in the `special` layer and are red. This is the default cascade layer behavior, where rules in the `special` layer take precedence over rules in the `base` layer.
 
-This is example of revert layer
+### Revert to style in previous cascade layer
+
+Let's examine how the `revert-layer` keyword changes the default cascade layer behavior. For this example, the `special` layer contains an additional `feature` rule targeting the first `<li>` element. The `color` property in this rule is set to `revert-layer`.
 
 #### HTML
 
@@ -113,40 +111,11 @@ This is example of revert layer
 
 #### Result
 
-{{EmbedLiveSample('Revert to value in a previous cascade layer with revert-layer')}}
+{{EmbedLiveSample('Revert_to_style_in_previous_cascade_layer')}}
 
-The color of items in both lists is derived from the `color` property values in the matching rules in the `special` layer. Specifically, items in 'List One' match the `item` rule and are red, and items in 'List Two' match the more specific `feature` rule and are green. The `feature` rule in the `base` layer is ignored.
-
-Now let's examine how the `revert-layer` keyword changes this default behavior.
-
-
-Consider the case where `color` is set to `revert-layer` in the `feature` rule in the `special` layer.
-
-
-The `feature` rule applies to items in 'List Two', which also match the `item` and `list` rules, in that order. Of the three rules, only `feature` and `list` rules are defined in the previous cascade layer `base`.
-
-With `color` set to `revert-layer`, the `color` property value rolls back to the value in the more specific matching `feature` rule in the previous layer `base`, and so the items in 'List Two' are now blue.
-
-
-Now consider if instead of the `feature` rule, `color` is set to `revert-layer` in the `item` rule in `special` layer.
-
-
-The `item` rule impacts items in 'List One' most specifically. Items in 'List One' also match the `list` rule. There is no `item` rule in the previous layer `base`, but there is a matching `list` rule.
-
-With `color` set to `revert-layer`, the `color` property value rolls back to the value in the matching `list` rule in the previous layer `base`, and so the items in 'List One' are now rebeccapurple.
-
-### Revert to inherited value in current cascade layer
-
-The example below shows what happens if there is no cascade layer with a matching CSS rule for the target element to revert to. The CSS file in the previous example has been modified slightly to demonstrate this scenario.
-
-
-The `color` property is set to `revert-layer` in the `item` rule in `special` layer. This rule most specifically impacts items in 'List One'. Items in 'List One' also match `list` rule. However, neither of these matching CSS rules exist in the previous `base` layer, and so there is no cascade layer to roll back to.
-
-Therefore, items in 'List One' fall back to inheriting the `color` property value from the matching `list` rule in the current `special` layer.
+With `color` set to `revert-layer`, the `color` property value rolls back to the value in the matching `feature` rule in the previous layer `base`, and so 'Item one' is now green.
 
 ### Revert to style in previous origin
-
-If there's no style in a previous cascade layer it goes to origin
 
 This example shows the `revert-layer` keyword behavior when there is no cascade layer to revert to _and_ there is no matching CSS rule in the current layer to inherit the property value.
 
@@ -165,8 +134,6 @@ This example shows the `revert-layer` keyword behavior when there is no cascade 
 #### CSS
 
 ```css
-@layer base;
-
 @layer base {
   .item {
     color: revert-layer;
@@ -174,9 +141,9 @@ This example shows the `revert-layer` keyword behavior when there is no cascade 
 }
 ```
 
-{{EmbedLiveSample('Revert_to_style_in_previous_origin', 0, 280)}}
+{{EmbedLiveSample('Revert_to_style_in_previous_origin')}}
 
-The style for items in 'List One' in this example rolls back to the defaults in the user-agent origin.
+The style for all `<li>` elements rolls back to the defaults in the user-agent origin.
 
 ## Specifications
 

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -11,26 +11,35 @@ browser-compat: css.types.global_keywords.revert-layer
 ---
 {{CSSRef}}
 
-The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in a previous cascade layer or a previous [style origin](/en-US/docs/Glossary/Style_origin). It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
+The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in the matching CSS rule in a previous cascade layer. The value of the property with this keyword is recalculated as if no rules were specified in the current cascade layer on the target element.
+
+- If there is no other cascade layer to revert to for the matching CSS rule, the property value rolls back to the {{cssxref("computed_value", "computed value")}} derived from the current layer. (See this [example](/en-US/docs/Web/CSS/revert-layer#revert_to_inherited_value_in_current_cascade_layer).)
+
+- Furthermore, if there is no matching CSS rule in the current layer, the property value for the element rolls back to the style defined in a previous [style origin](/en-US/docs/Glossary/Style_origin).
+
+
+This keyword can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
 ## Revert-layer vs revert
 
-The `revert-layer` keyword lets you rollback values to the ones specified in previous cascade layers, which exist within the author origin. The {{cssxref("revert")}} keyword, in comparison, lets you remove values applied in the author origin and roll back to user or user agent styles.
+The `revert-layer` keyword lets you rollback styles to the ones specified in previous cascade layers. All cascade layers exist in the [author origin](/en-US/docs/Glossary/Style_origin). The {{cssxref("revert")}} keyword, in comparison, lets you remove styles applied in the author origin and roll back to user or user agent styles.
 
 The `revert-layer` keyword is ideally meant for applying on properties inside a layer. However, if the `revert-layer` keyword is set on a property outside a layer, the value of the property will roll back to the default value established by the user agent's stylesheet (or by user styles, if any exist). So in this scenario, the `revert-layer` keyword behaves like the {{cssxref("revert")}} keyword.
 
-## Example
+## Examples
 
 ### Revert to value in a previous cascade layer
 
-In the example below, two cascade layers are defined - `base` and `special`. Rules for the `color` property are defined in both the layers. Ordinarily, rules in the `special` layer will override competing rules in the `base` layer because of the order of the layers in the `@layer` declaration statement. However, when the `revert-layer` keyword is applied to the competing rule in the `special` layer, the property value rolls back to it's definition in the `base` layer.
+In the example below, two cascade layers are defined in the CSS, `base` and `special`. By default, rules in the `special` layer will override competing rules in the `base` layer because `special` is listed after `base` in the `@layer` declaration statement.
+
+Let's examine how the `revert-layer` keyword changes the default behavior.
 
 #### HTML
 
 ```html
-<div class="item">
-  <p>This text is green because <code>color</code> is set to <code>revert-layer</code> in the <code>special</code> layer. So the <code>color</code> property rolls back one layer and gets it's value from the <code>base</code> layer.</p>
-  <p>The styles for <code>border</code> and <code>font-size</code> come from the <code>base</code> layer.
+<div class="primary">
+  <p>Introduction</p>
+  <p class="item">This text is green because <code>color</code> is set to <code>revert-layer</code> in the <code>special</code> layer. So the <code>color</code> property rolls back to the matching CSS rule in the previous layer and gets it's value from the <code>base</code> layer.</p>
 </div>
 ```
 
@@ -40,6 +49,9 @@ In the example below, two cascade layers are defined - `base` and `special`. Rul
 @layer base, special;
 
 @layer special {
+  .primary {
+    color: red;
+  }
   .item {
     color: revert-layer;
   }
@@ -48,13 +60,61 @@ In the example below, two cascade layers are defined - `base` and `special`. Rul
 @layer base {
   .item {
     color: green;
-    border: 3px solid blue;
-    font-size: 1.3em;
   }
 }
 ```
+#### Result
 
 {{EmbedLiveSample('Revert_to_value_in_a_previous_cascade_layer')}}
+
+- The first `p` element gets its red color as an inherited style from its parent `div` element. This is the default behavior, where the style is coming from the `special` layer.
+
+- The second `p` element gets its green color from the `base` layer. This paragraph is styled by the `item` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. This keyword rolls back the `color` property value to the matching CSS rule of `item` class selector in the previous layer `base`.
+
+### Revert to inherited value in current cascade layer
+
+Building on the previous example, the example below shows what happens if there is no cascade layer to revert to for the matching CSS rule. An additional `p` element has been added inside the `div` element.
+
+#### HTML
+
+```html
+<div class="primary">
+  <p>Introduction</p>
+  <p class="item">This text is green because <code>color</code> is set to <code>revert-layer</code> in the <code>special</code> layer. So the <code>color</code> property rolls back to the matching CSS rule in the previous layer and gets it's value from the <code>base</code> layer.</p>
+  <p class="additional">This is some additional text.</p>
+</div>
+```
+
+#### CSS
+
+```css
+@layer base, special;
+
+@layer special {
+  .primary {
+    color: red;
+  }
+  .item {
+    color: revert-layer;
+  }
+  .additional {
+    color: revert-layer;
+  }
+}
+
+@layer base {
+  .item {
+    color: green;
+  }
+}
+```
+#### Result
+
+{{EmbedLiveSample('Revert_to_inherited_value_current_cascade_layer')}}
+
+- The previous [example](en-US/docs/Web/CSS/revert-layer#revert_to_value_in_a_previous_cascade_layer) explained how the first and second `p` elements get their respective colors.
+
+- The third `p` element here gets its red color as an inherited style from its parent `div` element, as specified in the  `special` layer. This paragraph is styled by the `additional` class selector in the `special` layer, in which the `color` property is set to `revert-layer`. There is no matching CSS rule for this element in the previous layer `base`, so there is no cascade layer to roll back to. Therefore, this element falls back to inheriting the style from the current layer `special`. Had there been no matching CSS rule in the current layer, the style would have defaulted to the user-agent origin (or user origin if available).
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

A new global keyword was introduced in FF97, the `revert-layer` keyword.
This keyword was added to the existing list of other global keywords:`initial`, `inherit`, `unset`, and `revert`.

This PR adds the documentation for the `revert-layer` keyword.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

#### Related issues

Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for updating "Specifications" and "Browser compatibility" sections: https://github.com/mdn/browser-compat-data/pull/15524

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
