### PR TITLE
WebAPI: Clean syntax from property pages, part 14

### DIFF
--- a/files/en-us/web/api/navigator/appcodename/index.md
+++ b/files/en-us/web/api/navigator/appcodename/index.md
@@ -19,13 +19,7 @@ compatibility purposes.
 > **Note:** Do not rely on this property to return a real
 > product name. All browsers return "`Mozilla`" as the value of this property.
 
-## Syntax
-
-```js
-codeName = navigator.appCodeName
-```
-
-### Value
+## Value
 
 The string "`Mozilla`".
 

--- a/files/en-us/web/api/navigator/appname/index.md
+++ b/files/en-us/web/api/navigator/appname/index.md
@@ -18,13 +18,7 @@ purposes.
 
 > **Note:** Do not rely on this property to return a real browser name. All browsers return "`Netscape`" as the value of this property.
 
-## Syntax
-
-```js
-appName = navigator.appName
-```
-
-### Value
+## Value
 
 The string "`Netscape`".
 

--- a/files/en-us/web/api/navigator/appversion/index.md
+++ b/files/en-us/web/api/navigator/appversion/index.md
@@ -17,18 +17,12 @@ the browser.
 
 > **Note:** Do not rely on this property to return the correct browser version.
 
-## Syntax
-
-```js
-window.navigator.appVersion
-```
-
-### Value
+## Value
 
 Either "`4.0`" or a string representing version information about the
 browser.
 
-## Example
+## Examples
 
 ```js
 alert('Your browser version is reported as ' + navigator.appVersion);

--- a/files/en-us/web/api/navigator/buildid/index.md
+++ b/files/en-us/web/api/navigator/buildid/index.md
@@ -13,17 +13,11 @@ browser-compat: api.Navigator.buildID
 
 Returns the build identifier of the browser. In modern browsers this property now returns a fixed timestamp as a privacy measure, e.g. `20181001000000` in Firefox 64 onwards.
 
-## Syntax
-
-```js
-buildID = navigator.buildID;
-```
-
-### Value
+## Value
 
 A string representing the build identifier of the application. The build ID is in the form `YYYYMMDDHHMMSS`.
 
-## Example
+## Examples
 
 ```js
 console.log(navigator.buildID);

--- a/files/en-us/web/api/navigator/clipboard/index.md
+++ b/files/en-us/web/api/navigator/clipboard/index.md
@@ -29,13 +29,7 @@ the web site or app permission to access the clipboard. This permission must be 
 from the [Permissions API](/en-US/docs/Web/API/Permissions_API) using the
 `"clipboard-read"` and/or `"clipboard-write"` permissions.
 
-## Syntax
-
-```js
-theClipboard = navigator.clipboard;
-```
-
-### Value
+## Value
 
 The {{domxref("Clipboard")}} object used to access the system clipboard.
 

--- a/files/en-us/web/api/navigator/credentials/index.md
+++ b/files/en-us/web/api/navigator/credentials/index.md
@@ -17,17 +17,11 @@ methods to request credentials. The {{domxref("CredentialsContainer")}} interfac
 notifies the user agent when an interesting event occurs, such as a successful sign-in
 or sign-out. This interface can be used for feature detection.
 
-## Syntax
-
-```js
-var credentialsContainer = navigator.credentials
-```
-
-### Value
+## Value
 
 The {{domxref("CredentialsContainer")}} interface.
 
-## Example
+## Examples
 
 ```js
 if ('credentials' in navigator) {

--- a/files/en-us/web/api/navigator/devicememory/index.md
+++ b/files/en-us/web/api/navigator/devicememory/index.md
@@ -22,18 +22,12 @@ rounding down to the nearest power of 2, then dividing that number by 1024. It i
 clamped within lower and upper bounds to protect the privacy of owners of very low- or
 high-memory devices.
 
-## Syntax
-
-```js
-memoryAmount = navigator.deviceMemory
-```
-
-### Value
+## Value
 
 A floating point number; one of `0.25`, `0.5`, `1`,
 `2`, `4`, `8`.
 
-## Example
+## Examples
 
 ```js
 const memory = navigator.deviceMemory

--- a/files/en-us/web/api/navigator/hardwareconcurrency/index.md
+++ b/files/en-us/web/api/navigator/hardwareconcurrency/index.md
@@ -15,12 +15,6 @@ The **`navigator.hardwareConcurrency`** read-only property
 returns the number of logical processors available to run threads on the user's
 computer.
 
-## Syntax
-
-```js
-logicalProcessors = window.navigator.hardwareConcurrency
-```
-
 ## Value
 
 A number between 1 and the number of logical processors potentially available to the user agent.

--- a/files/en-us/web/api/navigator/hid/index.md
+++ b/files/en-us/web/api/navigator/hid/index.md
@@ -17,13 +17,7 @@ read-only property returns an {{domxref("HID")}} object providing methods
 for connecting to HID devices, listing attached HID devices, and event
 handlers for connected HID devices.
 
-## Syntax
-
-```js
-var hidVar = navigator.hid
-```
-
-### Value
+## Value
 
 An {{domxref("HID")}} object.
 

--- a/files/en-us/web/api/navigator/keyboard/index.md
+++ b/files/en-us/web/api/navigator/keyboard/index.md
@@ -19,13 +19,7 @@ of the {{domxref("Navigator")}} interface returns a {{domxref('Keyboard')}} obje
 which provides access to functions that retrieve keyboard layout maps and toggle
 capturing of key presses from the physical keyboard.
 
-## Syntax
-
-```js
-var keyboard = navigator.keyboard
-```
-
-### Value
+## Value
 
 A {{domxref('Keyboard')}} object.
 

--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -16,13 +16,7 @@ The **`Navigator.language`** read-only property returns
 a string representing the preferred language of the user, usually the language of the
 browser UI.
 
