### PR TITLE
WebAPI: Clean syntax from property pages, part 8

### DIFF
--- a/files/en-us/web/api/intersectionobserver/rootmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/rootmargin/index.md
@@ -27,13 +27,7 @@ See {{SectionOnPage("/en-US/docs/Web/API/Intersection_Observer_API", "The root e
   and root margin")}} for a more in-depth look at the root margin and how it works with
 the root's bounding box.
 
-## Syntax
-
-```js
-var marginString = IntersectionObserver.rootMargin;
-```
-
-### Value
+## Value
 
 A string, formatted similarly to the CSS {{cssxref("margin")}} property's value, which
 contains offsets for one or more sides of the root's bounding box. These offsets are

--- a/files/en-us/web/api/intersectionobserver/thresholds/index.md
+++ b/files/en-us/web/api/intersectionobserver/thresholds/index.md
@@ -24,13 +24,7 @@ array containing that single value.
 See {{SectionOnPage("/en-US/docs/Web/API/Intersection_Observer_API", "Thresholds")}} to
 learn how thresholds work.
 
-## Syntax
-
-```js
-var thresholds = IntersectionObserver.thresholds;
-```
-
-### Value
+## Value
 
 An array of intersection thresholds, originally specified using the
 `threshold` property when instantiating the observer. If only one observer

--- a/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.md
@@ -19,13 +19,7 @@ The {{domxref("IntersectionObserverEntry")}} interface's read-only
 {{domxref("DOMRectReadOnly")}} which in essence describes a rectangle describing the
 smallest rectangle that contains the entire target element.
 
-## Syntax
-
-```js
-var boundsRect = IntersectionObserverEntry.boundingClientRect;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMRectReadOnly")}} which describes the smallest rectangle that contains
 every part of the target element whose intersection change is being described. This

--- a/files/en-us/web/api/intersectionobserverentry/rootbounds/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/rootbounds/index.md
@@ -21,13 +21,7 @@ read-only **`rootBounds`** property is a
 rectangle, offset by the {{domxref("IntersectionObserver.rootMargin")}} if one is
 specified.
 
-## Syntax
-
-```js
-var rootBounds = IntersectionObserverEntry.rootBounds;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMRectReadOnly")}} which describes the root intersection rectangle. For
 roots which are the {{domxref("Document")}}'s viewport, this rectangle is the bounds

--- a/files/en-us/web/api/keyboardlayoutmap/keys/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/keys/index.md
@@ -20,13 +20,7 @@ the {{domxref("KeyboardLayoutMap")}} interface returns a new Array
 Iterator object that contains the keys for each index in the
 array.
 
-## Syntax
-
-```js
-iterator = KeyboardLayoutMap.keys
-```
-
-### Value
+## Value
 
 An iterator.
 

--- a/files/en-us/web/api/keyboardlayoutmap/size/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/size/index.md
@@ -19,13 +19,7 @@ The **`size`** read-only property of
 the {{domxref("KeyboardLayoutMap")}} interface returns the number of elements in the
 map.
 
-## Syntax
-
-```js
-var size = KeyboardLayoutMap.size()
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/keyboardlayoutmap/values/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/values/index.md
@@ -20,13 +20,7 @@ the {{domxref("KeyboardLayoutMap")}} interface returns a new Array
 Iterator object that contains the values for each index in the
 map.
 
-## Syntax
-
-```js
-var iterator = KeyboardLayoutMap.values
-```
-
-### Value
+## Value
 
 An iterator.
 

--- a/files/en-us/web/api/mediadeviceinfo/deviceid/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/deviceid/index.md
@@ -21,13 +21,7 @@ It is un-guessable by other applications, and unique to the origin of
 the calling application. It is reset when the user clears cookies. For private browsing,
 a different identifier is used that is not persisted across sessions.
 
-## Syntax
-
-```js
-var deviceID = MediaDeviceInfo.deviceId
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/mediadeviceinfo/kind/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/kind/index.md
@@ -16,13 +16,7 @@ The **`kind`** readonly property of
 the {{domxref("MediaDeviceInfo")}} interface returns an enumerated value, that is
 either "videoinput", "audioinput" or "audiooutput".
 
-## Syntax
-
-```js
-var kind = MediaDeviceInfo.kind
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/mediadeviceinfo/label/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/label/index.md
@@ -23,13 +23,7 @@ property of the {{domxref("MediaDeviceInfo")}} interface returns a
 Only available during active `MediaStream`
 use, or when persistent permissions have been granted.
 
-## Syntax
-
-```js
-var label = MediaDeviceInfo.label;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which describes the media device. For security reasons, the
 `label` is always an empty string (`""`) if the user has not

--- a/files/en-us/web/api/mediakeystatusmap/size/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/size/index.md
@@ -16,13 +16,7 @@ The **`size`** read-only property of
 the {{domxref("MediaKeyStatusMap")}} interface returns the number of key/value paIrs
 in the status map.
 
-## Syntax
-
-```js
-var size = MediaKeyStatusMap.size;
-```
-
-### Value
+## Value
 
 A long integer.
 

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
@@ -19,13 +19,7 @@ rate in use.
 This may differ from the bit rate specified in the constructor (if
 it was provided).
 
-## Syntax
-
-```js
-var audioBitsPerSecond = MediaRecorder.audioBitsPerSecond
-```
-
-### Value
+## Value
 
 A {{jsxref("Number")}} (unsigned long).
 

--- a/files/en-us/web/api/networkinformation/downlink/index.md
+++ b/files/en-us/web/api/networkinformation/downlink/index.md
@@ -21,13 +21,7 @@ connections, excluding connections made to a private address space. In the absen
 recent bandwidth measurement data, the attribute value is determined by the properties
 of the underlying connection technology.
 
-## Syntax
-
-```js
-var downLink = NetworkInformation.downlink
-```
-
-### Value
+## Value
 
 A {{jsxref("double")}}.
 

--- a/files/en-us/web/api/networkinformation/savedata/index.md
+++ b/files/en-us/web/api/networkinformation/savedata/index.md
@@ -18,13 +18,7 @@ The **`NetworkInformation.saveData`** read-only
 property of the {{domxref("NetworkInformation")}} interface returns `true` if
 the user has set a reduced data usage option on the user agent.
 
-## Syntax
-
-```js
-var saveData = NetworkInformation.saveData;
-```
-
-### Value
+## Value
 
 A {{jsxref('Boolean')}}.
 

--- a/files/en-us/web/api/notification/badge/index.md
+++ b/files/en-us/web/api/notification/badge/index.md
@@ -17,13 +17,7 @@ The **`badge`** property of the {{domxref("Notification")}}
 interface returns the URL of the image used to represent the notification when there is
 not enough space to display the notification itself.
 
-## Syntax
-
-```js
-var url = Notification.badge
-```
-
-### Value
+## Value
 
 A {{domxref('USVString')}} containing a URL.
 

--- a/files/en-us/web/api/notification/image/index.md
+++ b/files/en-us/web/api/notification/image/index.md
@@ -18,13 +18,7 @@ The `image` read-only property of the
 part of the notification, as specified in the `image` option of the
 {{domxref("Notification.Notification","Notification()")}} constructor.
 
-## Syntax
-
-```js
-var image = Notification.image;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/offlineaudiocontext/length/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/length/index.md
@@ -16,13 +16,7 @@ The **`length`** property of the
 {{domxref("OfflineAudioContext")}} interface returns an integer representing the size of
 the buffer in sample-frames.
 
-## Syntax
-
-```js
-var length = OfflineAudioContext.length;
-```
-
-### Value
+## Value
 
 An integer representing the size of the buffer in sample-frames.
 

--- a/files/en-us/web/api/overconstrainederror/constraint/index.md
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.md
@@ -21,13 +21,7 @@ The **`constraint`** read-only property of the
 {{domxref("OverconstrainedError")}} interface returns the constraint that was supplied
 in the constructor, meaning the constraint that was not satisfied.
 
-## Syntax
-
-```js
-var constraint = Overconstrainederror.constraint;
-```
-
-### Value
+## Value
 
 A {{domxref('String')}}
 

--- a/files/en-us/web/api/paintworklet/devicepixelratio/index.md
+++ b/files/en-us/web/api/paintworklet/devicepixelratio/index.md
@@ -19,13 +19,7 @@ browser-compat: api.PaintWorkletGlobalScope.devicePixelRatio
 
 The **`PaintWorkletGlobalScope.devicePixelRatio`** read-only property of the {{domxref("PaintWorklet")}} interface returns the current device's ratio of physical pixels to logical pixels.
 
-## Syntax
-
-```js
-var devicePixelRatio = PaintWorkletGlobalScope.devicePixelRatio;
-```
-
-### Value
+## Value
 
 A double-precision integer.
 

--- a/files/en-us/web/api/paymentaddress/addressline/index.md
+++ b/files/en-us/web/api/paymentaddress/addressline/index.md
@@ -25,13 +25,7 @@ These
 lines may include the street name, house number, apartment number, rural delivery route,
 descriptive instructions, or post office box.
 
-## Syntax
-
-```js
-var paymentAddressLines = PaymentAddress.addressLine;
-```
-
-### Value
+## Value
 
 An array of {{domxref("DOMString")}} objects, each containing one line of the address.
 For example, the `addressLine` array for the Mozilla Space in London would

--- a/files/en-us/web/api/paymentaddress/city/index.md
+++ b/files/en-us/web/api/paymentaddress/city/index.md
@@ -23,13 +23,7 @@ The **`city`** read-only property of
 the {{domxref('PaymentAddress')}} interface returns a string containing the city or
 town portion of the address.
 
-## Syntax
-
-```js
-var paymentCity = PaymentAddress.city;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} indicating the city or town portion of the address described
 by the {{domxref("PaymentAddress")}} object.

--- a/files/en-us/web/api/paymentaddress/country/index.md
+++ b/files/en-us/web/api/paymentaddress/country/index.md
@@ -24,13 +24,7 @@ always in its canonical upper-case form.
 Some examples of valid `country` values: `"US"`,
 `"GB"`, `"CN"`, or `"JP"`.
 
-## Syntax
-
-```js
-var paymentCountry = PaymentAddress.country;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains the ISO3166-1 alpha-2 code identifying the
 country in which the address is located, or an empty string if no country is available,

--- a/files/en-us/web/api/paymentaddress/dependentlocality/index.md
+++ b/files/en-us/web/api/paymentaddress/dependentlocality/index.md
@@ -19,13 +19,7 @@ sublocality designation within a city, such as a  neighborhood, borough, distric
 in the United Kingdom, a dependent locality. Also known as a _post
 town_.
 
-## Syntax
-
-```js
-var paymentDependentLocality = PaymentAddress.dependentLocality;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} indicating the sublocality portion of the address. This may
 be an empty string if no sublocality is available or required. It's used to provide

--- a/files/en-us/web/api/paymentaddress/organization/index.md
+++ b/files/en-us/web/api/paymentaddress/organization/index.md
@@ -23,13 +23,7 @@ The **`organization`** read-only
 property of the {{domxref('PaymentAddress')}} interface returns a string containing
 the name of the organization, firm, company, or institution at the address.
 
-## Syntax
-
-```js
-var paymentOrganization = PaymentAddress.organization;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value is the name of the organization or company
 located at the address described by the `PaymentAddress` object. This should

--- a/files/en-us/web/api/paymentaddress/phone/index.md
+++ b/files/en-us/web/api/paymentaddress/phone/index.md
@@ -23,13 +23,7 @@ The read-only **`phone`** property of the
 {{domxref('PaymentAddress')}} interface returns a string containing the telephone number
 of the recipient or contact person.
 
-## Syntax
-
-```js
-var paymentPhone = PaymentAddress.phone;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the telephone number for the recipient of the
 shipment or of the responsible party for payment. If no phone number is available, this

--- a/files/en-us/web/api/paymentaddress/postalcode/index.md
+++ b/files/en-us/web/api/paymentaddress/postalcode/index.md
@@ -29,13 +29,7 @@ jurisdiction for mail routing, for example, the {{interwiki("wikipedia", "ZIP Co
 in the United States or the {{interwiki("wikipedia", "Postal Index Number")}} (PIN code)
 in India.
 
-## Syntax
-
-```js
-var paymentPostalCode = PaymentAddress.postalCode;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains the postal code portion of the address. A
 postal code is a string (either numeric or alphanumeric) which is used by a postal

--- a/files/en-us/web/api/paymentaddress/recipient/index.md
+++ b/files/en-us/web/api/paymentaddress/recipient/index.md
@@ -17,13 +17,7 @@ The read-only **`recipient`** property of the
 {{domxref('PaymentAddress')}} interface returns a string containing the name of the
 recipient, purchaser, or contact person at the payment address.
 
-## Syntax
-
-```js
-var paymentRecipient = PaymentAddress.recipient;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} giving the name of the person receiving  or paying for the
 purchase, or the name of a contact person in other contexts. If no name is available,

--- a/files/en-us/web/api/paymentaddress/region/index.md
+++ b/files/en-us/web/api/paymentaddress/region/index.md
@@ -26,13 +26,7 @@ The read-only **`region`** property of the
 administrative subdivision of the country in which the address is located. For example,
 this may be a state, province, oblast, or prefecture.
 
-## Syntax
-
-```js
-var paymentRegion = PaymentAddress.region;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the top-level administrative subdivision within
 the country in which the address is located. This region has different names in

--- a/files/en-us/web/api/paymentaddress/sortingcode/index.md
+++ b/files/en-us/web/api/paymentaddress/sortingcode/index.md
@@ -21,13 +21,7 @@ The **`sortingCode`** read-only property of the
 {{domxref('PaymentAddress')}} interface returns a string containing a postal sorting
 code such as is used in France.
 
-## Syntax
-
-```js
-var sortingCode = PaymentAddress.sortingCode;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the sorting code portion of the address.
 

--- a/files/en-us/web/api/paymentresponse/payername/index.md
+++ b/files/en-us/web/api/paymentresponse/payername/index.md
@@ -20,13 +20,7 @@ option is only present when the `requestPayerName` option is set to
 `true` in the options parameter of the
 {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.
 
-## Syntax
-
-```js
-var payerName = PaymentResponse.payerName;
-```
-
-### Value
+## Value
 
 A string containing the payer name.
 

--- a/files/en-us/web/api/resizeobserverentry/target/index.md
+++ b/files/en-us/web/api/resizeobserverentry/target/index.md
@@ -20,14 +20,7 @@ The **`target`** read-only property of the
 {{domxref("ResizeObserverEntry")}} interface returns a reference to the
 {{domxref('Element')}} or {{domxref('SVGElement')}} that is being observed.
 
-## Syntax
-
-```js
-var element = ResizeObserverEntry.target;
-var svgElement = ResizeObserverEntry.target;
-```
-
-### Value
+## Value
 
 An {{domxref('Element')}} or {{domxref('SVGElement')}} representing the element being
 observed.

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.md
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.md
@@ -15,13 +15,7 @@ The **`blockSize`** read-only property of the {{domxref("ResizeObserverSize")}} 
 
 > **Note:** For more explanation of writing modes and block and inline dimensions, read [Handling different text directions](/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions).
 
-## Syntax
-
-```js
-var blockSize = ResizeObserverSize.blockSize;
-```
-
-### Value
+## Value
 
 A decimal representing the block size in pixels.
 

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.md
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.md
@@ -15,13 +15,7 @@ The **`inlineSize`** read-only property of the {{domxref("ResizeObserverSize")}}
 
 > **Note:** For more explanation of writing modes and block and inline dimensions, read [Handling different text directions](/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions).
 
-## Syntax
-
-```js
-var inlineSize = ResizeObserverSize.inlineSize;
-```
-
-### Value
+## Value
 
 A decimal representing the inline size in pixels.
 

--- a/files/en-us/web/api/rtcdatachannelevent/channel/index.md
+++ b/files/en-us/web/api/rtcdatachannelevent/channel/index.md
@@ -15,13 +15,7 @@ browser-compat: api.RTCDataChannelEvent.channel
 The read-only property **`RTCDataChannelEvent.channel`**
 returns the {{domxref("RTCDataChannel")}} associated with the event.
 
-## Syntax
-
-```js
- var channel = RTCDataChannelEvent.channel;
-```
-
-### Value
+## Value
 
 A {{domxref("RTCDataChannel")}} object representing the data channel linking the
 receiving {{domxref("RTCPeerConnection")}} to its remote peer.

--- a/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.md
@@ -24,13 +24,7 @@ call {{domxref("RTCDTMFSender.insertDTMF", "insertDTMF()")}}.
 
 Tones are removed from the string as they're played, so only upcoming tones are listed.
 
-## Syntax
-
-```js
-var toneBuffer = RTCDTMFSender.toneBuffer;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} listing the tones to be played. If the string is empty,
 there are no tones pending.

--- a/files/en-us/web/api/rtcicecandidate/address/index.md
+++ b/files/en-us/web/api/rtcicecandidate/address/index.md
@@ -25,13 +25,7 @@ The `address` is `null` by default if not otherwise specified.
 The `address` field's value is set from the `candidateInfo` options object passed to the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate()")}} constructor.
 You can't specify the value of `address` directly in the options object, but its value is automatically extracted from the object's `candidate` a-line, if it's formatted properly.
 
-## Syntax
-
-```js
-var address = RTCIceCandidate.address;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} providing the IP address from which the candidate comes.
 

--- a/files/en-us/web/api/rtcicecandidate/candidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/candidate/index.md
@@ -24,13 +24,7 @@ Most of the other properties of `RTCIceCandidate` are actually extracted from th
 
 This property can be configured using the `candidate` property of the object passed into the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate() constructor")}} or {{domxref("RTCPeerConnection.addIceCandidate()")}}.
 
-## Syntax
-
-```js
-var candidate = RTCIceCandidate.candidate;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} describing the properties of the candidate, taken directly from the {{Glossary("SDP")}} attribute `"candidate"`.
 The candidate string specifies the network connectivity information for the candidate.

--- a/files/en-us/web/api/rtcicecandidate/component/index.md
+++ b/files/en-us/web/api/rtcicecandidate/component/index.md
@@ -27,13 +27,7 @@ an RTCP candidate.
 If a candidate represents both RTP and RTCP multiplexed together, it is reported as an
 RTP candidate.
 
-## Syntax
-
-```js
-var component = RTCIceCandidate.component;
-```
-
-### Value
+## Value
 
 A string which is one of the following:
 

--- a/files/en-us/web/api/rtcicecandidate/foundation/index.md
+++ b/files/en-us/web/api/rtcicecandidate/foundation/index.md
@@ -25,13 +25,7 @@ which uniquely identifies the candidate across multiple transports.
 The `foundation` can therefore be used to correlate candidates that are present on
 multiple {{domxref("RTCIceTransport")}} objects
 
-## Syntax
-
-```js
-var foundation = RTCIceCandidate.foundation;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the candidate across all
 `RTCIceTransport`s on which it is available.

--- a/files/en-us/web/api/rtcicecandidate/port/index.md
+++ b/files/en-us/web/api/rtcicecandidate/port/index.md
@@ -24,13 +24,7 @@ number on the device at the address given by {{domxref("RTCIceCandidate.address"
 The `port` field's value is set from the `candidateInfo` options object passed to the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate()")}} constructor.
 You can't specify the value of `port` directly in the options object, but its value is automatically extracted from the object's `candidate` a-line, if it's formatted properly.
 
-## Syntax
-
-```js
-var port = RTCIceCandidate.port;
-```
-
-### Value
+## Value
 
 A 16-bit number indicating the port number on the device at the address indicated by {{domxref("RTCIceCandidate/address", "address")}} at which the candidate's peer can be reached.
 

--- a/files/en-us/web/api/rtcicecandidate/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidate/priority/index.md
@@ -22,13 +22,7 @@ The **{{domxref("RTCIceCandidate")}}** interface's read-only **`priority`** prop
 The `priority` field's value is set from the `candidateInfo` options object passed to the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate()")}} constructor.
 You can't specify the value of `priority` directly in the options object, but its value is automatically extracted from the object's `candidate` a-line, if it's formatted properly.
 
-## Syntax
-
-```js
-var priority = RTCIceCandidate.priority;
-```
-
-### Value
+## Value
 
 A long, unsigned integer value indicating the priority of the candidate according to the remote peer.
 The larger this value is, the more preferable the remote peer considers this candidate to be.

--- a/files/en-us/web/api/rtcicecandidate/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidate/protocol/index.md
@@ -24,13 +24,7 @@ You can't specify the value of `protocol` directly in the options object, but it
 
 `protocol` is `null` by default if not specified properly in the SDP, but this is an error condition and will result in a thrown exception when you call {{domxref("RTCPeerConnection.addIceCandidate()")}}.
 
-## Syntax
-
-```js
-var protocol = RTCIceCandidate.protocol;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} that indicates what network protocol the candidate uses:
 

--- a/files/en-us/web/api/rtcicecandidate/relatedaddress/index.md
+++ b/files/en-us/web/api/rtcicecandidate/relatedaddress/index.md
@@ -30,13 +30,7 @@ You can't specify the value of `relatedAddress` directly in the options object, 
 The related address and port ({{domxref("RTCIceCandidate.relatedPort", "relatedPort")}}) are not used at all by {{Glossary("ICE")}} itself; they are provided
 for analysis and diagnostic purposes only, and their inclusion may be blocked by security systems, so do not rely on them having non-`null` values.
 
-## Syntax
-
-```js
-var relAddress = RTCIceCandidate.relatedAddress;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains the candidate's related address. For both
 peer and server reflexive candidates, the related address (and related port) are the

--- a/files/en-us/web/api/rtcicecandidate/relatedport/index.md
+++ b/files/en-us/web/api/rtcicecandidate/relatedport/index.md
@@ -29,13 +29,7 @@ You can't specify the value of `relatedPort` directly in the options object, but
 The related address ({{domxref("RTCIceCandidate.relatedAddress", "relatedAddress")}}) and port are not used at all by {{Glossary("ICE")}} itself; they are provided for
 analysis and diagnostic purposes only, and their inclusion may be blocked by security systems, so do not rely on them having non-`null` values.
 
-## Syntax
-
-```js
-var relPort = RTCIceCandidate.relatedPort;
-```
-
-### Value
+## Value
 
 An unsigned 16-bit value containing the candidate's related port number, if any. For
 both peer and server reflexive candidates, the related address and port describe the

--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
@@ -26,13 +26,7 @@ This ID uniquely identifies a given stream for the component with which the cand
 This property can be configured by specifying the value of the `sdpMid` property in the `candidateInfo` options object that is passed to the {{domxref("RTCIceCandidate.RTCIceCandidate","RTCIceCandidate()")}} constructor.
 If you call the constructor with an m-line string instead of the options object, the value of `sdpMid` is extracted from the specified candidate m-line string.
 
-## Syntax
-
-```js
-var sdpMid = RTCIceCandidate.sdpMid;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the source media component from
 which the candidate draws data, or `null` if no such association exists for the candidate.

--- a/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
@@ -25,13 +25,7 @@ is a zero-based index of the m-line describing the media associated with the can
 This property can be configured by specifying the value of the `sdpMLineIndex` property in the `candidateInfo` options object that is passed to the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate()")}} constructor.
 If you call the constructor with an m-line string instead of the options object, the value of `sdpMLineIndex` is extracted from the specified candidate m-line string.
 
-## Syntax
-
-```js
-var sdpMLineIndex = RTCIceCandidate.sdpMLineIndex;
-```
-
-### Value
+## Value
 
 A number containing a 0-based index into the set of m-lines providing media descriptions,
 indicating which media source is associated with the candidate, or `null` if no such association is available.

--- a/files/en-us/web/api/rtcicecandidate/tcptype/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tcptype/index.md
@@ -23,13 +23,7 @@ The **{{domxref("RTCIceCandidate")}}** interface's read-only **`tcpType`** prope
 The `tcpType` field's value is set from the `candidateInfo` options object passed to the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate()")}} constructor.
 You can't specify the value of `tcpType` directly in the options object, but its value is automatically extracted from the object's `candidate` a-line, if it's formatted properly.
 
-## Syntax
-
-```js
-var tcpType = RTCIceCandidate.tcpType;
-```
-
-### Value
+## Value
 
 If the {{domxref("RTCIceCandidate.protocol","protocol")}} is "tcp", `tcpType` has one of the following values:
 

--- a/files/en-us/web/api/rtcicecandidate/type/index.md
+++ b/files/en-us/web/api/rtcicecandidate/type/index.md
@@ -23,13 +23,7 @@ The **{{domxref("RTCIceCandidate")}}** interface's read-only **`type`** specifie
 The `type` field's value is set from the `candidateInfo` options object passed to the {{domxref("RTCIceCandidate.RTCIceCandidate", "RTCIceCandidate()")}} constructor.
 You can't specify the value of `type` directly in the options object, but its value is automatically extracted from the object's `candidate` a-line (the `cand-type` field), if it's formatted properly.
 
-## Syntax
-
-```js
-var type = RTCIceCandidate.type;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value is one of those defined below. These candidate types are listed in order of priority; the higher in the list they are, the more efficient they are.
 

--- a/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
+++ b/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
@@ -26,13 +26,7 @@ If you call the constructor with an m-line string instead of the options object,
 
 Note that 24 bits of the username fragment are required to be randomized by the browser. See [Randomization](#randomization) below for details.
 
-## Syntax
-
-```js
-var ufrag = RTCIceCandidate.usernameFragment;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the username fragment (usually referred to in
 shorthand as "ufrag" or "ice-ufrag") that, along with the ICE password ("ice-pwd"),

--- a/files/en-us/web/api/rtcicecandidatepair/local/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.md
@@ -23,13 +23,7 @@ The **`local`** property of the
 {{domxref("RTCIceCandidate")}} which describes the configuration of the local end of a
 viable WebRTC connection.
 
-## Syntax
-
-```js
-localCandidate = RTCIceCandidatePair.local;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCIceCandidate")}} which describes the configuration of the local end of
 a viable pair of ICE candidates. The `RTCIceCandidatePair` is returned by the

--- a/files/en-us/web/api/rtcicecandidatepair/remote/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/remote/index.md
@@ -23,13 +23,7 @@ The **`remote`** property of the
 {{domxref("RTCIceCandidate")}} describing the configuration of the remote end of a
 viable WebRTC connection.
 
-## Syntax
-
-```js
-remoteCandidate = RTCIceCandidatePair.remote;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCIceCandidate")}} which describes the configuration of the remote end
 of a viable pair of ICE candidates. The `RTCIceCandidatePair` is returned by

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
@@ -32,13 +32,7 @@ this sender has produced to date on the video track corresponding to this
 In general, the higher this
 number is, the more heavily compressed the video data is.
 
-## Syntax
-
-```js
-var qpSum = RTCOutboundRtpStreamStats.qpSum;
-```
-
-### Value
+## Value
 
 An unsigned 64-bit integer value which indicates the sum of the quantization parameter
 (QP) value for every frame sent so far on the track described by the

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.md
@@ -33,13 +33,7 @@ potential ways that can be done can be found in
 {{domxref("RTCOutboundRtpStreamStats.qualityLimitationDurations",
   "qualityLimitationDurations")}}.
 
-## Syntax
-
-```js
-var qualityLimitationReason = RTCOutboundRtpStreamStats.qualityLimitationReason;
-```
-
-### Value
+## Value
 
 A {{jsxref("Map")}} whose keys are {{domxref("DOMString")}}s whose values come from the
 {{domxref("RTCQualityLimitationReason")}} enumerated type, and whose values are the

--- a/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -35,13 +35,7 @@ property and then wait until the value of
 `"completed"` before creating and sending the initial offer. That way, the
 offer contains all of the candidates.
 
-## Syntax
-
-```js
-var canTrickle = RTCPeerConnection.canTrickleIceCandidates;
-```
-
-### Value
+## Value
 
 A boolean value that is `true` if the remote peer can accept
 trickled ICE candidates and `false` if it cannot. If no remote peer has

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.md
@@ -33,13 +33,7 @@ that is, the {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 You can detect when this value has changed by watching for the
 {{DOMxRef("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}} event.
 
-## Syntax
-
-```js
-var state = RTCPeerConnection.iceConnectionState;
-```
-
-### Value
+## Value
 
 The current state of the ICE agent and its connection. The value is one of the following strings:
 

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.md
@@ -19,13 +19,7 @@ This lets you detect, for example, when collection of ICE candidates has finishe
 You can detect when the value of this property changes by watching for an event of type
 {{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}}.
 
-## Syntax
-
-```js
- var state = RTCPeerConnection.iceGatheringState;
-```
-
-### Value
+## Value
 
 The possible values are:
 

--- a/files/en-us/web/api/rtcpeerconnection/sctp/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/sctp/index.md
@@ -20,13 +20,7 @@ received. If SCTP hasn't been negotiated, this value is `null`.
 The SCTP transport is used for transmitting and receiving data for any and all
 {{domxref("RTCDataChannel")}}s on the peer connection.
 
-## Syntax
-
-```js
-var sctp = RTCPeerConnection.sctp;
-```
-
-### Value
+## Value
 
 A {{domxref("RTCSctpTransport")}} object describing the SCTP transport being used by
 the {{domxref("RTCPeerConnection")}} for transmitting and receiving on its data

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.md
@@ -42,13 +42,7 @@ In addition, when the value of this property changes, a
 {{DOMxRef("RTCPeerConnection/signalingstatechange_event", "signalingstatechange")}} event is sent to the {{domxref("RTCPeerConnection")}}
 instance.
 
-## Syntax
-
-```js
- var state = RTCPeerConnection.signalingState;
-```
-
-### Value
+## Value
 
 The allowed string values are:
 

--- a/files/en-us/web/api/rtcrtpsender/dtmf/index.md
+++ b/files/en-us/web/api/rtcrtpsender/dtmf/index.md
@@ -21,13 +21,7 @@ The read-only **`dtmf`** property on the
 over the {{domxref("RTCPeerConnection")}} . See [Using DTMF](/en-US/docs/Web/API/WebRTC_API/Using_DTMF) for details on how to
 make use of the returned `RTCDTMFSender` object.
 
-## Syntax
-
-```js
-var dtmfSender = RTCRtpSender.dtmf;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCDTMFSender")}} which can be used to send DTMF over the RTP session, or
 `null` if the track being carried by the RTP session or the

--- a/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
@@ -33,13 +33,7 @@ sent or received to date on the video track corresponding to this
 In general, the higher this number is,
 the more heavily compressed the video data is.
 
-## Syntax
-
-```js
-var qpSum = RTCRtpStreamStats.qpSum;
-```
-
-### Value
+## Value
 
 An unsigned 64-bit integer value which indicates the sum of the quantization parameter
 (QP) value for every frame sent or received so far on the track described by the

--- a/files/en-us/web/api/serialport/readable/index.md
+++ b/files/en-us/web/api/serialport/readable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SerialPort.readable
 
 The **`readable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("ReadableStream")}} for receiving data from the device connected to the port. Chunks read from this stream are instances of {{jsxref("Uint8Array")}}. This property is non-null as long as the port is open and has not encountered a fatal error.
 
-## Syntax
-
-```js
-var readableStream = SerialPort.readable;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/serialport/writable/index.md
+++ b/files/en-us/web/api/serialport/writable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SerialPort.writable
 
 The **`writable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("WritableStream")}} for sending data to the device connected to the port. Chunks written to this stream must be instances of {{domxref("BufferSource")}} (for example, an {{jsxref("ArrayBuffer")}} or {{domxref("ArrayBufferView")}} such as {{jsxref("Uint8Array")}}). This property is non-null as long as the port is open and has not encountered a fatal error.
 
-## Syntax
-
-```js
-var writableStream = SerialPort.writable;
-```
-
-### Value
+## Value
 
 A {{domxref("WritableStream")}}
 

--- a/files/en-us/web/api/serviceworker/scripturl/index.md
+++ b/files/en-us/web/api/serviceworker/scripturl/index.md
@@ -16,13 +16,7 @@ Returns the `ServiceWorker` serialized script URL defined as part of [`ServiceWo
 Must be on the same origin as the document that registers the
 `ServiceWorker`.
 
-## Syntax
-
-```js
-someURL = ServiceWorker.scriptURL
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} (see the [WebIDL definition of
 USVString](https://heycam.github.io/webidl/#idl-USVString).)

--- a/files/en-us/web/api/serviceworker/state/index.md
+++ b/files/en-us/web/api/serviceworker/state/index.md
@@ -18,13 +18,7 @@ of the service worker. It can be one of the following values: `installing`,
 `installed,` `activating`, `activated`, or
 `redundant`.
 
-## Syntax
-
-```js
-someURL = ServiceWorker.state
-```
-
-### Value
+## Value
 
 A {{jsxref("String")}} that can take one of the following values:
 

--- a/files/en-us/web/api/serviceworkermessageevent/data/index.md
+++ b/files/en-us/web/api/serviceworkermessageevent/data/index.md
@@ -22,13 +22,7 @@ The **`data`** read-only property of the
 {{domxref("ServiceWorkerMessageEvent")}} interface returns the event's data. It can be
 any data type.
 
-## Syntax
-
-```js
-var myData = ServiceWorkerMessageEventInstance.data;
-```
-
-### Value
+## Value
 
 Any data type.
 

--- a/files/en-us/web/api/serviceworkermessageevent/lasteventid/index.md
+++ b/files/en-us/web/api/serviceworkermessageevent/lasteventid/index.md
@@ -22,13 +22,7 @@ The **`lastEventID`** read-only property of the
 {{domxref("ServiceWorkerMessageEvent")}} interface represents, in [server-sent
 events](/en-US/docs/Web/API/en-US/docs/Server-sent_events/Using_server-sent_events), the last event ID of the event source.
 
-## Syntax
-
-```js
-var myLastEventId = ServiceWorkerMessageEventInstance.lastEventId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/serviceworkermessageevent/origin/index.md
+++ b/files/en-us/web/api/serviceworkermessageevent/origin/index.md
@@ -22,13 +22,7 @@ The `origin` read-only property of the
 {{domxref("ServiceWorkerMessageEvent")}} interface returns the origin of the service
 worker's environment settings object.
 
-## Syntax
-
-```js
-var myOrigin = ServiceWorkerMessageEventInstance.origin;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/serviceworkermessageevent/ports/index.md
+++ b/files/en-us/web/api/serviceworkermessageevent/ports/index.md
@@ -23,13 +23,7 @@ The `source` read-only property of the
 {{domxref("MessagePort")}} objects connected with the message channel the message is
 being sent through.
 
-## Syntax
-
-```js
-var myPorts = ServiceWorkerMessageEventInstance.ports;
-```
-
-### Value
+## Value
 
 An array of {{domxref("MessagePort")}} objects.
 

--- a/files/en-us/web/api/serviceworkermessageevent/source/index.md
+++ b/files/en-us/web/api/serviceworkermessageevent/source/index.md
@@ -23,13 +23,7 @@ The **`source`** read-only property of the
 {{domxref("ServiceWorker")}} object of the associated service worker that sent the
 message.
 
-## Syntax
-
-```js
-var mySource = ServiceWorkerMessageEventInstance.source;
-```
-
-### Value
+## Value
 
 A {{domxref("ServiceWorker")}} or {{domxref("MessagePort")}} object.
 

--- a/files/en-us/web/api/serviceworkerregistration/index/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index/index.md
@@ -19,13 +19,7 @@ The **`index`** read-only property of the
 {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the
 {{domxref('ContentIndex')}} interface, which allows for indexing of offline content.
 
-## Syntax
-
-```js
-var contentIndexObject = ServiceWorkerRegistration.index;
-```
-
-### Value
+## Value
 
 A ContentIndex {{jsxref('Object')}}
 

--- a/files/en-us/web/api/serviceworkerregistration/periodicsync/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/periodicsync/index.md
@@ -19,13 +19,7 @@ the {{domxref("ServiceWorkerRegistration")}} interface returns a reference to th
 {{domxref('PeriodicSyncManager')}} interface, which allows for registering of tasks to
 run at specific intervals.
 
-## Syntax
-
-```js
-var PeriodicSyncManagerObject = ServiceWorkerRegistration.periodicSync;
-```
-
-### Value
+## Value
 
 A PeriodicSyncManager {{jsxref('Object')}}.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/size/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/size/index.md
@@ -18,13 +18,7 @@ The **`size`** read-only property of the
 {{domxref("StylePropertyMapReadOnly")}} interface returns an unsinged long integer
 containing the size of the `StylePropertyMapReadOnly` object.
 
-## Syntax
-
-```js
-var size = StylePropertyMapReadOnly.size
-```
-
-### Value
+## Value
 
 An unsigned long integer.
 

--- a/files/en-us/web/api/stylesheetlist/length/index.md
+++ b/files/en-us/web/api/stylesheetlist/length/index.md
@@ -13,13 +13,7 @@ browser-compat: api.StyleSheetList.length
 
 The **`length`** read-only property of the {{domxref("StyleSheetList")}} interface returns the number of {{domxref("CSSStyleSheet")}} objects in the collection.
 
-## Syntax
-
-```js
-let length = StyleSheetList.length;
-```
-
-### Value
+## Value
 
 An integer indicating the number of items in the collection.
 

--- a/files/en-us/web/api/svgimageelement/decoding/index.md
+++ b/files/en-us/web/api/svgimageelement/decoding/index.md
@@ -18,14 +18,7 @@ The **`decoding`** property of the
 {{domxref("SVGImageElement")}} interface represents a hint given to the browser on how
 it should decode the image.
 
-## Syntax
-
-```js
-var refStr = SVGImageElement.decoding
-SVGImageElement.decoding = refStr;
-```
-
-### Values
+## Values
 
 A {{domxref("DOMString")}} representing the decoding hint. Possible values are:
 

--- a/files/en-us/web/api/svgmarkerelement/markerheight/index.md
+++ b/files/en-us/web/api/svgmarkerelement/markerheight/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.markerHeight
 
 The **`markerHeight`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the height of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerHeight")}} attribute.
 
-## Syntax
-
-```js
-let height = SVGMarkerElement.markerHeight;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `height`.
 

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.md
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.markerUnits
 
 The **`markerUnits`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object. This object returns an integer which represents the keyword values that the {{SVGattr("markerUnits")}} attribute accepts.
 
-## Syntax
-
-```js
-let markerUnits = SVGMarkerElement.markerUnits;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object. The `baseVal` property of this object contains one of the following values:
 

--- a/files/en-us/web/api/svgmarkerelement/markerwidth/index.md
+++ b/files/en-us/web/api/svgmarkerelement/markerwidth/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.markerWidth
 
 The **`markerWidth`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the width of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerWidth")}} attribute.
 
-## Syntax
-
-```js
-let width = SVGMarkerElement.markerWidth;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `width`.
 

--- a/files/en-us/web/api/svgmarkerelement/orientangle/index.md
+++ b/files/en-us/web/api/svgmarkerelement/orientangle/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.orientAngle
 
 The **`orientAngle`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedAngle")}} object containing the angle of the {{SVGattr("orient")}} attribute.
 
-## Syntax
-
-```js
-let angle = SVGMarkerElement.orientAngle;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedAngle")}} object. The `baseVal` property of this object returns an {{domxref("SVGAngle")}}, the value of which returns the `angle`.
 

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.md
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.md
@@ -15,13 +15,7 @@ The **`orientType`** read-only property of the {{domxref("SVGMarkerElement")}} i
 
 This _something else_ is most likely to be the keyword `auto-start-reverse` however the spec leaves it open for this to be other values. Unsupported values will generally be thrown away by the parser, leaving the value the default of `auto`.
 
-## Syntax
-
-```js
-let orientType = SVGMarkerElement.orientType;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object. This contains one of the following values:
 

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.md
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.preserveAspectRatio
 
 The **`preserveAspectRatio`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedPreserveAspectRatio")}} object containing the value of the {{SVGattr("preserveAspectRatio")}} attribute of the {{SVGElement("marker")}}.
 
-## Syntax
-
-```js
-let preserveAspectRatio = SVGMarkerElement.preserveAspectRatio;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedPreserveAspectRatio")}} object. The `baseVal` property of this object returns an {{domxref("SVGPreserveAspectRatio")}} object, with the following properties:
 

--- a/files/en-us/web/api/svgmarkerelement/refx/index.md
+++ b/files/en-us/web/api/svgmarkerelement/refx/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.refX
 
 The **`refX`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.
 
-## Syntax
-
-```js
-let refX = SVGMarkerElement.refX;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `refX`.
 

--- a/files/en-us/web/api/svgmarkerelement/refy/index.md
+++ b/files/en-us/web/api/svgmarkerelement/refy/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.refY
 
 The **`refY`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.
 
-## Syntax
-
-```js
-let refY = SVGMarkerElement.refY;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `refY`.
 

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.md
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGMarkerElement.viewBox
 
 The **`viewBox`** read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedRect")}} object which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.
 
-## Syntax
-
-```js
-let viewBox = SVGMarkerElement.viewBox;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedRect")}} object. The `baseVal` property of this object returns an {{domxref("SVGRect")}} object, from which can be returned the `x` and `y` co-ordinates, plus the `width` and `height` of the {{SVGElement("marker")}} {{SVGattr("viewBox")}} attribute.
 

--- a/files/en-us/web/api/svgpointlist/length/index.md
+++ b/files/en-us/web/api/svgpointlist/length/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGPointList.length
 
 The **`length`** read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.
 
-## Syntax
-
-```js
-let length = SVGPointList.length;
-```
-
-### Value
+## Value
 
 The number of items in the list.
 

--- a/files/en-us/web/api/svgpointlist/numberofitems/index.md
+++ b/files/en-us/web/api/svgpointlist/numberofitems/index.md
@@ -13,13 +13,7 @@ browser-compat: api.SVGPointList.numberOfItems
 
 The **`numberOfItems`** read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.
 
-## Syntax
-
-```js
-let numberOfItems = SVGPointList.numberOfItems;
-```
-
-### Value
+## Value
 
 The number of items in the list.
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.md
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextDecoderStream.encoding
 
 The **`encoding`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the specific encoder.
 
-## Syntax
-
-```js
-var encoding = TextDecoderStream.encoding;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("DOMString")}}, ASCII lowercased.
 

--- a/files/en-us/web/api/textdecoderstream/fatal/index.md
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.md
@@ -15,13 +15,7 @@ The **`fatal`** read-only property of the {{domxref("TextDecoderStream")}} inter
 
 The two possible values of error mode are `fatal` or `replacement`, the default being `replacement` which pushes a replacement character `U+FFFD` (�) to the output.
 
-## Syntax
-
-```js
-var fatal = TextDecoderStream.fatal;
-```
-
-### Value
+## Value
 
 A {{jsxref("boolean")}} which will return `true` if the error mode is set to `fatal`. Otherwise it returns `false`.
 

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.md
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.md
@@ -14,13 +14,7 @@ browser-compat: api.TextDecoderStream.ignoreBOM
 
 The **`ignoreBOM`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{jsxref("boolean")}} indicating if the byte order mark (BOM) is to be ignored.
 
-## Syntax
-
-```js
-var ignoreBOM = TextDecoderStream.ignoreBOM;
-```
-
-### Value
+## Value
 
 A {{jsxref("boolean")}}, initially `false`
 

--- a/files/en-us/web/api/textdecoderstream/readable/index.md
+++ b/files/en-us/web/api/textdecoderstream/readable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextDecoderStream.readable
 
 The **`readable`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("ReadableStream")}}.
 
-## Syntax
-
-```js
-var readable = TextDecoderStream.readable;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/textdecoderstream/writable/index.md
+++ b/files/en-us/web/api/textdecoderstream/writable/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextDecoderStream.writable
 
 The **`writable`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("WritableStream")}}.
 
-## Syntax
-
-```js
-var writable = TextDecoderStream.writable;
-```
-
-### Value
+## Value
 
 A {{domxref("WritableStream")}}.
 

--- a/files/en-us/web/api/textencoderstream/encoding/index.md
+++ b/files/en-us/web/api/textencoderstream/encoding/index.md
@@ -15,13 +15,7 @@ browser-compat: api.TextEncoderStream.encoding
 The **`encoding`** read-only property of the {{domxref("TextEncoderStream")}} interface returns a
 {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the current `TextEncoderStream` object.
 
-## Syntax
-
-```js
-var encoding = TextEncoderStream.encoding;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("DOMString")}} containing `utf-8` encoded data.
 

--- a/files/en-us/web/api/textencoderstream/readable/index.md
+++ b/files/en-us/web/api/textencoderstream/readable/index.md
@@ -14,13 +14,7 @@ browser-compat: api.TextEncoderStream.readable
 
 The **`readable`** read-only property of the {{domxref("TextEncoderStream")}} interface returns a {{domxref("ReadableStream")}}.
 
-## Syntax
-
-```js
-var readable = TextEncoderStream.readable;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/textencoderstream/writable/index.md
+++ b/files/en-us/web/api/textencoderstream/writable/index.md
@@ -14,13 +14,7 @@ browser-compat: api.TextEncoderStream.writable
 
 The **`writable`** read-only property of the {{domxref("TextEncoderStream")}} interface returns a {{domxref("WritableStream")}}.
 
-## Syntax
-
-```js
-var writable = TextEncoderStream.writable;
-```
-
-### Value
+## Value
 
 A {{domxref("WritableStream")}}.
 

--- a/files/en-us/web/api/texttrack/activecues/index.md
+++ b/files/en-us/web/api/texttrack/activecues/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextTrack.activeCues
 
 The **`activeCues`** read-only property of the {{domxref("TextTrack")}} interface returns a {{domxref("TextTrackCueList")}} object listing the currently active cues.
 
-## Syntax
-
-```js
-let activeCues = TextTrack.activeCues;
-```
-
-### Value
+## Value
 
 A {{domxref("TextTrackCueList")}} object.
 

--- a/files/en-us/web/api/texttrack/cues/index.md
+++ b/files/en-us/web/api/texttrack/cues/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextTrack.cues
 
 The **`cues`** read-only property of the {{domxref("TextTrack")}} interface returns a {{domxref("TextTrackCueList")}} object containing all of the track's cues.
 
-## Syntax
-
-```js
-let cues = TextTrack.cues;
-```
-
-### Value
+## Value
 
 A {{domxref("TextTrackCueList")}} object.
 

--- a/files/en-us/web/api/texttrack/id/index.md
+++ b/files/en-us/web/api/texttrack/id/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextTrack.id
 
 The **`id`** read-only property of the {{domxref("TextTrack")}} interface returns the ID of the track if it has one.
 
-## Syntax
-
-```js
-let id = TextTrack.id;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing the ID, or an empty string.
 

--- a/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.md
+++ b/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.md
@@ -17,13 +17,7 @@ An in-band metadata dispatch type is a string extracted from a media resource sp
 
 The value of this attribute could be used to attach these tracks to dedicated script modules as they are loaded.
 
-## Syntax
-
-```js
-let label = TextTrack.label;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing the `inBandMetadataTrackDispatchType`, or an empty string.
 

--- a/files/en-us/web/api/texttrack/kind/index.md
+++ b/files/en-us/web/api/texttrack/kind/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextTrack.kind
 
 The **`kind`** read-only property of the {{domxref("TextTrack")}} interface returns the kind of text track this object represents. This decides how the track will be handled by a user agent.
 
-## Syntax
-
-```js
-let kind = TextTrack.kind;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}. One of:
 

--- a/files/en-us/web/api/texttrack/label/index.md
+++ b/files/en-us/web/api/texttrack/label/index.md
@@ -13,13 +13,7 @@ browser-compat: api.TextTrack.label
 
 The **`label`** read-only property of the {{domxref("TextTrack")}} interface returns a human-readable label for the text track, if it is available.
 
-## Syntax
-
-```js
-let label = TextTrack.label;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing the `label`, or an empty string.
 

--- a/files/en-us/web/api/texttrack/language/index.md
+++ b/files/en-us/web/api/texttrack/language/index.md
@@ -15,13 +15,7 @@ The **`language`** read-only property of the {{domxref("TextTrack")}} interface 
 
 This uses the same values as the HTML {{htmlattrxref("lang")}} attribute. These values are documented in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
-## Syntax
-
-```js
-let language = TextTrack.language;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing a language identifier. For example, `"en-US"` for United States English or `"pt-BR"` for Brazilian Portuguese.
 

--- a/files/en-us/web/api/texttrackcue/endtime/index.md
+++ b/files/en-us/web/api/texttrackcue/endtime/index.md
@@ -13,14 +13,7 @@ browser-compat: api.TextTrackCue.endTime
 
 The **`endTime`** property of the {{domxref("TextTrackCue")}} interface returns and sets the end time of the cue.
 
-## Syntax
-
-```js
-let endTime = TextTrackCue.endTime;
-TextTrackCue.endTime = 10;
-```
-
-### Value
+## Value
 
 An integer representing the end time, in seconds.
 

--- a/files/en-us/web/api/texttrackcue/id/index.md
+++ b/files/en-us/web/api/texttrackcue/id/index.md
@@ -13,14 +13,7 @@ browser-compat: api.TextTrackCue.id
 
 The **`id`** property of the {{domxref("TextTrackCue")}} interface returns and sets the identifier for this cue.
 
-## Syntax
-
-```js
-let id = TextTrackCue.id;
-TextTrackCue.id = a;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing the ID of this cue.
 


### PR DESCRIPTION

## Summary

Sequel of https://github.com/mdn/content/pull/14195
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
