### PR TITLE
Fix link to the “labelable” content category in HTML `<label>`

### DIFF
--- a/files/en-us/web/html/element/label/index.md
+++ b/files/en-us/web/html/element/label/index.md
@@ -48,7 +48,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("for")}}
 
-  - : The value of the `for` attribute must be a single {{htmlattrxref("id")}} for a [labelable](/en-US/docs/Web/Guide/HTML/Content_categories#form_labelable) form-related element in the same document as the `<label>` element. So, any given `label` element can be associated with only one form control.
+  - : The value of the `for` attribute must be a single {{htmlattrxref("id")}} for a [labelable](/en-US/docs/Web/Guide/HTML/Content_categories#labelable) form-related element in the same document as the `<label>` element. So, any given `label` element can be associated with only one form control.
 
     > **Note:** To programmatically set the `for` attribute, use [`htmlFor`](/en-US/docs/Web/API/HTMLLabelElement/htmlFor).
   
@@ -169,7 +169,7 @@ An {{HTMLElement("input")}} element with a `type="button"` declaration and a val
         <a href="/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content"
           >Phrasing content</a
         >, but no descendant <code>label</code> elements. No
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#form_labelable"
+        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#labelable"
           >labelable</a
         >
         elements other than the labeled control are allowed.


### PR DESCRIPTION
#### Summary

The `id` in the link to the [labelable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#labelable) category of content is the wrong one. This PR fix it.

#### Motivation

Better navigation by fixing broken links.

#### Metadata

This PR…
- [ ] ~Adds a new document~
- [ ] ~Rewrites (or significantly expands) a document~
- [x] Fixes a typo, bug, or other error
