### PR TITLE
KeyframeEffect: added more code for better understanding of the context

### DIFF
--- a/files/en-us/web/api/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/index.md
@@ -67,8 +67,8 @@ const rabbitDownKeyframes = new KeyframeEffect(
   
 const rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
   
-  // Play rabbit animation
-  rabbitDownAnimation.play();
+// Play rabbit animation
+rabbitDownAnimation.play();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/index.md
@@ -5,7 +5,6 @@ tags:
   - API
   - Animation
   - Animations
-  - Experimental
   - Interface
   - KeyframeEffect
   - Reference
@@ -13,7 +12,7 @@ tags:
   - web animations api
 browser-compat: api.KeyframeEffect
 ---
-{{SeeCompatTable}}{{ APIRef("Web Animations") }}
+{{ APIRef("Web Animations") }}
 
 The **`KeyframeEffect`** interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) lets us create sets of animatable properties and values, called **keyframes.** These can then be played using the {{domxref("Animation.Animation", "Animation()")}} constructor.
 
@@ -55,7 +54,9 @@ _This interface inherits some of its methods from its parent, {{domxref("Animati
 In the [Follow the White Rabbit example](http://codepen.io/rachelnabors/pen/eJyWzm/?editors=0010), the KeyframeEffect constructor is used to create a set of keyframes that dictate how the White Rabbit should animate down the hole:
 
 ```js
- var rabbitDownKeyframes = new KeyframeEffect(
+ let whiteRabbit = document.getElementById("rabbit");
+
+ let rabbitDownKeyframes = new KeyframeEffect(
     whiteRabbit, // element to animate
     [
       { transform: 'translateY(0%)' }, // keyframe
@@ -63,6 +64,11 @@ In the [Follow the White Rabbit example](http://codepen.io/rachelnabors/pen/eJyW
     ],
     { duration: 3000, fill: 'forwards' } // keyframe options
   );
+  
+  let rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
+  
+  // Play rabbit animation
+  rabbitDownAnimation.play();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/index.md
@@ -54,9 +54,9 @@ _This interface inherits some of its methods from its parent, {{domxref("Animati
 In the [Follow the White Rabbit example](http://codepen.io/rachelnabors/pen/eJyWzm/?editors=0010), the KeyframeEffect constructor is used to create a set of keyframes that dictate how the White Rabbit should animate down the hole:
 
 ```js
- let whiteRabbit = document.getElementById("rabbit");
+const whiteRabbit = document.getElementById('rabbit');
 
- let rabbitDownKeyframes = new KeyframeEffect(
+const rabbitDownKeyframes = new KeyframeEffect(
     whiteRabbit, // element to animate
     [
       { transform: 'translateY(0%)' }, // keyframe
@@ -65,7 +65,7 @@ In the [Follow the White Rabbit example](http://codepen.io/rachelnabors/pen/eJyW
     { duration: 3000, fill: 'forwards' } // keyframe options
   );
   
-  let rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
+const rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
   
   // Play rabbit animation
   rabbitDownAnimation.play();

--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
@@ -81,9 +81,9 @@ The single argument constructor (see above) creates a clone of an existing  {{do
 In the [Follow the White Rabbit example](https://codepen.io/rachelnabors/pen/eJyWzm/?editors=0010), the `KeyframeEffect` constructor is used to create a set of keyframes that dictate how the White Rabbit should animate down the hole:
 
 ```js
-let whiteRabbit = document.getElementById("rabbit");
+const whiteRabbit = document.getElementById('rabbit');
 
-let rabbitDownKeyframes = new KeyframeEffect(
+const rabbitDownKeyframes = new KeyframeEffect(
     whiteRabbit, // element to animate
     [
       { transform: 'translateY(0%)' }, // keyframe
@@ -92,7 +92,7 @@ let rabbitDownKeyframes = new KeyframeEffect(
     { duration: 3000, fill: 'forwards' } // keyframe options
   );
   
-let rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
+const rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
   
 // Play rabbit animation
 rabbitDownAnimation.play();

--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
@@ -5,14 +5,13 @@ tags:
   - API
   - Animation
   - Constructor
-  - Experimental
   - KeyframeEffect
   - Reference
   - waapi
   - web animations api
 browser-compat: api.KeyframeEffect.KeyframeEffect
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}
+{{ APIRef("Web Animations API") }}
 
 The **`KeyframeEffect()`** constructor of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns a new `{{domxref("KeyframeEffect")}}` object instance, and also allows you to clone an existing keyframe effect object instance.
 
@@ -82,7 +81,9 @@ The single argument constructor (see above) creates a clone of an existing  {{do
 In the [Follow the White Rabbit example](https://codepen.io/rachelnabors/pen/eJyWzm/?editors=0010), the `KeyframeEffect` constructor is used to create a set of keyframes that dictate how the White Rabbit should animate down the hole:
 
 ```js
-var rabbitDownKeyframes = new KeyframeEffect(
+let whiteRabbit = document.getElementById("rabbit");
+
+let rabbitDownKeyframes = new KeyframeEffect(
     whiteRabbit, // element to animate
     [
       { transform: 'translateY(0%)' }, // keyframe
@@ -90,6 +91,11 @@ var rabbitDownKeyframes = new KeyframeEffect(
     ],
     { duration: 3000, fill: 'forwards' } // keyframe options
   );
+  
+let rabbitDownAnimation = new Animation(rabbitDownKeyframes, document.timeline);
+  
+// Play rabbit animation
+rabbitDownAnimation.play();
 ```
 
 ## Specifications


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect#examples

## Summary
Added more code to the example for better understanding of the context in which the interface is used.

As per the BCD table the interface is not experimental anymore.

#### Motivation
Just creating an object was not giving enough understanding of it's use in the Example section.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
