### PR TITLE
body element - non conforming change to do not use

### DIFF
--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -91,22 +91,22 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("alink")}} {{deprecated_inline}}
   - : Color of text for hyperlinks when selected.
-    **Do not use this attribute! Use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} pseudo-class instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} pseudo-class instead.**
 - {{htmlattrdef("background")}} {{deprecated_inline}}
   - : URI of a image to use as a background.
-    **Do not use this attribute! Use CSS {{cssxref("background")}} property on the element instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("background")}} property on the element instead.**
 - {{htmlattrdef("bgcolor")}} {{deprecated_inline}}
   - : Background color for the document.
-    **Do not use this attribute! Use CSS {{cssxref("background-color")}} property on the element instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("background-color")}} property on the element instead.**
 - {{htmlattrdef("bottommargin")}} {{deprecated_inline}}
   - : The margin of the bottom of the body.
-    **Do not use this attribute! Use  CSS {{cssxref("margin-bottom")}} property on the element instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("margin-bottom")}} property on the element instead.**
 - {{htmlattrdef("leftmargin")}} {{deprecated_inline}}
   - : The margin of the left of the body.
-    **Do not use this attribute! Use CSS {{cssxref("margin-left")}} property on the element instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("margin-left")}} property on the element instead.**
 - {{htmlattrdef("link")}} {{deprecated_inline}}
   - : Color of text for unvisited hypertext links.
-    **Do not use this attribute! Use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":link")}} pseudo-class instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":link")}} pseudo-class instead.**
 - {{htmlattrdef("onafterprint")}}
   - : Function to call after the user has printed the document.
 - {{htmlattrdef("onbeforeprint")}}
@@ -145,16 +145,16 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Function to call when the document is going away.
 - {{htmlattrdef("rightmargin")}} {{deprecated_inline}}
   - : The margin of the right of the body.
-    **Do not use this attribute! Use CSS {{cssxref("margin-right")}} property on the element instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("margin-right")}} property on the element instead.**
 - {{htmlattrdef("text")}} {{deprecated_inline}}
   - : Foreground color of text.
     **Do not use this attribute! Use CSS {{cssxref("color")}} property on the element instead.**
 - {{htmlattrdef("topmargin")}} {{deprecated_inline}}
   - : The margin of the top of the body.
-    **Do not use this attribute! Use CSS {{cssxref("margin-top")}} property on the element instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("margin-top")}} property on the element instead.**
 - {{htmlattrdef("vlink")}} {{deprecated_inline}}
   - : Color of text for visited hypertext links.
-    **Do not use this attribute! Use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":visited")}} pseudo-class instead.**
+    **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":visited")}} pseudo-class instead.**
 
 ## Example
 

--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -90,17 +90,23 @@ The **`<body>`** [HTML](/en-US/docs/Web/HTML) element represents the content of 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
 - {{htmlattrdef("alink")}} {{deprecated_inline}}
-  - : Color of text for hyperlinks when selected. _This method is non-conforming, use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} pseudo-class instead._
+  - : Color of text for hyperlinks when selected.
+    **Do not use this attribute! Use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} pseudo-class instead.**
 - {{htmlattrdef("background")}} {{deprecated_inline}}
-  - : URI of a image to use as a background. _This method is non-conforming, use CSS {{cssxref("background")}} property on the element instead._
+  - : URI of a image to use as a background.
+    **Do not use this attribute! Use CSS {{cssxref("background")}} property on the element instead.**
 - {{htmlattrdef("bgcolor")}} {{deprecated_inline}}
-  - : Background color for the document. _This method is non-conforming, use CSS {{cssxref("background-color")}} property on the element instead._
+  - : Background color for the document.
+    **Do not use this attribute! Use CSS {{cssxref("background-color")}} property on the element instead.**
 - {{htmlattrdef("bottommargin")}} {{deprecated_inline}}
-  - : The margin of the bottom of the body. _This method is non-conforming, use CSS {{cssxref("margin-bottom")}} property on the element instead._
+  - : The margin of the bottom of the body.
+    **Do not use this attribute! Use  CSS {{cssxref("margin-bottom")}} property on the element instead.**
 - {{htmlattrdef("leftmargin")}} {{deprecated_inline}}
-  - : The margin of the left of the body. _This method is non-conforming, use CSS {{cssxref("margin-left")}} property on the element instead._
+  - : The margin of the left of the body.
+    **Do not use this attribute! Use CSS {{cssxref("margin-left")}} property on the element instead.**
 - {{htmlattrdef("link")}} {{deprecated_inline}}
-  - : Color of text for unvisited hypertext links. _This method is non-conforming, use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":link")}} pseudo-class instead._
+  - : Color of text for unvisited hypertext links.
+    **Do not use this attribute! Use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":link")}} pseudo-class instead.**
 - {{htmlattrdef("onafterprint")}}
   - : Function to call after the user has printed the document.
 - {{htmlattrdef("onbeforeprint")}}
@@ -138,13 +144,17 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - {{htmlattrdef("onunload")}}
   - : Function to call when the document is going away.
 - {{htmlattrdef("rightmargin")}} {{deprecated_inline}}
-  - : The margin of the right of the body. _This method is non-conforming, use CSS {{cssxref("margin-right")}} property on the element instead._
+  - : The margin of the right of the body.
+    **Do not use this attribute! Use CSS {{cssxref("margin-right")}} property on the element instead.**
 - {{htmlattrdef("text")}} {{deprecated_inline}}
-  - : Foreground color of text. _This method is non-conforming, use CSS {{cssxref("color")}} property on the element instead._
+  - : Foreground color of text.
+    **Do not use this attribute! Use CSS {{cssxref("color")}} property on the element instead.**
 - {{htmlattrdef("topmargin")}} {{deprecated_inline}}
-  - : The margin of the top of the body. _This method is non-conforming, use CSS {{cssxref("margin-top")}} property on the element instead._
+  - : The margin of the top of the body.
+    **Do not use this attribute! Use CSS {{cssxref("margin-top")}} property on the element instead.**
 - {{htmlattrdef("vlink")}} {{deprecated_inline}}
-  - : Color of text for visited hypertext links. _This method is non-conforming, use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":visited")}} pseudo-class instead._
+  - : Color of text for visited hypertext links.
+    **Do not use this attribute! Use CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":visited")}} pseudo-class instead.**
 
 ## Example
 


### PR DESCRIPTION
The body element docs used the term "This method is non-conforming" but it isn't clear what that means to a user. [From the spec](https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features) it means "completely obsolete so do not use."

This makes that clear using bold text **Do not use this attribute!**