### PR TITLE
Drop a couple auto-assigned labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,10 +30,6 @@ Content:Learn:
   - files/en-us/learn/**/*
   - files/en-us/web/guide/**/*
   - files/en-us/web/tutorials/**/*
-Content:Learn:Django:
-  - files/en-us/learn/server-side/django/**/*
-Content:Learn:Express:
-  - files/en-us/learn/server-side/express_nodejs/**/*
 Content:Other:
   - files/en-us/games/**/*
   - files/en-us/mdn/**/*


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This eliminates the auto-assignment of deeply-nested `Content:Learn:*` labels.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The content team thinks the existing `Content:Learn` sublabels are too finely sliced (and incomplete).

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
