### PR TITLE
fix: markdownlint issues

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -71,15 +71,15 @@ If an extension attempts to store items that exceed these limits, the call to [`
 
 The `sync` object implements the methods defined on the {{WebExtAPIRef("storage.StorageArea")}} type:
 
-- {{WebExtAPIRef("storage.StorageArea.get()", "storage.<let>StorageArea</let>.get()")}}
+- {{WebExtAPIRef("storage.StorageArea.get()", "storage.StorageArea.get()")}}
   - : Retrieves one or more items from the storage area.
-- {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.<let>StorageArea</let>.getBytesInUse()")}}
+- {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.StorageArea.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used one or more items being stored in the storage area.
-- {{WebExtAPIRef("storage.StorageArea.set()", "storage.<let>StorageArea</let>.set()")}}
+- {{WebExtAPIRef("storage.StorageArea.set()", "storage.StorageArea.set()")}}
   - : Stores one or more items in the storage area. If the item already exists, its value will be updated.
-- {{WebExtAPIRef("storage.StorageArea.remove()", "storage.<let>StorageArea</let>.remove()")}}
+- {{WebExtAPIRef("storage.StorageArea.remove()", "storage.StorageArea.remove()")}}
   - : Removes one or more items from the storage area.
-- {{WebExtAPIRef("storage.StorageArea.clear()", "storage.<let>StorageArea</let>.clear()")}}
+- {{WebExtAPIRef("storage.StorageArea.clear()", "storage.StorageArea.clear()")}}
   - : Removes all items from the storage area.
 
 ## Browser compatibility

--- a/files/en-us/web/accessibility/aria/roles/index.md
+++ b/files/en-us/web/accessibility/aria/roles/index.md
@@ -36,6 +36,7 @@ Document Structure roles are used to provide a structural description for a sect
 - [note](/en-US/docs/Web/Accessibility/ARIA/Roles/note_role)
 
 For most document structure roles, semantic HTML equivalent elements are available and supported. Avoid using:
+
 - [application](/en-US/docs/Web/Accessibility/ARIA/Roles/application_role)
 - [article](/en-US/docs/Web/Accessibility/ARIA/Roles/article_role) (use {{HTMLElement('article')}})
 - [cell](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role) (use {{HTMLElement('td')}})

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -188,7 +188,6 @@ Some properties only apply to input element types that support the corresponding
 - {{domxref("HTMLInputElement.size", "size")}}
   - : `unsigned long`: **Returns / Sets** the element's {{ htmlattrxref("size", "input") }} attribute, containing visual size of the control. This value is in pixels unless the value of {{htmlattrxref("type","input")}} is `text` or `password`, in which case, it is an integer number of characters. Applies only when {{htmlattrxref("type","input")}} is set to `text`, `search`, `tel`, `url`, `email`, or `password`.
 
-
 ## Methods
 
 - {{domxref("HTMLElement/blur", "blur()")}}

--- a/files/en-us/web/api/svgnumberlist/index.md
+++ b/files/en-us/web/api/svgnumberlist/index.md
@@ -24,7 +24,7 @@ An `SVGNumberList` object can be designated as read only, which means that attem
   <tbody>
     <tr>
       <th scope="row">Also implement</th>
-      <td><var>None</var></td>
+      <td>None</td>
     </tr>
     <tr>
       <th scope="row">Methods</th>

--- a/files/en-us/web/css/css_container_queries/index.md
+++ b/files/en-us/web/css/css_container_queries/index.md
@@ -114,9 +114,10 @@ You can then target just that query container by adding the name to the containe
 }
 ```
 
-There are many things to be worked out, however this is the basic concept. The basic features as shown here can already be tested out in Chrome and Safari Technology Preview. 
- - Chrome: Go to `chrome://flags`, search for Container Queries and enable that flag.
- - Safari Technology Preview: Enabled by default.
+There are many things to be worked out, however this is the basic concept. The basic features as shown here can already be tested out in Chrome and Safari Technology Preview.
+
+- Chrome: Go to `chrome://flags`, search for Container Queries and enable that flag.
+- Safari Technology Preview: Enabled by default.
 
 You can then take a look at [my demo](https://codepen.io/rachelandrew/pen/NWdaxde) showing a simple `inline-size` scenario, or [this growing collection of container queries demos](https://codepen.io/collection/XQrgJo).
 

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -278,7 +278,7 @@ Note that [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_
       </td>
       <td>left-to-right</td>
       <td>
-        <code>… ( <var>… </var>)</code>
+        <code>… ( … )</code>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.md
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.md
@@ -64,7 +64,7 @@ html,body,svg { height:100% }
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td><code>none</code> | <var>&#x3C;dasharray></var></td>
+      <td><code>none</code> | <code>&#x3C;dasharray></code></td>
     </tr>
     <tr>
       <th scope="row">Default value</th>


### PR DESCRIPTION
- Spacing
- "let" tag from sample var -> let conversion