### PR TITLE
Update the "all" property page for new value "revert-layer"

### DIFF
--- a/files/en-us/web/css/all/index.md
+++ b/files/en-us/web/css/all/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.all
 ---
 {{CSSRef}}
 
-The **`all`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property resets all of an element's properties except {{cssxref("unicode-bidi")}}, {{cssxref("direction")}}, and [CSS Custom Properties](/en-US/docs/Web/CSS/Using_CSS_custom_properties). It can set properties to their initial or inherited values, or to the values specified in another stylesheet origin.
+The **`all`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property resets all of an element's properties except {{cssxref("unicode-bidi")}}, {{cssxref("direction")}}, and [CSS Custom Properties](/en-US/docs/Web/CSS/Using_CSS_custom_properties). It can set properties to their initial or inherited values, or to the values specified in another cascade layer or stylesheet origin.
 
 {{EmbedInteractiveExample("pages/css/all.html")}}
 
@@ -21,8 +21,9 @@ The **`all`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US
 /* Global values */
 all: initial;
 all: inherit;
-all: revert;
 all: unset;
+all: revert;
+all: revert-layer;
 ```
 
 The `all` property is specified as one of the CSS global keyword values. Note that none of these values affect the {{cssxref("unicode-bidi")}} and {{cssxref("direction")}} properties.
@@ -36,15 +37,13 @@ The `all` property is specified as one of the CSS global keyword values. Note th
 - {{cssxref("unset")}}
   - : Specifies that all the element's properties should be changed to their inherited values if they inherit by default, or to their initial values if not.
 - {{cssxref("revert")}}
-
   - : Specifies behavior that depends on the stylesheet origin to which the declaration belongs:
+    - If the rule belongs to the [author origin](/en-US/docs/Web/CSS/Cascade#author_stylesheets), the `revert` value rolls back the [cascade](/en-US/docs/Web/CSS/Cascade) to the user level, so that the [specified values](/en-US/docs/Web/CSS/specified_value) are calculated as if no author-level rules were specified for the element. For purposes of `revert`, the author origin includes the Override and Animation origins.
+    - If the rule belongs to the [user origin](/en-US/docs/Web/CSS/Cascade#user_stylesheets), the `revert` value rolls back the [cascade](/en-US/docs/Web/CSS/Cascade) to the user-agent level, so that the [specified values](/en-US/docs/Web/CSS/specified_value) are calculated as if no author-level or user-level rules were specified for the element.
+    - If the rule belongs to the [user-agent origin](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets), the `revert` value acts like `unset`.
+- {{cssxref("revert-layer")}}
+  - : Specifies that all the element's properties should roll back the cascade to a previous [cascade layer](/en-US/docs/Web/CSS/@layer), if one exists. If no other cascade layer exists, the element's properties will roll back to the matching rule, if one exists, in the current layer or to a previous [style origin](/en-US/docs/Glossary/Style_origin).
 
-    - [User-agent origin](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets)
-      - : Equivalent to `unset`.
-    - [User origin](/en-US/docs/Web/CSS/Cascade#user_stylesheets)
-      - : Rolls back the [cascade](/en-US/docs/Web/CSS/Cascade) to the user-agent level, so that the [specified values](/en-US/docs/Web/CSS/specified_value) are calculated as if no author-level or user-level rules were specified for the element.
-    - [Author origin](/en-US/docs/Web/CSS/Cascade#author_stylesheets)
-      - : Rolls back the [cascade](/en-US/docs/Web/CSS/Cascade) to the user level, so that the [specified values](/en-US/docs/Web/CSS/specified_value) are calculated as if no author-level rules were specified for the element. For purposes of `revert`, the Author origin includes the Override and Animation origins.
 
 ## Formal definition
 
@@ -56,7 +55,9 @@ The `all` property is specified as one of the CSS global keyword values. Note th
 
 ## Examples
 
-### HTML
+In this example, the CSS file contains styling for the {{HTMLElement("blockquote")}} element in addition to some styling for the parent `<body>` element. Various outputs in the Results subsection demonstrate how the styling of the `<blockquote>` element is affected when different values are applied to the `all` property inside the `blockquote` rule.
+
+#### HTML
 
 ```html
 <blockquote id="quote">
