### PR TITLE
Fix live sample iframe size

### DIFF
--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -271,7 +271,7 @@ function log(msg) {
 
 You can test this example on mobile devices by touching the box below.
 
-{{EmbedLiveSample('Example','100%', 880)}}
+{{EmbedLiveSample('Example','100%', 900)}}
 
 > **Note:** More generally, the example will work on platforms that provide touch events.
 > You can test this on desktop platforms that can simulate such events:


### PR DESCRIPTION
The iframe for this example was a little short, so we got a scrollbar.