### PR TITLE
Stream API tidy

### DIFF
--- a/files/en-us/web/api/readablestream/cancel/index.md
+++ b/files/en-us/web/api/readablestream/cancel/index.md
@@ -25,32 +25,28 @@ still and not completely get rid of the stream, you'd use
 ## Syntax
 
 ```js
-var promise = readableStream.cancel(reason);
+readableStream.cancel()
+readableStream.cancel(reason)
 ```
 
 ### Parameters
 
-- reason {{optional_inline}}
+- `reason` {{optional_inline}}
   - : A human-readable reason for the cancellation. The underlying source may or may not use it.
 
 ### Return value
 
-A {{jsxref("Promise")}}, which fulfills with the value given in the `reason`
-parameter.
+A {{jsxref("Promise")}}, which fulfills with the value given in the `reason` parameter.
 
 ### Exceptions
 
-- TypeError
-  - : The stream you are trying to cancel is not a {{domxref("ReadableStream")}}, or it is
-    locked.
+- `TypeError`
+  - : The stream you are trying to cancel is not a {{domxref("ReadableStream")}}, or it is locked.
 
 ## Examples
 
-In Jake Archibald's [cancelling a
-fetch](https://jsbin.com/gameboy/edit?js,console) example, a stream is used to fetch the WHATWG HTML spec chunk by chunk; each
-chunk is searched for the string "service workers". When the search terms is found,
-`cancel()` is used to cancel the stream — the job is finished so it is no
-longer needed.
+In Jake Archibald's [cancelling a fetch](https://jsbin.com/gameboy/edit?js,console) example, a stream is used to fetch the WHATWG HTML spec chunk by chunk; each
+chunk is searched for the string "service workers". When the search terms is found, `cancel()` is used to cancel the stream — the job is finished so it is no longer needed.
 
 ```js
 var searchTerm = "service workers";

--- a/files/en-us/web/api/readablestream/getreader/index.md
+++ b/files/en-us/web/api/readablestream/getreader/index.md
@@ -12,51 +12,43 @@ browser-compat: api.ReadableStream.getReader
 ---
 {{APIRef("Streams")}}
 
-The **`getReader()`** method of the
-{{domxref("ReadableStream")}} interface creates a reader and locks the stream to it.
+The **`getReader()`** method of the {{domxref("ReadableStream")}} interface creates a reader and locks the stream to it.
 While the stream is locked, no other reader can be acquired until this one is released.
 
 ## Syntax
 
 ```js
-var reader = readableStream.getReader({mode});
+readableStream.getReader()
+readableStream.getReader({mode})
 ```
 
 ### Parameters
 
-- {mode} {{optional_inline}}
+- `{mode}` {{optional_inline}}
 
-  - : An object containing a property `mode`, specifying the type of reader to
-    create.  Values can be:
+  - : An object containing a property `mode`, specifying the type of reader to create.
+    Values can be:
 
-    - `"byob"`, which results in a {{domxref("ReadableStreamBYOBReader")}}
-      being created that can read readable byte streams (i.e. can handle "bring your own
-      buffer" reading).
-    - `undefined` (or not specified at all — this is the default), which
-      results in a {{domxref("ReadableStreamDefaultReader")}} being created that can
-      read individual chunks from a stream.
+    - `"byob"`, which results in a {{domxref("ReadableStreamBYOBReader")}} being created that can read readable byte streams (i.e. can handle "bring your own buffer" reading).
+    - `undefined` (or not specified at all — this is the default), which results in a {{domxref("ReadableStreamDefaultReader")}} being created that can read individual chunks from a stream.
 
 ### Return value
 
-A {{domxref("ReadableStreamDefaultReader")}} or {{domxref("ReadableStreamBYOBReader")}}
-object instance, depending on the `mode` value.
+A {{domxref("ReadableStreamDefaultReader")}} or {{domxref("ReadableStreamBYOBReader")}} object instance, depending on the `mode` value.
 
 ### Exceptions
 
-- RangeError
+- `RangeError`
   - : The provided mode value is not `"byob"` or `undefined`.
-- TypeError
+- `TypeError`
   - : The stream you are trying to create a reader for is not a
     {{domxref("ReadableStream")}}.
 
 ## Examples
 
-In the following simple example, a previously-created custom
-`ReadableStream` is read using a {{domxref("ReadableStreamDefaultReader")}}
-created using `getReader()`. (see our [Simple random
-stream example](https://mdn.github.io/dom-examples/streams/simple-random-stream/) for the full code). Each chunk is read sequentially and output to
-the UI, until the stream has finished being read, at which point we return out of the
-recursive function and print the entire stream to another part of the UI.
+In the following simple example, a previously-created custom `ReadableStream` is read using a {{domxref("ReadableStreamDefaultReader")}} created using `getReader()`.
+(see our [Simple random stream example](https://mdn.github.io/dom-examples/streams/simple-random-stream/) for the full code).
+Each chunk is read sequentially and output to the UI, until the stream has finished being read, at which point we return out of the recursive function and print the entire stream to another part of the UI.
 
 ```js
 function fetchStream() {

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -27,7 +27,7 @@ The `ReadableStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_
 ## Properties
 
 - {{domxref("ReadableStream.locked")}} {{readonlyInline}}
-  - : The `locked` getter returns whether or not the readable stream is [locked to a reader](https://streams.spec.whatwg.org/#locked-to-a-reader).
+  - : The `locked` getter returns whether or not the readable stream is locked to a reader.
 
 ## Methods
 

--- a/files/en-us/web/api/readablestream/locked/index.md
+++ b/files/en-us/web/api/readablestream/locked/index.md
@@ -12,13 +12,14 @@ browser-compat: api.ReadableStream.locked
 ---
 {{APIRef("Streams")}}
 
-The **`locked`** read-only property of the
-{{domxref("ReadableStream")}} interface returns whether or not the readable stream is [locked
-to a reader](https://streams.spec.whatwg.org/#lock).
+The **`locked`** read-only property of the {{domxref("ReadableStream")}} interface returns whether or not the readable stream is locked to a reader.
+
+A readable stream can have at most one active reader at a time, and is locked to that reader until it is released.
+A reader might be obtained using [`ReadableStream.getReader()`](/en-US/docs/Web/API/ReadableStream/getReader) and released using the reader's `releaseLock()` method.
 
 ## Value
 
-A boolean value indicating whether or not the readable stream is locked.
+A {{Glossary("boolean")}} value indicating whether or not the readable stream is locked.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestream/pipethrough/index.md
+++ b/files/en-us/web/api/readablestream/pipethrough/index.md
@@ -3,7 +3,6 @@ title: ReadableStream.pipeThrough()
 slug: Web/API/ReadableStream/pipeThrough
 tags:
   - API
-  - Experimental
   - Method
   - ReadableStream
   - Reference
@@ -11,25 +10,23 @@ tags:
   - pipeThrough
 browser-compat: api.ReadableStream.pipeThrough
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
-The **`pipeThrough()`** method of the
-{{domxref("ReadableStream")}} interface provides a chainable way of piping the current
+The **`pipeThrough()`** method of the {{domxref("ReadableStream")}} interface provides a chainable way of piping the current
 stream through a transform stream or any other writable/readable pair.
 
-Piping a stream will generally lock it for the duration of the pipe, preventing other
-readers from locking it.
+Piping a stream will generally lock it for the duration of the pipe, preventing other readers from locking it.
 
 ## Syntax
 
 ```js
-pipeThrough(transformStream);
-pipeThrough(transformStream, options);
+pipeThrough(transformStream)
+pipeThrough(transformStream, options)
 ```
 
 ### Parameters
 
-- transformStream
+- `transformStream`
   - : A {{domxref("TransformStream")}} (or an object with the structure
     `{writable, readable}`) consisting of a readable stream and a writable
     stream working together to transform some data from one form to another. Data written
@@ -37,7 +34,7 @@ pipeThrough(transformStream, options);
     `readable` stream. For example, a {{domxref("TextDecoder")}}, has bytes
     written to it and strings read from it, while a video decoder has encoded bytes
     written to it and uncompressed video frames read from it.
-- options {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : The options that should be used when piping to the `writable` stream.
     Available options are:
@@ -70,9 +67,8 @@ The `readable` side of the `transformStream`.
 
 ### Exceptions
 
-- TypeError
-  - : The `writable` and/or `readable` property of
-    `transformStream` are undefined.
+- `TypeError`
+  - : The `writable` and/or `readable` property of `transformStream` are undefined.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -3,7 +3,6 @@ title: ReadableStream.pipeTo()
 slug: Web/API/ReadableStream/pipeTo
 tags:
   - API
-  - Experimental
   - Method
   - ReadableStream
   - Reference
@@ -11,53 +10,38 @@ tags:
   - pipeTo
 browser-compat: api.ReadableStream.pipeTo
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
-The **`pipeTo()`** method of the
-{{domxref("ReadableStream")}} interface pipes the current `ReadableStream` to
-a given {{domxref("WritableStream")}} and returns a {{jsxref("Promise")}} that fulfills when the
-piping process completes successfully, or rejects if any errors were encountered.
+The **`pipeTo()`** method of the {{domxref("ReadableStream")}} interface pipes the current `ReadableStream` to a given {{domxref("WritableStream")}} and returns a {{jsxref("Promise")}} that fulfills when the piping process completes successfully, or rejects if any errors were encountered.
 
-Piping a stream will generally lock it for the duration of the pipe, preventing other
-readers from locking it.
+Piping a stream will generally [lock](/en-US/docs/Web/API/ReadableStream/locked) it for the duration of the pipe, preventing other readers from locking it.
 
 ## Syntax
 
 ```js
-var promise = readableStream.pipeTo(destination[, options]);
+readableStream.pipeTo(destination)
+readableStream.pipeTo(destination, options)
 ```
 
 ### Parameters
 
-- destination
-  - : A {{domxref("WritableStream")}} that acts as the final destination for the
-    {{domxref("ReadableStream")}}.
-- options {{optional_inline}}
+- `destination`
+  - : A {{domxref("WritableStream")}} that acts as the final destination for the {{domxref("ReadableStream")}}.
+
+- `options` {{optional_inline}}
 
   - : The options that should be used when piping to the `writable` stream.
     Available options are:
 
-    1. `preventClose`: If this is set to `true`, the source
-        `ReadableStream` closing will no longer cause the destination
-        `WritableStream` to be closed. The method will return a fulfilled
-        promise once this process completes, unless an error is encountered while closing
-        the destination in which case it will be rejected with that error.
-    2. `preventAbort`: If this is set to `true`, errors in the
-        source `ReadableStream` will no longer abort the destination
-        `WritableStream`. The method will return a promise rejected with the
-        source's error, or with any error that occurs during aborting the destination.
-    3. `preventCancel`: If this is set to `true`, errors in the
-        destination `WritableStream` will no longer cancel the source
-        `ReadableStream`. In this case the method will return a promise
-        rejected with the source's error, or with any error that occurs during canceling
-        the source. In addition, if the destination writable stream starts out closed or
-        closing, the source readable stream will no longer be canceled. In this case the
-        method will return a promise rejected with an error indicating piping to a closed
-        stream failed, or with any error that occurs during canceling the source.
-    4. `signal`: If set to an
-        [`AbortSignal`](/en-US/docs/Web/API/AbortSignal) object,
-        ongoing pipe operations can then be aborted via the corresponding
-        [`AbortController`](/en-US/docs/Web/API/AbortController).
+    1. `preventClose`: If this is set to `true`, the source `ReadableStream` closing will no longer cause the destination `WritableStream` to be closed.
+        The method will return a fulfilled promise once this process completes, unless an error is encountered while closing the destination in which case it will be rejected with that error.
+    2. `preventAbort`: If this is set to `true`, errors in the source `ReadableStream` will no longer abort the destination `WritableStream`.
+        The method will return a promise rejected with the source's error, or with any error that occurs during aborting the destination.
+    3. `preventCancel`: If this is set to `true`, errors in the destination `WritableStream` will no longer cancel the source `ReadableStream`.
+        In this case the method will return a promise rejected with the source's error, or with any error that occurs during cancelingthe source.
+        In addition, if the destination writable stream starts out closed or closing, the source readable stream will no longer be canceled.
+        In this case the method will return a promise rejected with an error indicating piping to a closed stream failed, or with any error that occurs during canceling the source.
+    4. `signal`: If set to an [`AbortSignal`](/en-US/docs/Web/API/AbortSignal) object, ongoing pipe operations can then be aborted via the corresponding [`AbortController`](/en-US/docs/Web/API/AbortController).
 
 ### Return value
 
@@ -66,8 +50,7 @@ A {{jsxref("Promise")}} that resolves when the piping process has completed.
 ### Exceptions
 
 - TypeError
-  - : The `writableStream` and/or `readableStream` objects are not a
-    writable stream/readable stream, or one or both of the streams are locked.
+  - : The `writableStream` and/or `readableStream` objects are not a writable stream/readable stream, or one or both of the streams are locked.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestream/tee/index.md
+++ b/files/en-us/web/api/readablestream/tee/index.md
@@ -29,7 +29,7 @@ will generally lock it for the duration, preventing other readers from locking i
 ## Syntax
 
 ```js
-var teedStreams = readableStream.tee();
+readableStream.tee()
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ An {{jsxref("Array")}} containing two {{domxref("ReadableStream")}} instances.
 
 ### Exceptions
 
-- TypeError
+- `TypeError`
   - : The source stream is not a `ReadableStream`.
 
 ## Examples

--- a/files/en-us/web/api/streams_api/using_writable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_writable_streams/index.md
@@ -14,13 +14,11 @@ tags:
 
 As a JavaScript developer, programmatically writing data to a stream is very useful! This article explains the [Streams API](/en-US/docs/Web/API/Streams_API)'s writable stream functionality.
 
-> **Note:** This article assumes that you understand the use cases of writable streams, and are aware of the high-level concepts. If not, we suggest that you first read the [Streams concepts and usage overview](/en-US/docs/Web/API/Streams_API#Concepts_and_usage) and dedicated [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts) article, then come back.
+> **Note:** This article assumes that you understand the use cases of writable streams, and are aware of the high-level concepts.
+> If not, we suggest that you first read the [Streams concepts and usage overview](/en-US/docs/Web/API/Streams_API#Concepts_and_usage) and dedicated [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts) article, then come back.
 
 > **Note:** If you are looking for information about readable streams, try [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams) instead.
 
-## Browser support
-
-The Streams API is experimental, and support is at an early stage right now. Only Chrome currently has basic writable streams implemented.
 
 ## Introducing an example
 

--- a/files/en-us/web/api/transformstream/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/transformstream/index.md
@@ -15,10 +15,10 @@ The **`TransformStream()`** constructor creates a new {{domxref("TransformStream
 ## Syntax
 
 ```js
-new TransformStream();
-new TransformStream(transformer);
-new TransformStream(transformer, writableStrategy);
-new TransformStream(transformer, writableStrategy, readableStrategy);
+new TransformStream()
+new TransformStream(transformer)
+new TransformStream(transformer, writableStrategy)
+new TransformStream(transformer, writableStrategy, readableStrategy)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/writablestream/abort/index.md
+++ b/files/en-us/web/api/writablestream/abort/index.md
@@ -3,7 +3,6 @@ title: WritableStream.abort()
 slug: Web/API/WritableStream/abort
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Streams
@@ -11,34 +10,29 @@ tags:
   - abort
 browser-compat: api.WritableStream.abort
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
-The **`abort()`** method of the
-{{domxref("WritableStream")}} interface aborts the stream, signaling that the producer
-can no longer successfully write to the stream and it is to be immediately moved to an
-error state, with any queued writes discarded.
+The **`abort()`** method of the {{domxref("WritableStream")}} interface aborts the stream, signaling that the producer can no longer successfully write to the stream and it is to be immediately moved to an error state, with any queued writes discarded.
 
 ## Syntax
 
 ```js
-var promise = writableStream.abort(reason);
+writableStream.abort(reason)
 ```
 
 ### Parameters
 
-- reason
+- `reason`
   - : A {{domxref("DOMString")}} providing a human-readable reason for the abort.
 
 ### Return value
 
-A {{jsxref("Promise")}}, which fulfills with the value given in the `reason`
-parameter.
+A {{jsxref("Promise")}}, which fulfills with the value given in the `reason` parameter.
 
 ### Exceptions
 
 - TypeError
-  - : The stream you are trying to abort is not a {{domxref("WritableStream")}}, or it is
-    locked.
+  - : The stream you are trying to abort is not a {{domxref("WritableStream")}}, or it is locked.
 
 ## Examples
 

--- a/files/en-us/web/api/writablestream/getwriter/index.md
+++ b/files/en-us/web/api/writablestream/getwriter/index.md
@@ -3,7 +3,6 @@ title: WritableStream.getWriter()
 slug: Web/API/WritableStream/getWriter
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Streams
@@ -11,17 +10,15 @@ tags:
   - getWriter
 browser-compat: api.WritableStream.getWriter
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
-The **`getWriter()`** method of the
-{{domxref("WritableStream")}} interface returns a new instance of
-{{domxref("WritableStreamDefaultWriter")}} and locks the stream to that instance. While
-the stream is locked, no other writer can be acquired until this one is released.
+The **`getWriter()`** method of the {{domxref("WritableStream")}} interface returns a new instance of {{domxref("WritableStreamDefaultWriter")}} and locks the stream to that instance. 
+While the stream is locked, no other writer can be acquired until this one is released.
 
 ## Syntax
 
 ```js
-var writer = writableStream.getWriter();
+getWriter()
 ```
 
 ### Parameters
@@ -34,9 +31,8 @@ A {{domxref("WritableStreamDefaultWriter")}} object instance.
 
 ### Exceptions
 
-- TypeError
-  - : The stream you are trying to create a writer for is not a
-    {{domxref("WritableStream")}}.
+- `TypeError`
+  - : The stream you are trying to create a writer for is not a {{domxref("WritableStream")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -3,16 +3,16 @@ title: WritableStream
 slug: Web/API/WritableStream
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - Streams
   - WritableStream
 browser-compat: api.WritableStream
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
-The **`WritableStream`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) provides a standard abstraction for writing streaming data to a destination, known as a sink. This object comes with built-in backpressure and queuing.
+The **`WritableStream`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) provides a standard abstraction for writing streaming data to a destination, known as a sink.
+This object comes with built-in backpressure and queuing.
 
 ## Constructor
 
@@ -106,7 +106,8 @@ You can find the full code in our [Simple writer example](https://mdn.github.io/
 
 ### Backpressure
 
-Because of how backpressure is supported in the API, its implementation in code may be less than obvious. To see how backpressure is implemented look for three things.
+Because of how [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is supported in the API, its implementation in code may be less than obvious.
+To see how backpressure is implemented look for three things:
 
 - The `highWaterMark` property, which is set when creating the counting strategy (line 35), sets the maximum amount of data that the `WritableStream` instance will handle in a single `write()` operation. In this example, it's the maximum amount of data that can be sent to `defaultWriter.write()` (line 11).
 - The `defaultWriter.ready` property returns a promise that resolves when the sink (the first property of the `WritableStream` constructor) is done writing data. The data source can either write more data (line 9) or call `close()` (line 24). Calling close() too early can prevent data from being written. This is why the example calls `defaultWriter.ready` twice (lines 9 and 22).

--- a/files/en-us/web/api/writablestream/locked/index.md
+++ b/files/en-us/web/api/writablestream/locked/index.md
@@ -3,7 +3,6 @@ title: WritableStream.locked
 slug: Web/API/WritableStream/locked
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Streams
@@ -11,11 +10,9 @@ tags:
   - locked
 browser-compat: api.WritableStream.locked
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
-The **`locked`** read-only property of the
-{{domxref("WritableStream")}} interface returns a boolean indicating whether the
-`WritableStream` is locked to a writer.
+The **`locked`** read-only property of the {{domxref("WritableStream")}} interface returns a boolean indicating whether the `WritableStream` is locked to a writer.
 
 ## Value
 

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -4,13 +4,12 @@ slug: Web/API/WritableStream/WritableStream
 tags:
   - API
   - Constructor
-  - Experimental
   - Reference
   - Streams
   - WritableStream
 browser-compat: api.WritableStream.WritableStream
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`WritableStream()`** constructor creates
 a new {{domxref("WritableStream")}} object instance.
@@ -24,12 +23,12 @@ new WritableStream(underlyingSink, queuingStrategy)
 
 ### Parameters
 
-- underlyingSink {{optional_inline}}
+- `underlyingSink` {{optional_inline}}
 
   - : An object containing methods and properties that define how the constructed stream
     instance will behave. `underlyingSink` can contain the following:
 
-    - start(controller) {{optional_inline}}
+    - `start(controller)` {{optional_inline}}
       - : This is a method, called immediately when the object is constructed. The
         contents of this method are defined by the developer, and should aim to get access
         to the underlying sink. If this process is to be done asynchronously, it can
@@ -37,7 +36,7 @@ new WritableStream(underlyingSink, queuingStrategy)
         parameter passed to this method is a
         {{domxref("WritableStreamDefaultController")}}. This can be used by the developer
         to control the stream during set up.
-    - write(chunk, controller) {{optional_inline}}
+    - `write(chunk, controller)` {{optional_inline}}
       - : This method, also defined by the developer, will be called when a new chunk of
         data (specified in the `chunk` parameter) is ready to be written to the
         underlying sink. It can return a promise to signal success or failure of the write
@@ -46,7 +45,7 @@ new WritableStream(underlyingSink, queuingStrategy)
         to control the stream as more chunks are submitted for writing. This method will
         be called only after previous writes have succeeded, and never after the stream is
         closed or aborted (see below).
-    - close(controller) {{optional_inline}}
+    - `close(controller)` {{optional_inline}}
       - : This method, also defined by the developer, will be called if the app signals
         that it has finished writing chunks to the stream. The contents should do whatever
         is necessary to finalize writes to the underlying sink, and release access to it.
@@ -55,7 +54,7 @@ new WritableStream(underlyingSink, queuingStrategy)
         succeeded. The `controller` parameter passed to this method is a
         {{domxref("WritableStreamDefaultController")}}, which can be used to control the
         stream at the end of writing.
-    - abort(reason) {{optional_inline}}
+    - `abort(reason)` {{optional_inline}}
       - : This method, also defined by the developer, will be called if the app signals
         that it wishes to abruptly close the stream and put it in an errored state. It can
         clean up any held resources, much like `close()`, but
@@ -64,24 +63,22 @@ new WritableStream(underlyingSink, queuingStrategy)
         signal success or failure. The `reason` parameter contains a
         {{domxref("DOMString")}} describing why the stream was aborted.
 
-- queuingStrategy {{optional_inline}}
+- `queuingStrategy` {{optional_inline}}
 
   - : An object that optionally defines a queuing strategy for the stream. This takes two
     parameters:
 
-    - highWaterMark
+    - `highWaterMark`
       - : A non-negative integer — this defines the total number of chunks that can be
         contained in the internal queue before backpressure is applied.
-    - size(chunk)
-      - : A method containing a parameter `chunk` — this indicates the size to
-        use for each chunk, in bytes.
+    - `size(chunk)`
+      - : A method containing a parameter `chunk` — this indicates the size to use for each chunk, in bytes.
 
     > **Note:** You could define your own custom
     > `queuingStrategy`, or use an instance of
     > {{domxref("ByteLengthQueuingStrategy")}} or {{domxref("CountQueuingStrategy")}}
     > for this object value. If no `queuingStrategy` is supplied, the default
-    > used is the same as a `CountQueuingStrategy` with a high water mark of
-    > 1\.
+    > used is the same as a `CountQueuingStrategy` with a high water mark of 1\.
 
 ### Return value
 


### PR DESCRIPTION
[writableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) (and friends) and [`readableStream.pipeTo()`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeTo) are being enabled in FF100.

This does relatively minor changes to the streaming API documents to bring them up to some of the current ways of working:
- Syntax sections updated
- Add code markup for parameters
- Remove experimental tag/header when that is not in BCD
- Remove notes about how experimental streaming is.

There are very few real changes. I'll mark them with a separate comment.

Other docs work can be tracked in #14408