### PR TITLE
Include Intl.Segmenter in JS Ref index, aka lonely follow-up of #8402

### DIFF
--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -131,6 +131,7 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 - {{JSxRef("Global_Objects/Intl/NumberFormat", "Intl.NumberFormat")}}
 - {{JSxRef("Global_Objects/Intl/PluralRules", "Intl.PluralRules")}}
 - {{JSxRef("Global_Objects/Intl/RelativeTimeFormat", "Intl.RelativeTimeFormat")}}
+- {{JSxRef("Global_Objects/Intl/Segmenter", "Intl.Segmenter")}}
 
 ### WebAssembly
 


### PR DESCRIPTION
#### Summary
Completes the JS Ref landing page with a ref to `Intl.Segmenter`

#### Motivation
I didn't catch it under #8402 :( 

#### Supporting details
#8402 

#### Related issues
None that I know of

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
