### PR TITLE
pointer_lock_api : chromium does support `allow-pointer-lock` now

### DIFF
--- a/files/en-us/web/api/pointer_lock_api/index.md
+++ b/files/en-us/web/api/pointer_lock_api/index.md
@@ -229,7 +229,7 @@ function canvasDraw() {
 
 Pointer lock can only lock one iframe at a time. If you lock one iframe, you cannot try to lock another iframe and transfer the target to it; pointer lock will error out. To avoid this limitation, first unlock the locked iframe, and then lock the other.
 
-While iframes work by default, "sandboxed" iframes block Pointer lock. The ability to avoid this limitation, in the form of the attribute/value combination `<iframe sandbox="allow-pointer-lock">`, is expected to appear in Chrome soon.
+While iframes work by default, "sandboxed" iframes block Pointer lock. To avoid this limitation, use `<iframe sandbox="allow-pointer-lock">`.
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary
Firefox and Chromium do support `allow-pointer-lock` now.

#### Motivation
Correct outdated statement.

#### Supporting details
If not used it now throws error:
> Blocked pointer lock on an element because the element's frame is sandboxed and the 'allow-pointer-lock' permission is not set.

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
