### PR TITLE
PageMacro: Remove from HTMLVideoElement.videowidth and tidy

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/videoheight/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videoheight/index.md
@@ -23,26 +23,18 @@ browser-compat: api.HTMLVideoElement.videoHeight
 ---
 {{APIRef("HTML DOM")}}
 
-The {{domxref("HTMLVideoElement")}} interface's read-only
-**`videoHeight`** property indicates the **intrinsic
-height** of the video, expressed in CSS pixels. In simple terms, this is the
-height of the media in its natural size.
+The {{domxref("HTMLVideoElement")}} interface's read-only **`videoHeight`** property indicates the [intrinsic height](#about_intrinsic_width_and_height) of the video, expressed in CSS pixels.
+In simple terms, this is the height of the media in its natural size.
 
-See [About intrinsic width and
-  height](#about_intrinsic_width_and_height) for more details.
 
 ## Value
 
-An integer value specifying the intrinsic height of the video in CSS pixels. If the
-element's {{domxref("HTMLMediaElement.readyState", "readyState")}} is
-`HTMLMediaElement.HAVE_NOTHING`, then the value of this property is 0,
-because neither video nor poster frame size information is yet available.
+An integer value specifying the intrinsic height of the video in CSS pixels.
+If the element's {{domxref("HTMLMediaElement.readyState", "readyState")}} is `HTMLMediaElement.HAVE_NOTHING`, then the value of this property is 0, because neither video nor poster frame size information is yet available.
 
 ### About intrinsic width and height
 
-A {{Glossary("user agent")}} calculates the intrinsic width and height of the element's
-media by starting with the media's raw pixel width and height, then taking into account
-factors including:
+A {{Glossary("user agent")}} calculates the intrinsic width and height of the element's media by starting with the media's raw pixel width and height, then taking into account factors including:
 
 - The media's aspect ratio.
 - The media's clean aperture (the sub-rectangle centered within the media that matches
@@ -50,22 +42,14 @@ factors including:
 - The target device's resolution.
 - Any other factors required by the media format.
 
-If the element is currently displaying the poster frame rather than rendered video, the
-poster frame's intrinsic size is considered to be the size of the
-`<video>` element.
+If the element is currently displaying the poster frame rather than rendered video, the poster frame's intrinsic size is considered to be the size of the `<video>` element.
 
-If at any time the intrinsic size of the media changes and the element's
-{{domxref("HTMLMediaElement.readyState", "readyState")}} isn't
-`HAVE_NOTHING`, a {{domxref("HTMLMediaElement.resize", "resize")}} event will
-be sent to the `<video>` element. This can happen when the element
-switches from displaying the poster frame to displaying video content, or when the
-displayed video track changes.
+If at any time the intrinsic size of the media changes and the element's {{domxref("HTMLMediaElement.readyState", "readyState")}} isn't `HAVE_NOTHING`, a {{domxref("HTMLMediaElement.resize", "resize")}} event will be sent to the `<video>` element.
+This can happen when the element switches from displaying the poster frame to displaying video content, or when the displayed video track changes.
 
 ## Examples
 
-This example creates a handler for the {{domxref("HTMLVideoElement.resize", "resize")}}
-event that resizes the {{HTMLElement("video")}} element to match the intrinsic size of
-its contents.
+This example creates a handler for the {{domxref("HTMLVideoElement.resize", "resize")}} event that resizes the {{HTMLElement("video")}} element to match the intrinsic size of its contents.
 
 ```js
 let v = document.getElementById("myVideo");
@@ -81,9 +65,8 @@ v.addEventListener("resize", ev => {
 }, false);
 ```
 
-Note that this only applies the change if both the `videoWidth` and the
-`videoHeight` are non-zero. This avoids applying invalid changes when there's
-no true information available yet for dimensions.
+Note that this only applies the change if both the `videoWidth` and the `videoHeight` are non-zero.
+This avoids applying invalid changes when there's no true information available yet for dimensions.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.md
@@ -19,21 +19,15 @@ browser-compat: api.HTMLVideoElement.videoWidth
 ---
 {{APIRef("HTML DOM")}}
 
-The {{domxref("HTMLVideoElement")}} interface's read-only
-**`videoWidth`** property indicates the **intrinsic
-width** of the video, expressed in CSS pixels. In simple terms, this is the
-width of the media in its natural size.
+The {{domxref("HTMLVideoElement")}} interface's read-only **`videoWidth`** property indicates the [intrinsic width](/en-US/docs/Web/API/HTMLVideoElement/videoHeight"#about_intrinsic_width_and_height) of the video, expressed in CSS pixels.
+In simple terms, this is the width of the media in its natural size.
 
-See [About intrinsic width and height](#about_intrinsic_width_and_height) for more details.
+See [`HTMLVideoElement.videoHeight` > About intrinsic width and height](/en-US/docs/Web/API/HTMLVideoElement/videoHeight"#about_intrinsic_width_and_height) for more details.
 
 ## Value
 
-An integer value specifying the intrinsic width of the video in CSS pixels. If the
-element's {{domxref("HTMLMediaElement.readyState", "readyState")}} is
-`HTMLMediaElement.HAVE_NOTHING`, then the value of this property is 0,
-because neither video nor poster frame size information is yet available.
-
-{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "About intrinsic width and height", 0, 1)}}
+An integer value specifying the intrinsic width of the video in CSS pixels.
+If the element's {{domxref("HTMLMediaElement.readyState", "readyState")}} is `HTMLMediaElement.HAVE_NOTHING`, then the value of this property is 0, because neither video nor poster frame size information is yet available.
 
 ## Specifications
 


### PR DESCRIPTION
`HTMLVideoElement.videoWidth` was importing a section defining intrinsic width and height from  [`HTMLVideoElement.videoHeight` here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoHeight#about_intrinsic_width_and_height)

I decided rather than duplicating to link to the text from the introduction in `HTMLVideoElement.videoWidth` - almost as though the information about intrinsic width was a glossary entry.

Also update `HTMLVideoElement.videoHeight` to tidy the link down to the same information - you don't need "for more info see XXX" when XXX is right there.

Not also, I did consider linking to CSS intrinsic width/height but they are defined quite differently from this. 
I couldn't work out how much value there would therefore be in doing so and decided not to.

This is part of removing page macros - see #3196