### PR TITLE
Un-deprecate navigator.platform (was: Replace Deprecated_Header in navigator.platform doc and adjust navigator.userAgentData.platform note wording)

### DIFF
--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Navigator.platform
 
 > **Warning:** Use of this feature is discouraged. It may have known problems, or it may be a feature that works as expected now, but which in the future may change in a way that will break code that relies on it continuing to work in the same way it does now. Or it may be a feature which a specification has marked as deprecated or obsolete. Avoid using it, and update existing code if possible; see the [compatibility table](#browser_compatibility) to guide your decision.
 
-> **Note:** An alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not yet supported by most browsers, and the specification which defines it has not yet been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
+> **Note:** An alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not supported by most browsers, and the specification which defines it has not been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
 
 Returns a string representing the platform of the browser.
 The specification allows browsers to always return the empty string, so don't rely on this property to get a reliable answer.

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }}
 
-> **Warning:** Use of this feature is discouraged. It may have known problems, or it may be a feature that works as expected now, but for which in the future behavior may change in a way that will break code that relies on it continuing to work in the same way it does now. Or it may be a feature which a specification has marked as deprecated or obsolete. Avoid using it, and update existing code if possible; see the [compatibility table](#browser_compatibility) to guide your decision.
+> **Warning:** Use of this feature is discouraged. It may have known problems, or it may be a feature that works as expected now, but which in the future may change in a way that will break code that relies on it continuing to work in the same way it does now. Or it may be a feature which a specification has marked as deprecated or obsolete. Avoid using it, and update existing code if possible; see the [compatibility table](#browser_compatibility) to guide your decision.
 
 > **Note:** An alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not yet supported by most browsers, and the specification which defines it has not yet been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
 

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }}
 
-Returns a string identify the platform on which the user’s browser is running.
+Returns a string identifying the platform on which the user’s browser is running.
 
 > **Note:** In general, you should whenever possible avoid writing code that uses methods or properties like this one to try to find out information about the user’s environment, and instead write code that does [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection).
 

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -32,7 +32,7 @@ if (navigator.platform.indexOf("Mac") === 0 || navigator.platform === "iPhone") 
 }
 ```
 
-That is, check `navigator.platform` for a match on the substring `"Mac"`, or an exact match for the string `"iPhone"`, and then based on whether or not there’s a match, choose the modifier key that your web application’s UI will advise users to press in keyboard shortcuts.
+That is, check if `navigator.platform` starts with `"Mac"` or else is an exact match for `"iPhone"`, and then based on whether either of those is true, choose the modifier key your web application’s UI will advise users to press in keyboard shortcuts.
 
 ## Usage notes
 

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -1,5 +1,5 @@
 ---
-title: Navigator.platform
+title: navigator.platform
 slug: Web/API/Navigator/platform
 tags:
   - API
@@ -13,25 +13,26 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }}
 
-> **Warning:** Use of this feature is discouraged. It may have known problems, or it may be a feature that works as expected now, but which in the future may change in a way that will break code that relies on it continuing to work in the same way it does now. Or it may be a feature which a specification has marked as deprecated or obsolete. Avoid using it, and update existing code if possible; see the [compatibility table](#browser_compatibility) to guide your decision.
+Returns a string identify the platform on which the user’s browser is running.
 
-> **Note:** An alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not supported by most browsers, and the specification which defines it has not been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
-
-Returns a string representing the platform of the browser.
-The specification allows browsers to always return the empty string, so don't rely on this property to get a reliable answer.
+> **Note:** In general, you should whenever possible avoid writing code that uses methods or properties like this one to try to find out information about the user’s environment, and instead write code that does [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection).
 
 ## Value
 
-A {{domxref("DOMString")}} identifying the platform on which the browser is running, or an empty string if the browser declines to (or is unable to) identify the platform.
-`platform` is a string that must be an empty string or a string representing the platform on which the browser is executing.
-
-For example: "`MacIntel`", "`Win32`", "`FreeBSD i386`", "`WebTV OS`"
+A string identifying the platform on which the user’s browser is running; for example: "`MacIntel`", "`Win32`", "`Linux x86_64`", "`Linux x86_64`".
 
 ## Example
 
+`navigator.platform` should almost always be avoided in favor of [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection). But there is one case where, among the options you could use, `navigator.platform` may be the least-bad option: When you need to show users advice about whether the modifier key for keyboard shortcuts is the `⌘` command key (found on Apple systems) rather than the `⌃` control key (on non-Apple systems):
+
 ```js
