### PR TITLE
FF100 RelNote: WritableStream/ReadableStream.pipeTo()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -39,6 +39,8 @@ This article provides information about the changes in Firefox 100 that will aff
 
 ### APIs
 
+- [`WritableStream`](/en-US/docs/Web/API/WritableStream), [`WritableStreamDefaultWriter`](/en-US/docs/Web/API/WritableStreamDefaultWriter), [`WritableStreamDefaultController`](/en-US/docs/Web/API/WritableStreamDefaultController), and [`ReadableStream.pipeTo()`](/en-US/docs/Web/API/ReadableStream/pipeTo) are now supported ({{bug(1759597)}}).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF100 supports `WritableStream`, `WritableStreamDefaultWriter`, `WritableStreamDefaultController` and `ReadableStream.pipeTo()` - see https://bugzilla.mozilla.org/show_bug.cgi?id=1759597

This adds a release note. 

Related docs work in https://github.com/mdn/content/issues/14408

