### PR TITLE
Fix a minor typo in `AudioData.format` page

### DIFF
--- a/files/en-us/web/api/audiodata/format/index.md
+++ b/files/en-us/web/api/audiodata/format/index.md
@@ -20,17 +20,17 @@ A string. One of:
 - `"u8"`
   - : 8-bit unsigned integer samples, in an interleaved format.
 - `"s16"`
-  - : 16-bit unsigned integer samples, in an interleaved format.
+  - : 16-bit signed integer samples, in an interleaved format.
 - `"s32"`
-  - : 32-bit unsigned integer samples, in an interleaved format.
+  - : 32-bit signed integer samples, in an interleaved format.
 - `"f32"`
   - : 32-bit float samples, in an interleaved format.
 - `"u8-planar"`
   - : 8-bit unsigned integer samples, in a planar format.
 - `"s16-planar"`
-  - : 16-bit unsigned integer samples, in a planar format.
+  - : 16-bit signed integer samples, in a planar format.
 - `"s32-planar"`
-  - : 32-bit unsigned integer samples, in a planar format.
+  - : 32-bit signed integer samples, in a planar format.
 - `"f32-planar"`
   - : 32-bit float samples, in a planar format.
 


### PR DESCRIPTION
#### Summary
Fix a minor typo in the [`AudioData.format`](https://developer.mozilla.org/en-US/docs/Web/API/AudioData/format) page.
The signed formats (`s16*` & `s32*`) were described as unsigned.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
See [specification](https://w3c.github.io/webcodecs/#enumdef-audiosampleformat).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
