### PR TITLE
WebAPI: Clean syntax from property pages, part 16

### DIFF
--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.md
@@ -30,13 +30,7 @@ used to identify the {{domxref("RTCInboundRtpStreamStats")}} object whose
 Together, these two objects provide statistics about the inbound and outbound
 sides of the same synchronization source (SSRC).
 
-## Syntax
-
-```js
-let localId = rtcRemoteOutboundRtpStreamStats.localId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which can be compared to the value of an
 {{domxref("RTCInboundRtpStreamStats")}} object's
@@ -59,7 +53,7 @@ statistics about the incoming data from the local peer's perspective.
 You can [examine, try out, and experiment](#try_it_and_fork_it) with this
 example on Glitch.
 
-## Example
+## Examples
 
 In this example, we have a pair of functions: the first,
 `networkTestStart()`, captures an initial report, and the second,

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.md
@@ -25,13 +25,7 @@ The {{domxref("RTCRemoteOutboundRtpStreamStats")}} property
 at which these statistics were sent. This differs from `timestamp`, which
 indicates the time at which the statistics were generated or received locally.
 
-## Syntax
-
-```js
-let remoteTimestamp = rtcRemoteOutboundRtpStreamStats.remoteTimestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} value indicating the timestamp on the remote peer
 at which it sent these statistics. This is different from the value

--- a/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.md
@@ -22,13 +22,7 @@ level contained in the last RTP packet played from the described source.
 `audioLevel` will be the level value defined in \[RFC6465] if the RFC 6465 header extension
 is present, and otherwise null.
 
-## Syntax
-
-```js
-var audioLevel = RTCRtpContributingSource.audioLevel
-```
-
-### Value
+## Value
 
 A double-precision floating-point number which indicates the volume level of the audio
 in the most recently received RTP packet from the source described by the

--- a/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.md
@@ -24,13 +24,7 @@ property of the {{domxref("RTCRtpContributingSource")}} dictionary contains a
 {{domxref("DOMHighResTimeStamp")}} indicating the source-generated time at which the
 media contained int he packet was first sampled or obtained.
 
-## Syntax
-
-```js
-let rtpTimestamp = RTCRtpContributingSource.rtpTimestamp
-```
-
-### Value
+## Value
 
 An integer value specifying a source-generated timestamp indicating the time at which
 the media in this packet, scheduled for play out at the time indicated by

--- a/files/en-us/web/api/rtcrtpcontributingsource/source/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/source/index.md
@@ -22,13 +22,7 @@ or synchronization source (SSRC) identifier, depending on whether the object is 
 `RTCRtpContributingSource` or {{domxref("RTCRtpSynchronizationSource")}},
 which is based on the former.
 
