### PR TITLE
updates to using the status role page

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_status_role/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_status_role/index.html
@@ -14,16 +14,16 @@ tags:
 
 <p class="p1">The status role is a type of <a href="https://www.w3.org/WAI/PF/aria/terms#def_liveregion">live region</a> and a container whose content is advisory information for the user that is not important enough to justify an <a href="https://www.w3.org/TR/wai-aria-practices/#alert">alert</a>, and is often presented as a status bar. When the role is added to an element, the browser will send out an accessible status event to assistive technology products which can then notify the user about it.</p>
 
-<p class="p1">Status information content must be provided within a status object, and it should be ensured that this object does not receive focus. If another part of the page controls what appears in the status, the relationship should be made explicit via the <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-controls">aria-controls</a> attribute.</p>
+<p class="p1">Status information content must be provided within a status object, and it should be ensured that this object does not receive focus.</p>
 
 <p class="p1">Assistive technologies may reserve some cells of a Braille display to render the status.</p>
 
-<h3 id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology </h3>
+<h3 id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology</h3>
 
 <p class="p1">When the status role is added to an element, or such an element becomes visible, the user agent should do the following:</p>
 
 <ul class="ul1">
- <li class="li2">Expose the element as having a status role in the operating system's accessibility API. </li>
+ <li class="li2">Expose the element as having a status role in the operating system's accessibility API.</li>
  <li class="li2">Fire an accessible status event using the operating system's accessibility API if it supports it.</li>
 </ul>
 
@@ -40,13 +40,13 @@ tags:
 
 <h4 id="Example_1_Adding_the_status_role_in_HTML">Example 1: Adding the status role in HTML</h4>
 
-<p class="p1">The snippet below shows how the status role is added directly into the html source code. </p>
+<p class="p1">The snippet below shows how the status role is added directly into the HTML source code.</p>
 
 <pre class="brush: html">&lt;p role="status"&gt;Your changes were automatically saved.&lt;/p&gt; </pre>
 
 <h4 id="Working_Examples">Working Examples:</h4>
 
-<h3 id="Notes">Notes </h3>
+<h3 id="Notes">Notes</h3>
 
 <h3 id="ARIA_attributes_used">ARIA attributes used</h3>
 


### PR DESCRIPTION
I removed the sentence indicating that `aria-controls` should be used.  There is no practical benefit to doing this, and arguably `aria-details` would be a more appropriate attribute to use depending on the context.  

It may be worth mentioning here that the HTML output element has an implicit `role=status`.

