### PR TITLE
Update timeZoneName constant to timeZone

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -75,8 +75,8 @@ Possible types are the following:
     "`2019`".
 - second
   - : The string used for the second, for example "`07`" or "`42`".
-- timeZoneName
-  - : The string used for the name of the time zone, for example "`UTC`".
+- timeZone
+  - : The string used for the name of the time zone, for example "`UTC`". Default is the timezone of the current environment.
 - weekday
   - : The string used for the weekday, for example "`M`",
     "`Monday`", or "`Montag`".


### PR DESCRIPTION
#### Summary
Correct `timeZoneName` and mention what default value of `timeZone` is.

#### Motivation
Correct misleading information. Example and description was not mentioning the same option name.

#### Supporting details
-

#### Related issues
-

#### Metadata
This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