-## Syntax
-
-```js
-var sourceID = RTCRtpContributingSource.source
-```
-
-### Value
+## Value
 
 An unsigned, 32-bit integer value which uniquely identifies the source of RTP packets
 described by this `RTCRtpContributingSource` (in which case the value is a

--- a/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.md
@@ -18,13 +18,7 @@ of the {{domxref("RTCRtpContributingSource")}} dictionary contains a
 {{domxref("DOMHighResTimeStamp")}} indicating the most recent time of playout of an
 RTP packet from the source.
 
-## Syntax
-
-```js
-var domHighResTimeStamp = RTCRtpContributingSource.timestamp
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} which indicates the time at which the most recent
 RTP packet from the corresponding source was played out.

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.md
@@ -24,19 +24,7 @@ The {{domxref("RTCRtpEncodingParameters")}} dictionary's
 **`maxBitrate`** property specifies the maximum number of bits
 per second to allow a track encoded with this encoding to use.
 
-## Syntax
-
-```js
-rtpEncodingParameters.maxBitrate = maxBitsPerSecond;
-
-rtpEncodingParameters = {
-  maxBitrate: maxBitsPerSecond
-};
-
-maxBitsPerSecond = rtpEncodingParameters.maxBitrate;
-```
-
-### Value
+## Value
 
 An unsigned long integer value specifying the maximum bandwidth this encoding is
 permitted to use for a track of media it encodes in terms of bits per second. Other

--- a/files/en-us/web/api/rtcrtpreceiver/track/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/track/index.md
@@ -20,13 +20,7 @@ The **`track`** read-only property of the
 {{domxref("RTCRtpReceiver")}} interface returns the {{domxref("MediaStreamTrack")}}
 associated with the current {{domxref("RTCRtpReceiver")}} instance.
 
-## Syntax
-
-```js
-var mediaStreamTrack = rtcRtpReceiver.track
-```
-
-### Value
+## Value
 
 A {{domxref("MediaStreamTrack")}} instance.
 

--- a/files/en-us/web/api/rtcrtpsender/track/index.md
+++ b/files/en-us/web/api/rtcrtpsender/track/index.md
@@ -20,13 +20,7 @@ The **`track`** read-only property of
 the {{domxref("RTCRtpSender")}} interface returns the {{domxref("MediaStreamTrack")}}
 which is being handled by the `RTCRtpSender`.
 
-## Syntax
-
-```js
-var mediaStreamTrack = rtcRtpSender.track
-```
-
-### Value
+## Value
 
 A {{domxref("MediaStreamTrack")}} object representing the media associated with the
 `RTCRtpSender`. If no track is associated with the sender, this value is

--- a/files/en-us/web/api/rtcrtpsender/transport/index.md
+++ b/files/en-us/web/api/rtcrtpsender/transport/index.md
@@ -28,13 +28,7 @@ Real-time Transport Control Protocol ({{Glossary("RTCP")}}) packets.
 This transport is responsible for receiving the data for the media on the sender's
 {{domxref("RTCRtpReceiver.track", "track")}}.
 
-## Syntax
-
-```js
-let transport = rtcRtpSender.transport;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCDtlsTransport")}} object representing the underlying transport being
 used by the sender to exchange packets with the remote peer, or `null` if the

--- a/files/en-us/web/api/rtcrtpstreamstats/codecid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/codecid/index.md
@@ -26,13 +26,7 @@ The {{domxref("RTCRtpStreamStats")}} dictionary's
 the object that was inspected to produce the data in the {{domxref("RTCCodecStats")}}
 for the {{Glossary("RTP")}} stream.
 
-## Syntax
-
-```js
-var codecID = RTCRtpStreamStats.codecId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the object from which the contents
 of the stream's {{domxref("RTCCodecStats")}} are derived.

--- a/files/en-us/web/api/rtcrtpstreamstats/fircount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/fircount/index.md
@@ -29,13 +29,7 @@ the sender.
 This is a measure of how often the stream falls behind and has to
 skip frames in order to catch up.
 
-## Syntax
-
-```js
-var firCount = RTCRtpStreamStats.firCount;
-```
-
-### Value
+## Value
 
 An integer value indicating how many FIR packets have been received by the sender
 during the current connection. This value is available only on receivers for video

--- a/files/en-us/web/api/rtcrtpstreamstats/kind/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/kind/index.md
@@ -31,13 +31,7 @@ This property was previously called `mediaType`. The name was changed in the
 specification in February, 2018. See [Browser compatibility](#browser_compatibility) below to
 determine how this affects the browsers you're targeting.
 
-## Syntax
-
-```js
-mediaKind = RTCRtpStreamStats.kind;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value is `"audio"` if the track whose
 statistics are given by the `RTCRtpStreamStats` object contains audio, or

--- a/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.md
@@ -29,13 +29,7 @@ A NACK
 (Negative ACKnowledgement, also called "Generic NACK") packet tells the sender that one
 or more of the {{Glossary("RTP")}} packets it sent were lost in transport.
 
-## Syntax
-
-```js
-var nackCount = RTCRtpStreamStats.nackCount;
-```
-
-### Value
+## Value
 
 An integer value indicating how many times the receiver sent a NACK packet to the
 sender after detecting that one or more packets were lost during transport.

--- a/files/en-us/web/api/rtcrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/plicount/index.md
@@ -31,13 +31,7 @@ packet to the sender.
 A PLI packet indicates that some amount of encoded video
 data has been lost for one or more frames.
 
-## Syntax
-
-```js
-var pliCount = RTCRtpStreamStats.pliCount;
-```
-
-### Value
+## Value
 
 An integer value indicating the number of times a PLI packet was sent by the stream's
 receiver to the sender.

--- a/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
@@ -67,7 +67,7 @@ index used to derive a scaling matrix used during the quantization process.
 Additionally, QP is not likely to be the only parameter the codec uses to adjust the
 compression. See the individual codec specifications for details.
 
-## Example
+## Examples
 
 ### Calculating average quantization
 

--- a/files/en-us/web/api/rtcrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/slicount/index.md
@@ -31,13 +31,7 @@ sender.
 An SLI packet is used by a decoder to let the encoder know that it's
 detected corruption of one or more consecutive macroblocks in the received media.
 
-## Syntax
-
-```js
-var sliCount = RTCRtpStreamStats.sliCount;
-```
-
-### Value
+## Value
 
 An unsigned long integer indicating the number of SLI packets the sender received from
 the receiver due to lost runs of macroblocks. A high value of `sliCount` may

--- a/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.md
@@ -24,13 +24,7 @@ The {{domxref("RTCRtpStreamStats")}} dictionary's
 packets whose statistics are covered by the {{domxref("RTCStatsReport")}} that
 includes this `RTCRtpStreamStats` dictionary.
 
-## Syntax
-
-```js
-var ssrc = RTCRtpStreamStats.ssrc;
-```
-
-### Value
+## Value
 
 The Synchronization Source (SSRC) is a 32-bit integer uniquely identifying the source
 of the RTP packets whose statistics are covered by the {{domxref("RTCStatsReport")}}

--- a/files/en-us/web/api/rtcrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/trackid/index.md
@@ -25,13 +25,7 @@ the {{domxref("RTCMediaStreamTrackStats")}} object which contains the track stat
 for the {{domxref("MediaStreamTrack")}} for which statistics are provided in this
 object.
 
-## Syntax
-
-```js
-var trackID = RTCRtpStreamStats.trackId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the
 {{domxref("RTCMediaStreamTrackStats")}} object that provides statistics for the track

--- a/files/en-us/web/api/rtcrtpstreamstats/transportid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/transportid/index.md
@@ -23,13 +23,7 @@ identifies the object from which the statistics contained in the
 {{domxref("RTCTransportStats")}} properties in the
 {{domxref("RTCStatsReport")}}.
 
-## Syntax
-
-```js
-var transportID = RTCRtpStreamStats.transportId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} uniquely identifying the source of the statistics contained
 the {{domxref("RTCTransportStats")}} properties in the {{domxref("RTCStatsReport")}}.

--- a/files/en-us/web/api/rtcrtptransceiver/currentdirection/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/currentdirection/index.md
@@ -25,13 +25,7 @@ Its value is one of the strings defined in the table below.
 You can examine and set the transceiver's preferred directionality using
 {{domxref("RTCRtpTransceiver.direction", "direction")}} property.
 
-## Syntax
-
-```js
-var direction = RTCRtpTransceiver.currentDirection
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value is one of the strings which are a member of the following values.
 

--- a/files/en-us/web/api/rtcrtptransceiver/direction/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/direction/index.md
@@ -25,13 +25,7 @@ Its value must be one of the strings defined in the table below.
 The transceiver's _current_ direction is indicated by the
 {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}} property.
 
-## Syntax
-
-```js
-var direction = RTCRtpTransceiver.direction
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} whose value is one of the strings which are a member of the following values, indicating the transceiver's preferred direction.
 

--- a/files/en-us/web/api/rtcrtptransceiver/mid/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/mid/index.md
@@ -22,13 +22,7 @@ The read-only {{domxref("RTCRtpTransceiver")}} interface's
 (`mid`) which the local and remote peers have agreed upon to uniquely
 identify the stream's pairing of sender and receiver.
 
-## Syntax
-
-```js
-var mediaID = RTCRtpTransceiver.mid;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the pairing of source and
 destination of the transceiver's stream. Its value is taken from the media ID of the SDP

--- a/files/en-us/web/api/rtcrtptransceiver/receiver/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/receiver/index.md
@@ -19,13 +19,7 @@ of WebRTC's {{domxref("RTCRtpTransceiver")}} interface indicates the
 {{domxref("RTCRtpReceiver")}} responsible for receiving and decoding incoming media
 data for the transceiver's stream.
 
-## Syntax
-
-```js
-var rtpReceiver = RTCRtpTransceiver.receiver;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCRtpReceiver")}} object which is responsible for receiving and decoding
 incoming media data whose media ID is the same as the current value of

--- a/files/en-us/web/api/rtcrtptransceiver/sender/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/sender/index.md
@@ -20,13 +20,7 @@ of WebRTC's {{domxref("RTCRtpTransceiver")}} interface indicates the
 {{domxref("RTCRtpSender")}} responsible for encoding and sending outgoing media data
 for the transceiver's stream.
 
