### PR TITLE
WebAPI: Clean syntax from property pages, part 9

### DIFF
--- a/files/en-us/web/api/audioworkletnode/parameters/index.md
+++ b/files/en-us/web/api/audioworkletnode/parameters/index.md
@@ -21,13 +21,7 @@ underlying {{domxref("AudioWorkletProcessor")}} according to its
 {{domxref("AudioWorkletProcessor.parameterDescriptors", "parameterDescriptors")}} static
 getter.
 
-## Syntax
-
-```js
-audioWorkletNodeInstance.parameters
-```
-
-### Value
+## Value
 
 The {{domxref("AudioParamMap")}} object containing {{domxref("AudioParam")}} instances.
 They can be automated in the same way as with default `AudioNode`s, and their

--- a/files/en-us/web/api/audioworkletnode/port/index.md
+++ b/files/en-us/web/api/audioworkletnode/port/index.md
@@ -21,13 +21,7 @@ associated {{domxref("AudioWorkletProcessor")}}.
 > available under the {{domxref("AudioWorkletProcessor.port", "port")}} property of the
 > processor.
 
-## Syntax
-
-```js
-audioWorkletNodeInstance.port;
-```
-
-### Value
+## Value
 
 The {{domxref("MessagePort")}} object that is connecting the
 `AudioWorkletNode` and its associated `AudioWorkletProcessor`.

--- a/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.md
@@ -23,13 +23,7 @@ interface, but, if defined, it is called internally by the
 
 Defining the getter is optional.
 
-## Syntax
-
-```js
-AudioWorkletProcessorSubclass.parameterDescriptors;
-```
-
-### Value
+## Value
 
 An iterable of {{domxref("AudioParamDescriptor")}}-based objects. The properties of
 these objects are as follows:

--- a/files/en-us/web/api/audioworkletprocessor/port/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/port/index.md
@@ -21,13 +21,7 @@ The read-only **`port`** property of the
 > **Note:** The port at the other end of the channel is
 > available under the {{domxref("AudioWorkletNode.port", "port")}} property of the node.
 
-## Syntax
-
-```js
-AudioWorkletProcessorInstance.port;
-```
-
-### Value
+## Value
 
 The {{domxref("MessagePort")}} object that is connecting the `AudioWorkletProcessor` and the associated `AudioWorkletNode`.
 

--- a/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
@@ -24,13 +24,7 @@ that corresponds to the private key that has created the attestation signature i
 known; however, there are various well known attestation public key chains for different
 ecosystems (for example, Android or TPM attestations).
 
