### PR TITLE
Fix OfflineAudioContext constructor sample-rate lower bound

### DIFF
--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
@@ -43,7 +43,7 @@ as either the same set of parameters as are inputs into the
     `5 * 48000 = 240000` sample-frames.
 - `sampleRate`
   - : The sample-rate of the linear audio data in sample-frames per second. All user
-    agents are required to support a range of 22050Hz to 96000Hz, and may support a wider
+    agents are required to support a range of 8000Hz to 96000Hz, and may support a wider
     range than that. The most commonly-used rate is 44100Hz, which is the sample rate used
     by CD audio.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix the lower bound of required sample rate range of `OfflineAudioContext` constructor.
from: 22050Hz
to: 8000Hz

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
According to [W3C Web Audio API spec](https://webaudio.github.io/web-audio-api/), 8000Hz is the correct value. For the exact location of the information in the spec, please see the links on "Supporting details" below.


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate

https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