-## Syntax
-
-```js
-var rtpSender = RTCRtpTransceiver.sender;
-```
-
-### Value
+## Value
 
 An {{domxref("RTCRtpSender")}} object used to encode and send media whose media ID
 matches the current value of {{domxref("RTCRtpTransceiver.mid", "mid")}}.

--- a/files/en-us/web/api/rtcrtptransceiver/stopped/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/stopped/index.md
@@ -27,13 +27,7 @@ caused the transceiver to be stopped for some reason.
 > at the value of {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}}.
 > Its value is `stopped` if the transceiver has stopped.
 
-## Syntax
-
-```js
-var isStopped = RTCRtpTransceiver.stopped;
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the transceiver's
 {{domxref("RTCRtpTransceiver.sender", "sender")}} will no longer send data, and its

--- a/files/en-us/web/api/rtcsctptransport/state/index.md
+++ b/files/en-us/web/api/rtcsctptransport/state/index.md
@@ -22,13 +22,7 @@ The **`state`** read-only property of the
 {{DOMxRef("RTCSctpTransport")}} interface provides information which describes a Stream
 Control Transmission Protocol (**{{Glossary("SCTP")}}**) transport state.
 
-## Syntax
-
-```js
-var myState = sctpTransport.state;
-```
-
-### Value
+## Value
 
 A string whose value is taken from the `RTCSctpTransportState` enumerated
 type. Its value is one of the following:

--- a/files/en-us/web/api/rtcstats/id/index.md
+++ b/files/en-us/web/api/rtcstats/id/index.md
@@ -26,13 +26,7 @@ order to monitor statistics over time for a given WebRTC object, such as an
 {{Glossary("RTP")}} stream, an {{domxref("RTCPeerConnection")}}, or an
 {{domxref("RTCDataChannel")}}.
 
-## Syntax
-
-```js
-var id = RTCStats.id;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which uniquely identifies the object for which this
 `RTCStats`-based object provides statistics.

--- a/files/en-us/web/api/rtcstats/timestamp/index.md
+++ b/files/en-us/web/api/rtcstats/timestamp/index.md
@@ -28,13 +28,7 @@ by the statistics was received at the corresponding endpoint.
 The time is given in milliseconds elapsed since the UNIX epoch (the first moment of
 January 1, 1970, UTC).
 
-## Syntax
-
-```js
-var timestamp = RTCStats.timestamp;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} value indicating the time at which the activity
 described by the statistics in this object was recorded, in milliseconds elapsed since

--- a/files/en-us/web/api/rtcstats/type/index.md
+++ b/files/en-us/web/api/rtcstats/type/index.md
@@ -24,13 +24,7 @@ represented by the object, where the permitted values are drawn from the enum ty
 The string can be used to determine which of the
 {{domxref("RTCStats")}}-based dictionaries are the foundation of the statistics object.
 
-## Syntax
-
-```js
-var type = RTCStats.type;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} which specifies which type of statistic is represented by
 the object. The string comes from the {{domxref("RTCStatsType")}} enum and corresponds to

--- a/files/en-us/web/api/rtctrackevent/receiver/index.md
+++ b/files/en-us/web/api/rtctrackevent/receiver/index.md
@@ -24,13 +24,7 @@ of the {{domxref("RTCTrackEvent")}} interface indicates the
 {{domxref("RTCRtpReceiver")}} which is used to receive data containing media for the
 {{domxref("RTCTrackEvent.track", "track")}} to which the event refers.
 
-## Syntax
-
-```js
-var rtpReceiver = trackEvent.receiver;
-```
-
-### Value
+## Value
 
 The {{domxref("RTCRtpTransceiver")}} which pairs the `receiver` with a
 sender and other properties which establish a single bidirectional {{Glossary("RTP", "SRTP")}}

--- a/files/en-us/web/api/rtctrackevent/streams/index.md
+++ b/files/en-us/web/api/rtctrackevent/streams/index.md
@@ -23,13 +23,7 @@ interface {{domxref("RTCTrackEvent")}}'s read-only
 {{domxref("MediaStream")}} objects, one for each of the streams that comprise the
 track being added to the {{domxref("RTCPeerConnection")}}.
 
-## Syntax
-
-```js
-var streams = trackEvent.streams;
-```
-
-### Value
+## Value
 
 An {{jsxref("Array")}} of {{domxref("MediaStream")}} objects, one for each stream that
 make up the new track.

--- a/files/en-us/web/api/rtctrackevent/track/index.md
+++ b/files/en-us/web/api/rtctrackevent/track/index.md
@@ -23,13 +23,7 @@ interface {{domxref("RTCTrackEvent")}}'s read-only **`track`**
 property specifies the {{domxref("MediaStreamTrack")}} that has been added to the
 {{domxref("RTCPeerConnection")}}.
 
-## Syntax
-
-```js
-var track = trackEvent.track;
-```
-
-### Value
+## Value
 
 A {{domxref("MediaStreamTrack")}} indicating the track which has been added to the
 {{domxref("RTCPeerConnection")}}.

--- a/files/en-us/web/api/rtctrackevent/transceiver/index.md
+++ b/files/en-us/web/api/rtctrackevent/transceiver/index.md
@@ -24,13 +24,7 @@ read-only **`transceiver`** property indicates the
 The transceiver pairs the track's
 {{domxref("RTCTrackEvent.receiver", "receiver")}} with an {{domxref("RTCRtpSender")}}.
 
-## Syntax
-
-```js
-var rtpTransceiver = trackEvent.transceiver;
-```
-
-### Value
+## Value
 
 The {{domxref("RTCRtpTransceiver")}} which pairs the `receiver` with a
 sender and other properties which establish a single bidirectional {{Glossary("RTP", "SRTP")}}

--- a/files/en-us/web/api/screen/availheight/index.md
+++ b/files/en-us/web/api/screen/availheight/index.md
@@ -22,13 +22,7 @@ exposed on the {{DOMxRef("Window")}} interface's {{DOMxRef("Window.screen",
 You can similarly use {{DOMxRef("Screen.availWidth")}} to get the number of pixels
 which are horizontally available to the browser for its use.
 
