### PR TITLE
Array.groupByXxxx - clarify thisArg

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupby/index.md
@@ -59,7 +59,10 @@ groupBy(function(element, index, array) { /* ... */ }, thisArg)
 
 - `thisArg` {{optional_inline}}
   - : Object to use as {{jsxref("Operators/this", "this")}} inside `callbackFn`.
-      If not specified, `undefined` will be used.
+
+     The argument is ignored in arrow functions, as they have their own lexical scope that will be used instead.
+     Otherwise, if `thisArg` not specified, then either the `this` of the executing scope is used, or `undefined` if the function is called in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode).
+      
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/groupbytomap/index.md
@@ -59,7 +59,10 @@ groupByToMap(function(element, index, array) { /* ... */ }, thisArg)
 
 - `thisArg` {{optional_inline}}
   - : Object to use as {{jsxref("Operators/this", "this")}} inside `callbackFn`.
-      If not specified, `undefined` will be used.
+
+     The argument is ignored in arrow functions, as they have their own lexical scope that will be used instead.
+     Otherwise, if `thisArg` not specified, then either the `this` of the executing scope is used, or `undefined` if the function is called in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode).
+
 
 ### Return value
 


### PR DESCRIPTION
[Array.groupBy()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/groupBy) and [Array.groupByToMap()](http://localhost:5042/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/groupByToMap) take a `thisArg` parameter.

The docs followed the spec, which stated that the function is called with `undefined` if the argument is not specified. The [engineering team](https://bugzilla.mozilla.org/show_bug.cgi?id=1739648#c20) clarified that this is is not the full story - functions are always called with a this argument, and the handling depends on the function and scope. 

Upshot is that if `thisArg` will actually only be undefined in a normal function called in strict mode. Otherwise it will take the scope appropriate for the function type - i.e. in an arrow function the lexical scope. In a normal function the calling scope. 

This follows on from discussion here: https://github.com/mdn/content/pull/13171/files#r816339510
