### PR TITLE
Update initial, inherit, revert, unset pages for the new revert-layer keyword

### DIFF
--- a/files/en-us/web/css/inherit/index.md
+++ b/files/en-us/web/css/inherit/index.md
@@ -16,11 +16,11 @@ browser-compat: css.types.global_keywords.inherit
 ---
 {{CSSRef}}
 
-The **`inherit`** CSS keyword causes the element for which it is specified to take the [computed value](/en-US/docs/Web/CSS/computed_value) of the property from its parent element. It can be applied to any CSS property, including the CSS shorthand {{cssxref("all")}}.
+The **`inherit`** CSS keyword causes the element to take the [computed value](/en-US/docs/Web/CSS/computed_value) of the property from its parent element. It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
 For [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), this reinforces the default behavior, and is only needed to override another rule.
 
-Inheritance is always from the parent element in the document tree, even when the parent element is not the containing block.
+> **Note:** Inheritance is always from the parent element in the document tree, even when the parent element is not the containing block.
 
 ## Examples
 
@@ -34,7 +34,7 @@ h2 { color: green; }
 #sidebar h2 { color: inherit; }
 ```
 
-In this example the `h2` elements inside the sidebar might be different colors. For example, if one of them were the child of a div matched by the rule ...
+In this example, the `h2` elements inside the sidebar might be different colors. For example, if one of them were the child of a `div` matched by the rule ...
 
 ```css
 div#current { color: blue; }
@@ -53,7 +53,8 @@ div#current { color: blue; }
 ## See also
 
 - [Inheritance](/en-US/docs/Web/CSS/inheritance)
-- Use {{cssxref("initial")}} to set a property to its initial value.
-- Use {{cssxref("unset")}} to set a property to its inherited value if it inherits, or to its initial value if not.
-- Use {{cssxref("revert")}} to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
+- Use the {{cssxref("initial")}} keyword to set a property to its initial value.
+- Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
+- Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
+- Use the {{cssxref("unset")}} keyword to set a property to its inherited value if it inherits or to its initial value if not.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/initial/index.md
+++ b/files/en-us/web/css/initial/index.md
@@ -15,9 +15,9 @@ browser-compat: css.types.global_keywords.initial
 ---
 {{CSSRef}}
 
-The **`initial`** CSS keyword applies the [initial (or default) value](/en-US/docs/Web/CSS/initial_value) of a property to an element. It can be applied to any CSS property. This includes the CSS shorthand {{cssxref("all")}}, with which `initial` can be used to restore all CSS properties to their initial state.
+The **`initial`** CSS keyword applies the [initial (or default) value](/en-US/docs/Web/CSS/initial_value) of a property to an element. It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}. With `all` set to `initial`, all CSS properties can be restored to their respective initial values in one go instead of restoring each one separately.
 
-On [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), the initial value may be unexpected. You should consider using the {{cssxref("inherit")}}, {{cssxref("unset")}}, or {{cssxref("revert")}} keywords instead.
+On [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), the initial value may be unexpected. You should consider using the {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}, or {{cssxref("revert-layer")}} keywords instead.
 
 ## Examples
 
