### PR TITLE
streams_api : removed the warning

### DIFF
--- a/files/en-us/web/api/streams_api/index.md
+++ b/files/en-us/web/api/streams_api/index.md
@@ -78,8 +78,6 @@ You can also write data to streams using {{domxref("WritableStream")}}.
 
 ### ByteStream-related interfaces
 
-> **Warning:** these are not implemented anywhere as yet, and questions have been raised as to whether the spec details are in a finished enough state for them to be implemented. This may change over time.
-
 - {{domxref("ReadableStreamBYOBReader")}}
   - : Represents a BYOB ("bring your own buffer") reader that can be used to read stream data supplied by the developer (e.g. a custom {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}} constructor).
 - {{domxref("ReadableByteStreamController")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The [page section](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API#bytestream-related_interfaces) says:
> Warning: these are not implemented anywhere as yet, and questions have been raised as to whether the spec details are in a finished enough state for them to be implemented. This may change over time.

This is no longer valid.

#### Supporting details
https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader#browser_compatibility
BCD tables for all 3 interfaces say they have been implemented by all major browsers.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
