### PR TITLE
WebAPI: Clean syntax from property pages, part 11

### DIFF
--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.md
@@ -18,21 +18,13 @@ The `ratio` property's default value is `12` and it can be set between `1` and `
 
 ![Describes the effect of different ratio on the output signal](webaudioratio.png)
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var compressor = audioCtx.createDynamicsCompressor();
-compressor.ratio.value = 12;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 ```js
 var audioCtx = new AudioContext();

--- a/files/en-us/web/api/dynamicscompressornode/reduction/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/reduction/index.md
@@ -16,17 +16,11 @@ The **`reduction`** read-only property of the {{ domxref("DynamicsCompressorNode
 
 Intended for metering purposes, it returns a value in dB, or `0` (no gain reduction) if no signal is fed into the `DynamicsCompressorNode`. The range of this value is between `-20` and `0` (in dB).
 
-## Syntax
-
-```js
-var myReduction = compressorNodeInstance.reduction;
-```
-
-### Value
+## Value
 
 A float.
 
-## Example
+## Examples
 
 ```js
 var audioCtx = new AudioContext();

--- a/files/en-us/web/api/dynamicscompressornode/release/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.md
@@ -16,21 +16,13 @@ The `release` property of the {{ domxref("DynamicsCompressorNode") }} interface 
 
 The `release` property's default value is `0.25` and it can be set between `0` and `1`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var compressor = audioCtx.createDynamicsCompressor();
-compressor.release.value = 0.25;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 ```js
 var audioCtx = new AudioContext();

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.md
@@ -18,21 +18,13 @@ The `threshold` property's default value is `-24` and it can be set between `-10
 
 ![The threshold attribute has no effect on signals lowers than its value, but induce volume reduction on signal stronger than its value.](webaudiothreshold.png)
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var compressor = audioCtx.createDynamicsCompressor();
-compressor.threshold.value = -50;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 ```js
 var audioCtx = new AudioContext();

--- a/files/en-us/web/api/element/attributes/index.md
+++ b/files/en-us/web/api/element/attributes/index.md
@@ -19,11 +19,9 @@ methods and the {{domxref("Attr")}} nodes' indexes may differ among browsers. To
 specific, `attributes` is a key/value pair of strings that represents any
 information regarding that attribute.
 
-## Syntax
+## Value
 
-```js
-var attr = element.attributes;
-```
+A {{domxref("NamedNodeMap")}} object.
 
 ## Example
 

--- a/files/en-us/web/api/element/childelementcount/index.md
+++ b/files/en-us/web/api/element/childelementcount/index.md
@@ -13,13 +13,7 @@ browser-compat: api.Element.childElementCount
 The **`Element.childElementCount`** read-only property
 returns the number of child elements of this element.
 
-## Syntax
-
-```js
-element.childElementCount;
-```
-
-## Example
+## Examples
 
 ```js
 let sidebar = document.getElementById('sidebar');

--- a/files/en-us/web/api/element/children/index.md
+++ b/files/en-us/web/api/element/children/index.md
@@ -17,16 +17,7 @@ which contains all of the child {{domxref("Element", "elements")}} of the elemen
 
 `Element.children` includes only element nodes. To get all child nodes, including non-element nodes like text and comment nodes, use {{domxref("Node.childNodes")}}.
 
-## Syntax
-
-```js
-// Getter
-collection = myElement.children;
-
-// No setter; read-only property
-```
-
-### Return value
+## Value
 
 An {{ domxref("HTMLCollection") }} which is a live, ordered collection of the DOM
 elements which are children of `node`. You can access the
@@ -37,7 +28,7 @@ JavaScript array-style notation.
 If the element has no element children, then `children` is an empty list with a
 `length` of `0`.
 
-## Example
+## Examples
 
 ```js
 const myElement = document.getElementById('foo');

--- a/files/en-us/web/api/element/classlist/index.md
+++ b/files/en-us/web/api/element/classlist/index.md
@@ -19,13 +19,7 @@ attributes of the element. This can then be used to manipulate the class list.
 Using `classList` is a convenient alternative to accessing an element's list
 of classes as a space-delimited string via {{domxref("element.className")}}.
 
-## Syntax
-
-```js
-const elementClasses = elementNodeReference.classList;
-```
-
-### Returns
+## Value
 
 A {{domxref("DOMTokenList")}} representing the contents of the element's
 `class` attribute. If the `class` attribute is not set or empty,

--- a/files/en-us/web/api/element/classname/index.md
+++ b/files/en-us/web/api/element/classname/index.md
@@ -15,17 +15,11 @@ The **`className`** property of the
 {{domxref("Element")}} interface gets and sets the value of the [`class` attribute](/en-US/docs/Web/HTML/Global_attributes/class)
 of the specified element.
 
-## Syntax
+## Value
 
-```js
-var cName = elementNodeReference.className;
-elementNodeReference.className = cName;
-```
+A string variable representing the class or space-separated classes of the current element.
 
-- `cName` is a string variable representing the class or space-separated
-  classes of the current element.
-
-## Example
+## Examples
 
 ```js
 let el = document.getElementById('item');

