### PR TITLE
Fix media query syntax in the media="" attribute

### DIFF
--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -47,7 +47,7 @@ By default, CSS is treated as a [render blocking](/en-US/docs/Web/Performance/Cr
 
 ```html
 <link href="style.css"    rel="stylesheet" media="all">
-<link href="portrait.css" rel="stylesheet" media="orientation:portrait">
+<link href="portrait.css" rel="stylesheet" media="(orientation:portrait)">
 <link href="print.css"    rel="stylesheet" media="print">
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix the syntax in an example.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Parens have to be included for media conditions.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.w3.org/TR/mediaqueries-5/#typedef-media-condition

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