-## Syntax
-
-```js
-let availHeight = window.screen.availHeight;
-```
-
-### Value
+## Value
 
 A numeric value indicating the number of CSS pixels tall the screen's available space
 is. This can be no larger than the value of {{DOMxRef("Screen.height",
@@ -42,7 +36,7 @@ the Dock and menu bar, as seen in the diagram below.
 
 [![Diagram showing how Screen.availHeight relates to Screen.height and the screen's contents](availheight-diagram.svg)](availheight-diagram.svg)
 
-## Example
+## Examples
 
 If your web application needs to open a new window, such as a tool palette which can
 contain multiple panels, and wants to position it so that it occupies the entire

--- a/files/en-us/web/api/screenorientation/angle/index.md
+++ b/files/en-us/web/api/screenorientation/angle/index.md
@@ -17,13 +17,7 @@ The **`angle`** read-only property of the
 {{domxref("ScreenOrientation")}} interface returns the document's current orientation
 angle.
 
-## Syntax
-
-```js
-angle = screen.orientation.angle
-```
-
-### Value
+## Value
 
 An unsigned short integer.
 

--- a/files/en-us/web/api/screenorientation/type/index.md
+++ b/files/en-us/web/api/screenorientation/type/index.md
@@ -18,13 +18,7 @@ The **`type`** read-only property of the
 type, one of "portrait-primary", "portrait-secondary", "landscape-primary", or
 "landscape-secondary".
 
-## Syntax
-
-```js
-type = screen.orientation.type
-```
-
-### Value
+## Value
 
 A {{jsxref("String")}}.
 

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.md
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.md
@@ -16,19 +16,11 @@ The `bufferSize` property of the {{domxref("ScriptProcessorNode")}} interface re
 
 > **Note:** This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var scriptNode = audioCtx.createScriptProcessor(4096, 1, 1);
-console.log(scriptNode.bufferSize);
-```
-
-### Value
+## Value
 
 An integer.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createScriptProcessor()`](/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example) for example code.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
@@ -18,17 +18,11 @@ The **`blockedURI`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
 representing the URI of the resource that was blocked because it violates a policy.
 
-## Syntax
-
-```js
-let blockedURI = violationEventInstance.blockedURI;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} representing the URI of the blocked resource.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -19,17 +19,11 @@ The **`columnNumber`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is the column number in the
 document or worker at which the violation occurred.
 
-## Syntax
-
-```js
-let colNum = violationEventInstance.columnNumber;
-```
-
-### Value
+## Value
 
 A number representing the column number where the violation occurred.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
@@ -19,19 +19,13 @@ The **`disposition`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface indicates how the violated policy
 is configured to be treated by the user agent.
 
-## Syntax
-
-```js
-let disposition = violationEventInstance.disposition;
-```
-
-### Value
+## Value
 
 A value defined in the [SecurityPolicyViolationEventDisposition
 enum](https://w3c.github.io/webappsec-csp/#enumdef-securitypolicyviolationeventdisposition) representing the URI of the blocked resource. Possible values are
 `"enforce"` or `"report"`
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
@@ -19,18 +19,12 @@ The **`documentURI`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
 representing the URI of the document or worker in which the violation was found.
 
-## Syntax
-
-```js
-let documentURI = violationEventInstance.documentURI;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} representing the URI of the document or worker in which the
 violation was found.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
@@ -19,18 +19,12 @@ The **`effectiveDirective`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
 representing the directive whose enforcement uncovered the violation.
 
-## Syntax
-
-```js
-let effDir = violationEventInstance.effectiveDirective;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the directive whose enforcement uncovered the
 violation.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
@@ -19,17 +19,11 @@ The **`lineNumber`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is the line number in the document
 or worker at which the violation occurred.
 
-## Syntax
-
-```js
-let lineNumber = violationEventInstance.lineNumber;
-```
-
-### Value
+## Value
 
 A number representing the line number at which the violation occurred.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
@@ -19,18 +19,12 @@ The **`originalPolicy`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
 containing the policy whose enforcement uncovered the violation.
 
-## Syntax
-
-```js
-let origPolicy = violationEventInstance.originalPolicy;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the policy whose enforcement uncovered the
 violation.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
@@ -20,18 +20,12 @@ The **`referrer`** read-only property of the
 representing the referrer of the resources whose policy was violated. This will be a URL
 or `null`.
 
-## Syntax
-
-```js
-let referrer = violationEventInstance.referrer;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} representing the URL of the referrer of the violating
 resources.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
@@ -19,20 +19,14 @@ The **`sample`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
 representing a sample of the resource that caused the violation.
 
-## Syntax
-
-```js
-let sample = violationEventInstance.sample;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing a sample of the resource that caused the
 violation, usually the first 40 characters. This will only be populated if the resource
 is an inline script, event handler, or style — external resources causing a violation
 will not generate a sample.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
@@ -19,18 +19,12 @@ The **`sourceFile`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
 representing the URI of the document or worker in which the violation was found.
 
-## Syntax
-
-```js
-let source = violationEventInstance.sourceFile;
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}} representing the URI of the document or worker in which the
 violation was found.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
@@ -19,18 +19,12 @@ The **`statusCode`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a number representing the HTTP
 status code of the document or worker in which the violation occurred.
 
-## Syntax
-
-```js
-let status = violationEventInstance.statusCode;
-```
-
-### Value
+## Value
 
 A number representing the status code of the document or worker in which the violation
 occurred.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
@@ -19,18 +19,12 @@ The **`violatedDirective`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
 representing the directive whose enforcement uncovered the violation.
 
-## Syntax
-
-```js
-let violatedDir = violationEventInstance.violatedDirective;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the directive whose enforcement uncovered the
 violation.
 
-## Example
+## Examples
 
 ```js
 document.addEventListener("securitypolicyviolation", (e) => {

--- a/files/en-us/web/api/selection/type/index.md
+++ b/files/en-us/web/api/selection/type/index.md
@@ -15,13 +15,7 @@ The **`type`** read-only property of the
 {{domxref("Selection")}} interface returns a {{domxref("DOMString")}} describing the
 type of the current selection.
 
-## Syntax
-
-```js
-value = sel.type
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} describing the type of the current selection. Possible
 values are:
@@ -31,7 +25,7 @@ values are:
   text, but no range has been selected).
 - `Range`: A range has been selected.
 
-## Example
+## Examples
 
 In this example, the event handler will fire each time a new selection is made.
 `console.log(selection.type)` will return `Caret` or

--- a/files/en-us/web/api/sensor/activated/index.md
+++ b/files/en-us/web/api/sensor/activated/index.md
@@ -18,16 +18,10 @@ The **`activated`** read-only property
 of the {{domxref("Sensor")}} interface returns a boolean value indicating
 whether the sensor is active.
 
-## Syntax
-
-```js
-var boolean = sensorInstance.activated
-```
-
 Because {{domxref('Sensor')}} is a base class, `activated` may only be read
 from one of its derived classes.
 
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/sensor/hasreading/index.md
+++ b/files/en-us/web/api/sensor/hasreading/index.md
@@ -18,16 +18,10 @@ The **`hasReading`** read-only
 property of the {{domxref("Sensor")}} interface returns a boolean value
 indicating whether the sensor has a reading.
 
-## Syntax
-
-```js
-var boolean = sensorInstance.hasReading
-```
-
 Because {{domxref('Sensor')}} is a base class, `hasReading` may only be read
 from one of its derived classes.
 
-### Value
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/sensor/timestamp/index.md
+++ b/files/en-us/web/api/sensor/timestamp/index.md
@@ -18,16 +18,10 @@ The **`timestamp`** read-only property
 of the {{domxref("Sensor")}} interface returns the time stamp of the latest sensor
 reading.
 
-## Syntax
-
-```js
-var timestamp = sensorInstance.timestamp
-```
-
 Because {{domxref('Sensor')}} is a base class, `timestamp` may only be read
 from one of its derived classes.
 
-### Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}}.
 

--- a/files/en-us/web/api/sensorerrorevent/error/index.md
+++ b/files/en-us/web/api/sensorerrorevent/error/index.md
@@ -19,13 +19,7 @@ The **`error`** read-only property of
 the {{domxref("SensorErrorEvent")}} interface returns the {{domxref('DOMException')}}
 object passed in the event's constructor.
 
-## Syntax
-
-```js
-var domException = sensorErrorEvent.error;
-```
-
-### Value
+## Value
 
 A {{domxref('DOMException')}}.
 

--- a/files/en-us/web/api/serviceworkercontainer/controller/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/controller/index.md
@@ -22,17 +22,11 @@ property of the {{domxref("ServiceWorkerContainer")}} interface returns a
 `null` if the request is a force refresh (_Shift_ + refresh) or if
 there is no active worker.
 
-## Syntax
-
-```js
-var myController = navigator.serviceWorker.controller;
-```
-
-### Value
+## Value
 
 A {{domxref("ServiceWorker")}} object.
 
-## Example
+## Examples
 
 ```js
 if ('serviceWorker' in navigator) {

--- a/files/en-us/web/api/serviceworkercontainer/ready/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/ready/index.md
@@ -21,18 +21,12 @@ an {{domxref("ServiceWorkerRegistration.active","active")}} worker. Once that
 condition is met, it resolves with
 the {{domxref("ServiceWorkerRegistration")}}.
 
-## Syntax
-
-```js
-navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) { /* ... */ });
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}} that will never reject, and which may eventually resolve with a
 {{domxref("ServiceWorkerRegistration")}}.
 