--- a/files/en-us/web/api/element/clientheight/index.md
+++ b/files/en-us/web/api/element/clientheight/index.md
@@ -27,17 +27,11 @@ is a special case of `clientHeight`](https://www.w3.org/TR/2016/WD-cssom-view-1-
 > **Note:** This property will round the value to an integer. If you need
 > a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
-## Syntax
+## Value
 
-```js
-var intElemClientHeight = element.clientHeight;
-```
+A number.
 
-`intElemClientHeight` is an integer corresponding to the
-`clientHeight` of `element` in pixels. The
-`clientHeight` property is read–only.
-
-## Example
+## Examples
 
 ![](dimensions-client.png)
 

--- a/files/en-us/web/api/element/clientleft/index.md
+++ b/files/en-us/web/api/element/clientleft/index.md
@@ -25,13 +25,11 @@ is an overflow causing a left vertical scrollbar to be rendered.
 > `display: inline`, `clientLeft` returns `0`
 > regardless of the element's border.
 
-## Syntax
+## Value
 
-```js
-var left = element.clientLeft;
-```
+A number.
 
-## Example
+## Examples
 
 In the following example, the client area has a white background and a 24px black `border-left`. The `clientLeft` value is the distance from where the margin (yellow) area ends and the padding and content areas (white) begin: that is, 24px.
 

--- a/files/en-us/web/api/element/clienttop/index.md
+++ b/files/en-us/web/api/element/clienttop/index.md
@@ -27,13 +27,11 @@ then **`clientTop`** is also zero.
 > **Note:** This property will round the value to an integer. If you
 > need a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
-## Syntax
+## Value
 
-```js
-var top = element.clientTop;
-```
+A number.
 
-## Example
+## Examples
 
 In the following example, the client area has a white background and a 24px black `border-top`. The `clientTop` value is the distance from where the margin (yellow) area ends and the padding and content areas (white) begin: that is, 24px.
 

--- a/files/en-us/web/api/element/clientwidth/index.md
+++ b/files/en-us/web/api/element/clientwidth/index.md
@@ -24,17 +24,11 @@ is a special case of `clientWidth`](https://www.w3.org/TR/2016/WD-cssom-view-1-2
 > **Note:** This property will round the value to an integer. If you need
 > a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
-## Syntax
+## Value
 
-```js
-var intElemClientWidth = element.clientWidth;
-```
+A number.
 
-`intElemClientWidth` is an integer corresponding to the
-`clientWidth` of `element` in pixels. The
-`clientWidth` property is read–only.
-
-## Example
+## Examples
 
 ![](dimensions-client.png)
 

--- a/files/en-us/web/api/element/firstelementchild/index.md
+++ b/files/en-us/web/api/element/firstelementchild/index.md
@@ -17,16 +17,11 @@ are no child elements.
 `Element.firstElementChild` includes only element nodes.
 To get all child nodes, including non-element nodes like text and comment nodes, use {{domxref("Node.firstChild")}}.
 
-## Syntax
+## Value
 
-```js
-// Getter
-element = el.firstElementChild;
+An {{domxref("Element")}} object, or `null`.
 
-// No setter; read-only property
-```
-
-## Example
+## Examples
 
 ```html
 <ul id="list">

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -26,17 +26,9 @@ the document with [CSS](/en-US/docs/Web/CSS).
 > **Note:** Identifiers are case-sensitive, but you should avoid creating
 > IDs that differ only in the capitalization.
 
-## Syntax
+## Value
 
-```js
-var idStr = element.id; // Get the id
-```
-
-```js
-element.id = 'newid'; // Set the id
-```
-
-- `idStr` is the identifier of the element.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/lastelementchild/index.md
+++ b/files/en-us/web/api/element/lastelementchild/index.md
@@ -17,16 +17,11 @@ are no child elements.
 `Element.lastElementChild` includes only element nodes.
 To get all child nodes, including non-element nodes like text and comment nodes, use {{domxref("Node.lastChild")}}.
 
-## Syntax
+## Value
 
-```js
-// Getter
-element = el.lastElementChild;
+A {{domxref("Element")}} object, or `null`
 
-// No setter; read-only property
-```
-
-## Example
+## Examples
 
 ```html
 <ul id="list">

--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -15,17 +15,11 @@ browser-compat: api.Element.localName
 The **`Element.localName`** read-only property returns the
 local part of the qualified name of an element.
 
-## Syntax
-
-```js
-name = element.localName
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMString")}} representing the local part of the element's qualified name.
 
-## Example
+## Examples
 
 (Must be served with XML content type, such as `text/xml` or
 `application/xhtml+xml`.)

--- a/files/en-us/web/api/element/namespaceuri/index.md
+++ b/files/en-us/web/api/element/namespaceuri/index.md
@@ -17,7 +17,7 @@ namespace URI of the element, or `null` if the element is not in a namespace.
 
 ## Value
 
-A string or `null`.
+A string, or `null`.
 
 ## Examples
 

--- a/files/en-us/web/api/element/namespaceuri/index.md
+++ b/files/en-us/web/api/element/namespaceuri/index.md
@@ -15,13 +15,11 @@ browser-compat: api.Element.namespaceURI
 The **`Element.namespaceURI`** read-only property returns the
 namespace URI of the element, or `null` if the element is not in a namespace.
 
-## Syntax
+## Value
 
-```js
-namespace = element.namespaceURI
-```
+A string or `null`.
 
-## Example
+## Examples
 
 In this snippet, an element is being examined for its {{domxref("Element.localName", "localName")}} and its
 `namespaceURI`. If the `namespaceURI` returns the XUL namespace

--- a/files/en-us/web/api/element/nextelementsibling/index.md
+++ b/files/en-us/web/api/element/nextelementsibling/index.md
@@ -14,16 +14,11 @@ The **`Element.nextElementSibling`** read-only
 property returns the element immediately following the specified one in its parent's
 children list, or `null` if the specified element is the last one in the list.
 
-## Syntax
+## Value
 
-```js
-// Getter
-element = el.nextElementSibling;
+A {{domxref("Element")}} object, or `null`.
 
-// No setter; read-only property
-```
-
-## Example
+## Examples
 
 ```html
 <div id="div-01">Here is div-01</div>

--- a/files/en-us/web/api/element/part/index.md
+++ b/files/en-us/web/api/element/part/index.md
@@ -16,11 +16,9 @@ represents the part identifier(s) of the element (i.e. set using the `part`
 attribute), returned as a {{domxref("DOMTokenList")}}. These can be used to style parts
 of a shadow DOM, via the {{cssxref("::part")}} pseudo-element.
 
-## Syntax
+## Value
 
-```js
-let elementPartList = element.part
-```
+A {{domxref("DOMTokenList")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/element/prefix/index.md
+++ b/files/en-us/web/api/element/prefix/index.md
@@ -16,11 +16,9 @@ The **`Element.prefix`** read-only property returns the
 namespace prefix of the specified element, or `null` if no prefix is
 specified.
 
-## Syntax
+## Value
 
-```js
-string = element.prefix
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/previouselementsibling/index.md
+++ b/files/en-us/web/api/element/previouselementsibling/index.md
@@ -18,7 +18,7 @@ one in its parent's children list, or `null` if the specified element is the fir
 
 ## Value
 
-An {{domxref("Element")}} object, or `null1.
+An {{domxref("Element")}} object, or `null`.
 
 ## Examples
 

--- a/files/en-us/web/api/element/previouselementsibling/index.md
+++ b/files/en-us/web/api/element/previouselementsibling/index.md
@@ -16,16 +16,11 @@ The **`Element.previousElementSibling`**
 read-only property returns the {{domxref("Element")}} immediately prior to the specified
 one in its parent's children list, or `null` if the specified element is the first one in the list.
 
-## Syntax
+## Value
 
-```js
-// Getter
-element = el.previousElementSibling;
+An {{domxref("Element")}} object, or `null1.
 
-// No setter; read-only property
-```
-
-## Example
+## Examples
 
 ```html
 <div id="div-01">Here is div-01</div>

--- a/files/en-us/web/api/element/scrollleft/index.md
+++ b/files/en-us/web/api/element/scrollleft/index.md
@@ -18,29 +18,7 @@ If the element's {{cssxref("direction")}} is `rtl` (right-to-left), then
 position (at the start of the scrolled content), and then increasingly negative as you
 scroll towards the end of the content.
 
-> **Warning:** On systems using display scaling, `scrollLeft` may give you a decimal
-> value.
-
-## Syntax
-
-### Getting the value
-
-```js
-// Get the number of pixels scrolled
-var sLeft = element.scrollLeft;
-```
-
-`sLeft` is an integer representing the number of pixels that
-`element` has been scrolled from the left edge.
-
-### Setting the value
-
-```js
-// Set the number of pixels scrolled
-element.scrollLeft = 10;
-```
-
-`scrollLeft` can be specified as any integer value. However:
+It can be specified as any integer value. However:
 
 - If the element can't be scrolled (e.g., it has no overflow), `scrollLeft`
   is set to `0`.
@@ -49,7 +27,14 @@ element.scrollLeft = 10;
 - If specified as a value greater than the maximum that the content can be scrolled,
   `scrollLeft` is set to the maximum.
 
-## Example
+> **Warning:** On systems using display scaling, `scrollLeft` may give you a decimal
+> value.
+
+## Value
+
+A number.
+
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/element/scrollleftmax/index.md
+++ b/files/en-us/web/api/element/scrollleftmax/index.md
@@ -17,11 +17,9 @@ The **`Element.scrollLeftMax`** read-only property returns a
 number representing the maximum left scroll offset possible for the
 element.
 
-## Syntax
+## Value
 
-```js
-var pxl = element.scrollLeftMax;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/scrolltop/index.md
+++ b/files/en-us/web/api/element/scrolltop/index.md
@@ -16,29 +16,19 @@ The **`Element.scrollTop`** property gets or sets the number of pixels that an e
 
 An element's `scrollTop` value is a measurement of the distance from the element's top to its topmost _visible_ content. When an element's content does not generate a vertical scrollbar, then its `scrollTop` value is `0`.
 
-When `scrollTop` is used on the root element (the `<html>` element), the `scrollY` of the window is returned. [This is a special case of `scrollTop`](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-scrolltop).
-
-> **Warning:** On systems using display scaling, `scrollTop` may give you a decimal value.
-
-## Syntax
-
-```js
-// Get the number of pixels scrolled.
-var intElemScrollTop = someElement.scrollTop;
-```
-
-After running this code, `intElemScrollTop` is an integer corresponding to the number of pixels that the {{domxref("element")}}'s content has been scrolled upwards.
-
-```js
-// Set the number of pixels scrolled.
-element.scrollTop = intValue;
-```
-
 `scrollTop` can be set to any integer value, with certain caveats:
 
 - If the element can't be scrolled (e.g. it has no overflow or if the element has a property of "**non-scrollable**"), `scrollTop` is `0`.
 - `scrollTop` doesn't respond to negative values; instead, it sets itself back to `0`.
 - If set to a value greater than the maximum available for the element, `scrollTop` settles itself to the maximum value.
+
+When `scrollTop` is used on the root element (the `<html>` element), the `scrollY` of the window is returned. [This is a special case of `scrollTop`](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-scrolltop).
+
+> **Warning:** On systems using display scaling, `scrollTop` may give you a decimal value.
+
+## Value
+
+A number.
 
 ## Examples
 

--- a/files/en-us/web/api/element/scrolltopmax/index.md
+++ b/files/en-us/web/api/element/scrolltopmax/index.md
@@ -17,11 +17,9 @@ The **`Element.scrollTopMax`** read-only property returns a
 number representing the maximum top scroll offset possible for the
 element.
 
-## Syntax
+## Value
 
-```js
-var pxl = elt.scrollTopMax;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/scrollwidth/index.md
+++ b/files/en-us/web/api/element/scrollwidth/index.md
@@ -28,16 +28,11 @@ without a need for horizontal scrollbar, its `scrollWidth` is equal to
 > **Note:** This property will round the value to an integer. If you need a fractional value,
 > use {{ domxref("element.getBoundingClientRect()") }}.
 
-## Syntax
+## Value
 
-```js
-var xScrollWidth = element.scrollWidth;
-```
+A number.
 
-`xScrollWidth` is the width of the content of
-`element` in pixels.
-
-## Example
+## Examples
 
 ```html
 <!DOCTYPE html>

--- a/files/en-us/web/api/file/lastmodified/index.md
+++ b/files/en-us/web/api/file/lastmodified/index.md
@@ -16,17 +16,11 @@ last modified date of the file as the number of milliseconds since the Unix
 epoch (January 1, 1970 at midnight). Files without a known last modified date return the
 current date.
 
-## Syntax
-
-```js
-const time = instanceOfFile.lastModified;
-```
-
-### Value
+## Value
 
 A number that represents the number of milliseconds since the Unix epoch.
 
-## Example
+## Examples
 
 ### Reading from file input
 

--- a/files/en-us/web/api/file/lastmodifieddate/index.md
+++ b/files/en-us/web/api/file/lastmodifieddate/index.md
@@ -17,17 +17,11 @@ browser-compat: api.File.lastModifiedDate
 
 The **`File.lastModifiedDate`** read-only property returns the last modified date of the file. Files without a known last modified date returns the current date .
 
-## Syntax
-
-```js
-var time = instanceOfFile.lastModifiedDate
-```
-
-### Value
+## Value
 
 A [`Date`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object indicating the date and time at which the file was last modified.
 
-## Example
+## Examples
 
 ```js
 // fileInput is a HTMLInputElement: <input type="file" multiple id="myfileinput">

--- a/files/en-us/web/api/file/name/index.md
+++ b/files/en-us/web/api/file/name/index.md
@@ -14,17 +14,11 @@ browser-compat: api.File.name
 Returns the name of the file represented by a {{domxref("File")}} object. For security
 reasons, the path is excluded from this property.
 
-## Syntax
-
-```js
-var name = file.name;
-```
-
 ## Value
 
 A string, containing the name of the file without path, such as "My Resume.rtf".
 
-## Example
+## Examples
 
 ```html
 <input type="file" multiple onchange="processSelectedFiles(this)">

--- a/files/en-us/web/api/file/type/index.md
+++ b/files/en-us/web/api/file/type/index.md
@@ -14,17 +14,11 @@ browser-compat: api.File.type
 
 Returns the media type ([MIME](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)) of the file represented by a {{domxref("File")}} object.
 
-## Syntax
-
-```js
-var name = file.type;
-```
-
 ## Value
 
 A string, containing the media type(MIME) indicating the type of the file, for example "image/png" for PNG images
 
-## Example
+## Examples
 
 ```html
 <input type="file" multiple onchange="showType(this)">

--- a/files/en-us/web/api/filereader/error/index.md
+++ b/files/en-us/web/api/filereader/error/index.md
@@ -14,12 +14,6 @@ browser-compat: api.FileReader.error
 The {{domxref("FileReader")}} **`error`** property returns the
 error that occurred while reading the file.
 
-## Syntax
-
-```js
-var error = instanceOfFileReader.error
-```
-
 ## Value
 
 A {{domxref("DOMError")}} containing the relevant error. In Chrome 48+/Firefox 58+ this

--- a/files/en-us/web/api/filereader/result/index.md
+++ b/files/en-us/web/api/filereader/result/index.md
@@ -18,13 +18,7 @@ file's contents. This property is only valid after the read operation is complet
 the format of the data depends on which of the methods was used to initiate the read
 operation.
 
-## Syntax
-
-```js
-var file = instanceOfFileReader.result
-```
-
-### Value
+## Value
 
 An appropriate string or {{jsxref("ArrayBuffer")}} based on which of the reading methods
 was used to initiate the read operation. The value is `null` if the reading
@@ -78,7 +72,7 @@ The result types are described below.
   </tbody>
 </table>
 
-## Example
+## Examples
 
 This example presents a function, `read()`, which reads a file from a [file input](/en-US/docs/Web/HTML/Element/input/file). It works by creating a
 {{domxref("FileReader")}} object and creating a listener for

--- a/files/en-us/web/api/filerequest/lockedfile/index.md
+++ b/files/en-us/web/api/filerequest/lockedfile/index.md
@@ -17,12 +17,6 @@ tags:
 The `lockedFile` property represents the {{domxref("LockedFile")}} object
 from which the request was started.
 
-## Syntax
-
-```js
-var lockedFile = instanceOfFileRequest.lockedFile
-```
-
 ## Value
 
 A {{domxref("LockedFile")}} object.

--- a/files/en-us/web/api/filerequest/onprogress/index.md
+++ b/files/en-us/web/api/filerequest/onprogress/index.md
@@ -16,14 +16,6 @@ tags:
 
 This property specifies a callback function to be run repeatedly while the operation represented by a {{ domxref("FileRequest") }} object is in progress.
 
-## Syntax
-
-```js
-instanceOfFileRequest.onprogress = function;
-```
-
-Where `instanceOfFileRequest` is a {{ domxref("FileRequest") }} object and `function` is the JavaScript function to execute.
-
 Each time the function callback is called, it gets an object as its first parameter. Those objects contain two properties:
 
 - `loaded`
@@ -31,7 +23,11 @@ Each time the function callback is called, it gets an object as its first parame
 - `total`
   - : A number representing the total amount of bytes that will be processed by the operation.
 
-## Example
+## Value
+
+A {{jsxref("Function")}} object.
+
+## Examples
 
 ```js
 // Assuming 'request' which is a FileRequest object

--- a/files/en-us/web/api/focusevent/relatedtarget/index.md
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.md
@@ -56,11 +56,9 @@ security reasons, like when tabbing in or out of a page.
 
 {{domxref("MouseEvent.relatedTarget")}} is a similar property for mouse events.
 
-## Syntax
+## Value
 
-```js
-secondTarget = focusEvent.relatedTarget
-```
+An instance of {{domxref("EventTarget")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/family/index.md
+++ b/files/en-us/web/api/fontface/family/index.md
@@ -19,18 +19,11 @@ allows the author to get or set the font family of a {{domxref("FontFace")}} obj
 This is equivalent to the {{cssxref("@font-face/font-family", "font-family")}}
 descriptor of {{cssxref("@font-face")}}.
 
-## Syntax
-
-```js
-instanceOfFontFace.family = 'font family name';
-let fontFace = instanceOfFontFace.family; // "font family name"
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 ```js
 let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)');

--- a/files/en-us/web/api/formdataevent/formdata/index.md
+++ b/files/en-us/web/api/formdataevent/formdata/index.md
@@ -16,13 +16,7 @@ The `formData` read only property of the {{domxref("FormDataEvent")}}
 interface contains the {{domxref("FormData")}} object representing the data contained in
 the form when the event was fired.
 
-## Syntax
-
-```js
-formData = formDataEvent.formData
-```
-
-### Returns
+## Value
 
 A {{domxref("FormData")}} object.
 

--- a/files/en-us/web/api/gainnode/gain/index.md
+++ b/files/en-us/web/api/gainnode/gain/index.md
@@ -14,21 +14,13 @@ browser-compat: api.GainNode.gain
 
 The `gain` property of the {{ domxref("GainNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing the amount of gain to apply.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var gainNode = audioCtx.createGain();
-gainNode.gain.value = 0.5;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createGain()`](/en-US/docs/Web/API/BaseAudioContext/createGain#example) for example code showing how to use an `AudioContext` to create a `GainNode`, which is then used to mute and unmute the audio by changing the gain property value.
 

--- a/files/en-us/web/api/gamepad/axes/index.md
+++ b/files/en-us/web/api/gamepad/axes/index.md
@@ -20,13 +20,11 @@ interface returns an array representing the controls with axes present on the de
 Each entry in the array is a floating point value in the range -1.0 – 1.0, representing
 the axis position from the lowest value (-1.0) to the highest value (1.0).
 
-## Syntax
+## Value
 
-```js
-const axes = gamepad.axes;
-```
+An array.
 
-## Example
+## Examples
 
 ```js
 function gameLoop() {

--- a/files/en-us/web/api/gamepad/buttons/index.md
+++ b/files/en-us/web/api/gamepad/buttons/index.md
@@ -28,13 +28,11 @@ if the button is pressed. Each {{domxref("gamepadButton")}} object has two prope
   are normalized to the range 0.0 – 1.0, with 0.0 representing a button that is not
   pressed, and 1.0 representing a button that is fully pressed.
 
-## Syntax
+## Value
 
-```js
-const buttons = gamepad.buttons;
-```
+An array.
 
-## Example
+## Examples
 
 The following code is taken from my Gamepad API button demo (you can [view the demo live](https://chrisdavidmills.github.io/gamepad-buttons/), and
 [find the source

--- a/files/en-us/web/api/gamepad/buttons/index.md
+++ b/files/en-us/web/api/gamepad/buttons/index.md
@@ -30,7 +30,7 @@ if the button is pressed. Each {{domxref("gamepadButton")}} object has two prope
 
 ## Value
 
-An array.
+An array of {{domxref("gamepadButton")}} objects.
 
 ## Examples
 

--- a/files/en-us/web/api/gamepad/connected/index.md
+++ b/files/en-us/web/api/gamepad/connected/index.md
@@ -20,13 +20,11 @@ still connected to the system.
 If the gamepad is connected, the value is `true`; if not, it is
 `false`.
 
-## Syntax
+## Value
 
-```js
-const connected = gamepad.connected;
-```
+A boolean.
 
-## Example
+## Examples
 
 ```js
 var gp = navigator.getGamepads()[0];

--- a/files/en-us/web/api/gamepad/id/index.md
+++ b/files/en-us/web/api/gamepad/id/index.md
@@ -28,13 +28,11 @@ For example, a PS2 controller returned **810-3-USB Gamepad**.
 This information is intended to allow you to find a mapping for the controls on the
 device as well as display useful feedback to the user.
 
-## Syntax
+## Value
 
-```js
-const id = gamepad.id;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 window.addEventListener("gamepadconnected", function() {

--- a/files/en-us/web/api/gamepad/timestamp/index.md
+++ b/files/en-us/web/api/gamepad/timestamp/index.md
@@ -26,13 +26,11 @@ newer values will always be greater than or equal to older values.
 
 > **Note:** This property is not currently supported anywhere.
 
-## Syntax
+## Value
 
-```js
-const timestamp = gamepad.timestamp;
-```
+A {{domxref("DOMHighResTimeStamp")}} object.
 
-## Example
+## Examples
 
 ```js
 var gp = navigator.getGamepads()[0];

--- a/files/en-us/web/api/gamepadevent/gamepad/index.md
+++ b/files/en-us/web/api/gamepadevent/gamepad/index.md
@@ -15,13 +15,11 @@ The **`GamepadEvent.gamepad`** property of the
 object, providing access to the associated gamepad data for fired
 {{event("gamepadconnected")}} and {{event("gamepaddisconnected")}} events.
 
-## Syntax
+## Value
 
-```js
-readonly attribute Gamepad gamepad;
-```
+A {{domxref("Gamepad")}} object.
 
-## Example
+## Examples
 
 The `gamepad` property being called on a fired
 {{event("gamepadconnected")}} event.

--- a/files/en-us/web/api/hashchangeevent/newurl/index.md
+++ b/files/en-us/web/api/hashchangeevent/newurl/index.md
@@ -15,17 +15,11 @@ The **`newURL`** read-only property of the
 {{domxref("HashChangeEvent")}} interface returns the new URL to which the window is
 navigating.
 
-## Syntax
-
-```js
-let newEventUrl = event.newURL;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 ```js
 window.addEventListener('hashchange', function(event) {

--- a/files/en-us/web/api/hashchangeevent/oldurl/index.md
+++ b/files/en-us/web/api/hashchangeevent/oldurl/index.md
@@ -15,17 +15,11 @@ The **`oldURL`** read-only property of the
 {{domxref("HashChangeEvent")}} interface returns the previous URL from which the window
 was navigated.
 
-## Syntax
-
-```js
-let oldEventUrl = event.oldURL;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 ```js
 window.addEventListener('hashchange', function(event) {

--- a/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlanchorelement/referrerpolicy/index.md
@@ -17,14 +17,7 @@ The
 property reflect the HTML {{htmlattrxref("referrerpolicy","a")}} attribute of the
 {{HTMLElement("a")}} element defining which referrer is sent when fetching the resource.
 
-## Syntax
-
-```js
-refStr = anchorElt.referrerPolicy;
-anchorElt.referrerPolicy = refStr;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}; one of the following:
 

--- a/files/en-us/web/api/htmlareaelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlareaelement/referrerpolicy/index.md
@@ -18,14 +18,7 @@ property reflect the HTML {{htmlattrxref("referrerpolicy","area")}} attribute of
 {{HTMLElement("area")}} element defining which referrer is sent when fetching the
 resource.
 
-## Syntax
-
-```js
-refStr = areaElt.referrerPolicy;
-areaElt.referrerPolicy = refStr;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}; one of the following:
 

--- a/files/en-us/web/api/htmldialogelement/open/index.md
+++ b/files/en-us/web/api/htmldialogelement/open/index.md
@@ -20,14 +20,7 @@ The **`open`** property of the
 {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is
 available for interaction.
 
-## Syntax
-
-```js
-dialogInstance.open = true;
-var myOpenValue = dialogInstance.open;
-```
-
-### Value
+## Value
 
 A boolean value representing the state of the {{htmlattrxref("open",
   "dialog")}} HTML attribute. `true` means it is set, and therefore the dialog

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -20,14 +20,7 @@ The **`returnValue`** property of the
 `<dialog>`, usually to indicate which button the user pressed to
 close it.
 
-## Syntax
-
-```js
-dialogInstance.returnValue = 'myReturnValue';
-var myReturnValue = dialogInstance.returnValue;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the `returnValue` of the dialog.
 

--- a/files/en-us/web/api/htmlelement/dataset/index.md
+++ b/files/en-us/web/api/htmlelement/dataset/index.md
@@ -90,13 +90,7 @@ For example, a `data-abc-def` attribute corresponds to
 - To remove an attribute, you can use the [`delete`
   operator](/en-US/docs/Web/JavaScript/Reference/Operators/delete): `delete element.dataset.keyname`
 
-## Syntax
-
-```js
-const dataAttrMap = element.dataset
-```
-
-### Value
+## Value
 
 A {{domxref("DOMStringMap")}}.
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -16,12 +16,6 @@ The **`style`** read-only property returns the _inline_ style of an element in t
 
 > **Note:** See the [CSS Properties Reference](/en-US/docs/Web/CSS/CSS_Properties_Reference) for a list of the CSS properties accessible via `style`. The `style` property has the same (and highest) priority in the CSS cascade as an inline style declaration set via the `style` attribute.
 
-## Syntax
-
-```js
-style = element.style
-```
-
 ## Value
 
 A {{domxref("CSSStyleDeclaration")}} object, with the following properties:

--- a/files/en-us/web/api/htmlelement/tabindex/index.md
+++ b/files/en-us/web/api/htmlelement/tabindex/index.md
@@ -28,18 +28,11 @@ Elements that are disabled do not participate in the tabbing order.
 Values don't need to be sequential, nor must they begin with any particular value. They
 may even be negative, though each browser trims very large values.
 
-## Syntax
-
-```js
-element.tabIndex = index;
-var index = element.tabIndex;
-```
-
-### Value
+## Value
 
 `index` is an integer
 
-## Example
+## Examples
 
 ```js
 const b1 = document.getElementById('button1');

--- a/files/en-us/web/api/htmlformelement/length/index.md
+++ b/files/en-us/web/api/htmlformelement/length/index.md
@@ -30,20 +30,11 @@ that any whose type is "image" are omitted for historical reasons),
 {{HTMLElement("object")}}, {{HTMLElement("output")}}, {{HTMLElement("select")}},
 and {{HTMLElement("textarea")}}.
 
-## Syntax
+## Value
 
-```js
-numControls = form.length;
-```
+A number.
 
-### Value
-
-`numControls` is the number of form controls within the
-`<form>`. This is the same as the number of the elements in the
-{{domxref("HTMLFormControlsCollection")}} returned by the
-{{domxref("HTMLFormElement.elements", "elements")}} property.
-
-## Example
+## Examples
 
 ```js
 if (document.getElementById('form1').length > 1) {

--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.md
@@ -17,14 +17,7 @@ property reflects the HTML {{htmlattrxref("referrerpolicy","iframe")}} attribute
 {{HTMLElement("iframe")}} element defining which referrer is sent when fetching the
 resource.
 
-## Syntax
-
-```js
-refStr = iframeElt.referrerPolicy;
-iframeElt.referrerPolicy = refStr;
-```
-
-### Values
+## Value
 
 - no-referrer
   - : The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer

--- a/files/en-us/web/api/htmlimageelement/decoding/index.md
+++ b/files/en-us/web/api/htmlimageelement/decoding/index.md
@@ -16,14 +16,7 @@ The **`decoding`** property of the
 {{domxref("HTMLImageElement")}} interface represents a hint given to the browser on how
 it should decode the image.
 
-## Syntax
-
-```js
-refStr = imgElem.decoding;
-imgElem.decoding = refStr;
-```
-
-### Values
+## Value
 
 A {{domxref("DOMString")}} representing the decoding hint. Possible values are:
 

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
@@ -17,14 +17,7 @@ property reflects the HTML {{htmlattrxref("referrerpolicy","img")}} attribute of
 {{HTMLElement("img")}} element defining which referrer is sent when fetching the
 resource.
 
-## Syntax
-
-```js
-refStr = imgElt.referrerPolicy;
-imgElt.referrerPolicy = refStr;
-```
-
-### Values
+## Value
 
 A {{domxref("DOMString")}}; one of the following:
 

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -26,13 +26,7 @@ of contents are included in the set of selected items. The selected file system
 entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries",
     "webkitEntries")}} property.
 
-## Syntax
-
-```js
- HTMLInputElement.webkitdirectory = boolValue
-```
-
-### Value
+## Value
 
 A Boolean; `true` if the {{HTMLElement("input")}} element should allow
 picking only directories or `false` if only files should be selectable.
@@ -81,7 +75,7 @@ possible to know the hierarchy even though the {{domxref("FileList")}} is flat.
 > in _Chromium < 72_. See [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=124187) for
 > further details.
 
-## Example
+## Examples
 
 In this example, a directory picker is presented which lets the user choose one or more
 directories. When the {{domxref("HTMLElement/change_event", "change")}} event occurs, a list of all files contained

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
@@ -19,13 +19,7 @@ resource.
 
 See the HTTP {{HTTPHeader("Referrer-Policy")}} header for details.
 
-## Syntax
-
-```js
-DOMString HTMLLinkElement.referrerPolicy
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}; one of the following:
 
@@ -59,7 +53,7 @@ A {{domxref("DOMString")}}; one of the following:
     will leak origins and paths from TLS-protected resources to insecure origins.
     Carefully consider the impact of this setting.
 
-## Example
+## Examples
 
 ```js
 var links = document.getElementsByTagName("link");

--- a/files/en-us/web/api/htmlmediaelement/audiotracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/audiotracks/index.md
@@ -31,13 +31,7 @@ the list, you can monitor it for changes to detect when new audio tracks are add
 existing ones removed. See {{SectionOnPage("/en-US/docs/Web/API/AudioTrackList", "Event
   handlers")}} to learn more about watching for changes to a media element's track list.
 
-## Syntax
-
-```js
-var audioTracks = mediaElement.audioTracks;
-```
-
-### Value
+## Value
 
 A {{domxref("AudioTrackList")}} object representing the list of audio tracks included
 in the media element. The list of tracks can be accessed using array notation, or using

--- a/files/en-us/web/api/htmlmediaelement/buffered/index.md
+++ b/files/en-us/web/api/htmlmediaelement/buffered/index.md
@@ -16,17 +16,11 @@ The **`buffered`** read-only property of {{domxref("HTMLMediaElement")}} objects
 
 > **Note:** This feature is not available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
-## Syntax
-
-```js
-var timeRange = audioObject.buffered
-```
-
-### Value
+## Value
 
 A new static [normalized TimeRanges object](/en-US/docs/Web/API/TimeRanges#normalized_timeranges_objects) that represents the ranges of the media resource, if any, that the user agent has buffered at the moment the `buffered` property is accessed.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/controller/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controller/index.md
@@ -14,17 +14,11 @@ browser-compat: api.HTMLMediaElement.controller
 
 The **`HTMLMediaElement.controller`** property represents the media controller assigned to the element.
 
-## Syntax
-
-```js
-...
-```
-
-### Value
+## Value
 
 A `MediaController` object or `null` if no media controller is assigned to the element. The default is `null`.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/htmlmediaelement/controls/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controls/index.md
@@ -15,19 +15,12 @@ The **`HTMLMediaElement.controls`** property reflects the
 {{htmlattrxref("controls", "video")}} HTML attribute, which controls whether user
 interface controls for playing the media item will be displayed.
 
-## Syntax
-
-```js
-var myControls = video.controls;
-audio.controls = true;
-```
-
-### Value
+## Value
 
 A boolean value. A value of `true` means controls will be
 displayed.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
@@ -17,13 +17,7 @@ absolute URL of the chosen media resource. This could happen, for example, if th
 server selects a media file based on the resolution of the user's display. The value
 is an empty string if the `networkState` property is `EMPTY`.
 
-## Syntax
-
-```js
-var mediaUrl = audioObject.currentSrc;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} object containing the absolute URL of the chosen media
 source; this may be an empty string if `networkState` is `EMPTY`;
@@ -31,7 +25,7 @@ otherwise, it will be one of the resources listed by the
 {{domxref("HTMLSourceElement")}} contained within the media element, or the value or src
 if no {{HTMLElement("source")}} element is provided.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/defaultmuted/index.md
+++ b/files/en-us/web/api/htmlmediaelement/defaultmuted/index.md
@@ -13,18 +13,11 @@ browser-compat: api.HTMLMediaElement.defaultMuted
 
 The **`HTMLMediaElement.defaultMuted`** property reflects the {{htmlattrxref("muted", "video")}} HTML attribute, which indicates whether the media element's audio output should be muted by default. This property has no dynamic effect. To mute and unmute the audio output, use the {{domxref("HTMLMediaElement.muted", "muted")}} property.
 
-## Syntax
-
-```js
-var dMuted = video.defaultMuted;
-audio.defaultMuted = true;
-```
-
-### Value
+## Value
 
 A boolean value. A value of `true` means that the audio output will be muted by default.
 
-## Example
+## Examples
 
 ```js
 var videoEle = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.md
@@ -13,14 +13,7 @@ browser-compat: api.HTMLMediaElement.defaultPlaybackRate
 
 The **`HTMLMediaElement.defaultPlaybackRate`** property indicates the default playback rate for the media.
 
-## Syntax
-
-```js
-var dSpeed = video.defaultPlaybackRate;
-audio.defaultPlaybackRate = 1.0;
-```
-
-### Value
+## Value
 
 A double. `1.0` is "normal speed," values lower than `1.0` make the media play slower than normal, higher values make it play faster.
 
@@ -29,7 +22,7 @@ A double. `1.0` is "normal speed," values lower than `1.0` make the media play s
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the specified value is not supported.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/loop/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loop/index.md
@@ -13,18 +13,11 @@ browser-compat: api.HTMLMediaElement.loop
 
 The **`HTMLMediaElement.loop`** property reflects the {{htmlattrxref("loop", "video")}} HTML attribute, which controls whether the media element should start over when it reaches the end.
 
-## Syntax
-
-```js
-var loop = video.loop;
-audio.loop = true;
-```
-
-### Value
+## Value
 
 A boolean value.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
@@ -14,17 +14,11 @@ browser-compat: api.HTMLMediaElement.mediaGroup
 
 The **`HTMLMediaElement.mediaGroup`** property reflects the {{htmlattrxref("mediaGroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common `controller`.
 
-## Syntax
-
-```js
-...
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/htmlmediaelement/muted/index.md
+++ b/files/en-us/web/api/htmlmediaelement/muted/index.md
@@ -14,19 +14,12 @@ browser-compat: api.HTMLMediaElement.muted
 The **`HTMLMediaElement.muted`** indicates whether the media
 element muted.
 
-## Syntax
-
-```js
-var isMuted = audioOrVideo.muted
-audio.muted = true;
-```
-
-### Value
+## Value
 
 A boolean value. `true` means muted and `false` means
 not muted.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/networkstate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/networkstate/index.md
@@ -15,13 +15,7 @@ The
 **`HTMLMediaElement.networkState`** property indicates the
 current state of the fetching of media over the network.
 
-## Syntax
-
-```js
-var networkState = audioOrVideo.networkState;
-```
-
-### Value
+## Value
 
 An `unsigned short`. Possible values are:
 

--- a/files/en-us/web/api/htmlmediaelement/onerror/index.md
+++ b/files/en-us/web/api/htmlmediaelement/onerror/index.md
@@ -24,13 +24,7 @@ processing {{event("error")}} events.
 The `error` event fires when some form of error occurs while attempting to
 load or perform the media.
 
-## Syntax
-
-```js
-HTMLMediaElement.onerror = EventListener;
-```
-
-### Value
+## Value
 
 A {{jsxref("function")}} which serves as the event handler for the {{event("error")}}
 event. When an error occurs, the specified function will be called. If

--- a/files/en-us/web/api/htmlmediaelement/paused/index.md
+++ b/files/en-us/web/api/htmlmediaelement/paused/index.md
@@ -14,18 +14,12 @@ browser-compat: api.HTMLMediaElement.paused
 The read-only **`HTMLMediaElement.paused`** property
 tells whether the media element is paused.
 
-## Syntax
-
-```js
-var isPaused = audioOrVideo.paused
-```
-
-### Value
+## Value
 
 A boolean value. `true` is paused and `false` is not
 paused.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/playbackrate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/playbackrate/index.md
@@ -18,20 +18,11 @@ The audio is muted when the fast forward or slow motion is outside a useful rang
 
 The pitch of the audio is corrected by default. You can disable pitch correction using the {{domxref("HTMLMediaElement.preservesPitch")}} property.
 
-## Syntax
-
-```js
-// video
-video.playbackRate = 1.5;
-// audio
-audio.playbackRate = 1.0;
-```
-
-### Value
+## Value
 
 A [`double`](https://en.wikipedia.org/wiki/Double-precision_floating-point_format). `1.0` is "normal speed," values lower than `1.0` make the media play slower than normal, higher values make it play faster. (**Default:** `1.0`)
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/readystate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/readystate/index.md
@@ -15,13 +15,7 @@ browser-compat: api.HTMLMediaElement.readyState
 The **`HTMLMediaElement.readyState`** property indicates the
 readiness state of the media.
 
-## Syntax
-
-```js
-var readyState = audioOrVideo.readyState;
-```
-
-### Value
+## Value
 
 An `unsigned short`. Possible values are:
 

--- a/files/en-us/web/api/htmlmediaelement/seekable/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seekable/index.md
@@ -19,13 +19,7 @@ browser-compat: api.HTMLMediaElement.seekable
 
 The **`seekable`** read-only property of {{domxref("HTMLMediaElement")}} objects returns a new static [normalized `TimeRanges` object](/en-US/docs/Web/API/TimeRanges#normalized_timeranges_objects) that represents the ranges of the media resource, if any, that the user agent is able to seek to at the time `seekable` property is accessed.
 
-## Syntax
-
-```js
-var seekable = audioOrVideo.seekable;
-```
-
-### Value
+## Value
 
 A new static [normalized TimeRanges object](/en-US/docs/Web/API/TimeRanges#normalized_timeranges_objects) that represents the ranges of the media resource, if any, that the user agent is able to seek to at the time `seekable` property is accessed.
 

--- a/files/en-us/web/api/htmlmediaelement/videotracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/videotracks/index.md
@@ -28,13 +28,7 @@ the list, you can monitor it for changes to detect when new video tracks are add
 existing ones removed. See {{SectionOnPage("/en-US/docs/Web/API/VideoTrackList", "Event
   handlers")}} to learn more about watching for changes to a media element's track list.
 
-## Syntax
-
-```js
-var videoTracks = mediaElement.videoTracks;
-```
-
-### Value
+## Value
 
 A {{DOMxRef("VideoTrackList")}} object representing the list of video tracks included
 in the media element. The list of tracks can be accessed using array notation, or using

--- a/files/en-us/web/api/htmlmediaelement/volume/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volume/index.md
@@ -15,18 +15,12 @@ browser-compat: api.HTMLMediaElement.volume
 The **`HTMLMediaElement.volume`** property sets the volume at
 which the media will be played.
 
-## Syntax
-
-```js
-var volume = video.volume; //1
-```
-
-### Value
+## Value
 
 A double values must fall between 0 and 1, where 0 is effectively muted and 1 is the
 loudest possible value.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('audio');

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
@@ -16,14 +16,7 @@ The **`referrerPolicy`** property of the
 {{htmlattrxref("referrerpolicy","script")}} of the {{HTMLElement("script")}} element and
 fetches made by that script, defining which referrer is sent when fetching the resource.
 
-## Syntax
-
-```js
-refStr = scriptElem.referrerPolicy;
-scriptElem.referrerPolicy = refStr;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}; one of the following:
 

--- a/files/en-us/web/api/htmltableelement/rows/index.md
+++ b/files/en-us/web/api/htmltableelement/rows/index.md
@@ -25,20 +25,14 @@ contained within any {{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, and
 Although the property itself is read-only, the returned object is live and allows the
 modification of its content.
 
-## Syntax
-
-```js
-HTMLCollectionObject = table.rows;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLCollection")}} providing a live-updating list of the
 {{domxref("HTMLTableRowElement")}} objects representing all of the {{HTMLElement("tr")}}
 elements contained in the table. This provides quick access to all of the table rows,
 without having to manually search for them.
 
-## Example
+## Examples
 
 ```js
 myrows = mytable.rows;

--- a/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.md
@@ -17,12 +17,6 @@ horizontally in the display.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-HTMLVideoElement.msHorizontalMirror: {{JSxRef("Boolean", "boolean")}};
-```
-
 ## Value
 
 Boolean value set to _true_ flips the video playback horizontally.
@@ -31,7 +25,7 @@ Video perspective is flipped on a horizontal axis - this may be useful for playb
 a webcam video, providing the user with better mirroring of their real behaviors (ie.
 when user moves left, their representation on-screen would move left as well).
 
-## Example
+## Examples
 
 ```js
        var myVideo = document.getElementById("videoTag1");

--- a/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.md
@@ -17,12 +17,6 @@ which indicates whether the video can be rendered more efficiently.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-HTMLVideoElement.msIsLayoutOptimalForPlayback: {{DOMxRef("DOMString")}};
-```
-
 ## Value
 
 Boolean value set to _true_ indicates that video is being rendered optimally

--- a/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.md
@@ -17,12 +17,6 @@ whether the system considers the loaded video source to be stereo 3-D or not.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-HTMLVideoElement.msIsStereo3D: {{JSxRef("Boolean","boolean")}};
-```
-
 ## Value
 
 {{JSxRef("Boolean")}} value set to _true_ indicates that the video source is

--- a/files/en-us/web/api/htmlvideoelement/mszoom/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mszoom/index.md
@@ -17,12 +17,6 @@ video display.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-HTMLVideoElement.msZoom;
-```
-
 ## Value
 
 Boolean value set to _true_ trims the video frame to the display space. Set to
@@ -44,7 +38,7 @@ stream coming in is in 16:9 aspect ratio, the `msZoom` option can be used to
 render the 16:9 video in 4:3 aspect ratio. The rendered video will then take up the full
 space of the video object.
 
-## Example
+## Examples
 
 This examples gets a Video object and sets the `msZoom` property to true.
 

--- a/files/en-us/web/api/idbcursor/direction/index.md
+++ b/files/en-us/web/api/idbcursor/direction/index.md
@@ -22,13 +22,7 @@ section below for possible values.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var direction = cursor.direction;
-```
-
-### Value
+## Value
 
 A string (defined by the [`IDBCursorDirection`
 enum](https://w3c.github.io/IndexedDB/#enumdef-idbcursordirection)) indicating the direction in which the cursor is traversing the data.
@@ -74,7 +68,7 @@ Possible values are:
   </tbody>
 </table>
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we

--- a/files/en-us/web/api/idbcursor/key/index.md
+++ b/files/en-us/web/api/idbcursor/key/index.md
@@ -21,17 +21,11 @@ key can be any data type.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var key = cursor.key;
-```
-
-### Value
+## Value
 
 A value of any type.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we

--- a/files/en-us/web/api/idbcursor/primarykey/index.md
+++ b/files/en-us/web/api/idbcursor/primarykey/index.md
@@ -21,17 +21,11 @@ undefined. The cursor's primary key can be any data type.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var value = cursor.primaryKey;
-```
-
-### Value
+## Value
 
 A value of any data type.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we

--- a/files/en-us/web/api/idbcursor/request/index.md
+++ b/files/en-us/web/api/idbcursor/request/index.md
@@ -18,13 +18,7 @@ The **`request`** read-only property of the {{domxref("IDBCursor")}} interface r
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-IDBCursor.request;
-```
-
-### Value
+## Value
 
 An {{domxref("IDBRequest")}} object instance.
 

--- a/files/en-us/web/api/idbcursor/source/index.md
+++ b/files/en-us/web/api/idbcursor/source/index.md
@@ -22,18 +22,12 @@ iterated past its end, or its transaction is not active.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var source = cursor.source;
-```
-
-### Value
+## Value
 
 The {{domxref("IDBObjectStore")}} or {{domxref("IDBIndex")}} that the cursor is
 iterating over.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we

--- a/files/en-us/web/api/idbcursorwithvalue/value/index.md
+++ b/files/en-us/web/api/idbcursorwithvalue/value/index.md
@@ -20,17 +20,11 @@ whatever that is.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var value = myIDBCursorWithValue.value;
-```
-
-### Value
+## Value
 
 The value of the current cursor.
 
-## Example
+## Examples
 
 In this example we create a transaction, retrieve an object store, then use a cursor to
 iterate through all the records in the object store. Within each iteration we log the

--- a/files/en-us/web/api/idbindex/isautolocale/index.md
+++ b/files/en-us/web/api/idbindex/isautolocale/index.md
@@ -17,18 +17,11 @@ browser-compat: api.IDBIndex.isAutoLocale
 
 The **`isAutoLocale`** read-only property of the {{domxref("IDBIndex")}} interface returns a boolean value indicating whether the index had a `locale` value of `auto` specified upon its creation (see [`createIndex()`'s optionalParameters](/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters).)
 
-## Syntax
-
-```js
-var myIndex = objectStore.index('index');
-console.log(myIndex.isAutoLocale);
-```
-
-### Value
+## Value
 
 A boolean value.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the index `lName` from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an `ObjectStore` using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.
 

--- a/files/en-us/web/api/idbindex/keypath/index.md
+++ b/files/en-us/web/api/idbindex/keypath/index.md
@@ -20,17 +20,11 @@ path](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key_path) of the curre
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myKeyPath = myIndex.keyPath;
-```
-
-### Value
+## Value
 
 Any data type that can be used as a key path.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbindex/locale/index.md
+++ b/files/en-us/web/api/idbindex/locale/index.md
@@ -17,18 +17,11 @@ browser-compat: api.IDBIndex.locale
 
 The **`locale`** read-only property of the {{domxref("IDBIndex")}} interface returns the locale of the index (for example `en-US`, or `pl`) if it had a `locale` value specified upon its creation (see [`createIndex()`'s optionalParameters](/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters).) Note that this property always returns the current locale being used in this index, in other words, it never returns `"auto"`.
 
-## Syntax
-
-```js
-var myIndex = objectStore.index('index');
-console.log(myIndex.locale);
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the index `lName` from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an `ObjectStore` using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.
 

--- a/files/en-us/web/api/idbindex/multientry/index.md
+++ b/files/en-us/web/api/idbindex/multientry/index.md
@@ -24,13 +24,7 @@ This is decided when the index is created, using the
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var isMultiEntry = myIndex.multiEntry;
-```
-
-### Value
+## Value
 
 A boolean value:
 
@@ -39,7 +33,7 @@ A boolean value:
 | true  | There is one record in the index for each item in an array of keys. |
 | false | There is one record for each key that is an array.                  |
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbindex/objectstore/index.md
+++ b/files/en-us/web/api/idbindex/objectstore/index.md
@@ -19,17 +19,11 @@ interface returns the name of the object store referenced by the current index.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myIDBObjectStore = myIndex.objectStore;
-```
-
-### Value
+## Value
 
 An {{ domxref("IDBObjectStore") }}.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbkeyrange/lower/index.md
+++ b/files/en-us/web/api/idbkeyrange/lower/index.md
@@ -19,18 +19,12 @@ The **`lower`** read-only property of the
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var lower = myKeyRange.lower
-```
-
-### Value
+## Value
 
 The lower bound of the key range (can be any
 type.)
 
-## Example
+## Examples
 
 The following example illustrates how you'd use a key range. Here we
 declare `keyRangeValue = IDBKeyRange.upperBound("F", "W", true, true);` — a

--- a/files/en-us/web/api/idbkeyrange/loweropen/index.md
+++ b/files/en-us/web/api/idbkeyrange/loweropen/index.md
@@ -20,13 +20,7 @@ lower-bound value is included in the key range.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var lowerOpen = myKeyRange.lowerOpen
-```
-
-### Value
+## Value
 
 A boolean value:
 
@@ -35,7 +29,7 @@ A boolean value:
 | `true`  | The lower-bound value is not included in the key range. |
 | `false` | The lower-bound value is included in the key range.     |
 
-## Example
+## Examples
 
 The following example illustrates how you'd use a key range. Here we
 declare `keyRangeValue = IDBKeyRange.upperBound("F", "W", true, true);` — a

--- a/files/en-us/web/api/idbkeyrange/upper/index.md
+++ b/files/en-us/web/api/idbkeyrange/upper/index.md
@@ -19,17 +19,11 @@ The **`upper`** read-only property of the
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var upper = myKeyRange.upper
-```
-
-### Value
+## Value
 
 The upper bound of the key range (can be any type.)
 
-## Example
+## Examples
 
 The following example illustrates how you'd use a key range. Here we
 declare `keyRangeValue = IDBKeyRange.upperBound("F", "W", true, true);` — a

--- a/files/en-us/web/api/idbkeyrange/upperopen/index.md
+++ b/files/en-us/web/api/idbkeyrange/upperopen/index.md
@@ -20,13 +20,7 @@ upper-bound value is included in the key range.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var upperOpen = myKeyRange.upperOpen
-```
-
-### Value
+## Value
 
 A boolean value:
 
@@ -35,7 +29,7 @@ A boolean value:
 | `true`  | The upper-bound value is not included in the key range. |
 | `false` | The upper-bound value is included in the key range.     |
 
-## Example
+## Examples
 
 The following example illustrates how you'd use a key range. Here we
 declare `keyRangeValue = IDBKeyRange.upperBound("F", "W", true, true);` — a

--- a/files/en-us/web/api/idbmutablefile/name/index.md
+++ b/files/en-us/web/api/idbmutablefile/name/index.md
@@ -15,12 +15,6 @@ tags:
 
 Provides the name of the file.
 
-## Syntax
-
-```js
-var name = instanceOfFileHandle.name
-```
-
 ## Value
 
 A string.

--- a/files/en-us/web/api/idbmutablefile/type/index.md
+++ b/files/en-us/web/api/idbmutablefile/type/index.md
@@ -15,12 +15,6 @@ tags:
 
 Provides the mime type of the file.
 
-## Syntax
-
-```js
-var type = instanceOfFileHandle.type
-```
-
 ## Value
 
 A string.

--- a/files/en-us/web/api/idbobjectstore/autoincrement/index.md
+++ b/files/en-us/web/api/idbobjectstore/autoincrement/index.md
@@ -22,13 +22,7 @@ Note that every object store has its own separate auto increment counter.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myAutoIncrement = objectStore.autoIncrement;
-```
-
-### Value
+## Value
 
 A boolean value:
 
@@ -37,7 +31,7 @@ A boolean value:
 | `true`  | The object store auto increments.           |
 | `false` | The object store does not auto increment.   |
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store using `add()`. After the object store has been

--- a/files/en-us/web/api/idbobjectstore/indexnames/index.md
+++ b/files/en-us/web/api/idbobjectstore/indexnames/index.md
@@ -20,17 +20,11 @@ in this object store.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myindexNames = objectStore.indexNames;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMStringList")}}.
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store using `add()`. After the object store has been

--- a/files/en-us/web/api/idbobjectstore/keypath/index.md
+++ b/files/en-us/web/api/idbobjectstore/keypath/index.md
@@ -23,17 +23,11 @@ operation.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var mykeyPath = objectStore.keyPath;
-```
-
-### Value
+## Value
 
 Any value type.
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store using `add()`. After the object store has been

--- a/files/en-us/web/api/idbobjectstore/transaction/index.md
+++ b/files/en-us/web/api/idbobjectstore/transaction/index.md
@@ -20,17 +20,11 @@ object store belongs.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var myTransaction = objectStore.transaction;
-```
-
-### Value
+## Value
 
 An {{domxref("IDBTransaction")}} object.
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store using `add()`. After the object store has been


### PR DESCRIPTION
## Summary
Sequel of https://github.com/mdn/content/pull/14195
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error