### PR TITLE
Fixing private methods explanation

### DIFF
--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -138,7 +138,7 @@ Run the code using [JSFiddle](https://jsfiddle.net/vnkuZ/7726/).
 
 Languages such as Java allow you to declare methods as private, meaning that they can be called only by other methods in the same class.
 
-JavaScript does not provide a native way of doing this, but it is possible to emulate private methods using closures. Private methods aren't just useful for restricting access to code. They also provide a powerful way of managing your global namespace.
+JavaScript previously didn't have a native way of declaring [`private methods`](en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#private_methods), but it was possible to emulate private methods using closures. Private methods aren't just useful for restricting access to code. They also provide a powerful way of managing your global namespace.
 
 The following code illustrates how to use closures to define public functions that can access private functions and variables. Note that these closures follow the [Module Design Pattern](http://www.google.com/search?q=javascript+module+pattern).
 


### PR DESCRIPTION
Nowadays JS has a way to declare private methods, that's why the explanation in the **Emulating private methods with closures** example is not accurate.

 **NOTE:** Not sure if we need to rewrite the whole section, I've thought that this minimal addition should suffice. Would be happy to hear other opinions.