-## Syntax
-
-```js
-const lang = navigator.language
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}. _`lang`_ stores a string representing the
 language version as defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. Examples of valid language
@@ -31,7 +25,7 @@ codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 Note that in Safari on iOS prior to 10.2, the country code returned is lowercase:
 "en-us", "fr-fr" etc.
 
-## Example
+## Examples
 
 ```js
 if (/^en\b/.test(navigator.language)) {

--- a/files/en-us/web/api/navigator/locks/index.md
+++ b/files/en-us/web/api/navigator/locks/index.md
@@ -18,13 +18,7 @@ the {{domxref("Navigator")}} interface returns a {{domxref("LockManager")}} obje
 which provides methods for requesting a new {{domxref('Lock')}} object and querying
 for an existing `Lock` object.
 
-## Syntax
-
-```js
-var lockManager = navigator.locks
-```
-
-### Value
+## Value
 
 A {{domxref("LockManager")}} object.
 

--- a/files/en-us/web/api/navigator/mediasession/index.md
+++ b/files/en-us/web/api/navigator/mediasession/index.md
@@ -36,13 +36,7 @@ physical play, pause, seek, and other similar controls. An internet radio app, f
 example, can use `setActionHandler()` to let fhe media controls on a keyboard
 or elsewhere on the user's device be used to control the app's media playback.
 
-## Syntax
-
-```js
-let mediaSession = navigator.mediaSession;
-```
-
-### Value
+## Value
 
 A {{domxref("MediaSession")}} object the current document can use to share information
 about media it's playing and its current playback status. This information can include
@@ -50,7 +44,7 @@ typical metadata such as the title, artist, and album name of the song being pla
 well as potentially one or more images containing things like album art, artist photos,
 and so forth.
 
-## Example
+## Examples
 
 In this example, metadata is submitted to the `mediaSession` object. Note
 that the code begins by ensuring that the {{domxref("navigator.mediaSession")}} property

--- a/files/en-us/web/api/navigator/mimetypes/index.md
+++ b/files/en-us/web/api/navigator/mimetypes/index.md
@@ -31,7 +31,7 @@ If PDF inline viewing is supported this has entries for MIME types `application/
 Otherwise an empty `MimeTypeArray` is returned.
 The description and file suffixes supported by enabled plugins are hard coded to `'pdf'` and `'Portable Document Format'`, respectively.
 
-## Example
+## Examples
 
 The code below tests whether PDF files can be viewed inline, and then prints the description of the plugin and the file suffixes it supports.
 

--- a/files/en-us/web/api/navigator/online/index.md
+++ b/files/en-us/web/api/navigator/online/index.md
@@ -37,15 +37,9 @@ only looks for LAN connection like Chrome and Safari giving false positives.
 
 You can see changes in the network state by listening for the events on [`document.ononline`](/en-US/docs/Web/API/Document/ononline) and [`document.onoffline`](/en-US/docs/Web/API/Document/onoffline).
 
-## Syntax
+## Value
 
-```js
-online = window.navigator.onLine;
-```
-
-### Value
-
-`online` is a boolean `true` or `false`.
+A boolean.
 
 ## Examples
 

--- a/files/en-us/web/api/navigator/oscpu/index.md
+++ b/files/en-us/web/api/navigator/oscpu/index.md
@@ -14,13 +14,7 @@ browser-compat: api.Navigator.oscpu
 
 The **`Navigator.oscpu`** property returns a string that identifies the current operating system.
 
-## Syntax
-
-```js
-oscpuInfo = navigator.oscpu
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} providing a string which identifies the operating system on which the browser is running.
 
@@ -38,7 +32,7 @@ A {{domxref("DOMString")}} providing a string which identifies the operating sys
 
 In this table `x.y` refers to the version of the operating system
 
-## Example
+## Examples
 
 ```js
 function osInfo() {

--- a/files/en-us/web/api/navigator/permissions/index.md
+++ b/files/en-us/web/api/navigator/permissions/index.md
@@ -16,12 +16,6 @@ The **`Navigator.permissions`** read-only property returns a
 {{domxref("Permissions")}} object that can be used to query and update permission
 status of APIs covered by the [Permissions API](/en-US/docs/Web/API/Permissions_API).
 
-## Syntax
-
-```js
-permissionsObj = globalObj.navigator.permissions
-```
-
 ## Value
 
 A {{domxref("Permissions")}} object.

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -25,7 +25,7 @@ A {{domxref("DOMString")}} identifying the platform on which the browser is runn
 
 For example: "`MacIntel`", "`Win32`", "`FreeBSD i386`", "`WebTV OS`"
 
-## Example
+## Examples
 
 ```js
 console.log(navigator.platform);

--- a/files/en-us/web/api/navigator/product/index.md
+++ b/files/en-us/web/api/navigator/product/index.md
@@ -17,13 +17,7 @@ purposes.
 
 > **Note:** Do not rely on this property to return a real product name. All browsers return "`Gecko`" as the value of this property.
 
-## Syntax
-
-```js
-productName = navigator.product
-```
-
-### Value
+## Value
 
 The string "`Gecko`".
 

--- a/files/en-us/web/api/navigator/serial/index.md
+++ b/files/en-us/web/api/navigator/serial/index.md
@@ -15,13 +15,7 @@ The **`serial`** read-only property of the {{domxref("Navigator")}} interface re
 
 When getting, the same instance of the {{domxref("Serial")}} object will always be returned.
 
-## Syntax
-
-```js
-var serialObj = navigator.serial;
-```
-
-### Value
+## Value
 
 A {{domxref("Serial")}} object.
 

--- a/files/en-us/web/api/navigator/serviceworker/index.md
+++ b/files/en-us/web/api/navigator/serviceworker/index.md
@@ -20,13 +20,7 @@ communication with the {{domxref("ServiceWorker")}}.
 
 The feature may not be available in private mode.
 
-## Syntax
-
-```js
-const workerContainerInstance = navigator.serviceWorker;
-```
-
-### Value
+## Value
 
 {{domxref("ServiceWorkerContainer")}}.
 

--- a/files/en-us/web/api/navigator/storage/index.md
+++ b/files/en-us/web/api/navigator/storage/index.md
@@ -19,13 +19,7 @@ The returned object lets you examine and configure persistence of data stores an
 learn approximately how much more space your browser has available for local storage
 use.
 
-## Syntax
-
-```js
-var storageManager = navigator.storage;
-```
-
-### Value
+## Value
 
 A {{domxref("StorageManager")}} object you can use to maintain persistence for stored
 data, as well as to determine roughly how much room there is for data to be stored.

--- a/files/en-us/web/api/navigator/useragent/index.md
+++ b/files/en-us/web/api/navigator/useragent/index.md
@@ -37,13 +37,7 @@ string is user configurable. For example:
 - Safari and iCab allow users to change the browser user agent string to predefined
   Internet Explorer or Netscape strings via a menu.
 
-## Syntax
-
-```js
-var ua = navigator.userAgent;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the complete user agent string the browser
 provides both in {{Glossary("HTTP")}} headers and in response to this and other related
@@ -60,7 +54,7 @@ Localization; rv: revision-version-number) product/productSub
 Application-Name Application-Name-version
 ```
 