-## Syntax
-
-```js
-attestObj = authenticatorAttestationResponse.attestationObject
-```
-
-## Properties
+## Value
 
 After decoding the [CBOR](https://datatracker.ietf.org/doc/html/rfc7049) encoded
 `ArrayBuffer`, the resulting JavaScript object will contain the following

--- a/files/en-us/web/api/baseaudiocontext/audioworklet/index.md
+++ b/files/en-us/web/api/baseaudiocontext/audioworklet/index.md
@@ -21,13 +21,7 @@ The `audioWorklet` read-only property of the
 {{domxref("AudioWorkletProcessor")}}-derived classes which implement custom audio
 processing.
 
-## Syntax
-
-```js
-baseAudioContextInstance.audioWorklet;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioWorklet")}} instance.
 

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.md
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.md
@@ -17,14 +17,11 @@ The `currentTime` read-only property of the {{ domxref("BaseAudioContext") }}
 interface returns a double representing an ever-increasing hardware timestamp in seconds that
 can be used for scheduling audio playback, visualizing timelines, etc. It starts at 0.
 
-## Syntax
+## Value
 
-```js
-var curTime = baseAudioContext.currentTime;
-```
+A floating point number.
 
-## Example
-
+## Examples
 ```js
 var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();

--- a/files/en-us/web/api/baseaudiocontext/destination/index.md
+++ b/files/en-us/web/api/baseaudiocontext/destination/index.md
@@ -18,18 +18,11 @@ interface returns an {{ domxref("AudioDestinationNode") }} representing the fina
 destination of all audio in the context. It often represents an actual audio-rendering
 device such as your device's speakers.
 
-## Syntax
-
-```js
-baseAudioContext.destination;
-```
-
-### Value
+## Value
 
 An {{ domxref("AudioDestinationNode") }}.
 
-## Example
-
+## Examples
 > **Note:** for a full example implementation, see one of our Web Audio
 > Demos on the [MDN Github repo](https://github.com/mdn/), like [voice-change-o-matic](https://github.com/mdn/voice-change-o-matic).
 

--- a/files/en-us/web/api/baseaudiocontext/listener/index.md
+++ b/files/en-us/web/api/baseaudiocontext/listener/index.md
@@ -18,18 +18,11 @@ The `listener` property of the {{ domxref("BaseAudioContext") }} interface
 returns an {{ domxref("AudioListener") }} object that can then be used for
 implementing 3D audio spatialization.
 
-## Syntax
-
-```js
-baseAudioContext.listener;
-```
-
-### Value
+## Value
 
 An {{ domxref("AudioListener") }} object.
 
-## Example
-
+## Examples
 > **Note:** for a full Web Audio spatialization example, see our [panner-node](https://github.com/mdn/panner-node) demo.
 
 ```js

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.md
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.md
@@ -18,19 +18,12 @@ The `sampleRate` property of the {{
 the sample rate, in samples per second, used by all nodes in this audio
 context. This limitation means that sample-rate converters are not supported.
 
-## Syntax
-
-```js
-baseAudioContext.sampleRate;
-```
-
-### Value
+## Value
 
 A floating point number indicating the audio context's sample rate, in samples per
 second.
 
-## Example
-
+## Examples
 > **Note:** for a full Web Audio example implementation, see one of our
 > Web Audio Demos on the [MDN Github repo](https://github.com/mdn/), like [panner-node](https://github.com/mdn/panner-node). Try entering
 > `audioCtx.sampleRate` into your browser console.

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -17,13 +17,7 @@ browser-compat: api.BaseAudioContext.state
 The `state` read-only property of the {{ domxref("BaseAudioContext") }}
 interface returns the current state of the `AudioContext`.
 
-## Syntax
-
-```js
-baseAudioContext.state;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}. Possible values are:
 

--- a/files/en-us/web/api/biquadfilternode/detune/index.md
+++ b/files/en-us/web/api/biquadfilternode/detune/index.md
@@ -14,19 +14,12 @@ browser-compat: api.BiquadFilterNode.detune
 
 The `detune` property of the {{ domxref("BiquadFilterNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing detuning of the frequency in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var biquadFilter = audioCtx.createBiquadFilter();
-biquadFilter.detune.value = 100;
-```
-
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
-
 ### Value
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
+
+> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+
 
 ## Example
 

--- a/files/en-us/web/api/biquadfilternode/frequency/index.md
+++ b/files/en-us/web/api/biquadfilternode/frequency/index.md
@@ -16,19 +16,11 @@ The `frequency` property of the {{ domxref("BiquadFilterNode") }} interface is a
 
 Its default value is `350`, with a nominal range of `10` to the [Nyquist frequency](https://en.wikipedia.org/wiki/Nyquist_frequency) — that is, half of the sample rate.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var biquadFilter = audioCtx.createBiquadFilter();
-biquadFilter.frequency.value = 3000;
-```
-
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
-
 ### Value
 
 An {{domxref("AudioParam")}}.
+
+> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Example
 

--- a/files/en-us/web/api/biquadfilternode/gain/index.md
+++ b/files/en-us/web/api/biquadfilternode/gain/index.md
@@ -18,19 +18,11 @@ When its value is positive, it represents a real gain; when negative, it represe
 
 It is expressed in dB, has a default value of `0`, and can take a value in a nominal range of `-40` to `40`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var biquadFilter = audioCtx.createBiquadFilter();
-biquadfilter.gain.value = 25;
-```
-
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
-
 ### Value
 
 An {{domxref("AudioParam")}}.
+
+> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Example
 

--- a/files/en-us/web/api/biquadfilternode/q/index.md
+++ b/files/en-us/web/api/biquadfilternode/q/index.md
@@ -16,19 +16,11 @@ The `Q` property of the {{ domxref("BiquadFilterNode") }} interface is an [a-rat
 
 It is a dimensionless value with a default value of `1` and a nominal range of `0.0001` to `1000`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var biquadFilter = audioCtx.createBiquadFilter();
-biquadfilter.Q.value = 100;
-```
-
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
-
 ### Value
 
 An {{domxref("AudioParam")}}.
+
+> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Example
 

--- a/files/en-us/web/api/biquadfilternode/type/index.md
+++ b/files/en-us/web/api/biquadfilternode/type/index.md
@@ -14,15 +14,7 @@ browser-compat: api.BiquadFilterNode.type
 
 The `type` property of the {{ domxref("BiquadFilterNode") }} interface is a string (enum) value defining the kind of filtering algorithm the node is implementing.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var biquadFilter = audioCtx.createBiquadFilter();
-biquadFilter.type = 'lowpass';
-```
-
-### Value
+## Value
 
 A string (enum) representing a [BiquadFilterType](https://webaudio.github.io/web-audio-api/#idl-def-BiquadFilterType).
 
@@ -170,8 +162,7 @@ A string (enum) representing a [BiquadFilterType](https://webaudio.github.io/web
   </tbody>
 </table>
 
-## Example
-
+## Examples
 The following example shows basic usage of an AudioContext to create a Biquad filter node. For a complete working example, check out our [voice-change-o-matic](https://mdn.github.io/voice-change-o-matic/) demo (look at the [source code](https://github.com/mdn/voice-change-o-matic) too).
 
 ```js

--- a/files/en-us/web/api/blobevent/data/index.md
+++ b/files/en-us/web/api/blobevent/data/index.md
@@ -17,11 +17,9 @@ browser-compat: api.BlobEvent.data
 The **`BlobEvent.data`** read-only property represents a
 {{domxref("Blob")}} associated with the event.
 
-## Syntax
+## Value
 
-```js
-associatedBlob = BlobEvent.data
-```
+A {{domxref("Blob")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothdevice/gatt/index.md
+++ b/files/en-us/web/api/bluetoothdevice/gatt/index.md
@@ -16,13 +16,7 @@ The
 **`BluetoothDevice.gatt`** read-only property returns
 a reference to the device's {{DOMxRef("BluetoothRemoteGATTServer")}}.
 
-## Syntax
-
-```js
-var gattServer = instanceOfBluetoothDevice.gatt
-```
-
-### Returns
+## Value
 
 A reference to the device's {{DOMxRef("BluetoothRemoteGATTServer")}}.
 

--- a/files/en-us/web/api/bluetoothdevice/id/index.md
+++ b/files/en-us/web/api/bluetoothdevice/id/index.md
@@ -16,13 +16,7 @@ browser-compat: api.BluetoothDevice.id
 The **`BluetoothDevice.id`** read-only property returns a
 {{DOMxRef("DOMString")}} that uniquely identifies a device.
 
-## Syntax
-
-```js
-var id = instanceOfBluetoothDevice.id
-```
-
-### Returns
+## Value
 
 A {{DOMxRef("DOMString")}}.
 

--- a/files/en-us/web/api/bluetoothdevice/name/index.md
+++ b/files/en-us/web/api/bluetoothdevice/name/index.md
@@ -22,13 +22,7 @@ The **`BluetoothDevice.name`** read-only property returns a
 > {{DOMxRef("BluetoothDevice_%28Firefox_OS%29/name", "BluetoothDevice.name
     (Firefox OS)")}}.
 
-## Syntax
-
-```js
-var name = instanceOfBluetoothDevice.name
-```
-
-### Returns
+## Value
 
 A {{DOMxRef("DOMString")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - getDescriptor()

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - getDescriptors()

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.md
@@ -18,13 +18,7 @@ The **`BluetoothRemoteGATTCharacteristic.properties`**
 read-only property returns a {{domxref('BluetoothCharacteristicProperties')}} instance
 containing the properties of this characteristic.
 
-## Syntax
-
-```js
-var properties = BluetoothRemoteGATTCharacteristic.properties
-```
-
-### Returns
+### Value
 
 The properties of this characteristic.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - readValue

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.md
@@ -17,13 +17,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.service
 The **`BluetoothRemoteGATTCharacteristic.service`** read-only
 property returns the {{domxref("BluetoothRemoteGATTService")}} this characteristic belongs to.
 
-## Syntax
-
-```js
-var bluetoothRemoteGATTServiceInstance = BluetoothRemoteGATTCharacteristic.service
-```
-
-### Returns
+## Value
 
 An instance {{domxref("BluetoothRemoteGATTService")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - startNotifications()

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - stopNotifications

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.md
@@ -20,13 +20,7 @@ property returns {{domxref("DOMString")}} containing the UUID of the characteris
 example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate
 Measurement characteristic.
 
-## Syntax
-
-```js
-var uuid = BluetoothRemoteGATTCharacteristic.uuid
-```
-
-### Returns
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.md
@@ -18,13 +18,7 @@ The **`BluetoothRemoteGATTCharacteristic.value`** read-only
 property returns currently cached characteristic value. This value gets updated when the
 value of the characteristic is read or updated via a notification or indication.
 
-## Syntax
-
-```js
-var value = BluetoothRemoteGATTCharacteristic.value
-```
-
-### Returns
+## Value
 
 The currently cached characteristic value.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - writeValue

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - writeValueWithoutResponse

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTCharacteristic
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - writeValueWithResponse

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
@@ -17,13 +17,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.uuid
 The **`BluetoothRemoteGATTDescriptor.uuid`** read-only property returns the {{Glossary("UUID")}} of the characteristic descriptor.
 For example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient Characteristic Configuration descriptor.
 
-## Syntax
-
-```js
-var uuid = BluetoothRemoteGATTDescriptor.uuid
-```
-
-### Returns
+## Value
 
 A UUID.
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.md
@@ -19,13 +19,7 @@ The **`BluetoothRemoteGATTDescriptor.value`**
 read-only property returns an {{jsxref("ArrayBuffer")}} containing the currently cached
 descriptor value. This value gets updated when the value of the descriptor is read.
 
-## Syntax
-
-```js
-var characteristic = BluetoothRemoteGATTDescriptor.characteristic
-```
-
-### Returns
+## Value
 
 An {{jsxref("ArrayBuffer")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
@@ -7,7 +7,7 @@ tags:
   - BluetoothGattDescriptor
   - BluetoothRemoteGATTDescriptor
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - writeValue()

--- a/files/en-us/web/api/bluetoothremotegattserver/connected/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connected/index.md
@@ -18,11 +18,9 @@ property returns a boolean value that returns true while this script execution
 environment is connected to `this.device`. It can be false while the user
 agent is physically connected.
 
-## Syntax
+## Value
 
-```js
-var connected = BluetoothRemoteGATTServer.connected
-```
+A `boolean`.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattserver/device/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/device/index.md
@@ -15,11 +15,9 @@ browser-compat: api.BluetoothRemoteGATTServer.device
 The **`BluetoothRemoteGATTServer.device`** read-only property
 returns a reference to the {{domxref("BluetoothDevice")}} running the server.
 
-## Syntax
+## Value
 
-```js
-var device = BluetoothRemoteGATTServer.device
-```
+A reference to the {{domxref("BluetoothDevice")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattservice/device/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/device/index.md
@@ -18,13 +18,7 @@ The **`BluetoothGATTService.device`** read-only property
 returns information about a Bluetooth device through an instance of
 {{domxref("BluetoothDevice")}}.
 
-## Syntax
-
-```js
-var bluetoothDeviceInstance = BluetoothGATTService.device
-```
-
-### Returns
+## Value
 
 An instance of {{domxref("BluetoothDevice")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTService
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - getCharacteristic()

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
@@ -6,7 +6,7 @@ tags:
   - Bluetooth
   - BluetoothRemoteGATTService
   - Experimental
-  - Property
+  - Method
   - Reference
   - Web Bluetooth API
   - getCharacteristics()

--- a/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.md
@@ -18,13 +18,7 @@ The **`BluetoothGATTService.isPrimary`** read-only property
 returns a boolean value that indicates whether this is a primary service. If it
 is not a primary service, it is a secondary service.
 
-## Syntax
-
-```js
-var isPrimary = BluetoothGATTService.isPrimary
-```
-
-### Returns
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/bluetoothremotegattservice/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/uuid/index.md
@@ -17,13 +17,7 @@ browser-compat: api.BluetoothRemoteGATTService.uuid
 The **`BluetoothGATTService.uuid`** read-only property
 returns a {{domxref("DOMString")}} representing the UUID of this service.
 
-## Syntax
-
-```js
-var uuid = BluetoothGATTService.uuid
-```
-
-### Returns
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/caches/index.md
+++ b/files/en-us/web/api/caches/index.md
@@ -19,18 +19,11 @@ The global **`caches`** read-only property returns the
 enables functionality such as storing assets for offline use, and generating custom
 responses to requests.
 
-## Syntax
-
-```js
-var myCacheStorage = self.caches; // or just caches
-```
-
-### Value
+## Value
 
 A {{domxref("CacheStorage")}} object.
 
-## Example
-
+## Examples
 The following example shows how you'd use a cache in a [service worker](/en-US/docs/Web/API/Service_Worker_API) context to store
 assets offline.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -16,11 +16,9 @@ The **`CanvasRenderingContext2D.canvas`** property, part of the
 {{domxref("HTMLCanvasElement")}} object that is associated with a given context. It
 might be {{jsxref("null")}} if there is no associated {{HTMLElement("canvas")}} element.
 
-## Syntax
+## Value
 
-```js
-ctx.canvas;
-```
+A {{domxref("HTMLCanvasElement")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.md
@@ -19,15 +19,9 @@ property of the Canvas 2D API returns or sets a {{domxref("DOMMatrix")}} (curren
 specification) or {{domxref("SVGMatrix")}} {{deprecated_inline}} (old specification)
 object for the current transformation matrix.
 
-## Syntax
+## Value
 
-```js
-ctx.currentTransform [= value];
-```
-
-- `value`
-  - : A {{domxref("DOMMatrix")}} or {{domxref("SVGMatrix")}} {{deprecated_inline}} object
-    to use as the current transformation matrix.
+A {{domxref("DOMMatrix")}} or {{domxref("SVGMatrix")}} {{deprecated_inline}} object to use as the current transformation matrix.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/direction/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/direction/index.md
@@ -16,13 +16,7 @@ The
 **`CanvasRenderingContext2D.direction`**
 property of the Canvas 2D API specifies the current text direction used to draw text.
 
-## Syntax
-
-```js
-ctx.direction = "ltr" || "rtl" || "inherit";
-```
-
-### Options
+## Value
 
 Possible values:
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -23,13 +23,11 @@ color, gradient, or pattern to use inside shapes. The default style is `#000`
 
 ## Value
 
-- `color`
-  - : A {{domxref("DOMString")}} parsed as [CSS](/en-US/docs/Web/CSS)
-    {{cssxref("&lt;color&gt;")}} value.
-- `gradient`
-  - : A {{domxref("CanvasGradient")}} object (a linear or radial gradient).
-- `pattern`
-  - : A {{domxref("CanvasPattern")}} object (a repeating image).
+One of the followings:
+
+- A {{domxref("DOMString")}} parsed as CSS {{cssxref("<color>")}} value.
+- A {{domxref("CanvasGradient")}} object (a linear or radial gradient).
+- A {{domxref("CanvasPattern")}} object (a repeating image).
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -21,15 +21,7 @@ color, gradient, or pattern to use inside shapes. The default style is `#000`
 > styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas
 > tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
-## Syntax
-
-```js
-ctx.fillStyle = color;
-ctx.fillStyle = gradient;
-ctx.fillStyle = pattern;
-```
-
-### Options
+## Value
 
 - `color`
   - : A {{domxref("DOMString")}} parsed as [CSS](/en-US/docs/Web/CSS)

--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
@@ -16,14 +16,7 @@ The
 property of the Canvas 2D API provides filter effects such as blurring and grayscaling.
 It is similar to the CSS {{cssxref("filter")}} property and accepts the same values.
 
-## Syntax
-
-```js
-ctx.filter = "<filter-function1> [<filter-function2>] [<filter-functionN>]";
-ctx.filter = "none";
-```
-
-### Values
+## Value
 
 The `filter` property accepts a value of `"none"` or one or more
 of the following filter functions in a {{domxref("DOMString")}}.

--- a/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
@@ -17,17 +17,9 @@ property of the Canvas 2D API specifies the current text style to use when drawi
 This string uses the same syntax as the [CSS font](/en-US/docs/Web/CSS/font)
 specifier.
 
-## Syntax
+## Value
 
-```js
-ctx.font = value;
-```
-
-### Options
-
-- `value`
-  - : A {{domxref("DOMString")}} parsed as CSS {{cssxref("font")}} value. The default font
-    is 10px sans-serif.
+A {{domxref("DOMString")}} parsed as CSS {{cssxref("font")}} value. The default font is 10px sans-serif.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
@@ -20,19 +20,9 @@ to shapes and images before they are drawn onto the canvas.
 > styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas
 > Tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
-## Syntax
+## Value
 
-```js
-ctx.globalAlpha = value;
-```
-
-### Options
-
-- `value`
-  - : A number between `0.0` (fully transparent) and `1.0` (fully
-    opaque), inclusive. The default value is `1.0`. Values outside that range,
-    including {{jsxref("Infinity")}} and {{jsxref("NaN")}}, will not be set, and
-    `globalAlpha` will retain its previous value.
+A number between `0.0` (fully transparent) and `1.0` (fully opaque), inclusive. The default value is `1.0`. Values outside that range, including {{jsxref("Infinity")}} and {{jsxref("NaN")}}, will not be set, and `globalAlpha` will retain its previous value.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
Sequel of https://github.com/mdn/content/pull/14195
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Here, changes are not just removing `## Syntax` section, so commiting only 50 files.
Changes:
- Enforced heading names to `## Value`, `## Examples`.
- In Bluetooth API some methods have been marked as properties, e.g. getdescriptor. Corrected the tag to `Method`.
- In  Canvas API, converted `## Options` section to `## Value`.


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
