### PR TITLE
See also: added related property

### DIFF
--- a/files/en-us/web/css/tab-size/index.md
+++ b/files/en-us/web/css/tab-size/index.md
@@ -105,4 +105,5 @@ p {
 
 ## See also
 
+- {{cssxref('white-space')}}
 - [Controlling size of a tab character (U+0009)](https://lists.w3.org/Archives/Public/www-style/2008Dec/0009.html), an email by Anne van Kesteren to the CSSWG.


### PR DESCRIPTION
tab-size only works when white-space is not `normal`, so linking to that is white space is important.
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
