### PR TITLE
Remove line breaks inside Markdown links

### DIFF
--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -59,21 +59,12 @@ false + false // 0
 
 ## See also
 
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
@@ -63,7 +63,5 @@ foo += 'bar' // "foobar"
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)

--- a/files/en-us/web/javascript/reference/operators/assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/assignment/index.md
@@ -47,5 +47,4 @@ x = y = z // x, y and z are all 25
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)

--- a/files/en-us/web/javascript/reference/operators/async_function/index.md
+++ b/files/en-us/web/javascript/reference/operators/async_function/index.md
@@ -14,8 +14,8 @@ browser-compat: javascript.operators.async_function
 The **`async function`** keyword can be used to define
 `async` functions inside expressions.
 
-You can also define async functions using an [async
-function statement](/en-US/docs/Web/JavaScript/Reference/Statements/async_function).
+You can also define async functions using an
+[async function statement](/en-US/docs/Web/JavaScript/Reference/Statements/async_function).
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -36,8 +36,8 @@ If the `Promise` is rejected, the `await` expression throws the
 rejected value.
 
 If the value of the _expression_ following the `await` operator is
-not a `Promise`, it's converted to a [resolved
-Promise](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve).
+not a `Promise`, it's converted to a
+[resolved Promise](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve).
 
 An `await` splits execution flow, allowing the caller of the async function
 to resume execution. After the `await` defers the continuation of the async

--- a/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
@@ -79,7 +79,5 @@ Bitwise ANDing any number `x` with `0` yields
 
 ## See also
 
