### PR TITLE
Fix the description of values

### DIFF
--- a/files/en-us/web/api/domtokenlist/entries/index.md
+++ b/files/en-us/web/api/domtokenlist/entries/index.md
@@ -11,7 +11,7 @@ browser-compat: api.DOMTokenList.entries
 The **`entries()`** method of the {{domxref("DOMTokenList")}} interface
 returns an {{jsxref("Iteration_protocols",'iterator')}} allowing you
 to go through all key/value pairs contained in this object. The values are
-{{jsxref("String")}} objects, each representing a single token.
+{{jsxref("Array")}}s which have [key, value] pairs, each representing a single token.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The description says the values are `String` objects, but an iterator which is returned by this method returns an array rather than a String object.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
