### PR TITLE
Fixes multiline links + some typography

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -161,15 +161,13 @@ parentheses around expression:
 params => ({foo: "a"}) // returning the object {foo: "a"}
 ```
 
-[Rest
-parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) are supported:
+[Rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) are supported:
 
 ```js
 (a, b, ...r) => expression
 ```
 
-[Default
-parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) are supported:
+[Default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) are supported:
 
 ```js
 (a=400, b=20, c) => expression
@@ -228,17 +226,17 @@ Object.defineProperty(obj, 'b', {
 The
 [`call`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call),
 [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
-and [`bind`
-](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)methods are **NOT suitable** for Arrow functions -- as they were
-designed to allow methods to execute within different scopes -- because **Arrow
-functions establish "this" based on the scope the Arrow function is defined
-within.**
+and [`bind`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+methods are **NOT suitable** as arrow functions – as they were
+designed to allow methods to execute within different scopes – because _arrow
+functions establish `this` based on the scope the arrow function is defined
+within._
 
 For example
 [`call`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call),
 [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
-and [`bind`
-](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)work as expected with Traditional functions, because we establish the scope for each
+and [`bind`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+work as expected with traditional functions, because we establish the scope for each
 of the methods:
 
 ```js
@@ -304,10 +302,10 @@ console.log(bound(1, 2, 3)) // result 2026
 ```
 
 Perhaps the greatest benefit of using Arrow functions is with DOM-level methods
-(setTimeout, setInterval, addEventListener) that usually required some kind of closure,
+(`setTimeout`, `setInterval`, `addEventListener`) that usually required some kind of closure,
 call, apply or bind to ensure the function executed in the proper scope.
 
-**Traditional Example:**
+#### Traditional function example
 
 ```js
 var obj = {
@@ -323,7 +321,7 @@ var obj = {
 obj.doSomethingLater(); // console prints "NaN", because the property "count" is not in the window scope.
 ```
 
-**Arrow Example:**
+#### Arrow function example
 
 ```js
 var obj = {
@@ -346,9 +344,8 @@ obj.doSomethingLater();
 
 ### No binding of `arguments`
 
-Arrow functions do not have their own [`arguments`
-object](/en-US/docs/Web/JavaScript/Reference/Functions/arguments). Thus, in this example, `arguments` is a reference to the
-arguments of the enclosing scope:
+Arrow functions do not have their own [`arguments` object](/en-US/docs/Web/JavaScript/Reference/Functions/arguments).
+Thus, in this example, `arguments` is a reference to the arguments of the enclosing scope:
 
 ```js
 var arguments = [1, 2, 3];
@@ -364,8 +361,8 @@ function foo(n) {
 foo(3); // 3 + 3 = 6
 ```
 
-In most cases, using [rest
-parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) is a good alternative to using an `arguments` object.
+In most cases, using [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
+is a good alternative to using an `arguments` object.
 
 ```js
 function foo(n) {
@@ -397,15 +394,14 @@ console.log(Foo.prototype); // undefined
 
 ### Use of the `yield` keyword
 
-The
-[`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield)
+The [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield)
 keyword may not be used in an arrow function's body (except when permitted within
 functions further nested within it). As a consequence, arrow functions cannot be used as
 generators.
 
 ### Function body
 
-Arrow functions can have either a "concise body" or the usual "block body".
+Arrow functions can have either a _concise body_ or the usual _block body_.
 
 In a concise body, only an expression is specified, which becomes the implicit return
 value. In a block body, you must use an explicit `return` statement.
@@ -478,8 +474,9 @@ var func = (
 ### Parsing order
 
 Although the arrow in an arrow function is not an operator, arrow functions have
-special parsing rules that interact differently with [operator
-precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) compared to regular functions.
+special parsing rules that interact differently with
+[operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
+compared to regular functions.
 
 ```js
 let callback;
@@ -550,5 +547,4 @@ setTimeout( () => {
 
 ## See also
 
-- ["ES6 In
-  Depth: Arrow functions" on hacks.mozilla.org](https://hacks.mozilla.org/2015/06/es6-in-depth-arrow-functions/)
+- ["ES6 In Depth: Arrow functions" on hacks.mozilla.org](https://hacks.mozilla.org/2015/06/es6-in-depth-arrow-functions/)

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -182,9 +182,9 @@ withoutDefaults.call({value: '=^_^='});
 
 ### Scope Effects
 
-If default parameters are defined for one or more parameter, then a [second
-scope](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation) (Environment Record) is created, specifically for the identifiers within the
-parameter list. This scope is a parent of the scope created for the function body.
+If default parameters are defined for one or more parameter,
+then a [second scope](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation) (Environment Record) is created, specifically for the identifiers within the parameter list.
+This scope is a parent of the scope created for the function body.
 
 This means that functions and variables declared in the function body cannot be
 referred to from default value parameter initializers; attempting to do so throws a

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -46,9 +46,9 @@ setter in conjunction to create a type of pseudo-property.
 Note the following when working with the `get` syntax:
 
 - It can have an identifier which is either a number or a string;
-- It must have exactly zero parameters (see [Incompatible ES5
-  change: literal getter and setter functions must now have exactly zero or one
-  arguments](https://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/) for more information);
+- It must have exactly zero parameters
+  (see [Incompatible ES5 change: literal getter and setter functions must now have exactly zero or one arguments](https://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/)
+  for more information);
 - It must not appear in an object literal with another `get` e.g. the following is forbidden
 
   ```js example-bad
@@ -141,7 +141,7 @@ of calculating the value until the value is needed. If it is never needed, you n
 the cost.
 
 An additional optimization technique to lazify or delay the calculation of a property
-value and cache it for later access are **smart (or "[memoized](https://en.wikipedia.org/wiki/Memoization)") getters**.
+value and cache it for later access are _smart_ (or _[memoized](https://en.wikipedia.org/wiki/Memoization)_) getters.
 The value is calculated the first time the getter is called, and is then cached so
 subsequent accesses return the cached value without recalculating it. This is useful in
 the following situations:
@@ -218,5 +218,4 @@ console.log(
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Object/__defineGetter__", "__defineGetter__")}}
 - {{jsxref("Object/__defineSetter__", "__defineSetter__")}}
-- [Defining
-  Getters and Setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters) in JavaScript Guide
+- [Defining getters and setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters) in JavaScript Guide

--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -24,8 +24,8 @@ functions can be called. In brief, they are
 [`Function`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 objects.
 
-For more examples and explanations, see also the [JavaScript guide about
-functions](/en-US/docs/Web/JavaScript/Guide/Functions).
+For more examples and explanations,
+see the [JavaScript guide about functions](/en-US/docs/Web/JavaScript/Guide/Functions).
 
 ## Description
 
@@ -79,8 +79,8 @@ myFunc(mycar);
 console.log(mycar.brand);
 ```
 
-The [`this`
-keyword](/en-US/docs/Web/JavaScript/Reference/Operators/this) does not refer to the currently executing function, so you must refer to
+The [`this` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/this)
+does not refer to the currently executing function, so you must refer to
 `Function` objects by name, even within the function body.
 
 ## Defining functions
@@ -89,8 +89,8 @@ There are several ways to define functions:
 
 ### The function declaration (`function` statement)
 
-There is a special syntax for declaring functions (see [function
-statement](/en-US/docs/Web/JavaScript/Reference/Statements/function) for details):
+There is a special syntax for declaring functions
+(see [function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function) for details):
 
 ```js
 function name([param[, param[, ... param]]]) {
@@ -108,9 +108,9 @@ function name([param[, param[, ... param]]]) {
 ### The function expression (`function` expression)
 
 A function expression is similar to and has the same syntax as a function declaration
-(see [function
-expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) for details). A function expression may be a part of a larger
-expression. One can define "named" function expressions (where the name of the
+(see [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) for details).
+A function expression may be a part of a larger expression.
+One can define "named" function expressions (where the name of the
 expression might be used in the call stack for example) or "anonymous" function
 expressions. Function expressions are not _hoisted_ onto the beginning of the
 scope, therefore they cannot be used before they appear in the code.
@@ -205,9 +205,8 @@ function* [name]([param[, param[, ... param]]]) {
 
 ### The arrow function expression (=>)
 
-An arrow function expression has a shorter syntax and lexically binds its
-`this` value (see [arrow
-functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) for details):
+An arrow function expression has a shorter syntax and lexically binds its `this` value
+(see [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) for details):
 
 ```js
 ([param[, param]]) => {
@@ -280,14 +279,13 @@ the `new` operator) has the same effect as invoking it as a constructor.
 ### Default parameters
 
 Default function parameters allow formal parameters to be initialized with default
-values if no value or `undefined` is passed. For more details, see [default
-parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters).
+values if no value or `undefined` is passed. For more details,
+see [default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters).
 
 ### Rest parameters
 
-The rest parameter syntax allows representing an indefinite number of arguments as an
-array. For more details, see [rest
-parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters).
+The rest parameter syntax allows representing an indefinite number of arguments as an array.
+For more details, see [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters).
 
 ## The `arguments` object
 
@@ -322,8 +320,8 @@ The syntax for defining getters and setters uses the object literal syntax.
 ### Method definition syntax
 
 Starting with ECMAScript 2015, you are able to define own methods in a shorter syntax,
-similar to the getters and setters. See [method
-definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) for more information.
+similar to the getters and setters.
+See [method definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) for more information.
 
 ```js
 var obj = {
@@ -385,8 +383,8 @@ var y = function x() {};
 alert(x); // throws an error
 ```
 
-The function name also appears when the function is serialized via [`Function`'s
-toString method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString).
+The function name also appears when the function is serialized via
+[`Function`'s toString method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString).
 
 On the other hand, the variable the function is assigned to is limited only by its
 scope, which is guaranteed to include the scope in which the function is declared.
@@ -665,5 +663,4 @@ are no brackets "()" after the function name so the actual function is not calle
 - {{jsxref("Functions/get", "getter")}}
 - {{jsxref("Functions/set", "setter")}}
 - {{jsxref("Functions/Method_definitions", "Method definitions")}}
-- [Functions
-  and function scope](/en-US/docs/Web/JavaScript/Reference/Functions)
+- [Functions and function scope](/en-US/docs/Web/JavaScript/Reference/Functions)

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -72,8 +72,7 @@ const obj = {
 
 ### Generator methods
 
-[Generator
-methods](/en-US/docs/Web/JavaScript/Reference/Statements/function*) can be defined using the shorthand syntax as well.
+[Generator methods](/en-US/docs/Web/JavaScript/Reference/Statements/function*) can be defined using the shorthand syntax as well.
 
 When doing so:
 
@@ -81,10 +80,9 @@ When doing so:
   generator property name. (That is, `* g(){}` will work,
   but `g *(){}` will not.)
 - Non-generator method definitions cannot contain the `yield` keyword.
-  This means that [legacy
-  generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/Legacy_generator_function) won't work either, and will throw a
-  {{jsxref("SyntaxError")}}. Always use `yield` in conjunction with the
-  asterisk (`*`).
+  This means that [legacy generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/Legacy_generator_function)
+  won't work either, and will throw a {{jsxref("SyntaxError")}}.
+  Always use `yield` in conjunction with the asterisk (`*`).
 
 ```js
 // Using a named property
@@ -135,8 +133,7 @@ const obj3 = {
 
 ### Async generator methods
 
-[Generator
-methods](/en-US/docs/Web/JavaScript/Reference/Statements/function*) can also be {{jsxref("Statements/async_function", "async", "", 1)}}.
+[Generator methods](/en-US/docs/Web/JavaScript/Reference/Statements/function*) can also be {{jsxref("Statements/async_function", "async", "", 1)}}.
 
 ```js
 const obj4 = {

--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -45,8 +45,9 @@ a property that holds an actual value.
 Note the following when working with the `set` syntax:
 
 - It can have an identifier which is either a number or a string;
-- It must have exactly one parameter (see [Incompatible ES5 change: literal getter and setter
-  functions must now have exactly zero or one arguments](http://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/) for more information);
+- It must have exactly one parameter
+  (see [Incompatible ES5 change: literal getter and setter functions must now have exactly zero or one arguments](http://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/)
+  for more information);
 - It must not appear in an object literal with another `set` or with a
   data entry for the same property.
   ( `{ set x(v) { }, set x(v) { } }` and
@@ -141,5 +142,4 @@ console.log(obj.baz);
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Object.defineGetter", "__defineGetter__")}}
 - {{jsxref("Object.defineSetter", "__defineSetter__")}}
-- [Defining
-  Getters and Setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Defining_getters_and_setters) in JavaScript Guide
+- [Defining getters and setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Defining_getters_and_setters) in JavaScript Guide


### PR DESCRIPTION
This fixes some more multiline links.

I also updated the typography of 2 pages: there were some late additions that were not following our typography, also there was too much boldface in it (likely the editor adding them felt strongly about the importance of the change and abused a bit the bold).

No editorial changes.