### PR TITLE
Web Workers API: removed duplicate content.

### DIFF
--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -11,8 +11,6 @@ tags:
 
 **Web Workers** makes it possible to run a script operation in a background thread separate from the main execution thread of a web application. The advantage of this is that laborious processing can be performed in a separate thread, allowing the main (usually the UI) thread to run without being blocked/slowed down.
 
-> **Note:** Web Workers can also use the Web Worker API (i.e. workers can spawn workers, provided they are hosted within the same [origin](/en-US/docs/Glossary/Origin) as the parent page).
-
 ## Web Workers concepts and usage
 
 A worker is an object created using a constructor (e.g. {{DOMxRef("Worker.Worker", "Worker()")}}) that runs a named JavaScript file — this file contains the code that will run in the worker thread.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API

## Summary
The note:
> Note: Web Workers can also use the Web Worker API (i.e. workers can spawn workers, provided they are hosted within the same [origin](https://5546.content.dev.mdn.mozit.cloud/en-US/docs/Glossary/Origin) as the parent page).

mentions the same thing with less information. Also, the name `Web Worker API` should be `Web Workers API`. Plural indicator 's' is missing.

In the next section `Web Workers concepts and usage` the same thing has been explained in more detail:
> Workers may in turn spawn new workers, as long as those workers are hosted within the same [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) as the parent page. In addition, workers may use [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for network I/O, with the exception that the responseXML and channel attributes on XMLHttpRequest always return null.

This makes note redundant.

#### Metadata
- [x] Fixes a typo, bug, or other error