### PR TITLE
DataTransfer: intended events for getData

### DIFF
--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -48,7 +48,7 @@ dataTransfer.getData(format);
     During the `dragstart` event, new data can be added to the drag data store.
 
     During the `drop` event, the list of items representing dragged data can be read,
-    including the data and new data can be added.
+    including the data. No new data can be added.
 
     For all other events, the formats and kinds in the drag data store list of items
     representing dragged data can be enumerated,

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -45,7 +45,14 @@ dataTransfer.getData(format);
     **`DataTransfer.getData()`** not returning an expected
     value, because not all browsers enforce this restriction.
     
-    During the dragstart event, new data can be added to the drag data store. During the drop event, the list of items representing dragged data can be read, including the data and new data can be added. For all other events, the formats and kinds in the drag data store list of items representing dragged data can be enumerated, but the data itself is unavailable and no new data can be added.
+    During the `dragstart` event, new data can be added to the drag data store.
+
+    During the `drop` event, the list of items representing dragged data can be read,
+    including the data and new data can be added.
+
+    For all other events, the formats and kinds in the drag data store list of items
+    representing dragged data can be enumerated,
+    but the data itself is unavailable and no new data can be added.
 
 
 ## Example

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -41,9 +41,12 @@ dataTransfer.getData(format);
 - Data availability
   - : The [HTML5
     Drag and Drop Specification](https://www.w3.org/TR/2011/WD-html5-20110113/dnd.html#drag-data-store-mode) dictates a `drag data store mode`.
-    This may result in unexpected behavior, being
+    This may result in undefined behavior, being
     **`DataTransfer.getData()`** not returning an expected
-    value.
+    value, because not all browsers enforce this restriction.
+    
+    During the dragstart event, new data can be added to the drag data store. During the drop event, the list of items representing dragged data can be read, including the data and new data can be added. For all other events, the formats and kinds in the drag data store list of items representing dragged data can be enumerated, but the data itself is unavailable and no new data can be added.
+
 
 ## Example
 

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -41,19 +41,11 @@ dataTransfer.getData(format);
 - Data availability
   - : The [HTML5
     Drag and Drop Specification](https://www.w3.org/TR/2011/WD-html5-20110113/dnd.html#drag-data-store-mode) dictates a `drag data store mode`.
-    This may result in undefined behavior, being
+    This may result in unexpected behavior, being
     **`DataTransfer.getData()`** not returning an expected
     value, because not all browsers enforce this restriction.
-    
-    During the `dragstart` event, new data can be added to the drag data store.
 
-    During the `drop` event, the list of items representing dragged data can be read,
-    including the data. No new data can be added.
-
-    For all other events, the formats and kinds in the drag data store list of items
-    representing dragged data can be enumerated,
-    but the data itself is unavailable and no new data can be added.
-
+    During the `dragstart` and `drop` events, it is safe to access the data. For all other events, the data should be considered unavailable. Despite this, the items and their formats can still be enumerated.
 
 ## Example
 


### PR DESCRIPTION
#### Summary
Added events, where getData returns the intended data.

#### Motivation
I had the documentation open while implementing drag&drop for some element. In Firefox you could validate the drag data during `dragover`, and show a matching indication. However, Chromium always provided the empty string which fails the validation.

I've checked the formatting using the awesome local environment. The final commit is the short summary of what I think is relevant for the getData page.

#### Supporting details
- https://www.w3.org/TR/2011/WD-html5-20110113/dnd.html#drag-data-store-mode

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
