### PR TITLE
WebAPI: Clean syntax from property pages, part 11

### DIFF
--- a/files/en-us/web/api/accelerometer/x/index.md
+++ b/files/en-us/web/api/accelerometer/x/index.md
@@ -24,7 +24,7 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 
 A {{jsxref('Number')}}.
 
-## Example
+## Examples
 
 Acceleration is typically read in the {{domxref('Sensor.reading_event', 'reading')}} event callback. In the example below this occurs sixty times a second.
 

--- a/files/en-us/web/api/accelerometer/y/index.md
+++ b/files/en-us/web/api/accelerometer/y/index.md
@@ -24,7 +24,7 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 
 A {{jsxref('Number')}}.
 
-## Example
+## Examples
 
 Acceleration is typically read in the {{domxref('Sensor.reading_event', 'reading')}} event callback. In the example below this occurs sixty times a second.
 

--- a/files/en-us/web/api/accelerometer/z/index.md
+++ b/files/en-us/web/api/accelerometer/z/index.md
@@ -24,7 +24,7 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 
 A {{jsxref('Number')}}.
 
-## Example
+## Examples
 
 Acceleration is typically read in the {{domxref('Sensor.reading_event', 'reading')}} event callback. In the example below this occurs sixty times a second.
 

--- a/files/en-us/web/api/ambientlightsensor/illuminance/index.md
+++ b/files/en-us/web/api/ambientlightsensor/illuminance/index.md
@@ -23,7 +23,7 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 
 A {{jsxref('Number')}} indicating the current light level in lux.
 
