### PR TITLE
Markdown links on one line (Part 5 and final part for javascript/)

### DIFF
--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -25,8 +25,9 @@ The [JavaScript reference](/en-US/docs/Web/JavaScript/Reference/Statements)
 contains exhaustive details about the statements in this chapter. The semicolon
 (`;`) character is used to separate statements in JavaScript code.
 
-Any JavaScript expression is also a statement. See [Expressions and
-operators](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators) for complete information about expressions.
+Any JavaScript expression is also a statement.
+See [Expressions and operators](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators)
+for complete information about expressions.
 
 ## Block statement
 
@@ -297,8 +298,7 @@ are created equal. While it is common to throw numbers or strings as errors, it 
 frequently more effective to use one of the exception types specifically created for
 this purpose:
 
-- [ECMAScript
-  exceptions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types)
+- [ECMAScript exceptions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types)
 - [`DOMException`](/en-US/docs/Web/API/DOMException)
   and [`DOMError`](/en-US/docs/Web/API/DOMError)
 
@@ -506,9 +506,8 @@ If an inner `try` block does _not_ have a corresponding
 2. the enclosing `try...catch` statement's `catch` block is
     checked for a match.
 
-For more information, see [nested
-try-blocks](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#nested_try-blocks) on the
-[`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
+For more information, see [nested try-blocks](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#nested_try-blocks)
+on the [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
 reference page.
 
 ### Utilizing Error objects

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -290,8 +290,8 @@ For more information about objects, read [Working with Objects][object].)
 #### Avoid assignment chains
 
 Chaining assignments or nesting assignments in other expressions can
-result in surprising behavior. For this reason, [chaining assignments
-in the same statement is discouraged][discourage assign chain]).
+result in surprising behavior. For this reason,
+[chaining assignments in the same statement is discouraged][discourage assign chain]).
 
 In particular, putting a variable chain in a [`const`][], [`let`][], or [`var`][] statement often does *not* work.
 Only the outermost/leftmost variable would get declared;
@@ -463,8 +463,7 @@ var var2 = 4;
 </table>
 
 > **Note:** `=>` is not a comparison operator but rather is the notation
-> for [Arrow
-> functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
+> for [Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
 ### Arithmetic operators
 
@@ -847,8 +846,8 @@ mystring += 'bet'; // evaluates to "alphabet" and assigns this value to mystring
 
 ### Conditional (ternary) operator
 
-The [conditional
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) is the only JavaScript operator that takes three operands.
+The [conditional operator](/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator)
+is the only JavaScript operator that takes three operands.
 The operator can have one of two values based on a condition.
 The syntax is:
 
@@ -871,8 +870,8 @@ This statement assigns the value "adult" to the variable `status` if
 
 ### Comma operator
 
-The [comma
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator) (`,`) evaluates both of its operands and returns the value of the last operand.
+The [comma operator](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator) (`,`)
+evaluates both of its operands and returns the value of the last operand.
 This operator is primarily used inside a `for` loop, to allow multiple variables to be updated each time through the loop.
 It is regarded bad style to use it elsewhere, when it is not necessary.
 Often two separate statements can and should be used instead.
@@ -1004,8 +1003,7 @@ typeof String;   // returns "function"
 
 #### `void`
 
-The [`void`
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/void) is used in either of the following ways:
+The [`void` operator](/en-US/docs/Web/JavaScript/Reference/Operators/void) is used in either of the following ways:
 
 ```js
 void (expression)
@@ -1055,9 +1053,8 @@ var mycar = { make: 'Honda', model: 'Accord', year: 1998 };
 
 #### `instanceof`
 
-The [`instanceof`
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) returns `true` if the specified object is of the specified
-object type. The syntax is:
+The [`instanceof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) returns `true`
+if the specified object is of the specified object type. The syntax is:
 
 ```js
 objectName instanceof objectType
@@ -1104,8 +1101,8 @@ The following table describes the precedence of operators, from highest to lowes
 | comma                  | `,`                                                     |
 
 A more detailed version of this table, complete with links to additional details about
-each operator, may be found in [JavaScript
-Reference](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table).
+each operator, may be found in the
+[JavaScript Reference](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table).
 
 ## Expressions
 

--- a/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
@@ -29,8 +29,8 @@ TypeError: Cannot redefine property: "x" (Chrome)
 It was attempted to redefine a property, but that property is [non-configurable](/en-US/docs/Web/JavaScript/Data_structures#properties). The
 `configurable` attribute controls whether the property can be deleted from
 the object and whether its attributes (other than `writable`) can be changed.
-Usually, properties in an object created by an [object
-initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) are configurable. However, for example, when using
+Usually, properties in an object created by an
+[object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) are configurable. However, for example, when using
 {{jsxref("Object.defineProperty()")}}, the property isn't configurable by default.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -13,22 +13,22 @@ browser-compat: javascript.functions.arrow_functions
 {{jsSidebar("Functions")}}
 
 An **arrow function expression** is a compact alternative to a traditional
-[function
-expression](/en-US/docs/Web/JavaScript/Reference/Operators/function), but is limited and can't be used in all situations.
+[function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function),
+but is limited and can't be used in all situations.
 
-**Differences & Limitations:**
+There are differences between _arrow functions_ and _traditional functions_, as well as some limitations:
 
-- Does not have its own bindings to
+- Arrow functions don't have their own bindings to
   [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) or [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super),
   and should not be used as [`methods`](/en-US/docs/Glossary/Method).
-- Does not have [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) keyword.
-- Not suitable for
+- Arrow function don't have access to the [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) keyword.
+- Arrow functions aren't suitable for
   [`call`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call),
   [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
   and [`bind`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
   methods, which generally rely on establishing a [scope](/en-US/docs/Glossary/Scope).
-- Can not be used as [constructors](/en-US/docs/Glossary/Constructor).
-- Can not use [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield), within its body.
+- Arrow functions cannot be used as [constructors](/en-US/docs/Glossary/Constructor).
+- Arrow functions cannot use [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield), within its body.
 
 {{EmbedInteractiveExample("pages/js/functions-arrow.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -72,8 +72,8 @@ that have been deleted or are uninitialized. (For sparse arrays, [see example be
 If a `thisArg` parameter is provided to `forEach()`,
 it will be used as callback's `this` value. The
 `thisArg` value ultimately observable by
-`callbackFn` is determined according to [the usual rules for
-determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
+`callbackFn` is determined according to
+[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
 
 The range of elements processed by `forEach()` is set before the first
 invocation of `callbackFn`. Elements which are assigned to indexes
@@ -230,8 +230,9 @@ Since the `thisArg` parameter (`this`) is provided to
 `forEach()`, it is passed to `callback` each time it's
 invoked. The callback uses it as its `this` value.
 
-> **Note:** If passing the callback function used an [arrow function
-> expression](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), the `thisArg` parameter could be omitted,
+> **Note:** If passing the callback function used an
+> [arrow function expression](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
+> the `thisArg` parameter could be omitted,
 > since all arrow functions lexically bind the {{jsxref("Operators/this", "this")}}
 > value.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -45,8 +45,8 @@ The last index of the element in the array; **-1** if not found.
 ## Description
 
 `lastIndexOf` compares `searchElement` to elements of the Array
-using [strict
-equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same method used by the `===`, or triple-equals, operator).
+using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)
+(the same method used by the `===`, or triple-equals, operator).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -60,7 +60,7 @@ There are five basic forms for the `Date()` constructor:
     - `dateString`
 
       - : A string value representing a date, specified in a format recognized by the
-        {{jsxref("Date.parse()")}} method. (These formats are 
+        {{jsxref("Date.parse()")}} method. (These formats are
         [IETF-compliant RFC 2822 timestamps](https://datatracker.ietf.org/doc/html/rfc2822#page-14),
         and also strings in a
         [version of ISO8601](https://www.ecma-international.org/ecma-262/11.0/#sec-date.parse).)

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -140,8 +140,10 @@ formatter.formatToParts(date);
 ```
 
 Now the information is available separately and it can be formatted and concatenated
-again in a customized way. For example by using {{jsxref("Array.prototype.map()")}}, [arrow
-functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch), [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals),
+again in a customized way. For example by using {{jsxref("Array.prototype.map()")}},
+[arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
+a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch),
+[template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals),
 and {{jsxref("Array.prototype.join()")}}.
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.md
@@ -84,8 +84,8 @@ function getMaxOfArray(numArray) {
 }
 ```
 
-The new [spread
-operator](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) is a shorter way of writing the `apply` solution to get the
+The new [spread operator](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)
+is a shorter way of writing the `apply` solution to get the
 maximum of an array:
 
 ```js
@@ -95,9 +95,9 @@ var max = Math.max(...arr);
 
 However, both spread (`...`) and `apply` will either fail or
 return the wrong result if the array has too many elements, because they try to pass the
-array elements as function parameters. See [Using
-apply and built-in functions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_and_built-in_functions) for more details. The `reduce` solution
-does not have this problem.
+array elements as function parameters.
+See [Using apply and built-in functions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_and_built-in_functions)
+for more details. The `reduce` solution does not have this problem.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
@@ -84,5 +84,4 @@ Math.pow(-7, 1/3); // NaN
 - {{jsxref("Math.exp()")}}
 - {{jsxref("Math.log()")}}
 - {{jsxref("Math.sqrt()")}}
-- [Exponentiation
-  operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
+- [Exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)

--- a/files/en-us/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/is/index.md
@@ -130,6 +130,5 @@ if (!Object.is) {
 ## See also
 
 - [Polyfill of `Object.is` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
-- [Equality
-  comparisons and sameness](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness) — a comparison of all three built-in sameness
+- [Equality comparisons and sameness](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness) — a comparison of all three built-in sameness
   facilities

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
@@ -47,9 +47,9 @@ The last index of the element in the array; `-1` if not found.
 
 ## Description
 
-`lastIndexOf` compares `searchElement` to elements of
-the typed array using [strict
-equality](/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Using_the_Equality_Operators) (the same method used by the ===, or triple-equals, operator).
+`lastIndexOf` compares `searchElement` to elements of the typed array using
+[strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Using_the_Equality_Operators)
+(the same method used by the ===, or triple-equals, operator).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -78,8 +78,8 @@ If a `thisArg` parameter is provided to `map()`, it
 will be passed to `callbackFn` when invoked, for use as its
 `this` value. Otherwise, the value {{jsxref("undefined")}} will be passed for
 use as its `this` value. The `this` value ultimately observable by
-`callbackFn` is determined according to [the usual rules for
-determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
+`callbackFn` is determined according to
+[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
 
 `map()` does not mutate the typed array on which it is called (although
 `callbackFn`, if invoked, may do so).

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -12,8 +12,8 @@ browser-compat: javascript.builtins.TypedArray.of
 ---
 {{JSRef}}
 
-The **`TypedArray.of()`** method creates a new [typed
-array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects) from a variable number of arguments. This method is nearly the same as
+The **`TypedArray.of()`** method creates a new
+[typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects) from a variable number of arguments. This method is nearly the same as
 {{jsxref("Array.of()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-of.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/compilestreaming/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/compilestreaming/index.md
@@ -51,8 +51,7 @@ representing the compiled module.
 ### Compile streaming
 
 The following example (see our [compile-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/compile-streaming.html)
-demo on GitHub, and [view
-it live](https://mdn.github.io/webassembly-examples/js-api-examples/compile-streaming.html) also) directly streams a .wasm module from an underlying source then
+demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/compile-streaming.html) also) directly streams a .wasm module from an underlying source then
 compiles it to a {{jsxref("WebAssembly.Module")}} object. Because the
 `compileStreaming()` function accepts a promise for a [`Response`](/en-US/docs/Web/API/Response)
 object, you can directly pass it a [`fetch()`](/en-US/docs/Web/API/fetch)
@@ -81,5 +80,4 @@ The resulting module instance is then instantiated using
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instance/exports/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instance/exports/index.md
@@ -45,8 +45,7 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 ```
 
 > **Note:** You can also find this example as [instantiate-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/instantiate-streaming.html)
-> on GitHub ([view
-> it live also](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html)).
+> on GitHub ([view it live also](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html)).
 
 ## Specifications
 
@@ -60,5 +59,4 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instance/instance/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instance/instance/index.md
@@ -89,5 +89,4 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instantiate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instantiate/index.md
@@ -60,8 +60,7 @@ fields:
   compiled WebAssembly module. This `Module` can be instantiated again,
   shared via {{domxref("Worker.postMessage", "postMessage()")}} or [cached in IndexedDB](/en-US/docs/WebAssembly/Caching_modules).
 - `instance`: A {{jsxref("WebAssembly.Instance")}} object that contains all
-  the [Exported WebAssembly
-  functions](/en-US/docs/WebAssembly/Exported_functions).
+  the [Exported WebAssembly functions](/en-US/docs/WebAssembly/Exported_functions).
 
 #### Exceptions
 
@@ -129,14 +128,13 @@ fetch('simple.wasm').then(response =>
 ```
 
 > **Note:** You can also find this example at [index.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index.html)
-> on GitHub ([view
-> it live also](https://mdn.github.io/webassembly-examples/js-api-examples/)).
+> on GitHub ([view it live also](https://mdn.github.io/webassembly-examples/js-api-examples/)).
 
 ### Second overload example
 
 The following example (see our [index-compile.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index-compile.html)
-demo on GitHub, and [view
-it live](https://mdn.github.io/webassembly-examples/js-api-examples/index-compile.html) also) compiles the loaded simple.wasm byte code using the
+demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/index-compile.html) also)
+compiles the loaded simple.wasm byte code using the
 {{jsxref("WebAssembly.compileStreaming()")}} method and then sends it to a [worker](/en-US/docs/Web/API/Web_Workers_API) using
 {{domxref("Worker.postMessage", "postMessage()")}}.
 
@@ -187,5 +185,4 @@ onmessage = function(e) {
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.md
@@ -48,8 +48,7 @@ fields:
   compiled WebAssembly module. This `Module` can be instantiated again or
   shared via [postMessage()](/en-US/docs/Web/API/Worker/postMessage).
 - `instance`: A {{jsxref("WebAssembly.Instance")}} object that contains all
-  the [Exported WebAssembly
-  functions](/en-US/docs/WebAssembly/Exported_functions).
+  the [Exported WebAssembly functions](/en-US/docs/WebAssembly/Exported_functions).
 
 ### Exceptions
 
@@ -64,8 +63,8 @@ fields:
 ### Instantiating streaming
 
 The following example (see our [instantiate-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/instantiate-streaming.html)
-demo on GitHub, and [view
-it live](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html) also) directly streams a .wasm module from an underlying source then
+demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html) also)
+directly streams a .wasm module from an underlying source then
 compiles and instantiates it, the promise fulfilling with a `ResultObject`.
 Because the `instantiateStreaming()` function accepts a promise for a [`Response`](/en-US/docs/Web/API/Response)
 object, you can directly pass it a [`fetch()`](/en-US/docs/Web/API/fetch)
@@ -96,5 +95,4 @@ exported function invoked.
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/linkerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/linkerror/index.md
@@ -66,5 +66,4 @@ try {
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/grow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/grow/index.md
@@ -69,5 +69,4 @@ pages.
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
@@ -73,8 +73,7 @@ var memory = new WebAssembly.Memory({initial:10, maximum:100});
 
 The second way to get a `WebAssembly.Memory` object is to have it exported
 by a WebAssembly module. The following example (see [memory.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.html)
-on GitHub, and [view it
-live also](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) fetches and instantiates the loaded memory.wasm byte code using the
+on GitHub, and [view it live also](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) fetches and instantiates the loaded memory.wasm byte code using the
 {{jsxref("WebAssembly.instantiateStreaming()")}} method, while importing the memory
 created in the line above. It then stores some values in that memory, then exports a
 function and uses it to sum some values.
@@ -93,9 +92,9 @@ WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
 
 ### Creating a shared memory
 
-By default, WebAssembly memories are unshared. You can create a [shared
-memory](/en-US/docs/WebAssembly/Understanding_the_text_format#Shared_memories) by passing `shared: true` in the constructor's initialization
-object:
+By default, WebAssembly memories are unshared.
+You can create a [shared memory](/en-US/docs/WebAssembly/Understanding_the_text_format#Shared_memories)
+by passing `shared: true` in the constructor's initialization object:
 
 ```js
 let memory = new WebAssembly.Memory({initial:10, maximum:100, shared:true});
@@ -116,5 +115,4 @@ This memory's `buffer` property will return a
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
@@ -45,13 +45,13 @@ If `module` is not a {{jsxref("WebAssembly.Module")}} object instance, a
 A wasm module is comprised of a sequence of **sections**. Most of these
 sections are fully specified and validated by the wasm spec, but modules can also
 contain **custom sections** that are ignored and skipped over during
-validation. (Read [High
-level structure](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#high-level-structure) for information on section structures, and how normal sections
+validation. (Read [High level structure](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#high-level-structure)
+for information on section structures, and how normal sections
 ("known sections") and custom sections are distinguished.)
 
-This provides developers with a way to include custom data inside wasm modules for
-other purposes, for example the [name
-custom section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#name-section), which allows developers to provide names for all the functions and
+This provides developers with a way to include custom data inside wasm modules for other purposes,
+for example the [name custom section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#name-section),
+which allows developers to provide names for all the functions and
 locals in the module (like "symbols" in a native build).
 
 Note that the WebAssembly text format currently doesn't have a syntax specified for
@@ -70,8 +70,8 @@ wast2wasm simple-name-section.was -o simple-name-section.wasm --debug-names
 ### Using customSections
 
 The following example (see the custom-section.html [source](https://github.com/mdn/webassembly-examples/blob/master/other-examples/custom-section.html)
-and [live
-example](https://mdn.github.io/webassembly-examples/other-examples/custom-section.html)) compiles the loaded simple-name-section.wasm byte code.
+and [live example](https://mdn.github.io/webassembly-examples/other-examples/custom-section.html))
+compiles the loaded simple-name-section.wasm byte code.
 
 We then do a check using `WebAssembly.Module.customSections`, looking to see
 whether the module instance contains a "name" custom section by checking that its
@@ -101,5 +101,4 @@ WebAssembly.compileStreaming(fetch('simple-name-section.wasm'))
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/exports/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/exports/index.md
@@ -43,8 +43,8 @@ If module is not a {{jsxref("WebAssembly.Module")}} object instance, a
 ### Using exports
 
 The following example (see our [index-compile.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index-compile.html)
-demo on GitHub, and [view
-it live](https://mdn.github.io/webassembly-examples/js-api-examples/index-compile.html) also) compiles the loaded simple.wasm byte code using the
+demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/index-compile.html) also)
+compiles the loaded simple.wasm byte code using the
 {{jsxref("WebAssembly.compileStreaming()")}} method and then sends it to a [worker](/en-US/docs/Web/API/Web_Workers_API) using [postMessage()](/en-US/docs/Web/API/Worker/postMessage).
 
 ```js
@@ -104,5 +104,4 @@ The `exports[0]` output looks like this:
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/imports/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/imports/index.md
@@ -41,10 +41,10 @@ If module is not a {{jsxref("WebAssembly.Module")}} object instance, a
 
 ### Using imports
 
-The following example (see imports.html [source
-code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/imports.html); [see it
-live also](https://mdn.github.io/webassembly-examples/js-api-examples/imports.html)) compiles the loaded simple.wasm module.  This module is then queried
-for its imports.
+The following example (see imports.html [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/imports.html);
+[see it live also](https://mdn.github.io/webassembly-examples/js-api-examples/imports.html))
+compiles the loaded simple.wasm module.
+This module is then queried for its imports.
 
 ```js
 WebAssembly.compileStreaming(fetch('simple.wasm'))
@@ -72,5 +72,4 @@ The output looks like this:
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/module/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/module/index.md
@@ -13,8 +13,7 @@ browser-compat: javascript.builtins.WebAssembly.Module.Module
 
 A **`WebAssembly.Module()`** constructor creates a new Module
 object containing stateless WebAssembly code that has already been compiled by the
-browser and can be efficiently [shared
-with Workers](/en-US/docs/Web/API/Worker/postMessage), and instantiated multiple times.
+browser and can be efficiently [shared with Workers](/en-US/docs/Web/API/Worker/postMessage), and instantiated multiple times.
 
 The `WebAssembly.Module()` constructor function can be called to
 synchronously compile given WebAssembly binary code. However, the primary way to get a
@@ -78,5 +77,4 @@ fetch('simple.wasm').then(response =>
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.md
@@ -65,5 +65,4 @@ try {
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/get/index.md
@@ -44,8 +44,8 @@ to {{jsxref("WebAssembly/Table/length","Table.prototype.length")}}, a
 ### Using get
 
 The following example (see [table.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table.html)
-on GitHub, and [view it
-live](https://mdn.github.io/webassembly-examples/js-api-examples/table.html) also) compiles and instantiates the loaded table.wasm byte code using the
+on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/table.html) also)
+compiles and instantiates the loaded table.wasm byte code using the
 {{jsxref("WebAssembly.instantiateStreaming()")}} method. It then retrieves the
 references stored in the exported table.
 
@@ -75,5 +75,4 @@ simple value.
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/grow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/grow/index.md
@@ -68,5 +68,4 @@ console.log(table.length);   // "3"
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/length/index.md
@@ -48,5 +48,4 @@ console.log(table.length);   // "3"
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/set/index.md
@@ -48,9 +48,9 @@ Void.
 
 ### Using Table.set
 
-The following example (see table2.html [source
-code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) and [live
-version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2
+The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html)
+and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html))
+creates a new WebAssembly Table instance with an initial size of 2
 references. We then print out the table length and contents of the two indexes
 (retrieved via {{jsxref("WebAssembly/Table/get","Table.prototype.get()")}}) to show that
 the length is two, and the indexes currently contain no function references (they
@@ -76,8 +76,8 @@ var importObj = {
 Finally, we load and instantiate a wasm module (table2.wasm) using the
 {{jsxref("WebAssembly.instantiateStreaming()")}}, log the table length, and invoke the
 two referenced functions that are now stored in the table (the table2.wasm module (see
-[text
-representation](https://github.com/mdn/webassembly-examples/blob/master/text-format-examples/table2.was)) adds two function references to the table, both of which print out
+[text representation](https://github.com/mdn/webassembly-examples/blob/master/text-format-examples/table2.was))
+adds two function references to the table, both of which print out
 a simple value):
 
 ```js
@@ -108,5 +108,4 @@ same table is visible and callable inside the wasm instance too.
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/table/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/table/index.md
@@ -43,9 +43,9 @@ new WebAssembly.Table(tableDescriptor)
 
 ### Creating a new WebAssembly Table instance
 
-The following example (see table2.html [source
-code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) and [live
-version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2
+The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html)
+and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html))
+creates a new WebAssembly Table instance with an initial size of 2
 elements. We then print out the table length and contents of the two indexes (retrieved
 via {{jsxref("WebAssembly/Table/get", "Table.prototype.get()")}} to show that the length
 is two and both elements are {{jsxref("null")}}.
@@ -70,8 +70,9 @@ var importObj = {
 Finally, we load and instantiate a wasm module (table2.wasm) using the
 {{jsxref("WebAssembly.instantiateStreaming()")}} method.  The table2.wasm module
 contains two functions (one that returns 42 and another that returns 83) and stores both
-into elements 0 and 1 of the imported table (see [text
-representation](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.wat)).  So after instantiation, the table still has length 2, but the
+into elements 0 and 1 of the imported table
+(see [text representation](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.wat)).
+So after instantiation, the table still has length 2, but the
 elements now contain callable [Exported WebAssembly Functions](/en-US/docs/WebAssembly/Exported_functions)
 which we can call from JS.
 
@@ -103,5 +104,4 @@ same table is visible and callable inside the wasm instance too.
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/validate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/validate/index.md
@@ -43,10 +43,10 @@ a {{jsxref("TypeError")}} is thrown.
 
 ### Using validate
 
-The following example (see the validate.html [source
-code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/validate.html), and [see it
-live too](https://mdn.github.io/webassembly-examples/js-api-examples/validate.html)) fetches a .wasm module and converts it into a typed array. The
-`validate()` method is then used to check whether the module is valid.
+The following example (see the validate.html [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/validate.html),
+and [see it live too](https://mdn.github.io/webassembly-examples/js-api-examples/validate.html))
+fetches a .wasm module and converts it into a typed array.
+The `validate()` method is then used to check whether the module is valid.
 
 ```js
 fetch('simple.wasm').then(response =>
@@ -70,5 +70,4 @@ fetch('simple.wasm').then(response =>
 
 - [WebAssembly](/en-US/docs/WebAssembly) overview page
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
-- [Using the WebAssembly
-  JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)


### PR DESCRIPTION
Fixes Markdown links to be on one line (better readability and maintenance) + typos

This is the final part for javascript/ 🎉 