### PR TITLE
Remove -webkit-text-emphasis as it's now unprefixed

### DIFF
--- a/files/en-us/web/css/text-emphasis-color/index.md
+++ b/files/en-us/web/css/text-emphasis-color/index.md
@@ -58,9 +58,7 @@ text-emphasis-color: unset;
 
 ```css
 em {
-  -webkit-text-emphasis-color: green;
   text-emphasis-color: green;
-  -webkit-text-emphasis-style: "*";
   text-emphasis-style: "*";
 }
 ```

--- a/files/en-us/web/css/text-emphasis-position/index.md
+++ b/files/en-us/web/css/text-emphasis-position/index.md
@@ -124,7 +124,6 @@ Some editors prefer to hide emphasis marks when they conflict with ruby. In HTML
 
 ```css
 ruby {
-  -webkit-text-emphasis: none;
   text-emphasis: none;
 }
 ```
@@ -135,7 +134,6 @@ Some other editors prefer to hide ruby when they conflict with emphasis marks. I
 
 ```css
 em {
-  -webkit-text-emphasis: dot;
   text-emphasis: dot; /* Set text-emphasis for <em> elements */
 }
 

--- a/files/en-us/web/css/text-emphasis/index.md
+++ b/files/en-us/web/css/text-emphasis/index.md
@@ -98,7 +98,6 @@ This example draws a heading with triangles used to emphasize each character.
 
 ```css
 h2 {
-  -webkit-text-emphasis: triangle #D55;
   text-emphasis: triangle #D55;
 }
 ```


### PR DESCRIPTION
#### Summary

text-emphasis properties are now unprefixed in the major engines
(Blink, Gecko and WebKit). It looks we could remove the prefixed
version from the documentation.

#### Motivation

No need to keep people using the prefixed version when is no longer needed.

#### Supporting details

These properties have never been prefixed in Gecko.
They've been unprefixed in WebKit since 2014: https://trac.webkit.org/changeset/162207/webkit
They've been unprefixed in Chromium since version 99: https://chromiumdash.appspot.com/commit/a0d4ce22e17b2cdc22311d731c8fe9cca9ae3a8e

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
