### PR TITLE
Overlay property compatibility on Safari note

### DIFF
--- a/files/en-us/web/css/overflow/index.md
+++ b/files/en-us/web/css/overflow/index.md
@@ -59,7 +59,7 @@ The `overflow` property is specified as one or two keywords chosen from the list
 - `auto`
   - : Depends on the {{Glossary("user agent")}}. If content fits inside the padding box, it looks the same as `visible`, but still establishes a new block formatting context. Desktop browsers provide scrollbars if content overflows.
 - `overlay` {{deprecated_inline}}
-  - : Behaves the same as `auto`, but with the scrollbars drawn on top of content instead of taking up space. Not fully supported by all browsers; for example, Safari will recognize `overlay` but will treat it the same as `auto`.
+  - : Behaves the same as `auto`, but with the scrollbars drawn on top of content instead of taking up space.
 
 #### Mozilla extensions
 

--- a/files/en-us/web/css/overflow/index.md
+++ b/files/en-us/web/css/overflow/index.md
@@ -59,7 +59,7 @@ The `overflow` property is specified as one or two keywords chosen from the list
 - `auto`
   - : Depends on the {{Glossary("user agent")}}. If content fits inside the padding box, it looks the same as `visible`, but still establishes a new block formatting context. Desktop browsers provide scrollbars if content overflows.
 - `overlay` {{deprecated_inline}}
-  - : Behaves the same as `auto`, but with the scrollbars drawn on top of content instead of taking up space. Only supported in WebKit-based (e.g., Safari) and Blink-based (e.g., Chrome or Opera) browsers.
+  - : Behaves the same as `auto`, but with the scrollbars drawn on top of content instead of taking up space. Not fully supported by all browsers; for example, Safari will recognize `overlay` but will treat it the same as `auto`.
 
 #### Mozilla extensions
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The `overlay` property is not actually supported in Safari as is currently implied.

#### Motivation
I tried to use `overflow: overlay` thinking it would be compatible with Safari and it is not. I'd like to save others the time.

#### Supporting details

https://caniuse.com/?search=overlay

#### Related issues

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
