### PR TITLE
Fix viewport meta tag link in PWA app_structure

### DIFF
--- a/files/en-us/web/progressive_web_apps/app_structure/index.md
+++ b/files/en-us/web/progressive_web_apps/app_structure/index.md
@@ -46,7 +46,7 @@ It's important to remember the PWA advantages and keep them in mind when designi
 
 - Linkable: Even though it behaves like a native app, it is still a website — you can click on the links within the page and send a URL to someone if you want to share it.
 - Progressive: Start with the "good, old basic website" and progressively add new features while remembering to detect if they are available in the browser and gracefully handle any errors that crop up if support is not available. For example, an offline mode with the help of service workers is just an extra trait that makes the website experience better, but it's still perfectly usable without it.
-- Responsive: Responsive web design also applies to progressive web apps, as both are mainly for mobile devices. There are so many varied devices with browsers — it's important to prepare your website so it works on different screen sizes, viewports or pixel densities, using technologies like [viewport meta tag](/en-US/docs/Mozilla/Mobile/Viewport_meta_tag), [CSS media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries), [Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout), and [CSS Grid](/en-US/docs/Web/CSS/CSS_Grid_Layout).
+- Responsive: Responsive web design also applies to progressive web apps, as both are mainly for mobile devices. There are so many varied devices with browsers — it's important to prepare your website so it works on different screen sizes, viewports or pixel densities, using technologies like [viewport meta tag](/en-US/docs/Web/HTML/Viewport_meta_tag), [CSS media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries), [Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout), and [CSS Grid](/en-US/docs/Web/CSS/CSS_Grid_Layout).
 
 ## Different concept: streams
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix the URL pointing to the viewport meta tag documentation page

#### Motivation
While reading the PWA documentation, found a link leading to a Page Not Found (404) error. 
This will help the readers to navigate to the expected page.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
