### PR TITLE
Using const instead of let for more meaningful

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -352,7 +352,7 @@ let flattened = [[0, 1], [2, 3], [4, 5]].reduce(
 ### Counting instances of values in an object
 
 ```js
-let names = ['Alice', 'Bob', 'Tiff', 'Bruce', 'Alice']
+const names = ['Alice', 'Bob', 'Tiff', 'Bruce', 'Alice']
 
 let countedNames = names.reduce(function (allNames, name) {
   if (name in allNames) {
@@ -370,7 +370,7 @@ let countedNames = names.reduce(function (allNames, name) {
 ### Grouping objects by a property
 
 ```js
-let people = [
+const people = [
   { name: 'Alice', age: 21 },
   { name: 'Max', age: 20 },
   { name: 'Jane', age: 20 }
@@ -403,7 +403,7 @@ let groupedPeople = groupBy(people, 'age')
 ```js
 // friends - an array of objects
 // where object field "books" is a list of favorite books
-let friends = [{
+const friends = [{
   name: 'Anna',
   books: ['Bible', 'Harry Potter'],
   age: 21
@@ -438,7 +438,7 @@ let allbooks = friends.reduce(function(previousValue, currentValue) {
 > duplicate items have been removed.
 
 ```js
-let myArray = ['a', 'b', 'a', 'b', 'c', 'e', 'e', 'c', 'd', 'd', 'd', 'd']
+const myArray = ['a', 'b', 'a', 'b', 'c', 'e', 'e', 'c', 'd', 'd', 'd', 'd']
 let myArrayWithNoDuplicates = myArray.reduce(function (previousValue, currentValue) {
   if (previousValue.indexOf(currentValue) === -1) {
     previousValue.push(currentValue)


### PR DESCRIPTION
Use of let keyword makes developers think that these variable may get reassigned some time later, but which is not the case here.
So, const would make more meaningful and also makes it to be uniform with other code blocks in the page.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
