### PR TITLE
WebAPI: Clean syntax from property pages, part 13

### DIFF
--- a/files/en-us/web/api/magnetometer/x/index.md
+++ b/files/en-us/web/api/magnetometer/x/index.md
@@ -28,7 +28,7 @@ instructions.
 
 A {{jsxref('Number')}}.
 
-## Example
+## Examples
 
 The magnetometer is typically read in the {{domxref('Sensor.reading_event', 'reading')}} event
 callback. In the example below this occurs sixty times a second.

--- a/files/en-us/web/api/magnetometer/y/index.md
+++ b/files/en-us/web/api/magnetometer/y/index.md
@@ -28,7 +28,7 @@ instructions.
 
 A {{jsxref('Number')}}.
 
-## Example
+## Examples
 
 The magnetometer is typically read in the {{domxref('Sensor.reading_event', 'reading')}} event
 callback. In the example below this occurs sixty times a second.

--- a/files/en-us/web/api/magnetometer/z/index.md
+++ b/files/en-us/web/api/magnetometer/z/index.md
@@ -28,7 +28,7 @@ instructions.
 
 A {{jsxref('Number')}}.
 
-## Example
+## Examples
 
 The magnetometer is typically read in the {{domxref('Sensor.reading_event', 'reading')}} event
 callback. In the example below this occurs sixty times a second.

--- a/files/en-us/web/api/mediadeviceinfo/groupid/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/groupid/index.md
@@ -22,13 +22,7 @@ Two devices have the same group identifier if they
 belong to the same physical device; for example, a monitor with both a built-in camera
 and microphone.
 
-## Syntax
-
-```js
-var groupID = mediaDeviceInfo.groupId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the group of related devices to
 which this device belongs.

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.md
@@ -22,13 +22,7 @@ either using the {{domxref("MediaElementAudioSourceNode.MediaElementAudioSourceN
   "MediaElementAudioSourceNode()")}} constructor or the
 {{domxref("AudioContext.createMediaElementSource()")}} method.
 
-## Syntax
-
-```js
-audioSourceElement = mediaElementAudioSourceNode.mediaElement;
-```
-
-### Value
+## Value
 
 An {{domxref("HTMLMediaElement")}} representing the element which contains the source
 of audio for the node.

--- a/files/en-us/web/api/mediaerror/code/index.md
+++ b/files/en-us/web/api/mediaerror/code/index.md
@@ -21,13 +21,7 @@ The read-only property **`MediaError.code`** returns a numeric
 value which represents the kind of error that occurred on a media element. To get a text
 string with specific diagnostic information, see {{domxref("MediaError.message")}}.
 
-## Syntax
-
-```js
-var myError = mediaError.code;
-```
-
-### Value
+## Value
 
 A numeric value indicating the general type of error which occurred. The possible
 values are described below, in [Media error code constants](#media_error_code_constants).
@@ -79,7 +73,7 @@ values are described below, in [Media error code constants](#media_error_code_co
   </tbody>
 </table>
 
-## Example
+## Examples
 
 This example creates a {{HTMLElement("video")}} element, establishes an error handler
 for it, and then sets the element's {{htmlattrxref("src", "video")}} attribute to the

--- a/files/en-us/web/api/mediaerror/message/index.md
+++ b/files/en-us/web/api/mediaerror/message/index.md
@@ -21,13 +21,7 @@ diagnostic details related to the error described by the `MediaError` object,
 or an empty string (`""`) if no diagnostic information can be determined or
 provided.
 
-## Syntax
-
-```js
-var errorMessage = mediaError.message;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} providing a detailed, specific explanation of what went
 wrong and possibly how it might be fixed. This is _not_ a generic description of
@@ -35,7 +29,7 @@ the {{domxref("MediaError.code")}} property's value, but instead goes deeper int
 specifics of this particular error and its circumstances. If no specific details are
 available, this string is empty.
 
-## Example
+## Examples
 
 This example creates a {{HTMLElement("audio")}} element, establishes an error handler
 for it, then lets the user click buttons to choose whether to assign a valid audio file

--- a/files/en-us/web/api/mediakeysession/closed/index.md
+++ b/files/en-us/web/api/mediakeysession/closed/index.md
@@ -19,13 +19,7 @@ The `MediaKeySession.closed` read-only property returns a
 promise can only be fulfilled and is never rejected. Closing a session means that
 licenses and keys associated with it are no longer valid for decrypting media data.
 
-## Syntax
-
-```js
-var promise = mediaKeySessionObj.closed;
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/medialist/mediatext/index.md
+++ b/files/en-us/web/api/medialist/mediatext/index.md
@@ -16,14 +16,7 @@ The **`mediaText`** property of the {{domxref("MediaList")}}
 interface is a {{Glossary("stringifier")}} that returns a {{domxref("DOMString")}} representing the
 `MediaList` as text, and also allows you to set a new `MediaList`.
 
-## Syntax
-
-```js
-mediaListInstance.mediaText;
-mediaListInstance.mediaText = string;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the media queries of a stylesheet. Each one is
 separated by a comma, for example

--- a/files/en-us/web/api/mediametadata/album/index.md
+++ b/files/en-us/web/api/mediametadata/album/index.md
@@ -14,14 +14,7 @@ The **`album`** property of the
 {{domxref("MediaMetaData")}} interface returns or sets the name of the album or
 collection containing the media to be played.
 
-## Syntax
-
-```js
-var album = mediaMetaData.album
-mediaMetaData.album = album
-```
-
-### Value
+## Value
 
 A {{jsxref("String")}} containing the name of the album.
 

