### PR TITLE
Fix example using lastIndexOf instead of indexOf

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -35,7 +35,7 @@ indexOf(searchString, position)
 
     - `'hello world hello'.indexOf('o', -5)` returns `4` — because it causes the method to behave as if the second argument were `0`, and the first occurrence of `hello` at a position greater or equal to `0` is at position `4`.
 
-    - `'hello world hello'.lastIndexOf('world', 12)` returns `-1` — because, while it's true the substring `world` occurs at index `6`, that position is not greater than or equal to `12`.
+    - `'hello world hello'.indexOf('world', 12)` returns `-1` — because, while it's true the substring `world` occurs at index `6`, that position is not greater than or equal to `12`.
 
     - `'hello world hello'.indexOf('o', 99)` returns `-1`— because `99` is greater than the length of `hello world hello`, which causes the method to not search the string at all.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
One of the examples for `indexOf` doc was using `lastIndexOf` when it should have been `indexOf`. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I believe it was a typo and this change fixes it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