@@ -49,6 +49,8 @@ em {
 
 {{EmbedLiveSample('Using_initial_to_reset_color_for_an_element')}}
 
+With the `initial` keyword in this example, `color` value on the `em` element is restored to the initial value of [`color`](/en-US/docs/Web/CSS/color#formal_definition), as defined in the specification.
+
 ## Specifications
 
 {{Specifications}}
@@ -59,7 +61,8 @@ em {
 
 ## See also
 
-- Use {{cssxref("unset")}} to set a property to its inherited value if it inherits, or to its initial value if not.
-- Use {{cssxref("revert")}} to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
-- Use {{cssxref("inherit")}} to make an element's property the same as its parent.
+- Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
+- Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
+- Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
+- Use the {{cssxref("unset")}} keyword to set a property to its inherited value if it inherits or to its initial value if not.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/revert/index.md
+++ b/files/en-us/web/css/revert/index.md
@@ -15,9 +15,9 @@ browser-compat: css.types.global_keywords.revert
 ---
 {{CSSRef}}
 
-The **`revert`** CSS keyword reverts the cascaded value of the property from its current value to the value the property would have had if no changes had been made by the current **{{Glossary("style origin")}}** to the current element. Thus, it resets the property to its inherited value if it inherits from its parent or to the default value established by the user agent's stylesheet (or by user styles, if any exist). It can be applied to any CSS property, including the CSS shorthand {{cssxref("all")}}.
+The **`revert`** CSS keyword reverts the cascaded value of the property from its current value to the value the property would have had if no changes had been made by the current **{{Glossary("style origin")}}** to the current element. Thus, it resets the property to its inherited value if it inherits from its parent or to the default value established by the user agent's stylesheet (or by user styles, if any exist). It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
-This removes from the cascade all of the styles that have been overridden until the style being rolled back to is reached.
+This keyword removes from the cascade all of the styles that have been overridden until the style being rolled back to is reached.
 
 - If used by a site's own styles (the author origin), `revert` rolls back the property's cascaded value to the user's custom style, if one exists; otherwise, it rolls the style back to the user agent's default style.
 - If used in a user's custom stylesheet, or if the style was applied by the user (the user origin), `revert` rolls back the cascaded value to the user agent's default style.
@@ -25,21 +25,36 @@ This removes from the cascade all of the styles that have been overridden until 
 
 The `revert` keyword works exactly the same as [`unset`](/en-US/docs/Web/CSS/unset) in many cases. The only difference is for properties that have values set by the browser or by custom stylesheets created by users (set on the browser side).
 
-Revert will not affect rules applied to children of an element you reset (but will remove effects of a parent rule on a child). So if you have a `color: green` for all sections and `all: revert` on a specific section the color of the section will be black. But if you have a rule to make all paragraphs red then all paragraphs will still be red in all sections.
+Revert will not affect rules applied to children of an element you reset (but will remove effects of a parent rule on a child). So if you have a `color: green` for all sections and `all: revert` on a specific section, the color of the section will be black. But if you have a rule to make all paragraphs red, then all paragraphs will still be red in all sections.
 
-> **Note:** Revert is just a value. It is still possible to override `revert` value using [specificity](/en-US/docs/Web/CSS/Specificity).
+> **Note:** Revert is just a value. It is still possible to override the `revert` value using [specificity](/en-US/docs/Web/CSS/Specificity).
 
-> **Note:** The `revert` keyword is different from and should not be confused with {{cssxref("initial")}}, which uses the [initial value](/en-US/docs/Web/CSS/initial_value) defined on a per-property basis by the CSS specifications. In contrast, user-agent stylesheets set default values on the basis of CSS selectors.
+> **Note:** The `revert` keyword is different from and should not be confused with the {{cssxref("initial")}} keyword, which uses the [initial value](/en-US/docs/Web/CSS/initial_value) defined on a per-property basis by the CSS specifications. In contrast, user-agent stylesheets set default values on the basis of CSS selectors.
 >
-> For example, the [initial value](/en-US/docs/Web/CSS/initial_value) for the {{cssxref("display")}} property is `inline`, whereas a normal user-agent stylesheet sets the default {{cssxref("display")}} value of {{HTMLElement("div")}}s to `block`, of {{HTMLElement("table")}}s to `table`, etc.
+> For example, the [initial value](/en-US/docs/Web/CSS/initial_value) for the [`display`](en-US/docs/Web/CSS/display#formal_definition) property is `inline`, whereas a normal user-agent stylesheet sets the default {{cssxref("display")}} value of {{HTMLElement("div")}}s to `block`, of {{HTMLElement("table")}}s to `table`, etc.
 
 ## Examples
 
 ### Revert vs unset
 
-Although `revert` and `unset` are similar they differ for some properties for some elements.
+Although `revert` and `unset` are similar, they differ for some properties for some elements.
 
-So in the below example, we set custom `font-weight` in a global stylesheet, but then try to unset and revert. Unset will keep the text normal because this is an initial value for font-weight property. Revert will revert to bold because this is a default value for headers in most browsers.
+So in the below example, we set custom [`font-weight`](/en-US/docs/Web/CSS/font-weight#formal_definition), but then try to `revert` and `unset` it inline in the HTML document. The `revert` keyword will revert the text to bold because that is the default value for headers in most browsers. The `unset` keyword will keep the text normal because that is the initial value for the `font-weight` property.
+
+#### HTML
+
+```html
+<h3 style="font-weight: revert; color: revert;">
+  This should have its original font-weight (bold) and color: black
+</h3>
+<p>Just some text</p>
+<h3 style="font-weight: unset; color: unset;">
+  This will still have font-weight: normal, but color: black
+</h3>
+<p>Just some text</p>
+```
+
+#### CSS
 
 ```css
 h3 {
@@ -48,18 +63,26 @@ h3 {
 }
 ```
 
-```html
-<h3 style="font-weight: unset; color: unset;">This will still have font-weight: normal, but color: black</h3>
-<p>Just some text</p>
-<h3 style="font-weight: revert; color: revert;">This should have its original font-weight (bold) and color: black</h3>
-<p>Just some text</p>
-```
+#### Result
 
-{{EmbedLiveSample('Revert_vs_unset')}}
+{{EmbedLiveSample('Revert_vs_unset', 0, 200)}}
 
 ### Revert all
 
-Reverting all values is useful when you did heavy modifications for something and then want to revert to defaults. So to iterate on above example instead of reverting font-weight and color separately you could just revert all of them.
+Reverting all values is useful in a situation where you've made several style changes and then you want to revert to the browser default values. So in the above example, instead of reverting `font-weight` and `color` separately, you could just revert all of them at once - by applying the `revert` keyword on `all`.
+
+#### HTML
+
+```html
+<h3>This will have custom styles</h3>
+<p>Just some text</p>
+<h3 style="all: revert">
+  This should be reverted to browser/user defaults.
+</h3>
+<p>Just some text</p>
+```
+
+#### CSS
 
 ```css
 h3 {
@@ -69,24 +92,15 @@ h3 {
 }
 ```
 
-```html
-<h3>This will have custom styles</h3>
-<p>Just some text</p>
-<h3 style="all: revert">This should be reverted to browser/user defaults</h3>
-<p>Just some text</p>
-```
+#### Result
 
-{{EmbedLiveSample('Revert_all')}}
+{{EmbedLiveSample('Revert_all', 0, 200)}}
 
 ### Revert on a parent
 
-Reverting effectively removes the value for the element you select with some rule and only for that element. To illustrate this we will set a green color on a section and red color on a paragraph.
+Reverting effectively removes the value for the element you select with some rule and this happens only for that element. To illustrate this, we will set a green color on a section and red color on a paragraph.
 
-```css
-section { color: darkgreen }
-p { color: red }
-section.with-revert { color: revert }
-```
+#### HTML
 
 ```html
 <section>
@@ -101,7 +115,17 @@ section.with-revert { color: revert }
 </section>
 ```
 
-Notice how paragraph still has a red color even though a color property for the section was reverted. Also note that both the header and plain text node is black. This is exactly the same as if `section { color: darkgreen }` would not exist for the second section.
+#### CSS
+
+```css
+section { color: darkgreen }
+p { color: red }
+section.with-revert { color: revert }
+```
+
+Notice how paragraph still has a red color even though a color property for the section was reverted. Also note that both the header and plain text node are black. This is exactly the same as if `section { color: darkgreen }` would not exist for the second section.
+
+#### Result
 
 {{EmbedLiveSample('Revert_on_a_parent')}}
 
@@ -115,7 +139,8 @@ Notice how paragraph still has a red color even though a color property for the 
 
 ## See also
 
-- Use {{cssxref("initial")}} to set a property to its initial value.
-- Use {{cssxref("unset")}} to set a property to its inherited value if it inherits, or to its initial value if not.
-- Use {{cssxref("inherit")}} to make an element's property the same as its parent.
+- Use the {{cssxref("initial")}} keyword to set a property to its initial value.
+- Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
+- Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
+- Use the {{cssxref("unset")}} keyword to set a property to its inherited value if it inherits or to its initial value if not.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/unset/index.md
+++ b/files/en-us/web/css/unset/index.md
@@ -16,11 +16,13 @@ browser-compat: css.types.global_keywords.unset
 
 The **`unset`** CSS keyword resets a property to its inherited value if the property naturally inherits from its parent, and to its [initial value](/en-US/docs/Web/CSS/initial_value) if not. In other words, it behaves like the {{cssxref("inherit")}} keyword in the first case, when the property is an [inherited property](/en-US/docs/Web/CSS/inheritance#inherited_properties), and like the {{cssxref("initial")}} keyword in the second case, when the property is a [non-inherited property](/en-US/docs/Web/CSS/inheritance#non-inherited_properties).
 
-**`unset`** can be applied to any CSS property, including the CSS shorthand {{cssxref("all")}}.
+**`unset`** can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
 ## Examples
 
 ### Color
+
+[`color`](/en-US/docs/Web/CSS/color#formal_definition) is an inherited property.
 
 #### HTML
 
@@ -40,6 +42,7 @@ The **`unset`** CSS keyword resets a property to its inherited value if the prop
 .foo {
   color: blue;
 }
+
 .bar {
   color: green;
 }
@@ -47,6 +50,7 @@ The **`unset`** CSS keyword resets a property to its inherited value if the prop
 p {
   color: red;
 }
+
 .bar p {
   color: unset;
 }
@@ -57,6 +61,8 @@ p {
 {{ EmbedLiveSample('Color') }}
 
 ### Border
+
+[`border`](/en-US/docs/Web/CSS/border#formal_definition) is a non-inherited property.
 
 #### HTML
 
@@ -100,7 +106,8 @@ p {
 
 ## See also
 
-- Use {{cssxref("initial")}} to set a property to its initial value.
-- Use {{cssxref("revert")}} to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
-- Use {{cssxref("inherit")}} to make an element's property the same as its parent.
+- Use the {{cssxref("initial")}} keyword to set a property to its initial value.
+- Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
+- Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
+- Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

- A new global keyword was introduced in FF97, the `revert-layer `keyword.

- This PR updates the existing documentation for existing global keywords - `initial`, `inherit`, `unset`, and `revert` - to reflect the new keyword. The "See also" section, in particular, has been updated in all these pages to add the link for `revert-layer`.

- In addition to adding reference to `revert-layer` in these pages, the following changes were made:
    - initial page: minor edits, added an explanation after the example
    - inherit page: minor edit, changed text to note
    - revert page: minor edits, in the "Examples" section, added HTML, CSS, and Result headings as well as reordered HTML to appear after CSS to match the sequence in other pages
    - unset page: minor content additions to Examples section


FYI, `revert-layer`-related updates to the `all` property page and other inheritance pages will be submitted in separate PRs.
- https://github.com/mdn/content/pull/14414


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for the new `revert-layer` page: https://github.com/mdn/content/pull/14287

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