--- a/files/en-us/web/api/mediametadata/title/index.md
+++ b/files/en-us/web/api/mediametadata/title/index.md
@@ -19,14 +19,7 @@ The **`title`** property of the
 {{domxref("MediaMetaData")}} interface returns or sets the title of the media to be
 played.
 
-## Syntax
-
-```js
-var title = mediaMetaData.title
-mediaMetaData.title = title
-```
-
-### Value
+## Value
 
 A {{jsxref("String")}} containing the title of the media.
 

--- a/files/en-us/web/api/mediaquerylist/matches/index.md
+++ b/files/en-us/web/api/mediaquerylist/matches/index.md
@@ -25,13 +25,7 @@ You can be notified when the value of `matches` changes by watching for the
 {{domxref("MediaQueryList.change_event", "change")}} event to be fired at the
 `MediaQueryList`.
 
-## Syntax
-
-```js
-var matches = <varm>MediaQueryList.matches;
-```
-
-### Value
+## Value
 
 A boolean value that is `true` if the {{DOMxRef("document")}}
 currently matches the media query list; otherwise, it's `false`.

--- a/files/en-us/web/api/mediarecorder/mimetype/index.md
+++ b/files/en-us/web/api/mediarecorder/mimetype/index.md
@@ -31,13 +31,7 @@ about container and codec support across browsers.
 > historical; these strings are now officially known as **media types**.
 > MDN Web Docs content uses the terms interchangeably.
 
