### PR TITLE
Fix link to fit-content function

### DIFF
--- a/files/en-us/web/css/fit-content/index.md
+++ b/files/en-us/web/css/fit-content/index.md
@@ -15,7 +15,7 @@ The **`fit-content`** behaves as `fit-content(stretch)`. In practice this means 
 
 When used as laid out box size for {{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} and {{cssxref("max-height")}} the maximum and minimum sizes refer to the content size.
 
-> **Note:** The CSS Sizing specification also defines the {{cssxref("fit-content", "fit-content()")}} function. This page details the keyword.
+> **Note:** The CSS Sizing specification also defines the {{cssxref("fit-content_function", "fit-content()")}} function. This page details the keyword.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
[fit-content](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content) keyword while redirecting to [fit-content function](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function), was actually redirecting to itself. Current PR should fix this problem.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
