### PR TITLE
VideoDecoder(): added missing argument in syntax

### DIFF
--- a/files/en-us/web/api/videodecoder/videodecoder/index.md
+++ b/files/en-us/web/api/videodecoder/videodecoder/index.md
@@ -15,7 +15,7 @@ The **`VideoDecoder()`** constructor creates a new {{domxref("VideoDecoder")}} o
 ## Syntax
 
 ```js
-new VideoDecoder();
+new VideoDecoder(init);
 ```
 
 ### Parameters


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/VideoDecoder

## Summary
`init` argument is missing.
No argument constructor throws error.

## Supporting details
Other constructors in the api https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/VideoEncoder

#### Metadata
- [x] Fixes a typo, bug, or other error
