### PR TITLE
Do not throw when `document.currentScript` is `null`

### DIFF
--- a/files/en-us/web/api/document/currentscript/index.md
+++ b/files/en-us/web/api/document/currentscript/index.md
@@ -28,7 +28,7 @@ var curScriptElement = document.currentScript;
 This example checks to see if the script is being executed asynchronously:
 
 ```js
-if (document.currentScript.async) {
+if (document.currentScript?.async) {
   console.log("Executing asynchronously");
 } else {
   console.log("Executing synchronously");


### PR DESCRIPTION
Allows continued execution of the `else` statement.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Adds optional chaining to allow the script to be run in the browser console with throwing.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Allowing the reader to see error-free output.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
