### PR TITLE
WebAPI: Clean syntax from property pages, part 15

### DIFF
--- a/files/en-us/web/api/response/ok/index.md
+++ b/files/en-us/web/api/response/ok/index.md
@@ -18,7 +18,7 @@ The **`ok`** read-only property of the {{domxref("Response")}} interface contain
 
 A boolean value.
 
-## Example
+## Examples
 
 In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
 we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.

--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -21,7 +21,7 @@ For example, `200` for success, `404` if the resource could not be found.
 A unsigned short number.
 This is one of the [HTTP response status codes](/en-US/docs/Web/HTTP/Status).
 
-## Example
+## Examples
 
 In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
 we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.

--- a/files/en-us/web/api/response/statustext/index.md
+++ b/files/en-us/web/api/response/statustext/index.md
@@ -24,7 +24,7 @@ The default value is "".
 See [HTTP response status codes](/en-US/docs/Web/HTTP/Status) for a list of codes and their associated status messages.
 Note that HTTP/2 [does not support](https://fetch.spec.whatwg.org/#concept-response-status-message) status messages.
 
-## Example
+## Examples
 
 In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.

--- a/files/en-us/web/api/response/type/index.md
+++ b/files/en-us/web/api/response/type/index.md
@@ -32,7 +32,7 @@ It can be one of the following:
 
 A `ResponseType` string indicating the type of the response.
 
-## Example
+## Examples
 
 In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.

--- a/files/en-us/web/api/response/url/index.md
+++ b/files/en-us/web/api/response/url/index.md
@@ -19,7 +19,7 @@ The value of the `url` property will be the final URL obtained after any redirec
 
 A {{domxref("USVString")}}.
 
-## Example
+## Examples
 
 In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.

--- a/files/en-us/web/api/rtcdtlstransport/icetransport/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/icetransport/index.md
@@ -16,13 +16,7 @@ The read-only **{{DOMxRef("RTCDtlsTransport")}}**
 property **`iceTransport`** contains a reference
 to the underlying {{DOMxRef("RTCIceTransport")}}.
 
-## Syntax
-
-```js
-var iceTransport = rtcDtlsTransport.iceTransport;
-```
-
-### Value
+## Value
 
 The underlying {{DOMxRef("RTCIceTransport")}} instance.
 

--- a/files/en-us/web/api/rtcdtlstransport/state/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/state/index.md
@@ -17,13 +17,7 @@ The **`state`** read-only property of the
 {{DOMxRef("RTCDtlsTransport")}} interface provides information which describes a
 Datagram Transport Layer Security (**{{Glossary("DTLS")}}**) transport state.
 
-## Syntax
-
-```js
-let myState = dtlsTransport.state;
-```
-
-### Value
+## Value
 
 A string. Its value is one of the following:
 

--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -26,13 +26,7 @@ browser-compat: api.RTCError.errorDetail
 The {{domxref("RTCError")}} interface's read-only
 **`errorDetail`** property is a string indicating the [WebRTC](/en-US/docs/Web/API/WebRTC_API)-specific error code that occurred.
 
-## Syntax
-
-```js
-let rtcErrorDetail = rtcError.errorDetail;
-```
-
-### Value
+## Value
 
 A read-only string whose value indicates the type of WebRTC-specific error that
 occurred on an {{domxref("RTCPeerConnection")}}. The possible values are taken from the

--- a/files/en-us/web/api/rtcerror/receivedalert/index.md
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.md
@@ -22,13 +22,7 @@ The {{domxref("RTCError")}} read-only property
 **`receivedAlert`** specifies the fatal {{Glossary("DTLS")}}
 error which resulted in an alert being received from the remote peer.
 
-## Syntax
-
-```js
-let receivedAlert = rtcError.receivedAlert;
-```
-
-### Value
+## Value
 
 An unsigned long integer value specifying the fatal {{Glossary("DTLS")}} error which
 resulted in an alert being received from the remote peer.

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.md
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.md
@@ -22,13 +22,7 @@ The read-only **`sctpCauseCode`** property in an
 {{domxref("RTCError")}} object provides the {{Glossary("SCTP")}} cause code explaining
 why the SCTP negotiation failed, if the `RTCError` represents an SCTP error.
 
-## Syntax
-
-```js
-let sctpCause = rtcError.sctpCauseCode;
-```
-
-### Value
+## Value
 
 An unsigned long integer value specifying SCTP cause code explaining why the error
 occurred. This property is `null` if the error isn't an SCTP error, with its

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.md
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.md
@@ -22,13 +22,7 @@ The {{domxref("RTCError")}} interface's read-only property
 **`sdpLineNumber`** specifies the line number within the
 {{Glossary("SDP")}} at which a syntax error occurred while parsing it.
 
-## Syntax
-
-```js
-let errorLineNumber = rtcError.sdpLineNumber;
-```
-
-### Value
+## Value
 
 An unsigned integer value indicating the line within the SDP at which the syntax error
 described by the `RTCError` object occurred. The lines are numbed starting

--- a/files/en-us/web/api/rtcerror/sentalert/index.md
+++ b/files/en-us/web/api/rtcerror/sentalert/index.md
@@ -22,13 +22,7 @@ The read-only **`sentAlert`** property in an
 {{domxref("RTCError")}} object specifies the {{Glossary("DTLS")}} alert number occurred
 while sending data to the remote peer, if the error represents an outbound DTLS error.
 
-## Syntax
-
-```js
-let sentAlert = rtcError.sentAlert;
-```
-
-### Value
+## Value
 
 An unsigned integer value providing the DTLS alert number corresponding to the DTLS
 error which was sent to the remote peer, as represented by this `RTCError`

--- a/files/en-us/web/api/rtcerrorevent/error/index.md
+++ b/files/en-us/web/api/rtcerrorevent/error/index.md
@@ -23,13 +23,7 @@ The read-only {{domxref("RTCErrorEvent")}} property **`error`**
 contains an {{domxref("RTCError")}} object describing the details of the error which the
 event is announcing.
 
-## Syntax
-
-```js
-let errorInfo = rtcErrorEvent.error;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCError")}} object whose properties provide details about the error
 which has occurred in the context of a {{Glossary("WebRTC")}} operation.

--- a/files/en-us/web/api/rtcicecandidate/address/index.md
+++ b/files/en-us/web/api/rtcicecandidate/address/index.md
@@ -79,7 +79,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host
 
 The fifth field, `"192.168.0.56"` is the IP address in this candidate's a-line string.
 
-## Example
+## Examples
 
 This code snippet uses the value of `address` to implement an IP address based ban feature.
 

--- a/files/en-us/web/api/rtcicecandidate/candidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/candidate/index.md
@@ -52,7 +52,7 @@ attributes for this example candidate is:
 - {{domxref("RTCIceCandidate.port", "port")}} = 44323
 - {{domxref("RTCIceCandidate.type", "type")}} = `"host"`
 
-## Example
+## Examples
 
 In this example, we see a function which receives as input an SDP string containing an
 ICE candidate received from the remote peer during the signaling process.

--- a/files/en-us/web/api/rtcicecandidate/component/index.md
+++ b/files/en-us/web/api/rtcicecandidate/component/index.md
@@ -51,7 +51,7 @@ component ID. A value of `"1"` indicates RTP, which is recorded in the
 `"2"`, the a-line would be describing an RTCP candidate, and
 `component` would be `"rtcp"`.
 
-## Example
+## Examples
 
 This code snippet examines a candidate's component type and dispatches the candidate to
 different handlers depending on the value.

--- a/files/en-us/web/api/rtcicecandidate/foundation/index.md
+++ b/files/en-us/web/api/rtcicecandidate/foundation/index.md
@@ -46,7 +46,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host
 
 The field `"4234997325"` is the foundation.
 
-## Example
+## Examples
 
 This code snippet uses the `foundation` of two candidates to determine if
 they're actually the same candidate.

--- a/files/en-us/web/api/rtcicecandidate/port/index.md
+++ b/files/en-us/web/api/rtcicecandidate/port/index.md
@@ -46,7 +46,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host
 
 The port number is found in the sixth field, which is `"44323"`. In this case, the value of `port` will be 44323.
 
-## Example
+## Examples
 
 This code snippet fetches the IP address and port number of the candidate, storing them
 into an object for future use.

--- a/files/en-us/web/api/rtcicecandidate/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidate/priority/index.md
@@ -45,7 +45,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host
 The priority is the number after the protocol, so it's the fourth field in the candidate string.
 In this example, the priority is 2043278322.
 
-## Example
+## Examples
 
 This candidate examines the `priority` of the candidate and, if it's greater
 than the priority of a previously-seen candidate, remembers the candidate for later use.

--- a/files/en-us/web/api/rtcicecandidate/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidate/protocol/index.md
@@ -47,7 +47,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host
 The third field, `"udp"`, is the protocol type, indicating that the
 candidate would use the UDP transport protocol.
 
-## Example
+## Examples
 
 This code snippet examines the value of `protocol` to decide if it should
 look at the value of {{domxref("RTCIceCandidate.tcpType", "tcpType")}} to see if it's a

--- a/files/en-us/web/api/rtcicecandidate/relatedaddress/index.md
+++ b/files/en-us/web/api/rtcicecandidate/relatedaddress/index.md
@@ -55,7 +55,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 6502 typ srflx raddr 192.16
 The remote address, `relatedAddress`, is the dotted quad (for IPv4) or
 colon-delineated 64-bit address (for IPv6) immediately following the text `"raddr"`, or `"192.168.2.77"`.
 
-## Example
+## Examples
 
 In this example, the candidate's {{domxref("RTCIceCandidate.type", "type")}} is
 checked, and then debugging output is presented, based on the candidate type, including

--- a/files/en-us/web/api/rtcicecandidate/relatedport/index.md
+++ b/files/en-us/web/api/rtcicecandidate/relatedport/index.md
@@ -53,7 +53,7 @@ a=candidate:4234997325 1 udp 2043278322 192.168.0.56 6502 typ srflx raddr 192.16
 
 The remote port, `relatedPort`, is the number immediately following the `"rport"` label on the a-line, or 32768.
 
-## Example
+## Examples
 
 In this example, the candidate's {{domxref("RTCIceCandidate.type", "type")}} is
 checked, and then debugging output is presented, based on the candidate type, including

--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
@@ -34,7 +34,7 @@ which the candidate draws data, or `null` if no such association exists for the 
 > **Note:** Attempting to add a candidate (using {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}}) that has a
 > value of `null` for both `sdpMid` and `sdpMLineIndex` will throw a `TypeError` exception.
 
-## Example
+## Examples
 
 ...
 

--- a/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
@@ -35,7 +35,7 @@ indicating which media source is associated with the candidate, or `null` if no 
 > value of `null` for either `sdpMid` or
 > `sdpMLineIndex` will throw a `TypeError` exception.
 
-## Example
+## Examples
 
 ...
 

--- a/files/en-us/web/api/rtcicecandidate/tcptype/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tcptype/index.md
@@ -36,7 +36,7 @@ If the {{domxref("RTCIceCandidate.protocol","protocol")}} is "tcp", `tcpType` ha
 
 `tcpType` is `null` for {{Glossary("UDP")}} candidates.
 
-## Example
+## Examples
 
 In this example, the candidate's {{domxref("RTCIceCandidate.protocol", "protocol")}}
 and `tcpType` are used to adjust the user interface for simultaneous-open TCP candidates.

--- a/files/en-us/web/api/rtcicecandidate/type/index.md
+++ b/files/en-us/web/api/rtcicecandidate/type/index.md
@@ -41,7 +41,7 @@ If `type` is `null`, that information was missing from the
 {{domxref("RTCPeerConnection.addIceCandidate()")}} to throw an
 `OperationError` exception.
 
-## Example
+## Examples
 
 In this example, the candidate's {{domxref("RTCIceCandidate.type", "type")}} is used to
 present a modified user interface for host candidates (those where the

--- a/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
+++ b/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
@@ -55,7 +55,7 @@ to inject themselves into an ICE exchange.
 
 The `usernameFragment` and password both change every time an [ICE restart](/en-US/docs/Web/API/WebRTC_API/Session_lifetime#ice_restart) occurs.
 
-## Example
+## Examples
 
 Although the WebRTC infrastructure will filter out obsolete candidates for you after an
 ICE restart, you can do it yourself if you're trying to absolutely minimize the number

--- a/files/en-us/web/api/rtcicecandidatepair/local/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.md
@@ -30,7 +30,7 @@ a viable pair of ICE candidates. The `RTCIceCandidatePair` is returned by the
 {{domxref("RTCIceTransport")}} method
 {{domxref("RTCIceTransport.getSelectedCandidatePair", "getSelectedCandidatePair()")}}.
 
-## Example
+## Examples
 
 This one-line example obtains the current candidate pair and then from that gets the
 local candidate.

--- a/files/en-us/web/api/rtcicecandidatepair/remote/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/remote/index.md
@@ -30,7 +30,7 @@ of a viable pair of ICE candidates. The `RTCIceCandidatePair` is returned by
 the {{domxref("RTCIceTransport")}} method
 {{domxref("RTCIceTransport.getSelectedCandidatePair", "getSelectedCandidatePair()")}}.
 
-## Example
+## Examples
 
 This one-line example obtains the current candidate pair and then from that gets the
 remote candidate.

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.md
@@ -32,13 +32,7 @@ You can get the incoming available bitrate from
 {{domxref("RTCIceCandidatePairStats.availableIncomingBitrate",
   "availableIncomingBitrate")}}.
 
-## Syntax
-
-```js
-availableOutgoingBitrate = rtcIceCandidatePairStats.availableOutgoingBitrate;
-```
-
-### Value
+## Value
 
 A floating-point value which approximates the amount of available bandwidth for
 outgoing data on the network connection described by the

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.md
@@ -28,13 +28,7 @@ received to date on the connection described by the candidate pair.
 The {{domxref("RTCIceCandidatePairStats.bytesSent", "bytesSent")}} property reports the
 number of bytes sent so far on the described connection.
 
-## Syntax
-
-```js
-received = rtcIceCandidatePairStats.bytesReceived;
-```
-
-### Value
+## Value
 
 An integer value indicating the total number of bytes received so far on the connection
 described by this candidate pair. Only data bytes are counted; overhead such as padding,

--- a/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.md
@@ -24,13 +24,7 @@ unexpected connection abort on this specific connection configuration.
 A circuit breaker trigger is fired each time the connection times out or otherwise
 needs to be halted automatically.
 
-## Syntax
-
-```js
-cbtCount = rtcIceCandidatePairStats.circuitBreakerTriggerCount;
-```
-
-### Value
+## Value
 
 An integer value indicating the number of times the circuit-breaker has been triggered
 for the 5-tuple used by this connection. A 5-tuple defining a TCP connection is made up

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.md
@@ -30,13 +30,7 @@ the current STUN bindings — the mapping of the IP address and port configurati
 both peers on the {{Glossary("WebRTC")}} connection — are due to expire. If this time
 has arrived or passed, the bindings have expired.
 
-## Syntax
-
-```js
-consentExpiration = rtcIceCandidatePairStats.consentExpiredTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object that indicates the time at which the STUN
 binding that allows the two peers described by this {{domxref("RTCIceCandidatePair")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.md
@@ -25,13 +25,7 @@ The {{domxref("RTCIceCandidatePairStats")}} property
 **`firstRequestTimestamp`** specifies the time at which the
 first {{Glossary("STUN")}} request was sent on the described candidate pair.
 
-## Syntax
-
-```js
-firstRequestTimestamp = rtcIceCandidatePairStats.firstRequestTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object indicating the timestamp at which the first
 STUN request was sent on the connection described by the described pair of candidates.

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.md
@@ -23,13 +23,7 @@ The {{domxref("RTCIceCandidatePairStats")}} property
 the connection described by the candidate pair last received a packet.
 {{Glossary("STUN")}} packets are not included.
 
-## Syntax
-
-```js
-lastPacketReceivedTimestamp = rtcIceCandidatePairStats.lastPacketReceivedTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object indicating the timestamp at which the
 connection described by pair of candidates last received a packet, STUN packets

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.md
@@ -25,13 +25,7 @@ The {{domxref("RTCIceCandidatePairStats")}} property
 connection described by the candidate pair last sent a packet, not including
 {{Glossary("STUN")}} packets.
 
-## Syntax
-
-```js
-lastPacketSentTimestamp = rtcIceCandidatePairStats.lastPacketSentTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object indicating the timestamp at which the
 connection described by pair of candidates last sent a packet, STUN packets excluded.

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.md
@@ -26,13 +26,7 @@ The {{domxref("RTCIceCandidatePairStats")}} property
 most recent {{Glossary("STUN")}} request was sent on the described candidate
 pair.
 
-## Syntax
-
-```js
-lastRequestTimestamp = rtcIceCandidatePairStats.lastRequestTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object indicating the timestamp at which the last
 (most recent) STUN request was sent on the connection indicated by the described pair of

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.md
@@ -26,13 +26,7 @@ The {{domxref("RTCIceCandidatePairStats")}} property
 last {{Glossary("STUN")}} response was received on the described candidate
 pair.
 
-## Syntax
-
-```js
-lastResponseTimestamp = rtcIceCandidatePairStats.lastResponseTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} object indicating the timestamp at which the most
 recent STUN response was received on the connection defined by the described pair of

--- a/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.md
@@ -27,13 +27,7 @@ the local {{Glossary("ICE")}} candidate which was analyzed to generate the
 {{domxref("RTCIceCandidateStats")}} used to compute the statistics for this pair of
 candidates.
 
-## Syntax
-
-```js
-localCandidateId = rtcIceCandidatePairStats.localCandidateId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} giving a unique identifier for the local
 {{domxref("RTCIceCandidate")}} for the connection described by this

--- a/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.md
@@ -22,13 +22,7 @@ The {{domxref("RTCIceCandidatePairStats")}} property
 described by the underlying `RTCIceCandidatePair` has been nominated to be
 used as the configuration for the WebRTC connection.
 
-## Syntax
-
-```js
-nominated = rtcIceCandidatePairStats.nominated;
-```
-
-### Value
+## Value
 
 A Boolean value which is set to `true` by the ICE layer if the controlling
 user agent has indicated that the candidate pair should be used to configure the WebRTC

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.md
@@ -26,13 +26,7 @@ candidates.
 The number of packets sent to date on the connection can be obtained using
 {{domxref("RTCIceCandidatePairStats.packetsSent", "packetsSent")}}.
 
-## Syntax
-
-```js
-packetsReceived = rtcIceCandidatePairStats.packetsReceived;
-```
-
-### Value
+## Value
 
 An integer value indicating the total number of packets, of any kind, which have been
 received on the connection described by the two candidates comprising this pair.

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.md
@@ -28,13 +28,7 @@ candidates.
 The number of packets received to date on the connection can be obtained using
 {{domxref("RTCIceCandidatePairStats.packetsReceived", "packetsReceived")}}.
 
-## Syntax
-
-```js
-packetsSent = rtcIceCandidatePairStats.packetsSent;
-```
-
-### Value
+## Value
 
 An integer value indicating the total number of packets, of any kind, which have been
 sent on the connection described by the two candidates comprising this pair.

--- a/files/en-us/web/api/rtcicecandidatepairstats/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/priority/index.md
@@ -23,13 +23,7 @@ pair as an integer value. The higher the value, the more likely the WebRTC
 layer is to select the candidate pair when the time comes to establish (or re-establish)
 a connection between the two peers.
 
-## Syntax
-
-```js
-pairPriority = rtcIceCandidatePairStats.priority;
-```
-
-### Value
+## Value
 
 An integer value indicating the priority of this pair of candidates as compared to
 other pairs on the same peer connection. The higher this value, the better the WebRTC

--- a/files/en-us/web/api/rtcicecandidatepairstats/readable/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/readable/index.md
@@ -23,13 +23,7 @@ property **`readable`** reports whether or not the connection
 described by the candidate pair has received at least one valid incoming ICE
 request.
 
-## Syntax
-
-```js
-isReadable = rtcIceCandidatePairStats.readable;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the connection described by this
 candidate pair has received at least one valid ICE request, and is therefore ready to be

--- a/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.md
@@ -26,13 +26,7 @@ the remote {{Glossary("ICE")}} candidate which was analyzed to generate the
 {{domxref("RTCIceCandidateStats")}} used to compute the statistics for this pair of
 candidates.
 
-## Syntax
-
-```js
-remoteCandidateId = rtcIceCandidatePairStats.remoteCandidateId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} uniquely identifies the remote {{Glossary("ICE")}}
 candidate—that is, the candidate describing a configuration for the remote peer—which is

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.md
@@ -23,13 +23,7 @@ The {{domxref("RTCIceCandidatePairStats")}} dictionary's
 {{Glossary("STUN")}} connectivity check requests that have been received so far on the
 connection described by this pairing of candidates.
 
-## Syntax
-
-```js
-requestsReceived = rtcIceCandidatePairStats.requestsReceived;
-```
-
-### Value
+## Value
 
 An integer value which specifies the number of STUN connectivity and/or consent
 requests that have been received to date on the connection described by this pair of

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
@@ -24,13 +24,7 @@ The {{domxref("RTCIceCandidatePairStats")}} dictionary's
 {{Glossary("STUN")}} connectivity check requests that have been sent so far on the
 connection described by this pair of candidates.
 
-## Syntax
-
-```js
-requestsSent = rtcIceCandidatePairStats.requestsSent;
-```
-
-### Value
+## Value
 
 An integer value which specifies the number of STUN connectivity requests that have
 been sent to date on the connection described by this pair of {{Glossary("ICE")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
@@ -26,13 +26,7 @@ in the {{domxref("RTCIceCandidatePairStats")}} dictionary indicates the total nu
 of {{Glossary("STUN")}} connectivity check responses that have been received on the
 connection described by this pair of candidates.
 
-## Syntax
-
-```js
-responsesReceived = rtcIceCandidatePairStats.responsesReceived;
-```
-
-### Value
+## Value
 
 An integer value which specifies the number of STUN connectivity request responses that
 have been received on the connection described by this pair of candidates so far.

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.md
@@ -25,13 +25,7 @@ The {{domxref("RTCIceCandidatePairStats")}} dictionary's
 {{Glossary("STUN")}} connectivity check responses that have been sent so far on the
 connection described by this pair of candidates.
 
-## Syntax
-
-```js
-responsesSent = rtcIceCandidatePairStats.responsesSent;
-```
-
-### Value
+## Value
 
 An integer value indicating the number of times a response has been sent to a
 {{Glossary("STUN")}} connectivity check request.

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.md
@@ -30,13 +30,7 @@ The number of retransmissions that have been sent on the connection can be
 found in {{domxref("RTCIceCandidatePairStats.retransmissionsSent",
   "retransmissionsSent")}}.
 
-## Syntax
-
-```js
-retransmissionsReceived = rtcIceCandidatePairStats.retransmissionsReceived;
-```
-
-### Value
+## Value
 
 An integer value indicating the total number of retransmitted STUN connectivity check
 requests have been received on the connection referenced by this candidate pair so far.

--- a/files/en-us/web/api/rtcicecandidatepairstats/state/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/state/index.md
@@ -25,13 +25,7 @@ The **`state`** property in an
 {{domxref("RTCIceCandidatePairStats")}} object indicates the state of the check list
 of which the candidate pair is a member.
 
-## Syntax
-
-```js
-state = rtcIceCandidatePairStats.state;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value is one of those found in the
 {{domxref("RTCStatsIceCandidatePairState")}} enumerated type.

--- a/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.md
@@ -29,13 +29,7 @@ all such requests that have been made so far on the pair of candidates described
 this `RTCIceCandidatePairStats` object. This value includes both
 connectivity check and consent check requests.
 
-## Syntax
-
-```js
-totalRTT = rtcIceCandidatePairStats.totalRoundTripTime;
-```
-
-### Value
+## Value
 
 This floating-point value indicates the total number of seconds which have elapsed
 between sending out STUN connectivity and consent check requests and receiving their

--- a/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.md
@@ -25,13 +25,7 @@ uniquely identifies the {{domxref("RTCIceTransport")}} that was inspected to obt
 the transport-related statistics contained in the
 {{domxref("RTCIceCandidatePairStats")}} object.
 
-## Syntax
-
-```js
-transportId = rtcIceCandidatePairStats.transportId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the `RTCIceTransport`
 object from which the transport-related data was obtained for the statistics contained

--- a/files/en-us/web/api/rtcicecandidatepairstats/writable/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/writable/index.md
@@ -22,13 +22,7 @@ The _obsolete_ {{domxref("RTCIceCandidatePairStats")}}
 property **`writable`** reports whether or not the connection
 described by the candidate pair is writable.
 
-## Syntax
-
-```js
-isWritable = rtcIceCandidatePairStats.writable;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the connection described by this
 candidate pair has received acknowledgement of receipt (ACK) for at least one ICE

--- a/files/en-us/web/api/rtcicecandidatestats/address/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/address/index.md
@@ -30,13 +30,7 @@ well.
 When a domain name is specified, the first IP address selected for that
 address is used, even if the domain name maps to multiple IP addresses.
 
-## Syntax
-
-```js
-candidateAddress = rtcIceCandidateStats.address;
-```
-
-### Value
+## Value
 
 Either an IPv4 or IPv6 address or a fully-qualified domain name, which corresponds to
 the candidate.

--- a/files/en-us/web/api/rtcicecandidatestats/deleted/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/deleted/index.md
@@ -18,13 +18,7 @@ The {{domxref("RTCIceCandidateStats")}} dictionary's
 **`deleted`** property indicates whether or not the candidate
 has been deleted or released.
 
-## Syntax
-
-```js
-isDeleted = rtcIceCandidateStats.deleted;
-```
-
-### Value
+## Value
 
 A Boolean value indicating whether or not the candidate has been deleted or released.
 If this value is `true`, the candidate described by the
@@ -45,7 +39,7 @@ meaning varies depending on the type of candidate:
 The net result is the same; the candidate is no longer under consideration if this
 value is `true`.
 
-## Example
+## Examples
 
 In this example, {{domxref("setInterval()")}}
 is used to set up a function that runs periodically to display the latest statistics for

--- a/files/en-us/web/api/rtcicecandidatestats/networktype/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/networktype/index.md
@@ -29,13 +29,7 @@ a local candidate to communicate with a remote peer.
 > generated locally and included in an {{Glossary("SDP")}} offer or answer that has been
 > sent to the remote peer).
 
-## Syntax
-
-```js
-networkType = rtcIceCandidateStats.networkType;
-```
-
-### Value
+## Value
 
 A string which indicates the type of network connection that the described candidate would use to communicate with the other peer.
 
@@ -58,7 +52,7 @@ The permitted values are:
 
 > **Note:** Keep in mind that the specified value only reflects the initial connection between the local peer and the next hop along the network toward reaching the remote peer. For example, if the `networkType` is `wifi` but the user is connected using a cellular hotspot, the connection will be bottlenecked by the underlying cellular network (and any other networks between the two peers).
 
-## Example
+## Examples
 
 This example sets up a periodic function using
 {{domxref("setInterval()")}} that outputs

--- a/files/en-us/web/api/rtcicecandidatestats/port/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/port/index.md
@@ -22,13 +22,7 @@ browser-compat: api.RTCIceCandidateStats.port
 The {{domxref("RTCIceCandidateStats")}} dictionary's **`port`**
 property specifies the network port used by the candidate.
 
-## Syntax
-
-```js
-candidatePort = rtcIceCandidateStats.port;
-```
-
-### Value
+## Value
 
 An integer value indicating the network port used by the {{domxref("RTCIceCandidate")}}
 described by the `RTCIceCandidateStats` object.

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
@@ -23,13 +23,7 @@ The {{domxref("RTCIceCandidateStats")}} dictionary's
 **`protocol`**  property specifies the protocol the specified
 candidate would use for communication with the remote peer.
 
-## Syntax
-
-```js
-protocol = rtcIceCandidateStats.protocol;
-```
-
-### Value
+## Value
 
 The value is one of the following string:
 

--- a/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.md
@@ -28,13 +28,7 @@ server.
 The ICE protocol being used by the candidate otherwise can be obtained from the
 {{domxref("RTCIceCandidateStats.protocol", "protocol")}} property.
 
-## Syntax
-
-```js
-relayProtocol = rtcIceCandidateStats.relayProtocol;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} identifying the protocol being used by the endpoint to
 communicate with the TURN server. The possible values are:

--- a/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
@@ -29,13 +29,7 @@ The {{domxref("RTCIceCandidateStats")}} dictionary's
 identifies the transport that produced the {{domxref("RTCTransportStats")}} from which
 information about this candidate was taken.
 
-## Syntax
-
-```js
-transportID = rtcIceCandidateStats.transportId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value uniquely identifies the transport from which any
 transport-related information accumulated in the {{domxref("RTCIceCandidateStats")}} was

--- a/files/en-us/web/api/rtcicecandidatestats/url/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/url/index.md
@@ -27,13 +27,7 @@ The {{domxref("RTCIceCandidateStats")}} dictionary's
 {{Glossary("ICE")}} server from which the described candidate was obtained. This
 property is _only_ available for local candidates.
 
-## Syntax
-
-```js
-url = rtcIceCandidateStats.url;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the URL of the ICE server from which the
 candidate described by the `RTCIceCandidateStats` was obtained. This is the

--- a/files/en-us/web/api/rtciceparameters/password/index.md
+++ b/files/en-us/web/api/rtciceparameters/password/index.md
@@ -23,13 +23,7 @@ password that, in tandem with the {{domxref("RTCIceParameters.usernameFragment",
     "usernameFragment")}}, uniquely identifies an ICE session for its entire
 duration.
 
-## Syntax
-
-```js
-password = RTCIceParameters.password;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the password that corresponds to the transport's
 `usernameFragment` string

--- a/files/en-us/web/api/rtciceparameters/usernamefragment/index.md
+++ b/files/en-us/web/api/rtciceparameters/usernamefragment/index.md
@@ -26,13 +26,7 @@ The **{{domxref("RTCIceParameters")}}** dictionary's
 ("ufrag") that uniquely identifies the corresponding ICE session for the duration of the
 current ICE session.
 
-## Syntax
-
-```js
-ufrag = RTCIceParameters.usernameFragment;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the username fragment that, in tandem with the
 {{domxref("RTCIceParameters.password", "password")}}, uniquely identify the ICE session

--- a/files/en-us/web/api/rtcicetransport/component/index.md
+++ b/files/en-us/web/api/rtcicetransport/component/index.md
@@ -24,13 +24,7 @@ The read-only **{{domxref("RTCIceTransport")}}**
 property **`component`** specifies whether the object is
 serving to transport {{Glossary("RTP")}} or {{Glossary("RTCP")}}.
 
-## Syntax
-
-```js
-iceComponent = RTCIceTransport.component;
-```
-
-### Value
+## Value
 
 A string which is one of the following:
 

--- a/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
+++ b/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
@@ -18,13 +18,7 @@ browser-compat: api.RTCIceTransport.gatheringState
 
 The read-only **{{domxref("RTCIceTransport")}}** property **`gatheringState`** returns a {{domxref("DOMString")}} that indicates the current gathering state of the ICE agent: `"new"`, `"gathering"`, or `"complete"`.
 
-## Syntax
-
-```js
-gatherState = RTCIceTransport.gatheringState;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} that indicates the current state of the ICE agent's candidate gathering process:
 

--- a/files/en-us/web/api/rtcicetransport/role/index.md
+++ b/files/en-us/web/api/rtcicetransport/role/index.md
@@ -30,13 +30,7 @@ You can learn more about ICE roles in
 {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Connectivity", "Choosing a candidate
   pair")}}.
 
-## Syntax
-
-```js
-iceRole = RTCIceTransport.role;
-```
-
-### Value
+## Value
 
 A string specifying whether the {{domxref("RTCIceTransport")}}
 represents the controlling agent or the controlled agent. The value must be one of the following:

--- a/files/en-us/web/api/rtcicetransport/state/index.md
+++ b/files/en-us/web/api/rtcicetransport/state/index.md
@@ -27,13 +27,7 @@ currently is operating.
 This differs from the {{domxref("RTCIceTransport.gatheringState", "gatheringState")}},
 which only indicates whether or not ICE gathering is currently underway.
 
-## Syntax
-
-```js
-iceState = iceTransport.state;
-```
-
-### Value
+## Value
 
 A string whose value is one of the following:
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.md
@@ -26,13 +26,7 @@ indicating the average {{Glossary("RTCP")}} transmission interval, in seconds.
 The RTCP interval is the amount of time that should elapse between transmissions of RTCP
 packets.
 
-## Syntax
-
-```js
-var averageRtcpInterval = rtcInboundRtpStreamStats.averageRtcpInterval;
-```
-
-### Value
+## Value
 
 A floating-point value indicating the average interval, in seconds, between
 transmissions of RTCP packets. This interval is computed following the formula outlined

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.md
@@ -25,13 +25,7 @@ The {{domxref("RTCInboundRtpStreamStats")}} dictionary's
 indicates the total number of bytes received so far from this synchronization source
 (SSRC).
 
-## Syntax
-
-```js
-var bytesReceived = rtcInboundRtpStreamStats.bytesReceived;
-```
-
-### Value
+## Value
 
 An unsigned integer value indicating the total number of bytes received so far on this
 RTP stream, not including header and padding bytes. This value can be used to calculate

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.md
@@ -24,13 +24,7 @@ of the {{domxref("RTCInboundRtpStreamStats")}} dictionary is a numeric value
 indicating the number of {{Glossary("RTP")}} Forward Error Correction (FEC) packets
 that have been discarded.
 
-## Syntax
-
-```js
-var fecPacketsDiscarded = rtcInboundRtpStreamStats.fecPacketsDiscarded;
-```
-
-### Value
+## Value
 
 An unsigned integer value indicating how many FEC packets have been received whose
 error correction payload has been discarded.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.md
@@ -28,13 +28,7 @@ the receiver to the sender.
 The receiver sends a FIR packet when the stream
 falls behind and needs to skip frames in order to catch up.
 
-## Syntax
-
-```js
-var firCount = rtcInboundRtpStreamStats.firCount;
-```
-
-### Value
+## Value
 
 An integer value indicating how many FIR packets have been received by the sender
 during the current connection. This statistic is available only for video tracks.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.md
@@ -26,13 +26,7 @@ The **`framesDecoded`** property of
 the {{domxref("RTCInboundRtpStreamStats")}} dictionary indicates the total number of
 frames which have been decoded successfully for this media source.
 
-## Syntax
-
-```js
-var framesDecoded = rtcInboundRtpStreamStats.framesDecoded;
-```
-
-### Value
+## Value
 
 An integer value indicating the total number of video frames which have been decoded
 for this stream so far. This represents the number of frames that would have been

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
@@ -23,13 +23,7 @@ The **`lastPacketReceivedTimestamp`**
 property of the {{domxref("RTCInboundRtpStreamStats")}} dictionary indicates the time
 at which the most recently received packet arrived from this source.
 
-## Syntax
-
-```js
-var lastPacketTimestamp = rtcInboundRtpStreamStats.lastPacketReceivedTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} which specifies the time at which the most
 recently received packet arrived on this RTP stream.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.md
@@ -26,13 +26,7 @@ number of times the receiver sent a **NACK** packet to the sender.
 A NACK (Negative ACKnowledgement, also called "Generic NACK") packet tells the sender
 that one or more of the {{Glossary("RTP")}} packets it sent were lost in transport.
 
-## Syntax
-
-```js
-var nackCount = rtcInboundRtpStreamStats.nackCount;
-```
-
-### Value
+## Value
 
 An integer value indicating how many times the receiver sent a NACK packet to the
 sender after detecting that one or more packets were lost during transport.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.md
@@ -28,13 +28,7 @@ packets.
 These packets are not counted by the
 {{domxref("RTCInboundRtpStreamStats.packetsDiscarded", "packetsDiscarded")}} property.
 
-## Syntax
-
-```js
-var packetsDuplicated = rtcInboundRtpStreamStats.packetsDuplicated;
-```
-
-### Value
+## Value
 
 An integer value which specifies how many duplicate packets have been received by the
 local end of this RTP stream so far. These duplicate packets are not included in the

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.md
@@ -24,13 +24,7 @@ property of the {{domxref("RTCInboundRtpStreamStats")}} dictionary indicates the
 number of {{Glossary("RTP")}} packets which failed to be decrypted successfully after
 being received by the local end of the connection during this session.
 
-## Syntax
-
-```js
-var packetsFailedDecryption = rtcInboundRtpStreamStats.packetsFailedDecryption;
-```
-
-### Value
+## Value
 
 An integer value which indicates how many packets the local end of the RTP connection
 could not be successfully decrypted.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.md
@@ -28,13 +28,7 @@ that DCSP.
 > **Note:** Not all operating systems make data available on a per-DSCP
 > basis, so this property shouldn't be relied upon on those systems.
 
-## Syntax
-
-```js
-var perDscpPacketsReceived = rtcInboundRtpStreamStats.perDscpPacketsReceived;
-```
-
-### Value
+## Value
 
 A record comprised of string/value pairs. Each key is the string representation of a
 single Differentiated Services Code Point (DSCP)'s ID number.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.md
@@ -29,13 +29,7 @@ A PLI
 packet indicates that some amount of encoded video data has been lost for one or more
 frames.
 
-## Syntax
-
-```js
-var pliCount = RTCInboundRtpStreamStats.pliCount;
-```
-
-### Value
+## Value
 
 An integer value indicating the number of times a PLI packet was sent by the
 {{domxref("RTCRtpReceiver")}} to the sender. These are sent by the receiver's decoder to

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.md
@@ -28,13 +28,7 @@ sent or received to date on the video track corresponding to this
 In general, the higher this
 number is, the more heavily compressed the video data is.
 
-## Syntax
-
-```js
-var qpSum = rtcInboundRtpStreamStats.qpSum;
-```
-
-### Value
+## Value
 
 An unsigned 64-bit integer value which indicates the sum of the quantization parameter
 (QP) value for every frame sent or received so far on the track described by the
@@ -68,7 +62,7 @@ index used to derive a scaling matrix used during the quantization process.
 Additionally, QP is not likely to be the only parameter the codec uses to adjust the
 compression. See the individual codec specifications for details.
 
-## Example
+## Examples
 
 ### Calculating average quantization
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.md
@@ -27,13 +27,7 @@ The **`receiverId`** property of the
 {{domxref("RTCVideoReceiverStats")}} object representing the
 {{domxref("RTCRtpReceiver")}} receiving the stream.
 
-## Syntax
-
-```js
-var receiverStatsId = rtcInboundRtpStreamStats.receiverId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which contains the ID of the
 `RTCAudioReceiverStats` or `RTCVideoReceiverStats` object which

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.md
@@ -28,13 +28,7 @@ The **`remoteId`** property of the
 object representing the remote peer's {{domxref("RTCRtpSender")}} which is sending the
 media to the local peer.
 
-## Syntax
-
-```js
-var remoteStatsId = rtcInboundRtpStreamStats.remoteId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the ID of the
 {{domxref("RTCRemoteOutboundRtpStreamStats")}} object that represents the remote peer's

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.md
@@ -36,13 +36,7 @@ In general, what's usually of interest is that the higher this number is, the mo
 stream data is becoming corrupted between the sender and the receiver, requiring resends
 or dropping frames.
 
-## Syntax
-
-```js
-var sliCount = rtcInboundRtpStreamStats.sliCount;
-```
-
-### Value
+## Value
 
 An unsigned integer indicating the number of SLI packets this receiver sent to the
 remote sender due to lost runs of macroblocks. A high value of `sliCount` may

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.md
@@ -27,13 +27,7 @@ The **`trackId`** property of the
 {{domxref("RTCReceiverVideoTrackAttachmentStats")}} object representing the
 {{domxref("MediaStreamTrack")}} which is receiving the incoming media.
 
-## Syntax
-
-```js
-var trackStatsId = rtcInboundRtpStreamStats.trackId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the ID of the
 {{domxref("RTCReceiverAudioTrackAttachmentStats")}} or

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.md
@@ -28,13 +28,7 @@ of the {{domxref("RTCOutboundRtpStreamStats")}} dictionary is a floating-point v
 indicating the average time that should pass between transmissions of
 {{Glossary("RTCP")}} packets on this stream.
 
-## Syntax
-
-```js
-var averageRtcpInterval = RTCOutboundRtpStreamStats.averageRtcpInterval;
-```
-
-### Value
+## Value
 
 A floating-point value indicating the average interval, in seconds, between
 transmissions of RTCP packets. This interval is computed following the formula outlined

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.md
@@ -32,13 +32,7 @@ of a delta frame.
 
 Available only on video media.
 
-## Syntax
-
-```js
-var firCount = RTCOutboundRtpStreamStats.firCount;
-```
-
-### Value
+## Value
 
 An integer value indicating how many FIR packets have been received by the sender
 during the current connection. This statistic is available only for video tracks.

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.md
@@ -26,13 +26,7 @@ the {{domxref("RTCOutboundRtpStreamStats")}} dictionary indicates the total numb
 frames that have been encoded by this {{domxref("RTCRtpSender")}} for this media
 source.
 
-## Syntax
-
-```js
-var framesEncoded = RTCOutboundRtpStreamStats.framesEncoded;
-```
-
-### Value
+## Value
 
 An integer value indicating the total number of video frames that this sender has
 encoded so far for this stream.

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.md
@@ -25,13 +25,7 @@ at which the {{domxref("RTCRtpSender")}} described by this
 {{domxref("RTCOutboundRtpStreamStats")}} object last transmitted a packet to the
 remote receiver.
 
-## Syntax
-
-```js
-var lastPacketTimestamp = RTCOutboundRtpStreamStats.lastPacketSentTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} which specifies the time at which the most
 recently received packet arrived on this RTP stream.

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.md
@@ -33,13 +33,7 @@ ACKnowledgement, also called "Generic NACK") packet is used by the
 {{domxref("RTCRtpReceiver")}} to inform the sender that one or more {{Glossary("RTP")}}
 packets it sent were lost in transport.
 
