### PR TITLE
Removed hidden from "passwordrules" div

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
@@ -60,7 +60,7 @@ The tooltip should appear on focus or when the element is hovered on, without ke
 ```html
 <label for="password">Password:</label>
 <input aria-describedby="passwordrules" id="password" type="password" />
-<div hidden role="tooltip" id="passwordrules">
+<div role="tooltip" id="passwordrules">
   <p>
       Password Rules:
   </p>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

When copying the html into an online sandbox, the tooltip would not pop up when hidden was is in the "passwordrules" div. Taking it out allowed the tooltip to appear on hover and disappear when not hovering. Not sure if it's a browser-specific issue, I'm using Chrome Version 99.0.4844.83 (Official Build) (x86_64) on macOS Version 12.2.1.

#### Motivation
Example should make it easier for users to understand how to use tooltips

#### Supporting details

N/A

#### Related issues
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
