### PR TITLE
WebAPI: Clean syntax from property pages, part 17

### DIFF
--- a/files/en-us/web/api/speechsynthesisutterance/text/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/text/index.md
@@ -20,14 +20,7 @@ The **`text`** property of the
 The text may be provided as plain text, or a well-formed [SSML](https://www.w3.org/TR/speech-synthesis/) document.
 The SSML tags will be stripped away by devices that don't support SSML.
 
-## Syntax
-
-```js
-var myText = speechSynthesisUtteranceInstance.text;
-speechSynthesisUtteranceInstance.text = 'Hello I am speaking';
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} representing the text to the synthesized.
 The maximum length of the text that can be spoken in each utterance is 32,767 characters.

--- a/files/en-us/web/api/speechsynthesisutterance/voice/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/voice/index.md
@@ -19,14 +19,7 @@ The **`voice`** property of the {{domxref("SpeechSynthesisUtterance")}} interfac
 This should be set to one of the {{domxref("SpeechSynthesisVoice")}} objects returned by {{domxref("SpeechSynthesis.getVoices()")}}.
 If not set by the time the utterance is spoken, the voice used will be the most suitable default voice available for the utterance's {{domxref("SpeechSynthesisUtterance.lang","lang")}} setting.
 
-## Syntax
-
-```js
-var myVoice = speechSynthesisUtteranceInstance.voice;
-speechSynthesisUtteranceInstance.voice = speechSynthesisVoiceInstance;
-```
-
-### Value
+## Value
 
 A {{domxref("SpeechSynthesisVoice")}} object.
 

--- a/files/en-us/web/api/speechsynthesisutterance/volume/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/volume/index.md
@@ -18,14 +18,7 @@ The **`volume`** property of the {{domxref("SpeechSynthesisUtterance")}} interfa
 
 If not set, the default value 1 will be used.
 
-## Syntax
-
-```js
-var myVolume = speechSynthesisUtteranceInstance.volume;
-speechSynthesisUtteranceInstance.volume = 0.5;
-```
-
-### Value
+## Value
 
 A float that represents the volume value, between 0 (lowest) and 1 (highest.)
 

--- a/files/en-us/web/api/staticrange/collapsed/index.md
+++ b/files/en-us/web/api/staticrange/collapsed/index.md
@@ -20,13 +20,7 @@ The **`collapsed`** read-only property
 of the {{domxref("StaticRange")}} interface returns `true` if the range's
 start position and end position are the same.
 
-## Syntax
-
-```js
-var isCollapsed = staticRange.collapsed
-```
-
-### Value
+## Value
 
 A boolean value which is `true` if the range
 is **collapsed**. A collapsed range is one in which the start and end

--- a/files/en-us/web/api/staticrange/endcontainer/index.md
+++ b/files/en-us/web/api/staticrange/endcontainer/index.md
@@ -17,14 +17,7 @@ browser-compat: api.StaticRange.endContainer
 
 The **`endContainer`** property of the {{domxref("StaticRange")}} interface returns the end {{domxref("Node")}} for the range.
 
-## Syntax
-
-```js
-var node = staticNode.endContainer
-staticNode.endContainer = endContainer
-```
-
-### Value
+## Value
 
 The DOM {{domxref("Node")}} which contains the final character of the range.
 

--- a/files/en-us/web/api/staticrange/endoffset/index.md
+++ b/files/en-us/web/api/staticrange/endoffset/index.md
@@ -20,13 +20,7 @@ browser-compat: api.StaticRange.endOffset
 The **`endOffset`** property of the {{domxref("StaticRange")}}
 interface returns the offset into the end node of the range's end position.
 
-## Syntax
-
-```js
-var endOffset = staticRange.endOffset
-```
-
-### Value
+## Value
 
 An integer value indicating the number of characters into the {{domxref("Node")}}
 indicated by {{domxref("StaticRange.endContainer", "endContainer")}} at which the final

--- a/files/en-us/web/api/staticrange/startcontainer/index.md
+++ b/files/en-us/web/api/staticrange/startcontainer/index.md
@@ -22,13 +22,7 @@ The read-only **`startContainer`**
 property of the {{domxref("StaticRange")}} interface returns the start
 {{domxref("Node")}} for the range.
 
-## Syntax
-
-```js
-var node = staticNode.startContainer
-```
-
-### Value
+## Value
 
 The DOM {{domxref("Node")}} inside which the start position of the range is found.
 

--- a/files/en-us/web/api/staticrange/startoffset/index.md
+++ b/files/en-us/web/api/staticrange/startoffset/index.md
@@ -19,13 +19,7 @@ The read-only **`startOffset`**
 property of the {{domxref("StaticRange")}} interface returns the offset into the start
 node of the range's start position.
 
-## Syntax
-
-```js
-var startOffset = staticRange.startOffset
-```
-
-### Value
+## Value
 
 An integer value indicating the number of characters into the {{domxref("Node")}}
 indicated by {{domxref("StaticRange.startContainer", "startContainer")}} at which the

--- a/files/en-us/web/api/stylepropertymapreadonly/size/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/size/index.md
@@ -22,7 +22,7 @@ containing the size of the `StylePropertyMapReadOnly` object.
 
 An unsigned long integer.
 
-## Example
+## Examples
 
 Here we use the size property to return the total entries within the button elements
 {{domxref('Element.computedStyleMap()','computedStyleMap')}}.

--- a/files/en-us/web/api/submitevent/submitter/index.md
+++ b/files/en-us/web/api/submitevent/submitter/index.md
@@ -20,13 +20,7 @@ The read-only **`submitter`** property found on
 the {{domxref("SubmitEvent")}} interface specifies the submit button or other element
 that was invoked to cause the form to be submitted.
 
-## Syntax
-
-```js
-let submitter = submitEvent.submitter;
-```
-
-### Value
+## Value
 
 An element, indicating the element that sent
 the {{domxref("HTMLFormElement.submit_event", "submit")}} event to the form. While this

--- a/files/en-us/web/api/svgaelement/target/index.md
+++ b/files/en-us/web/api/svgaelement/target/index.md
@@ -17,19 +17,13 @@ The **`SVGAElement.target`** read-only property of {{domxref("SVGAElement")}} re
 
 This property is used when there are multiple possible targets for the ending resource, like when the parent document is a multi-frame HTML or XHTML document.
 
-## Syntax
-
-```js
-myLink.target = 'value';
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedString")}} indicating the ending resource target that opens the document when the link is activated.
 
 Sample values can be found [here](https://www.w3.org/TR/2011/REC-SVG11-20110816/linking.html#AElementTargetAttribute)
 
-## Example
+## Examples
 
 The code is taken from the ["SVGAElement example code"](/en-US/docs/Web/API/SVGAElement#Example)
 

--- a/files/en-us/web/api/svgaltglyphelement/glyphref/index.md
+++ b/files/en-us/web/api/svgaltglyphelement/glyphref/index.md
@@ -20,19 +20,12 @@ The **`SVGAltGlyphElement.glyphRef`** property is a
 'glyphRef' property on the {{domxref("SVGGlyphRefElement")}} interface of the
 {{SVGElement("glyphRef")}} element.
 
-## Syntax
-
-```js
-string = myGlyph.glyphRef;
-myGlyph.glyphRef = string;
-```
-
-### Value
+## Value
 
 The return value is a Glyph Identifier, the value of which depends on the
 format of the given font.
 
-## Example
+## Examples
 
 ```js
 myGlyph.glypRef = "#glyphID";

--- a/files/en-us/web/api/svgcircleelement/cx/index.md
+++ b/files/en-us/web/api/svgcircleelement/cx/index.md
@@ -16,17 +16,11 @@ The **`cx`** read-only property of the {{domxref("SVGCircleElement")}} interface
 
 If unspecified, the effect is as if the value is set to `0`.
 
-## Syntax
-
-```js
-var xCoordinate = element.cx;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} representing the x-coordinate of the circle's center.
 
-## Example
+## Examples
 
 ### SVG
 

--- a/files/en-us/web/api/svgcircleelement/cy/index.md
+++ b/files/en-us/web/api/svgcircleelement/cy/index.md
@@ -16,17 +16,11 @@ The **`cy`** read-only property of the {{domxref("SVGCircleElement")}} interface
 
 If unspecified, the effect is as if the value is set to `0`.
 
-## Syntax
-
-```js
-var yCoordinate = element.cy;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} representing the y-coordinate of the circle's center.
 
-## Example
+## Examples
 
 ### SVG
 

--- a/files/en-us/web/api/svgcircleelement/r/index.md
+++ b/files/en-us/web/api/svgcircleelement/r/index.md
@@ -16,17 +16,11 @@ The **`r`** read-only property of the {{domxref("SVGCircleElement")}} interface 
 
 If unspecified, the effect is as if the value is set to `0`.
 
-## Syntax
-
-```js
-var radius = element.r;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}} representing the radius of the circle.
 