-## Example
+## Examples
 
 ```js
 if ('serviceWorker' in navigator) {

--- a/files/en-us/web/api/serviceworkerglobalscope/clients/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/clients/index.md
@@ -17,13 +17,7 @@ The **`clients`** read-only property of the
 {{domxref("ServiceWorkerGlobalScope")}} interface returns the [`Clients`](/en-US/docs/Web/API/Clients)
 object associated with the service worker.
 
-## Syntax
-
-```js
-swClients = self.clients
-```
-
-### Value
+## Value
 
 The {{domxref("Clients")}} object associated with the specific worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/registration/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/registration/index.md
@@ -15,13 +15,7 @@ browser-compat: api.ServiceWorkerGlobalScope.registration
 
 The **`registration`** read-only property of the {{domxref("ServiceWorkerGlobalScope")}} interface returns a reference to the {{domxref("ServiceWorkerRegistration")}} object, which represents the service worker's registration.
 
-## Syntax
-
-```js
-serviceWorkerRegistration = self.registration
-```
-
-### Value
+## Value
 
 A {{domxref("ServiceWorkerRegistration")}} object.
 

--- a/files/en-us/web/api/serviceworkerregistration/active/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/active/index.md
@@ -27,13 +27,7 @@ falls within the scope of the registration (the `scope` option set when
 > runtime script error nor a force termination of the active worker prevents the active
 > worker from getting `activated`.
 
-## Syntax
-
-```js
-var serviceWorker = serviceWorkerRegistration.active;
-```
-
-### Value
+## Value
 
 A {{domxref("ServiceWorker")}} object's property, if it is currently in an
 `activating` or `activated` state.

--- a/files/en-us/web/api/serviceworkerregistration/installing/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/installing/index.md
@@ -19,13 +19,7 @@ initially set to `null`.
 
 > **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
-## Syntax
-
-```js
-var serviceWorker = serviceWorkerRegistration.installing;
-```
-
-### Value
+## Value
 
 A {{domxref("ServiceWorker")}} object, if it is currently in an `installing`
 state.

--- a/files/en-us/web/api/serviceworkerregistration/pushmanager/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/pushmanager/index.md
@@ -19,13 +19,7 @@ The **`pushManager`** property of the
 support for subscribing, getting an active subscription, and accessing push permission
 status.
 
-## Syntax
-
-```js
-var pushManager = serviceWorkerRegistration.pushManager;
-```
-
-### Value
+## Value
 
 A {{domxref("PushManager")}} object.
 

--- a/files/en-us/web/api/serviceworkerregistration/sync/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/sync/index.md
@@ -18,13 +18,7 @@ The **`sync`** property of the
 {{domxref("SyncManager")}} interface, which manages background synchronization
 processes.
 
-## Syntax
-
-```js
-var syncManager = serviceWorkerRegistration.sync;
-```
-
-### Value
+## Value
 
 A {{domxref("SyncManager")}} object.
 

--- a/files/en-us/web/api/serviceworkerregistration/updateviacache/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/updateviacache/index.md
@@ -26,7 +26,7 @@ Returns one of the following values:
 - `all`, meaning the HTTP cache is consulted in both cases
 - `none`, meaning the HTTP cache is never consulted.
 
-## Example
+## Examples
 
 The following example shows the use of updateViaCache.
 

--- a/files/en-us/web/api/serviceworkerregistration/waiting/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/waiting/index.md
@@ -19,13 +19,7 @@ set to `null`.
 
 > **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
-## Syntax
-
-```js
-var serviceWorker = serviceWorkerRegistration.waiting;
-```
-
-### Value
+## Value
 
 A {{domxref("ServiceWorker")}} object, if it is currently in an `installed`
 state.

--- a/files/en-us/web/api/shadowroot/activeelement/index.md
+++ b/files/en-us/web/api/shadowroot/activeelement/index.md
@@ -15,13 +15,7 @@ browser-compat: api.ShadowRoot.activeElement
 The **`activeElement`** read-only property of the
 {{domxref("ShadowRoot")}} interface returns the element within the shadow tree that has focus.
 
-## Syntax
-
-```js
-shadowRoot.activeElement
-```
-
-### Value
+## Value
 
 The {{domxref('Element')}} which currently has focus, or `null` if there is no focused element.
 

--- a/files/en-us/web/api/shadowroot/fullscreenelement/index.md
+++ b/files/en-us/web/api/shadowroot/fullscreenelement/index.md
@@ -15,13 +15,7 @@ browser-compat: api.ShadowRoot.fullscreenElement
 The **`fullscreenElement`** read-only property of the
 {{domxref("ShadowRoot")}} interface returns the element within the shadow tree that is currently displayed in full screen.
 
-## Syntax
-
-```js
-shadowRoot.fullscreenElement
-```
-
-### Value
+## Value
 
 The {{domxref('Element')}} which is currently is displayed in full screen mode,
 or `null` if there is no full screen element.

--- a/files/en-us/web/api/shadowroot/host/index.md
+++ b/files/en-us/web/api/shadowroot/host/index.md
@@ -16,13 +16,7 @@ The **`host`** read-only property of
 the {{domxref("ShadowRoot")}} returns a reference to the DOM element the
 `ShadowRoot` is attached to.
 
-## Syntax
-
-```js
-const someElement = shadowRoot.host
-```
-
-### Value
+## Value
 
 A  DOM {{domxref('Element')}}.
 

--- a/files/en-us/web/api/shadowroot/innerhtml/index.md
+++ b/files/en-us/web/api/shadowroot/innerhtml/index.md
@@ -16,14 +16,7 @@ The **`innerHTML`** property of the {{domxref("ShadowRoot")}}
 interface sets or returns a reference to the DOM tree inside the
 `ShadowRoot`.
 
-## Syntax
-
-```js
-var domString = shadowRoot.innerHTML
-shadowRoot.innerHTML = domString
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 