-## Syntax
-
-```js
-var nackCount = RTCOutboundRtpStreamStats.nackCount;
-```
-
-### Value
+## Value
 
 An integer value indicating how many times the sender received a NACK packet from the
 receiver, indicating the loss of one or more packets.

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.md
@@ -27,13 +27,7 @@ Services Code Point and the value is the number of packets sent for that DCSP.
 > **Note:** Not all operating systems make data available on a per-DSCP
 > basis, so this property shouldn't be relied upon on those systems.
 
-## Syntax
-
-```js
-var perDscpPacketsSent = RTCOutboundRtpStreamStats.perDscpPacketsSent;
-```
-
-### Value
+## Value
 
 A record comprised of string/value pairs. Each key is the string representation of a
 single Differentiated Services Code Point (DSCP)'s ID number.

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.md
@@ -28,13 +28,7 @@ for which this object provides statistics.
 A PLI packet indicates that some
 amount of encoded video data has been lost for one or more frames.
 
-## Syntax
-
-```js
-var pliCount = RTCOutboundRtpStreamStats.pliCount;
-```
-
-### Value
+## Value
 
 An integer value indicating the number of times a PLI packet was sent to this sender by
 the remote peer's {{domxref("RTCRtpReceiver")}}. These are sent by the receiver's

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
@@ -65,7 +65,7 @@ index used to derive a scaling matrix used during the quantization process.
 Additionally, QP is not likely to be the only parameter the codec uses to adjust the
 compression. See the individual codec specifications for details.
 
