### PR TITLE
Fix height of void operator interactive example

### DIFF
--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.operators.void
 The **`void` operator** evaluates the given
 `expression` and then returns {{jsxref("undefined")}}.
 
-{{EmbedInteractiveExample("pages/js/expressions-voidoperator.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-voidoperator.html", "taller")}}
 
 ## Syntax
 


### PR DESCRIPTION
In https://github.com/mdn/interactive-examples/pull/2065 , the height of the example increased to the point where it gets the taller editor, so we have to add a "taller" argument to the macro call, so it creates an iframe big enough to fit without scrolling.