--- a/files/en-us/web/api/shadowroot/mode/index.md
+++ b/files/en-us/web/api/shadowroot/mode/index.md
@@ -21,13 +21,7 @@ implementation internals are inaccessible and unchangeable from JavaScript—in 
 way the implementation internals of, for example, the {{HTMLElement("video")}} element
 are inaccessible and unchangeable from JavaScript.
 
-## Syntax
-
-```js
-var mode = shadowRoot.mode
-```
-
-### Value
+## Value
 
 A value defined in the
 [`ShadowRootMode`](https://dom.spec.whatwg.org/#enumdef-shadowrootmode)

--- a/files/en-us/web/api/shadowroot/pictureinpictureelement/index.md
+++ b/files/en-us/web/api/shadowroot/pictureinpictureelement/index.md
@@ -17,13 +17,7 @@ The **`pictureInPictureElement`** read-only property of the
 presented in picture-in-picture mode in this shadow tree, or `null` if
 picture-in-picture mode is not currently in use.
 
-## Syntax
-
-```js
-shadowRoot.pictureInPictureElement
-```
-
-### Value
+## Value
 
 A reference to the {{domxref("Element")}} object that's currently in
 picture-in-picture mode, or, if picture-in-picture mode isn't currently in use by the

--- a/files/en-us/web/api/shadowroot/pointerlockelement/index.md
+++ b/files/en-us/web/api/shadowroot/pointerlockelement/index.md
@@ -18,13 +18,7 @@ element set as the target for mouse events while the pointer is locked. It is
 `null` if lock is pending, pointer is unlocked, or the target is in another
 tree.
 
-## Syntax
-
-```js
-shadowRoot.pointerLockElement;
-```
-
-### Value
+## Value
 
 An {{domxref("Element")}} or `null`.
 

--- a/files/en-us/web/api/shadowroot/stylesheets/index.md
+++ b/files/en-us/web/api/shadowroot/stylesheets/index.md
@@ -14,13 +14,7 @@ browser-compat: api.ShadowRoot.styleSheets
 The **`styleSheets`** read-only property of the {{domxref("ShadowRoot")}} interface
 returns a {{domxref('StyleSheetList')}} of {{domxref('CSSStyleSheet')}} objects, for stylesheets explicitly linked into or embedded in a shadow tree.
 
-## Syntax
-
-```js
-shadowRoot.styleSheets
-```
-
-### Value
+## Value
 
 A {{domxref('StyleSheetList')}} of {{domxref('CSSStyleSheet')}} objects.
 

--- a/files/en-us/web/api/sharedworker/port/index.md
+++ b/files/en-us/web/api/sharedworker/port/index.md
@@ -16,17 +16,11 @@ The **`port`** property of the {{domxref("SharedWorker")}}
 interface returns a {{domxref("MessagePort")}} object used to communicate and control
 the shared worker.
 
-## Syntax
-
-```js
-myWorker.port;
-```
-
-### Value
+## Value
 
 A {{domxref("MessagePort")}} object.
 
-## Example
+## Examples
 
 The following code snippet shows creation of a `SharedWorker` object using
 the {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} constructor. Multiple

--- a/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.md
@@ -14,17 +14,11 @@ browser-compat: api.SharedWorkerGlobalScope.applicationCache
 
 The **`applicationCache`** read-only property of the {{domxref("SharedWorkerGlobalScope")}} interface returns the {{domxref("ApplicationCache")}} object for the worker.
 
-## Syntax
-
-```js
-var nameObj = self.applicationCache;
-```
-
-### Value
+## Value
 
 An {{domxref("ApplicationCache")}}.
 
-## Example
+## Examples
 
 If a shared worker has an AppCache associated with it, you can return a reference to the cache using
 

--- a/files/en-us/web/api/sharedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/name/index.md
@@ -18,17 +18,11 @@ The **`name`** read-only property of the
 that the {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} constructor can pass
 to get a reference to the {{domxref("SharedWorkerGlobalScope")}}.
 
-## Syntax
-
-```js
-var nameObj = self.name;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
-## Example
+## Examples
 
 If a shared worker is created using a constructor with a `name` option:
 

--- a/files/en-us/web/api/sourcebuffer/appendwindowend/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendwindowend/index.md
@@ -24,15 +24,7 @@ appended, whereas those outside the range will be filtered out.
 
 The default value of `appendWindowEnd` is positive infinity.
 
-## Syntax
-
-```js
-var myAppendWindowEnd = sourceBuffer.appendWindowEnd;
-
-sourceBuffer.appendWindowEnd = 120.0;
-```
-
-### Value
+## Value
 
 A double, indicating the end time of the append window, in seconds.
 
@@ -49,7 +41,7 @@ The following exceptions may be thrown when setting a new value for this propert
         currently <code>true</code>), or this <code>SourceBuffer</code> has been
         removed from the {{domxref("MediaSource")}}.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
@@ -25,15 +25,7 @@ appended, whereas those outside the range will be filtered out.
 The default value of `appendWindowStart` is the presentation start time,
 which is the beginning time of the playable media.
 
-## Syntax
-
-```js
-var myAppendWindowStart = sourceBuffer.appendWindowStart;
-
-sourceBuffer.appendWindowStart = 2.0;
-```
-
-### Value
+## Value
 
 A double, indicating the start time of the append window, in seconds.
 
@@ -51,7 +43,7 @@ The following exceptions may be thrown when setting a new value for this propert
         currently `true`), or this `SourceBuffer` has been
         removed from the {{domxref("MediaSource")}}.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/audiotracks/index.md
+++ b/files/en-us/web/api/sourcebuffer/audiotracks/index.md
@@ -19,17 +19,11 @@ The **`audioTracks`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns a list of the audio tracks currently
 contained inside the `SourceBuffer`.
 
-## Syntax
-
-```js
-var myAudioTracks = sourceBuffer.audioTracks;
-```
-
-### Value
+## Value
 
 An {{domxref("AudioTrackList")}} object.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/buffered/index.md
+++ b/files/en-us/web/api/sourcebuffer/buffered/index.md
@@ -21,17 +21,11 @@ The **`buffered`** read-only property of the
 buffered in the `SourceBuffer` as a normalized {{domxref("TimeRanges")}}
 object.
 
-## Syntax
-
-```js
-var myBufferedRange = sourceBuffer.buffered;
-```
-
-### Value
+## Value
 
 A {{domxref("TimeRanges")}} object.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/mode/index.md
+++ b/files/en-us/web/api/sourcebuffer/mode/index.md
@@ -44,15 +44,7 @@ This property cannot be changed during while the `SourceBuffer` is
 processing either an {{domxref("SourceBuffer.appendBuffer","appendBuffer()")}} or
 {{domxref("SourceBuffer.remove","remove()")}} call.
 
-## Syntax
-
-```js
-var myMode = sourceBuffer.mode;
-
-sourceBuffer.mode = 'sequence';
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}.
 