-## Example
+## Examples
 
 ### SVG
 

--- a/files/en-us/web/api/svgimageelement/decoding/index.md
+++ b/files/en-us/web/api/svgimageelement/decoding/index.md
@@ -18,7 +18,7 @@ The **`decoding`** property of the
 {{domxref("SVGImageElement")}} interface represents a hint given to the browser on how
 it should decode the image.
 
-## Values
+## Value
 
 A {{domxref("DOMString")}} representing the decoding hint. Possible values are:
 

--- a/files/en-us/web/api/svgimageelement/height/index.md
+++ b/files/en-us/web/api/svgimageelement/height/index.md
@@ -20,13 +20,7 @@ The **`height`** read-only property of the
 corresponding to the {{SVGAttr("height")}} attribute of the given
 {{SVGElement("image")}} element.
 
-## Syntax
-
-```js
-var height = svgImageElement.height
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}}.
 

--- a/files/en-us/web/api/svgimageelement/preserveaspectratio/index.md
+++ b/files/en-us/web/api/svgimageelement/preserveaspectratio/index.md
@@ -21,13 +21,7 @@ property of the {{domxref("SVGImageElement")}} interface returns an
 {{SVGAttr("preserveAspectRatio")}} attribute of the given {{SVGElement("image")}}
 element.
 
-## Syntax
-
-```js
-var svgAnimatedPreserveAspectRatio = svgImageElement.preserveAspectRatio;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedPreserveAspectRatio")}}.
 

--- a/files/en-us/web/api/svgimageelement/width/index.md
+++ b/files/en-us/web/api/svgimageelement/width/index.md
@@ -20,13 +20,7 @@ The **`width`** read-only property of the
 corresponding to the {{SVGAttr("width")}} attribute of the given {{SVGElement("image")}}
 element.
 
-## Syntax
-
-```js
-var width = svgImageElement.width;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}}.
 

--- a/files/en-us/web/api/svgimageelement/x/index.md
+++ b/files/en-us/web/api/svgimageelement/x/index.md
@@ -20,13 +20,7 @@ The **`x`** read-only property of the
 corresponding to the {{SVGAttr("x")}} attribute of the given {{SVGElement("image")}}
 element.
 
-## Syntax
-
-```js
-var x = svgImageElement.x;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}}.
 

--- a/files/en-us/web/api/svgimageelement/y/index.md
+++ b/files/en-us/web/api/svgimageelement/y/index.md
@@ -20,13 +20,7 @@ The **`y`** read-only property of the
 corresponding to the {{SVGAttr("y")}} attribute of the given {{SVGElement("image")}}
 element.
 
-## Syntax
-
-```js
-var y = svgImageElement.y;
-```
-
-### Value
+## Value
 
 An {{domxref("SVGAnimatedLength")}}.
 

--- a/files/en-us/web/api/syncevent/lastchance/index.md
+++ b/files/en-us/web/api/syncevent/lastchance/index.md
@@ -20,13 +20,7 @@ make further synchronization attempts after the current attempt. This is the val
 passed in the `lastChance` parameter of the
 {{domxref("SyncEvent.SyncEvent","SyncEvent()")}} constructor.
 
-## Syntax
-
-```js
-var lastChance = SyncEvent.lastChance
-```
-
-### Value
+## Value
 
 A boolean value that indicates whether the user agent will not make further
 synchronization attempts after the current attempt.

