### PR TITLE
Fix 'Loose equality comparisons', ToPrimitive(A) calc step

### DIFF
--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
@@ -72,7 +72,7 @@ Traditionally, and according to ECMAScript, all primitives and objects are loose
 Loose equality comparisons among other combinations of operand types are performed as shown in the tables below. The following notations are used in the tables:
 
 - `ToNumber(A)` attempts to convert its argument to a number before comparison. Its behavior is equivalent to `+A` (the unary + operator).
-- `ToPrimitive(A)` attempts to convert its object argument to a primitive value, by invoking varying sequences of `A.toString()` and `A.valueOf()` methods on `A`.
+- `ToPrimitive(A)` attempts to convert its object argument to a primitive value, by invoking varying sequences of `A[Symbol.toPrimitive]()`, `A.valueOf()` and `A.toString()` methods on `A`.
 - `ℝ(A)` attempts to convert its argument to an ECMAScript [mathematical value](https://tc39.es/ecma262/#mathematical-value).
 - `StringToBigInt(A)` attempts to convert its argument to a `BigInt` by applying the ECMAScript [`StringToBigInt`](https://tc39.es/ecma262/#sec-stringtobigint) algorithm.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix the 'Loose equality comparisons' content 'ToPrimitive(A)' calculation step.

#### Motivation
Accroding to the spec, `ToPrimitive(A)` will first call `A[Symbol.toPrimitive]()` if the method not exist, it will call in order `A.valueOf()` and `A.toString()` .

#### Supporting details
 [tc39.es/ecma262 7.1.1 ToPrimitive](https://tc39.es/ecma262/#sec-toprimitive)

#### Related issues

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