@@ -71,7 +63,7 @@ The following exceptions may be thrown when setting a new value for this propert
         `SourceBuffer` has been removed from the
         {{domxref("MediaSource")}}.
 
-## Example
+## Examples
 
 This snippet sets the `sourceBuffer` mode to `'sequence'` if it
 is currently set to `'segments'`, thus setting the play order to the sequence

--- a/files/en-us/web/api/sourcebuffer/texttracks/index.md
+++ b/files/en-us/web/api/sourcebuffer/texttracks/index.md
@@ -19,17 +19,11 @@ The **`textTracks`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns a list of the text tracks currently
 contained inside the `SourceBuffer`.
 
-## Syntax
-
-```js
-var myTextTracks = sourceBuffer.textTracks;
-```
-
-### Value
+## Value
 
 An {{domxref("TextTrackList")}} object.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/timestampoffset/index.md
+++ b/files/en-us/web/api/sourcebuffer/timestampoffset/index.md
@@ -22,15 +22,7 @@ media segments that are appended to the `SourceBuffer`.
 
 The initial value of `timestampOffset` is 0.
 
-## Syntax
-
-```js
-var myOffset = sourceBuffer.timestampOffset;
-
-sourceBuffer.timestampOffset = 2.5;
-```
-
-### Value
+## Value
 
 A double, with the offset amount expressed in seconds.
 
@@ -47,7 +39,7 @@ The following exception may be thrown when setting a new value for this property
         `SourceBuffer` has been removed from the
         {{domxref("MediaSource")}}.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/updating/index.md