--- a/files/en-us/web/api/syncevent/tag/index.md
+++ b/files/en-us/web/api/syncevent/tag/index.md
@@ -19,13 +19,7 @@ The **`SyncEvent.tag`** read-only property of the
 this `SyncEvent`. This is the value passed in the `tag` parameter
 of the {{domxref("SyncEvent.SyncEvent","SyncEvent()")}} constructor.
 
-## Syntax
-
-```js
-var tag = SyncEvent.tag
-```
-
-### Value
+## Value
 
 The developer-defined identifier for this `SyncEvent`.
 

--- a/files/en-us/web/api/taskattributiontiming/containerid/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.md
@@ -17,13 +17,7 @@ The **`containerId`** readonly property of the
 attribute. A container is the iframe, embed or object etc. that is being implicated, on
 the whole, for a long task.
 
-## Syntax
-
-```js
-var containerId = TaskAttributionTiming.containerId;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the containers `id` attribute.
 

--- a/files/en-us/web/api/taskattributiontiming/containername/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.md
@@ -17,13 +17,7 @@ The **`containerName`** readonly property of the
 attribute. A container is the iframe, embed or object etc. that is being implicated, on
 the whole, for a long task.
 
-## Syntax
-
-```js
-var containerName = TaskAttributionTiming.containerName;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the container's `name` attribute.
 

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.md
@@ -17,13 +17,7 @@ The **`containerSrc`** readonly property of the
 attribute. A container is the iframe, embed or object etc. that is being implicated, on
 the whole, for a long task.
 
-## Syntax
-
-```js
-var containerSrc = TaskAttributionTiming.containerSrc;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the container's `src` attribute.
 

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.md
@@ -16,13 +16,7 @@ The **`containerType`** readonly property of the
 {{domxref("TaskAttributionTiming")}} interface returns the type of frame container, one
 of `iframe`, `embed`, or `object`.
 
-## Syntax
-
-```js
-var containerType = TaskAttributionTiming.containerType;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} containing the container's type, one of `iframe`,
 `embed`, or `object`.

--- a/files/en-us/web/api/texttracklist/length/index.md
+++ b/files/en-us/web/api/texttracklist/length/index.md
@@ -30,7 +30,7 @@ A number indicating how many text tracks are included in the
 `TextTrackList`. Each track can be accessed by treating the
 `TextTrackList` as an array of objects of type {{domxref("TextTrack")}}.
 
-## Example
+## Examples
 
 This snippet gets the number of text tracks in the first media element found in the
 {{Glossary("DOM")}} by {{domxref("Document.querySelector", "querySelector()")}}.

--- a/files/en-us/web/api/uievent/sourcecapabilities/index.md
+++ b/files/en-us/web/api/uievent/sourcecapabilities/index.md
@@ -30,13 +30,7 @@ window to be resized with a mouse or a keyboard, but this detail is not exposed 
 web platform in any way, and so the sourceCapabilities of a resize event will typically
 be null.
 
-## Syntax
-
-```js
-var iDC = event.sourceCapabilities
-```
-
-### Value
+## Value
 
 An instance of {{domxref('InputDeviceCapabilities')}}.
 

--- a/files/en-us/web/api/uievent/which/index.md
+++ b/files/en-us/web/api/uievent/which/index.md
@@ -37,7 +37,7 @@ In this case, the values are read from right to left.
 
 > **Note:** Consider {{domxref("MouseEvent.button")}} for new code.
 
-## Example
+## Examples
 
 ```html
 <html>

--- a/files/en-us/web/api/url/search/index.md
+++ b/files/en-us/web/api/url/search/index.md
@@ -21,14 +21,7 @@ parse out the parameters from the query string.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-const searchParams = object.search
-url.search = newSearchParams
-```
-
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/hash/index.md
+++ b/files/en-us/web/api/urlpattern/hash/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/hostname/index.md
+++ b/files/en-us/web/api/urlpattern/hostname/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/password/index.md
+++ b/files/en-us/web/api/urlpattern/password/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/pathname/index.md
+++ b/files/en-us/web/api/urlpattern/pathname/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/port/index.md
+++ b/files/en-us/web/api/urlpattern/port/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/protocol/index.md
+++ b/files/en-us/web/api/urlpattern/protocol/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/search/index.md
+++ b/files/en-us/web/api/urlpattern/search/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/urlpattern/username/index.md
+++ b/files/en-us/web/api/urlpattern/username/index.md
@@ -20,7 +20,7 @@ normalization.
 
 {{AvailableInWorkers}}
 
-### Value
+## Value
 
 A {{domxref("USVString")}}.
 

--- a/files/en-us/web/api/usbdevice/configuration/index.md
+++ b/files/en-us/web/api/usbdevice/configuration/index.md
@@ -22,7 +22,7 @@ the currently selected interface for a paired USB device.
 
 A {{domxref("USBConfiguration")}} object.
 
-## Example
+## Examples
 
 The following example uses this property to test for the existence of a
 USBConfiguration property to select a configuration before claiming an interface.

--- a/files/en-us/web/api/usbdevice/opened/index.md
+++ b/files/en-us/web/api/usbdevice/opened/index.md
@@ -22,7 +22,7 @@ paired USB device. A device must be opened before it can be controlled by a web 
 
 A {{jsxref("boolean")}}.
 
-## Example
+## Examples
 
 This example is for a hypothetical USB device with a multi-colored LED. It shows how to
 test that a device is open before calling {{domxref("USBDevice.controlTransferOut")}} to

--- a/files/en-us/web/api/videocolorspace/transfer/index.md
+++ b/files/en-us/web/api/videocolorspace/transfer/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoColorSpace.transfer
 
 The **`transfer`** read-only property of the {{domxref("VideoColorSpace")}} interface returns the opto-electronic transfer characteristics of the video.
 
-### Value
+## Value
 
 A string containing one of the following values:
 

--- a/files/en-us/web/api/videoframe/codedheight/index.md
+++ b/files/en-us/web/api/videoframe/codedheight/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.codedHeight
 
 The **`codedHeight`** property of the {{domxref("VideoFrame")}} interface returns the height of the VideoFrame in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/videoframe/codedrect/index.md