-## Syntax
-
-```js
-var mimeType = mediaRecorder.mimeType
-```
-
-### Value
+## Value
 
 The MIME media type which describes the format of the recorded media, as a
 {{domxref("DOMString")}}. This string _may_ include the [`codecs`
@@ -49,7 +43,7 @@ The media type strings are standardized by the Internet Assigned Numbers Authori
 on the IANA site. See also [media types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) to learn more
 about media types and how they're used in web content and by web browsers.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediarecorder/state/index.md
+++ b/files/en-us/web/api/mediarecorder/state/index.md
@@ -15,7 +15,7 @@ browser-compat: api.MediaRecorder.state
 The **`MediaRecorder.state`** read-only property returns the
 current state of the current `MediaRecorder` object.
 
-## Values
+## Value
 
 A string containing one of the following values:
 
@@ -27,7 +27,7 @@ A string containing one of the following values:
 - `paused`
   - : Recording has been started, then paused, but not yet stopped or resumed.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediarecorder/stream/index.md
+++ b/files/en-us/web/api/mediarecorder/stream/index.md
@@ -16,12 +16,12 @@ The **`MediaRecorder.stream`** read-only property returns the
 stream that was passed into the `MediaRecorder()` constructor when the
 `MediaRecorder` was created.
 
-## Values
+## Value
 
 The MediaStream passed into the `MediaRecorder()` constructor when the
 `MediaRecorder` was originally created.
 
-## Example
+## Examples
 
 ```js
 if (navigator.getUserMedia) {

--- a/files/en-us/web/api/mediasource/activesourcebuffers/index.md
+++ b/files/en-us/web/api/mediasource/activesourcebuffers/index.md
@@ -22,18 +22,12 @@ containing a subset of the {{domxref("SourceBuffer")}} objects contained within
 {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}} — the list of objects
 providing the selected video track, enabled audio tracks, and shown/hidden text tracks.
 
-## Syntax
-
-```js
-var myActiveSourceBuffers = mediaSource.activeSourceBuffers;
-```
-
-### Value
+## Value
 
 A {{domxref("SourceBufferList")}} containing the {{domxref("SourceBuffer")}} objects
 for each of the active tracks.
 
-## Example
+## Examples
 
 The following snippet is based on a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediasource/duration/index.md
+++ b/files/en-us/web/api/mediasource/duration/index.md
@@ -19,15 +19,7 @@ browser-compat: api.MediaSource.duration
 The **`duration`** property of the {{domxref("MediaSource")}}
 interface gets and sets the duration of the current media being presented.
 
-## Syntax
-
-```js
-mediaSource.duration = 5.5; // 5.5 seconds
-
-var myDuration = mediaSource.duration;
-```
-
-### Value
+## Value
 
 A double. A value in seconds is expected.
 
@@ -45,7 +37,7 @@ The following exceptions may be thrown when setting a new value for this propert
         (i.e. their {{domxref("SourceBuffer.updating")}} property is
       `true`.)
 
-## Example
+## Examples
 
 The following snippet is based on a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediasource/readystate/index.md
+++ b/files/en-us/web/api/mediasource/readystate/index.md
@@ -26,17 +26,11 @@ current `MediaSource`. The three possible values are:
 - `ended`: The source is attached to a media element but the stream has
   been ended via a call to {{domxref("MediaSource.endOfStream()")}}.
 
-## Syntax
-
-```js
-var myReadyState = mediaSource.readyState;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 The following snippet is from a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediasource/sourcebuffers/index.md
+++ b/files/en-us/web/api/mediasource/sourcebuffers/index.md
@@ -21,17 +21,11 @@ The **`sourceBuffers`** read-only property of the
 containing the list of {{domxref("SourceBuffer")}} objects associated with this
 `MediaSource`.
 
-## Syntax
-
-```js
-var mySourceBuffers = mediaSource.sourceBuffers;
-```
-
-### Value
+## Value
 
 A {{domxref("SourceBufferList")}}.
 
-## Example
+## Examples
 
 The following snippet is based on a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediastream/active/index.md
+++ b/files/en-us/web/api/mediastream/active/index.md
@@ -26,7 +26,7 @@ state. Once every track has ended, the stream's `active` property becomes
 A Boolean value which is `true` if the stream is currently active;
 otherwise, the value is `false`.
 
-## Example
+## Examples
 
 In this example, a new stream whose source is the user's local camera and microphone is
 requested using {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}}. When that

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.md
@@ -17,19 +17,11 @@ The `stream` property of the {{ domxref("AudioContext") }} interface represents 
 
 You can use this property to get a stream out of the audio graph and feed it into another construct, such as a [Media Recorder](/en-US/docs/Web/API/MediaStream_Recording_API).
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var destination = audioCtx.createMediaStreamDestination();
-var myStream = destination.stream;
-```
-
-### Value
+## Value
 
 A {{domxref("MediaStream")}} containing a single audio track. The audio track is a {{domxref("MediaStreamTrack")}} whose {{domxref("MediaStreamTrack.kind", "kind")}} is `audio`.
 
-## Example
+## Examples
 
 See [`AudioContext.createMediaStreamDestination()`](/en-US/docs/Web/API/AudioContext/createMediaStreamDestination#examples) for example code that creates a `MediaStreamAudioDestinationNode` and uses its `stream` property as a source for audio to be recorded.
 

--- a/files/en-us/web/api/mediastreamtrack/muted/index.md
+++ b/files/en-us/web/api/mediastreamtrack/muted/index.md
@@ -23,13 +23,7 @@ indicating whether or not the track is currently unable to provide media output.
 > (audio frames in which every sample is 0, or video frames in which every pixel is
 > black).
 
-## Syntax
-
-```js
-const mutedFlag = track.muted
-```
-
-### Value
+## Value
 
 A {{jsxref('Boolean')}} which is `true` if the track is currently muted, or
 `false` if the track is currently unmuted.
@@ -37,7 +31,7 @@ A {{jsxref('Boolean')}} which is `true` if the track is currently muted, or
 > **Note:** When possible, avoid polling `muted` to monitor the track's muting status.
 > Instead, add event listeners for the {{event("mute")}} and {{event("unmute")}} events.
 
-## Example
+## Examples
 
 This example counts the number of tracks in an array of {{domxref("MediaStreamTrack")}}
 objects which are currently muted.

--- a/files/en-us/web/api/mediastreamtrack/readystate/index.md
+++ b/files/en-us/web/api/mediastreamtrack/readystate/index.md
@@ -16,13 +16,7 @@ browser-compat: api.MediaStreamTrack.readyState
 The **`MediaStreamTrack.readyState`** read-only property
 returns an enumerated value giving the status of the track.
 
-## Syntax
-
-```js
-const state = track.readyState
-```
-
-### Value
+## Value
 
 It takes one of the following values:
 

--- a/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
@@ -27,15 +27,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.aspectRatio")}} as return
 call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { aspectRatio: constraint };
-
-constraintsObject.aspectRatio = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDouble) describing the acceptable or required value(s) for a
 video track's aspect ratio. The value is the width divided by the height and is rounded
@@ -50,7 +42,7 @@ exact match to the required aspect ratio (if `exact` is specified or both
 `min` and `max` are provided and have the same value) or to a
 best-possible value.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
@@ -29,15 +29,7 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 Automatic gain control is typically a feature provided by microphones, although it can
 be provided by other input sources as well.
 
-## Syntax
-
-```js
-var constraintsObject = { autoGainControl: constraint };
-
-constraintsObject.autoGainControl = constraint;
-```
-
-### Value
+## Value
 
 If this value is a simple `true` or `false`, the user agent will
 attempt to obtain media with automatic gain control enabled or disabled as specified, if
@@ -46,7 +38,7 @@ object with an `exact` field, that field's Boolean value indicates a required
 setting for the automatic gain control feature; if it can't be met, then the request
 will result in an error.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
@@ -26,15 +26,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.channelCount")}} as retur
 call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { channelCount: constraint };
-
-constraintsObject.channelCount = constraint;
-```
-
-### Value
+## Value
 
 If this value is a number, the user agent will attempt to obtain media whose channel
 count is as close as possible to this number given the capabilities of the hardware and
@@ -46,7 +38,7 @@ best-possible value.
 
 The channel count is 1 for monaural sound, 2 for stereo, and so forth.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/cursor/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/cursor/index.md
@@ -32,15 +32,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.cursor")}} as returned by
 to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this is
 unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { cursor: constraint };
-
-constraintsObject.cursor = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString) which specifies whether or not the mouse cursor
 should be rendered into the video track in the {{domxref("MediaStream")}} returned by

--- a/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
@@ -31,15 +31,7 @@ Because {{Glossary("RTP")}} doesn't include this information, tracks associated 
 [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("RTCPeerConnection")}}
 will never include this property.
 
-## Syntax
-
-```js
-var constraintsObject = { deviceId: constraint };
-
-constraintsObject.deviceId = constraint;
-```
-
-### Value
+## Value
 
 An object based on [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString) specifying one or more acceptable,
 ideal, and/or exact (mandatory) device IDs which are acceptable as the source of media
