### PR TITLE
change a box-shadow offset demonstration colour

### DIFF
--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -147,8 +147,8 @@ We added a margin the size of the widest box-shadow to ensure the shadow doesn't
 
 ```css
 p {
-  box-shadow: 0 0 0 2em #F4AAB9,
-              0 0 0 4em #66CCFF;
+  box-shadow: 0 0 0 2em #2E3436,
+              0 0 0 4em #EDD400;
   margin: 4em;
   padding:1em;
 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

"Box-shadow offset demonstration has poor colour contrast and is potentially non-compliant with WCAG guidelines. It is particularly hostile to low vision, but otherwise sighted individuals due to poor contrast issues. Poorly contrasting adjacent elements, even if they may be entirely discernable to users with optimal vision, can be difficult or impossible for low-vision users to parse, which may render the rendered example visually confusing and difficult to understand." this is the issues #14372 comment so i just apply the suggestion that  he make


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