+++ b/files/en-us/web/api/videoframe/codedrect/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.codedRect
 
 The **`codedRect`** property of the {{domxref("VideoFrame")}} interface returns a {{domxref("DOMRectReadOnly")}} with the width and height matching {{domxref("VideoFrame.codedWidth")}} and {{domxref("VideoFrame.codedHeight")}}.
 
-### Value
+## Value
 
 A {{domxref("DOMRectReadOnly")}}.
 

--- a/files/en-us/web/api/videoframe/codedwidth/index.md
+++ b/files/en-us/web/api/videoframe/codedwidth/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.codedWidth
 
 The **`codedWidth`** property of the {{domxref("VideoFrame")}} interface returns the width of the `VideoFrame` in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/videoframe/colorspace/index.md
+++ b/files/en-us/web/api/videoframe/colorspace/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.colorSpace
 
 The **`colorSpace`** property of the {{domxref("VideoFrame")}} interface returns a {{domxref("VideoColorSpace")}} object representing the color space of the video.
 
-### Value
+## Value
 
 A {{domxref("VideoColorSpace")}} object.
 

--- a/files/en-us/web/api/videoframe/displayheight/index.md
+++ b/files/en-us/web/api/videoframe/displayheight/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.displayHeight
 
 The **`displayHeight`** property of the {{domxref("VideoFrame")}} interface returns the height of the `VideoFrame` after applying aspect ratio adjustments.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/videoframe/displaywidth/index.md
+++ b/files/en-us/web/api/videoframe/displaywidth/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.displayWidth
 
 The **`displayWidth`** property of the {{domxref("VideoFrame")}} interface returns the width of the `VideoFrame` after applying aspect ratio adjustments.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/videoframe/duration/index.md
+++ b/files/en-us/web/api/videoframe/duration/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.duration
 
 The **`duration`** property of the {{domxref("VideoFrame")}} interface returns an integer indicating the duration of the video in microseconds.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/videoframe/format/index.md
+++ b/files/en-us/web/api/videoframe/format/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.format
 
 The **`format`** property of the {{domxref("VideoFrame")}} interface returns the pixel format of the `VideoFrame`.
 
-### Value
+## Value
 
 A {{domxref("DOMString","string")}} containing a video pixel format, one of:
 

--- a/files/en-us/web/api/videoframe/timestamp/index.md
+++ b/files/en-us/web/api/videoframe/timestamp/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.timestamp
 
 The **`timestamp`** property of the {{domxref("VideoFrame")}} interface returns an integer indicating the timestamp of the video in microseconds.
 
-### Value
+## Value
 
 An integer.
 

--- a/files/en-us/web/api/videoframe/visiblerect/index.md
+++ b/files/en-us/web/api/videoframe/visiblerect/index.md
@@ -13,7 +13,7 @@ browser-compat: api.VideoFrame.visibleRect
 
 The **`visibleRect`**  property of the {{domxref("VideoFrame")}} interface returns a {{domxref("DOMRectReadOnly")}} describing the visible rectangle of pixels for this `VideoFrame`.
 
-### Value
+## Value
 
 A {{domxref("DOMRectReadOnly")}}.
 

--- a/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
@@ -37,7 +37,7 @@ corrupted video frame. If a corrupted frame is dropped, then both
 {{domxref("VideoPlaybackQuality.droppedVideoFrames", "droppedVideoFrames")}} are
 incremented.
 
-## Example
+## Examples
 
 This example determines the percentage of frames which have been corrupted, and if the
 value is greater than 5%, calls a function called `downgradeVideo()` that

--- a/files/en-us/web/api/videoplaybackquality/creationtime/index.md
+++ b/files/en-us/web/api/videoplaybackquality/creationtime/index.md
@@ -29,7 +29,7 @@ this sample of the video quality was obtained.
 
 For details on how the time is determined, see {{domxref("Performance.now()")}}.
 
-## Example
+## Examples
 
 This example calls `getVideoPlaybackQuality()` to obtain a
 {{domxref("VideoPlaybackQuality")}} object, then determines what percentage of frames

--- a/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
@@ -35,7 +35,7 @@ to avoid dropping frames.
 Frames are typically dropped either before or after decoding them, when it's determined
 that it will not be possible to draw them to the screen at the correct time.
 
-## Example
+## Examples
 
 This example calls {{domxref("HTMLVideoElement.getVideoPlaybackQuality",
   "getVideoPlaybackQuality()")}} to obtain a {{domxref("VideoPlaybackQuality")}} object,

--- a/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
@@ -33,7 +33,7 @@ the element _would have presented_ had no problems occurred.
 
 This value is reset when the media is reloaded or replaced.
 
-## Example
+## Examples
 
 This example calls {{domxref("HTMLVideoElement.getVideoPlaybackQuality",
   "getVideoPlaybackQuality()")}} to obtain a {{domxref("VideoPlaybackQuality")}} object,

--- a/files/en-us/web/api/videotrack/label/index.md
+++ b/files/en-us/web/api/videotrack/label/index.md
@@ -33,7 +33,7 @@ For example, a track whose {{domxref("VideoTrack.kind", "kind")}} is
 `"sign"` might have a `label` such as
 `"A sign-language interpretation."`.
 
-## Example
+## Examples
 
 This example returns an array of track kinds and labels for potential use in a user
 interface to select video tracks for a specified media element. The list is filtered to

--- a/files/en-us/web/api/videotracklist/length/index.md
+++ b/files/en-us/web/api/videotracklist/length/index.md
@@ -31,7 +31,7 @@ A number indicating how many video tracks are included in the
 `VideoTrackList`. Each track can be accessed by treating the
 `VideoTrackList` as an array of objects of type {{domxref("VideoTrack")}}.
 
