### PR TITLE
WebAPI: Clean syntax from property pages, part 10

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -22,16 +22,11 @@ See also [Compositing and
 clipping](/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing) in the [Canvas
 Tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
-## Syntax
+## Value
 
-```js
-ctx.globalCompositeOperation = type;
-```
+A string identifying which of the compositing or blending mode operations to use.
 
-`type` is a string identifying which of the compositing or
-blending mode operations to use.
-
-### Types
+### Operations
 
 {{EmbedLiveSample("Compositing_example", 750, 6900, ""
   ,"Web/API/Canvas_API/Tutorial/Compositing/Example")}}

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -24,17 +24,9 @@ images, the default resizing algorithm will blur the pixels. Set this property t
 > {{domxref("CanvasRenderingContext2D.imageSmoothingQuality", "imageSmoothingQuality")}}
 > property.
 
-## Syntax
+## Value
 
-```js
-ctx.imageSmoothingEnabled = value;
-```
-
-### Options
-
-- `value`
-  - : A boolean value indicating whether to smooth scaled images or not. The
-    default value is `true`.
+A boolean value indicating whether to smooth scaled images or not. The default value is `true`.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
@@ -21,15 +21,9 @@ image smoothing.
 > {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}}
 > must be `true`.
 
-## Syntax
+## Value
 
-```js
-ctx.imageSmoothingQuality = "low" || "medium" || "high"
-```
-
-### Options
-
-Possible values:
+One of the followings:
 
 - `"low"`
   - : Low quality.
@@ -38,7 +32,7 @@ Possible values:
 - `"high"`
   - : High quality.
 
-## Example
+## Examples
 
 ### Setting image smoothing quality
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -20,13 +20,7 @@ property of the Canvas 2D API determines the shape used to draw the end points o
     "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}},
 > and {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}} methods.
 
-## Syntax
-
-```js
-ctx.lineCap = "butt" || "round" || "square";
-```
-
-### Options
+## Value
 
 - `"butt"`
   - : The ends of lines are squared off at the endpoints. Default value.

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -22,6 +22,8 @@ property of the Canvas 2D API determines the shape used to draw the end points o
 
 ## Value
 
+One of the followings:
+
 - `"butt"`
   - : The ends of lines are squared off at the endpoints. Default value.
 - `"round"`

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
@@ -18,15 +18,9 @@ property of the Canvas 2D API sets the line dash offset, or "phase."
 > **Note:** Lines are drawn by calling the
 > {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}} method.
 
-## Syntax
+## Value
 
-```js
-ctx.lineDashOffset = value;
-```
-
-- `value`
-  - : A float specifying the amount of the line dash offset. The default value is
-    `0.0`.
+A float specifying the amount of the line dash offset. The default value is `0.0`.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.md
@@ -26,16 +26,9 @@ ignored.
     "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}},
 > and {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}} methods.
 
-## Syntax
+## Value
 
-```js
-ctx.lineJoin = "bevel" || "round" || "miter";
-```
-
-### Options
-
-There are three possible values for this property: `"round"`,
-`"bevel"`, and `"miter"`. The default is `"miter"`.
+There are three possible values for this property: `"round"`, `"bevel"`, and `"miter"`. The default is `"miter"`.
 
 ![](canvas_linejoin.png)
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.md
@@ -20,18 +20,9 @@ property of the Canvas 2D API sets the thickness of lines.
     "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}},
 > and {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}} methods.
 
-## Syntax
+## Value
 
-```js
-ctx.lineWidth = value;
-```
-
-### Options
-
-- `value`
-  - : A number specifying the line width, in coordinate space units. Zero, negative,
-    {{jsxref("Infinity")}}, and {{jsxref("NaN")}} values are ignored. This value is
-    `1.0` by default.
+A number specifying the line width, in coordinate space units. Zero, negative, {{jsxref("Infinity")}}, and {{jsxref("NaN")}} values are ignored. This value is `1.0` by default.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.md
@@ -18,18 +18,9 @@ Canvas 2D API sets the miter limit ratio.
 > styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas
 > tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
-## Syntax
+## Value
 
-```js
-ctx.miterLimit = value;
-```
-
-### Options
-
-- `value`
-  - : A number specifying the miter limit ratio, in coordinate space units. Zero,
-    negative, {{jsxref("Infinity")}}, and {{jsxref("NaN")}} values are ignored. The
-    default value is `10.0`.
+A number specifying the miter limit ratio, in coordinate space units. Zero, negative, {{jsxref("Infinity")}}, and {{jsxref("NaN")}} values are ignored. The default value is `10.0`.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.md
@@ -23,18 +23,9 @@ default is `0` (no blur).
 > {{domxref("CanvasRenderingContext2D.shadowOffsetY", "shadowOffsetY")}} properties must
 > be non-zero, as well.
 
-## Syntax
+## Value
 
-```js
-ctx.shadowBlur = level;
-```
-
-- `level`
-  - : A non-negative float specifying the level of shadow blur, where `0`
-    represents no blur and larger numbers represent increasingly more blur. This value
-    doesn't correspond to a number of pixels, and is not affected by the current
-    transformation matrix. The default value is `0`. Negative,
-    {{jsxref("Infinity")}}, and {{jsxref("NaN")}} values are ignored.
+A non-negative float specifying the level of shadow blur, where `0` represents no blur and larger numbers represent increasingly more blur. This value doesn't correspond to a number of pixels, and is not affected by the current transformation matrix. The default value is `0`. Negative, {{jsxref("Infinity")}}, and {{jsxref("NaN")}} values are ignored.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.md
@@ -27,15 +27,9 @@ stroking.
 > {{domxref("CanvasRenderingContext2D.shadowOffsetY", "shadowOffsetY")}} properties must
 > be non-zero, as well.
 
-## Syntax
+## Value
 
-```js
-ctx.shadowColor = color;
-```
-
-- `color`
-  - : A {{domxref("DOMString")}} parsed as a [CSS](/en-US/docs/Web/CSS)
-    {{cssxref("&lt;color&gt;")}} value. The default value is fully-transparent black.
+A {{domxref("DOMString")}} parsed as a [CSS](/en-US/docs/Web/CSS) {{cssxref("&lt;color&gt;")}} value. The default value is fully-transparent black.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.md
@@ -23,17 +23,9 @@ horizontally.
 > {{domxref("CanvasRenderingContext2D.shadowOffsetY", "shadowOffsetY")}} properties must
 > be non-zero, as well.
 
-## Syntax
+## Value
 
-```js
-ctx.shadowOffsetX = offset;
-```
-
-- `offset`
-  - : A float specifying the distance that shadows will be offset horizontally. Positive
-    values are to the right, and negative to the left. The default value is `0`
-    (no horizontal offset). {{jsxref("Infinity")}} and {{jsxref("NaN")}} values are
-    ignored.
+A float specifying the distance that shadows will be offset horizontally. Positive values are to the right, and negative to the left. The default value is `0` (no horizontal offset). {{jsxref("Infinity")}} and {{jsxref("NaN")}} values are ignored.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.md
@@ -23,16 +23,9 @@ vertically.
     "shadowOffsetX")}}, or `shadowOffsetY` properties must be non-zero, as
 > well.
 
-## Syntax
+## Value
 
-```js
-ctx.shadowOffsetY = offset;
-```
-
-- `offset`
-  - : A float specifying the distance that shadows will be offset vertically. Positive
-    values are down, and negative are up. The default value is `0` (no vertical
-    offset). {{jsxref("Infinity")}} and {{jsxref("NaN")}} values are ignored.
+A float specifying the distance that shadows will be offset vertically. Positive values are down, and negative are up. The default value is `0` (no vertical offset). {{jsxref("Infinity")}} and {{jsxref("NaN")}} values are ignored.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -19,15 +19,9 @@ Canvas 2D API specifies the color, gradient, or pattern to use for the strokes
 > styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas
 > tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
-## Syntax
+## Value
 
-```js
-ctx.strokeStyle = color;
-ctx.strokeStyle = gradient;
-ctx.strokeStyle = pattern;
-```
-
-### Options
+One of the followings:
 
 - `color`
   - : A {{domxref("DOMString")}} parsed as [CSS](/en-US/docs/Web/CSS)

--- a/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.md
@@ -21,13 +21,7 @@ The alignment is relative to the `x` value of the
 `textAlign` is `"center"`, then the text's left edge will be at
 `x - (textWidth / 2)`.
 
-## Syntax
-
-```js
-ctx.textAlign = "left" || "right" || "center" || "start" || "end";
-```
-
-### Options
+## Value
 
 Possible values:
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
@@ -16,13 +16,7 @@ The
 property of the Canvas 2D API specifies the current text baseline used when drawing
 text.
 
-## Syntax
-
-```js
-ctx.textBaseline = "top" || "hanging" || "middle" || "alphabetic" || "ideographic" || "bottom";
-```
-
-### Options
+## Value
 
 Possible values:
 

--- a/files/en-us/web/api/client/frametype/index.md
+++ b/files/en-us/web/api/client/frametype/index.md
@@ -17,7 +17,12 @@ browser-compat: api.Client.frameType
 
 The **`frameType`** read-only property of the {{domxref("Client")}} interface indicates the type of browsing context of the current {{domxref("Client")}}. This value can be one of `"auxiliary"`, `"top-level"`, `"nested"`, or `"none"`.
 
+## Value
+
+One of these four strings: `"auxiliary"`, `"top-level"`, `"nested"`, or `"none"`.
+
 ## Examples
+
 ```js
 TBD
 ```

--- a/files/en-us/web/api/client/frametype/index.md
+++ b/files/en-us/web/api/client/frametype/index.md
@@ -17,14 +17,7 @@ browser-compat: api.Client.frameType
 
 The **`frameType`** read-only property of the {{domxref("Client")}} interface indicates the type of browsing context of the current {{domxref("Client")}}. This value can be one of `"auxiliary"`, `"top-level"`, `"nested"`, or `"none"`.
 
-## Syntax
-
-```js
-var myFrameType = client.frameType;
-```
-
-## Example
-
+## Examples
 ```js
 TBD
 ```

--- a/files/en-us/web/api/client/id/index.md
+++ b/files/en-us/web/api/client/id/index.md
@@ -17,14 +17,7 @@ browser-compat: api.Client.id
 
 The **`id`** read-only property of the {{domxref("Client")}} interface returns the universally unique identifier of the {{domxref("Client")}} object.
 
