### PR TITLE
Update module list to include current module

### DIFF
--- a/files/en-us/learn/forms/html5_input_types/index.md
+++ b/files/en-us/learn/forms/html5_input_types/index.md
@@ -283,6 +283,7 @@ That brings us to the end of our tour of the HTML5 form input types. There are a
 - [Your first form](/en-US/docs/Learn/Forms/Your_first_form)
 - [How to structure a web form](/en-US/docs/Learn/Forms/How_to_structure_a_web_form)
 - [Basic native form controls](/en-US/docs/Learn/Forms/Basic_native_form_controls)
+- [The HTML5 input types](/en-US/docs/Learn/Forms/HTML5_input_types)
 - [Other form controls](/en-US/docs/Learn/Forms/Other_form_controls)
 - [Styling web forms](/en-US/docs/Learn/Forms/Styling_web_forms)
 - [Advanced form styling](/en-US/docs/Learn/Forms/Advanced_form_styling)


### PR DESCRIPTION
The module list on this page doesn't include the current module (HTML5 Input Types), and I noticed that on other pages the current module is usually included with bold text to indicate the user's progress through the modules. Thanks and hope I helped!

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Update the module list at the bottom of the HTML5 Input Types page to include the current module.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I think the change improves layout consistency of the module lists for the form tutorial.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This is the page containing the incomplete module list at the bottom:
https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