-## Example
+## Examples
 
 This snippet gets the number of video tracks in the first {{HTMLElement("video")}}
 element found in the {{Glossary("DOM")}} by {{domxref("Document.querySelector",

--- a/files/en-us/web/api/waveshapernode/curve/index.md
+++ b/files/en-us/web/api/waveshapernode/curve/index.md
@@ -20,19 +20,11 @@ If necessary, intermediate values of the distortion curve are linearly interpola
 
 > **Note:** The array can be a `null` value: in that case, no distortion is applied to the input signal.
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var distortion = audioCtx.createWaveShaper();
-distortion.curve = myCurveDataArray; // myCurveDataArray is a Float32Array
-```
-
-### Value
+## Value
 
 A {{jsxref("Float32Array")}}.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createWaveShaper()`](/en-US/docs/Web/API/BaseAudioContext/createWaveShaper#example) for example code.
 

--- a/files/en-us/web/api/waveshapernode/oversample/index.md
+++ b/files/en-us/web/api/waveshapernode/oversample/index.md
@@ -24,18 +24,11 @@ The possible `oversample` values are:
 | `'2x'`   | Double the amount of samples before applying the shaping curve.        |
 | `'4x'`   | Multiply by 4 the amount of samples before applying the shaping curve. |
 
-## Syntax
+## Value
 
-```js
-distortion.oversample = enumeratedValue;
-```
+One of `'none'`, `'2x'`, or `'4x'`.
 
-### Values
-
-- _distortion_ is a {{domxref("WaveShaperNode")}}.
-- _enumeratedValue_ is one of `'none'`, `'2x'`, or `'4x'`.
-
-## Example
+## Examples
 
 See [`BaseAudioContext.createWaveShaper()`](/en-US/docs/Web/API/BaseAudioContext/createWaveShaper#example) for example code.
 

--- a/files/en-us/web/api/websocket/binarytype/index.md
+++ b/files/en-us/web/api/websocket/binarytype/index.md
@@ -14,12 +14,6 @@ browser-compat: api.WebSocket.binaryType
 The **`WebSocket.binaryType`** property controls the type of
 binary data being received over the WebSocket connection.
 
-## Syntax
-
-```js
-var binaryType = aWebSocket.binaryType;
-```
-
 ## Value
 
 A {{DOMXref("DOMString")}}:

--- a/files/en-us/web/api/websocket/bufferedamount/index.md
+++ b/files/en-us/web/api/websocket/bufferedamount/index.md
@@ -17,12 +17,6 @@ not yet transmitted to the network. This value resets to zero once all queued da
 been sent. This value does not reset to zero when the connection is closed; if you keep
 calling [`send()`](/en-US/docs/Web/API/WebSocket/send), this will continue to climb.
 
-## Syntax
-
-```js
-var bufferedAmount = aWebSocket.bufferedAmount;
-```
-
 ## Value
 
 An `unsigned long`.

--- a/files/en-us/web/api/websocket/extensions/index.md
+++ b/files/en-us/web/api/websocket/extensions/index.md
@@ -15,12 +15,6 @@ The **`WebSocket.extensions`** read-only property returns the
 extensions selected by the server. This is currently only the empty string or a list of
 extensions as negotiated by the connection.
 
-## Syntax
-
-```js
-var extensions = aWebSocket.extensions;
-```
-
 ## Value
 
 A {{domxref("DOMString")}}.

--- a/files/en-us/web/api/websocket/protocol/index.md
+++ b/files/en-us/web/api/websocket/protocol/index.md
@@ -16,12 +16,6 @@ name of the sub-protocol the server selected; this will be one of the strings sp
 in the `protocols` parameter when creating the {{domxref("WebSocket")}}
 object, or the empty string if no connection is established.
 
-## Syntax
-
-```js
-const protocol = aWebSocket.protocol;
-```
-
 ## Value
 
 A [`DOMString`](/en-US/docs/Web/API/DOMString).

--- a/files/en-us/web/api/websocket/url/index.md
+++ b/files/en-us/web/api/websocket/url/index.md
@@ -14,12 +14,6 @@ browser-compat: api.WebSocket.url
 The **`WebSocket.url`** read-only property returns the absolute
 URL of the {{domxref("WebSocket")}} as resolved by the constructor.
 
-## Syntax
-
-```js
-var url = aWebSocket.url;
-```
-
 ## Value
 
 A [`DOMString`](/en-US/docs/Web/API/DOMString).

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -25,7 +25,7 @@ The element which the window is embedded into. If the window isn't embedded into
 another document, or if the document into which it's embedded has a different
 {{glossary("origin")}}, the value is {{jsxref("null")}} instead.
 
-## Example
+## Examples
 
 ```js
 const frameEl = window.frameElement;

--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -43,7 +43,7 @@ the root {{HTMLElement("html")}} element's {{domxref("Element.clientHeight",
 Both `innerHeight` and `innerWidth` are available on any window
 or any object that behaves like a window, such as a tab or frame.
 
-## Example
+## Examples
 
 ### Assuming a frameset
 

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -42,7 +42,7 @@ property instead.
 The `innerWidth` property is available on any window or object that behaves
 like a window, such as a frame or tab.
 
-## Example
+## Examples
 
 ```js
 // This will return the width of the viewport

--- a/files/en-us/web/api/window/localstorage/index.md
+++ b/files/en-us/web/api/window/localstorage/index.md
@@ -38,7 +38,7 @@ For documents loaded from `file:` URLs (that is, files opened in the browser dir
 
 In all current browsers, `localStorage` seems to return a different object for each `file:` URL. In other words, each `file:` URL seems to have its own unique local-storage area. But there are no guarantees about that behavior, so you shouldn't rely on it because, as mentioned above, the requirements for `file:` URLs remains undefined. So it's possible that browsers may change their `file:` URL handling for `localStorage` at any time. In fact some browsers _have_ changed their handling for it over time.
 
-## Example
+## Examples
 
 The following snippet accesses the current domain's local {{DOMxRef("Storage")}} object and adds a data item to it using {{DOMxRef("Storage.setItem()")}}.
 

--- a/files/en-us/web/api/window/pageyoffset/index.md
+++ b/files/en-us/web/api/window/pageyoffset/index.md
@@ -41,7 +41,7 @@ window's content area.
 Since this property is an alias for {{domxref("Window.scrollY")}}, see that article for
 additional details on this value and its use.
 
-## Example
+## Examples
 
 ```js hidden
 var contentHTML = `

--- a/files/en-us/web/api/window/scrollx/index.md
+++ b/files/en-us/web/api/window/scrollx/index.md
@@ -35,7 +35,7 @@ In more technical terms, `scrollX` returns the X coordinate of the left edge
 of the current {{Glossary("viewport")}}. If there is no viewport, the returned value is
 0\.
 
-## Example
+## Examples
 
 This example checks the current horizontal scroll position of the document. If it's
 greater than 400 pixels, the window is scrolled back to the beginning.

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -37,7 +37,7 @@ In more technical terms, `scrollY` returns the Y coordinate of the top edge
 of the current {{Glossary("viewport")}}. If there is no viewport, the returned value is
 0\.
 
-## Example
+## Examples
 
 ```js
 // make sure and go down to the second page

--- a/files/en-us/web/api/windowclient/focused/index.md
+++ b/files/en-us/web/api/windowclient/focused/index.md
@@ -22,7 +22,7 @@ the current client has focus.
 
 A boolean value.
 
-## Example
+## Examples
 
 ```js
 self.addEventListener('notificationclick', function(event) {

--- a/files/en-us/web/api/windowclient/visibilitystate/index.md
+++ b/files/en-us/web/api/windowclient/visibilitystate/index.md
@@ -23,7 +23,7 @@ This value can be one of `"hidden"`, `"visible"`, or
 
 A {{domxref("DOMString")}} (See {{domxref("Document.visibilityState")}} for values).
 
-## Example
+## Examples
 
 ```js
 event.waitUntil(clients.matchAll({

--- a/files/en-us/web/api/windoweventhandlers/onlanguagechange/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onlanguagechange/index.md
@@ -22,20 +22,11 @@ These events are received by the object implementing this interface, usually a
 the preferred languages list has been updated. The list is accessible via
 {{domxref("Navigator.languages")}}.
 
-## Syntax
+## Value
 
-```js
-object.onlanguagechange = function;
-```
+A user-defined function, without the `()` suffix or any parameters, or an anonymous function declaration, such as `function(event) {...}`. An event handler always has one single parameter, containing the event, here of type {{domxref("Event")}}.
 
-### Value
-
-- `function` is the name of a user-defined function, without the
-  `()` suffix or any parameters, or an anonymous function declaration, such
-  as `function(event) {...}`. An event handler always has one single
-  parameter, containing the event, here of type {{domxref("Event")}}.
-
-## Example
+## Examples
 
 ```js
 window.onlanguagechange = function(event) {

--- a/files/en-us/web/api/windoweventhandlers/onstorage/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onstorage/index.md
@@ -20,19 +20,11 @@ events.
 The `storage` event fires when a storage area has been changed in the
 context of another document.
 
-## Syntax
+## Value
 
-```js
- window.onstorage = functionRef;
-```
+A function name or a [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function). This function receives a {{domxref("StorageEvent")}} as its sole argument.
 
-### Value
-
-`functionRef` is a function name or a [function
-expression](/en-US/docs/Web/JavaScript/Reference/Operators/function). This function receives a {{domxref("StorageEvent")}} as its sole
-argument.
-
-## Example
+## Examples
 
 This example logs the value for a storage key whenever it changes in another document.
 

--- a/files/en-us/web/api/windoweventhandlers/onunhandledrejection/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onunhandledrejection/index.md
@@ -20,17 +20,9 @@ The **`onunhandledrejection`** property of the
 processing {{event("unhandledrejection")}} events. These events are raised for unhandled
 {{jsxref("Promise")}} rejections.
 
-## Syntax
+## Value
 
-```js
-window.onunhandledrejection = function;
-```
-
-### Value
-
-`function` is an [event handler](/en-US/docs/Web/Events/Event_handlers) or function to call when
-`unhandledrejection` events are received by the window. The event handler
-receives as an input parameter as a {{domxref("PromiseRejectionEvent")}}.
+An [event handler](/en-US/docs/Web/Events/Event_handlers) or function to call when `unhandledrejection` events are received by the window. The event handler receives as an input parameter as a {{domxref("PromiseRejectionEvent")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/workerglobalscope/console/index.md
+++ b/files/en-us/web/api/workerglobalscope/console/index.md
@@ -14,17 +14,11 @@ browser-compat: api.WorkerGlobalScope.console
 
 The **`console`** read-only property of the {{domxref("WorkerGlobalScope")}} interface returns a {{domxref("console")}} object providing access to the browser console for the worker.
 
-## Syntax
-
-```js
-var consoleObj = self.console;
-```
-
-### Value
+## Value
 
 A {{domxref("console")}} object.
 
-## Example
+## Examples
 
 This property allows you to have access to a browser console for debugging purposes, inside a worker. So for example you could call
 

--- a/files/en-us/web/api/workerglobalscope/location/index.md
+++ b/files/en-us/web/api/workerglobalscope/location/index.md
@@ -14,17 +14,11 @@ browser-compat: api.WorkerGlobalScope.location
 
 The **`location`** read-only property of the {{domxref("WorkerGlobalScope")}} interface returns the {{domxref("WorkerLocation")}} associated with the worker. It is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
 
-## Syntax
-
-```js
-var locationObj = self.location;
-```
-
-### Value
+## Value
 
 A {{domxref("WorkerLocation")}} object.
 
-## Example
+## Examples
 
 If you called the following in a document served at `localhost:8000`
 

--- a/files/en-us/web/api/workerglobalscope/navigator/index.md
+++ b/files/en-us/web/api/workerglobalscope/navigator/index.md
@@ -14,17 +14,11 @@ browser-compat: api.WorkerGlobalScope.navigator
 
 The **`navigator`** read-only property of the {{domxref("WorkerGlobalScope")}} interface returns the {{domxref("WorkerNavigator")}} associated with the worker. It is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
 
-## Syntax
-
-```js
-var navigatorObj = self.navigator;
-```
-
-### Value
+## Value
 
 A {{domxref("WorkerNavigator")}} object.
 
-## Example
+## Examples
 
 If you call the following
 

--- a/files/en-us/web/api/workerglobalscope/self/index.md
+++ b/files/en-us/web/api/workerglobalscope/self/index.md
@@ -14,17 +14,11 @@ browser-compat: api.WorkerGlobalScope.self
 
 The **`self`** read-only property of the {{domxref("WorkerGlobalScope")}} interface returns a reference to the `WorkerGlobalScope` itself. Most of the time it is a specific scope like {{domxref("DedicatedWorkerGlobalScope")}},  {{domxref("SharedWorkerGlobalScope")}}, or {{domxref("ServiceWorkerGlobalScope")}}.
 
-## Syntax
-
-```js
-var selfRef = self;
-```
-
-### Value
+## Value
 
 A global scope object (differs depending on the type of worker you are dealing with, as indicated above).
 
-## Example
+## Examples
 
 If you called
 

--- a/files/en-us/web/api/workernavigator/appcodename/index.md
+++ b/files/en-us/web/api/workernavigator/appcodename/index.md
@@ -19,13 +19,7 @@ compatibility purposes.
 > **Note:** Do not rely on this property to return a real
 > product name. All browsers return "`Mozilla`" as the value of this property.
 
-## Syntax
-
-```js
-codeName = navigator.appCodeName
-```
-
-### Value
+## Value
 
 The string "`Mozilla`".
 

--- a/files/en-us/web/api/workernavigator/appname/index.md
+++ b/files/en-us/web/api/workernavigator/appname/index.md
@@ -18,13 +18,7 @@ purposes.
 
 > **Note:** Do not rely on this property to return a real browser name. All browsers return "`Netscape`" as the value of this property.
 
-## Syntax
-
-```js
-appName = navigator.appName
-```
-
-### Value
+## Value
 
 The string "`Netscape`".
 

--- a/files/en-us/web/api/workernavigator/appversion/index.md
+++ b/files/en-us/web/api/workernavigator/appversion/index.md
@@ -17,18 +17,12 @@ the browser.
 
 > **Note:** Do not rely on this property to return the correct browser version.
 
-## Syntax
-
-```js
-window.navigator.appVersion
-```
-
-### Value
+## Value
 
 Either "`4.0`" or a string representing version information about the
 browser.
 
-## Example
+## Examples
 
 ```js
 alert('Your browser version is reported as ' + navigator.appVersion);

--- a/files/en-us/web/api/workernavigator/hardwareconcurrency/index.md
+++ b/files/en-us/web/api/workernavigator/hardwareconcurrency/index.md
@@ -17,12 +17,6 @@ The **`navigator.hardwareConcurrency`** read-only property
 returns the number of logical processors available to run threads on the user's
 computer.
 
-## Syntax
-
-```js
-logicalProcessors = navigator.hardwareConcurrency
-```
-
 ## Value
 
 A {{jsxref("Number")}} indicating the number of logical processor cores.

--- a/files/en-us/web/api/workernavigator/language/index.md
+++ b/files/en-us/web/api/workernavigator/language/index.md
@@ -16,13 +16,7 @@ The **`WorkerNavigator.language`** read-only property returns
 a string representing the preferred language of the user, usually the language of the
 browser UI.
 
-## Syntax
-
-```js
-const lang = navigator.language
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}}. _`lang`_ stores a string representing the
 language version as defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. Examples of valid language
@@ -31,7 +25,7 @@ codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 Note that in Safari on iOS prior to 10.2, the country code returned is lowercase:
 "en-us", "fr-fr" etc.
 
-## Example
+## Examples
 
 You can run this insert a web worker:
 

--- a/files/en-us/web/api/workernavigator/locks/index.md
+++ b/files/en-us/web/api/workernavigator/locks/index.md
@@ -17,13 +17,7 @@ the {{domxref("WorkerNavigator")}} interface returns a {{domxref("LockManager")}
 object which provides methods for requesting a new {{domxref('Lock')}} object and
 querying for an existing `Lock` object.
 
-## Syntax
-
-```js
-var lockManager = navigator.locks
-```
-
-### Value
+## Value
 
 A {{domxref("LockManager")}} object.
 

--- a/files/en-us/web/api/workernavigator/online/index.md
+++ b/files/en-us/web/api/workernavigator/online/index.md
@@ -36,13 +36,7 @@ In Firefox and Internet Explorer, switching the browser to offline mode sends a
 `true` value; testing actual behavior on Nightly 68 on Windows shows that it
 only looks for LAN connection like Chrome and Safari giving false positives.
 
-## Syntax
-
-```js
-online = navigator.onLine;
-```
-
-### Value
+## Value
 
 `online` is a boolean `true` or `false`.
 

--- a/files/en-us/web/api/workernavigator/permissions/index.md
+++ b/files/en-us/web/api/workernavigator/permissions/index.md
@@ -18,12 +18,6 @@ The **`WorkerNavigator.permissions`** read-only property
 returns a {{domxref("Permissions")}} object that can be used to query and update
 permission status of APIs covered by the [Permissions API](/en-US/docs/Web/API/Permissions_API).
 
-## Syntax
-
-```js
-permissionsObj = navigator.permissions
-```
-
 ## Value
 
 A {{domxref("Permissions")}} object.

--- a/files/en-us/web/api/workernavigator/platform/index.md
+++ b/files/en-us/web/api/workernavigator/platform/index.md
@@ -17,13 +17,7 @@ Returns a string representing the platform of the browser. The specification all
 browsers to always return the empty string, so don't rely on this property to get a
 reliable answer.
 
-## Syntax
-
-```js
-platform = navigator.platform
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} identifying the platform on which the browser is running, or
 an empty string if the browser declines to (or is unable to) identify the platform.
@@ -32,7 +26,7 @@ the platform on which the browser is executing.
 
 For example: "`MacIntel`", "`Win32`", "`FreeBSD i386`", "`WebTV OS`"
 
-## Example
+## Examples
 
 ```js
 console.log(navigator.platform);

--- a/files/en-us/web/api/workernavigator/product/index.md
+++ b/files/en-us/web/api/workernavigator/product/index.md
@@ -17,13 +17,7 @@ purposes.
 
 > **Note:** Do not rely on this property to return a real product name. All browsers return "`Gecko`" as the value of this property.
 
-## Syntax
-
-```js
-productName = navigator.product
-```
-
-### Value
+## Value
 
 The string "`Gecko`".
 

--- a/files/en-us/web/api/workernavigator/serial/index.md
+++ b/files/en-us/web/api/workernavigator/serial/index.md
@@ -15,13 +15,7 @@ The **`serial`** read-only property of the {{domxref("WorkerNavigator")}} interf
 
 When getting, the same instance of the {{domxref("Serial")}} object will always be returned.
 
-## Syntax
-
-```js
-var serialObj = navigator.serial;
-```
-
-### Value
+## Value
 
 A {{domxref("Serial")}} object.
 

--- a/files/en-us/web/api/workernavigator/storage/index.md
+++ b/files/en-us/web/api/workernavigator/storage/index.md
@@ -19,13 +19,7 @@ The returned object lets you examine and configure persistence of data stores an
 learn approximately how much more space your browser has available for local storage
 use.
 
-## Syntax
-
-```js
-var storageManager = navigator.storage;
-```
-
-### Value
+## Value
 
 A {{domxref("StorageManager")}} object you can use to maintain persistence for stored
 data, as well as to determine roughly how much room there is for data to be stored.

--- a/files/en-us/web/api/workernavigator/useragent/index.md
+++ b/files/en-us/web/api/workernavigator/useragent/index.md
@@ -37,13 +37,7 @@ string is user configurable. For example:
 - Safari and iCab allow users to change the browser user agent string to predefined
   Internet Explorer or Netscape strings via a menu.
 
-## Syntax
-
-```js
-var ua = navigator.userAgent;
-```
-
-### Value
+## Value
 
 A {{domxref("DOMString")}} specifying the complete user agent string the browser
 provides both in {{Glossary("HTTP")}} headers and in response to this and other related
@@ -60,7 +54,7 @@ Localization; rv: revision-version-number) product/productSub
 Application-Name Application-Name-version
 ```
 
-## Example
+## Examples
 
 ```js
 alert(navigator.userAgent)

--- a/files/en-us/web/api/workernavigator/useragentdata/index.md
+++ b/files/en-us/web/api/workernavigator/useragentdata/index.md
@@ -14,13 +14,7 @@ browser-compat: api.WorkerNavigator.userAgentData
 The **`userAgentData`** read-only property of the {{domxref("WorkerNavigator")}} interface returns an {{domxref("NavigatorUAData")}} object
 which can be used to access the {{domxref("User-Agent Client Hints API")}}.
 
-## Syntax
-
-```js
-let userAgentData = navigator.userAgentData
-```
-
-### Value
+## Value
 
 A {{domxref("NavigatorUAData")}} object.
 

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -39,7 +39,7 @@ with the exception that when reading text data using a `responseType` of
 response so far while the request is still in the `LOADING`
 {{domxref("XMLHttpRequest.readyState", "readyState")}} (3).
 
-## Example
+## Examples
 
 This example presents a function, `load()`, which loads and processes a page
 from the server. It works by creating an {{domxref("XMLHttpRequest")}} object and

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -41,7 +41,7 @@ You know the entire content has been received when the value of
     string or `"text"`. Since the `responseText` property is
     only valid for text content, any other value is an error condition.
 
-## Example
+## Examples
 
 ```js
 var xhr = new XMLHttpRequest();

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -52,7 +52,7 @@ data is not XML/HTML.
   - : Thrown if the {{domxref("XMLHttpRequest.responseType", "responseType")}} isn't either
     `document` or an empty string.
 
-## Example
+## Examples
 
 ```js
 var xhr = new XMLHttpRequest;

--- a/files/en-us/web/api/xpathexception/code/index.md
+++ b/files/en-us/web/api/xpathexception/code/index.md
@@ -17,13 +17,7 @@ The **`code`** read-only property of the
 {{domxref("XPathException")}} interface returns a `short` that contains one
 of the [error code constants](/en-US/docs/Web/API/XPathException#Constants).
 
-## Syntax
-
-```js
-var exceptionCode = exception.code;
-```
-
-### Value
+## Value
 
 A `short` number representing the error code.
 

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.md
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.md
@@ -54,7 +54,7 @@ The input source's {{domxref("XRInputSource.targetRaySpace", "targetRaySpace")}}
 indicates the position and orientation of the target ray, and can be used to determine
 where to render the ray.
 
-## Example
+## Examples
 
 This fragment of code shows part of a function to be called once every frame. It looks for inputs which have a non-`null` {{domxref("XRInputSource.targetRaySpace", "targetRaySpace")}}. Inputs which have a value for this property represent inputs that project a target ray outward from the user.
 

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.md
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.md
@@ -73,7 +73,7 @@ pass it into the {{domxref("XRFrame")}} method {{domxref("XRFrame.getPose",
   "getPose()")}} method, then use the returned {{domxref("XRPose")}} object's
 {{domxref("XRPose.transform", "transform")}} to gather the spatial information you need.
 
-## Example
+## Examples
 
 This fragment of code shows part of a function to be called once every frame. It looks for inputs which have a non-`null` {{domxref("XRInputSource.targetRaySpace", "targetRaySpace")}}. Inputs which have a value for this property represent inputs that project a target ray outward from the user.
 

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
@@ -37,7 +37,7 @@ An {{domxref("XRInputSource")}} object identifying the source of the user input 
 This event indicates an action the user has taken using a WebXR input controller, such
 as a hand controller, motion sensing device, or other input apparatus.
 
-## Example
+## Examples
 
 The snippet below shows a handler for the {{domxref("XRSession.select_event",
   "select")}} event which looks specifically for events which happen on `gaze`

--- a/files/en-us/web/api/xrpose/transform/index.md
+++ b/files/en-us/web/api/xrpose/transform/index.md
@@ -33,7 +33,7 @@ An {{domxref("XRRigidTransform")}} which provides the position and orientation o
 `XRPose` is aligned. This is the same pose that's returned by the frame's
 {{domxref("XRFrame.getPose", "getPose()")}} method.
 
-## Example
+## Examples
 
 This handler for the {{domxref("XRSession")}} event {{domxref("XRSession.select_event",
   "select")}} handles events for tracked pointers. It determines the targeted object by

--- a/files/en-us/web/api/xrrigidtransform/position/index.md
+++ b/files/en-us/web/api/xrrigidtransform/position/index.md
@@ -33,7 +33,7 @@ transform matrix. The units are meters.
 
 > **Note:** The `w` component of the point is always 1.0.
 
-## Example
+## Examples
 
 To create a reference space which can be used to place an object at eye level (assuming
 eye level is 1.5 meters):


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error