### PR TITLE
update role=status doc

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/status_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/status_role/index.md
@@ -15,11 +15,9 @@ The `status` role defines a [live region](/en-US/docs/Web/Accessibility/ARIA/ARI
 
 ## Description
 
-A `status` is a type of [live region](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) providing advisory information that is not important enough to justify an alert. It is often, but not necessarily, presented as a status bar.
+A `status` is a type of [live region](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) providing advisory information that is not important enough to justify an alert, which would immediately interrupt the announcement of a user's current activity. It is often, but not necessarily, presented as a status bar.
 
-As the content is not vital, do not give focus to the status when its content updates.
-
-If another part of the page controls what appears in the status, make the relationship explicit with the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) attribute on the controlling element (not on the status).
+Do not give focus to the status when its content updates. Live regions are meant to inform users of dynamic updates that have occurred in other areas of the current web page, but which do not necessitate interrupting the user's current activity with a change in context. If a situation requires that focus needs to be moved, then using a `status`, or other live region, are likely not appropraite.
 
 Elements with the role status have an implicit [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) value of `polite` and an implicit [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) value of `true`.  
 


### PR DESCRIPTION
Follow on to https://github.com/mdn/content/pull/14508

- per other PR, removes reference to needing `aria-controls`.
- adds context to the diff between `status` and `alert` to clarify the "justify an alert" sentence.
- rewrite and expand the sentence about focus - because being vital or not is irrelevant to the purpose of live regions.