### PR TITLE
FF100 Remove HTTP Large-Allocation Header

### DIFF
--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -31,6 +31,8 @@ This article provides information about the changes in Firefox 100 that will aff
 
 #### Removals
 
+- The non-standard {{httpheader("Large-Allocation")}} HTTP header has been removed ({{bug(1598759)}}).
+
 ### Security
 
 #### Removals

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -376,7 +376,7 @@ _Learn more about CORS [here](CORS)._
   - : Contains the date and time at which the message was originated.
 - {{HTTPHeader("Early-Data")}} {{experimental_inline}}
   - : Indicates that the request has been conveyed in TLS early data.
-- {{HTTPHeader("Large-Allocation")}}
+- {{HTTPHeader("Large-Allocation")}} {{deprecated_inline}}
   - : Tells the browser that the page being loaded is going to want to perform a large allocation.
 - {{HTTPHeader("Link")}}
   - : The [`Link`](https://datatracker.ietf.org/doc/html/rfc5988#section-5) entity-header field provides a means for serializing one or more links in HTTP headers. It is semantically equivalent to the HTML {{HTMLElement("link")}} element.

--- a/files/en-us/web/http/headers/large-allocation/index.md
+++ b/files/en-us/web/http/headers/large-allocation/index.md
@@ -4,17 +4,17 @@ slug: Web/HTTP/Headers/Large-Allocation
 tags:
   - HTTP
   - HTTP Header
-  - Non-standard
   - Reference
   - Response Header
   - header
+  - Deprecated
+  - Non-standard
 browser-compat: http.headers.Large-Allocation
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}} {{Deprecated_Header}}
 
-The non-standard **`Large-Allocation`** response header tells
-the browser that the page being loaded is going to want to perform a large allocation.
-It is currently only implemented in Firefox, but is harmless to send to every browser.
+The non-standard **`Large-Allocation`** response header tells the browser that the page being loaded is going to want to perform a large allocation.
+It not implemented in current versions of any browser, but is harmless to send to any browser.
 
 [WebAssembly](/en-US/docs/WebAssembly) or asm.js applications can use large
 contiguous blocks of allocated memory. For complex games, for example, these allocations
@@ -104,15 +104,12 @@ console](/en-US/docs/Tools/Web_Console).
   - : Firefox currently only supports the `Large-Allocation` header in our
     32-bit Windows builds, as memory fragmentation is not an issue in 64-bit builds. If
     you are running a non-win32 version of Firefox, this error will appear. This check can
-    be disabled with the "dom.largeAllocation.
-
-    forceEnable" boolean preference in about:config.
+    be disabled with the "dom.largeAllocation.forceEnable" boolean preference in about:config.
 
 ## Specifications
 
 Not part of any current specifications. An explainer of the ideas behind this header
-can be found in [this
-document](https://gist.github.com/mystor/5739e222e398efc6c29108be55eb6fe3).
+can be found in [this document](https://gist.github.com/mystor/5739e222e398efc6c29108be55eb6fe3).
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/large-allocation/index.md
+++ b/files/en-us/web/http/headers/large-allocation/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.Large-Allocation
 {{HTTPSidebar}} {{Deprecated_Header}}
 
 The non-standard **`Large-Allocation`** response header tells the browser that the page being loaded is going to want to perform a large allocation.
-It not implemented in current versions of any browser, but is harmless to send to any browser.
+It's not implemented in current versions of any browser, but is harmless to send to any browser.
 
 [WebAssembly](/en-US/docs/WebAssembly) or asm.js applications can use large
 contiguous blocks of allocated memory. For complex games, for example, these allocations
@@ -104,7 +104,7 @@ console](/en-US/docs/Tools/Web_Console).
   - : Firefox currently only supports the `Large-Allocation` header in our
     32-bit Windows builds, as memory fragmentation is not an issue in 64-bit builds. If
     you are running a non-win32 version of Firefox, this error will appear. This check can
-    be disabled with the "dom.largeAllocation.forceEnable" boolean preference in about:config.
+    be disabled with the `dom.largeAllocation.forceEnable` boolean preference in about:config.
 
 ## Specifications
 

--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -85,5 +85,4 @@ And what's even better is that it is being developed as a web standard via the [
 - [webassembly.org](https://webassembly.org/)
 - [WebAssembly articles on Mozilla Hacks blog](https://hacks.mozilla.org/category/webassembly/)
 - [W3C WebAssembly Community Group](https://www.w3.org/community/webassembly/)
-- [Large-Allocation HTTP header](/en-US/docs/Web/HTTP/Headers/Large-Allocation)
 - [Emscripting a C Library to Wasm](https://developers.google.com/web/updates/2018/03/emscripting-a-c-library)


### PR DESCRIPTION
This is part of FF100 docs for removal of the [Large-Allocation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Large-Allocation) HTTP header in https://bugzilla.mozilla.org/show_bug.cgi?id=1598759

It includes the release note and updates to add deprecation tagging etc.

Other docs work can be tracked in #14407