### PR TITLE
Page macro: remove from HTMLFormElement.elements

### DIFF
--- a/files/en-us/web/api/htmlformelement/elements/index.md
+++ b/files/en-us/web/api/htmlformelement/elements/index.md
@@ -38,7 +38,7 @@ This is a live collection; if form controls are added to or removed from the for
 The form controls in the returned collection are in the same order in which they appear in the form by following a preorder, depth-first traversal of the tree.
 This is called **tree order**.
 
-Only the following elements returned:
+Only the following elements are returned:
 
 - {{HTMLElement("button")}}
 - {{HTMLElement("fieldset")}}

--- a/files/en-us/web/api/htmlformelement/elements/index.md
+++ b/files/en-us/web/api/htmlformelement/elements/index.md
@@ -28,28 +28,31 @@ index or the element's `name` or `id` attributes.
 Prior to HTML 5, the returned object was an {{domxref("HTMLCollection")}}, on which
 `HTMLFormControlsCollection` is based.
 
-> **Note:** Similarly, you can get a list of all of the forms contained
-> within a given document using the document's {{domxref("Document.forms", "forms")}}
-> property.
+> **Note:** Similarly, you can get a list of all of the forms contained within a given document using the document's {{domxref("Document.forms", "forms")}} property.
 
 ## Value
 
-An {{domxref("HTMLFormControlsCollection")}} containing all non-image controls in the
-form. This is a live collection; if form controls are added to or removed from the form,
-this collection will update to reflect the change.
+An {{domxref("HTMLFormControlsCollection")}} containing all non-image controls in the form.
+This is a live collection; if form controls are added to or removed from the form, this collection will update to reflect the change.
 
-The form controls in the returned collection are in the same order in which they appear
-in the form by following a preorder, depth-first traversal of the tree. This is called
-**tree order**.
+The form controls in the returned collection are in the same order in which they appear in the form by following a preorder, depth-first traversal of the tree.
+This is called **tree order**.
 
-{{page("/en-US/docs/Web/API/HTMLFormElement", "Elements that are considered form controls")}}
+Only the following elements returned:
+
+- {{HTMLElement("button")}}
+- {{HTMLElement("fieldset")}}
+- {{HTMLElement("input")}} (with the exception that any whose {{htmlattrxref("type", "input")}} is `"image"` are omitted for historical reasons)
+- {{HTMLElement("object")}}
+- {{HTMLElement("output")}}
+- {{HTMLElement("select")}}
+- {{HTMLElement("textarea")}}
 
 ## Examples
 
 ### Quick syntax example
 
-In this example, we see how to obtain the list of form controls as well as how to
-access its members by index and by name or ID.
+In this example, we see how to obtain the list of form controls as well as how to access its members by index and by name or ID.
 
 ```html
 <form id="my-form">


### PR DESCRIPTION
[HTMLFormElement/elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements) was using the page macro to import a list of [elements from its parent here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#elements_that_are_considered_form_controls). 

The list was small, so I have simply duplicated it.

This is part of globally removing the page macro: #3196