### PR TITLE
Include preventExtensions for Proxy isExtensible references

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -100,3 +100,4 @@ Object.isExtensible(p); // TypeError is thrown
 - {{jsxref("Proxy.handler", "handler")}}
 - {{jsxref("Object.isExtensible()")}}
 - {{jsxref("Reflect.isExtensible()")}}
+- {{jsxref("Reflect.preventExtensions()")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Include `Reflect.preventExtensions` for `Proxy`'s `handler.isExtensible` documentation

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

`Reflect.preventExtensions` references `Object.isExtensible`, and a code example for `handler.isExtensible` includes usage of this, it makes sense to include



#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

See code example for https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible 

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
