### PR TITLE
Callback function parameters are all optional.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -41,13 +41,15 @@ every(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : A function to test for each element, taking three arguments:
+  - : A function to test for each element.
+  
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.
-    - `index` {{Optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array` {{Optional_inline}}
+    - `array`
       - : The array `every` was called upon.
 
 - `thisArg` {{Optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -42,13 +42,13 @@ filter(function(element, index, array) { /* ... */ }, thisArg)
 
   - : Function is a predicate, to test each element of the array. Return a value that coerces to `true` to keep the element, or to `false` otherwise.
 
-    It accepts three arguments:
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.
-    - `index`{{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array`{{optional_inline}}
+    - `array`
       - : The array on which `filter()` was called.
 
 - `thisArg`{{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -48,13 +48,15 @@ find(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to execute on each value in the array, taking 3 arguments:
+  - : Function to execute on each value in the array.
+  
+    The function is called with the following arguments:
 
     - `element`
       - : The current element in the array.
-    - `index` {{optional_inline}}
+    - `index`
       - : The index (position) of the current element in the array.
-    - `array` {{optional_inline}}
+    - `array`
       - : The array that `find` was called on.
 
     The callback must return a [truthy](/en-US/docs/Glossary/Truthy) value to indicate a matching element has been found.

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -46,21 +46,19 @@ findIndex(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : A function to execute on each value in the array until the function returns
-    `true`, indicating that the satisfying element was found.
+  - : A function to execute on each value in the array until the function returns `true`, indicating that the satisfying element was found.
 
-    It takes three arguments:
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.
-    - `index` {{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array` {{optional_inline}}
+    - `array`
       - : The array `findIndex()` was called upon.
 
 - `thisArg` {{optional_inline}}
-  - : Optional object to use as `this` when executing
-    `callbackFn`.
+  - : Optional object to use as `this` when executing `callbackFn`.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -43,13 +43,15 @@ flatMap(function(currentValue, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function that produces an element of the new Array, taking three arguments:
+  - : Function that produces an element of the new Array.
+
+    The function is called with the following arguments:
 
     - `currentValue`
       - : The current element being processed in the array.
-    - `index`{{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array`{{optional_inline}}
+    - `array`
       - : The array `flatMap` was called upon.
 
 - `thisArg`{{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -41,13 +41,15 @@ forEach(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to execute on each element. It accepts between one and three arguments:
+  - : Function to execute on each element.
+  
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.
-    - `index` {{optional_inline}}
+    - `index`
       - : The index of `element` in the array.
-    - `array` {{optional_inline}}
+    - `array`
       - : The array `forEach()` was called upon.
 
 - `thisArg` {{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -43,7 +43,9 @@ groupBy(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to execute on each element in the array, taking 3 arguments:
+  - : Function to execute on each element in the array
+  
+    The function is called with the following arguments:
 
     - `element`
       - : The value of the current element in the array.

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -44,7 +44,9 @@ groupByToMap(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to execute on each element in the array, taking 3 arguments:
+  - : Function to execute on each element in the array.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element in the array.

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -45,7 +45,7 @@ map(function(element, index, array) { /* ... */ }, thisArg)
   - : Function that is called for every element of `arr`.
     Each time `callbackFn` executes, the returned value is added to `newArray`.
 
-    The `callbackFn` function is called with the following arguments:
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -42,17 +42,16 @@ map(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function that is called for every element of `arr`. Each time
-    `callbackFn` executes, the returned value is added to
-    `newArray`.
+  - : Function that is called for every element of `arr`.
+    Each time `callbackFn` executes, the returned value is added to `newArray`.
 
-    The `callbackFn` function accepts the following arguments:
+    The `callbackFn` function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.
-    - `index`{{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array`{{optional_inline}}
+    - `array`
       - : The array `map` was called upon.
 
 - `thisArg`{{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -51,7 +51,10 @@ reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ },
 ### Parameters
 
 - `callbackFn`
-  - : A "reducer" function that takes four arguments:
+  - : A "reducer" function.
+
+    The function is called with the following arguments:
+  
     - `previousValue`: the value resulting from the previous call to `callbackFn`.
       On first call, `initialValue` if specified, otherwise the value of `array[0]`.
     - `currentValue`: the value of the current element.

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -44,16 +44,18 @@ reduceRight(function(accumulator, currentValue, index, array) { /* ... */ }, ini
 
 - `callbackFn`
 
-  - : Function to execute on each value in the array, taking four arguments:
+  - : Function to execute on each value in the array.
+
+    The function is called with the following arguments:
 
     - `accumulator`
       - : The value previously returned in the last invocation of the callback, or
         `initialValue`, if supplied. (See below.)
     - `currentValue`
       - : The current element being processed in the array.
-    - `index`{{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array`{{optional_inline}}
+    - `array`
       - : The array `reduceRight()` was called upon.
 
 - `initialValue` {{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -42,13 +42,15 @@ some(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : A function to test for each element, taking three arguments:
+  - : A function to test for each element.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the array.
-    - `index`{{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the array.
-    - `array`{{optional_inline}}
+    - `array`
       - : The array `some()` was called upon.
 
 - `thisArg`{{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -43,13 +43,15 @@ every(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : A function to test for each element, taking three arguments:
+  - : A function to test for each element.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the typed array.
-    - `index` {{Optional_inline}}
+    - `index`
       - : The index of the current element being processed in the typed array.
-    - `array` {{Optional_inline}}
+    - `array`
       - : The typed array `every` was called upon.
 
 - `thisArg` {{Optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -42,9 +42,10 @@ filter(function(element, index, array) { /* ... */ }, thisArg)
 ### Parameters
 
 - `callbackFn`
-  - : Function to test each element of the typed array. Invoked with arguments
-    `(element, index, array)`. Return
-    `true` to keep the element, `false` otherwise.
+  - : Function to test each element of the typed array.
+
+    The function is called with the following arguments: `(element, index, array)`. 
+    Return `true` to keep the element, `false` otherwise.
 - `thisArg`{{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -47,7 +47,9 @@ find(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to execute on each value in the typed array, taking three arguments:
+  - : Function to execute on each value in the typed array.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the typed array.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -46,7 +46,9 @@ findIndex(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to execute on each value in the typed array, taking three arguments:
+  - : Function to execute on each value in the typed array.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the typed array.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -42,7 +42,9 @@ forEach(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function that produces an element of the new typed array, taking three arguments:
+  - : Function that produces an element of the new typed array.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the typed array.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -44,14 +44,15 @@ map(function(currentValue, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : A callback function that produces an element of the new typed array, taking three
-    arguments:
+  - : A callback function that produces an element of the new typed array.
+
+    The function is called with the following arguments:
 
     - `currentValue`
       - : The current element being processed in the typed array.
-    - `index` {{optional_inline}}
+    - `index`
       - : The index of the current element being processed in the typed array.
-    - `array` {{optional_inline}}
+    - `array`
       - : The typed array `map()` was called upon.
 
 - `thisArg` {{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -45,7 +45,9 @@ reduce(function(accumulator, currentValue, index, array) { /* ... */ }, initialV
 
 - `callbackFn`
 
-  - : Function to execute on each value in the typed array, taking four arguments:
+  - : Function to execute on each value in the typed array.
+
+    The function is called with the following arguments:
 
     - `accumulator`
       - : The value previously returned in the last invocation of the callback, or

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -43,11 +43,12 @@ reduceRight(function(accumulator, currentValue, index, array) { /* ... */ }, ini
 
 - `callbackFn`
 
-  - : Function to execute on each value in the typed array, taking four arguments:
+  - : Function to execute on each value in the typed array.
+
+    The function is called with the following arguments:
 
     - `accumulator`
-      - : The value previously returned in the last invocation of the callback, or
-        `initialValue`, if supplied (see below).
+      - : The value previously returned in the last invocation of the callback, or `initialValue`, if supplied (see below).
     - `currentValue`
       - : The current element being processed in the typed array.
     - `index`
@@ -56,8 +57,7 @@ reduceRight(function(accumulator, currentValue, index, array) { /* ... */ }, ini
       - : The typed array `reduceRight()` was called upon.
 
 - `initialValue`
-  - : Optional. Object to use as the first argument to the first call of the
-    `callbackFn`.
+  - : Optional. Object to use as the first argument to the first call of the `callbackFn`.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -43,7 +43,9 @@ some(function(element, index, array) { /* ... */ }, thisArg)
 
 - `callbackFn`
 
-  - : Function to test for each element, taking three arguments:
+  - : Function to test for each element.
+
+    The function is called with the following arguments:
 
     - `element`
       - : The current element being processed in the typed array.


### PR DESCRIPTION
This follows on from a discussion here: https://github.com/mdn/content/pull/14243

Essentially the optional_inline macro is used to differentiate between mandatory and optional arguments when you **call** a function.  This is important because if you don't specify a mandatory parameter the function will throw an exception.

Sometimes people apply this also to callback functions to indicate the parameters you're most likely to use in your implementation vs those that you might choose not to. However this is incorrect (all parameters are optional for the implementer). 

This PR removes the use of optional inline tagging in existing APIs to reduce confusion for users.