@@ -62,7 +54,7 @@ the same source for multiple calls to {{domxref("MediaDevices.getUserMedia",
 > private browsing mode will use a different ID, and will change it each browsing
 > session.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
@@ -37,15 +37,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.displaySurface")}} as ret
 a call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { displaySurface: constraint };
-
-constraintsObject.displaySurface = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString) which specifies the type of display surface that's
 being captured. This value _does not_ affect the list of display sources in the

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -31,15 +31,7 @@ Because {{Glossary("RTP")}} doesn't include this information, tracks associated 
 [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("RTCPeerConnection")}}
 will never include this property.
 
-## Syntax
-
-```js
-var constraintsObject = { echoCancellation: constraint };
-
-constraintsObject.echoCancellation = constraint;
-```
-
-### Value
+## Value
 
 If this value is a simple `true` or `false`, the user agent will
 attempt to obtain media with echo cancellation enabled or disabled as specified, if
@@ -48,7 +40,7 @@ object with an `exact` field, that field's Boolean value indicates a required
 setting for the echo cancellation feature; if it can't be met, then the request will
 result in an error.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
@@ -32,15 +32,7 @@ Because {{Glossary("RTP")}} doesn't include this information, tracks associated 
 [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("RTCPeerConnection")}}
 will never include this property.
 
-## Syntax
-
-```js
-var constraintsObject = { facingMode: constraint };
-
-constraintsObject.facingMode = constraint;
-```
-
-### Value
+## Value
 
 An object based on [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString) specifying one or more acceptable,
 ideal, and/or exact (mandatory) facing modes are acceptable for a video track.
@@ -59,7 +51,7 @@ camera, or the user declines permission to use that camera, the media request wi
 
 {{page("/en-US/docs/Web/API/MediaTrackSettings/facingMode", "VideoFacingModeEnum")}}
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/framerate/index.md
@@ -27,15 +27,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.frameRate")}} as returned
 call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { frameRate: constraint };
-
-constraintsObject.frameRate = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDouble) describing the acceptable or required value(s) for a
 video track's frame rate, in frames per second.
@@ -47,7 +39,7 @@ will guide the user agent in its efforts to provide an exact match to the requir
 rate (if `exact` is specified or both `min` and `max`
 are provided and have the same value) or to a best-possible value.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/groupid/index.md
@@ -27,15 +27,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.groupId")}} as returned b
 to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this is
 unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { groupId: constraint };
-
-constraintsObject.groupId = constraint;
-```
-
-### Value
+## Value
 
 An object based on [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDOMString) specifying one or more acceptable,
 ideal, and/or exact (mandatory) group IDs which are acceptable as the source of media
@@ -60,7 +52,7 @@ Because of this, there's no use for the group ID when calling
 value, and you can't use it to ensure the same group is used across multiple browsing
 sessions when calling `getUserMedia()`.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/height/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/height/index.md
@@ -26,15 +26,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.height")}} as returned by
 to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this is
 unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { height: constraint };
-
-constraintsObject.height = constraint;
-```
-
-### Value
+## Value
 
 If this value is a number, the user agent will attempt to obtain media whose height is
 as close as possible to this number given the capabilities of the hardware and the other
@@ -43,7 +35,7 @@ guide the user agent in its efforts to provide an exact match to the required he
 `exact` is specified or both `min` and `max` are
 provided and have the same value) or to a best-possible value.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/latency/index.md
@@ -31,15 +31,7 @@ Because {{Glossary("RTP")}} doesn't include this information, tracks associated 
 [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("RTCPeerConnection")}}
 will never include this property.
 
-## Syntax
-
-```js
-var constraintsObject = { latency: constraint };
-
-constraintsObject.latency = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDouble) describing the acceptable or required value(s) for an
 audio track's latency, with values specified in seconds. In audio processing, latency is
@@ -61,7 +53,7 @@ best-possible value.
 > constraints, and so forth, so even in an "exact" match, some variation should be
 > expected.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
@@ -39,15 +39,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.logicalSurface")}} as ret
 a call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { logicalSurface: constraint };
-
-constraintsObject.logicalSurface = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainBoolean) which is `true` if logical surfaces should
 be permitted among the selections available to the user.

--- a/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
@@ -29,15 +29,7 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 Noise suppression is typically provided by microphones, although it can be provided by
 other input sources as well.
 
-## Syntax
-
-```js
-var constraintsObject = { noiseSuppression: constraint };
-
-constraintsObject.noiseSuppression = constraint;
-```
-
-### Value
+## Value
 
 If this value is a simple `true` or `false`, the user agent will
 attempt to obtain media with noise suppression enabled or disabled as specified, if
@@ -46,7 +38,7 @@ object with an `exact` field, that field's Boolean value indicates a required
 setting for the noise suppression feature; if it can't be met, then the request will
 result in an error.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
@@ -27,15 +27,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.sampleRate")}} as returne
 call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { sampleRate: constraint };
-
-constraintsObject.sampleRate = constraint;
-```
-
-### Value
+## Value
 
 If this value is a number, the user agent will attempt to obtain media whose sample
 rate is as close as possible to this number given the capabilities of the hardware and
@@ -45,7 +37,7 @@ exact match to the required sample rate (if `exact` is specified or both
 `min` and `max` are provided and have the same value) or to a
 best-possible value.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
@@ -26,15 +26,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.sampleSize")}} as returne
 call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this
 is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { sampleSize: constraint };
-
-constraintsObject.sampleSize = constraint;
-```
-
-### Value
+## Value
 
 If this value is a number, the user agent will attempt to obtain media whose sample
 size (in bits per linear sample) is as close as possible to this number given the
@@ -47,7 +39,7 @@ best-possible value.
 > **Note:** Since this property can only represent linear sample sizes, this constraint can only
 > be met by devices that can produce audio with linear samples.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/volume/index.md
@@ -28,15 +28,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.volume")}} as returned by
 to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this is
 unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { volume: constraint };
-
-constraintsObject.volume = constraint;
-```
-
-### Value
+## Value
 
 A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#ConstrainDouble) describing the acceptable or required value(s) for an
 audio track's volume, on a linear scale where 0.0 means silence and 1.0 is the highest