-## Example
+## Examples
 
 ### Calculating average quantization
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.md
@@ -25,13 +25,7 @@ The **`remoteId`** property of the
 object representing the remote peer's {{domxref("RTCRtpReceiver")}} which is sending
 the media to the local peer for this SSRC.
 
-## Syntax
-
-```js
-var remoteStatsId = RTCOutboundRtpStreamStats.remoteId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the ID of the
 {{domxref("RTCRemoteInboundRtpStreamStats")}} object that represents the remote peer's

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.md
@@ -34,13 +34,7 @@ received media.In general, what's usually of interest is that the higher this nu
 the more the stream data is becoming corrupted between the sender and the receiver,
 causing the receiver to request retransmits or to drop frames entirely.
 
-## Syntax
-
-```js
-var sliCount = RTCOutboundRtpStreamStats.sliCount;
-```
-
-### Value
+## Value
 
 An unsigned integer indicating the number of SLI packets the sender received from the
 receiver due to lost runs of macroblocks. A high value of `sliCount` may be

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.md
@@ -31,13 +31,7 @@ The **`trackId`** property of the
 {{domxref("RTCSenderVideoTrackAttachmentStats")}} object representing the
 {{domxref("MediaStreamTrack")}} which is being sent on this stream.
 
-## Syntax
-
-```js
-var trackStatsId = RTCOutboundRtpStreamStats.trackId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the ID of the
 {{domxref("RTCSenderAudioTrackAttachmentStats")}} or

