### PR TITLE
Link Date and Time picker tutorial has moved

### DIFF
--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -486,6 +486,6 @@ daySelect.onchange = function() {
 ## See also
 
 - The generic {{HTMLElement("input")}} element and the interface used to manipulate it, {{domxref("HTMLInputElement")}}
-- [Date and Time picker tutorial](/en-US/docs/Learn/Forms/Basic_native_form_controls#date_and_time_picker)
+- [Date and Time picker tutorial](/en-US/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers)
 - [Date and time formats used in HTML](/en-US/docs/Web/HTML/Date_and_time_formats)
 - [Compatibility of CSS properties](/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls)


### PR DESCRIPTION
The link on line 489 with the label Date and Time picker tutorial has moved from https://developer.mozilla.org/en-US/docs/Learn/Forms/Basic_native_form_controls#date_and_time_picker to the new address https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
changed the link from /en-US/docs/Learn/Forms/Basic_native_form_controls#date_and_time_picker to /en-US/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was unable to find the tutorial on /en-US/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I was able to find the tutorial on /en-US/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes  Issue with "<input type="date">": broken link #3948 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
