### PR TITLE
Add CSS revert-layer to FF 97 release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -20,13 +20,15 @@ No notable changes
 ### CSS
 
 - The CSS units `cap` and `ic` are now supported for use with {{cssxref("&lt;length&gt;")}} and {{cssxref("&lt;length-percentage&gt;")}} data types.
-  For more information see {{bug(1702924)}} and {{bug(1531223)}}
+  For more information, see {{bug(1702924)}} and {{bug(1531223)}}.
 
 - The CSS property `color-adjust` has been renamed to {{cssxref("print-color-adjust")}} to match the relevant specification.
   The `color-adjust` shorthand name is deprecated.
   See {{bug(747595)}} for details.
 
 - CSS cascade layers are now available by default. The [`@layer`](/en-US/docs/Web/CSS/@layer) rule declares a cascade layer, which allows declaration of styles and can be imported via the [`@import`](/en-US/docs/Web/CSS/@import) rule using the `layer()` function. See {{bug(1699217)}} for more details.
+
+- The global CSS keyword {{cssxref("revert-layer")}} has been added to allow rolling back of property values in one cascade layer to the matching rules in the previous cascade layer. This keyword can be applied on any property, including the CSS shorthand property {{cssxref("all")}}. For more information, see {{bug(1699220)}}.
 
 - The CSS [`scrollbar-gutter`](/en-US/docs/Web/CSS/scrollbar-gutter) property is now supported. This gives developers control over reserved space for the scrollbar, preventing unwanted layout changes as the content grows.
   See {{bug(1715112)}} for more details.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

A new global keyword was introduced in FF97, the `revert-layer` keyword.

This PR updates the FF97 release note to indicate the introduction of this keyword.



#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Content issue tracking this work: https://github.com/mdn/content/issues/13373
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