@@ -52,7 +44,7 @@ provided and have the same value) or to a best-possible value.
 Any constraint set which only permits values outside the range 0.0 to 1.0 cannot be
 satisfied and will result in failure.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatrackconstraints/width/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/width/index.md
@@ -26,15 +26,7 @@ the value of {{domxref("MediaTrackSupportedConstraints.width")}} as returned by 
 to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically this is
 unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-## Syntax
-
-```js
-var constraintsObject = { width: constraint };
-
-constraintsObject.width = constraint;
-```
-
-### Value
+## Value
 
 If this value is a number, the user agent will attempt to obtain media whose width is
 as close as possible to this number given the capabilities of the hardware and the other
@@ -43,7 +35,7 @@ guide the user agent in its efforts to provide an exact match to the required wi
 `exact` is specified or both `min` and `max` are
 provided and have the same value) or to a best-possible value.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.md
@@ -38,7 +38,7 @@ track's aspect ratio. The aspect ratio is computed by taking the track's width, 
 by its height, and rounding the result to ten decimal places. For example, the standard
 16:9 high-definition aspect ratio can be computed as 1920/1080, or 1.7777777778.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
@@ -39,7 +39,7 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 A Boolean value which is `true` if the track has automatic gain control
 enabled or `false` if AGC is disabled.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.md
@@ -36,7 +36,7 @@ is unnecessary since browsers will ignore any constraints they're unfamiliar wit
 An integer value indicating the number of audio channels on the track. A value of 1
 indicates monaural sound, 2 means stereo, and so forth.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/cursor/index.md
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.md
@@ -27,13 +27,7 @@ should be captured as part of the video track included in the
 {{domxref("MediaStream")}} returned by {{domxref("MediaDevices.getDisplayMedia",
     "getDisplayMedia()")}}.
 
-## Syntax
-
-```js
-cursorSetting = mediaTrackSettings.cursor;
-```
-
-### Value
+## Value
 
 The value of `cursor` comes from the `CursorCaptureConstraint`
 enumerated string type, and may have one of the following values:

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.md
@@ -54,7 +54,7 @@ constraints when calling {{domxref("MediaStreamTrack.applyConstraints()")}}.
 > private browsing mode will use a different ID, and will change it each browsing
 > session.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.md
@@ -27,13 +27,7 @@ The {{domxref("MediaTrackSettings")}} dictionary's
 **`displaySurface`** property indicates the type of display
 surface being captured.
 
-## Syntax
-
-```js
-displaySurface = mediaTrackSettings.displaySurface;
-```
-
-### Value
+## Value
 
 The value of `displaySurface` is a string that comes from the
 `DisplayCaptureSurfaceType` enumerated type, and is one of the following:

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.md
@@ -45,7 +45,7 @@ will never include this property.
 A Boolean value which is `true` if the track has echo cancellation
 functionality enabled or `false` if echo cancellation is disabled.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.md
@@ -59,7 +59,7 @@ pointed.
   - : The video source is facing toward the user but to their right, such as a camera
     aimed toward the user but over their right shoulder.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/framerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.md
@@ -36,7 +36,7 @@ is unnecessary since browsers will ignore any constraints they're unfamiliar wit
 A double-precision floating-point number indicating the current configuration of the
 track's frame rate, in frames per second.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/groupid/index.md
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.md
@@ -57,7 +57,7 @@ group (or that they don't use devices from the same group). There is no situatio
 which the groupId is useful when calling `applyConstraints()`, since the
 value can't be changed.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/height/index.md
+++ b/files/en-us/web/api/mediatracksettings/height/index.md
@@ -35,7 +35,7 @@ unnecessary since browsers will ignore any constraints they're unfamiliar with.
 An integer value indicating the height, in pixels, of the video track as currently
 configured.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/latency/index.md
+++ b/files/en-us/web/api/mediatracksettings/latency/index.md
@@ -43,7 +43,7 @@ will never include this property.
 A double-precision floating-point number indicating the estimated latency, in seconds,
 of the audio track as currently configured.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
@@ -39,7 +39,7 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 A Boolean value which is `true` if the input track has noise suppression
 enabled or `false` if AGC is disabled.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.md
@@ -41,7 +41,7 @@ values are often used to reduce bandwidth requirements; 8,000 samples per second
 adequate for comprehensible albeit imperfect human speech, and both 11,025 FPS and
 22,050 FPS are often used for low-bandwidth, reduced quality sound and music.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.md
@@ -44,7 +44,7 @@ sample actually uses
   "channelCount")}} bytes of data. For example, 16-bit stereo audio requires (16/8)\*2 or 4
 bytes per sample.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/volume/index.md
+++ b/files/en-us/web/api/mediatracksettings/volume/index.md
@@ -35,7 +35,7 @@ unnecessary since browsers will ignore any constraints they're unfamiliar with.
 A double-precision floating-point number indicating the volume, from 0.0 to 1.0, of the
 audio track as currently configured.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksettings/width/index.md
+++ b/files/en-us/web/api/mediatracksettings/width/index.md
@@ -35,7 +35,7 @@ unnecessary since browsers will ignore any constraints they're unfamiliar with.
 An integer value indicating the width, in pixels, of the video track as currently
 configured.
 