+++ b/files/en-us/web/api/sourcebuffer/updating/index.md
@@ -22,17 +22,11 @@ currently being updated — i.e. whether an {{domxref("SourceBuffer.appendBuffer
 {{domxref("SourceBuffer.appendStream()")}}, or {{domxref("SourceBuffer.remove()")}}
 operation is currently in progress.
 
-## Syntax
-
-```js
-var isUpdating = sourceBuffer.updating;
-```
-
-### Value
+## Value
 
 A boolean value.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebuffer/videotracks/index.md
+++ b/files/en-us/web/api/sourcebuffer/videotracks/index.md
@@ -19,17 +19,11 @@ The **`videoTracks`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns a list of the video tracks currently
 contained inside the `SourceBuffer`.
 
-## Syntax
-
-```js
-var myVideoTracks = sourceBuffer.videoTracks;
-```
-
-### Value
+## Value
 
 An {{domxref("VideoTrackList")}} object.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/sourcebufferlist/length/index.md
+++ b/files/en-us/web/api/sourcebufferlist/length/index.md
@@ -19,17 +19,11 @@ The **`length`** read-only property of the
 {{domxref("SourceBufferList")}} interface returns the number of
 {{domxref("SourceBuffer")}} objects in the list.
 
-## Syntax
-
-```js
-var myListLength = sourceBufferList.length;
-```
-
-### Value
+## Value
 
 An unsigned long number.
 
-## Example
+## Examples
 
 TBD
 

--- a/files/en-us/web/api/speechgrammar/src/index.md
+++ b/files/en-us/web/api/speechgrammar/src/index.md
@@ -19,13 +19,7 @@ The **`src`** property of the {{domxref("SpeechGrammar")}}
 interface sets and returns a string containing the grammar from within in the
 `SpeechGrammar` object.
 
-## Syntax
-
-```js
-var myGrammar = speechGrammarInstance.src;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the grammar.
 

--- a/files/en-us/web/api/speechgrammar/weight/index.md
+++ b/files/en-us/web/api/speechgrammar/weight/index.md
@@ -19,13 +19,7 @@ The optional **`weight`** property of the
 {{domxref("SpeechGrammar")}} interface sets and returns the weight of the
 `SpeechGrammar` object.
 
-## Syntax
-
-```js
-var myGrammarWeight = speechGrammarInstance.weight;
-```
-
-### Value
+## Value
 
 A float representing the weight of the grammar, in the range 0.0–1.0.
 

--- a/files/en-us/web/api/speechgrammarlist/length/index.md
+++ b/files/en-us/web/api/speechgrammarlist/length/index.md
@@ -19,13 +19,7 @@ The **`length`** read-only property of the
 {{domxref("SpeechGrammarList")}} interface returns the number of
 {{domxref("SpeechGrammar")}} objects contained in the {{domxref("SpeechGrammarList")}}.
 
-## Syntax
-
-```js
-var myListLength = speechGrammarListInstance.length;
-```
-
-### Value
+## Value
 
 A number indicating the number of {{domxref("SpeechGrammar")}} objects contained in the
 {{domxref("SpeechGrammarList")}}.

--- a/files/en-us/web/api/speechrecognitionerror/error/index.md
+++ b/files/en-us/web/api/speechrecognitionerror/error/index.md
@@ -21,13 +21,7 @@ The **`error`** read-only property of the
 > **Note:** This `SpeechRecognitionError` interface was renamed to
 > {{domxref("SpeechRecognitionErrorEvent")}} in the Web Speech API specification.
 
-## Syntax
-
-```js
-var myError = event.error;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} naming the type of error. The possible error types are:
 

--- a/files/en-us/web/api/speechrecognitionerror/message/index.md
+++ b/files/en-us/web/api/speechrecognitionerror/message/index.md
@@ -22,13 +22,7 @@ in more detail.
 > **Note:** This `SpeechRecognitionError` interface was renamed to
 > {{domxref("SpeechRecognitionErrorEvent")}} in the Web Speech API specification.
 
-## Syntax
-
-```js
-var myErrorMsg = event.message;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing more details about the error that was raised.
 Note that the spec does not define the exact wording of these messages — this is up to

--- a/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
@@ -18,13 +18,7 @@ browser-compat: api.SpeechRecognitionErrorEvent.error
 The **`error`** read-only property of the
 {{domxref("SpeechRecognitionErrorEvent")}} interface returns the type of error raised.
 
-## Syntax
-
-```js
-var myError = event.error;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} naming the type of error. The possible error types are:
 

--- a/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
@@ -19,13 +19,7 @@ The **`message`** read-only property of the
 {{domxref("SpeechRecognitionErrorEvent")}} interface returns a message describing the
 error in more detail.
 
-## Syntax
-
-```js
-var myErrorMsg = event.message;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing more details about the error that was raised.
 Note that the spec does not define the exact wording of these messages — this is up to

--- a/files/en-us/web/api/speechrecognitionevent/emma/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/emma/index.md
@@ -23,13 +23,7 @@ result.
 > **Note:** EMMA is defined in the specification [EMMA: Extensible MultiModal Annotation markup
 > language](https://www.w3.org/TR/emma/). You can see multiple EMMA examples in the spec.
 
-## Syntax
-
-```js
-var myEmma = event.emma;
-```
-
-### Value
+## Value
 
 A valid XML document. The exact contents can vary across user agents and recognition
 engines, but all supporting implementations will expose a valid XML document complete

--- a/files/en-us/web/api/speechrecognitionevent/interpretation/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/interpretation/index.md
@@ -24,13 +24,7 @@ a grammar (see
 [Semantic Interpretation for Speech Recognition (SISR) Version 1.0](https://www.w3.org/TR/semantic-interpretation/)
 for specification and examples.)
 
-## Syntax
-
-```js
-var myInterpretation = event.interpretation;
-```
-
-### Value
+## Value
 
 The returned value can be of any type. If no semantic interpretation has been returned
 by the speech recognition system, `null` will be returned.

--- a/files/en-us/web/api/speechrecognitionevent/resultindex/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/resultindex/index.md
@@ -22,13 +22,7 @@ the {{domxref("SpeechRecognitionResultList")}} "array" that has actually changed
 The {{domxref("SpeechRecognitionResultList")}} object is not an array, but it has a
 getter that allows it to be accessed by array syntax.
 
-## Syntax
-
-```js
-var myResultIndex = event.resultIndex;
-```
-
-### Value
+## Value
 
 A number.
 

--- a/files/en-us/web/api/speechrecognitionevent/results/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/results/index.md
@@ -27,13 +27,7 @@ interim result or by a final result — they may even be removed, if they are at
 of the "results" array and the array length decreases. Final results on the other hand
 will not be overwritten or removed.
 
-## Syntax
-
-```js
-var myResults = event.results;
-```
-
-### Value
+## Value
 
 A {{domxref("SpeechRecognitionResultList")}} object.
 

--- a/files/en-us/web/api/speechsynthesisutterance/lang/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/lang/index.md
@@ -18,14 +18,7 @@ The **`lang`** property of the {{domxref("SpeechSynthesisUtterance")}} interface
 
 If unset, the app's (i.e. the {{htmlelement("html")}} {{htmlattrxref("lang", "html")}} value) lang will be used, or the user-agent default if that is unset too.
 
-## Syntax
-
-```js
-var myLang = speechSynthesisUtteranceInstance.lang;
-speechSynthesisUtteranceInstance.lang = 'en-US';
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing a BCP 47 language tag.
 

--- a/files/en-us/web/api/speechsynthesisutterance/pitch/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/pitch/index.md
@@ -18,14 +18,7 @@ The **`pitch`** property of the {{domxref("SpeechSynthesisUtterance")}} interfac
 
 If unset, a default value of 1 will be used.
 
-## Syntax
-
-```js
-// default 1
-speechSynthesisUtteranceInstance.pitch = 1.5;
-```
-
-### Value
+## Value
 
 A float representing the pitch value.
 It can range between 0 (lowest) and 2 (highest), with 1 being the default pitch for the current platform or voice. Some speech synthesis engines or voices may constrain the minimum and maximum rates further.

--- a/files/en-us/web/api/speechsynthesisutterance/rate/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/rate/index.md
@@ -18,14 +18,7 @@ The **`rate`** property of the {{domxref("SpeechSynthesisUtterance")}} interface
 
 If unset, a default value of 1 will be used.
 
-## Syntax
-
-```js
-var myRate = speechSynthesisUtteranceInstance.rate;
-speechSynthesisUtteranceInstance.rate = 1.5;
-```
-
-### Value
+## Value
 
 A float representing the rate value.
 It can range between 0.1 (lowest) and 10 (highest), with 1 being the default pitch for the current platform or voice, which should correspond to a normal speaking rate.


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error