### PR TITLE
Removing 'this'

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
@@ -191,7 +191,7 @@ Next, we create a {{domxref("GainNode")}} object using the {{domxref("BaseAudioC
 const gainNode = audioCtx.createGain();
 
 volumeSlider.addEventListener('input', () => {
-  gainNode.gain.value = this.value;
+  gainNode.gain.value = volumeSlider.value;
 });
 ```
 


### PR DESCRIPTION
Arrow functions does not have their own 'this' context. 
Replacing 'this' with 'volumeSlider' to access value property OR we can replace the arrow function with 'function ()' and use 'this' to access value.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