-## Syntax
-
-```js
-var clientId = client.id;
-```
-
-## Example
-
+## Examples
 ```js
 TBD
 ```

--- a/files/en-us/web/api/client/id/index.md
+++ b/files/en-us/web/api/client/id/index.md
@@ -17,7 +17,12 @@ browser-compat: api.Client.id
 
 The **`id`** read-only property of the {{domxref("Client")}} interface returns the universally unique identifier of the {{domxref("Client")}} object.
 
+## Value
+
+A string uniquely identifying the object.
+
 ## Examples
+
 ```js
 TBD
 ```

--- a/files/en-us/web/api/convolvernode/buffer/index.md
+++ b/files/en-us/web/api/convolvernode/buffer/index.md
@@ -23,6 +23,7 @@ This _{{domxref("AudioBuffer")}}_ must have the same sample-rate as the `AudioCo
 An {{domxref("AudioBuffer")}}.
 
 ## Examples
+
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 var convolver = audioCtx.createConvolver();

--- a/files/en-us/web/api/convolvernode/buffer/index.md
+++ b/files/en-us/web/api/convolvernode/buffer/index.md
@@ -18,20 +18,11 @@ This is normally a simple recording of as-close-to-an-impulse as can be found in
 
 This _{{domxref("AudioBuffer")}}_ must have the same sample-rate as the `AudioContext` or an exception will be thrown. At the time when this attribute is set, the buffer and the state of the attribute will be used to configure the `ConvolverNode` with this impulse response having the given normalization. The initial value of this attribute is `null`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var convolver = audioCtx.createConvolver();
-convolver.buffer = myAudioBuffer;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioBuffer")}}.
 
-## Example
-
+## Examples
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 var convolver = audioCtx.createConvolver();

--- a/files/en-us/web/api/convolvernode/normalize/index.md
+++ b/files/en-us/web/api/convolvernode/normalize/index.md
@@ -23,20 +23,11 @@ set to `false`, then the convolution will be rendered with no
 pre-processing/scaling of the impulse response. Changes to this value do not take
 effect until the next time the `buffer` attribute is set.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var convolver = audioCtx.createConvolver();
-convolver.normalize = false;
-```
-
-### Value
+## Value
 
 A boolean.
 
-## Example
-
+## Examples
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 var convolver = audioCtx.createConvolver();

--- a/files/en-us/web/api/convolvernode/normalize/index.md
+++ b/files/en-us/web/api/convolvernode/normalize/index.md
@@ -28,6 +28,7 @@ effect until the next time the `buffer` attribute is set.
 A boolean.
 
 ## Examples
+
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 var convolver = audioCtx.createConvolver();

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -18,13 +18,7 @@ indicates whether a {{JSxRef("SharedArrayBuffer")}} can be sent via a
 This value is dependent on any {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
 {{HTTPHeader("Cross-Origin-Embedder-Policy")}} headers present in the response.
 
-## Syntax
-
-```js
-var myCrossOriginIsolated = self.crossOriginIsolated; // or just crossOriginIsolated
-```
-
-### Value
+## Value
 
 A boolean value
 

--- a/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
+++ b/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
@@ -14,13 +14,7 @@ browser-compat: api.CSSNamespaceRule.namespaceURI
 
 The read-only **`namespaceURI`** property of the {{domxref("CSSNamespaceRule")}} returns a {{domxref("DOMString")}} containing the text of the URI of the given namespace.
 
-## Syntax
-
-```js
-var namespaceURI = CSSNamespaceRule.namespaceURI
-```
-
-### Returns
+## Value
 
 A {{domxref("DOMString")}} containing a URI.
 

--- a/files/en-us/web/api/cssnamespacerule/prefix/index.md
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.md
@@ -14,13 +14,7 @@ browser-compat: api.CSSNamespaceRule.prefix
 
 The read-only **`prefix`** property of the {{domxref("CSSNamespaceRule")}} returns a {{domxref("DOMString")}} with the name of the prefix associated to this namespace. If there is no such prefix, it returns an empty string.
 
-## Syntax
-
-```js
-var prefix = CSSNamespaceRule.prefix
-```
-
-### Returns
+## Value
 
 A {{domxref("DOMString")}} containing the prefix associated to this namespace. If there is no prefix an empty string.
 

--- a/files/en-us/web/api/cssnumericarray/length/index.md
+++ b/files/en-us/web/api/cssnumericarray/length/index.md
@@ -17,13 +17,7 @@ The read-only **`length`** property of the
 {{domxref("CSSNumericArray")}} interface returns the number of
 {{domxref("CSSNumericValue")}} objects in the list.
 
-## Syntax
-
-```js
-var length = CSSNumericArray.length;
-```
-
-### Return value
+## Value
 
 An integer representing the number of {{domxref("CSSNumericValue")}} objects in the
 list.

--- a/files/en-us/web/api/cssnumericvalue/type/index.md
+++ b/files/en-us/web/api/cssnumericvalue/type/index.md
@@ -7,7 +7,7 @@ tags:
   - CSSNumericValue
   - Experimental
   - Houdini
-  - Property
+  - Method
   - Reference
   - Type
 browser-compat: api.CSSNumericValue.type

--- a/files/en-us/web/api/cssnumericvalue/type/index.md
+++ b/files/en-us/web/api/cssnumericvalue/type/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSSNumericValue.type
+title: CSSNumericValue.type()
 slug: Web/API/CSSNumericValue/type
 tags:
   - API

--- a/files/en-us/web/api/cssrule/csstext/index.md
+++ b/files/en-us/web/api/cssrule/csstext/index.md
@@ -25,7 +25,12 @@ stylesheet's {{domxref("CSSRuleList", "cssRules")}}`[index]` properties
 {{domxref("CSSStyleRule.style", ".style")}} (or its sub-properties). See [Using
 dynamic styling information](/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information) for details.
 
+## Value
+
+A string containing the actual text of the {{domxref("CSSStyleSheet")}} rule.
+
 ## Examples
+
 ```css
 body {
   background-color: darkblue;

--- a/files/en-us/web/api/cssrule/csstext/index.md
+++ b/files/en-us/web/api/cssrule/csstext/index.md
@@ -25,14 +25,7 @@ stylesheet's {{domxref("CSSRuleList", "cssRules")}}`[index]` properties
 {{domxref("CSSStyleRule.style", ".style")}} (or its sub-properties). See [Using
 dynamic styling information](/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information) for details.
 
-## Syntax
-
-```js
-string = cssRule.cssText
-```
-
-## Example
-
+## Examples
 ```css
 body {
   background-color: darkblue;

--- a/files/en-us/web/api/cssstyledeclaration/length/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/length/index.md
@@ -19,6 +19,7 @@ An integer that provides the number of styles explicitly set on the parent of
 the instance.
 
 ## Examples
+
 The following gets the number of explicitly set styles on the following HTML element:
 
 ```html

--- a/files/en-us/web/api/cssstyledeclaration/length/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/length/index.md
@@ -13,19 +13,12 @@ browser-compat: api.CSSStyleDeclaration.length
 The read-only property returns an integer that represents the
 number of style declarations in this CSS declaration block.
 
-## Syntax
-
-```js
-var num = styles.length;
-```
-
-### Value
+## Value
 
 An integer that provides the number of styles explicitly set on the parent of
 the instance.
 
-## Example
-
+## Examples
 The following gets the number of explicitly set styles on the following HTML element:
 
 ```html

--- a/files/en-us/web/api/cssstyledeclaration/parentrule/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/parentrule/index.md
@@ -15,19 +15,12 @@ property returns a {{domxref('CSSRule')}} that is the parent of this style
 block, e.g. a {{domxref('CSSStyleRule')}} representing the style for a CSS
 selector.
 
-## Syntax
-
-```js
-var rule = styles.parentRule;
-```
-
-### Value
+## Value
 
 The CSS rule that contains this declaration block or `null` if this
 {{domxref('CSSStyleDeclaration')}} is not attached to a {{domxref('CSSRule')}}.
 
-## Example
-
+## Examples
 The following JavaScript code gets the parent CSS style rule from a
 {{domxref('CSSStyleDeclaration')}}:
 

--- a/files/en-us/web/api/cssstyledeclaration/parentrule/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/parentrule/index.md
@@ -21,6 +21,7 @@ The CSS rule that contains this declaration block or `null` if this
 {{domxref('CSSStyleDeclaration')}} is not attached to a {{domxref('CSSRule')}}.
 
 ## Examples
+
 The following JavaScript code gets the parent CSS style rule from a
 {{domxref('CSSStyleDeclaration')}}:
 

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -16,13 +16,7 @@ browser-compat: api.CSSTransformComponent.is2D
 
 The **`is2D`** read-only property of the {{domxref("CSSTransformComponent")}} interface indicates where the transform is 2D or 3D.
 
-## Syntax
-
-```js
-var is2D = CSSTransformComponent.is2D;
-```
-
-### Return value
+## Value
 
 A boolean. True indicating the transform is a 2D transform, false if it is a 3D
 transform.

--- a/files/en-us/web/api/csstransformvalue/is2d/index.md
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.md
@@ -21,13 +21,7 @@ In the case of the `CSSTransformValue` this property returns
 true unless any of the individual functions return false for `Is2D`, in which
 case it returns false.
 
-## Syntax
-
-```js
-var is2D = CSSTransformValue.is2D;
-```
-
-### Return value
+## Value
 
 A boolean. True indicates that the transform is a 2D transform, false that it is a 3D
 transform.

--- a/files/en-us/web/api/csstransformvalue/length/index.md
+++ b/files/en-us/web/api/csstransformvalue/length/index.md
@@ -18,13 +18,7 @@ The read-only **`length`** property of the
 {{domxref("CSSTransformValue")}} interface returns the number of transform components in
 the list.
 
-## Syntax
-
-```js
-var length = CSSTransformValue.length;
-```
-
-### Return value
+## Value
 
 An integer representing the number of transform components in the list.
 

--- a/files/en-us/web/api/customstateset/size/index.md
+++ b/files/en-us/web/api/customstateset/size/index.md
@@ -1,5 +1,5 @@
 ---
-title: CustomStateSet.size()
+title: CustomStateSet.size
 slug: Web/API/CustomStateSet/size
 tags:
   - API
@@ -13,13 +13,7 @@ browser-compat: api.CustomStateSet.size
 
 The **`size`** property of the {{domxref("CustomStateSet")}} interface returns the number of values in the `CustomStateSet`.
 
-## Syntax
-
-```js
-CustomStateSet.size()
-```
-
-### Return Value
+## Value
 
 An integer indicating how many properties the `CustomStateSet` has.
 

--- a/files/en-us/web/api/datatransfer/dropeffect/index.md
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.md
@@ -36,13 +36,7 @@ had after the last {{event("dragenter")}} or {{event("dragover")}} event. In a
 {{event("dragend")}} event, for instance, if the desired dropEffect is "move", then the
 data being dragged should be removed from the source.
 
-## Syntax
-
-```js
-dataTransfer.dropEffect;
-```
-
-### Values
+## Value
 
 A {{domxref("DOMString")}} representing the drag operation effect. The possible values
 are:
@@ -59,8 +53,7 @@ are:
 Assigning any other value to `dropEffect` has no effect and the old value is
 retained.
 
-## Example
-
+## Examples
 This example shows the use of the `dropEffect` and
 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} properties.
 

--- a/files/en-us/web/api/datatransfer/dropeffect/index.md
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.md
@@ -54,6 +54,7 @@ Assigning any other value to `dropEffect` has no effect and the old value is
 retained.
 
 ## Examples
+
 This example shows the use of the `dropEffect` and
 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} properties.
 

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -59,6 +59,7 @@ Internet Explorer will change the value to be lowercased; thus, `linkMove`
 will become `linkmove`, and so on.
 
 ## Examples