-## Example
+## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:
   Constraint exerciser")}} for an example.

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
@@ -28,20 +28,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-aspectConstraintSupported = supportedConstraintsDictionary.aspectRatio;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `aspectRatio` constraint. If the property
 isn't present, this property is missing from the supported constraints dictionary, and
 you'll get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
@@ -35,20 +35,14 @@ the ability to automatically control the gain (volume) on media tracks; this obv
 is contingent on whether or not the individual device supports automatic gain control as
 well; it's typically a feature provided by microphones.
 
-## Syntax
-
-```js
-autoGainSupported = supportedConstraintsDictionary.autoGainControl;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `autoGainControl` constraint. If the property
 isn't present, this property is missing from the supported constraints dictionary, and
 you'll get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 This example displays whether or not your browser supports the
 `autoGainControl` constraint.

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
@@ -28,20 +28,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-channelCountConstraintSupported = supportedConstraintsDictionary.channelCount;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `channelCount` constraint. If the property
 isn't present, this property is missing from the supported constraints dictionary, and
 you'll get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/cursor/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/cursor/index.md
@@ -31,19 +31,13 @@ The supported constraints list is obtained by calling
 {{domxref("MediaDevices.getSupportedConstraints",
   "navigator.mediaDevices.getSupportedConstraints()")}}.
 
-## Syntax
-
-```js
-isCursorSupported = supportedConstraints.cursor;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the
 {{domxref("MediaTrackConstraints.cursor", "cursor")}} constraint is supported by the
 device and user agent.
 
-## Example
+## Examples
 
 This method sets up the constraints object specifying the options for the call to
 {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}. It adds the

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
@@ -28,20 +28,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-deviceIdConstraintSupported = supportedConstraintsDictionary.deviceId;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `deviceId` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
@@ -31,19 +31,13 @@ The supported constraints list is obtained by calling
 {{domxref("MediaDevices.getSupportedConstraints",
   "navigator.mediaDevices.getSupportedConstraints()")}}.
 
-## Syntax
-
-```js
-isDisplaySurfaceSupported = supportedConstraints.displaySurface;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the
 {{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}} constraint is
 supported by the device and user agent.
 
-## Example
+## Examples
 
 This method sets up the constraints object specifying the options for the call to
 {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}. It adds the

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-echoCancellationConstraintSupported = supportedConstraintsDictionary.echoCancellation;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `echoCancellation` constraint. If the property
 isn't present, this property is missing from the supported constraints dictionary, and
 you'll get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-facingModeConstraintSupported = supportedConstraintsDictionary.facingMode;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `facingMode` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
@@ -34,13 +34,7 @@ property lets you determine if the user agent allows constraining the video trac
 configuration by frame rate. See the [example](#example) to see how this can
 be used.
 
-## Syntax
-
-```js
-frameRateConstraintSupported = supportedConstraintsDictionary.frameRate;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary if the user agent supports the
 `frameRate` constraint. If the property isn't present, the user agent doesn't
@@ -48,7 +42,7 @@ allow specifying limits on the frame rate for video tracks.
 
 > **Note:** If this property is present, its value is always `true`.
 
-## Example
+## Examples
 
 This simple example looks to see if your browser supports constraining the frame rate
 when requesting video tracks.

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-groupIdConstraintSupported = supportedConstraintsDictionary.groupId;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `groupId` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-heightConstraintSupported = supportedConstraintsDictionary.height;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `height` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
@@ -28,20 +28,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-latencyConstraintSupported = supportedConstraintsDictionary.latency;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `latency` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
@@ -32,13 +32,7 @@ offers the ability to automatically control the gain (volume) on media tracks; t
 obviously is contingent on whether or not the individual device supports automatic gain
 control as well.
 
-## Syntax
-
-```js
-noiseSuppressionSupported = supportedConstraintsDictionary.noiseSuppression;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `noiseSuppression` constraint (and therefore
@@ -46,7 +40,7 @@ supports noise suppression on audio tracks). If the property isn't present, this
 property is missing from the supported constraints dictionary, and you'll get
 {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 This example displays whether or not your browser supports the
 `noiseSuppression` constraint.

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-sampleRateConstraintSupported = supportedConstraintsDictionary.sampleRate;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `sampleRate` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-sampleSizeConstraintSupported = supportedConstraintsDictionary.sampleSize;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `sampleSize` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
@@ -27,20 +27,14 @@ constraint isn't supported, it's not included in the list, so this value will ne
 You can access the supported constraints dictionary by calling
 `navigator.mediaDevices.getSupportedConstraints()`.
 
-## Syntax
-
-```js
-volumeConstraintSupported = supportedConstraintsDictionary.volume;
-```
-
-### Value
+## Value
 
 This property is present in the dictionary (and its value is always `true`)
 if the user agent supports the `volume` constraint. If the property isn't
 present, this property is missing from the supported constraints dictionary, and you'll
 get {{jsxref("undefined")}} if you try to look at its value.
 
-## Example
+## Examples
 
 ```html hidden
 <div id="result">

--- a/files/en-us/web/api/merchantvalidationevent/methodname/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/methodname/index.md
@@ -26,13 +26,7 @@ The {{domxref("MerchantValidationEvent")}} property
 indicating the payment method identifier which represents the payment handler that
 requires merchant validation.
 
-## Syntax
-
-```js
-methodID = merchantValidationEvent.methodName;
-```
-
-### Value
+## Value
 
 A read-only {{domxref("DOMString")}} which uniquely identifies the payment handler
 which is requesting merchant validation. See

--- a/files/en-us/web/api/merchantvalidationevent/validationurl/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/validationurl/index.md
@@ -26,13 +26,7 @@ merchant.
 This data should be passed into the {{domxref("MerchantValidationEvent.complete",
   "complete()")}} method to let the user agent complete the transaction.
 
