### PR TITLE
Add a new form-based page report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/page-report.yml
+++ b/.github/ISSUE_TEMPLATE/page-report.yml
@@ -18,6 +18,13 @@ body:
 
         ---
   - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
     id: section
     attributes:
       label: What specific section or headline is this issue about?
@@ -52,4 +59,4 @@ body:
     id: metadata-json
     attributes:
       label: MDN metadata
-      description: Added automatically. Do not modify.
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report.yml
+++ b/.github/ISSUE_TEMPLATE/page-report.yml
@@ -56,7 +56,7 @@ body:
         ---
         You're finished! The following fields are prefilled. Please click **Submit new issue**.
   - type: textarea
-    id: metadata-json
+    id: metadata
     attributes:
       label: MDN metadata
       description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report.yml
+++ b/.github/ISSUE_TEMPLATE/page-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         ### Before you start
 
-        **Want to edit this page?**
+        **Want to change this page yourself?** This content is open source!
         ↩ Go back and use the _Edit on GitHub_ link on the page.
 
         **Is your issue about the browser compatibility table?**

--- a/.github/ISSUE_TEMPLATE/page-report.yml
+++ b/.github/ISSUE_TEMPLATE/page-report.yml
@@ -8,7 +8,7 @@ body:
         ### Before you start
 
         **Want to edit this page?**
-        ↩ Go back and use the "Edit on GitHub" link on the page.
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
 
         **Is your issue about the browser compatibility table?**
         ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.

--- a/.github/ISSUE_TEMPLATE/page-report.yml
+++ b/.github/ISSUE_TEMPLATE/page-report.yml
@@ -1,0 +1,55 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["via page report", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to edit this page?**
+        ↩ Go back and use the "Edit on GitHub" link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata-json
+    attributes:
+      label: MDN metadata
+      description: Added automatically. Do not modify.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This creates a form-based template with required fields for prefilling via Yari.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

To improve response rates on new issues and to divert issues before they've opened.