-console.log(navigator.platform);
+let modifierKeyPrefix = "^"; // control key
+if (navigator.platform.indexOf("Mac") === 0 || navigator.platform === "iPhone") {
+    modifierKeyPrefix = "⌘"; // command key
+}
 ```
+
+That is, check `navigator.platform` for a match on the substring `"Mac"`, or an exact match for the string `"iPhone"`, and then based on whether or not there’s a match, choose the modifier key that your web application’s UI will advise users to press in keyboard shortcuts.
 
 ## Usage notes
 
@@ -45,3 +46,7 @@ Internet Explorer and versions of Firefox prior to version 63 still report `"Win
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`navigator.userAgentData.platform`](/en-US/docs/Web/API/NavigatorUAData/platform)

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -19,7 +19,7 @@ Returns a string identify the platform on which the user’s browser is running.
 
 ## Value
 
-A string identifying the platform on which the user’s browser is running; for example: "`MacIntel`", "`Win32`", "`Linux x86_64`", "`Linux x86_64`".
+A string identifying the platform on which the user’s browser is running; for example: `"MacIntel"`, `"Win32"`, `"Linux x86_64"`, `"Linux x86_64"`.
 
 ## Example
 

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -11,7 +11,9 @@ tags:
   - platform
 browser-compat: api.Navigator.platform
 ---
-{{ APIRef("HTML DOM") }} {{Deprecated_Header}}
+{{ APIRef("HTML DOM") }}
+
+> **Warning:** Use of this feature is discouraged. It may have known problems, or it may be a feature that works as expected now, but for which in the future behavior may change in a way that will break code that relies on it continuing to work in the same way it does now. Or it may be a feature which a specification has marked as deprecated or obsolete. Avoid using it, and update existing code if possible; see the [compatibility table](#browser_compatibility) to guide your decision.
 
 > **Note:** An alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not yet supported by most browsers, and the specification which defines it has not yet been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
 

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }} {{Deprecated_Header}}
 
-> **Note:** The recommended alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not yet supported by some major browsers, and the specification which defines it has not yet been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
+> **Note:** An alternative to this property is {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}}. However, {{domxref("NavigatorUAData.platform", "navigator.userAgentData.platform")}} is not yet supported by most browsers, and the specification which defines it has not yet been adopted by any standards group (specifically, it is not part of any specification published by the W3C or WHATWG).
 
 Returns a string representing the platform of the browser.
 The specification allows browsers to always return the empty string, so don't rely on this property to get a reliable answer.

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }}
 
-Returns a string identifying the platform on which the user’s browser is running.
+The **`platform`** property read-only property of the {{domxref("Navigator")}} interface returns a string identifying the platform on which the user’s browser is running.
 
 > **Note:** In general, you should whenever possible avoid writing code that uses methods or properties like this one to try to find out information about the user’s environment, and instead write code that does [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection).
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14429. For the `navigator.platform` article, this change does the following:

- Drop the `Deprecated_Header` macro.
- Add admonishments that `navigator.platform` should be avoided in favor of feature detection.
- Relegate mention of (equally-bad) `navigator.userAgentData.platform` to just being a **See also**.
- Add an example of the single known good case where using `navigator.platform` isn’t completely bad.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/15599

<details>
<summary>Previous/now-superseded issue description…</summary>

- 4db8611c2e Adjust wording of note about navigator.userAgentData.platform
- f73b2d9534 Replace Deprecated_Header in navigator.platform doc

Given `navigator.userAgentData.platform` is currently only supported in Blink, we shouldn’t be strongly “recommending” it; so 4db8611c2e drops the _“recommended”_ and instead just points out `navigator.userAgentData.platform` as an alternative — while changing the _“not yet supported by some major browsers”_ wording to instead more accurately state it’s _“not yet supported by **most** browsers”_.

And given that `navigator.platform` is not formally deprecated by the spec, f73b2d9534 replaces the `Deprecated_Header` macro and its boilerplate text with some more-appropriate alternative pseudo-boilerplate text that’s intentionally broadly worded in such as way as to not be specific to just the `navigator.platform` case but instead worded for the general case where we want to warn web developers to avoid using a particular feature.

See also https://github.com/mdn/content/pull/12017#issuecomment-1013619727.
</details>