### PR TITLE
WritableStream: example, fixed block character in the output

### DIFF
--- a/files/en-us/web/api/streams_api/using_writable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_writable_streams/index.md
@@ -68,15 +68,15 @@ The first object can contain up to four members, all of which are optional:
 The constructor call in our example looks like this:
 
 ```js
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/streams_api/using_writable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_writable_streams/index.md
@@ -68,7 +68,7 @@ The first object can contain up to four members, all of which are optional:
 The constructor call in our example looks like this:
 
 ```js
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestream/getwriter/index.md
+++ b/files/en-us/web/api/writablestream/getwriter/index.md
@@ -84,15 +84,15 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestream/getwriter/index.md
+++ b/files/en-us/web/api/writablestream/getwriter/index.md
@@ -84,7 +84,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -71,7 +71,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -71,15 +71,15 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -133,7 +133,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -133,15 +133,15 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -87,7 +87,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -87,15 +87,15 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -78,7 +78,7 @@ The following example shows the creation of a `WritableStream` with a custom sin
      });
  }
 
- const decoder = new TextDecoder("utf-8");
+ const decoder = new TextDecoder("utf-16");
  const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
  let result = "";
  const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -78,15 +78,15 @@ The following example shows the creation of a `WritableStream` with a custom sin
      });
  }
 
- const decoder = new TextDecoder("utf-16");
+ const decoder = new TextDecoder("utf-8");
  const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
  let result = "";
  const writableStream = new WritableStream({
    // Implement the sink
    write(chunk) {
      return new Promise((resolve, reject) => {
-       var buffer = new ArrayBuffer(2);
-       var view = new Uint16Array(buffer);
+       var buffer = new ArrayBuffer(1);
+       var view = new Uint8Array(buffer);
        view[0] = chunk;
        var decoded = decoder.decode(view, { stream: true });
        var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -84,15 +84,15 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -84,7 +84,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -90,15 +90,15 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-16");
+const decoder = new TextDecoder("utf-8");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({
   // Implement the sink
   write(chunk) {
     return new Promise((resolve, reject) => {
-      var buffer = new ArrayBuffer(2);
-      var view = new Uint16Array(buffer);
+      var buffer = new ArrayBuffer(1);
+      var view = new Uint8Array(buffer);
       view[0] = chunk;
       var decoded = decoder.decode(view, { stream: true });
       var listItem = document.createElement('li');

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -90,7 +90,7 @@ function sendMessage(message, writableStream) {
     });
 }
 
-const decoder = new TextDecoder("utf-8");
+const decoder = new TextDecoder("utf-16");
 const queuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 let result = "";
 const writableStream = new WritableStream({


### PR DESCRIPTION
## Summary
In the example https://developer.mozilla.org/en-US/docs/Web/API/WritableStream#examples ,
there are unwanted block characters in the output:
![screenshot](https://i.imgur.com/4ZQnmHK.png)

In JavaScript strings use UTF-16 encoding. 
With `utf-16` encoding for the decoder, the issue is fixed:
```
const decoder = new TextDecoder("utf-16");
```

After:
![fixed](https://i.imgur.com/4SCnRNq.png)

Tested in Chrome on Windows 10.

**Note**: I've created a PR for the same in mdn/dom-examples repo: https://github.com/mdn/dom-examples/pull/97
I have no idea who is the reviewer there.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
