### PR TITLE
docs(SubtleCrypto): fix example code

### DIFF
--- a/files/en-us/web/api/subtlecrypto/generatekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.md
@@ -91,7 +91,7 @@ This code generates an RSA-OAEP encryption key pair. [See
 the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/encrypt-decrypt/rsa-oaep.js)
 
 ```js
-let keyPair = window.crypto.subtle.generateKey(
+let keyPair = await window.crypto.subtle.generateKey(
   {
     name: "RSA-OAEP",
     modulusLength: 4096,
@@ -109,7 +109,7 @@ This code generates an ECDSA signing key pair. [See
 the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
 
 ```js
-let keyPair = window.crypto.subtle.generateKey(
+let keyPair = await window.crypto.subtle.generateKey(
   {
     name: "ECDSA",
     namedCurve: "P-384"
@@ -125,7 +125,7 @@ This code generates an HMAC signing key. [See
 the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
 
 ```js
-let key = window.crypto.subtle.generateKey(
+let key = await window.crypto.subtle.generateKey(
   {
     name: "HMAC",
     hash: {name: "SHA-512"}
@@ -141,7 +141,7 @@ This code generates an AES-GCM encryption key. [See
 the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/encrypt-decrypt/aes-gcm.js)
 
 ```js
-let key = window.crypto.subtle.generateKey(
+let key = await window.crypto.subtle.generateKey(
   {
     name: "AES-GCM",
     length: 256


### PR DESCRIPTION
`generateKey` returns a Promise. The variable names (`key` and `keyPair`) seem to indicate that these are actual values, but unawaited they are promises. Adding an await makes that more clear.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I'm fixing the example code in the SubtleCrypto `generateKey` docs; this method returns a Promise, but the example snippets suggest (at least implicitly) that they resolve immediately.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It will help people reading the SubtleCrypto docs.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