-## Example
+## Examples
 
 ```js
 alert(window.navigator.userAgent)

--- a/files/en-us/web/api/navigator/useragentdata/index.md
+++ b/files/en-us/web/api/navigator/useragentdata/index.md
@@ -14,13 +14,7 @@ browser-compat: api.Navigator.userAgentData
 The **`userAgentData`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("NavigatorUAData")}} object
 which can be used to access the {{domxref("User-Agent Client Hints API")}}.
 
-## Syntax
-
-```js
-let userAgentData = navigator.userAgentData
-```
-
-### Value
+## Value
 
 A {{domxref("NavigatorUAData")}} object.
 

--- a/files/en-us/web/api/navigator/vendor/index.md
+++ b/files/en-us/web/api/navigator/vendor/index.md
@@ -12,13 +12,7 @@ browser-compat: api.Navigator.vendor
 
 The value of the {{DomXref("Navigator")}} **`vendor`** property is always either "`Google Inc.`", "`Apple Computer, Inc.`", or (in Firefox) the empty string.
 
-## Syntax
-
-```js
-venString = navigator.vendor
-```
-
-### Value
+## Value
 
 - Either "`Google Inc.`", "`Apple Computer, Inc.`", or (in Firefox) the empty string.
 

--- a/files/en-us/web/api/navigator/vendorsub/index.md
+++ b/files/en-us/web/api/navigator/vendorsub/index.md
@@ -14,13 +14,7 @@ browser-compat: api.Navigator.vendorSub
 The value of the **`Navigator.vendorSub`** property is always
 the empty string, in any browser.
 
-## Syntax
-
-```js
-venSub = navigator.vendorSub
-```
-
-### Value
+## Value
 
 - The empty string
 

--- a/files/en-us/web/api/navigator/webdriver/index.md
+++ b/files/en-us/web/api/navigator/webdriver/index.md
@@ -29,13 +29,7 @@ The `navigator.webdriver` property is true when in:
   - : The `marionette.enabled` preference or `--marionette` flag is
     passed.
 
-## Syntax
-
-```js
-var isAutomated = navigator.webdriver
-```
-
-### Value
+## Value
 
 A {{JSxRef("Boolean")}}
 

--- a/files/en-us/web/api/navigator/windowcontrolsoverlay/index.md
+++ b/files/en-us/web/api/navigator/windowcontrolsoverlay/index.md
@@ -26,7 +26,7 @@ of the app window.
 
 The {{domxref("WindowControlsOverlay")}} interface.
 
-## Example
+## Examples
 
 ```js
 if ('windowControlsOverlay' in navigator) {

--- a/files/en-us/web/api/navigator/xr/index.md
+++ b/files/en-us/web/api/navigator/xr/index.md
@@ -28,7 +28,7 @@ The {{domxref("XRSystem")}} object used to interface with the [WebXR Device API]
 context. This can be used to present augmented and/or virtual reality imagery to the
 user.
 
-## Example
+## Examples
 
 Each {{domxref("Window")}} has its own instance of {{domxref("Navigator")}}, which can
 be accessed as {{domxref("Window.navigator","window.navigator")}} or as

--- a/files/en-us/web/api/notification/maxactions/index.md
+++ b/files/en-us/web/api/notification/maxactions/index.md
@@ -18,13 +18,7 @@ The **`maxActions`** attribute of the
 the device and the User Agent. Effectively, this is the maximum number of elements in
 {{domxref("Notification.actions")}} array which will be respected by the User Agent.
 
-## Syntax
-
-```js
-Notification.maxActions
-```
-
-### Value
+## Value
 
 An integer {{JSxRef("Number")}} which indicates the largest number of notification
 actions that can be presented to the user by the User Agent and the device.

--- a/files/en-us/web/api/notification/requireinteraction/index.md
+++ b/files/en-us/web/api/notification/requireinteraction/index.md
@@ -18,19 +18,7 @@ The **`requireInteraction`** read-only property of the {{domxref("Notification")
 
 > **Note:** This can be set when the notification is first created by setting the `requireInteraction` option to `true` in the options object of the {{domxref("Notification.Notification", "Notification()")}} constructor.
 
-## Syntax
-
-```js
-function spawnNotification(theTitle,theBody,shouldRequireInteraction) {
-  var options = {
-      body: theBody,
-      requireInteraction: shouldRequireInteraction
-  }
-  var n = new Notification(theTitle,options);
-}
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.md
@@ -16,13 +16,7 @@ The **`renderedBuffer`** read-only property of the
 {{domxref("OfflineAudioCompletionEvent")}} interface is an {{domxref("AudioBuffer")}}
 containing the result of processing an {{domxref("OfflineAudioContext")}}.
 
-## Syntax
-
-```js
-var buffer = offlineAudioCompletionEventInstance.renderedBuffer;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioBuffer")}}.
 

--- a/files/en-us/web/api/orientationsensor/quaternion/index.md
+++ b/files/en-us/web/api/orientationsensor/quaternion/index.md
@@ -20,21 +20,15 @@ property of the {{domxref("OrientationSensor")}} interface returns a four elemen
 {{jsxref('Array')}} whose elements contain the components of the unit
 {{Glossary("quaternion")}} representing the device's orientation.
 
-## Syntax
-
-```js
-var quaternion = orientationInstance.quaternion
-```
-
 Because {{domxref('OrientationSensor')}} is a base class, `quaternion` may
 only be read from one of its derived classes.
 
-### Value
+## Value
 
 An {{jsxref('Array')}} whose values are the x, y, z, and w components of the quaternion
 representing the device orientation.
 
-## Example
+## Examples
 
 ```js
 // TBD

--- a/files/en-us/web/api/origin/index.md
+++ b/files/en-us/web/api/origin/index.md
@@ -17,13 +17,7 @@ browser-compat: api.origin
 The global **`origin`** read-only property returns the origin of the global
 scope, serialized as a string.
 
-## Syntax
-
-```js
-var myOrigin = self.origin; // or just origin
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/oscillatornode/detune/index.md
+++ b/files/en-us/web/api/oscillatornode/detune/index.md
@@ -14,20 +14,13 @@ browser-compat: api.OscillatorNode.detune
 
 The `detune` property of the {{ domxref("OscillatorNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).
 
-## Syntax
-
-```js
-var oscillator = audioCtx.createOscillator();
-oscillator.detune.setValueAtTime(100, audioCtx.currentTime); // value in cents
-```
-
 > **Note:** though the `AudioParam` returned is read-only, the value it represents is not.
 
-### Value
+## Value
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For applied examples/information, check out our [Violent Theremin demo](https://mdn.github.io/violent-theremin/) ([see app.js](https://github.com/mdn/violent-theremin/blob/gh-pages/scripts/app.js) for relevant code).
 

--- a/files/en-us/web/api/oscillatornode/frequency/index.md
+++ b/files/en-us/web/api/oscillatornode/frequency/index.md
@@ -14,20 +14,13 @@ browser-compat: api.OscillatorNode.frequency
 
 The **`frequency`** property of the {{ domxref("OscillatorNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing the frequency of oscillation in hertz.
 
-## Syntax
-
-```js
-var oscillator = audioCtx.createOscillator();
-oscillator.frequency.setValueAtTime(440, audioCtx.currentTime); // value in hertz
-```
-
 > **Note:** though the `AudioParam` returned is read-only, the value it represents is not.
 
-### Value
+## Value
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/violent-theremin/) ([see app.js](https://github.com/mdn/violent-theremin/blob/gh-pages/scripts/app.js) for relevant code).
 

--- a/files/en-us/web/api/oscillatornode/type/index.md
+++ b/files/en-us/web/api/oscillatornode/type/index.md
@@ -18,13 +18,7 @@ oscillator will output. There are several common waveforms available, as well as
 option to specify a custom waveform shape. The shape of the waveform will affect the
 tone that is produced.
 
-## Syntax
-
-```js
-OscillatorNode.type = type;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the shape of oscillator wave. The different
 available values are:
@@ -51,7 +45,7 @@ available values are:
     {{domxref("OscillatorNode.setPeriodicWave", "setPeriodicWave()")}}. Doing so
     automatically sets the type for you.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{ domxref("AudioContext") }} to create
 an oscillator node. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/violent-theremin/) ([see

--- a/files/en-us/web/api/pagetransitionevent/persisted/index.md
+++ b/files/en-us/web/api/pagetransitionevent/persisted/index.md
@@ -13,17 +13,7 @@ browser-compat: api.PageTransitionEvent.persisted
 
 The **`persisted`** read-only property indicates if a webpage is loading from a cache.
 
-## Syntax
-
-```js
-window.addEventListener('pageshow', function(event) {
-  if (event.persisted) {
-    console.log('Page was loaded from cache.');
-  }
-});
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/pannernode/coneinnerangle/index.md
+++ b/files/en-us/web/api/pannernode/coneinnerangle/index.md
@@ -16,19 +16,11 @@ The `coneInnerAngle` property of the {{ domxref("PannerNode") }} interface is a 
 
 The `coneInnerAngle` property's default value is `360`, suitable for a non-directional source.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.coneInnerAngle = 360;
-```
-
-### Value
+## Value
 
 A double.
 
-## Example
+## Examples
 
 See [`PannerNode.orientationX`](/en-US/docs/Web/API/PannerNode/orientationX#example) for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.
 

--- a/files/en-us/web/api/pannernode/coneouterangle/index.md
+++ b/files/en-us/web/api/pannernode/coneouterangle/index.md
@@ -16,19 +16,11 @@ The `coneOuterAngle` property of the {{ domxref("PannerNode") }} interface is a 
 
 The `coneOuterAngle` property's default value is `0`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.coneOuterAngle = 0;
-```
-
-### Value
+## Value
 
 A double.
 
-## Example
+## Examples
 
 See [`PannerNode.orientationX`](/en-US/docs/Web/API/PannerNode/orientationX#example) for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.
 

--- a/files/en-us/web/api/pannernode/coneoutergain/index.md
+++ b/files/en-us/web/api/pannernode/coneoutergain/index.md
@@ -16,15 +16,7 @@ The `coneOuterGain` property of the {{ domxref("PannerNode") }} interface is a d
 
 The `coneOuterGain` property's default value is `0`, meaning that no sound can be heard outside the cone.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.coneOuterGain = 0;
-```
-
-### Value
+## Value
 
 A double. The default is `0`, and its value can be in the range 0–1.
 
@@ -33,7 +25,7 @@ A double. The default is `0`, and its value can be in the range 0–1.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the property has been given a value outside the accepted range (0–1).
 
-## Example
+## Examples
 
 See [`PannerNode.orientationX`](/en-US/docs/Web/API/PannerNode/orientationX#example) for example code that demonstrates how changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}} affects volume.
 

--- a/files/en-us/web/api/pannernode/distancemodel/index.md
+++ b/files/en-us/web/api/pannernode/distancemodel/index.md
@@ -25,19 +25,11 @@ The possible values are:
 
 `inverse` is the default value of `distanceModel`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.distanceModel = 'inverse';
-```
-
-### Value
+## Value
 
 A enum — see [`DistanceModelType`](https://webaudio.github.io/web-audio-api/#idl-def-DistanceModelType).
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/pannernode/maxdistance/index.md
+++ b/files/en-us/web/api/pannernode/maxdistance/index.md
@@ -16,15 +16,7 @@ The `maxDistance` property of the {{ domxref("PannerNode") }} interface is a dou
 
 The `maxDistance` property's default value is `10000`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.maxDistance = 10000;
-```
-
-### Value
+## Value
 
 A double. The default is `10000`, and non-positive values are not allowed.
 
@@ -33,7 +25,7 @@ A double. The default is `10000`, and non-positive values are not allowed.
 - `RangeError`
   - : The property has been given a value that is outside the accepted range.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/pannernode/orientationy/index.md
+++ b/files/en-us/web/api/pannernode/orientationy/index.md
@@ -40,7 +40,7 @@ can still change the value of the parameter by assigning a new value to its
 An {{domxref("AudioParam")}} whose `value` is the Y component of the
 direction the audio source is facing, in 3D Cartesian coordinate space.
 
-## Example
+## Examples
 
 See [`PannerNode.orientationX`](/en-US/docs/Web/API/PannerNode/orientationX#example) for example code that demonstrates the effect on volume of changing the {{domxref("PannerNode")}} orientation parameters in combination with {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}} and {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}.
 

--- a/files/en-us/web/api/pannernode/panningmodel/index.md
+++ b/files/en-us/web/api/pannernode/panningmodel/index.md
@@ -19,19 +19,11 @@ The possible values are:
 - `equalpower`: Represents the equal-power panning algorithm, generally regarded as simple and efficient. `equalpower` is the default value.
 - `HRTF`: Renders a stereo output of higher quality than `equalpower` — it uses a convolution with measured impulse responses from human subjects.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.panningModel = 'HRTF';
-```
-
-### Value
+## Value
 
 A enum — see [`PanningModelType`](https://webaudio.github.io/web-audio-api/#idl-def-PanningModelType).
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 

--- a/files/en-us/web/api/pannernode/positionx/index.md
+++ b/files/en-us/web/api/pannernode/positionx/index.md
@@ -41,7 +41,7 @@ can still change the value of the parameter by assigning a new value to its
 An {{domxref("AudioParam")}} whose `value` is the X coordinate of the audio
 source's position, in 3D Cartesian coordinates. The default value is 0.
 
-## Example
+## Examples
 
 The following example starts an oscillator, and pans it to the left after 1 second, to
 the right after 2 seconds, and back to the center after 3 seconds.

--- a/files/en-us/web/api/pannernode/positiony/index.md
+++ b/files/en-us/web/api/pannernode/positiony/index.md
@@ -40,7 +40,7 @@ can still change the value of the parameter by assigning a new value to its
 An {{domxref("AudioParam")}} whose `value` is the Y coordinate of the audio
 source's position, in 3D Cartesian coordinates.
 
-## Example
+## Examples
 
 The following example starts an oscillator and pans it above the listener after 1
 second, below the listener after 2 seconds, and back to the center after 3 seconds. Note

--- a/files/en-us/web/api/pannernode/positionz/index.md
+++ b/files/en-us/web/api/pannernode/positionz/index.md
@@ -40,7 +40,7 @@ can still change the value of the parameter by assigning a new value to its
 An {{domxref("AudioParam")}} whose `value` is the Z coordinate of the audio
 source's position, in 3D Cartesian coordinates.
 
-## Example
+## Examples
 
 The following example starts an oscillator and moves it in front of the listener after
 1 second, behind the listener after 2 seconds, and back to the listener's position after

--- a/files/en-us/web/api/pannernode/refdistance/index.md
+++ b/files/en-us/web/api/pannernode/refdistance/index.md
@@ -16,15 +16,7 @@ The `refDistance` property of the {{ domxref("PannerNode") }} interface is a dou
 
 The `refDistance` property's default value is `1`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.refDistance = 1;
-```
-
-### Value
+## Value
 
 A non-negative number. If the value is set to less than 0, a `RangeError` is thrown.
 
@@ -33,7 +25,7 @@ A non-negative number. If the value is set to less than 0, a `RangeError` is thr
 - `RangeError`
   - : The property has been given a value that is outside the accepted range.
 
-## Example
+## Examples
 
 This example demonstrates how different values of {{ domxref("PannerNode.refDistance", "refDistance") }} affect how the volume of a sound decays as it moves away from the listener. Unlike {{ domxref("PannerNode.rolloffFactor", "rolloffFactor") }}, changing this value also _delays_ the volume decay until the sound moves past the reference point.
 

--- a/files/en-us/web/api/pannernode/rollofffactor/index.md
+++ b/files/en-us/web/api/pannernode/rollofffactor/index.md
@@ -14,15 +14,7 @@ browser-compat: api.PannerNode.rolloffFactor
 
 The `rolloffFactor` property of the {{ domxref("PannerNode") }} interface is a double value describing how quickly the volume is reduced as the source moves away from the listener. This value is used by all distance models.The `rolloffFactor` property's default value is `1`.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.rolloffFactor = 1;
-```
-
-### Value
+## Value
 
 A number whose range depends on the {{ domxref("PannerNode.distanceModel", "distanceModel") }} of the panner as follows (negative values are not allowed):
 
@@ -38,7 +30,7 @@ A number whose range depends on the {{ domxref("PannerNode.distanceModel", "dist
 - `RangeError`
   - : The property has been given a value that is outside the accepted range.
 
-## Example
+## Examples
 
 This example demonstrates how different {{ domxref("PannerNode.rolloffFactor", "rolloffFactor") }} values affect how the volume of the test tone decreases with increasing distance from the listener:
 

--- a/files/en-us/web/api/passwordcredential/iconurl/index.md
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.md
@@ -18,13 +18,7 @@ of the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVStrin
 containing a URL pointing to an image for an icon. This image is intended for display
 in a credential chooser. The URL must be accessible without authentication.
 
-## Syntax
-
-```js
-url = passwordCredential.iconURL
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a URL.
 

--- a/files/en-us/web/api/passwordcredential/name/index.md
+++ b/files/en-us/web/api/passwordcredential/name/index.md
@@ -17,13 +17,7 @@ The **`name`** read-only property of
 the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
 containing a human-readable public name for display in a credential chooser.
 
-## Syntax
-
-```js
-name = passwordCredential.name
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a name.
 

--- a/files/en-us/web/api/passwordcredential/password/index.md
+++ b/files/en-us/web/api/passwordcredential/password/index.md
@@ -17,13 +17,7 @@ The **`password`** read-only property
 of the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
 containing the password of the credential.
 
-## Syntax
-
-```js
-password = passwordCredential.password
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a password.
 

--- a/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.md
@@ -22,13 +22,7 @@ containing any data the payment handler may provide to describe the change the u
 has made to their payment method. The value is `null` if no details
 are available.
 
-## Syntax
-
-```js
-details = paymentMethodChangeEvent.methodName;
-```
-
-### Value
+## Value
 
 An object containing any data needed to describe the changes made to the payment
 method. The contents vary depending on the actual payment method chosen, so you will
@@ -38,7 +32,7 @@ property first, then interpret the `methodDetails` after that.
 The default value is `null`, indicating that no additional details are
 available.
 
-## Example
+## Examples
 
 This example uses the {{event("paymentmethodchange")}} event to watch for changes to
 the payment method selected for Apple Pay, in order to compute a discount if the user

--- a/files/en-us/web/api/paymentmethodchangeevent/methodname/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/methodname/index.md
@@ -23,13 +23,7 @@ payment handler may be a payment technology, such as Apple Pay or Android Pay, a
 payment handler may support multiple payment methods; changes to the payment method
 within the payment handler are described by the `PaymentMethodChangeEvent`.
 
-## Syntax
-
-```js
-var methodName = paymentMethodChangeEvent.methodName;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the currently-selected payment
 handler. This may be a string chosen from the list of standardized payment method
@@ -39,7 +33,7 @@ identifiers, or a URL used by the payment processing service. See
 
 The default value is the empty string, `""`.
 
-## Example
+## Examples
 
 This example uses the {{event("paymentmethodchange")}} event to watch for changes to
 the payment method selected for Apple Pay, in order to compute a discount if the user

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.md
@@ -17,13 +17,7 @@ The **`paymentRequestId`** read-only property of the
 {{domxref("PaymentRequestEvent")}} interface returns the ID of the
 {{domxref("PaymentRequest")}} object.
 
-## Syntax
-
-```js
-var id = paymentRequestEvent.paymentRequestId
-```
-
-### Value
+## Value
 
 A DOMString contains the ID.
 

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
@@ -17,13 +17,7 @@ The **`paymentRequestOrigin`** read-only property of the
 {{domxref("PaymentRequestEvent")}} interface returns the origin where the
 {{domxref("PaymentRequest")}} object was initialized.
 
-## Syntax
-
-```js
-var aUsvString = paymentRequestEvent.paymentRequestOrigin
-```
-
-### Value
+## Value
 
 A USVString.
 

--- a/files/en-us/web/api/paymentrequestevent/toporigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/toporigin/index.md
@@ -17,13 +17,7 @@ The **`topOrigin`** read-only property of the
 {{domxref("PaymentRequestEvent")}} interface returns the top level payee origin where
 the {{domxref("PaymentRequest")}} object was initialized.
 
-## Syntax
-
-```js
-var aUsvString = paymentRequestEvent.topOrigin
-```
-
-### Value
+## Value
 
 A USVString
 

--- a/files/en-us/web/api/paymentrequestevent/total/index.md
+++ b/files/en-us/web/api/paymentrequestevent/total/index.md
@@ -18,13 +18,7 @@ The **`total`** readonly property of the
 {{domxref('PaymentCurrencyAmount')}} object containing the total amount being requested
 for payment.
 
-## Syntax
-
-```js
-var paymentCurrencyAmount = paymentRequestEvent.total
-```
-
-### Value
+## Value
 
 A {{domxref('PaymentCurrencyAmount')}} object.
 

--- a/files/en-us/web/api/paymentresponse/methodname/index.md
+++ b/files/en-us/web/api/paymentresponse/methodname/index.md
@@ -32,7 +32,7 @@ payment processor to handle payments. See
 {{SectionOnPage("/en-US/docs/Web/API/Payment_Request_API/Concepts", "Merchant
   validation")}} for more information.
 
-## Example
+## Examples
 
 The following example extracts the method name from the {{domxref('PaymentResponse')}}
 object to the promise returned from {{domxref('PaymentRequest.show()')}}. In a

--- a/files/en-us/web/api/paymentresponse/requestid/index.md
+++ b/files/en-us/web/api/paymentresponse/requestid/index.md
@@ -18,13 +18,7 @@ The **`requestId`** read-only property of the
 {{domxref("PaymentResponse")}} interface returns the free-form identifier supplied by
 the `PaymentResponse()` constructor by details.id.
 
-## Syntax
-
-```js
-var id = paymentRequest.id
-```
-
-### Value
+## Value
 
 A {{domxref('DOMString')}}.
 

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.md
@@ -24,7 +24,7 @@ containing the shipping address provided by the user.
 A {{domxref("PaymentAddress")}} object providing details comprising the shipping
 address provided by the user.
 
-## Example
+## Examples
 
 Generally, the user agent will fill the `shippingAddress` property for you.
 You can trigger this by

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -19,13 +19,7 @@ start time of the performance measurement.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var timeOrigin = performance.timeOrigin
-```
-
-### Value
+## Value
 
 A high resolution timestamp.
 

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -28,7 +28,7 @@ A {{domxref("DOMString","string")}} containing one of the following values:
 - `"prerender"`
   - : Navigation is initiated by a [prerender hint](https://www.w3.org/TR/resource-hints/#prerender).
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -21,17 +21,11 @@ is not intercepted by a Service Worker the property will always return 0.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.workerStart;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}}.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/permissionstatus/name/index.md
+++ b/files/en-us/web/api/permissionstatus/name/index.md
@@ -21,7 +21,7 @@ The **`name`** read-only property of the {{domxref("PermissionStatus")}} interfa
 
 A read-only value that is identical to the `name` argument passed to {{domxref("Permissions.query", "navigator.permissions.query()")}}.
 
-## Example
+## Examples
 
 ```js
 function stateChangeListener() {

--- a/files/en-us/web/api/presentation/receiver/index.md
+++ b/files/en-us/web/api/presentation/receiver/index.md
@@ -30,7 +30,7 @@ with the context which is the source of the presentation.
 If the current context is not receiving a presentation, `receiver` is
 `null`.
 
-## Example
+## Examples
 
 ### Determining whether or not the context is receiving a presentation
 

--- a/files/en-us/web/api/presentationconnection/url/index.md
+++ b/files/en-us/web/api/presentationconnection/url/index.md
@@ -18,13 +18,7 @@ The **`url`** readonly property of the
 {{domxref("PresentationConnection")}} interface returns the URL used to create or
 reconnect to the presentation.
 
-## Syntax
-
-```js
-var url = PresentationConnection.url
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} containing a URL.
 

--- a/files/en-us/web/api/publickeycredential/id/index.md
+++ b/files/en-us/web/api/publickeycredential/id/index.md
@@ -24,13 +24,7 @@ encoded](/en-US/docs/Glossary/Base64) version of {{domxref("PublicKeyCredential.
 > **Note:** This property may only be used in top-level contexts and will
 > not be available in an {{HTMLElement("iframe")}} for example.
 
-## Syntax
-
-```js
-id = publicKeyCredential.id
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} being the [base64url
 encoded](/en-US/docs/Glossary/Base64) version of {{domxref("PublicKeyCredential.rawId")}}.

--- a/files/en-us/web/api/publickeycredential/rawid/index.md
+++ b/files/en-us/web/api/publickeycredential/rawid/index.md
@@ -22,13 +22,7 @@ encoded](/en-US/docs/Glossary/Base64) version of this identifier.
 > **Note:** This property may only be used in top-level contexts and will
 > not be available in an {{HTMLElement("iframe")}} for example.
 
-## Syntax
-
-```js
-rawId = publicKeyCredential.rawId
-```
-
-### Value
+## Value
 
 A {{jsxref("ArrayBuffer")}} containing the identifier of the credentials. This
 identifier is expected to be globally unique and is appointed for the current

--- a/files/en-us/web/api/publickeycredential/response/index.md
+++ b/files/en-us/web/api/publickeycredential/response/index.md
@@ -42,13 +42,7 @@ needs both:
 > **Note:** This property may only be used in top-level contexts and will
 > not be available in an {{HTMLElement("iframe")}} for example.
 
-## Syntax
-
-```js
-response = publicKeyCredential.response
-```
-
-### Value
+## Value
 
 An {{domxref("AuthenticatorResponse")}} object containing the data a relying party's
 script will receive and which should be sent to the relying party's server in order to

--- a/files/en-us/web/api/pushevent/data/index.md
+++ b/files/en-us/web/api/pushevent/data/index.md
@@ -15,13 +15,7 @@ browser-compat: api.PushEvent.data
 
 The `data` read-only property of the **`PushEvent`** interface returns a reference to a {{domxref("PushMessageData")}} object containing data sent to the {{domxref("PushSubscription")}}.
 
-## Syntax
-
-```js
-var myPushData = PushEvent.data;
-```
-
-### Value
+## Value
 
 A {{domxref("PushMessageData")}} object.
 

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.md
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.md
@@ -17,13 +17,7 @@ The **`supportedContentEncodings`** read-only property of the
 {{domxref("PushManager")}} interface returns an array of supported content codings that
 can be used to encrypt the payload of a push message.
 
-## Syntax
-
-```js
-var encodings[] = PushManager.supportedContentEncodings
-```
-
-### Value
+## Value
 
 An array of strings.
 

--- a/files/en-us/web/api/pushsubscription/endpoint/index.md
+++ b/files/en-us/web/api/pushsubscription/endpoint/index.md
@@ -24,17 +24,11 @@ used to send a push message to the particular service worker instance that subsc
 the push service. For this reason, it is a good idea to keep your endpoint a secret, so
 others do not hijack it and abuse the push functionality.
 
-## Syntax
-
-```js
-var myEnd = pushSubscription.endpoint;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 
-## Example
+## Examples
 
 ```js
 navigator.serviceWorker.ready.then(function(reg) {

--- a/files/en-us/web/api/pushsubscription/expirationtime/index.md
+++ b/files/en-us/web/api/pushsubscription/expirationtime/index.md
@@ -19,13 +19,7 @@ The **`expirationTime`** read-only property of the
 of the subscription expiration time associated with the push subscription, if there is
 one, or null otherwise.
 
-## Syntax
-
-```js
-var expirationTime = pushSubscription.expirationTime
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}}.
 

--- a/files/en-us/web/api/pushsubscription/options/index.md
+++ b/files/en-us/web/api/pushsubscription/options/index.md
@@ -17,13 +17,7 @@ The **`options`** read-only property
 of the {{domxref("PushSubscription")}} interface is an object containing the options
 used to create the subscription.
 
-## Syntax
-
-```js
-var options = PushSubscription.options
-```
-
-### Value
+## Value
 
 An read-only {{domxref("PushSubscriptionOptions")}} object containing the following values:
 

--- a/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.md
@@ -17,13 +17,7 @@ The **`byobRequest`** read-only property of the
 {{domxref("ReadableByteStreamController")}} interface returns the current BYOB pull
 request, or `undefined` if there are no pending requests.
 
-## Syntax
-
-```js
-var request = readableByteStreamController.byobRequest;
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStreamBYOBRequest")}} object instance, or `undefined`.
 

--- a/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.md
@@ -17,13 +17,7 @@ The **`desiredSize`** read-only property of the
 {{domxref("ReadableByteStreamController")}} interface returns the desired size required
 to fill the stream's internal queue.
 
-## Syntax
-
-```js
-var desiredSize = readableByteStreamController.desiredSize;
-```
-
-### Value
+## Value
 
 An integer. Note that this can be negative if the queue is over-full.
 

--- a/files/en-us/web/api/readablestream/locked/index.md
+++ b/files/en-us/web/api/readablestream/locked/index.md
@@ -16,13 +16,7 @@ The **`locked`** read-only property of the
 {{domxref("ReadableStream")}} interface returns whether or not the readable stream is [locked
 to a reader](https://streams.spec.whatwg.org/#lock).
 
-## Syntax
-
-```js
-var locked = readableStream.locked;
-```
-
-### Value
+## Value
 
 A boolean value indicating whether or not the readable stream is locked.
 

--- a/files/en-us/web/api/readablestreambyobreader/closed/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.md
@@ -19,13 +19,7 @@ of the {{domxref("ReadableStreamBYOBReader")}} interface returns a
 stream throws an error or the reader's lock is released. This property enables you
 to write code that responds to an end to the streaming process.
 
-## Syntax
-
-```js
-var closed = readableStreamBYOBReader.closed;
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/readablestreambyobrequest/view/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/view/index.md
@@ -16,13 +16,7 @@ browser-compat: api.ReadableStreamBYOBRequest.view
 The **`view`** getter property of the
 {{domxref("ReadableStreamBYOBRequest")}} interface returns the current view.
 
-## Syntax
-
-```js
-var view = readableStreamBYOBRequestInstance.view;
-```
-
-### Value
+## Value
 
 A [typed array](/en-US/docs/Web/JavaScript/Typed_arrays) representing the
 destination region to which the controller can write generated data.

--- a/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.md
@@ -16,13 +16,7 @@ The **`desiredSize`** read-only property of the
 {{domxref("ReadableStreamDefaultController")}} interface returns the desired size
 required to fill the stream's internal queue.
 
-## Syntax
-
-```js
-var desiredSize = readableStreamDefaultController.desiredSize;
-```
-
-### Value
+## Value
 
 An integer. Note that this can be negative if the queue is over-full.
 

--- a/files/en-us/web/api/readablestreamdefaultreader/closed/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/closed/index.md
@@ -18,13 +18,7 @@ The **`closed`** read-only property of the
 stream throws an error or the reader's lock is released. This property enables you
 to write code that responds to an end to the streaming process.
 
-## Syntax
-
-```js
-var closed = readableStreamDefaultReader.closed;
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/request/body/index.md
+++ b/files/en-us/web/api/request/body/index.md
@@ -18,13 +18,7 @@ that have been added to the request. Note that a request using the
 `GET` or `HEAD` method cannot have a body
 and `null` is return in these cases.
 
-## Syntax
-
-```js
-request.body
-```
-
-### Value
+## Value
 
 A {{domxref("ReadableStream")}} or {{jsxref("null")}}.
 

--- a/files/en-us/web/api/request/bodyused/index.md
+++ b/files/en-us/web/api/request/bodyused/index.md
@@ -16,13 +16,7 @@ The read-only **`bodyUsed`** property of the
 {{domxref("Request")}} interface is a boolean value that indicates
 whether the request body has been read yet.
 
-## Syntax
-
-```js
-request.bodyUsed;
-```
-
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/request/cache/index.md
+++ b/files/en-us/web/api/request/cache/index.md
@@ -14,13 +14,7 @@ browser-compat: api.Request.cache
 
 The **`cache`** read-only property of the {{domxref("Request")}} interface contains the cache mode of the request. It controls how the request will interact with the browser's [HTTP cache](/en-US/docs/Web/HTTP/Caching).
 
-## Syntax
-
-```js
-var currentCacheMode = request.cache;
-```
-
-### Value
+## Value
 
 A `RequestCache` value. The available values are:
 
@@ -49,7 +43,7 @@ A `RequestCache` value. The available values are:
 
   The `"only-if-cached"` mode can only be used if the request's [`mode`](/en-US/docs/Web/API/Request/mode) is `"same-origin"`. Cached redirects will be followed if the request's `redirect` property is `"follow"` and the redirects do not violate the `"same-origin"` mode.
 
-## Example
+## Examples
 
 ```js
 // Download a resource with cache busting, to bypass the cache

--- a/files/en-us/web/api/request/credentials/index.md
+++ b/files/en-us/web/api/request/credentials/index.md
@@ -17,13 +17,7 @@ browser-compat: api.Request.credentials
 
 The **`credentials`** read-only property of the {{domxref("Request")}} interface indicates whether the user agent should send cookies from the other domain in the case of cross-origin requests.
 
-## Syntax
-
-```js
-var myCred = request.credentials;
-```
-
-### Value
+## Value
 
 A `RequestCredentials` dictionary value indicating whether the user agent should send cookies from the other domain in the case of cross-origin requests. Possible values are:
 
@@ -33,7 +27,7 @@ A `RequestCredentials` dictionary value indicating whether the user agent should
 
 This is similar to XHR's [`withCredentials`](/en-US/docs/Web/API/XMLHttpRequest/withCredentials) flag, but with three available values instead of two.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as the script), then save the request credentials in a variable:
 

--- a/files/en-us/web/api/request/destination/index.md
+++ b/files/en-us/web/api/request/destination/index.md
@@ -42,13 +42,7 @@ any of the {{domxref("Worklet")}}-based destinations
 {{domxref("Worker")}}-based destinations, including {{domxref("ServiceWorker")}}
 and {{domxref("SharedWorker")}}.
 
-## Syntax
-
-```js
-var destination = request.destination;
-```
-
-### Value
+## Value
 
 A string which indicates the type of content the request is asking for. This type is much broader than the usual document type values (such as `"document"` or `"manifest"`), and may include contextual cues such as `"image"` or `"worker"` or `"audioworklet"`.
 
@@ -93,7 +87,7 @@ Possible values are:
 - `"xslt"`
   - : The target is an XLST transform.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same

--- a/files/en-us/web/api/request/headers/index.md
+++ b/files/en-us/web/api/request/headers/index.md
@@ -16,17 +16,11 @@ The **`headers`** read-only property of the
 {{domxref("Request")}} interface contains the {{domxref("Headers")}} object associated
 with the request.
 
-## Syntax
-
-```js
-var myHeaders = request.headers;
-```
-
-### Value
+## Value
 
 A {{domxref("Headers")}} object.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as

--- a/files/en-us/web/api/request/integrity/index.md
+++ b/files/en-us/web/api/request/integrity/index.md
@@ -14,19 +14,13 @@ browser-compat: api.Request.integrity
 
 The **`integrity`** read-only property of the {{domxref("Request")}} interface contains the [subresource integrity](/en-US/docs/Web/Security/Subresource_Integrity) value of the request.
 
-## Syntax
-
-```js
-var myIntegrity = request.integrity;
-```
-
-### Value
+## Value
 
 The [subresource integrity](/en-US/docs/Web/Security/Subresource_Integrity) value of the request (e.g., `sha256-BpfBw7ivV8q2jLiT13fxDYAe2tJllusRSZ273h2nFSE=`).
 
 If an integrity has not been specified, the property returns `''`.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as the script), then save the request `integrity` value in a variable:
 

--- a/files/en-us/web/api/request/method/index.md
+++ b/files/en-us/web/api/request/method/index.md
@@ -15,17 +15,11 @@ The **`method`** read-only property of the
 {{domxref("Request")}} interface contains the request's method (`GET`,
 `POST`, etc.)
 
-## Syntax
-
-```js
-var myMethod = request.method;
-```
-
-### Value
+## Value
 
 A {{jsxref("String")}} indicating the method of the request.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as

--- a/files/en-us/web/api/request/mode/index.md
+++ b/files/en-us/web/api/request/mode/index.md
@@ -17,13 +17,7 @@ interface contains the mode of the request (e.g., `cors`,
 `no-cors`, `same-origin`, `navigate` or `websocket`.) This is used
 to determine if cross-origin requests lead to valid responses, and which properties of the response are readable.
 
-## Syntax
-
-```js
-var myMode = request.mode;
-```
-
-### Value
+## Value
 
 - A `RequestMode` value.
 
@@ -67,7 +61,7 @@ mode — that is, for the {{HTMLElement("link")}} or {{HTMLElement("script")}} e
 {{HTMLElement("video")}}, {{HTMLElement("object")}}, {{HTMLElement("embed")}}, or
 {{HTMLElement("iframe")}} elements.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as

--- a/files/en-us/web/api/request/priority/index.md
+++ b/files/en-us/web/api/request/priority/index.md
@@ -28,7 +28,7 @@ Possible values are:
 - **`auto`**: Default mode, which indicates no preference for
   the fetch priority. The browser decides what is best for the user.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an API endpoint)

--- a/files/en-us/web/api/request/redirect/index.md
+++ b/files/en-us/web/api/request/redirect/index.md
@@ -14,13 +14,7 @@ browser-compat: api.Request.redirect
 
 The **`redirect`** read-only property of the {{domxref("Request")}} interface contains the mode for how redirects are handled.
 
-## Syntax
-
-```js
-var myRedirect = request.redirect;
-```
-
-### Value
+## Value
 
 A `RequestRedirect` enum value, which can be one the following strings:
 
@@ -30,7 +24,7 @@ A `RequestRedirect` enum value, which can be one the following strings:
 
 If not specified when the request is created, it takes the default value of `follow`.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as the script), then save the request `redirect` value in a variable:
 

--- a/files/en-us/web/api/request/referrer/index.md
+++ b/files/en-us/web/api/request/referrer/index.md
@@ -19,17 +19,11 @@ Request. (e.g., `client`, `no-referrer`, or a URL.)
 > **Note:** If `referrer`'s value is `no-referrer`,
 > it returns an empty string.
 
-## Syntax
-
-```js
-var myReferrer = request.referrer;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the request's referrer.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as

--- a/files/en-us/web/api/request/referrerpolicy/index.md
+++ b/files/en-us/web/api/request/referrerpolicy/index.md
@@ -17,19 +17,13 @@ The **`referrerPolicy`** read-only property of the
 referrer information, sent in the {{HTTPHeader("Referer")}} header, should be included
 with the request.
 
-## Syntax
-
-```js
-var myReferrerPolicy = request.referrerPolicy;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the request's `referrerPolicy`. For
 more information and possible values, see the {{HTTPHeader("Referrer-Policy")}} HTTP
 header page.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as

--- a/files/en-us/web/api/request/url/index.md
+++ b/files/en-us/web/api/request/url/index.md
@@ -15,17 +15,11 @@ browser-compat: api.Request.url
 The **`url`** read-only property of the {{domxref("Request")}}
 interface contains the URL of the request.
 
-## Syntax
-
-```js
-var myURL = request.url;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} indicating the url of the request.
 
-## Example
+## Examples
 
 In the following snippet, we create a new request using the
 {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as

--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -20,7 +20,7 @@ A {{domxref("ReadableStream")}}, or else [`null`](/en-US/docs/Web/JavaScript/Ref
 
 > **Note:** Current browsers don't actually conform to the spec requirement to set the `body` property to `null` for responses with no body (for example, responses to [`HEAD`](/en-US/docs/Web/HTTP/Methods/HEAD) requests, or [`204 No Content`](/en-US/docs/Web/HTTP/Status/204) responses).
 
-## Example
+## Examples
 
 In our [simple stream pump](https://mdn.github.io/dom-examples/streams/simple-pump/) example we fetch an image,
 expose the response's stream using `response.body`, create a reader using {{domxref("ReadableStream.getReader()", "ReadableStream.getReader()")}},

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -18,7 +18,7 @@ The **`bodyUsed`** read-only property of the {{domxref("Response")}} interface i
 
 A boolean value.
 
-## Example
+## Examples
 
 In our [fetch request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (run [fetch request live](https://mdn.github.io/fetch-examples/fetch-request/)),
 we create a new request using the {{domxref("Request.Request","Request()")}} constructor,

--- a/files/en-us/web/api/response/headers/index.md
+++ b/files/en-us/web/api/response/headers/index.md
@@ -20,7 +20,7 @@ with the response.
 
 A {{domxref("Headers")}} object.
 
-## Example
+## Examples
 
 In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
 we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error