-## Example
+## Examples
 
 ```js
 if ( 'AmbientLightSensor' in window ) {

--- a/files/en-us/web/api/analysernode/fftsize/index.md
+++ b/files/en-us/web/api/analysernode/fftsize/index.md
@@ -25,7 +25,7 @@ Must be a power of 2 between 2^5 and 2^15, so one of: `32`, `64`, `128`, `256`, 
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if the value set is not a power of 2, or is outside the allowed range.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect time domain data repeatedly and draw an "oscilloscope style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -20,7 +20,7 @@ An unsigned integer, equal to the number of values that {{domxref("AnalyserNode.
 
 For technical reasons related to how the [Fast Fourier transform](https://en.wikipedia.org/wiki/Fast_Fourier_transform) is defined, it is always half the value of {{domxref("AnalyserNode.fftSize")}}. Therefore, it will be one of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`, `8192`, and `16384`.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bargraph style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.md
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.md
@@ -25,7 +25,7 @@ When getting data from `getByteFrequencyData()`, any frequencies with an amplitu
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if a value less than or equal to `AnalyserNode.minDecibels` is set.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bargraph style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -22,7 +22,7 @@ When getting data from `getByteFrequencyData()`, any frequencies with an amplitu
 
 > **Note:** If a value greater than `AnalyserNode.maxDecibels` is set, an `INDEX_SIZE_ERR` exception is thrown.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bargraph style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -24,7 +24,7 @@ In technical terms, we apply a [Blackman window](https://webaudio.github.io/web-
 
 > **Note:** If a value outside the range 0–1 is set, an `INDEX_SIZE_ERR` exception is thrown.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bargraph style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/animation/playstate/index.md
+++ b/files/en-us/web/api/animation/playstate/index.md
@@ -30,7 +30,7 @@ The **`Animation.playState`** property of the [Web Animations API](/en-US/docs/W
 
 Previously, Web Animations defined a **`pending`** value to indicate that some asynchronous operation such as initiating playback was yet to complete. This is now indicated by the separate {{domxref("Animation.pending")}} property.
 
-## Example
+## Examples
 
 In the [Growing/Shrinking Alice Game](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) example, players can get an ending with [Alice crying into a pool of tears](https://codepen.io/rachelnabors/pen/EPJdJx?editors=0010). In the game, for performance reasons, the tears should only be animating when they're visible. So they must be paused as soon as they are animated like so:
 

--- a/files/en-us/web/api/animation/ready/index.md
+++ b/files/en-us/web/api/animation/ready/index.md
@@ -29,7 +29,7 @@ animation.ready.then(function() {
 });
 ```
 
-## Example
+## Examples
 
 In the following example, the state of the animation will be `running` when the **current ready Promise** is resolved because the animation does not leave the `pending` play state in between the calls to `pause` and `play` and hence the **current ready Promise** does not change.
 

--- a/files/en-us/web/api/audiobuffer/duration/index.md
+++ b/files/en-us/web/api/audiobuffer/duration/index.md
@@ -20,7 +20,7 @@ stored in the buffer.
 
 A double.
 
-## Example
+## Examples
 
 ```js
 // Stereo

--- a/files/en-us/web/api/audiobuffer/length/index.md
+++ b/files/en-us/web/api/audiobuffer/length/index.md
@@ -20,7 +20,7 @@ stored in the buffer.
 
 An integer.
 
-## Example
+## Examples
 
 ```js
 // Stereo

--- a/files/en-us/web/api/audiobuffer/numberofchannels/index.md
+++ b/files/en-us/web/api/audiobuffer/numberofchannels/index.md
@@ -20,7 +20,7 @@ described by the PCM data stored in the buffer.
 
 An integer.
 
-## Example
+## Examples
 
 ```js
 // Stereo

--- a/files/en-us/web/api/audiobuffer/samplerate/index.md
+++ b/files/en-us/web/api/audiobuffer/samplerate/index.md
@@ -21,7 +21,7 @@ samples per second, of the PCM data stored in the buffer.
 A floating-point value indicating the current sample rate of the buffers data, in
 samples per second.
 
-## Example
+## Examples
 
 ```js
 // Stereo

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -27,7 +27,7 @@ generates a single channel containing silence (that is, every sample is 0).
 An {{domxref("AudioBuffer")}} which contains the data representing the sound which the
 node will play.
 
-## Example
+## Examples
 
 > **Note:** For a full working example, see [this code running
 > live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.md
@@ -28,7 +28,7 @@ whose value indicates the detuning of oscillation in [cents](https://en.wikipedi
 > **Note:** Though the `AudioParam` returned is read-only, the
 > value it represents is not.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.md
@@ -32,7 +32,7 @@ time specified by the {{domxref("AudioBufferSourceNode.loopEnd", "loopEnd")}} pr
 is reached, playback continues at the time specified by
 {{domxref("AudioBufferSourceNode.loopStart", "loopStart")}}
 
-## Example
+## Examples
 
 In this example, the {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} function is used to
 decode an audio track and put it into an {{domxref("AudioBufferSourceNode")}}. Buttons

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
@@ -32,7 +32,7 @@ only used if the {{domxref("AudioBufferSourceNode.loop", "loop")}} property is
 
 The default value is 0.
 
-## Example
+## Examples
 
 In this example, the {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} function is used to
 decode an audio track and put it into an {{domxref("AudioBufferSourceNode")}}. Buttons

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
@@ -27,7 +27,7 @@ A floating-point number indicating the offset, in seconds, into the audio buffer
 which each loop should begin during playback. This value is only used when the
 {{domxref("AudioBufferSourceNode.loop", "loop")}} parameter is `true`.
 
-## Example
+## Examples
 
 In this example, the {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} function is used to
 decode an audio track and put it into an {{domxref("AudioBufferSourceNode")}}. Buttons

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
@@ -35,7 +35,7 @@ second). Let's see what a few values of `playbackRate` do:
 - A `playbackRate` of 0.5 plays the audio at half speed, or 22,050 Hz.
 - A `playbackRate` of 2.0 doubles the audio's playback rate to 88,200 Hz.
 
-## Example
+## Examples
 
 In this example, the {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} function is used to
 decode an audio track, and put it into an {{domxref("AudioBufferSourceNode")}}. Buttons

--- a/files/en-us/web/api/audiocontext/baselatency/index.md
+++ b/files/en-us/web/api/audiocontext/baselatency/index.md
@@ -27,7 +27,7 @@ into the host system's audio subsystem ready for playing.
 
 A double representing the base latency in seconds.
 
-## Example
+## Examples
 
 ```js
 // default latency ("interactive")

--- a/files/en-us/web/api/audiocontext/outputlatency/index.md
+++ b/files/en-us/web/api/audiocontext/outputlatency/index.md
@@ -27,7 +27,7 @@ It varies depending on the platform and the available hardware.
 
 A double representing the output latency in seconds.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audiodata/duration/index.md
+++ b/files/en-us/web/api/audiodata/duration/index.md
@@ -13,7 +13,7 @@ browser-compat: api.AudioData.duration
 
 The **`duration`** read-only property of the {{domxref("AudioData")}} interface returns the duration in microseconds of this `AudioData` object.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audiodata/format/index.md
+++ b/files/en-us/web/api/audiodata/format/index.md
@@ -13,7 +13,7 @@ browser-compat: api.AudioData.format
 
 The **`format`** read-only property of the {{domxref("AudioData")}} interface returns the sample format of the `AudioData` object.
 
-### Value
+## Value
 
 A string. One of:
 

--- a/files/en-us/web/api/audiodata/numberofchannels/index.md
+++ b/files/en-us/web/api/audiodata/numberofchannels/index.md
@@ -13,7 +13,7 @@ browser-compat: api.AudioData.numberOfChannels
 
 The **`numberOfChannels`** read-only property of the {{domxref("AudioData")}} interface returns the number of channels in the `AudioData` object.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audiodata/numberofframes/index.md
+++ b/files/en-us/web/api/audiodata/numberofframes/index.md
@@ -13,7 +13,7 @@ browser-compat: api.AudioData.numberOfFrames
 
 The **`numberOfFrames`** read-only property of the {{domxref("AudioData")}} interface returns the number of frames in the `AudioData` object.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audiodata/samplerate/index.md
+++ b/files/en-us/web/api/audiodata/samplerate/index.md
@@ -13,7 +13,7 @@ browser-compat: api.AudioData.sampleRate
 
 The **`sampleRate`** read-only property of the {{domxref("AudioData")}} interface returns the sample rate in Hz.
 
-### Value
+## Value
 
 A decimal value.
 

--- a/files/en-us/web/api/audiodata/timestamp/index.md
+++ b/files/en-us/web/api/audiodata/timestamp/index.md
@@ -13,7 +13,7 @@ browser-compat: api.AudioData.timestamp
 
 The **`duration`** read-only property of the {{domxref("AudioData")}} interface returns the timestamp of this `AudioData` object.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
+++ b/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
@@ -20,7 +20,7 @@ The {{domxref("AudioNode.channelCount")}} property can be set between 0 and this
 
 An `unsigned long`.
 
-## Example
+## Examples
 
 The following would set up a simple audio graph, featuring an `AudioDestinationNode` with `maxChannelCount` of 2:
 

--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.md
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.md
@@ -25,7 +25,7 @@ The `dopplerFactor` property's default value is `1`, which is a sensible default
 
 A double indicating the doppler effect's pitch shift value. The value is 1 by default.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.md
+++ b/files/en-us/web/api/audiolistener/forwardx/index.md
@@ -21,7 +21,7 @@ The `forwardX` read-only property of the {{ domxref("AudioListener") }} interfac
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/forwardy/index.md
+++ b/files/en-us/web/api/audiolistener/forwardy/index.md
@@ -21,7 +21,7 @@ The `forwardY` read-only property of the {{ domxref("AudioListener") }} interfac
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [BaseAudioContext.createPanner()](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/forwardz/index.md
+++ b/files/en-us/web/api/audiolistener/forwardz/index.md
@@ -21,7 +21,7 @@ The `forwardZ` read-only property of the {{ domxref("AudioListener") }} interfac
 
 An {{domxref("AudioParam")}}. Its default value is -1, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -21,7 +21,7 @@ The `positionX` read-only property of the {{ domxref("AudioListener") }} interfa
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -21,7 +21,7 @@ The `positionY` read-only property of the {{ domxref("AudioListener") }} interfa
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -21,7 +21,7 @@ The `positionZ` read-only property of the {{ domxref("AudioListener") }} interfa
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/speedofsound/index.md
+++ b/files/en-us/web/api/audiolistener/speedofsound/index.md
@@ -29,7 +29,7 @@ shift](https://en.wikipedia.org/wiki/Doppler_effect) appropriate for the speed t
 
 A double.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/upx/index.md
+++ b/files/en-us/web/api/audiolistener/upx/index.md
@@ -21,7 +21,7 @@ The `upX` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 For more detailed example code see [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example).
 

--- a/files/en-us/web/api/audiolistener/upy/index.md
+++ b/files/en-us/web/api/audiolistener/upy/index.md
@@ -20,7 +20,7 @@ The `upY` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 An {{domxref("AudioParam")}}. Its default value is 1, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audiolistener/upz/index.md
+++ b/files/en-us/web/api/audiolistener/upz/index.md
@@ -21,7 +21,7 @@ The `upZ` read-only property of the {{ domxref("AudioListener") }} interface is 
 
 An {{domxref("AudioParam")}}. Its default value is 0, and it can range between positive and negative infinity.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/audionode/channelcount/index.md
+++ b/files/en-us/web/api/audionode/channelcount/index.md
@@ -24,7 +24,7 @@ The **`channelCount`** property of the {{ domxref("AudioNode") }} interface repr
 
 An integer.
 
-## Example
+## Examples
 
 ```js
 var AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -74,7 +74,7 @@ The possible values of `channelCountMode` and their meanings are:
 
 A enumerated value representing a [channelCountMode](https://webaudio.github.io/web-audio-api/#idl-def-ChannelCountMode).
 
-## Example
+## Examples
 
 ```js
 var AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/en-us/web/api/audionode/channelinterpretation/index.md
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.md
@@ -27,7 +27,7 @@ In summary:
 - `discrete`
   - : Input channels are mapped to output channels in order. If there are more inputs that outputs the additional inputs are dropped; if there are fewer then the unused outputs are silent.
 
-## Example
+## Examples
 
 ```js
 var AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/en-us/web/api/audionode/context/index.md
+++ b/files/en-us/web/api/audionode/context/index.md
@@ -22,7 +22,7 @@ the node is participating in.
 The {{domxref("AudioContext")}} or {{domxref("OfflineAudioContext")}} object that was
 used to construct this `AudioNode`.
 
-## Example
+## Examples
 
 ```js
 const AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/en-us/web/api/audionode/numberofinputs/index.md
+++ b/files/en-us/web/api/audionode/numberofinputs/index.md
@@ -21,7 +21,7 @@ property with a value of 0.
 
 An integer ≥ 0.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audionode/numberofoutputs/index.md
+++ b/files/en-us/web/api/audionode/numberofoutputs/index.md
@@ -21,7 +21,7 @@ a value of 0 for this attribute.
 
 An integer ≥ 0.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audioparam/defaultvalue/index.md
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.md
@@ -21,7 +21,7 @@ the `AudioParam`.
 
 A floating-point {{jsxref("Number")}}.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audioparam/maxvalue/index.md
+++ b/files/en-us/web/api/audioparam/maxvalue/index.md
@@ -25,7 +25,7 @@ parameter's nominal range.
 The default value of `maxValue` is the maximum positive single-precision
 floating-point value (+340,282,346,638,528,859,811,704,183,484,516,925,440).
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audioparam/minvalue/index.md
+++ b/files/en-us/web/api/audioparam/minvalue/index.md
@@ -25,7 +25,7 @@ parameter's nominal range.
 The default value of `minValue` is the minimum negative single-precision
 floating-point value (-340,282,346,638,528,859,811,704,183,484,516,925,440).
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -97,7 +97,7 @@ the value of a parameter:
 Thus, the `value` of a parameter is maintained to accurately reflect the
 state of the parameter over time.
 
-## Example
+## Examples
 
 This example instantly changes the volume of a {{domxref("GainNode")}} to 40%.
 

--- a/files/en-us/web/api/audiotrack/label/index.md
+++ b/files/en-us/web/api/audiotrack/label/index.md
@@ -33,7 +33,7 @@ For example, a track whose {{domxref("AudioTrack.kind", "kind")}} is
 `"commentary"` might have a `label` such as
 `"Commentary with director Mark Markmarkimark and star Donna Donnalidon"`.
 
-## Example
+## Examples
 
 This example returns an array of track kinds and labels for potential use in a user
 interface to select audio tracks for a specified media element. The list is filtered to

--- a/files/en-us/web/api/audiotrack/language/index.md
+++ b/files/en-us/web/api/audiotrack/language/index.md
@@ -37,7 +37,7 @@ For example, if the primary language used in the track is United States English,
 value would be `"en-US"`. For Brazilian Portuguese, the value would be
 `"pt-BR"`.
 
-## Example
+## Examples
 
 This example locates all of a media element's primary language and translated audio
 tracks and returns a list of objects containing each of those tracks'

--- a/files/en-us/web/api/audiotracklist/length/index.md
+++ b/files/en-us/web/api/audiotracklist/length/index.md
@@ -29,7 +29,7 @@ A number indicating how many audio tracks are included in the
 `AudioTrackList`. Each track can be accessed by treating the
 `AudioTrackList` as an array of objects of type {{domxref("AudioTrack")}}.
 
-## Example
+## Examples
 
 This snippet gets the number of audio tracks in the first {{HTMLElement("video")}}
 element found in the {{Glossary("DOM")}} by {{domxref("Document.querySelector",

--- a/files/en-us/web/api/biquadfilternode/detune/index.md
+++ b/files/en-us/web/api/biquadfilternode/detune/index.md
@@ -14,13 +14,13 @@ browser-compat: api.BiquadFilterNode.detune
 
 The `detune` property of the {{ domxref("BiquadFilterNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing detuning of the frequency in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).
 
-### Value
+## Value
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
 
 > **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a Biquad filter node. For a complete working example, check out our [voice-change-o-matic](https://mdn.github.io/voice-change-o-matic/) demo (look at the [source code](https://github.com/mdn/voice-change-o-matic) too).
 

--- a/files/en-us/web/api/biquadfilternode/frequency/index.md
+++ b/files/en-us/web/api/biquadfilternode/frequency/index.md
@@ -16,13 +16,13 @@ The `frequency` property of the {{ domxref("BiquadFilterNode") }} interface is a
 
 Its default value is `350`, with a nominal range of `10` to the [Nyquist frequency](https://en.wikipedia.org/wiki/Nyquist_frequency) — that is, half of the sample rate.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a Biquad filter node. For a complete working example, check out our [voice-change-o-matic](https://mdn.github.io/voice-change-o-matic/) demo (look at the [source code](https://github.com/mdn/voice-change-o-matic) too).
 

--- a/files/en-us/web/api/biquadfilternode/gain/index.md
+++ b/files/en-us/web/api/biquadfilternode/gain/index.md
@@ -18,13 +18,13 @@ When its value is positive, it represents a real gain; when negative, it represe
 
 It is expressed in dB, has a default value of `0`, and can take a value in a nominal range of `-40` to `40`.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a Biquad filter node. For a complete working example, check out our [voice-change-o-matic](https://mdn.github.io/voice-change-o-matic/) demo (look at the [source code](https://github.com/mdn/voice-change-o-matic) too).
 

--- a/files/en-us/web/api/biquadfilternode/q/index.md
+++ b/files/en-us/web/api/biquadfilternode/q/index.md
@@ -16,13 +16,13 @@ The `Q` property of the {{ domxref("BiquadFilterNode") }} interface is an [a-rat
 
 It is a dimensionless value with a default value of `1` and a nominal range of `0.0001` to `1000`.
 
-### Value
+## Value
 
 An {{domxref("AudioParam")}}.
 
 > **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a Biquad filter node. For a complete working example, check out our [voice-change-o-matic](https://mdn.github.io/voice-change-o-matic/) demo (look at the [source code](https://github.com/mdn/voice-change-o-matic) too).
 

--- a/files/en-us/web/api/blob/size/index.md
+++ b/files/en-us/web/api/blob/size/index.md
@@ -19,7 +19,7 @@ the size of the {{domxref("Blob")}} or {{domxref("File")}} in bytes.
 The number of bytes of data contained within the `Blob` (or
 `Blob`-based object, such as a {{domxref("File")}}).
 
-## Example
+## Examples
 
 This example uses an {{HTMLElement("input")}} element of type `file` to ask
 the user for a group of files, then iterates over those files outputting their names and

--- a/files/en-us/web/api/blob/type/index.md
+++ b/files/en-us/web/api/blob/type/index.md
@@ -18,7 +18,7 @@ The **`type`** property of a {{domxref("Blob")}} object returns the {{Glossary("
 A {{domxref("DOMString")}} containing the file's MIME type, or an empty string if the
 type could not be determined.
 
-## Example
+## Examples
 
 This example asks the user to select a number of files, then checks each file to make
 sure it's one of a given set of image file types.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.md
@@ -18,7 +18,7 @@ The **`BluetoothRemoteGATTCharacteristic.properties`**
 read-only property returns a {{domxref('BluetoothCharacteristicProperties')}} instance
 containing the properties of this characteristic.
 
-### Value
+## Value
 
 The properties of this characteristic.
 

--- a/files/en-us/web/api/client/type/index.md
+++ b/files/en-us/web/api/client/type/index.md
@@ -23,7 +23,7 @@ A string, representing the client type. The value can be one of
 - `"worker"`
 - `"sharedworker"`
 
-## Example
+## Examples
 
 ```js
 // service worker client (e.g. a document)

--- a/files/en-us/web/api/client/url/index.md
+++ b/files/en-us/web/api/client/url/index.md
@@ -20,7 +20,7 @@ interface returns the URL of the current service worker client.
 
 A {{domxref("USVString")}}.
 
-## Example
+## Examples
 
 ```js
 self.addEventListener('notificationclick', function(event) {

--- a/files/en-us/web/api/closeevent/code/index.md
+++ b/files/en-us/web/api/closeevent/code/index.md
@@ -12,7 +12,7 @@ browser-compat: api.CloseEvent.code
 
 The **`code`** read-only property of the {{domxref("CloseEvent")}} interface returns a [WebSocket connection close code](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.1.5) indicating the reason the server gave for closing the connection.
 
-### Value
+## Value
 
 An integer [WebSocket connection close code](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.1.5) in the range `1000`-`4999`, indicating the reason the server gave for closing the connection.
 
@@ -184,7 +184,7 @@ An integer [WebSocket connection close code](https://www.rfc-editor.org/rfc/rfc6
   </tbody>
 </table>
 
-## Example
+## Examples
 
 The following example prints the value of `code` to the console.
 

--- a/files/en-us/web/api/closeevent/reason/index.md
+++ b/files/en-us/web/api/closeevent/reason/index.md
@@ -12,7 +12,7 @@ browser-compat: api.CloseEvent.reason
 
 The **`reason`** read-only property of the {{domxref("CloseEvent")}} interface returns the [WebSocket connection close reason](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.1.6) the server gave for closing the connection; that is, a concise human-readable prose explanation for the closure.
 
-### Value
+## Value
 
 A {{domxref("DOMString","string")}}.
 

--- a/files/en-us/web/api/closeevent/wasclean/index.md
+++ b/files/en-us/web/api/closeevent/wasclean/index.md
@@ -12,7 +12,7 @@ browser-compat: api.CloseEvent.wasClean
 
 The **`wasClean`** read-only property of the {{domxref("CloseEvent")}} interface returns `true` if the connection closed cleanly.
 
-### Value
+## Value
 
 A {{jsxref("Boolean")}}. True if the connection closed cleanly, false otherwise.
 

--- a/files/en-us/web/api/constantsourcenode/offset/index.md
+++ b/files/en-us/web/api/constantsourcenode/offset/index.md
@@ -34,7 +34,7 @@ sample by this node. The default value is 1.0.
 To access the `offset` parameter's current value, access the parameter's
 `value` property, as shown in the syntax box above.
 
-## Example
+## Examples
 
 This example shows how to set up a `ConstantSourceNode` so its
 `offset` is used as the input to a pair of {{domxref("GainNode")}}s; this

--- a/files/en-us/web/api/credential/type/index.md
+++ b/files/en-us/web/api/credential/type/index.md
@@ -21,7 +21,7 @@ credential's type. Valid values are `password`, `federated` and
 
 A {{domxref("DOMString")}} contains a credential's given name.
 
-## Example
+## Examples
 
 ```js
 // TBD

--- a/files/en-us/web/api/crypto_property/index.md
+++ b/files/en-us/web/api/crypto_property/index.md
@@ -28,7 +28,7 @@ Although `crypto` is available on all windows, the returned `Crypto` object only
 
 An instance of the {{domxref("Crypto")}} interface, providing access to general-purpose cryptography and a strong random-number generator.
 
-## Example
+## Examples
 
 This example uses the `crypto` property to access the {{domxref("Crypto.getRandomValues", "getRandomValues()")}} method.
 

--- a/files/en-us/web/api/csskeyframerule/keytext/index.md
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.md
@@ -23,7 +23,7 @@ A {{domxref('CSSOMString')}}.
 - {{jsxref("SyntaxError")}}
   - : Thrown if `keyText` is updated with an invalid keyframe selector, in which case `keyText` remains untouched.
 
-## Example
+## Examples
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
 `myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual {{domxref("CSSKeyFrame")}} objects for each keyframe.

--- a/files/en-us/web/api/csskeyframerule/style/index.md
+++ b/files/en-us/web/api/csskeyframerule/style/index.md
@@ -27,7 +27,7 @@ A {{domxref("CSSStyleDeclaration")}} object, with the following properties:
 - owner node
   - : Null.
 
-## Example
+## Examples
 
 The CSS includes a {{cssxref("@keyframes")}} at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
 `myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual `CSSKeyFrame` objects for each keyframe.

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.md
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.md
@@ -18,7 +18,7 @@ The read-only **`cssRules`** property of the {{domxref("CSSKeyframeRule")}} inte
 
 A {{domxref('CSSRuleList')}}.
 
-## Example
+## Examples
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
 `myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object. The `cssRules` property returns a {{domxref("CSSRuleList")}} containing two rules.

--- a/files/en-us/web/api/csskeyframesrule/name/index.md
+++ b/files/en-us/web/api/csskeyframesrule/name/index.md
@@ -18,7 +18,7 @@ The **`name`** property of the {{domxref("CSSKeyframeRule")}} interface gets and
 
 A {{domxref('CSSOMString')}}.
 
-## Example
+## Examples
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
 `myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, with the `name` set to "slidein".

--- a/files/en-us/web/api/csspositionvalue/x/index.md
+++ b/files/en-us/web/api/csspositionvalue/x/index.md
@@ -23,7 +23,7 @@ page's horizontal axis.
 
 A {{domxref('CSSNumericValue')}}.
 
-## Example
+## Examples
 
 The following example positions a container `<div>` 5 pixels from the
 top and 10 pixels from the left of the page.

--- a/files/en-us/web/api/csspositionvalue/y/index.md
+++ b/files/en-us/web/api/csspositionvalue/y/index.md
@@ -23,7 +23,7 @@ vertical axis.
 
 A {{domxref('CSSNumericValue')}}.
 
-## Example
+## Examples
 
 The following example positions a container `<div>` 5 pixels from the
 top and 10 pixels from the left of the page.

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
@@ -230,7 +230,7 @@ An `unsigned short` representing the type of the value. Possible values are:
   </tbody>
 </table>
 
-## Example
+## Examples
 
 ```js
 var cs = window.getComputedStyle(document.body);

--- a/files/en-us/web/api/cssrule/parentrule/index.md
+++ b/files/en-us/web/api/cssrule/parentrule/index.md
@@ -15,14 +15,11 @@ The **`parentRule`** property of the {{domxref("CSSRule")}}
 interface returns the containing rule of the current rule if this exists, or otherwise
 returns null.
 
-## Values
+## Value
 
-- `parentRule`
-  - : A {{domxref("CSSRule")}} which is the type of the containing rules. If the current
-    rule is inside a media query, this would return {{domxref("CSSMediaRule")}}. Otherwise
-    it returns null.
+A {{domxref("CSSRule")}} which is the type of the containing rules. If the current rule is inside a media query, this would return {{domxref("CSSMediaRule")}}. Otherwise it returns null.
 
-## Example
+## Examples
 
 ```css
 @media (min-width: 500px) {

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -15,12 +15,11 @@ The **`parentStyleSheet`** property of the
 {{domxref("CSSRule")}} interface returns the {{domxref("StyleSheet")}} object in which
 the current rule is defined.
 
-## Values
+## Value
 
-- `stylesheet`
-  - : A {{domxref("StyleSheet")}} object.
+A {{domxref("StyleSheet")}} object.
 
-## Example
+## Examples
 
 ```js
 let myRules = document.styleSheets[0].cssRules;

--- a/files/en-us/web/api/cssstylerule/selectortext/index.md
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.md
@@ -17,7 +17,7 @@ The **`selectorText`** property of the {{domxref("CSSStyleRule")}} interface get
 
 A {{domxref('CSSOMString')}}.
 
-## Example
+## Examples
 
 The CSS includes one style rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`. `myRules[0].selectorText` therefore returns a literal string of the selector, in this case `"h1"`.
 

--- a/files/en-us/web/api/cssstylerule/style/index.md
+++ b/files/en-us/web/api/cssstylerule/style/index.md
@@ -26,7 +26,7 @@ A {{domxref("CSSStyleDeclaration")}} object, with the following properties:
 - owner node
   - : Null.
 
-## Example
+## Examples
 
 The CSS includes one style rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
 `myRules[0].style` therefore returns a {{domxref("CSSStyleDeclaration")}} object representing the declarations defined for `h1`.

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -27,7 +27,7 @@ interface represents the current computed CSS property value.
 
 A {{domxref("DOMString")}} representing the current CSS property value.
 
-## Example
+## Examples
 
 ```js
 var styleDeclaration = document.styleSheets[0].cssRules[0].style;

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.md
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.md
@@ -70,7 +70,7 @@ Possible values are:
   </tbody>
 </table>
 
-## Example
+## Examples
 
 ```js
 var styleDeclaration = document.styleSheets[0].cssRules[0].style;

--- a/files/en-us/web/api/datatransferitemlist/length/index.md
+++ b/files/en-us/web/api/datatransferitemlist/length/index.md
@@ -26,7 +26,7 @@ The number of drag data items in the list, or 0 if the list is empty or disabled
 drag item list is considered to be disabled if the item list's
 {{domxref("DataTransfer")}} object is not associated with a drag data store.
 
-## Example
+## Examples
 
 This example shows the use of the `length` property.
 

--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -38,7 +38,7 @@ aren't text input elements are not typically focusable by default.
 The {{domxref('Element')}} which currently has focus, {{HTMLElement("body")}} or
 `null` if there is no focused element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/document/anchors/index.md
+++ b/files/en-us/web/api/document/anchors/index.md
@@ -19,7 +19,7 @@ The **`anchors`** read-only property of the
 
 An {{domxref("HTMLCollection")}}.
 
-## Example
+## Examples
 
 ```js
 if (document.anchors.length >= 5) {

--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -24,7 +24,7 @@ interface returns a list of the applets within a document.
 
 An {{domxref("HTMLCollection")}}.
 
-## Example
+## Examples
 
 ```js
 // When you know the second applet is the one you want

--- a/files/en-us/web/api/document/compatmode/index.md
+++ b/files/en-us/web/api/document/compatmode/index.md
@@ -26,7 +26,7 @@ An enumerated value that can be:
 > **Note:** All these modes are now standardized, so the older "standards"
 > and "almost standards" names are nonsensical and no longer used in standards.
 
-## Example
+## Examples
 
 ```js
 if (document.compatMode == "BackCompat") {

--- a/files/en-us/web/api/document/designmode/index.md
+++ b/files/en-us/web/api/document/designmode/index.md
@@ -26,7 +26,7 @@ no longer supported. In IE6-10, the value is capitalized.
 A string indicating whether `designMode` is (or should be) set to on or off.
 Valid values are `on` and `off`.
 
-## Example
+## Examples
 
 Make an {{HTMLElement("iframe")}}'s document editable:
 

--- a/files/en-us/web/api/document/fullscreen/index.md
+++ b/files/en-us/web/api/document/fullscreen/index.md
@@ -26,7 +26,7 @@ Although this property is read-only, it will not throw if it is modified (even i
 
 A Boolean value which is `true` if the document is currently displaying an element in fullscreen mode; otherwise, the value is `false.`
 
-## Example
+## Examples
 
 This simple function reports whether or not fullscreen mode is currently active, using the obsolete `fullscreen` property.
 

--- a/files/en-us/web/api/document/fullscreenenabled/index.md
+++ b/files/en-us/web/api/document/fullscreenenabled/index.md
@@ -35,7 +35,7 @@ elements within can be placed into fullscreen mode by calling
 {{domxref("Element.requestFullscreen()")}}. If fullscreen mode isn't available, this
 value is `false`.
 
-## Example
+## Examples
 
 In this example, before attempting to request fullscreen mode for a
 {{htmlElement("video")}} element, the value of `fullscreenEnabled` is

--- a/files/en-us/web/api/document/head/index.md
+++ b/files/en-us/web/api/document/head/index.md
@@ -19,7 +19,7 @@ the current document.
 
 An {{domxref("HTMLHeadElement")}}.
 
-## Example
+## Examples
 
 ```html
 <!doctype html>

--- a/files/en-us/web/api/document/images/index.md
+++ b/files/en-us/web/api/document/images/index.md
@@ -33,7 +33,7 @@ firstImage = imageCollection.item(0);
 firstImage = imageCollection[0];
 ```
 
-## Example
+## Examples
 
 This example looks through the list of images and finds one whose name is
 `"banner.gif"`.

--- a/files/en-us/web/api/document/links/index.md
+++ b/files/en-us/web/api/document/links/index.md
@@ -17,7 +17,7 @@ The **`links`** read-only property of the {{domxref("Document")}} interface retu
 
 An {{domxref("HTMLCollection")}}.
 
-## Example
+## Examples
 
 ```js
 var links = document.links;

--- a/files/en-us/web/api/document/readystate/index.md
+++ b/files/en-us/web/api/document/readystate/index.md
@@ -16,7 +16,7 @@ state of the {{domxref("document")}}.
 When the value of this property changes, a {{event("readystatechange")}} event fires on
 the {{domxref("document")}} object.
 
-## Values
+## Value
 
 The `readyState` of a document can be one of following:
 

--- a/files/en-us/web/api/document/scripts/index.md
+++ b/files/en-us/web/api/document/scripts/index.md
@@ -21,7 +21,7 @@ elements in the document. The returned object is an
 An {{domxref("HTMLCollection")}}. You can use this just like an array to get all the
 elements in the list.
 
-## Example
+## Examples
 
 This example looks to see if the page has any {{HTMLElement("script")}} elements.
 

--- a/files/en-us/web/api/element/attributes/index.md
+++ b/files/en-us/web/api/element/attributes/index.md
@@ -23,7 +23,7 @@ information regarding that attribute.
 
 A {{domxref("NamedNodeMap")}} object.
 
-## Example
+## Examples
 
 ### Basic examples
 

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -155,7 +155,7 @@ For that reason, it is recommended that instead of `innerHTML` you use:
 > the extension to [addons.mozilla.org](https://addons.mozilla.org/), it may be rejected in the review process.
 > Please see [Safely inserting external content into a page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page) for alternative methods.
 
-## Example
+## Examples
 
 This example uses `innerHTML` to create a mechanism for logging messages into a box on a web page.
 

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -41,7 +41,7 @@ For {{domxref("Element")}} objects, the value of `tagName` is the same as
 the value of the {{domxref("Node.nodeName", "nodeName")}} property the element object
 inherits from {{domxref("Node")}}.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/encodedaudiochunk/duration/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/duration/index.md
@@ -13,7 +13,7 @@ browser-compat: api.EncodedAudioChunk.duration
 
 The **`duration`** read-only property of the {{domxref("EncodedAudioChunk")}} interface returns an integer indicating the duration of the audio in microseconds.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/encodedaudiochunk/timestamp/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/timestamp/index.md
@@ -13,7 +13,7 @@ browser-compat: api.EncodedAudioChunk.timestamp
 
 The **`timestamp`** read-only property of the {{domxref("EncodedAudioChunk")}} interface returns an integer indicating the timestamp of the audio in microseconds.
 
-### Value
+## Value
 
 An integer.
 


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