-- [Bitwise
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
-- [Bitwise
-  AND assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment)
+- [Bitwise operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
+- [Bitwise AND assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment)

--- a/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -44,7 +44,5 @@ a &= 2; // 0
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Bitwise AND
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Bitwise AND operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND)

--- a/files/en-us/web/javascript/reference/operators/bitwise_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_not/index.md
@@ -78,5 +78,4 @@ Note that due to using 32-bit representation for numbers both `~-1` and
 
 ## See also
 
-- [Bitwise
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
+- [Bitwise operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)

--- a/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
@@ -81,7 +81,5 @@ Bitwise ORing any number `x` with `0` yields
 
 ## See also
 
-- [Bitwise
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
-- [Bitwise
-  OR assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment)
+- [Bitwise operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
+- [Bitwise OR assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment)

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -46,9 +46,6 @@ a |= 2; // 7
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Bitwise OR
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR)
-- [Logical
-  OR assignment (`||=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Bitwise OR operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR)
+- [Logical OR assignment (`||=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment)

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
@@ -81,7 +81,5 @@ Bitwise XORing any number `x` with `0` yields
 
 ## See also
 
-- [Bitwise
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
-- [Bitwise
-  XOR assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment)
+- [Bitwise operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
+- [Bitwise XOR assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment)

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
@@ -51,7 +51,5 @@ console.log(b); // 00000000000000000000000000000101
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Bitwise XOR
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Bitwise XOR operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR)

--- a/files/en-us/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/comma_operator/index.md
@@ -59,9 +59,8 @@ for (var i = 0, j = 9; i <= 9; i++, j--)
 Note that the comma operators in assignments may appear not to have the normal effect
 of comma operators because they don't exist within an expression. In the following
 example, `a` is set to the value of `b = 3` (which is 3), but the
-`c = 4` expression still evaluates and its result returned to console (i.e.,
-4\). This is due to [operator
-precedence and associativity](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence).
+`c = 4` expression still evaluates and its result returned to console (i.e., 4\).
+This is due to [operator precedence and associativity](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence).
 
 ```js
 var a, b, c;
@@ -99,5 +98,4 @@ function myFunc() {
 
 ## See also
 
-- [`for`
-  loop](/en-US/docs/Web/JavaScript/Reference/Statements/for)
+- [`for` loop](/en-US/docs/Web/JavaScript/Reference/Statements/for)

--- a/files/en-us/web/javascript/reference/operators/decrement/index.md
+++ b/files/en-us/web/javascript/reference/operators/decrement/index.md
@@ -64,21 +64,12 @@ b = --a;
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -53,11 +53,11 @@ Throws {{jsxref("TypeError")}} in [strict mode](/en-US/docs/Web/JavaScript/Refer
 
 ## Description
 
-Unlike what common belief suggests (perhaps due to other programming languages like [delete
-in C++](https://docs.microsoft.com/cpp/cpp/delete-operator-cpp?view=vs-2019)), the `delete` operator has **nothing** to do
-with directly freeing memory. Memory management is done indirectly via breaking
-references. See the [memory
-management](/en-US/docs/Web/JavaScript/Memory_Management) page for more details.
+Unlike what common belief suggests (perhaps due to other programming languages like
+[delete in C++](https://docs.microsoft.com/cpp/cpp/delete-operator-cpp?view=vs-2019)),
+the `delete` operator has **nothing** to do with directly freeing memory.
+Memory management is done indirectly via breaking references.
+See the [memory management](/en-US/docs/Web/JavaScript/Memory_Management) page for more details.
 
 The **`delete`** operator removes a given property from an
 object. On successful deletion, it will return `true`, else
@@ -319,7 +319,6 @@ console.log(trees); // ["redwood", "bay", "cedar", "maple"]
 
 ## See also
 
-- [In depth analysis on
-  delete](http://perfectionkills.com/understanding-delete/)
+- [In depth analysis on delete](http://perfectionkills.com/understanding-delete/)
 - {{jsxref("Reflect.deleteProperty()")}}
 - {{jsxref("Map.prototype.delete()")}}

--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -53,21 +53,12 @@ Math.floor(3 / 2) // 1
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.md
@@ -46,7 +46,5 @@ bar /= 'foo' // NaN
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)

--- a/files/en-us/web/javascript/reference/operators/equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/equality/index.md
@@ -11,9 +11,9 @@ browser-compat: javascript.operators.equality
 {{jsSidebar("Operators")}}
 
 The equality operator (`==`) checks whether its two operands are equal,
-returning a Boolean result. Unlike the [strict
-equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) operator, it attempts to convert and compare operands that are of
-different types.
+returning a Boolean result.
+Unlike the [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) operator,
+it attempts to convert and compare operands that are of different types.
 
 {{EmbedInteractiveExample("pages/js/expressions-equality.html")}}
 
@@ -25,9 +25,10 @@ x == y
 
 ## Description
 
-The equality operators (`==` and `!=`) use the [Abstract Equality
-Comparison Algorithm](https://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3) to compare two operands. This can be roughly summarized as
-follows:
+The equality operators (`==` and `!=`) use
+the [Abstract Equality Comparison Algorithm](https://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3)
+to compare two operands.
+This can be roughly summarized as follows:
 
 - If the operands are both objects, return `true` only if both operands
   reference the same object.
@@ -54,9 +55,10 @@ follows:
   - Boolean: return `true` only if operands are both
     `true` or both `false`.
 
-The most notable difference between this operator and the [strict
-equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (`===`) operator is that the strict equality operator does not
-attempt type conversion. Instead, the strict equality operator always considers operands
+The most notable difference between this operator and
+the [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (`===`) operator is
+that the strict equality operator does not attempt type conversion.
+Instead, the strict equality operator always considers operands
 of different types to be different.
 
 ## Examples
@@ -135,9 +137,6 @@ console.log(d == s);    //true
 
 ## See also
 
-- [Inequality
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
-- [Strict
-  equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)
-- [Strict
-  inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)
+- [Inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
+- [Strict equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)
+- [Strict inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)

--- a/files/en-us/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation/index.md
@@ -48,8 +48,8 @@ immediately before the base number; doing so will cause a SyntaxError.
 ```
 
 Note that some programming languages use the caret symbol <kbd>^</kbd> for
-exponentiation, but JavaScript uses that symbol for the [bitwise
-logical XOR operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR).
+exponentiation, but JavaScript uses that symbol for the
+[bitwise logical XOR operator](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR).
 
 ## Examples
 
@@ -95,21 +95,12 @@ To force the base of an exponentiation expression to be a negative number:
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -44,7 +44,5 @@ bar **= 'foo' // NaN
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.md
@@ -72,8 +72,7 @@ let x = function*(y) {
 
 - {{jsxref("Statements/function*", "function*")}} statement
 - {{jsxref("GeneratorFunction")}} object
-- [The Iterator
-  protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
+- [The Iterator protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
 - {{jsxref("Operators/yield", "yield")}}
 - {{jsxref("Operators/yield*", "yield*")}}
 - {{jsxref("Function")}} object

--- a/files/en-us/web/javascript/reference/operators/greater_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than/index.md
@@ -95,9 +95,6 @@ console.log(NaN > 3);          // false
 
 ## See also
 
-- [Greater
-  than or equal operator](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal)
-- [Less than
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than)
-- [Less
-  than or equal operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal)
+- [Greater than or equal operator](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal)
+- [Less than operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than)
+- [Less than or equal operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal)

--- a/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
@@ -95,9 +95,6 @@ console.log(NaN >= 3);       // false
 
 ## See also
 
-- [Greater than
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than)
-- [Less than
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than)
-- [Less
-  than or equal operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal)
+- [Greater than operator](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than)
+- [Less than operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than)
+- [Less than or equal operator](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal)

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -24,8 +24,8 @@ expressions.
 ## Description
 
 The grouping operator consists of a pair of parentheses around an expression or
-sub-expression to override the normal [operator
-precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
+sub-expression to override the normal
+[operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
 so that operators with lower precedence can be evaluated before an operator
 with higher precedence. As it sounds, it groups what's inside of the
 parentheses.
@@ -76,7 +76,6 @@ The function `a` will be called before the function `b`, which will be called be
 
 ## See also
 
-- [Operator
-  precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
+- [Operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
 - {{jsxref("Operators/delete", "delete")}}
 - {{jsxref("Operators/typeof", "typeof")}}

--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -163,5 +163,4 @@ The code fragment below demonstrates a static function that checks whether a spe
 - [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete)
 - {{jsxref("Object.prototype.hasOwnProperty()")}}
 - {{jsxref("Reflect.has()")}}
-- [Enumerability and
-  ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
+- [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)

--- a/files/en-us/web/javascript/reference/operators/increment/index.md
+++ b/files/en-us/web/javascript/reference/operators/increment/index.md
@@ -64,21 +64,12 @@ b = ++a;
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/inequality/index.md
+++ b/files/en-us/web/javascript/reference/operators/inequality/index.md
@@ -11,9 +11,9 @@ browser-compat: javascript.operators.inequality
 {{jsSidebar("Operators")}}
 
 The inequality operator (`!=`) checks whether its two operands are not
-equal, returning a Boolean result. Unlike the [strict
-inequality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality) operator, it attempts to convert and compare operands that are of
-different types.
+equal, returning a Boolean result.
+Unlike the [strict inequality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality) operator,
+it attempts to convert and compare operands that are of different types.
 
 {{EmbedInteractiveExample("pages/js/expressions-inequality.html")}}
 
@@ -45,8 +45,7 @@ operands of different types:
 ```
 
 To prevent this, and require that different types are considered to be different, use
-the [strict
-inequality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality) operator instead:
+the [strict inequality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality) operator instead:
 
 ```js
 3 !== "3"; // true
@@ -102,9 +101,6 @@ object2 != object2 // false
 
 ## See also
 
-- [Equality
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
-- [Strict
-  equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)
-- [Strict
-  inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)
+- [Equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
+- [Strict equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)
+- [Strict inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
@@ -26,9 +26,8 @@ expr1 &&= expr2
 
 ### Short-circuit evaluation
 
-The [logical
-AND](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) operator is evaluated left to right, it is tested for possible short-circuit
-evaluation using the following rule:
+The [logical AND](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) operator is evaluated left to right,
+it is tested for possible short-circuit evaluation using the following rule:
 
 `(some falsy expression) && expr` is short-circuit evaluated to the
 falsy expression;
@@ -74,11 +73,8 @@ y &&= 0; // 0
 
 ## See also
 
-- [Logical AND
-  (&&)](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND)
-- [The
-  nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
-- [Bitwise
-  AND assignment (`&=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment)
+- [Logical AND (&&)](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND)
+- [The nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
+- [Bitwise AND assignment (`&=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment)
 - {{Glossary("Truthy")}}
 - {{Glossary("Falsy")}}

--- a/files/en-us/web/javascript/reference/operators/logical_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_not/index.md
@@ -45,9 +45,9 @@ Even though the `!` operator can be used with operands that are not Boolean
 values, it can still be considered a boolean operator since its return value can always
 be converted to a [boolean primitive](/en-US/docs/Web/JavaScript/Data_structures#boolean_type).
 To explicitly convert its return value (or any expression in general) to the
-corresponding boolean value, use a double [NOT
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT) or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}}
-constructor.
+corresponding boolean value,
+use a double [NOT operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT)
+or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}} constructor.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.md
@@ -27,9 +27,8 @@ expr1 ??= expr2
 
 ### Short-circuit evaluation
 
-The [nullish
-coalescing](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) operator is evaluated left to right, it is tested for possible
-short-circuit evaluation using the following rule:
+The [nullish coalescing](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) operator
+is evaluated left to right, it is tested for possible short-circuit evaluation using the following rule:
 
 `(some expression that is neither null nor undefined) ?? expr` is
 short-circuit evaluated to the left-hand side expression if the left-hand side proves to
@@ -77,8 +76,7 @@ config({}); // { duration: 100, speed: 25 }
 
 ## See also
 
-- [The
-  nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
+- [The nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
 - {{Glossary("Nullish")}}
 - {{Glossary("Truthy")}}
 - {{Glossary("Falsy")}}

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.md
@@ -77,8 +77,8 @@ console.log( B() || A() );
 ### Operator precedence
 
 The following expressions might seem equivalent, but they are not, because the
-`&&` operator is executed before the `||` operator (see [operator
-precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
+`&&` operator is executed before the `||` operator
+(see [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)).
 
 ```js
 true || false && false      // returns true, because && is executed first
@@ -106,8 +106,8 @@ o10 = false || varObject // f || object returns varObject
 
 > **Note:** If you use this operator to provide a default value to some
 > variable, be aware that any _falsy_ value will not be used. If you only need to
-> filter out {{jsxref("null")}} or {{jsxref("undefined")}}, consider using [the
-> nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator).
+> filter out {{jsxref("null")}} or {{jsxref("undefined")}}, consider using
+> [the nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator).
 
 ### Conversion rules for booleans
 
@@ -166,8 +166,7 @@ is always equal to:
 
 ## See also
 
-- [The
-  nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
+- [The nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
 - {{jsxref("Boolean")}}
 - {{Glossary("Truthy")}}
 - {{Glossary("Falsy")}}

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -83,11 +83,8 @@ otherwise you want to use the `??=` operator (for {{jsxref("null")}} or
 
 ## See also
 
-- [Logical OR
-  (||)](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR)
-- [The
-  nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
-- [Bitwise
-  OR assignment (`|=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment)
+- [Logical OR (||)](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR)
+- [The nullish coalescing operator (`??`)](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
+- [Bitwise OR assignment (`|=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment)
 - {{Glossary("Truthy")}}
 - {{Glossary("Falsy")}}

--- a/files/en-us/web/javascript/reference/operators/multiplication/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication/index.md
@@ -52,21 +52,12 @@ Infinity * Infinity  // Infinity
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -44,7 +44,5 @@ bar *= 'foo' // NaN
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)

--- a/files/en-us/web/javascript/reference/operators/new.target/index.md
+++ b/files/en-us/web/javascript/reference/operators/new.target/index.md
@@ -40,8 +40,8 @@ In ordinary functions, it refers to the function itself, assuming it was invoked
 the [new](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator;
 otherwise `new.target` is {{jsxref("undefined")}}.
 
-In [arrow
-functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), `new.target` is inherited from the surrounding scope.
+In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
+`new.target` is inherited from the surrounding scope.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
@@ -16,16 +16,17 @@ operator that returns its right-hand side operand when its left-hand side operan
 {{jsxref("null")}} or {{jsxref("undefined")}}, and otherwise returns its left-hand side
 operand.
 
-This can be seen as a special case of the [logical OR
-(`||`) operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR), which returns the right-hand side operand if the left
+This can be seen as a special case of the [logical OR (`||`) operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR),
+which returns the right-hand side operand if the left
 operand is _any_ {{Glossary("falsy")}} value, not only `null` or `undefined`. In other words,
 if you use `||` to provide some default value to another variable
 `foo`, you may encounter unexpected behaviors if you consider some falsy
 values as usable (e.g., `''` or `0`). See below for more examples.
 
-The nullish coalescing operator has the fifth-lowest [operator
-precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence), directly lower than `||` and directly higher than the [conditional
-(ternary) operator](/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator).
+The nullish coalescing operator has the fifth-lowest
+[operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence),
+directly lower than `||` and directly higher than the
+[conditional (ternary) operator](/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator).
 
 {{EmbedInteractiveExample("pages/js/expressions-nullishcoalescingoperator.html")}}
 
@@ -140,10 +141,9 @@ However, providing parenthesis to explicitly indicate precedence is correct:
 
 ### Relationship with the optional chaining operator (`?.`)
 
-The nullish coalescing operator treats `undefined` and `null` as
-specific values and so does the [optional
-chaining operator (`?.`)](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which is useful to access a property of an
-object which may be `null` or `undefined`.
+The nullish coalescing operator treats `undefined` and `null` as specific values and so does the
+[optional chaining operator (`?.`)](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
+which is useful to access a property of an object which may be `null` or `undefined`.
 
 ```js
 let foo = { someFooProp: "hi" };

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -135,8 +135,8 @@ console.log(object[bar])
 A method is not bound to the object that it is a method of. Specifically,
 `this` is not fixed in a method. Put another way, `this` does not
 necessarily refer to the object containing a method. Instead, `this` is
-"passed" by the function call. See [method
-binding](/en-US/docs/Web/JavaScript/Reference/Operators/this#method_binding).
+"passed" by the function call.
+See [method binding](/en-US/docs/Web/JavaScript/Reference/Operators/this#method_binding).
 
 ## Examples
 
@@ -172,5 +172,4 @@ x = document.forms['form_name'].elements[strFormControl].value
 
 - {{jsxref("Object")}}
 - {{jsxref("Object.defineProperty()")}}
-- [Optional
-  chaining](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
+- [Optional chaining](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)

--- a/files/en-us/web/javascript/reference/operators/remainder/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder/index.md
@@ -15,8 +15,9 @@ operand is divided by a second operand. It always takes the sign of the dividend
 
 {{EmbedInteractiveExample("pages/js/expressions-remainder.html")}}
 
-Note that while in most languages, '%' is a remainder operator, in some (e.g. [Python,
-Perl](https://en.wikipedia.org/wiki/Modulo_operation#In_programming_languages)) it is a modulo operator.
+Note that while in most languages, '%' is a remainder operator, in some
+(e.g. [Python, Perl](https://en.wikipedia.org/wiki/Modulo_operation#In_programming_languages))
+it is a modulo operator.
 For two values of the same sign, the two are equivalent, but
 when the dividend and divisor are of different signs, they give different results. To
 obtain a modulo in JavaScript, in place of `a % n`, use
@@ -72,23 +73,14 @@ Infinity % Infinity // NaN
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
 - [Remainder operator vs. modulo operator](https://2ality.com/2019/08/remainder-vs-modulo.html)
 - [Mod and Remainder are not the Same](https://rob.conery.io/2018/08/21/mod-and-remainder-are-not-the-same/)

--- a/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
@@ -45,7 +45,5 @@ bar %= 0     // NaN
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)

--- a/files/en-us/web/javascript/reference/operators/right_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift/index.md
@@ -69,7 +69,5 @@ preserved:
 
 ## See also
 
-- [Bitwise
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
-- [Right
-  shift assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment)
+- [Bitwise operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
+- [Right shift assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment)

--- a/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
@@ -44,7 +44,5 @@ b >>= 2;  // -2 (-00000000000000000000000000000010)
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Right shift
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Right shift operator](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift)

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -259,10 +259,9 @@ arr1 = [...arr2, ...arr1];
 
 ### Spread in object literals
 
-The [Rest/Spread
-Properties for ECMAScript](https://github.com/tc39/proposal-object-rest-spread) proposal (ES2018) added spread properties to
-{{jsxref("Operators/Object_initializer", "object literals", 1)}}. It copies own
-enumerable properties from a provided object onto a new object.
+The [Rest/Spread Properties for ECMAScript](https://github.com/tc39/proposal-object-rest-spread) proposal (ES2018)
+added spread properties to {{jsxref("Operators/Object_initializer", "object literals", 1)}}.
+It copies own enumerable properties from a provided object onto a new object.
 
 Shallow-cloning (excluding prototype) or merging of objects is now possible using a
 shorter syntax than {{jsxref("Object.assign()")}}.

--- a/files/en-us/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_equality/index.md
@@ -96,9 +96,6 @@ console.log(object1 === object1);  // true
 
 ## See also
 
-- [Equality
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
-- [Inequality
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
-- [Strict
-  inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)
+- [Equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
+- [Inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
+- [Strict inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)

--- a/files/en-us/web/javascript/reference/operators/strict_inequality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_inequality/index.md
@@ -25,9 +25,10 @@ x !== y
 
 ## Description
 
-The strict inequality operator checks whether its operands are not equal. It is the
-negation of the [strict
-equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) operator so the following two lines will always give the same result:
+The strict inequality operator checks whether its operands are not equal.
+It is the negation of the
+[strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) operator
+so the following two lines will always give the same result:
 
 ```js
 x !== y
@@ -35,8 +36,8 @@ x !== y
 !(x === y)
 ```
 
-For details of the comparison algorithm, see the page for the [strict
-equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) operator.
+For details of the comparison algorithm, see the page for the
+[strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) operator.
 
 Like the strict equality operator, the strict inequality operator will always consider
 operands of different types to be different:
@@ -97,9 +98,6 @@ console.log(object1 !== object1);  // false
 
 ## See also
 
-- [Equality
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
-- [Inequality
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
-- [Strict
-  equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)
+- [Equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
+- [Inequality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
+- [Strict equality operator](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)

--- a/files/en-us/web/javascript/reference/operators/subtraction/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction/index.md
@@ -46,21 +46,12 @@ x - y
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -44,7 +44,5 @@ bar -= 'foo' // NaN
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -16,9 +16,9 @@ The **super** keyword is used to access and call functions on an object's
 parent.
 
 The `super.prop` and `super[expr]` expressions are valid in any
-[method
-definition](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) in both [classes](/en-US/docs/Web/JavaScript/Reference/Classes) and [object
-literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer).
+[method definition](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
+in both [classes](/en-US/docs/Web/JavaScript/Reference/Classes) and
+[object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer).
 
 ## Syntax
 
@@ -37,8 +37,8 @@ also be used to call functions on a parent object.
 
 ### Using `super` in classes
 
-This code snippet is taken from the [classes
-sample](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html) ([live demo](https://googlechrome.github.io/samples/classes-es6/index.html)).
+This code snippet is taken from the [classes sample](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html)
+([live demo](https://googlechrome.github.io/samples/classes-es6/index.html)).
 Here `super()` is called to avoid duplicating the constructor parts' that are
 common between `Rectangle` and `Square`.
 
@@ -145,8 +145,8 @@ console.log(y.prop); // 1
 
 ### Using `super.prop` in object literals
 
-Super can also be used in the [object
-initializer / literal](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) notation. In this example, two objects define a method. In
+Super can also be used in the [object initializer / literal](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer)
+notation. In this example, two objects define a method. In
 the second object, `super` calls the first object's method. This works with
 the help of {{jsxref("Object.setPrototypeOf()")}} with which we are able to set the
 prototype of `obj2` to `obj1`, so that `super` is able

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -21,8 +21,9 @@ In most cases, the value of `this` is determined by how a function is called
 different each time the function is called. ES5 introduced the
 {{jsxref("Function.prototype.bind()", "bind()")}} method to {{jsxref('Operators/this',
   "set the value of a function's <code>this</code> regardless of how it's called",
-  'The_bind_method', 1)}}, and ES2015 introduced [arrow
-functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) which don't provide their own `this` binding (it retains the
+  'The_bind_method', 1)}}, and ES2015 introduced
+[arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+which don't provide their own `this` binding (it retains the
 `this` value of the enclosing lexical context).
 
 {{EmbedInteractiveExample("pages/js/expressions-this.html")}}
@@ -248,9 +249,9 @@ console.log(o.a, o.f(), o.g(), o.h()); // 37,37, azerty, azerty
 
 ### Arrow functions
 
-In [arrow
-functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), `this` retains the value of the enclosing lexical context's
-`this`. In global code, it will be set to the global object:
+In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
+`this` retains the value of the enclosing lexical context's `this`.
+In global code, it will be set to the global object:
 
 ```js
 var globalObject = this;
@@ -581,6 +582,5 @@ bird.sayBye();  // Bye from Ferrari
 ## See also
 
 - [Strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)
-- [Gentle
-  explanation of 'this' keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
+- [Gentle explanation of 'this' keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 - Getting the global context: {{jsxref("globalThis")}}

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -129,8 +129,9 @@ represented as the NULL pointer (`0x00` in most platforms). Consequently,
 `null` had `0` as type tag, hence the `typeof` return
 value `"object"`. ([reference](http://www.2ality.com/2013/10/typeof-null.html))
 
-A fix was proposed for ECMAScript (via an opt-in), but [was
-rejected](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null). It would have resulted in `typeof null === 'null'`.
+A fix was proposed for ECMAScript (via an opt-in), but
+[was rejected](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null).
+It would have resulted in `typeof null === 'null'`.
 
 ### Using `new` operator
 
@@ -176,10 +177,11 @@ could never generate an error.
 However, with the addition of block-scoped {{JSxRef("Statements/let", "let")}} and
 {{JSxRef("Statements/const", "const")}}, using `typeof` on `let` and
 `const` variables (or using `typeof` on a `class`) in a
-block before they are declared will throw a {{JSxRef("ReferenceError")}}. Block scoped
-variables are in a "[temporal
-dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)" from the start of the block until the initialization is processed,
-during which, it will throw an error if accessed.
+block before they are declared will throw a {{JSxRef("ReferenceError")}}.
+Block scoped variables are in a
+"[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)"
+from the start of the block until the initialization is processed,
+during which it will throw an error if accessed.
 
 ```js
 typeof undeclaredVariable === 'undefined';
@@ -256,8 +258,8 @@ On IE 6, 7, and 8 a lot of host objects are objects and not functions. For examp
 typeof alert === 'object'
 ```
 
-Some non-standard IE properties return other values ([tc39/ecma262#1440
-(comment)](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872)):
+Some non-standard IE properties return other values
+([tc39/ecma262#1440 (comment)](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872)):
 
 ```js
 typeof window.external.AddSearchProvider === "unknown";
@@ -267,5 +269,4 @@ typeof window.external.IsSearchProviderInstalled === "unknown";
 ## See also
 
 - {{JSxRef("Operators/instanceof", "instanceof")}}
-- [`document.all`
-  willful violation of the standard](https://github.com/tc39/ecma262/issues/668)
+- [`document.all` willful violation of the standard](https://github.com/tc39/ecma262/issues/668)

--- a/files/en-us/web/javascript/reference/operators/unary_negation/index.md
+++ b/files/en-us/web/javascript/reference/operators/unary_negation/index.md
@@ -53,21 +53,12 @@ const y = -x;
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary plus
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary plus operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)

--- a/files/en-us/web/javascript/reference/operators/unary_plus/index.md
+++ b/files/en-us/web/javascript/reference/operators/unary_plus/index.md
@@ -66,21 +66,12 @@ console.log(+y);
 
 ## See also
 
-- [Addition
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
-- [Subtraction
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
-- [Division
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
-- [Multiplication
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
-- [Increment
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
-- [Decrement
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
-- [Unary
-  negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Addition operator](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
+- [Subtraction operator](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
+- [Division operator](/en-US/docs/Web/JavaScript/Reference/Operators/Division)
+- [Multiplication operator](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
+- [Remainder operator](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Increment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
+- [Decrement operator](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)
+- [Unary negation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.md
@@ -72,7 +72,5 @@ However, this is not the case for negative numbers. For example,
 
 ## See also
 
-- [Bitwise
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
-- [Unsigned
-  right shift assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment)
+- [Bitwise operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators)
+- [Unsigned right shift assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment)

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
@@ -44,7 +44,5 @@ b >>>= 2;   // 1073741822 (00111111111111111111111111111110)
 
 ## See also
 
-- [Assignment
-  operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
-- [Unsigned
-  right shift operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift)
+- [Assignment operators in the JS guide](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#assignment)
+- [Unsigned right shift operator](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift)

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -32,8 +32,8 @@ The `void` operator is often used merely to obtain the
 equivalent to "`void 0`"). In these cases, the global variable
 {{jsxref("undefined")}} can be used.
 
-It should be noted that [the
-precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) of the `void` operator should be taken into account and that
+It should be noted that [the precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
+of the `void` operator should be taken into account and that
 parentheses can help clarify the resolution of the expression following the
 `void` operator:
 
@@ -46,9 +46,9 @@ void (2 == '2'); // void (2 == '2'), returns undefined
 
 ### Immediately Invoked Function Expressions
 
-When using an [immediately-invoked function
-expression](/en-US/docs/Glossary/IIFE), `void` can be used to force the `function`
-keyword to be treated as an expression instead of a declaration.
+When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE),
+`void` can be used to force the `function` keyword
+to be treated as an expression instead of a declaration.
 
 ```js
 void function iife() {

--- a/files/en-us/web/javascript/reference/operators/yield/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield/index.md
@@ -23,8 +23,9 @@ The `yield` keyword is used to pause and resume a [generator function](/en-US/do
 ```
 
 - `expression` {{optional_inline}}
-  - : Defines the value to return from the generator function via [the
-    iterator protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterator_protocol). If omitted, `undefined` is returned instead.
+  - : Defines the value to return from the generator function via 
+    [the iterator protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterator_protocol).
+    If omitted, `undefined` is returned instead.
 - `rv` {{optional_inline}}
   - : Retrieves the optional value passed to the generator's `next()` method
     to resume its execution.
@@ -139,8 +140,7 @@ console.log(generatorFunc.next(10).value); // 26
 
 ## See also
 
-- [The Iterator
-  protocol](/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol)
+- [The Iterator protocol](/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol)
 - {{jsxref("Statements/function*", "function*")}}
 - {{jsxref("Operators/function*", "function* expression")}}
 - {{jsxref("Operators/yield*", "yield*")}}

--- a/files/en-us/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield_star_/index.md
@@ -125,8 +125,7 @@ console.log(iterator.next()); // {value: 'foo', done: true}
 
 ## See also
 
-- [The Iterator
-  protocol](/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol)
+- [The Iterator protocol](/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol)
 - {{jsxref("Statements/function*", "function*")}}
 - {{jsxref("Operators/function*", "function* expression")}}
 - {{jsxref("Operators/yield", "yield")}}


### PR DESCRIPTION
Breaks inside the text of Markdown links are problematic:
- They make the Markdown harder to read (for writers)
- They make `See also` section difficult to maintain as they are difficult to read
- Don't work well with VSCode highlighter (and likely others)
- Don't work well with GitHub editor/highlighter (also in diffs)

I've yet to find one case where they were needed.

The ones in Javascript/Operators were bothering me, so I fixed them.