+
 This example shows the use of the `effectAllowed` and
 {{domxref("DataTransfer.dropEffect", "dropEffect")}} properties.
 

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -28,13 +28,7 @@ which effect is permitted.
 Assigning a value to `effectAllowed` in events other than
 {{event("dragstart")}} has no effect.
 
-## Syntax
-
-```js
-dataTransfer.effectAllowed;
-```
-
-### Values
+## Value
 
 A {{domxref("DOMString")}} representing the drag operation that is allowed. The
 possible values are:
@@ -64,8 +58,7 @@ is retained.
 Internet Explorer will change the value to be lowercased; thus, `linkMove`
 will become `linkmove`, and so on.
 
-## Example
-
+## Examples
 This example shows the use of the `effectAllowed` and
 {{domxref("DataTransfer.dropEffect", "dropEffect")}} properties.
 

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -23,6 +23,7 @@ A {{domxref("FileList","list")}} of the files in a drag operation, one list item
 each file in the operation. If the drag operation had no files, the list is empty.
 
 ## Examples
+
 There are two live examples of this interface:
 
 - Firefox only: <https://jsfiddle.net/9C2EF/>

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -17,19 +17,12 @@ includes no files, the list is empty.
 
 This feature can be used to drag files from a user's _desktop_ to the browser.
 
-## Syntax
-
-```js
-dataTransfer.files;
-```
-
-### Return value
+## Value
 
 A {{domxref("FileList","list")}} of the files in a drag operation, one list item for
 each file in the operation. If the drag operation had no files, the list is empty.
 
-## Example
-
+## Examples
 There are two live examples of this interface:
 
 - Firefox only: <https://jsfiddle.net/9C2EF/>

--- a/files/en-us/web/api/datatransfer/items/index.md
+++ b/files/en-us/web/api/datatransfer/items/index.md
@@ -23,6 +23,7 @@ objects representing the items being dragged in a drag operation, one list item 
 object being dragged. If the drag operation had no data, the list is empty.
 
 ## Examples
+
 This example shows the use of the `items` and
 {{domxref("DataTransfer.types","types")}} properties.
 

--- a/files/en-us/web/api/datatransfer/items/index.md
+++ b/files/en-us/web/api/datatransfer/items/index.md
@@ -16,20 +16,13 @@ The read-only {{domxref("DataTransfer")}} property `items` property is a
   transfer items")}} in a drag operation. The list includes one item for each item in the
 operation and if the operation had no items, the list is empty.
 
-## Syntax
-
-```js
-itemList = dataTransfer.items;
-```
-
-### Return value
+## Value
 
 A {{domxref("DataTransferItemList")}} object containing {{domxref("DataTransferItem")}}
 objects representing the items being dragged in a drag operation, one list item for each
 object being dragged. If the drag operation had no data, the list is empty.
 
-## Example
-
+## Examples
 This example shows the use of the `items` and
 {{domxref("DataTransfer.types","types")}} properties.
 

--- a/files/en-us/web/api/datatransfer/mozcursor/index.md
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.md
@@ -32,18 +32,11 @@ The possible values are:
 
 > **Note:** This property is Gecko-specific.
 
-## Syntax
-
-```js
-dataTransfer.mozCursor;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMString")}} representing one of the values listed above.
 
-## Example
-
+## Examples
 This example shows the use of the `mozCursor` property.
 
 ```js

--- a/files/en-us/web/api/datatransfer/mozcursor/index.md
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.md
@@ -37,6 +37,7 @@ The possible values are:
 A {{domxref("DOMString")}} representing one of the values listed above.
 
 ## Examples
+
 This example shows the use of the `mozCursor` property.
 
 ```js

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.md
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.md
@@ -22,18 +22,11 @@ dragged.
 
 This property is {{readonlyInline}}.
 
-## Syntax
-
-```js
-dataTransfer.mozItemCount;
-```
-
-### Return value
+## Value
 
 A `number` representing the number of items being dragged.
 
-## Example
-
+## Examples
 This example shows the use of the `mozItemCount` property.
 
 ```js

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.md
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.md
@@ -27,6 +27,7 @@ This property is {{readonlyInline}}.
 A `number` representing the number of items being dragged.
 
 ## Examples
+
 This example shows the use of the `mozItemCount` property.
 
 ```js

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.md
@@ -23,19 +23,12 @@ returned.
 
 This property is {{readonlyInline}}.
 
-## Syntax
-
-```js
-dataTransfer.mozSourceNode;
-```
-
-### Return value
+## Value
 
 A {{domxref("Node")}} representing `node` where the drag originated. Returns
 `null` for external drags or if the node cannot be accessed.
 
-## Example
-
+## Examples
 This example shows the use of the `mozSourceNode` property in the
 {{event("dragend")}} event handler.
 

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.md
@@ -29,6 +29,7 @@ A {{domxref("Node")}} representing `node` where the drag originated. Returns
 `null` for external drags or if the node cannot be accessed.
 
 ## Examples
+
 This example shows the use of the `mozSourceNode` property in the
 {{event("dragend")}} event handler.
 

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.md
@@ -29,6 +29,7 @@ A boolean value representing `true` if the user canceled the drag
 event and returns `false` otherwise.
 
 ## Examples
+
 This example shows the use of the `mozUserCancelled` property in the
 {{event("dragend")}} event handler.
 

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.md
@@ -23,19 +23,12 @@ event.
 
 This property is {{readonlyInline}}.
 
-## Syntax
-
-```js
-dataTransfer.mozUserCancelled;
-```
-
-### Return value
+## Value
 
 A boolean value representing `true` if the user canceled the drag
 event and returns `false` otherwise.
 
-## Example
-
+## Examples
 This example shows the use of the `mozUserCancelled` property in the
 {{event("dragend")}} event handler.
 

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -20,21 +20,14 @@ The formats are Unicode strings giving the type or format of the data, generally
 by a MIME type. Some values that are not MIME types are special-cased for legacy reasons
 (for example "`text`").
 
-## Syntax
-
-```js
-dataTransfer.types;
-```
-
-### Return value
+## Value
 
 An array of the data formats used in the drag operation. Each format is
 {{domxref("DOMString","string")}}. If the drag operation included no data, this list
 will be empty. If any files are included in the drag operation, then one of the types
 will be the string `Files`.
 
-## Example
-
+## Examples
 This example shows the use of the `types` and
 {{domxref("DataTransfer.items","items")}} properties.
 

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -28,6 +28,7 @@ will be empty. If any files are included in the drag operation, then one of the 
 will be the string `Files`.
 
 ## Examples
+
 This example shows the use of the `types` and
 {{domxref("DataTransfer.items","items")}} properties.
 

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -18,13 +18,7 @@ The read-only **`DataTransferItem.kind`** property returns a
 {{domxref("DataTransferItem")}} representing the _drag data item_ kind: some text
 or some file.
 
-## Syntax
-
-```js
-var itemKind = DataTransferItem.kind;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMString")}} representing the drag data item's kind. It must be one of
 the following values:
@@ -34,8 +28,7 @@ the following values:
 - `'string'`
   - : If the kind of drag data item is a _plain Unicode string_.
 
-## Example
-
+## Examples
 This example shows the use of the `kind` property.
 
 ```js

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -29,6 +29,7 @@ the following values:
   - : If the kind of drag data item is a _plain Unicode string_.
 
 ## Examples
+
 This example shows the use of the `kind` property.
 
 ```js

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -21,18 +21,11 @@ a MIME type is not required.
 
 Some example types are: `text/plain` and `text/html`.
 
-## Syntax
-
-```js
-dataItem.type;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMString")}} representing the drag data item's type.
 
-## Example
-
+## Examples
 This example shows the use of the `type` property.
 
 ```js

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -26,6 +26,7 @@ Some example types are: `text/plain` and `text/html`.
 A {{domxref("DOMString")}} representing the drag data item's type.
 
 ## Examples
+
 This example shows the use of the `type` property.
 
 ```js

--- a/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
@@ -24,6 +24,7 @@ the {{domxref("DedicatedWorkerGlobalScope")}}.
 A {{domxref("DOMString")}}.
 
 ## Examples
+
 If a worker is created using a constructor with a `name` option:
 
 ```js

--- a/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
@@ -19,18 +19,11 @@ The **`name`** read-only property of the
 the {{domxref("Worker.Worker", "Worker()")}} constructor can pass to get a reference to
 the {{domxref("DedicatedWorkerGlobalScope")}}.
 
-## Syntax
-
-```js
-var nameObj = self.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
-
+## Examples
 If a worker is created using a constructor with a `name` option:
 
 ```js

