### PR TITLE
Fix internal link to 'DOMString'

### DIFF
--- a/files/en-us/web/api/syncmanager/gettags/index.md
+++ b/files/en-us/web/api/syncmanager/gettags/index.md
@@ -25,7 +25,7 @@ SyncManager.getTags().then(function(tags[]) { /* ... */ })
 
 ### Returns
 
-A {{jsxref("Promise")}} that resolves to an array of {{jsxref("DOMString")}}s
+A {{jsxref("Promise")}} that resolves to an array of {{DOMxRef("DOMString")}}s
 containing developer-defined identifiers for `SyncManager` registrations.
 
 ### Parameters

--- a/files/en-us/web/api/syncmanager/gettags/index.md
+++ b/files/en-us/web/api/syncmanager/gettags/index.md
@@ -25,7 +25,7 @@ SyncManager.getTags().then(function(tags[]) { /* ... */ })
 
 ### Returns
 
-A {{jsxref("Promise")}} that resolves to an array of {{DOMxRef("DOMString")}}s
+A {{jsxref("Promise")}} that resolves to an array of strings
 containing developer-defined identifiers for `SyncManager` registrations.
 
 ### Parameters


### PR DESCRIPTION
#### Summary
The current link to DOMString is `jsxref("DOMString")`, but DOMString is under DOMxRef

#### Motivation
Change will link to DOMString page properly 

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