@@ -65,7 +66,7 @@ The `all` property is specified as one of the CSS global keyword values. Note th
 Phasellus eget velit sagittis.
 ```
 
-### CSS
+#### CSS
 
 ```css
 body {
@@ -82,9 +83,9 @@ blockquote {
 }
 ```
 
-### Result
+#### Results
 
-#### No `all` property
+#### A. No `all` property
 
 ```html hidden
 <blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
@@ -97,25 +98,9 @@ blockquote { background-color: skyblue;  color: red; }
 
 {{EmbedLiveSample("No_all_property", "200", "125")}}
 
-The {{HTMLElement("blockquote")}} uses the browser's default styling which gives it a margin, together with a specific background and text color. It also behaves as a _block_ element: the text that follows it is beneath it.
+This is the scenario in which no `all` property is set inside the `blockquote` rule. The {{HTMLElement("blockquote")}} element uses the browser's default styling which gives it a margin, together with a specific background and text color as specified in the stylesheet. It also behaves as a _block_ element: the text that follows it is beneath it.
 
-#### `all:unset`
-
-```html hidden
-<blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
-```
-
-```css hidden
-body { font-size: small; background-color: #F0F0F0; color:blue; }
-blockquote { background-color: skyblue;  color: red; }
-blockquote { all: unset; }
-```
-
-{{EmbedLiveSample("allunset", "200", "125")}}
-
-The {{HTMLElement("blockquote")}} doesn't use the browser default styling: it is an _inline_ element now (initial value), its {{cssxref("background-color")}} is `transparent` (initial value), but its {{cssxref("font-size")}} is still `small` (inherited value) and its {{cssxref("color")}} is `blue` (inherited value).
-
-#### `all:initial`
+#### B. `all: initial`
 
 ```html hidden
 <blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
@@ -129,9 +114,9 @@ blockquote { all: initial; }
 
 {{EmbedLiveSample("allinitial", "200", "125")}}
 
-The {{HTMLElement("blockquote")}} doesn't use the browser default styling: it is an _inline_ element now (initial value), its {{cssxref("background-color")}} is `transparent` (initial value), its {{cssxref("font-size")}} is `normal` (initial value) and its {{cssxref("color")}} is `black` (initial value).
+With the `all` property set to `initial` in the `blockquote` rule, the {{HTMLElement("blockquote")}} element doesn't use the browser default styling anymore: it is an _inline_ element now (initial value), its [`background-color`](en-US/docs/Web/CSS/background-color#formal_definition) is `transparent` (initial value), its [`font-size`](en-US/docs/Web/CSS/font-size#formal_definition) is `medium`, and its [`color`](en-US/docs/Web/CSS/color#formal_definition) is `black` (initial value).
 
-#### `all:inherit`
+#### C. `all: inherit`
 
 ```html hidden
 <blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
@@ -145,7 +130,55 @@ blockquote { all: inherit; }
 
 {{EmbedLiveSample("allinherit", "200", "125")}}
 
-The {{HTMLElement("blockquote")}} doesn't use the browser default styling: it is a _block_ element now (inherited value from its containing {{HTMLElement("body")}} element), its {{cssxref("background-color")}} is `#F0F0F0` (inherited value), its {{cssxref("font-size")}} is `small` (inherited value) and its {{cssxref("color")}} is `blue` (inherited value).
+In this case, the {{HTMLElement("blockquote")}} element doesn't use the browser default styling. Instead, it inherits style values from its parent {{HTMLElement("body")}} element: it is a _block_ element now (inherited value), its {{cssxref("background-color")}} is `#F0F0F0` (inherited value), its {{cssxref("font-size")}} is `small` (inherited value), and its {{cssxref("color")}} is `blue` (inherited value).
+
+#### D. `all: unset`
+
+```html hidden
+<blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
+```
+
+```css hidden
+body { font-size: small; background-color: #F0F0F0; color:blue; }
+blockquote { background-color: skyblue;  color: red; }
+blockquote { all: unset; }
+```
+
+{{EmbedLiveSample("allunset", "200", "125")}}
+
+When the `unset` value is applied to the `all` property in the `blockquote` rule, the {{HTMLElement("blockquote")}} element doesn't use the browser default styling. Because [`background-color`](en-US/docs/Web/CSS/background-color#formal_definition) is a non-inherited property and [`font-size`](en-US/docs/Web/CSS/font-size#formal_definition) and [`color`](en-US/docs/Web/CSS/color#formal_definition) are inherited properties, the `<blockquote>` element is an _inline_ element now (initial value), its {{cssxref("background-color")}} is `transparent` (initial value), but its {{cssxref("font-size")}} is still `small` (inherited value), and its {{cssxref("color")}} is `blue` (inherited value).
+
+#### E. `all: revert`
+
+```html hidden
+<blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
+```
+
+```css hidden
+body { font-size: small; background-color: #F0F0F0; color:blue; }
+blockquote { background-color: skyblue;  color: red; }
+blockquote { all: revert; }
+```
+
+{{EmbedLiveSample("allrevert", "200", "125")}}
+
+When the `all` property is set to `revert` in the `blockquote` rule, the `blockquote` rule is considered to be non-existent and the styling property values are inherited from the ones applied to the parent element `<body>`. So the `<blockquote>` element gets styled as a _block_ element, with {{cssxref("background-color")}} `#F0F0F0`, {{cssxref("font-size")}} `small`, and {{cssxref("color")}} `blue` - all values inherited from the `body` rule.
+
+#### F. `all: revert-layer`
+
+```html hidden
+<blockquote id="quote">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</blockquote> Phasellus eget velit sagittis.
+```
+
+```css hidden
+body { font-size: small; background-color: #F0F0F0; color:blue; }
+blockquote { background-color: skyblue;  color: red; }
+blockquote { all: revert-layer; }
+```
+
+{{EmbedLiveSample("allrevert-layer", "200", "125")}}
+
+There are no cascade layers defined in the CSS file, so the `<blockquote>` element inherits its style from the matching `body` rule. The `<blockquote>` element here is styled as a _block_ element, with {{cssxref("background-color")}} `#F0F0F0`, {{cssxref("font-size")}} `small`, and {{cssxref("color")}} `blue` - all values inherited from the `body` rule. This scenario is an example of the case when `all` set to `revert-layer` behaves the same as when `all` is set to `revert`.
 
 ## Specifications
 
@@ -157,4 +190,4 @@ The {{HTMLElement("blockquote")}} doesn't use the browser default styling: it is
 
 ## See also
 
-CSS global keyword values: {{cssxref("initial")}}, {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}
+CSS global keyword values: {{cssxref("initial")}}, {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}, {{cssxref("revert-layer")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

- A new global keyword was introduced in FF97, the `revert-layer` keyword.

- So the `all` property can now have another value `revert-layer` in addition to `initial`, `inherit`, `unset`, and `revert`

---
This PR updates the following:

- Update the intro paragraph to include reference to cascade layer (for the new `revert-layer` value)
- Update "Try it" interactive example (will be done through separate PR)
- Update the "Syntax"
- Update "Values" to add description for `revert-layer` and also:
    - Rewrite `revert` description to make the style origins bulleted as well as add more explanation
- Update "Formal Syntax" - https://github.com/mdn/data/pull/576
- Update "Examples" section to:
    - Add intro paragraph in the examples
    - Change "Result" to "Results"
    - Maintain same order as in syntax for consistency : `initial` followed by `inherit` followed by `unset`
    - Add missing example result for `all: revert`
    - Add new example result for `all: revert-layer`
    - Edit explanation for each of the result outputs for better clarity


- Update BCD table to remove `revert` (will be done through separate PR)
---

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for the new revert-layer page: https://github.com/mdn/content/pull/14287

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