-## Syntax
-
-```js
-validationURL = merchantValidationEvent.validationURL;
-```
-
-### Value
+## Value
 
 A read-only {{domxref("USVString")}} giving the URL from which to load payment handler
 specific data needed to complete the merchant verification process. Once this has been

--- a/files/en-us/web/api/messagechannel/port1/index.md
+++ b/files/en-us/web/api/messagechannel/port1/index.md
@@ -19,18 +19,12 @@ the port attached to the context that originated the channel.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-channel.port1;
-```
-
-### Value
+## Value
 
 A {{domxref("MessagePort")}} object, the first port of the channel, that is the port
 attached to the context that originated the channel.
 
-## Example
+## Examples
 
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel.MessageChannel", "MessageChannel()")}} constructor. When the

--- a/files/en-us/web/api/messagechannel/port2/index.md
+++ b/files/en-us/web/api/messagechannel/port2/index.md
@@ -20,18 +20,12 @@ initially sent to.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-channel.port2;
-```
-
-### Value
+## Value
 
 A {{domxref("MessagePort")}} object representing the second port of the channel, the
 port attached to the context at the other end of the channel.
 
-## Example
+## Examples
 
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor. When the

--- a/files/en-us/web/api/messageevent/data/index.md
+++ b/files/en-us/web/api/messageevent/data/index.md
@@ -16,17 +16,11 @@ browser-compat: api.MessageEvent.data
 The **`data`** read-only property of the
 {{domxref("MessageEvent")}} interface represents the data sent by the message emitter.
 
-## Syntax
-
-```js
-var data = messageEvent.data;
-```
-
-### Value
+## Value
 
 The data sent by the message emitter; this can be any data type.
 
-## Example
+## Examples
 
 ```js
 myWorker.onmessage = function(e) {

--- a/files/en-us/web/api/messageevent/lasteventid/index.md
+++ b/files/en-us/web/api/messageevent/lasteventid/index.md
@@ -17,17 +17,11 @@ The **`lastEventId`** read-only property of the
 {{domxref("MessageEvent")}} interface is a {{domxref("DOMString")}} representing a
 unique ID for the event.
 
-## Syntax
-
-```js
-var myId = messageEvent.lastEventId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the ID.
 
-## Example
+## Examples
 
 ```js
 myWorker.onmessage = function(e) {

--- a/files/en-us/web/api/messageevent/origin/index.md
+++ b/files/en-us/web/api/messageevent/origin/index.md
@@ -17,17 +17,11 @@ The **`origin`** read-only property of the
 {{domxref("MessageEvent")}} interface is a {{domxref("USVString")}} representing the
 origin of the message emitter.
 
-## Syntax
-
-```js
-var origin = messageEvent.origin;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} representing the origin.
 
-## Example
+## Examples
 
 ```js
 myWorker.onmessage = function(e) {

--- a/files/en-us/web/api/messageevent/ports/index.md
+++ b/files/en-us/web/api/messageevent/ports/index.md
@@ -19,17 +19,11 @@ representing the ports associated with the channel the message is being sent thr
 (where appropriate, e.g. in channel messaging or when sending a message to a shared
 worker).
 
-## Syntax
-
-```js
-var myPorts = messageEvent.ports;
-```
-
-### Value
+## Value
 
 An array of {{domxref("MessagePort")}} objects.
 
-## Example
+## Examples
 
 ```js
 onconnect = function(e) {

--- a/files/en-us/web/api/messageevent/source/index.md
+++ b/files/en-us/web/api/messageevent/source/index.md
@@ -18,19 +18,13 @@ The **`source`** read-only property of the
 a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or
 {{domxref("ServiceWorker")}} object) representing the message emitter.
 