--- a/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -46,7 +46,7 @@ been established, this value is `null`.
 > description is used by the ICE agent to determine whether or not the remote peer
 > supports trickled ICE candidates.
 
-## Example
+## Examples
 
 ```js
 const pc = new RTCPeerConnection();

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.md
@@ -76,7 +76,7 @@ The current state of the ICE agent and its connection. The value is one of the f
   - : The ICE agent for this {{domxref("RTCPeerConnection")}} has shut down
     and is no longer handling requests.
 
-## Example
+## Examples
 
 ```js
 var pc = new RTCPeerConnection();

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity/index.md
@@ -24,13 +24,7 @@ that resolves to an {{domxref("RTCIdentityAssertion")}} which contains a
 resolves successfully, the resulting identity is the **target peer
 identity** and cannot change for the duration of the connection.
 
-## Syntax
-
-```js
- var identity = rtcPeerConnection.peerIdentity;
-```
-
-### Value
+## Value
 
 A JavaScript {{jsxref("Promise")}} which resolves to an
 {{domxref("RTCIdentityAssertion")}} that describes the remote peer's identity.
@@ -49,7 +43,7 @@ attempts to authenticate occur.
 > `setRemoteDescription()` doesn't need to wait for validation to occur
 > before it resolves.
 
-## Example
+## Examples
 
 In this example, a function, `getIdentityAssertion()`, is created which
 asynchronously waits for the peer's identity to be verified, then returns the identity

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.md
@@ -83,7 +83,7 @@ The allowed string values are:
 - `closed`
   - : The {{domxref("RTCPeerConnection")}} has been closed.
 
-## Example
+## Examples
 
 ```js
 var pc = new RTCPeerConnection(configuration);

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
@@ -23,13 +23,7 @@ The {{domxref("RTCPeerConnectionIceErrorEvent")}} property
 being used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server
 during negotiations. The error which occurred involved this address.
 
-## Syntax
-
-```js
-let address = rtcPeerConnectionIceErrorEvent.address;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which specifies the local IP address of the network
 connection to the ICE server with which negotiations were occurring when the error


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error