### PR TITLE
Remove `module` "keyword" from ASI section

### DIFF
--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -525,7 +525,6 @@ a = b;
 - `break`
 - `return`
 - `yield`, `yield*`
-- `module`
 
 ```js
 return


### PR DESCRIPTION
#### Summary

Remove the `module` "keyword" from the ASI section of the [lexical-grammar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion) article.

#### Motivation

`module` isn't a reserved word in JavaScript and isn't mentioned in the [linked section](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar) or anywhere else in the  spec as a keyword, statement, or reserved word.

#### Supporting details

- https://github.com/denoland/deno/issues/14126#issuecomment-1080059983

#### Related issues

- https://github.com/denoland/deno/issues/14126
- https://github.com/swc-project/swc/issues/4176

#### Metadata

<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error