### PR TITLE
Fix link to CORS credentials

### DIFF
--- a/files/en-us/web/html/attributes/crossorigin/index.md
+++ b/files/en-us/web/html/attributes/crossorigin/index.md
@@ -53,7 +53,7 @@ These attributes are enumerated, and have the following possible values:
   </tbody>
 </table>
 
-By default (that is, when the attribute is not specified), CORS is not used at all. The "anonymous" keyword means that there will be no exchange of **user credentials** via cookies, client-side SSL certificates or HTTP authentication as described in the [Terminology section of the CORS specification](https://www.w3.org/TR/cors/#user-credentials), unless it is in the same origin.
+By default (that is, when the attribute is not specified), CORS is not used at all. The "anonymous" keyword means that there will be no exchange of **user credentials** via cookies, client-side SSL certificates or HTTP authentication as described in the [Infrastructure section of the CORS specification](https://fetch.spec.whatwg.org/#infrastructure), unless it is in the same origin.
 
 An invalid keyword and an empty string will be handled as the `anonymous` keyword.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
URL Fragment was broken because of using old w3c spec. It was pointing to [user-credentials](https://www.w3.org/TR/2020/SPSD-cors-20200602/#user-credentials), now the closest id is in [infrastructure](https://fetch.spec.whatwg.org/#infrastructure).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