--- a/files/en-us/web/api/delaynode/delaytime/index.md
+++ b/files/en-us/web/api/delaynode/delaytime/index.md
@@ -23,6 +23,7 @@ The `delayTime` property of the {{ domxref("DelayNode") }} interface is an [a-ra
 An {{domxref("AudioParam")}}.
 
 ## Examples
+
 See [`BaseAudioContext.createDelay()`](/en-US/docs/Web/API/BaseAudioContext/createDelay#example) for example code.
 
 ## Specifications

--- a/files/en-us/web/api/delaynode/delaytime/index.md
+++ b/files/en-us/web/api/delaynode/delaytime/index.md
@@ -16,22 +16,13 @@ The `delayTime` property of the {{ domxref("DelayNode") }} interface is an [a-ra
 
 `delayTime` is expressed in seconds, its minimal value is `0`, and its maximum value is defined by the `maxDelayTime` argument of the {{domxref("BaseAudioContext.createDelay")}} method that created it.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var myDelay = audioCtx.createDelay(5.0);
-myDelay.delayTime.value = 3.0;
-```
-
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
-## Example
-
+## Examples
 See [`BaseAudioContext.createDelay()`](/en-US/docs/Web/API/BaseAudioContext/createDelay#example) for example code.
 
 ## Specifications

--- a/files/en-us/web/api/devicemotionevent/acceleration/index.md
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.md
@@ -26,12 +26,6 @@ the gravity force, in contrast to
 > {{DOMxRef("DeviceMotionEvent")}}. In this situation, you'll need to use
 > {{DOMxRef("DeviceMotionEvent.accelerationIncludingGravity")}} instead.
 
-## Syntax
-
-```js
-var acceleration = deviceMotionEvent.acceleration;
-```
-
 ## Value
 
 The `acceleration` property is an object providing information about

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.md
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.md
@@ -30,12 +30,6 @@ the acceleration data, such as on devices that don't have a gyroscope.
 
 > **Note:** `accelerationIncludingGravity`'s name can be misleading. This property represents acceleration including _the effects of_ gravity. For example, if a device is lying flat on a horizontal surface with the screen pointing up, gravity would be -9.8 along the Z axis, while `acceleration.z` would be 0 and `accelerationIncludingGravity.z` would be 9.8. Similarly, if a device is in free fall with its screen horizontal and pointing up, gravity would be -9.8 along the Z axis, while `acceleration.z` would be -9.8 and `accelerationIncludingGravity.z` would be 0.
 
-## Syntax
-
-```js
-var acceleration = deviceMotionEvent.accelerationIncludingGravity;
-```
-
 ## Value
 
 The `accelerationIncludingGravity` property is an object providing

--- a/files/en-us/web/api/devicemotionevent/interval/index.md
+++ b/files/en-us/web/api/devicemotionevent/interval/index.md
@@ -18,11 +18,9 @@ browser-compat: api.DeviceMotionEvent.interval
 Returns the interval, in milliseconds, at which data is obtained from the underlying
 hardware. You can use this to determine the granularity of motion events.
 
-## Syntax
+## Value
 
-```js
-var interval = deviceMotionEvent.interval;
-```
+A number representing the interval of time, in milliseconds.
 
 ## Specifications
 

--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.md
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.md
@@ -23,12 +23,6 @@ second.
 > **Note:** If the hardware isn't capable of providing this
 > information, this property returns `null`.
 
-## Syntax
-
-```js
-var rotationRate = deviceMotionEvent.rotationRate;
-```
-
 ## Value
 
 The `rotationRate` property is a read only object describing the rotation

--- a/files/en-us/web/api/deviceorientationevent/absolute/index.md
+++ b/files/en-us/web/api/deviceorientationevent/absolute/index.md
@@ -18,17 +18,10 @@ in reference to the Earth's coordinate frame) or using some arbitrary frame dete
 by the device. See [Orientation and motion data
 explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained) for details.
 
-## Syntax
+## Value
 
-```js
-var absolute = instanceOfDeviceOrientationEvent.absolute;
-```
-
-On return, _`absolute`_ is `true` if the orientation data
-in `instanceOfDeviceOrientationEvent` is provided as the difference between
-the Earth's coordinate frame and the device's coordinate frame, or `false` if
-the orientation data is being provided in reference to some arbitrary, device-determined
-coordinate frame.
+- `true` if the orientation data in `instanceOfDeviceOrientationEvent` is provided as the difference between the Earth's coordinate frame and the device's coordinate frame
+- `false` if the orientation data is being provided in reference to some arbitrary, device-determined coordinate frame.
 
 ## Specifications
 

--- a/files/en-us/web/api/deviceorientationevent/alpha/index.md
+++ b/files/en-us/web/api/deviceorientationevent/alpha/index.md
@@ -17,11 +17,9 @@ Returns the rotation of the device around the Z axis; that is, the number of deg
 which the device is being twisted around the center of the screen. See [Orientation and motion data
 explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained) for details.
 
-## Syntax
+## Value
 
-```js
-var alpha = instanceOfDeviceOrientationEvent.alpha;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/deviceorientationevent/beta/index.md
+++ b/files/en-us/web/api/deviceorientationevent/beta/index.md
@@ -18,11 +18,9 @@ Returns the rotation of the device around the X axis; that is, the number of deg
 ranged between -180 and 180,  by which the device is tipped forward or backward. See [Orientation and motion data
 explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained) for details.
 
-## Syntax
+## Value
 
-```js
-var beta = instanceOfDeviceOrientationEvent.beta;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/deviceorientationevent/gamma/index.md
+++ b/files/en-us/web/api/deviceorientationevent/gamma/index.md
@@ -19,11 +19,9 @@ ranged between `-90` and `90`, by which the device is tilted left
 or right. See [Orientation and motion data
 explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained) for details.
 
-## Syntax
+## Value
 
-```js
-var gamma = orientationEvent.gamma;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/alinkcolor/index.md
+++ b/files/en-us/web/api/document/alinkcolor/index.md
@@ -14,16 +14,8 @@ browser-compat: api.Document.alinkColor
 Returns or sets the color of an active link in the document body. A link is active
 during the time between `mousedown` and `mouseup` events.
 
-## Syntax
-
-```js
-var color = document.alinkColor;
-document.alinkColor = color;
-```
-
-_color_ is a string containing the name of the color (e.g., `blue`,
-`darkblue`, etc.) or the hexadecimal value of the color (e.g.,
-`#0000FF`)
+## Value
+A string containing the name of the color (e.g., `blue`, `darkblue`, etc.) or the hexadecimal value of the color (e.g., `#0000FF`).
 
 ## Notes
 

--- a/files/en-us/web/api/document/alinkcolor/index.md
+++ b/files/en-us/web/api/document/alinkcolor/index.md
@@ -15,6 +15,7 @@ Returns or sets the color of an active link in the document body. A link is acti
 during the time between `mousedown` and `mouseup` events.
 
 ## Value
+
 A string containing the name of the color (e.g., `blue`, `darkblue`, etc.) or the hexadecimal value of the color (e.g., `#0000FF`).
 
 ## Notes

--- a/files/en-us/web/api/document/bgcolor/index.md
+++ b/files/en-us/web/api/document/bgcolor/index.md
@@ -22,6 +22,7 @@ current document.
 A string representing the color as a word (e.g., "red") or hexadecimal value (e.g., "`#ff0000`").
 
 ## Examples
+
 ```js
 document.bgColor = "darkblue";
 ```

--- a/files/en-us/web/api/document/bgcolor/index.md
+++ b/files/en-us/web/api/document/bgcolor/index.md
@@ -17,20 +17,11 @@ browser-compat: api.Document.bgColor
 The deprecated  `bgColor` property gets or sets the background color of the
 current document.
 
-## Syntax
+## Value
 
-```js
-color = document.bgColor
-document.bgColor = color
-```
+A string representing the color as a word (e.g., "red") or hexadecimal value (e.g., "`#ff0000`").
 
-### Parameters
-
-- `color` is a string representing the color as a word (e.g., "red") or
-  hexadecimal value (e.g., "`#ff0000`").
-
-## Example
-
+## Examples
 ```js
 document.bgColor = "darkblue";
 ```

--- a/files/en-us/web/api/document/body/index.md
+++ b/files/en-us/web/api/document/body/index.md
@@ -15,15 +15,16 @@ The **`Document.body`** property represents the
 {{HTMLElement("body")}} or {{HTMLElement("frameset")}} node of the current document, or
 `null` if no such element exists.
 
-## Syntax
+## Value
 
-```js
-const objRef = document.body
-document.body = objRef
-```
+One of the followings:
 
-## Example
+- {{HTMLElement("body")}} 
+- {{HTMLElement("frameset")}}
+- `null`
 
+
+## Examples
 ```js
 // Given this HTML: <body id="oldBodyElement"></body>
 alert(document.body.id); // "oldBodyElement"

--- a/files/en-us/web/api/document/body/index.md
+++ b/files/en-us/web/api/document/body/index.md
@@ -25,6 +25,7 @@ One of the followings:
 
 
 ## Examples
+
 ```js
 // Given this HTML: <body id="oldBodyElement"></body>
 alert(document.body.id); // "oldBodyElement"

--- a/files/en-us/web/api/document/characterset/index.md
+++ b/files/en-us/web/api/document/characterset/index.md
@@ -28,11 +28,9 @@ text](https://en.wikipedia.org/wiki/Mojibake).
 > **Note:** The properties `document.charset` and `document.inputEncoding`
 > are legacy aliases for `document.characterSet`. Do not use them any more.
 
-## Syntax
+## Value
 
-```js
-var string = document.characterSet;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/document/childelementcount/index.md
+++ b/files/en-us/web/api/document/childelementcount/index.md
@@ -20,6 +20,7 @@ To get the number of children of a specific element, see {{domxref("Element.chil
 A number.
 
 ## Examples
+
 ```js
 document.children;
 // HTMLCollection, usually containing an <html> element, the document's only child

--- a/files/en-us/web/api/document/childelementcount/index.md
+++ b/files/en-us/web/api/document/childelementcount/index.md
@@ -15,14 +15,11 @@ returns the number of child elements of the document.
 
 To get the number of children of a specific element, see {{domxref("Element.childElementCount")}}.
 
-## Syntax
+## Value
 
-```js
-document.childElementCount;
-```
+A number.
 
-## Example
-
+## Examples
 ```js
 document.children;
 // HTMLCollection, usually containing an <html> element, the document's only child

--- a/files/en-us/web/api/document/children/index.md
+++ b/files/en-us/web/api/document/children/index.md
@@ -19,16 +19,7 @@ For HTML documents, this is usually only the root `<html>` element.
 
 See {{domxref("Element.children")}} for child elements of specific HTML elements within the document.
 
-## Syntax
-
-```js
-// Getter
-collection = document.children;
-
-// No setter; read-only property
-```
-
-### Return value
+## Value
 
 An {{ domxref("HTMLCollection") }} which is a live, ordered collection of the DOM
 elements which are children of the current document. You can access the
@@ -39,8 +30,7 @@ JavaScript array-style notation.
 If the document has no element children, then `children` is an empty list with a
 `length` of `0`.
 
-## Example
-
+## Examples
 ```js
 document.children;
 // HTMLCollection [<html>]

--- a/files/en-us/web/api/document/children/index.md
+++ b/files/en-us/web/api/document/children/index.md
@@ -31,6 +31,7 @@ If the document has no element children, then `children` is an empty list with a
 `length` of `0`.
 
 ## Examples
+
 ```js
 document.children;
 // HTMLCollection [<html>]

--- a/files/en-us/web/api/document/currentscript/index.md
+++ b/files/en-us/web/api/document/currentscript/index.md
@@ -17,14 +17,11 @@ It's important to note that this will not reference the {{HTMLElement("script")}
 element if the code in the script is being called as a callback or event handler; it
 will only reference the element while it's initially being processed.
 
-## Syntax
+## Value
 
-```js
-var curScriptElement = document.currentScript;
-```
+A {{HTMLElement("script")}} or null.
 
-## Example
-
+## Examples
 This example checks to see if the script is being executed asynchronously:
 
 ```js

--- a/files/en-us/web/api/document/currentscript/index.md
+++ b/files/en-us/web/api/document/currentscript/index.md
@@ -22,6 +22,7 @@ will only reference the element while it's initially being processed.
 A {{HTMLElement("script")}} or null.
 
 ## Examples
+
 This example checks to see if the script is being executed asynchronously:
 
 ```js

--- a/files/en-us/web/api/document/defaultview/index.md
+++ b/files/en-us/web/api/document/defaultview/index.md
@@ -15,13 +15,11 @@ In browsers, **`document.defaultView`** returns the
 {{domxref("Window", "window")}} object associated with {{Glossary("Browsing_context", "a
   document")}}, or `null` if none is available.
 
-## Syntax
-
-```js
-var win = document.defaultView;
-```
-
 This property is read-only.
+
+## Value
+
+The {{domxref("Window", "window")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dir/index.md
+++ b/files/en-us/web/api/document/dir/index.md
@@ -16,12 +16,9 @@ representing the directionality of the text of the document, whether left to rig
 (default) or right to left. Possible values are `'rtl'`, right to left, and
 `'ltr'`, left to right.
 
-## Syntax
+## Value
 
-```js
-dirStr = document.dir
-document.dir = dirStr
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/doctype/index.md
+++ b/files/en-us/web/api/document/doctype/index.md
@@ -16,16 +16,13 @@ returned object implements the {{domxref("DocumentType")}} interface. Use
 {{domxref("DOMImplementation.createDocumentType()")}} to create a
 `DocumentType`.
 
-## Syntax
-
-```js
-doctype = document.doctype;
-```
-
 - `doctype` is a read-only property.
 
-## Example
+## Value
 
+A {{domxref("DocumentType")}} object.
+
+## Examples
 ```js
 var doctypeObj = document.doctype;
 

--- a/files/en-us/web/api/document/doctype/index.md
+++ b/files/en-us/web/api/document/doctype/index.md
@@ -23,6 +23,7 @@ returned object implements the {{domxref("DocumentType")}} interface. Use
 A {{domxref("DocumentType")}} object.
 
 ## Examples
+
 ```js
 var doctypeObj = document.doctype;
 

--- a/files/en-us/web/api/document/documentelement/index.md
+++ b/files/en-us/web/api/document/documentelement/index.md
@@ -21,6 +21,7 @@ example, the {{HTMLElement("html")}} element for HTML documents).
 A {{domxref("Element")}} object.
 
 ## Examples
+
 ```js
 const rootElement = document.documentElement;
 const firstTier = rootElement.childNodes;

--- a/files/en-us/web/api/document/documentelement/index.md
+++ b/files/en-us/web/api/document/documentelement/index.md
@@ -16,14 +16,11 @@ browser-compat: api.Document.documentElement
 {{domxref("Element")}} that is the root element of the {{domxref("document")}} (for
 example, the {{HTMLElement("html")}} element for HTML documents).
 
-## Syntax
+## Value
 
-```js
-const element = document.documentElement
-```
+A {{domxref("Element")}} object.
 
-## Example
-
+## Examples
 ```js
 const rootElement = document.documentElement;
 const firstTier = rootElement.childNodes;

--- a/files/en-us/web/api/document/documenturi/index.md
+++ b/files/en-us/web/api/document/documenturi/index.md
@@ -20,6 +20,7 @@ The **`documentURI`** read-only property of the
 A string.
 
 ## Examples
+
 ### JavaScript
 
 ```js

--- a/files/en-us/web/api/document/documenturi/index.md
+++ b/files/en-us/web/api/document/documenturi/index.md
@@ -15,14 +15,11 @@ browser-compat: api.Document.documentURI
 The **`documentURI`** read-only property of the
 {{domxref("Document")}} interface returns the document location as a string.
 
-## Syntax
+## Value
 
-```js
-const uri = document.documentURI
-```
+A string.
 
-## Example
-
+## Examples
 ### JavaScript
 
 ```js

--- a/files/en-us/web/api/document/domain/index.md
+++ b/files/en-us/web/api/document/domain/index.md
@@ -18,7 +18,19 @@ document, as used by the [same-origin policy](/en-US/docs/Web/Security/Same-orig
 
 ## Value
 
-### Getter
+A string.
+
+## Examples
+
+### Getting the domain
+
+For code running at the URL `https://developer.mozilla.org/en-US/docs/Web`,
+this example would set `currentDomain` to the string
+"`developer.mozilla.org`".
+
+```js
+const currentDomain = document.domain;
+```
 
 The getter for this property returns the domain portion of the current document's
 origin. In most cases, this will be the hostname portion of the document's URL. However,
@@ -29,9 +41,25 @@ there are some exceptions:
 - If the `document.domain` [setter](#setter) has been used, then
   it will return the value that was set.
 
-Usually it is better to use the {{domxref("Location.hostname")}} property instead.
+Although the getter is not dangerous in the same way that the setter is, it is likely
+simpler and more useful to use the {{domxref("Location.hostname")}} property instead.
+Then you can avoid `document.domain` entirely:
 
-### Setter
+```js
+const currentHostname = location.hostname;
+```
+
+For the URL `https://developer.mozilla.org/en-US/docs/Web`,
+`currentHostname` is also the string "`developer.mozilla.org`".
+Other alternatives that provide slightly different information are
+{{domxref("Location.host")}}, which includes the port, and
+{{domxref("origin")}}, which provides the full origin.
+
+### Setting the domain
+
+```js
+document.domain = domainString
+```
 
 The setter for this property can be used to _change_ a page's
 {{glossary("origin")}}, and thus modify how certain security checks are performed. It
@@ -113,32 +141,6 @@ Finally, setting `document.domain` does not change the origin used for
 origin-checks by some Web APIs, preventing sub-domain access via this mechanism.
 Affected APIs include (but are not limited to):
 {{domxref("Window.localStorage")}}, {{domxref("IndexedDB_API")}}, {{domxref("BroadcastChannel")}}, {{domxref("SharedWorker")}} .
-
-## Examples
-
-### Getting the domain
-
-For code running at the URL `https://developer.mozilla.org/en-US/docs/Web`,
-this example would set `currentDomain` to the string
-"`developer.mozilla.org`".
-
-```js
-const currentDomain = document.domain;
-```
-
-Although the getter is not dangerous in the same way that the setter is, it is likely
-simpler and more useful to use the {{domxref("Location.hostname")}} property instead.
-Then you can avoid `document.domain` entirely:
-
-```js
-const currentHostname = location.hostname;
-```
-
-For the URL `https://developer.mozilla.org/en-US/docs/Web`,
-`currentHostname` is also the string "`developer.mozilla.org`".
-Other alternatives that provide slightly different information are
-{{domxref("Location.host")}}, which includes the port, and
-{{domxref("origin")}}, which provides the full origin.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/domain/index.md
+++ b/files/en-us/web/api/document/domain/index.md
@@ -16,13 +16,9 @@ The **`domain`** property of the {{domxref("Document")}}
 interface gets/sets the domain portion of the {{glossary("origin")}} of the current
 document, as used by the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
-## Syntax
+## Value
 
 ### Getter
-
-```js
-const domainString = document.domain
-```
 
 The getter for this property returns the domain portion of the current document's
 origin. In most cases, this will be the hostname portion of the document's URL. However,
@@ -36,10 +32,6 @@ there are some exceptions:
 Usually it is better to use the {{domxref("Location.hostname")}} property instead.
 
 ### Setter
-
-```js
-document.domain = domainString
-```
 
 The setter for this property can be used to _change_ a page's
 {{glossary("origin")}}, and thus modify how certain security checks are performed. It

--- a/files/en-us/web/api/document/fgcolor/index.md
+++ b/files/en-us/web/api/document/fgcolor/index.md
@@ -16,20 +16,11 @@ browser-compat: api.Document.fgColor
 **`fgColor`** gets/sets the foreground color, or text color, of
 the current document.
 
-## Syntax
+## Value
 
-```js
-var color = document.fgColor;
-document.fgColor = color;
-```
+A string representing the color as a word (e.g., "red") or hexadecimal value (e.g., "`#ff0000`").
 
-### Parameters
-
-- _color_ is a string representing the color as a word (e.g., "red") or
-  hexadecimal value (e.g., "`#ff0000`").
-
-## Example
-
+## Examples
 ```js
 document.fgColor = "white";
 document.bgColor = "darkblue";

--- a/files/en-us/web/api/document/fgcolor/index.md
+++ b/files/en-us/web/api/document/fgcolor/index.md
@@ -21,6 +21,7 @@ the current document.
 A string representing the color as a word (e.g., "red") or hexadecimal value (e.g., "`#ff0000`").
 
 ## Examples
+
 ```js
 document.fgColor = "white";
 document.bgColor = "darkblue";

--- a/files/en-us/web/api/document/firstelementchild/index.md
+++ b/files/en-us/web/api/document/firstelementchild/index.md
@@ -23,6 +23,7 @@ See {{domxref("Element.firstElementChild")}} for the first child element of spec
 A {{domxref("Element")}} object, or `null`.
 
 ## Examples
+
 ```js
 document.firstElementChild;
 // returns the root <html> element, the only child of the document

--- a/files/en-us/web/api/document/firstelementchild/index.md
+++ b/files/en-us/web/api/document/firstelementchild/index.md
@@ -18,17 +18,11 @@ For HTML documents, this is usually the only child, the root `<html>` element.
 
 See {{domxref("Element.firstElementChild")}} for the first child element of specific elements within a document.
 
-## Syntax
+## Value
 
-```js
-// Getter
-element = document.firstElementChild;
+A {{domxref("Element")}} object, or `null`.
 
-// No setter; read-only property
-```
-
-## Example
-
+## Examples
 ```js
 document.firstElementChild;
 // returns the root <html> element, the only child of the document

--- a/files/en-us/web/api/document/fullscreenelement/index.md
+++ b/files/en-us/web/api/document/fullscreenelement/index.md
@@ -32,6 +32,7 @@ mode isn't currently in use by the `document`>, the returned
 value is `null`.
 
 ## Examples
+
 This example presents a function, `isVideoInFullscreen()`, which looks at
 the value returned by `fullscreenElement`; if the document is in fullscreen
 mode (`fullscreenElement` isn't `null`) and the fullscreen

--- a/files/en-us/web/api/document/fullscreenelement/index.md
+++ b/files/en-us/web/api/document/fullscreenelement/index.md
@@ -25,20 +25,13 @@ currently in use.
 Although this property is read-only, it will not throw if it is modified (even in
 strict mode); the setter is a no-operation and it will be ignored.
 
-## Syntax
-
-```js
-document.fullscreenElement
-```
-
-### Return value
+## Value
 
 The {{domxref("Element")}} object that's currently in fullscreen mode; if fullscreen
 mode isn't currently in use by the `document`>, the returned
 value is `null`.
 
-## Example
-
+## Examples
 This example presents a function, `isVideoInFullscreen()`, which looks at
 the value returned by `fullscreenElement`; if the document is in fullscreen
 mode (`fullscreenElement` isn't `null`) and the fullscreen

--- a/files/en-us/web/api/document/height/index.md
+++ b/files/en-us/web/api/document/height/index.md
@@ -21,14 +21,7 @@ browser-compat: api.Document.height
 Returns the height of the {{domxref("document")}} object. In most cases, this is equal
 to the {{HTMLElement("body")}} element of the current document.
 
-## Syntax
-
-```js
-pixels = document.height
-```
-
-## Example
-
+## Examples
 ```js
 // alert document height
 alert(document.height);

--- a/files/en-us/web/api/document/height/index.md
+++ b/files/en-us/web/api/document/height/index.md
@@ -22,6 +22,7 @@ Returns the height of the {{domxref("document")}} object. In most cases, this is
 to the {{HTMLElement("body")}} element of the current document.
 
 ## Examples
+
 ```js
 // alert document height
 alert(document.height);

--- a/files/en-us/web/api/document/implementation/index.md
+++ b/files/en-us/web/api/document/implementation/index.md
@@ -15,14 +15,11 @@ browser-compat: api.Document.implementation
 The **`Document.implementation`** property returns a
 {{domxref("DOMImplementation")}} object associated with the current document.
 
-## Syntax
+## Value
 
-```js
-DOMImpObj = document.implementation;
-```
+A {{domxref("DOMImplementation")}} object.
 
-## Example
-
+## Examples
 ```js
 var modName = "HTML";
 var modVer = "2.0";

--- a/files/en-us/web/api/document/implementation/index.md
+++ b/files/en-us/web/api/document/implementation/index.md
@@ -20,6 +20,7 @@ The **`Document.implementation`** property returns a
 A {{domxref("DOMImplementation")}} object.
 
 ## Examples
+
 ```js
 var modName = "HTML";
 var modVer = "2.0";

--- a/files/en-us/web/api/document/lastelementchild/index.md
+++ b/files/en-us/web/api/document/lastelementchild/index.md
@@ -18,17 +18,11 @@ For HTML documents, this is usually the only child, the root `<html>` element.
 
 See {{domxref("Element.lastElementChild")}} for the last child element of specific elements within a document.
 
-## Syntax
+## Value
 
-```js
-// Getter
-element = document.lastElementChild;
+The root `<html>` element.
 
-// No setter; read-only property
-```
-
-## Example
-
+## Examples
 ```js
 document.lastElementChild;
 // returns the root <html> element, the only child of the document

--- a/files/en-us/web/api/document/lastelementchild/index.md
+++ b/files/en-us/web/api/document/lastelementchild/index.md
@@ -23,6 +23,7 @@ See {{domxref("Element.lastElementChild")}} for the last child element of specif
 The root `<html>` element.
 
 ## Examples
+
 ```js
 document.lastElementChild;
 // returns the root <html> element, the only child of the document

--- a/files/en-us/web/api/document/lastmodified/index.md
+++ b/files/en-us/web/api/document/lastmodified/index.md
@@ -16,11 +16,9 @@ The **`lastModified`** property of the {{domxref("Document")}}
 interface returns a string containing the date and time on which the current document
 was last modified.
 
-## Syntax
+## Value
 
-```js
-var string = document.lastModified;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/document/laststylesheetset/index.md
+++ b/files/en-us/web/api/document/laststylesheetset/index.md
@@ -27,6 +27,7 @@ The style sheet set that was most recently set. If the current style sheet set h
 > {{domxref("document.enableStyleSheetsForSet()")}} is called.
 
 ## Examples
+
 ```js
 let lastSheetSet = document.lastStyleSheetSet;
 

--- a/files/en-us/web/api/document/laststylesheetset/index.md
+++ b/files/en-us/web/api/document/laststylesheetset/index.md
@@ -19,21 +19,14 @@ The **`Document.lastStyleSheetSet`** property returns the last enabled style she
 value changes whenever the {{domxref("document.selectedStyleSheetSet")}} property is
 changed.
 
-## Syntax
+## Value
 
-```js
-var lastStyleSheetSet = document.lastStyleSheetSet
-```
-
-On return, _lastStyleSheetSet_ indicates the style sheet set that was most
-recently set. If the current style sheet set has not been changed by setting
-{{domxref("document.selectedStyleSheetSet")}}, the returned value is `null`.
+The style sheet set that was most recently set. If the current style sheet set has not been changed by setting {{domxref("document.selectedStyleSheetSet")}}, the returned value is `null`.
 
 > **Note:** This value doesn't change when
 > {{domxref("document.enableStyleSheetsForSet()")}} is called.
 
-## Example
-
+## Examples
 ```js
 let lastSheetSet = document.lastStyleSheetSet;
 

--- a/files/en-us/web/api/document/linkcolor/index.md
+++ b/files/en-us/web/api/document/linkcolor/index.md
@@ -27,6 +27,7 @@ This property is deprecated. As an alternative, you can set the CSS
 A string representing the color as a word (e.g., `red`) or hexadecimal value (e.g., `#ff0000`).
 
 ## Examples
+
 ```js
 document.linkColor = 'blue';
 ```

--- a/files/en-us/web/api/document/linkcolor/index.md
+++ b/files/en-us/web/api/document/linkcolor/index.md
@@ -22,20 +22,11 @@ This property is deprecated. As an alternative, you can set the CSS
 `document.body.link`, although this is [deprecated in HTML
 4.01](https://www.w3.org/TR/html401/struct/global.html#adef-link).
 
-## Syntax
+## Value
 
-```js
-color = document.linkColor
-document.linkColor = color
-```
+A string representing the color as a word (e.g., `red`) or hexadecimal value (e.g., `#ff0000`).
 
-### Parameters
-
-- `color` is a string representing the color as a word (e.g.,
-  `red`) or hexadecimal value (e.g., `#ff0000`).
-
-## Example
-
+## Examples
 ```js
 document.linkColor = 'blue';
 ```

--- a/files/en-us/web/api/document/location/index.md
+++ b/files/en-us/web/api/document/location/index.md
@@ -29,12 +29,9 @@ property can also be used.
 If the current document is not in a browsing context, the returned value is
 `null`.
 
-## Syntax
+## Value
 
-```js
-locationObj = document.location
-document.location = 'http://www.mozilla.org' // Equivalent to document.location.href = 'http://www.mozilla.org'
-```
+A {{domxref("Location")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/document/mozsyntheticdocument/index.md
+++ b/files/en-us/web/api/document/mozsyntheticdocument/index.md
@@ -17,9 +17,10 @@ standalone image, video, audio, or the like.
 
 ## Value
 
-`true` if the document is a synthetic one otherwise it's `false`.
+A boolean value that is `true` if the document is synthetic, or `false` otherwise.
 
 ## Examples
+
 This can be useful if you have a contextual menu item you only want to display for
 synthetic documents (or, conversely, for documents that aren't synthetic).
 

--- a/files/en-us/web/api/document/mozsyntheticdocument/index.md
+++ b/files/en-us/web/api/document/mozsyntheticdocument/index.md
@@ -15,17 +15,11 @@ The **`Document.mozSyntheticDocument`** property indicates
 whether or not the document is a synthetic one; that is, a document representing a
 standalone image, video, audio, or the like.
 
-## Syntax
+## Value
 
-```js
-var isSynthetic = document.mozSyntheticDocument;
-```
+`true` if the document is a synthetic one otherwise it's `false`.
 
-On return, `isSynthetic` is `true` if the document is a synthetic
-one; otherwise it's `false`.
-
-## Example
-
+## Examples
 This can be useful if you have a contextual menu item you only want to display for
 synthetic documents (or, conversely, for documents that aren't synthetic).
 

--- a/files/en-us/web/api/document/origin/index.md
+++ b/files/en-us/web/api/document/origin/index.md
@@ -20,6 +20,10 @@ The **`Document.origin`** read-only property returns the
 document's origin. In most cases, this property is equivalent to
 `document.defaultView.location.origin`.
 
+## Value
+
+A string containing the document's origin.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/document/origin/index.md
+++ b/files/en-us/web/api/document/origin/index.md
@@ -20,12 +20,6 @@ The **`Document.origin`** read-only property returns the
 document's origin. In most cases, this property is equivalent to
 `document.defaultView.location.origin`.
 
-## Syntax
-
-```js
-var origin = document.origin;
-```
-
 ## Examples
 
 ```js

--- a/files/en-us/web/api/document/pictureinpictureelement/index.md
+++ b/files/en-us/web/api/document/pictureinpictureelement/index.md
@@ -25,13 +25,7 @@ picture-in-picture mode is not currently in use.
 Although this property is read-only, it will not throw if it is modified (even in
 strict mode); the setter is a no-operation and will be ignored.
 
-## Syntax
-
-```js
-document.pictureInPictureElement;
-```
-
-### Return value
+## Value
 
 A reference to the {{domxref("Element")}} object that's currently in
 picture-in-picture mode; if picture-in-picture mode isn't currently in use by the

--- a/files/en-us/web/api/document/pointerlockelement/index.md
+++ b/files/en-us/web/api/document/pointerlockelement/index.md
@@ -18,13 +18,7 @@ element set as the target for mouse events while the pointer is locked. It is
 `null` if lock is pending, pointer is unlocked, or the target is in another
 document.
 
-## Syntax
-
-```js
-document.pointerLockElement;
-```
-
-### Value
+## Value
 
 An {{domxref("Element")}} or `null`.
 

--- a/files/en-us/web/api/document/preferredstylesheetset/index.md
+++ b/files/en-us/web/api/document/preferredstylesheetset/index.md
@@ -25,6 +25,7 @@ The author's preferred style sheet set. This is determined from the order of sty
 If there isn't a preferred style sheet set defined by the author, the empty string (`""`) is returned.
 
 ## Examples
+
 ```js
 if (document.preferredStyleSheetSet) {
   console.log("The preferred style sheet set is: " + document.preferredStyleSheetSet);

--- a/files/en-us/web/api/document/preferredstylesheetset/index.md
+++ b/files/en-us/web/api/document/preferredstylesheetset/index.md
@@ -17,21 +17,14 @@ browser-compat: api.Document.preferredStyleSheetSet
 The **`preferredStyleSheetSet`** property returns the preferred style sheet set as set by the page
 author.
 
-## Syntax
+## Value
 
-```js
-preferredStyleSheetSet = document.preferredStyleSheetSet
-```
-
-On return, `preferredStyleSheetSet` indicates the author's preferred style
-sheet set. This is determined from the order of style sheet declarations and the
+The author's preferred style sheet set. This is determined from the order of style sheet declarations and the
 `Default-Style` HTTP header.
 
-If there isn't a preferred style sheet set defined by the author, the empty string
-(`""`) is returned.
+If there isn't a preferred style sheet set defined by the author, the empty string (`""`) is returned.
 
-## Example
-
+## Examples
 ```js
 if (document.preferredStyleSheetSet) {
   console.log("The preferred style sheet set is: " + document.preferredStyleSheetSet);

--- a/files/en-us/web/api/document/rootelement/index.md
+++ b/files/en-us/web/api/document/rootelement/index.md
@@ -19,12 +19,6 @@ that is the root element of the {{domxref("document")}} if it is an
 {{domxref("Document.documentElement")}}, which returns the root element for all
 documents.
 
-## Syntax
-
-```js
-const element = document.rootElement
-```
-
 ## Notes
 
 If the document is a non-empty SVG document, then the `rootElement` will be

--- a/files/en-us/web/api/document/rootelement/index.md
+++ b/files/en-us/web/api/document/rootelement/index.md
@@ -19,7 +19,10 @@ that is the root element of the {{domxref("document")}} if it is an
 {{domxref("Document.documentElement")}}, which returns the root element for all
 documents.
 
-## Notes
+## Value
+
+For SVG elements, the {{domxref("Element")}} that is the root element of the {{domxref("document")}}; otherwise `null`.
+
 
 If the document is a non-empty SVG document, then the `rootElement` will be
 an {{domxref("SVGSVGElement")}}, identical to the `documentElement`.

--- a/files/en-us/web/api/document/scrollingelement/index.md
+++ b/files/en-us/web/api/document/scrollingelement/index.md
@@ -20,7 +20,12 @@ When in quirks mode, the `scrollingElement` attribute returns the HTML
 `body` element if it exists and is [potentially
 scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.
 
+## Value
+
+The {{domxref("Element")}} that scrolls the document, usually the root element (unless not in standard mode).
+
 ## Examples
+
 ```js
 var scrollElm = document.scrollingElement;
 scrollElm.scrollTop = 0;

--- a/files/en-us/web/api/document/scrollingelement/index.md
+++ b/files/en-us/web/api/document/scrollingelement/index.md
@@ -20,14 +20,7 @@ When in quirks mode, the `scrollingElement` attribute returns the HTML
 `body` element if it exists and is [potentially
 scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.
 
-## Syntax
-
-```js
-var element = document.scrollingElement;
-```
-
-## Example
-
+## Examples
 ```js
 var scrollElm = document.scrollingElement;
 scrollElm.scrollTop = 0;

--- a/files/en-us/web/api/document/selectedstylesheetset/index.md
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.md
@@ -29,6 +29,7 @@ Setting the value of this property is equivalent to calling
 > attribute.
 
 ## Examples
+
 ```js
 console.log('Current style sheet set: ' + document.selectedStyleSheetSet);
 

--- a/files/en-us/web/api/document/selectedstylesheetset/index.md
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.md
@@ -15,16 +15,9 @@ browser-compat: api.Document.selectedStyleSheetSet
 
 The **`selectedStyleSheetSet`** property indicates the name of the style sheet set that's currently in use.
 
-## Syntax
+## Value
 
-```js
-currentStyleSheetSet = document.selectedStyleSheetSet;
-
-document.selectedStyleSheet = newStyleSheetSet;
-```
-
-On return, `currentStyleSheetSet` indicates the name of the style sheet set
-currently in use. You can also set the current style sheet set using this property.
+The name of the style sheet set currently in use. You can also set the current style sheet set using this property.
 
 Setting the value of this property is equivalent to calling
 {{domxref("document.enableStyleSheetsForSet()")}} with the value of
@@ -35,8 +28,7 @@ Setting the value of this property is equivalent to calling
 > the `disabled` attribute on style sheets will affect the value of this
 > attribute.
 
-## Example
-
+## Examples
 ```js
 console.log('Current style sheet set: ' + document.selectedStyleSheetSet);
 

--- a/files/en-us/web/api/document/stylesheets/index.md
+++ b/files/en-us/web/api/document/stylesheets/index.md
@@ -13,13 +13,7 @@ browser-compat: api.Document.styleSheets
 
 The **`styleSheets`** read-only property of the {{domxref("Document")}} interface returns a {{domxref('StyleSheetList')}} of {{domxref('CSSStyleSheet')}} objects, for stylesheets explicitly linked into or embedded in a document.
 
-## Syntax
-
-```js
-document.styleSheets
-```
-
-### Value
+## Value
 
 The returned list is ordered as follows:
 

--- a/files/en-us/web/api/document/stylesheetsets/index.md
+++ b/files/en-us/web/api/document/stylesheetsets/index.md
@@ -20,6 +20,7 @@ The **`styleSheetSets`** read-only property returns a live list of all of the cu
 A list of style sheet sets that are available.
 
 ## Examples
+
 Given an {{HTMLElement("ul")}} (list) element with the ID "sheetList", you can populate
 it with the names of all the available style sheet sets with code like this:
 

--- a/files/en-us/web/api/document/stylesheetsets/index.md
+++ b/files/en-us/web/api/document/stylesheetsets/index.md
@@ -15,16 +15,11 @@ browser-compat: api.Document.styleSheetSets
 
 The **`styleSheetSets`** read-only property returns a live list of all of the currently-available style sheet sets.
 
-## Syntax
+## Value
 
-```js
-var sets = document.styleSheetSets;
-```
+A list of style sheet sets that are available.
 
-On return, `sets` is a list of style sheet sets that are available.
-
-## Example
-
+## Examples
 Given an {{HTMLElement("ul")}} (list) element with the ID "sheetList", you can populate
 it with the names of all the available style sheet sets with code like this:
 

--- a/files/en-us/web/api/document/title/index.md
+++ b/files/en-us/web/api/document/title/index.md
@@ -17,16 +17,9 @@ The **`document.title`** property gets
 or sets the current [title](/en-US/docs/Web/HTML/Element/title) of the
 document.
 
-## Syntax
+## Value
 
-```js
-var docTitle = document.title;
-```
-
-_docTitle_ is a string containing the _document_'s title. If the
-title was overridden by setting `document.title`, it contains that value.
-Otherwise, it contains the title specified in the markup (see the [Notes](#notes)
-below).
+A string containing the _document_'s title. If the title was overridden by setting `document.title`, it contains that value. Otherwise, it contains the title specified in the markup (see the [Notes](#notes) below).
 
 ```js
 document.title = newTitle;
@@ -38,8 +31,7 @@ document (e.g. in the titlebar of the window or tab), and it also affects the DO
 document (e.g. the content of the `<title>` element in an HTML
 document).
 
-## Example
-
+## Examples
 ```js
 <!DOCTYPE html>
 <html>

--- a/files/en-us/web/api/document/title/index.md
+++ b/files/en-us/web/api/document/title/index.md
@@ -32,6 +32,7 @@ document (e.g. the content of the `<title>` element in an HTML
 document).
 
 ## Examples
+
 ```js
 <!DOCTYPE html>
 <html>

--- a/files/en-us/web/api/document/url/index.md
+++ b/files/en-us/web/api/document/url/index.md
@@ -14,14 +14,7 @@ browser-compat: api.Document.URL
 The **`URL`** read-only property of the {{domxref("Document")}}
 interface returns the document location as a string.
 
-## Syntax
-
-```js
-const url = document.URL
-```
-
-## Example
-
+## Examples
 ### JavaScript
 
 ```js

--- a/files/en-us/web/api/document/url/index.md
+++ b/files/en-us/web/api/document/url/index.md
@@ -14,7 +14,12 @@ browser-compat: api.Document.URL
 The **`URL`** read-only property of the {{domxref("Document")}}
 interface returns the document location as a string.
 
+## Value
+
+A string containing the URL of the document.
+
 ## Examples
+
 ### JavaScript
 
 ```js

--- a/files/en-us/web/api/document/vlinkcolor/index.md
+++ b/files/en-us/web/api/document/vlinkcolor/index.md
@@ -17,17 +17,9 @@ browser-compat: api.Document.vlinkColor
 The **`Document.vlinkColor`** property gets/sets the color of
 links that the user has visited in the document.
 
-## Syntax
+## Value
 
-```js
-color = document.vlinkColor
-document.vlinkColor = color
-```
-
-### Parameters
-
-- `color` is a string representing the color as a word (e.g.,
-  `"red"`) or hexadecimal value (e.g., `"#ff0000"`).
+A string representing the color as a word (e.g., `"red"`) or hexadecimal value (e.g., `"#ff0000"`).
 
 ## Notes
 

--- a/files/en-us/web/api/document/width/index.md
+++ b/files/en-us/web/api/document/width/index.md
@@ -23,7 +23,12 @@ pixels.
 
 Not supported by Internet Explorer.
 
+## Value
+
+A number that represents the width of the document in pixels.
+
 ## Examples
+
 ```js
 function init() {
   alert("The width of the document is " + document.width + " pixels.");

--- a/files/en-us/web/api/document/width/index.md
+++ b/files/en-us/web/api/document/width/index.md
@@ -23,14 +23,7 @@ pixels.
 
 Not supported by Internet Explorer.
 
-## Syntax
-
-```js
-pixels = document.width;
-```
-
-## Example
-
+## Examples
 ```js
 function init() {
   alert("The width of the document is " + document.width + " pixels.");

--- a/files/en-us/web/api/documentfragment/childelementcount/index.md
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.md
@@ -15,7 +15,11 @@ returns the number of child elements of a `DocumentFragment`.
 
 To get the number of children of a specific element, see {{domxref("Element.childElementCount")}}.
 
+## Value
+
+A number representing the number of children of the element.
 ## Examples
+
 ```js
 let fragment = new DocumentFragment()
 fragment.childElementCount; // 0

--- a/files/en-us/web/api/documentfragment/childelementcount/index.md
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.md
@@ -15,14 +15,7 @@ returns the number of child elements of a `DocumentFragment`.
 
 To get the number of children of a specific element, see {{domxref("Element.childElementCount")}}.
 
-## Syntax
-
-```js
-fragment.childElementCount;
-```
-
-## Example
-
+## Examples
 ```js
 let fragment = new DocumentFragment()
 fragment.childElementCount; // 0

--- a/files/en-us/web/api/documentfragment/childelementcount/index.md
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.md
@@ -18,6 +18,7 @@ To get the number of children of a specific element, see {{domxref("Element.chil
 ## Value
 
 A number representing the number of children of the element.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/documentfragment/children/index.md
+++ b/files/en-us/web/api/documentfragment/children/index.md
@@ -27,6 +27,7 @@ If the document fragment has no element children, then `children` is an empty li
 `length` of `0`.
 
 ## Examples
+
 ```js
 let fragment = new DocumentFragment()
 fragment.children; // HTMLCollection []

--- a/files/en-us/web/api/documentfragment/children/index.md
+++ b/files/en-us/web/api/documentfragment/children/index.md
@@ -15,16 +15,7 @@ browser-compat: api.DocumentFragment.children
 The read-only **`children`** property returns a live {{domxref("HTMLCollection")}}
 which contains all of the child {{domxref("Element", "elements")}} of the document fragment upon which it was called.
 
-## Syntax
-
-```js
-// Getter
-collection = myFragment.children;
-
-// No setter; read-only property
-```
-
-### Return value
+## Value
 
 An {{ domxref("HTMLCollection") }} which is a live, ordered collection of the DOM
 elements which are children of the document fragment. You can access the
@@ -35,8 +26,7 @@ JavaScript array-style notation.
 If the document fragment has no element children, then `children` is an empty list with a
 `length` of `0`.
 
-## Example
-
+## Examples
 ```js
 let fragment = new DocumentFragment()
 fragment.children; // HTMLCollection []

--- a/files/en-us/web/api/documentfragment/firstelementchild/index.md
+++ b/files/en-us/web/api/documentfragment/firstelementchild/index.md
@@ -14,17 +14,7 @@ The **`DocumentFragment.firstElementChild`** read-only property
 returns the document fragment's first child {{domxref("Element")}}, or `null` if there
 are no child elements.
 
-## Syntax
-
-```js
-// Getter
-element = fragment.firstElementChild;
-
-// No setter; read-only property
-```
-
-## Example
-
+## Examples
 ```js
 let fragment = new DocumentFragment();
 fragment.firstElementChild; // null

--- a/files/en-us/web/api/documentfragment/firstelementchild/index.md
+++ b/files/en-us/web/api/documentfragment/firstelementchild/index.md
@@ -14,7 +14,12 @@ The **`DocumentFragment.firstElementChild`** read-only property
 returns the document fragment's first child {{domxref("Element")}}, or `null` if there
 are no child elements.
 
+## Value
+
+An {{domxref("Element")}} that is the first child `Element` of the object, or `null` if there are none.
+
 ## Examples
+
 ```js
 let fragment = new DocumentFragment();
 fragment.firstElementChild; // null

--- a/files/en-us/web/api/documentfragment/lastelementchild/index.md
+++ b/files/en-us/web/api/documentfragment/lastelementchild/index.md
@@ -14,17 +14,7 @@ The **`DocumentFragment.lastElementChild`** read-only property
 returns the document fragment's last child {{domxref("Element")}}, or `null` if there
 are no child elements.
 
-## Syntax
-
-```js
-// Getter
-element = fragment.lastElementChild;
-
-// No setter; read-only property
-```
-
-## Example
-
+## Examples
 ```js
 let fragment = new DocumentFragment();
 fragment.lastElementChild; // null

--- a/files/en-us/web/api/documentfragment/lastelementchild/index.md
+++ b/files/en-us/web/api/documentfragment/lastelementchild/index.md
@@ -14,7 +14,12 @@ The **`DocumentFragment.lastElementChild`** read-only property
 returns the document fragment's last child {{domxref("Element")}}, or `null` if there
 are no child elements.
 
+## Value
+
+An {{domxref("Element")}} that is the last child `Element` of the object, or `null` if there are none.
+
 ## Examples
+
 ```js
 let fragment = new DocumentFragment();
 fragment.lastElementChild; // null

--- a/files/en-us/web/api/dompointreadonly/w/index.md
+++ b/files/en-us/web/api/dompointreadonly/w/index.md
@@ -27,13 +27,7 @@ If your script needs to be able
 to change the value of this property, you should instead use the {{domxref("DOMPoint")}}
 object.
 
-## Syntax
-
-```js
-const perspective = someDOMPointReadOnly.w
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the `w` perspective value
 for the point. This value is **unrestricted**, meaning that it is allowed

--- a/files/en-us/web/api/dompointreadonly/x/index.md
+++ b/files/en-us/web/api/dompointreadonly/x/index.md
@@ -25,13 +25,7 @@ read-only version of the `DOMPoint` object.
 In general, positive values `x` mean to the right, and negative values of
 `x` means to the left, assuming no transforms have resulted in a reversal.
 
-## Syntax
-
-```js
-const xPos = someDOMPointReadOnly.x;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the x coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be

--- a/files/en-us/web/api/dompointreadonly/y/index.md
+++ b/files/en-us/web/api/dompointreadonly/y/index.md
@@ -28,13 +28,7 @@ of this property, you should instead use the {{domxref("DOMPoint")}} object.
 In general, positive values of `y` mean downward, and negative values of
 `y` mean upward, assuming no transforms have resulted in a reversal.
 
-## Syntax
-
-```js
-const yPos = someDOMPointReadOnly.y;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the y coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be

--- a/files/en-us/web/api/dompointreadonly/z/index.md
+++ b/files/en-us/web/api/dompointreadonly/z/index.md
@@ -29,13 +29,7 @@ In general, positive values of `z` mean toward the user (out from the
 screen), and negative values of `z` mean away from the user (into the
 screen), assuming no transforms have resulted in a reversal.
 
-## Syntax
-
-```js
-const zPos = someDOMPointReadOnly.z;
-```
-
-### Value
+## Value
 
 A double-precision floating-point value indicating the z coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be

--- a/files/en-us/web/api/dragevent/datatransfer/index.md
+++ b/files/en-us/web/api/dragevent/datatransfer/index.md
@@ -16,20 +16,11 @@ operation's data (as a {{domxref("DataTransfer")}} object).
 
 This property is {{readonlyInline}}.
 
-## Syntax
+## Value
 
-```js
-let data = dragEvent.dataTransfer;
-```
+A {{domxref("DataTransfer")}} object which contains the {{domxref("DragEvent","drag event's data")}}.
 
-### Return value
-
-- `data`
-  - : A {{domxref("DataTransfer")}} object which contains the
-    {{domxref("DragEvent","drag event's data")}}.
-
-## Example
-
+## Examples
 This example illustrates accessing the drag and drop data within the
 {{event("dragend")}} event handler.
 

--- a/files/en-us/web/api/dragevent/datatransfer/index.md
+++ b/files/en-us/web/api/dragevent/datatransfer/index.md
@@ -21,6 +21,7 @@ This property is {{readonlyInline}}.
 A {{domxref("DataTransfer")}} object which contains the {{domxref("DragEvent","drag event's data")}}.
 
 ## Examples
+
 This example illustrates accessing the drag and drop data within the
 {{event("dragend")}} event handler.
 

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.md
@@ -23,6 +23,7 @@ An {{domxref("AudioParam")}}.
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
+
 ```js
 var audioCtx = new AudioContext();
 var compressor = audioCtx.createDynamicsCompressor();

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.md
@@ -16,22 +16,13 @@ The `attack` property of the {{ domxref("DynamicsCompressorNode") }} interface i
 
 The `attack` property's default value is `0.003` and it can be set between `0` and `1`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var compressor = audioCtx.createDynamicsCompressor();
-compressor.attack.value = 0;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
-## Example
-
+## Examples
 ```js
 var audioCtx = new AudioContext();
 var compressor = audioCtx.createDynamicsCompressor();

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.md
@@ -18,22 +18,13 @@ The `knee` property's default value is `30` and it can be set between `0` and `4
 
 ![Describes the effect of a knee, showing two curves one for a hard knee, the other for a soft knee.](webaudioknee.png)
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var compressor = audioCtx.createDynamicsCompressor();
-compressor.knee.value = 40;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
-## Example
-
+## Examples
 ```js
 var audioCtx = new AudioContext();
 var compressor = audioCtx.createDynamicsCompressor();

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.md
@@ -25,6 +25,7 @@ An {{domxref("AudioParam")}}.
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
+
 ```js
 var audioCtx = new AudioContext();
 var compressor = audioCtx.createDynamicsCompressor();


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