-## Syntax
-
-```js
-let mySource = messageEvent.source;
-```
-
-### Value
+## Value
 
 a `MessageEventSource` (which can be a {{domxref("WindowProxy")}},
 {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the
 message emitter.
 
-## Example
+## Examples
 
 ```js
 myWorker.onmessage = function(e) {

--- a/files/en-us/web/api/metadata/modificationtime/index.md
+++ b/files/en-us/web/api/metadata/modificationtime/index.md
@@ -28,7 +28,7 @@ changed.
 
 A {{jsxref("Date")}} timestamp indicating when the file system entry was last changed.
 
-## Example
+## Examples
 
 This example tries to get a particular working file at `tmp/workfile.json`.
 Once that file has been found, its metadata is obtained and the file's modification

--- a/files/en-us/web/api/metadata/size/index.md
+++ b/files/en-us/web/api/metadata/size/index.md
@@ -24,7 +24,7 @@ file or other file system object on disk.
 
 A number indicating the size of the file in bytes.
 
-## Example
+## Examples
 
 This example checks the size of a log file and removes it if it's larger than a
 megabyte.

--- a/files/en-us/web/api/mouseevent/altkey/index.md
+++ b/files/en-us/web/api/mouseevent/altkey/index.md
@@ -24,7 +24,7 @@ On some Linux variants, for example, a left mouse click combined with the <kbd>a
 
 A boolean value, where `true` indicates that the key is pressed, and `false` indicates that the key is _not_ pressed.
 
-## Example
+## Examples
 
 This example logs the `altKey` property when you trigger a {{Event("click")}} event.
 

--- a/files/en-us/web/api/mouseevent/button/index.md
+++ b/files/en-us/web/api/mouseevent/button/index.md
@@ -39,7 +39,7 @@ A mouse configured for left-handed use may have the button actions reversed.
 Some pointing devices only have one button and use keyboard or other input mechanisms to indicate main, secondary, auxiliary, etc.
 Others may have many buttons mapped to different functions and button values.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -36,7 +36,7 @@ For more than one button pressed simultaneously, the values are combined (e.g., 
 - `8`: 4th button (typically the "Browser Back" button)
 - `16` : 5th button (typically the "Browser Forward" button)
 
-## Example
+## Examples
 
 This example logs the `buttons` property when you trigger a {{domxref("Element/mousedown_event", "mousedown")}} event.
 

--- a/files/en-us/web/api/mouseevent/clientx/index.md
+++ b/files/en-us/web/api/mouseevent/clientx/index.md
@@ -22,7 +22,7 @@ For example, clicking on the left edge of the viewport will always result in a m
 
 A `double` floating point value.
 
-## Example
+## Examples
 
 This example displays your mouse's coordinates whenever you trigger the {{Event("mousemove")}} event.
 

--- a/files/en-us/web/api/mouseevent/clienty/index.md
+++ b/files/en-us/web/api/mouseevent/clienty/index.md
@@ -21,7 +21,7 @@ For example, clicking on the top edge of the viewport will always result in a mo
 
 A `double` floating point value.
 
-## Example
+## Examples
 
 This example displays your mouse's coordinates whenever you trigger the {{Event("mousemove")}} event.
 

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.md
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.md
@@ -21,7 +21,7 @@ The **`MouseEvent.ctrlKey`** read-only property is a boolean value that indicate
 
 A boolean value, where `true` indicates that the key is pressed, and `false` indicates that the key is _not_ pressed.
 
-## Example
+## Examples
 
 This example logs the `ctrlKey` property when you trigger a {{Event("click")}} event.
 

--- a/files/en-us/web/api/mouseevent/metakey/index.md
+++ b/files/en-us/web/api/mouseevent/metakey/index.md
@@ -25,7 +25,7 @@ On Windows, for example, this key may open the Start menu.
 
 A boolean value, where `true` indicates that the key is pressed, and `false` indicates that the key is _not_ pressed.
 
-## Example
+## Examples
 
 This example logs the `metaKey` property when you trigger a {{Event("click")}} event.
 

--- a/files/en-us/web/api/mouseevent/movementx/index.md
+++ b/files/en-us/web/api/mouseevent/movementx/index.md
@@ -23,7 +23,7 @@ In other words, the value of the property is computed like this: `currentEvent.m
 
 A number.
 
-## Example
+## Examples
 
 This example logs the amount of mouse movement using `movementX` and {{domxref("MouseEvent.movementY", "movementY")}}.
 

--- a/files/en-us/web/api/mouseevent/movementy/index.md
+++ b/files/en-us/web/api/mouseevent/movementy/index.md
@@ -23,7 +23,7 @@ In other words, the value of the property is computed like this: `currentEvent.m
 
 A number.
 
-## Example
+## Examples
 
 This example logs the amount of mouse movement using {{domxref("MouseEvent.movementX", "movementX")}} and `movementY`.
 

--- a/files/en-us/web/api/mouseevent/pagex/index.md
+++ b/files/en-us/web/api/mouseevent/pagex/index.md
@@ -39,7 +39,7 @@ Even though numeric types both are represented by `Number` in JavaScript, they m
 
 See [Browser compatibility](#browser_compatibility) to learn which browsers have been updated to use the revised data type.
 
-## Example
+## Examples
 
 ### Showing the mouse position relative to page origin
 

--- a/files/en-us/web/api/mouseevent/region/index.md
+++ b/files/en-us/web/api/mouseevent/region/index.md
@@ -20,7 +20,7 @@ If no hit region is affected, `null` is returned.
 
 A {{domxref("DOMString")}} representing the id of the hit region.
 
-## Example
+## Examples
 
 Example of using the `event.region` combined with `CanvasRenderingContext2D.addHitRegion()` method.
 

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.md
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.md
@@ -92,7 +92,7 @@ For events with no secondary target, `relatedTarget` returns
 
 An {{domxref("EventTarget")}} object or `null`.
 
-## Example
+## Examples
 
 Try moving your mouse cursor into and out of the red and blue boxes.
 

--- a/files/en-us/web/api/mouseevent/screeny/index.md
+++ b/files/en-us/web/api/mouseevent/screeny/index.md
@@ -20,7 +20,7 @@ A `double` floating point value.
 
 Early versions of the spec defined this as an integer referring to the number of pixels.
 
-## Example
+## Examples
 
 This example displays your mouse's coordinates whenever you trigger the {{Event("mousemove")}} event.
 

--- a/files/en-us/web/api/mouseevent/shiftkey/index.md
+++ b/files/en-us/web/api/mouseevent/shiftkey/index.md
@@ -19,7 +19,7 @@ The **`MouseEvent.shiftKey`** read-only property is a boolean value that indicat
 
 A boolean value, where `true` indicates that the key is pressed, and `false` indicates that the key is _not_ pressed.
 
-## Example
+## Examples
 
 This example logs the `shiftKey` property when you trigger a {{Event("click")}} event.
 

--- a/files/en-us/web/api/navigator/activevrdisplays/index.md
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.md
@@ -23,13 +23,7 @@ The **`activeVRDisplays`** read-only property of the
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
-## Syntax
-
-```js
-navigator.activeVRDisplays
-```
-
-### Value
+## Value
 
 An array of {{domxref("VRDisplay")}} objects.
 


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error