### PR TITLE
Remove redundant `break` statements

### DIFF
--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -265,7 +265,6 @@ switch (action) {
     break;
   default:
     console.log('Empty action received.');
-    break;
 }
 ```
 
@@ -296,7 +295,6 @@ switch (action) {
   } // added brackets
   default: { // added brackets
     console.log('Empty action received.');
-    break;
   } // added brackets
 }
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove redundant `break` statements from the `default` case of `switch` statements.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
