### PR TITLE
Fix variable name to the real one in Django example

### DIFF
--- a/files/en-us/learn/server-side/django/generic_views/index.md
+++ b/files/en-us/learn/server-side/django/generic_views/index.md
@@ -86,7 +86,7 @@ You can add attributes to change the default behavior above. For example, you ca
 ```python
 class BookListView(generic.ListView):
     model = Book
-    context_object_name = 'my_book_list'   # your own name for the list as a template variable
+    context_object_name = 'book_list'   # your own name for the list as a template variable
     queryset = Book.objects.filter(title__icontains='war')[:5] # Get 5 books containing the title war
     template_name = 'books/my_arbitrary_template_name_list.html'  # Specify your own template name/location
 ```


### PR DESCRIPTION
Fixes #14544
